### PR TITLE
feat(cli): machine fork/restore with --as and --branch

### DIFF
--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -150,6 +150,8 @@ impl Commands {
                 machine::MachineAction::Revert(a) | machine::MachineAction::Rewind(a) => a.json,
                 machine::MachineAction::Advance(a) => a.json,
                 machine::MachineAction::Ls(a) => a.json,
+                machine::MachineAction::Fork(a) => a.json,
+                machine::MachineAction::Restore(a) => a.json,
                 _ => false,
             },
             _ => false,

--- a/crates/mvm-cli/src/commands/machine/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/machine/checkpoint.rs
@@ -1,13 +1,108 @@
-//! User-facing warm fork/restore surface for `mvmctl machine warm-restore`.
+//! User-facing fork/restore surface for `mvmctl machine fork` and
+//! `mvmctl machine restore`.
 //!
-//! This routes into the Firecracker vm_full fork helpers in
-//! `commands::vm::checkpoint`, but presents a focused, backend-agnostic
-//! machine-level verb.
+//! These verbs sit on top of the consolidated `VmBackend`/checkpoint seam:
+//! `fork` captures a running machine as a vm_full checkpoint and then branches
+//! it into a fresh child VM; `restore` branches an existing vm_full checkpoint
+//! into a fresh child VM. Both deliver new identity, authority, and
+//! per-instance secrets through the same admit-and-boot path used by
+//! `machine warm-restore`.
 
 use anyhow::{Context, Result, bail};
 use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
 use mvm_core::config::vm_state_dir;
+use mvm_core::naming;
 use mvm_runtime::checkpoint::CheckpointStore;
+
+/// User-facing input to [`fork_machine`].
+pub(in crate::commands) struct ForkMachineInput {
+    /// Parent machine name (must be running).
+    pub parent_name: String,
+    /// Explicit child VM name (`--as`).
+    pub child_name: Option<String>,
+    /// Branch slug for auto-naming (`--branch`).
+    pub branch: Option<String>,
+    /// Emit machine-readable JSON instead of human text.
+    pub json: bool,
+}
+
+/// User-facing input to [`restore_machine`].
+pub(in crate::commands) struct RestoreMachineInput {
+    /// vm_full checkpoint id to restore.
+    pub checkpoint_id: String,
+    /// Explicit child VM name (`--as`).
+    pub child_name: Option<String>,
+    /// Branch slug for auto-naming (`--branch`).
+    pub branch: Option<String>,
+    /// Emit machine-readable JSON instead of human text.
+    pub json: bool,
+}
+
+/// User-facing `machine fork`: capture a running machine and branch it into a
+/// fresh child VM with a new identity.
+///
+/// The implementation first snapshots the parent as a vm_full checkpoint via
+/// the backend's pause/save/resume control, then forks that checkpoint using
+/// the same path as `machine warm-restore`. The intermediate checkpoint id is
+/// left in the store so the caller can inspect or remove it.
+pub(in crate::commands) fn fork_machine(input: ForkMachineInput) -> Result<()> {
+    naming::validate_id(&input.parent_name, "machine name")
+        .with_context(|| format!("invalid parent machine name {:?}", input.parent_name))?;
+    let child_name = resolve_child_name(
+        &input.parent_name,
+        input.child_name.as_deref(),
+        input.branch.as_deref(),
+        false,
+    )?;
+    let checkpoint_id =
+        crate::commands::vm::checkpoint::capture_vm_full_for_machine(&input.parent_name, None)
+            .with_context(|| format!("capturing full-VM snapshot of {}", input.parent_name))?;
+
+    fork_vm_full_machine(ForkVmFullMachineInput {
+        checkpoint_id: checkpoint_id.as_str().to_string(),
+        child_vm_name: Some(child_name),
+        json: input.json,
+    })
+    .with_context(|| format!("forking child from checkpoint {}", checkpoint_id.as_str()))?;
+    Ok(())
+}
+
+/// User-facing `machine restore`: branch an existing vm_full checkpoint into a
+/// fresh child VM with a new identity.
+///
+/// Unlike `vm checkpoint restore`, this does not resume the same identity; it
+/// treats the checkpoint as an immutable parent and admits a new claim-8 plan
+/// for the child.
+pub(in crate::commands) fn restore_machine(input: RestoreMachineInput) -> Result<()> {
+    let checkpoint = crate::commands::vm::checkpoint::validated_checkpoint_id(&input.checkpoint_id)
+        .with_context(|| format!("invalid checkpoint id {:?}", input.checkpoint_id))?;
+    let store = CheckpointStore::open();
+    let parent_meta = store
+        .read_meta(&checkpoint)
+        .with_context(|| format!("reading checkpoint {}", input.checkpoint_id))?;
+
+    if parent_meta.class != CheckpointClass::VmFull {
+        bail!(
+            "checkpoint '{}' is class {:?}; restore only supports vm_full checkpoints",
+            input.checkpoint_id,
+            parent_meta.class,
+        );
+    }
+
+    let child_name = resolve_child_name(
+        input.checkpoint_id.as_str(),
+        input.child_name.as_deref(),
+        input.branch.as_deref(),
+        false,
+    )?;
+
+    fork_vm_full_machine(ForkVmFullMachineInput {
+        checkpoint_id: input.checkpoint_id,
+        child_vm_name: Some(child_name),
+        json: input.json,
+    })?;
+    Ok(())
+}
 
 /// User-facing input to [`fork_vm_full_machine`].
 pub(in crate::commands) struct ForkVmFullMachineInput {
@@ -19,11 +114,11 @@ pub(in crate::commands) struct ForkVmFullMachineInput {
     pub json: bool,
 }
 
-/// User-facing Firecracker vm_full warm fork/restore.
+/// User-facing vm_full warm fork/restore.
 ///
 /// Validates the checkpoint, generates a fresh child identity, admits a new
-/// claim-8 plan, restores the saved machine state through the FC fork path,
-/// and delivers the post-restore generation token. The user-facing verb
+/// claim-8 plan, restores the saved machine state through the backend fork
+/// path, and delivers the post-restore generation token. The user-facing verb
 /// implicitly opts into the experimental Firecracker vm_full fork path, so
 /// the lower-level env-var guard is bypassed here.
 pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -> Result<()> {
@@ -46,7 +141,7 @@ pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -
     let child_vm_name = input
         .child_vm_name
         .unwrap_or_else(|| format!("{}-warm-{now}", checkpoint.as_str()));
-    mvm_core::naming::validate_vm_name(&child_vm_name)
+    naming::validate_vm_name(&child_vm_name)
         .with_context(|| format!("invalid child VM name {child_vm_name:?}"))?;
     let dest_dir = vm_state_dir(&child_vm_name);
     let child_id = CheckpointId::new(format!("fork-{child_vm_name}-{now}"));
@@ -65,4 +160,73 @@ pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -
         },
     )?;
     Ok(())
+}
+
+/// Resolve the child VM name from explicit `--as`, `--branch`, or a default.
+///
+/// * `--as <name>` is used verbatim.
+/// * `--branch <slug>` produces `<parent>-<slug>-<timestamp>`.
+/// * Neither produces `<parent>-fork-<timestamp>` unless `require_explicit` is
+///   true (used by `restore`, where a long checkpoint id is a poor default).
+fn resolve_child_name(
+    parent: &str,
+    explicit: Option<&str>,
+    branch: Option<&str>,
+    require_explicit: bool,
+) -> Result<String> {
+    if let Some(name) = explicit {
+        naming::validate_id(name, "child machine name")
+            .with_context(|| format!("invalid child name {name:?}"))?;
+        return Ok(name.to_string());
+    }
+    let now = crate::commands::vm::checkpoint::now_unix();
+    if let Some(branch) = branch {
+        naming::validate_id(branch, "branch name")
+            .with_context(|| format!("invalid branch name {branch:?}"))?;
+        return Ok(format!("{parent}-{branch}-{now}"));
+    }
+    if require_explicit {
+        bail!("--as <NAME> or --branch <BRANCH> is required");
+    }
+    Ok(format!("{parent}-fork-{now}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_explicit_child_name() {
+        assert_eq!(
+            resolve_child_name("parent", Some("child"), None, false).unwrap(),
+            "child"
+        );
+    }
+
+    #[test]
+    fn resolve_branch_child_name() {
+        let name = resolve_child_name("parent", None, Some("feature-x"), false).unwrap();
+        assert!(name.starts_with("parent-feature-x-"), "got {name}");
+    }
+
+    #[test]
+    fn resolve_default_child_name() {
+        let name = resolve_child_name("parent", None, None, false).unwrap();
+        assert!(name.starts_with("parent-fork-"), "got {name}");
+    }
+
+    #[test]
+    fn resolve_restore_requires_explicit_or_branch() {
+        assert!(resolve_child_name("ckpt-abc", None, None, true).is_err());
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_explicit() {
+        assert!(resolve_child_name("parent", Some("Bad Name"), None, false).is_err());
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_branch() {
+        assert!(resolve_child_name("parent", None, Some("bad/name"), false).is_err());
+    }
 }

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -447,6 +447,7 @@ impl MachineRunArgs {
             receipt: self.receipt,
             json: self.json,
             dry_run: self.dry_run,
+            no_detect: false,
             launch_plan: None,
             prod: false,
             // SDK-transport surface (`--mode`/`--dev`/`--ack-divergence`) stays

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -140,6 +140,12 @@ pub(in crate::commands) enum MachineAction {
     /// Restore a full-VM checkpoint into a fresh child VM
     #[command(name = "warm-restore", display_order = 18)]
     WarmRestore(MachineWarmRestoreArgs),
+    /// Fork a running machine into a fresh child VM with a new identity.
+    #[command(display_order = 19)]
+    Fork(MachineForkArgs),
+    /// Restore a vm_full checkpoint into a fresh child VM with a new identity.
+    #[command(display_order = 20)]
+    Restore(MachineRestoreArgs),
     /// Advanced single-VM operations (pause, snapshot, cp, fs, …). Hidden; use `machine <verb>` directly.
     #[command(flatten)]
     Vm(VmCmd),
@@ -174,6 +180,8 @@ impl MachineAction {
             MachineAction::Rewind(_) => "rewind",
             MachineAction::Advance(_) => "advance",
             MachineAction::WarmRestore(_) => "warm-restore",
+            MachineAction::Fork(_) => "fork",
+            MachineAction::Restore(_) => "restore",
         }
     }
 }
@@ -1075,6 +1083,38 @@ pub(in crate::commands) struct MachineWarmRestoreArgs {
     pub json: bool,
 }
 
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct MachineForkArgs {
+    /// Running machine to fork.
+    #[arg(value_name = "PARENT")]
+    pub parent: String,
+    /// Name for the fresh child VM.
+    #[arg(long = "as", value_name = "NAME", conflicts_with = "branch")]
+    pub child_name: Option<String>,
+    /// Auto-name the child as `<parent>-<branch>-<timestamp>`.
+    #[arg(long, value_name = "BRANCH", conflicts_with = "child_name")]
+    pub branch: Option<String>,
+    /// Output the result as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct MachineRestoreArgs {
+    /// vm_full checkpoint id to restore.
+    #[arg(value_name = "CHECKPOINT_ID")]
+    pub checkpoint: String,
+    /// Name for the fresh child VM.
+    #[arg(long = "as", value_name = "NAME", conflicts_with = "branch")]
+    pub child_name: Option<String>,
+    /// Auto-name the child as `<checkpoint>-<branch>-<timestamp>`.
+    #[arg(long, value_name = "BRANCH", conflicts_with = "child_name")]
+    pub branch: Option<String>,
+    /// Output the result as JSON.
+    #[arg(long)]
+    pub json: bool,
+}
+
 #[derive(Debug, Serialize)]
 struct MachineRemoveSummary {
     name: String,
@@ -1499,6 +1539,8 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
             complete_revert(cli, cfg, super::vm::checkpoint::run_advance(a)?)
         }
         MachineAction::WarmRestore(args) => run_warm_restore(args),
+        MachineAction::Fork(args) => run_fork(args),
+        MachineAction::Restore(args) => run_restore(args),
         MachineAction::Vm(cmd) => {
             super::vm::group::run(cli, super::vm::group::Args { action: cmd }, cfg)
         }
@@ -1513,6 +1555,26 @@ fn run_warm_restore(args: MachineWarmRestoreArgs) -> Result<()> {
         json: args.json,
     })?;
     Ok(())
+}
+
+/// Run `machine fork`: capture and branch a running machine into a fresh child VM.
+fn run_fork(args: MachineForkArgs) -> Result<()> {
+    checkpoint::fork_machine(checkpoint::ForkMachineInput {
+        parent_name: args.parent,
+        child_name: args.child_name,
+        branch: args.branch,
+        json: args.json,
+    })
+}
+
+/// Run `machine restore`: branch a vm_full checkpoint into a fresh child VM.
+fn run_restore(args: MachineRestoreArgs) -> Result<()> {
+    checkpoint::restore_machine(checkpoint::RestoreMachineInput {
+        checkpoint_id: args.checkpoint,
+        child_name: args.child_name,
+        branch: args.branch,
+        json: args.json,
+    })
 }
 
 /// Finish a restore. A checkpoint restore completes inside the engine (the fork

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -263,6 +263,9 @@ pub(in crate::commands) struct MachineRunArgs {
     /// Boot a local attested deployment (deploy.json plus rootfs.ext4).
     #[arg(long, value_name = "DIR", conflicts_with_all = ["image", "manifest", "flake", "runtime_pack"])]
     pub deployment: Option<PathBuf>,
+    /// Boot the OCI image referenced by a named template.
+    #[arg(long, value_name = "NAME", conflicts_with_all = ["image", "manifest", "flake", "runtime_pack", "deployment"])]
+    pub template: Option<String>,
     /// Select a flake package.
     #[arg(long, value_name = "PROFILE", requires = "flake")]
     pub flake_profile: Option<String>,
@@ -432,6 +435,7 @@ impl MachineRunArgs {
             pty: false,
             vm_name: self.name,
             image: self.image,
+            template: self.template,
             runtime_pack: self.runtime_pack,
             net: self.net,
             allow_host: self.allow_host,
@@ -1564,6 +1568,7 @@ fn run_args_for_image_revert(
             stdin: None,
             manifest,
             deployment: None,
+            template: None,
             runtime_pack: false,
             flake_profile: None,
             net: false,

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -452,6 +452,7 @@ pub(in crate::commands) fn boot_persistent_by_name(
             image: None,
             manifest: None,
             deployment: None,
+            template: None,
             runtime_pack: false,
             flake_profile: None,
             net: false,

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -56,6 +56,20 @@ fn parse_owned_run(argv: &[String]) -> Result<MachineRunArgs, clap::Error> {
     })
 }
 
+fn parse_fork(argv: &[&str]) -> Result<MachineForkArgs, clap::Error> {
+    parse(argv).map(|action| match action {
+        MachineAction::Fork(f) => f,
+        other => panic!("expected fork action, got {other:?}"),
+    })
+}
+
+fn parse_restore(argv: &[&str]) -> Result<MachineRestoreArgs, clap::Error> {
+    parse(argv).map(|action| match action {
+        MachineAction::Restore(r) => r,
+        other => panic!("expected restore action, got {other:?}"),
+    })
+}
+
 const SDK_RUN_EGRESS_BACKEND: &str = "libkrun";
 const SDK_RUN_EGRESS_ENFORCEMENT: &str = "libkrun:l4-host-port";
 
@@ -96,6 +110,8 @@ fn machine_subcommand(action: &MachineAction) -> &'static str {
         MachineAction::Rewind(_) => "rewind",
         MachineAction::Advance(_) => "advance",
         MachineAction::WarmRestore(_) => "warm-restore",
+        MachineAction::Fork(_) => "fork",
+        MachineAction::Restore(_) => "restore",
         MachineAction::Vm(_) => "vm",
     }
 }
@@ -105,6 +121,59 @@ fn machine_subcommand(action: &MachineAction) -> &'static str {
 /// CLI parser actually accepts, and must map to the verb its first line
 /// names. This is what catches an SDK emitting a flag the CLI rejects (e.g.
 /// `stop --name X` when `stop` takes a positional name).
+#[test]
+fn fork_parses_with_as() {
+    let args = parse_fork(&["fork", "parent", "--as", "child"]).unwrap();
+    assert_eq!(args.parent, "parent");
+    assert_eq!(args.child_name, Some("child".to_string()));
+    assert!(args.branch.is_none());
+}
+
+#[test]
+fn fork_parses_with_branch() {
+    let args = parse_fork(&["fork", "parent", "--branch", "feature-x"]).unwrap();
+    assert_eq!(args.parent, "parent");
+    assert!(args.child_name.is_none());
+    assert_eq!(args.branch, Some("feature-x".to_string()));
+}
+
+#[test]
+fn fork_rejects_as_and_branch_together() {
+    assert!(parse_fork(&["fork", "parent", "--as", "child", "--branch", "feature-x"]).is_err());
+}
+
+#[test]
+fn fork_allows_no_name() {
+    let args = parse_fork(&["fork", "parent"]).unwrap();
+    assert_eq!(args.parent, "parent");
+    assert!(args.child_name.is_none());
+    assert!(args.branch.is_none());
+}
+
+#[test]
+fn restore_auto_names_when_as_and_branch_are_omitted() {
+    let args = parse_restore(&["restore", "ckpt-abc"]).unwrap();
+    assert_eq!(args.checkpoint, "ckpt-abc");
+    assert!(args.child_name.is_none());
+    assert!(args.branch.is_none());
+}
+
+#[test]
+fn restore_parses_with_as() {
+    let args = parse_restore(&["restore", "ckpt-abc", "--as", "child"]).unwrap();
+    assert_eq!(args.checkpoint, "ckpt-abc");
+    assert_eq!(args.child_name, Some("child".to_string()));
+    assert!(args.branch.is_none());
+}
+
+#[test]
+fn restore_parses_with_branch() {
+    let args = parse_restore(&["restore", "ckpt-abc", "--branch", "feature-x"]).unwrap();
+    assert_eq!(args.checkpoint, "ckpt-abc");
+    assert!(args.child_name.is_none());
+    assert_eq!(args.branch, Some("feature-x".to_string()));
+}
+
 #[test]
 fn every_shared_machine_fixture_parses_to_its_verb() {
     let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/machine-fixtures");

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -108,8 +108,8 @@ pub(in crate::commands) struct Cli {
 #[derive(Subcommand, Debug, Clone)]
 #[allow(clippy::large_enum_variant)] // Up variant has many CLI fields; boxing breaks Clap derive
 pub(in crate::commands) enum Commands {
-    /// Beginner microVM workflows (run an OCI image and more)
-    #[command(display_order = 1)]
+    /// Persistent and advanced microVM lifecycle operations.
+    #[command(display_order = 2)]
     Machine(machine::Args),
     /// Build-time commands (image, compile, validate, kernel)
     #[command(display_order = 3)]
@@ -144,11 +144,12 @@ pub(in crate::commands) enum Commands {
     /// Manage versioned packs (list/rollback/prune/download/update)
     #[command(display_order = 9)]
     Pack(pack::Args),
-    /// SDK transport surface (`run --mode live/plan`). Hidden: the user-facing
-    /// transient-run role folded into `machine run`; `run` survives only as the
-    /// SDK Sandbox launcher the Python/TS SDKs shell to, so it stays hidden
-    /// rather than break that transport.
-    #[command(hide = true)]
+    /// Run a command in a fresh transient microVM.
+    ///
+    /// This is the one-shot sandbox UX: boot, run `<cmd>`, tear down. It shares
+    /// the same admitted execution path as `mvmctl machine run` and is kept
+    /// alongside it for users who prefer a flat `run <command>` shape.
+    #[command(display_order = 1)]
     Run(vm::exec::RunArgs),
     /// Internal SDK host-dispatch transport for `MVM_NO_VM=1`.
     #[command(name = "__sdk-no-vm", hide = true)]

--- a/crates/mvm-cli/src/commands/shared/mod.rs
+++ b/crates/mvm-cli/src/commands/shared/mod.rs
@@ -11,6 +11,7 @@ mod grants;
 mod hints;
 mod parse;
 mod resolve;
+mod runtime_detect;
 mod start;
 mod state;
 mod vsock;
@@ -29,6 +30,7 @@ pub(super) use resolve::{
     ManifestArgRef, egress_enforcement_label, resolve_effective_hypervisor, resolve_flake_ref,
     resolve_manifest_arg, resolve_run_network_policy, resolve_running_vm,
 };
+pub(super) use runtime_detect::detect_runtime_image;
 pub(super) use start::VmStartParams;
 pub(super) use state::{CHILD_PIDS, IN_CONSOLE_MODE};
 pub(super) use vsock::{emit_vsock_rpc_audit, wait_for_guest_agent};

--- a/crates/mvm-cli/src/commands/shared/runtime_detect.rs
+++ b/crates/mvm-cli/src/commands/shared/runtime_detect.rs
@@ -1,0 +1,187 @@
+//! Runtime image auto-detection for `mvmctl run`.
+//!
+//! Maps the trailing argv (e.g. `python3`, `node`) and project files in the
+//! working directory (e.g. `requirements.txt`, `package.json`) to a pinned OCI
+//! image reference. Detection is purely additive: an explicit `--image`,
+//! `--manifest`, or `--launch-plan` always wins, and `--no-detect` disables it.
+
+use std::path::Path;
+
+/// One entry in the runtime detection catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RuntimeMapping {
+    /// Command names that select this runtime (`python3`, `node`, ...).
+    pub command_names: &'static [&'static str],
+    /// Project files that select this runtime when no command name matches.
+    pub project_files: &'static [&'static str],
+    /// OCI image reference to use when this mapping matches.
+    pub image_ref: &'static str,
+}
+
+/// The built-in auto-detection catalog.
+///
+/// These are conservative, well-known defaults. They are not a replacement for
+/// a manifest; they exist so a casual one-shot (`mvmctl run npm test`) works
+/// without forcing the user to pick an image.
+pub(crate) const CATALOG: &[RuntimeMapping] = &[
+    RuntimeMapping {
+        command_names: &["python3", "python", "pip3", "pip"],
+        project_files: &["requirements.txt", "pyproject.toml", "Pipfile", "setup.py"],
+        image_ref: "python:3.12-alpine",
+    },
+    RuntimeMapping {
+        command_names: &["node", "npm", "npx", "yarn", "pnpm", "bun"],
+        project_files: &["package.json", "yarn.lock", "pnpm-lock.yaml"],
+        image_ref: "node:22-alpine",
+    },
+    RuntimeMapping {
+        command_names: &["cargo", "rustc", "rustup"],
+        project_files: &["Cargo.toml", "Cargo.lock"],
+        image_ref: "rust:1.85-alpine",
+    },
+    RuntimeMapping {
+        command_names: &["go", "gofmt"],
+        project_files: &["go.mod", "go.sum"],
+        image_ref: "golang:1.23-alpine",
+    },
+    RuntimeMapping {
+        command_names: &["ruby", "bundle", "rails", "gem"],
+        project_files: &["Gemfile"],
+        image_ref: "ruby:3.3-alpine",
+    },
+    RuntimeMapping {
+        command_names: &["java", "mvn", "gradle"],
+        project_files: &["pom.xml", "build.gradle", "build.gradle.kts"],
+        image_ref: "eclipse-temurin:21-alpine",
+    },
+    RuntimeMapping {
+        command_names: &["dotnet"],
+        project_files: &["*.csproj", "*.sln"],
+        image_ref: "mcr.microsoft.com/dotnet/sdk:8.0",
+    },
+    RuntimeMapping {
+        command_names: &["php", "composer"],
+        project_files: &["composer.json"],
+        image_ref: "php:8.3-alpine",
+    },
+    RuntimeMapping {
+        command_names: &["sh", "bash", "zsh"],
+        project_files: &[],
+        image_ref: "alpine:3.20",
+    },
+];
+
+/// Detect an OCI image ref for the given argv and working directory.
+///
+/// Returns `None` when:
+/// - detection is disabled (`no_detect` is true),
+/// - argv is empty,
+/// - no command name or project file matches the catalog.
+///
+/// The caller is responsible for preferring an explicit `--image` if one was
+/// supplied.
+pub(crate) fn detect_runtime_image(argv: &[String], cwd: &Path, no_detect: bool) -> Option<String> {
+    if no_detect || argv.is_empty() {
+        return None;
+    }
+
+    let command = argv.first().map(String::as_str).unwrap_or("");
+    // Strip any leading path component; "./script.py" is not a command name.
+    let command_name = Path::new(command)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(command);
+
+    for mapping in CATALOG {
+        if mapping.command_names.contains(&command_name) {
+            return Some(mapping.image_ref.to_string());
+        }
+    }
+
+    for mapping in CATALOG {
+        for file in mapping.project_files {
+            if file.contains('*') {
+                // Glob pattern (e.g. "*.csproj"). Keep it simple: any file in
+                // cwd matching the suffix counts.
+                let suffix = file.strip_prefix("*.").unwrap_or(file);
+                if cwd
+                    .read_dir()
+                    .ok()?
+                    .flatten()
+                    .any(|e| e.path().extension().is_some_and(|ext| ext == suffix))
+                {
+                    return Some(mapping.image_ref.to_string());
+                }
+            } else if cwd.join(file).exists() {
+                return Some(mapping.image_ref.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn detects_python_from_command() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            detect_runtime_image(
+                &["python3".into(), "-c".into(), "print()".into()],
+                dir.path(),
+                false
+            ),
+            Some("python:3.12-alpine".into())
+        );
+    }
+
+    #[test]
+    fn detects_node_from_project_file() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("package.json"), "{}").unwrap();
+        assert_eq!(
+            detect_runtime_image(&["npm".into(), "test".into()], dir.path(), false),
+            Some("node:22-alpine".into())
+        );
+    }
+
+    #[test]
+    fn explicit_no_detect_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("requirements.txt"), "").unwrap();
+        assert_eq!(
+            detect_runtime_image(&["python3".into(), "script.py".into()], dir.path(), true),
+            None
+        );
+    }
+
+    #[test]
+    fn empty_argv_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(detect_runtime_image(&[], dir.path(), false), None);
+    }
+
+    #[test]
+    fn unknown_command_and_files_return_none() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            detect_runtime_image(&["xyzzy".into()], dir.path(), false),
+            None
+        );
+    }
+
+    #[test]
+    fn command_name_wins_over_project_file() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("requirements.txt"), "").unwrap();
+        // Even though cwd looks like Python, `node` command selects Node.
+        assert_eq!(
+            detect_runtime_image(&["node".into()], dir.path(), false),
+            Some("node:22-alpine".into())
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/template.rs
+++ b/crates/mvm-cli/src/commands/template.rs
@@ -1,16 +1,20 @@
-//! `mvmctl template` — browse bundled and remote microVM templates.
+//! `mvmctl template` — browse, build, and inspect microVM templates.
 //!
-//! Templates are parameterized project scaffolds. The bundled core set
-//! ships offline with `mvmctl`; additional templates live in a separate
-//! registry repository and are fetched on demand.
+//! Templates are reusable workload bases. The bundled core set ships offline
+//! with `mvmctl`; built-in image templates provide pinned OCI runtimes for
+//! common languages; user-built image templates are created with
+//! `mvmctl template build --image <ref>`; and additional templates live in a
+//! separate registry repository fetched on demand.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 
 use mvm_core::user_config::MvmConfig;
 
 use super::Cli;
-use crate::template_registry::{RegistryConfig, list_available, search_remote};
+use crate::template_registry::{
+    RegistryConfig, list_available, persist_built_image_template, search_remote,
+};
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -20,14 +24,32 @@ pub(in crate::commands) struct Args {
 
 #[derive(Subcommand, Debug, Clone)]
 pub(in crate::commands) enum TemplateAction {
-    /// List available templates (bundled + cached remote).
+    /// List available templates (built + built-in image + bundled + cached remote).
     List,
+    /// Build a reusable image-backed template from an OCI reference.
+    Build {
+        /// OCI image reference (e.g. `python:3.12-alpine`).
+        #[arg(long, value_name = "REF")]
+        image: String,
+        /// Name for the template. Defaults to the image repository basename.
+        #[arg(long, value_name = "NAME")]
+        name: Option<String>,
+        /// Human-readable description.
+        #[arg(long, value_name = "TEXT")]
+        description: Option<String>,
+        /// Default vCPUs for runs using this template.
+        #[arg(long, value_name = "N")]
+        cpus: Option<u8>,
+        /// Default memory in MiB for runs using this template.
+        #[arg(long, value_name = "MIB")]
+        memory: Option<u32>,
+    },
     /// Search the remote registry for templates matching a query.
     Search {
         /// Search query.
         query: String,
     },
-    /// Show details for one template (bundled or remote).
+    /// Show details for one template (built, bundled, or remote).
     Info {
         /// Template name.
         name: String,
@@ -39,6 +61,19 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     let cfg = RegistryConfig::load();
     match args.action {
         TemplateAction::List => run_list(&cfg),
+        TemplateAction::Build {
+            image,
+            name,
+            description,
+            cpus,
+            memory,
+        } => run_build(
+            &image,
+            name.as_deref(),
+            description.as_deref(),
+            cpus,
+            memory,
+        ),
         TemplateAction::Search { query } => run_search(&cfg, &query),
         TemplateAction::Info { name } => run_info(&cfg, &name),
     }
@@ -52,6 +87,42 @@ fn run_list(cfg: &RegistryConfig) -> Result<()> {
     }
     print_table(&entries);
     Ok(())
+}
+
+fn run_build(
+    image_ref: &str,
+    name: Option<&str>,
+    description: Option<&str>,
+    cpus: Option<u8>,
+    memory: Option<u32>,
+) -> Result<()> {
+    let name = name
+        .map(ToString::to_string)
+        .unwrap_or_else(|| default_name_from_image_ref(image_ref));
+
+    persist_built_image_template(&name, image_ref, description, cpus, memory)
+        .with_context(|| format!("persisting built template {name}"))?;
+
+    println!("Built image template '{name}' from {image_ref}");
+    println!("Use it with: mvmctl run --template {name} -- <cmd>...");
+    Ok(())
+}
+
+fn default_name_from_image_ref(image_ref: &str) -> String {
+    // Strip tag/digest and repository prefix; keep the last path component.
+    let without_digest = image_ref
+        .split_once('@')
+        .map(|(l, _)| l)
+        .unwrap_or(image_ref);
+    let without_tag = without_digest
+        .split_once(':')
+        .map(|(l, _)| l)
+        .unwrap_or(without_digest);
+    without_tag
+        .split('/')
+        .next_back()
+        .unwrap_or(without_tag)
+        .to_string()
 }
 
 fn run_search(cfg: &RegistryConfig, query: &str) -> Result<()> {
@@ -77,6 +148,10 @@ fn run_info(cfg: &RegistryConfig, name: &str) -> Result<()> {
     match entry.source {
         crate::template_registry::TemplateSource::Bundled { .. } => {
             println!("source:      bundled");
+        }
+        crate::template_registry::TemplateSource::Image { image_ref } => {
+            println!("source:      image");
+            println!("image:       {image_ref}");
         }
         crate::template_registry::TemplateSource::Remote { cache_dir } => {
             println!("source:      remote");

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1048,13 +1048,13 @@ fn up_removed() {
 }
 
 #[test]
-fn run_kept_hidden_as_sdk_transport() {
-    // The user-facing transient-run role folded into `machine run`, but `run`
-    // survives hidden as the SDK Sandbox launcher (`run --mode live/plan`) the
-    // Python/TS SDKs shell to — so it must still parse.
+fn run_is_visible_top_level_command() {
+    // `mvmctl run` is a first-class one-shot sandbox command alongside
+    // `mvmctl machine run`. It still supports the SDK transport modes
+    // (`--mode live/plan`) the Python/TS SDKs shell to.
     let cli = Cli::try_parse_from(["mvmctl", "run", "--mode", "live", "script.py"]).unwrap();
     assert!(matches!(cli.command, Commands::Run(_)));
-    // …but it is hidden from top-level help.
+    // It is visible in top-level help.
     let help = {
         use clap::CommandFactory;
         let mut cmd = Cli::command();
@@ -1063,8 +1063,8 @@ fn run_kept_hidden_as_sdk_transport() {
         String::from_utf8(buf).unwrap()
     };
     assert!(
-        !help.contains("\n  run "),
-        "`run` must be hidden from top-level help"
+        help.contains("\n  run "),
+        "`run` must be visible in top-level help"
     );
 }
 

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2675,13 +2675,21 @@ fn test_vm_save_json_parses() {
 }
 
 #[test]
-fn test_vm_restore_json_parses() {
-    let cli = Cli::try_parse_from(["mvmctl", "machine", "restore", "ckpt-abc", "--json"]).unwrap();
+fn test_machine_restore_json_parses() {
+    let cli = Cli::try_parse_from([
+        "mvmctl", "machine", "restore", "ckpt-abc", "--as", "child", "--json",
+    ])
+    .unwrap();
     assert!(matches!(
         cli.command,
         Commands::Machine(machine::Args {
-            action: machine::MachineAction::Vm(group::VmCmd::Restore(checkpoint::RestoreArgs { id, json: true }))
-        }) if id == "ckpt-abc"
+            action: machine::MachineAction::Restore(machine::MachineRestoreArgs {
+                checkpoint,
+                child_name,
+                json: true,
+                ..
+            })
+        }) if checkpoint == "ckpt-abc" && child_name.as_deref() == Some("child")
     ));
 }
 
@@ -4606,7 +4614,7 @@ fn state_touching_commands_trigger_entry_convergence() {
     assert!(touches(&["mvmctl", "machine", "console", "myvm"]));
     assert!(touches(&["mvmctl", "machine", "pause", "myvm"]));
     assert!(touches(&["mvmctl", "machine", "save", "myvm"]));
-    assert!(touches(&["mvmctl", "machine", "restore", "ckpt-myvm"]));
+    assert!(touches(&["mvmctl", "machine", "resume", "myvm"]));
     assert!(touches(&["mvmctl", "machine", "ls"]));
 }
 

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -216,10 +216,6 @@ pub(in crate::commands) fn run_save(_cli: &Cli, args: SaveArgs) -> Result<()> {
     create_vm_full(&args.name, args.tag, args.json)
 }
 
-pub(in crate::commands) fn run_restore(_cli: &Cli, args: RestoreArgs) -> Result<()> {
-    restore(&args.id, args.json)
-}
-
 #[derive(Serialize)]
 struct CheckpointRemoveJson<'a> {
     schema_version: u8,
@@ -544,6 +540,38 @@ fn create_vm_full(name: &str, tag: Option<String>, json: bool) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+/// Capture a vm_full checkpoint of a running machine and return its id, without
+/// emitting human output. Used by `mvmctl machine fork` so the intermediate
+/// checkpoint can be created, branched, and (optionally) cleaned up by the caller.
+pub(in crate::commands) fn capture_vm_full_for_machine(
+    name: &str,
+    tag: Option<String>,
+) -> Result<CheckpointId> {
+    let backend = backend_for_vm(name);
+    ensure_save_restore_supported("fork", &backend)?;
+    if !vm_is_running(name) {
+        bail!("machine fork requires a running VM; start '{name}' first");
+    }
+    let state_dir = vm_state_dir(name);
+    let store = CheckpointStore::open();
+    let now = now_unix();
+    let id = CheckpointId::new(format!("ckpt-{name}-{now}"));
+
+    let meta = capture_vm_full_for_running_vm(CaptureVmFullArgs {
+        name,
+        state_dir: &state_dir,
+        store: &store,
+        backend: &backend,
+        id: id.clone(),
+        tag,
+        created_unix: now,
+    })
+    .with_context(|| format!("capturing vm_full checkpoint of {name:?}"))?;
+
+    bind_checkpoint_created(name, &meta);
+    Ok(id)
 }
 
 /// The permission set `name` was admitted under, read off its persisted plan so

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -132,6 +132,13 @@ pub(in crate::commands) struct RunArgs {
     /// Path to an mvmforge launch document. Mutually exclusive with trailing argv.
     #[arg(long, value_name = "PATH", conflicts_with = "argv")]
     pub launch_plan: Option<String>,
+    /// Run using a named template's OCI image reference.
+    ///
+    /// The name resolves to a user-built image template, a built-in language
+    /// template, or (for non-image sources) a bundled/remote template. Mutually
+    /// exclusive with `--image`, `--manifest`, and `--launch-plan`.
+    #[arg(long, value_name = "NAME", conflicts_with_all = ["image", "manifest", "launch_plan"])]
+    pub template: Option<String>,
     /// SDK transport mode for `mvmctl run`.
     ///
     /// - `--mode plan`: synthesize an ExecutionPlan per Sandbox call
@@ -268,6 +275,17 @@ pub(in crate::commands) fn run_secure_with_source(
     cfg: &MvmConfig,
     source_override: Option<crate::exec::ImageSource>,
 ) -> Result<()> {
+    // Resolve a named template to its OCI image reference before auto-detection.
+    // `--template` is mutually exclusive with `--image`, `--manifest`, and
+    // `--launch-plan` at the clap layer.
+    if let Some(template_name) = args.template.as_deref()
+        && args.image.is_none()
+    {
+        let image_ref = crate::template_registry::resolve_image_ref(template_name)
+            .with_context(|| format!("template {template_name:?} is not an image template"))?;
+        args.image = Some(image_ref);
+    }
+
     // Auto-detect the runtime image from the command or project files when
     // no explicit source was supplied. Explicit `--image` / `--manifest` /
     // `--launch-plan` always win; `--no-detect` disables this.
@@ -1621,6 +1639,7 @@ mod tests {
             dry_run: false,
             no_detect: false,
             launch_plan: None,
+            template: None,
             mode: None,
             dev: false,
             prod: false,

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -122,6 +122,12 @@ pub(in crate::commands) struct RunArgs {
     /// and host paths are omitted.
     #[arg(long)]
     pub dry_run: bool,
+    /// Do not auto-detect the runtime image from the command or project files.
+    ///
+    /// When set, `mvmctl run` uses only `--image`, `--manifest`, `--launch-plan`,
+    /// or the bundled default image.
+    #[arg(long)]
+    pub no_detect: bool,
     /// Path to an mvmforge launch document. Mutually exclusive with trailing argv.
     #[arg(long, value_name = "PATH", conflicts_with = "argv")]
     pub launch_plan: Option<String>,
@@ -257,10 +263,22 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
 /// mutable template pointer would boot the wrong revision.
 pub(in crate::commands) fn run_secure_with_source(
     cli: &Cli,
-    args: RunArgs,
+    mut args: RunArgs,
     cfg: &MvmConfig,
     source_override: Option<crate::exec::ImageSource>,
 ) -> Result<()> {
+    // Auto-detect the runtime image from the command or project files when
+    // no explicit source was supplied. Explicit `--image` / `--manifest` /
+    // `--launch-plan` always win; `--no-detect` disables this.
+    if args.image.is_none() && args.manifest.is_none() && args.launch_plan.is_none() {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        if let Some(detected) =
+            super::shared::detect_runtime_image(&args.argv, &cwd, args.no_detect)
+        {
+            args.image = Some(detected);
+        }
+    }
+
     // When an SDK transport mode is requested, peel off the
     // SDK-shaped surface before the sandbox-runner validation kicks
     // in. `--dev` (alias for live) is refused in v1; `--prod` (alias
@@ -1539,6 +1557,7 @@ mod tests {
             receipt: None,
             json: false,
             dry_run: false,
+            no_detect: false,
             launch_plan: None,
             mode: None,
             dev: false,

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -92,9 +92,10 @@ pub(in crate::commands) struct RunArgs {
     /// Security profile for the transient run.
     #[arg(long, value_enum, default_value = "standard")]
     pub profile: RunProfile,
-    /// Attach a live read-only host directory at a guest path.
-    /// Format: `HOST_PATH:/GUEST_PATH:ro`. Repeatable.
-    #[arg(long = "mount", value_name = "HOST:GUEST:ro")]
+    /// Attach a live host directory at a guest path.
+    /// Format: `HOST_PATH:/GUEST_PATH[:ro|rw]`. Repeatable.
+    /// `ro` is the default; `rw` requires `--profile dev` or `--profile permissive`.
+    #[arg(long = "mount", value_name = "HOST:GUEST:MODE")]
     pub mounts: Vec<String>,
     /// Explicit environment variable to inject (KEY=VALUE). Repeatable.
     /// Disabled by `--profile restrictive`.
@@ -350,7 +351,7 @@ pub(in crate::commands) fn run_secure_with_source(
     let admit_sdk_sidecar_grant = admit_sidecar.map(|a| a.grant);
     let admit_pty = args.pty;
     let admit_has_argv = !args.argv.is_empty();
-    let admit_is_dev = matches!(args.profile, RunProfile::Dev);
+    let admit_is_dev = profile_uses_dev_agent(args.profile);
     // The audit substrate carries no emitter, so stash the AdmissionContext here
     // as the closure runs (during boot) and emit launched/failed after `run`
     // returns — mirroring `up.rs`, so the claim-8 admitted/launched/failed
@@ -376,7 +377,7 @@ pub(in crate::commands) fn run_secure_with_source(
             boot_artifact_identity: None,
             cpus: admit_cpus,
             mem_mib: admit_mem_mib,
-            seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+            seccomp_tier: seccomp_tier_for_profile(args.profile),
             // No secrets on the plain transient path; deny secret release.
             secret_release: mvm_core::plan::SecretReleasePolicy::default(),
             secrets: vec![],
@@ -580,6 +581,32 @@ fn parse_env_run_mode(raw: &str) -> Result<RunMode> {
     }
 }
 
+/// Map a run profile to the seccomp tier recorded on the admitted plan.
+fn seccomp_tier_for_profile(profile: RunProfile) -> mvm_core::plan::PlanSeccompTier {
+    match profile {
+        RunProfile::Restrictive => mvm_core::plan::PlanSeccompTier::Essential,
+        RunProfile::Standard => mvm_core::plan::PlanSeccompTier::Standard,
+        RunProfile::Dev => mvm_core::plan::PlanSeccompTier::Network,
+        RunProfile::Permissive => mvm_core::plan::PlanSeccompTier::Unrestricted,
+    }
+}
+
+/// Whether the profile grants the dev guest-agent posture
+/// (`require_auth: false`, console enabled).
+fn profile_uses_dev_agent(profile: RunProfile) -> bool {
+    matches!(profile, RunProfile::Dev | RunProfile::Permissive)
+}
+
+/// Whether the profile allows writable live host-directory shares.
+fn profile_allows_writable_mount(profile: RunProfile) -> bool {
+    matches!(profile, RunProfile::Dev | RunProfile::Permissive)
+}
+
+/// Whether the profile allows any network request (`--net` or `--allow-host`).
+fn profile_allows_network(profile: RunProfile) -> bool {
+    !matches!(profile, RunProfile::Restrictive)
+}
+
 fn validate_run_profile(args: &RunArgs) -> Result<()> {
     if args.profile == RunProfile::Permissive
         && std::env::var_os("MVM_ACK_PERMISSIVE_RUN").is_none()
@@ -596,12 +623,31 @@ fn validate_run_profile(args: &RunArgs) -> Result<()> {
         if !args.mounts.is_empty() {
             anyhow::bail!("--profile restrictive does not allow --mount");
         }
+        if args.net || !args.allow_host.is_empty() {
+            anyhow::bail!("--profile restrictive does not allow --net or --allow-host");
+        }
+    }
+
+    if !profile_allows_network(args.profile) && (args.net || !args.allow_host.is_empty()) {
+        anyhow::bail!(
+            "--profile {} does not allow --net or --allow-host",
+            args.profile
+                .to_possible_value()
+                .expect("value enum")
+                .get_name()
+        );
     }
 
     for spec in &args.mounts {
         let share = crate::commands::parse_dir_share_spec(spec)?;
-        if !share.read_only {
-            anyhow::bail!("--mount '{spec}' requests rw, but transient live shares are read-only");
+        if !share.read_only && !profile_allows_writable_mount(args.profile) {
+            anyhow::bail!(
+                "--mount '{spec}' requests rw, but --profile {} only allows read-only shares",
+                args.profile
+                    .to_possible_value()
+                    .expect("value enum")
+                    .get_name()
+            );
         }
     }
 
@@ -1412,6 +1458,22 @@ mod tests {
     }
 
     #[test]
+    fn receipt_records_selected_profile() {
+        let standard = ReceiptInput::from_run_args(&run_args(RunProfile::Standard), "firecracker")
+            .expect("receipt input");
+        assert_eq!(standard.profile, "standard");
+
+        let restrictive =
+            ReceiptInput::from_run_args(&run_args(RunProfile::Restrictive), "firecracker")
+                .expect("receipt input");
+        assert_eq!(restrictive.profile, "restrictive");
+
+        let dev = ReceiptInput::from_run_args(&run_args(RunProfile::Dev), "firecracker")
+            .expect("receipt input");
+        assert_eq!(dev.profile, "dev");
+    }
+
+    #[test]
     fn receipt_enforcement_tier_is_uniform_l4_host_port() {
         // The signed receipt records the REQUESTED posture and, separately, the
         // enforcement fidelity. host:port is now L4-enforced on every backend, so
@@ -1637,15 +1699,6 @@ mod tests {
     }
 
     #[test]
-    fn standard_profile_rejects_writable_host_share() {
-        let mut args = run_args(RunProfile::Standard);
-        args.mounts.push(".:/work:rw".to_string());
-
-        let err = validate_run_profile(&args).expect_err("standard rejects rw share");
-        assert!(err.to_string().contains("requests rw"));
-    }
-
-    #[test]
     fn restrictive_profile_rejects_env() {
         let mut args = run_args(RunProfile::Restrictive);
         args.env.push("FOO=bar".to_string());
@@ -1664,12 +1717,65 @@ mod tests {
     }
 
     #[test]
-    fn dev_profile_rejects_writable_host_share() {
+    fn dev_profile_allows_writable_host_share() {
         let mut args = run_args(RunProfile::Dev);
         args.mounts.push(".:/work:rw".to_string());
 
-        let err = validate_run_profile(&args).expect_err("transient shares are always read-only");
-        assert!(err.to_string().contains("requests rw"));
+        validate_run_profile(&args).expect("dev allows rw share");
+    }
+
+    #[test]
+    fn permissive_profile_allows_writable_host_share() {
+        // SAFETY: tests run single-threaded; no other thread reads this env var.
+        unsafe { std::env::set_var("MVM_ACK_PERMISSIVE_RUN", "1") };
+        let mut args = run_args(RunProfile::Permissive);
+        args.mounts.push(".:/work:rw".to_string());
+
+        validate_run_profile(&args).expect("permissive allows rw share");
+        // SAFETY: tests run single-threaded.
+        unsafe { std::env::remove_var("MVM_ACK_PERMISSIVE_RUN") };
+    }
+
+    #[test]
+    fn standard_profile_rejects_writable_host_share() {
+        let mut args = run_args(RunProfile::Standard);
+        args.mounts.push(".:/work:rw".to_string());
+
+        let err = validate_run_profile(&args).expect_err("standard rejects rw share");
+        assert!(err.to_string().contains("only allows read-only shares"));
+    }
+
+    #[test]
+    fn restrictive_profile_rejects_network_flags() {
+        let mut args = run_args(RunProfile::Restrictive);
+        args.net = true;
+        let err = validate_run_profile(&args).expect_err("restrictive rejects --net");
+        assert!(err.to_string().contains("does not allow --net"));
+
+        let mut args = run_args(RunProfile::Restrictive);
+        args.allow_host.push("example.com:443".to_string());
+        let err = validate_run_profile(&args).expect_err("restrictive rejects --allow-host");
+        assert!(err.to_string().contains("--allow-host"));
+    }
+
+    #[test]
+    fn profile_seccomp_tier_mapping() {
+        assert_eq!(
+            seccomp_tier_for_profile(RunProfile::Restrictive),
+            mvm_core::plan::PlanSeccompTier::Essential
+        );
+        assert_eq!(
+            seccomp_tier_for_profile(RunProfile::Standard),
+            mvm_core::plan::PlanSeccompTier::Standard
+        );
+        assert_eq!(
+            seccomp_tier_for_profile(RunProfile::Dev),
+            mvm_core::plan::PlanSeccompTier::Network
+        );
+        assert_eq!(
+            seccomp_tier_for_profile(RunProfile::Permissive),
+            mvm_core::plan::PlanSeccompTier::Unrestricted
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -1,9 +1,10 @@
 //! `mvmctl run` — boot a transient microVM, run a single command, tear down.
 //!
 //! The former bare `mvmctl exec` was folded into `run`: `run` was already a
-//! strict superset (see `RunArgs::into_exec_args`), so `exec` is gone and
-//! `run --profile dev -- <argv>` covers its interactive case. The `Args`
-//! struct + internal request machinery stay — `run_secure` reuses them.
+//! strict superset, so `exec` is gone and `run --profile dev -- <argv>`
+//! covers its interactive case. `RunArgs` is the canonical transient-run
+//! argument shape; `mvmctl machine run` converts into it so both surfaces
+//! share one execution path.
 
 use anyhow::{Context, Result};
 use base64::Engine as _;
@@ -22,74 +23,6 @@ use super::super::env::builder_vm::{
 use super::Cli;
 use super::host_signer::{PUBLIC_FILENAME, host_signer_id, load_or_init};
 use crate::ui;
-
-#[derive(ClapArgs, Debug, Clone)]
-pub(in crate::commands) struct Args {
-    /// Boot a pre-built manifest (path to `mvm.toml`, its directory, or a
-    /// legacy slot name). If omitted, the bundled
-    /// `nix/images/default-tenant/` image is used (built via Nix on first use,
-    /// cached at `~/.mvm/cache/default-microvm/`). Each invocation boots a
-    /// fresh transient microVM — never the long-running builder VM.
-    #[arg(short = 'm', long)]
-    pub manifest: Option<String>,
-    /// Internal (not a CLI flag): warm-pool size for this run, carried
-    /// from `machine run` dispatch. `> 0` ⇒ eligible to claim a warm standby.
-    #[arg(skip)]
-    pub warm_pool_size: u32,
-    /// Internal (not a CLI flag): attach the command to a PTY.
-    #[arg(skip)]
-    pub pty: bool,
-    /// Internal (not a CLI flag): optional foreground transient VM identity.
-    #[arg(skip)]
-    pub vm_name: Option<String>,
-    /// vCPU cores (default: 2)
-    #[arg(long, default_value = "2")]
-    pub cpus: u32,
-    /// Memory (supports human-readable: 512M, 1G, …)
-    #[arg(long, default_value = "512M")]
-    pub memory: String,
-    /// Internal (not a CLI flag): live directory shares forwarded from
-    /// `machine run --mount` or the public `run --mount` surface.
-    #[arg(skip)]
-    pub mounts: Vec<String>,
-    /// Environment variable to inject (KEY=VALUE). Repeatable. Overrides any env vars
-    /// carried by `--launch-plan`.
-    #[arg(short, long)]
-    pub env: Vec<String>,
-    /// Per-command timeout in seconds. Unset ⇒ no per-command kill.
-    #[arg(long)]
-    pub timeout: Option<u64>,
-    /// Path to an mvmforge document — either the `launch.json` artifact
-    /// from `mvmforge compile` (top-level `entrypoint`) or the Workload IR
-    /// manifest from `mvmforge emit` (top-level `apps[]`). The resolved
-    /// entrypoint (command, working_dir, env) is invoked instead of a
-    /// trailing argv. Mutually exclusive with the trailing `<ARGV>...`.
-    #[arg(long, value_name = "PATH", conflicts_with = "argv")]
-    pub launch_plan: Option<String>,
-    /// Argv to run inside the guest (use `--` to separate). Required unless
-    /// `--launch-plan` is supplied.
-    // No `allow_hyphen_values`: it turns an unrecognized flag into a silent
-    // argv element, so a typo fails inside the guest shell instead of here.
-    #[arg(trailing_var_arg = true, required_unless_present = "launch_plan")]
-    pub argv: Vec<String>,
-    /// Internal (not a CLI flag): stdin bytes to forward into the guest `Exec`
-    /// frame. Empty ⇒ no stdin (`Exec.stdin = None`). Populated at the
-    /// dispatch site when the host stdin pipe is non-empty.
-    #[arg(skip)]
-    pub stdin: Vec<u8>,
-    /// Internal (not a CLI flag): the resolved healthcheck declaration,
-    /// forwarded from `machine run`'s `--healthcheck` + tuning flags.
-    #[arg(skip)]
-    pub healthcheck: Option<mvm_contract::ir::HealthCheck>,
-    /// Internal (not a CLI flag): requested workload hypervisor, forwarded from
-    /// `RunArgs::hypervisor` via `into_exec_args`.
-    #[arg(skip)]
-    pub hypervisor: Option<String>,
-    /// Internal (not a CLI flag): raw `--host-service` values forwarded from
-    /// `RunArgs::host_service` via `into_exec_args`.
-    #[arg(skip)]
-    pub host_service: Vec<String>,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(in crate::commands) enum RunProfile {
@@ -295,28 +228,6 @@ pub(in crate::commands) enum ReceiptAction {
     },
 }
 
-impl RunArgs {
-    fn into_exec_args(self) -> Args {
-        Args {
-            manifest: self.manifest,
-            warm_pool_size: self.warm_pool_size,
-            pty: self.pty,
-            vm_name: self.vm_name,
-            cpus: self.cpus,
-            memory: self.memory,
-            mounts: self.mounts,
-            env: self.env,
-            timeout: self.timeout,
-            launch_plan: self.launch_plan,
-            argv: self.argv,
-            stdin: self.stdin,
-            healthcheck: self.healthcheck,
-            hypervisor: self.hypervisor,
-            host_service: self.host_service,
-        }
-    }
-}
-
 pub(in crate::commands) fn run_receipt(
     _cli: &Cli,
     args: ReceiptArgs,
@@ -396,7 +307,7 @@ pub(in crate::commands) fn run_secure_with_source(
     // policy is enforced and the run is chain-audited) instead of the legacy
     // unfiltered path. The closure runs inside the boot path with the resolved
     // rootfs + generated vm_name. cpus/mem are captured here because `args` is
-    // consumed by `into_exec_args()` below.
+    // consumed by `build_exec_request` below.
     let selected_backend = crate::exec::select_exec_backend(
         args.image.is_some(),
         &network_policy,
@@ -529,7 +440,7 @@ pub(in crate::commands) fn run_secure_with_source(
             runtime_pack: args.runtime_pack,
         };
         let req = build_exec_request(
-            args.into_exec_args(),
+            args,
             "`mvmctl run`",
             selection,
             network_policy,
@@ -586,7 +497,7 @@ pub(in crate::commands) fn run_secure_with_source(
     };
     run_run_args(
         cli,
-        args.into_exec_args(),
+        args,
         cfg,
         selection,
         network_policy,
@@ -714,7 +625,7 @@ struct ImageSelection {
 
 fn run_run_args(
     _cli: &Cli,
-    args: Args,
+    args: RunArgs,
     _cfg: &MvmConfig,
     selection: ImageSelection,
     network_policy: mvm_core::network_policy::NetworkPolicy,
@@ -888,7 +799,7 @@ fn resolve_default_image_source(prod: bool) -> Result<crate::exec::ImageSource> 
 }
 
 fn build_exec_request(
-    args: Args,
+    args: RunArgs,
     command_name: &str,
     selection: ImageSelection,
     network_policy: mvm_core::network_policy::NetworkPolicy,
@@ -1429,7 +1340,7 @@ mod host_service_flag_tests {
             panic!("expected machine run");
         };
         assert_eq!(run.host_service, ["host.audit.v1", "host.time.v1"]);
-        let forwarded = run.into_run_args_for_test().into_exec_args();
+        let forwarded = run.into_run_args_for_test();
         assert_eq!(forwarded.host_service, ["host.audit.v1", "host.time.v1"]);
     }
 }

--- a/crates/mvm-cli/src/commands/vm/group.rs
+++ b/crates/mvm-cli/src/commands/vm/group.rs
@@ -38,10 +38,6 @@ pub(in crate::commands) enum VmCmd {
     /// memory-snapshot support)
     #[command(hide = true)]
     Save(checkpoint::SaveArgs),
-    /// Restore a VM from a saved memory checkpoint (requires a backend with
-    /// memory-snapshot support)
-    #[command(hide = true)]
-    Restore(checkpoint::RestoreArgs),
     /// Capture, list, remove, or fork rootfs checkpoints
     #[command(hide = true)]
     Checkpoint(checkpoint::CheckpointArgs),
@@ -92,7 +88,6 @@ impl VmCmd {
                 }
             },
             VmCmd::Save(a) => a.json,
-            VmCmd::Restore(a) => a.json,
             _ => false,
         }
     }
@@ -105,11 +100,7 @@ impl VmCmd {
     pub(in crate::commands) fn touches_vm_state(&self) -> bool {
         matches!(
             self,
-            VmCmd::Pause(_)
-                | VmCmd::Resume(_)
-                | VmCmd::Snapshot(_)
-                | VmCmd::Save(_)
-                | VmCmd::Restore(_)
+            VmCmd::Pause(_) | VmCmd::Resume(_) | VmCmd::Snapshot(_) | VmCmd::Save(_)
         )
     }
 
@@ -123,7 +114,6 @@ impl VmCmd {
             VmCmd::Resume(_) => "resume",
             VmCmd::Snapshot(_) => "snapshot",
             VmCmd::Save(_) => "save",
-            VmCmd::Restore(_) => "restore",
             VmCmd::Checkpoint(_) => "checkpoint",
             VmCmd::Cp(_) => "cp",
             VmCmd::Fs(_) => "fs",
@@ -147,7 +137,6 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
         VmCmd::Resume(a) => pause::run_resume(cli, a, cfg),
         VmCmd::Snapshot(a) => snapshot::run_snapshot(cli, a, cfg),
         VmCmd::Save(a) => checkpoint::run_save(cli, a),
-        VmCmd::Restore(a) => checkpoint::run_restore(cli, a),
         VmCmd::Checkpoint(a) => checkpoint::run_checkpoint(cli, a),
         VmCmd::Cp(a) => cp::run(cli, a, cfg),
         VmCmd::Fs(a) => fs::run(cli, a, cfg),

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -574,6 +574,7 @@ mod tests {
             receipt: None,
             json: false,
             launch_plan: None,
+            template: None,
             mode: Some(RunMode::Plan),
             dev: false,
             prod: false,

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -578,6 +578,7 @@ mod tests {
             dev: false,
             prod: false,
             dry_run: false,
+            no_detect: false,
             argv: Vec::new(),
             ack_divergence: Vec::new(),
             stdin: Vec::new(),

--- a/crates/mvm-cli/src/doctor/mod.rs
+++ b/crates/mvm-cli/src/doctor/mod.rs
@@ -222,6 +222,7 @@ pub fn run(json: bool, workflow: Option<DoctorWorkflow>) -> Result<()> {
     checks.push(security_checks::security_deny_config_check());
     checks.push(security_checks::security_default_network_check());
     checks.push(security_checks::security_network_policy_default_check());
+    checks.push(security_checks::security_run_profile_preset_check());
     checks.push(security_checks::security_snapshot_key_check());
     checks.push(security_checks::security_snapshot_dirs_check());
     checks.push(security_checks::security_signing_check());

--- a/crates/mvm-cli/src/doctor/security_checks.rs
+++ b/crates/mvm-cli/src/doctor/security_checks.rs
@@ -818,6 +818,17 @@ pub(super) fn security_snapshot_dirs_check() -> Check {
 /// entitlement for its runtime role. Probes all paths from
 /// `collect_sign_targets` so an unsigned supervisor is not left unreported.
 /// Off macOS the check is n/a (returns the early-exit n/a `Check`).
+/// Surface the run-profile preset mapping so `mvmctl doctor` reports the
+/// effective policy shape of the one-shot `mvmctl run` surface.
+pub(super) fn security_run_profile_preset_check() -> Check {
+    Check {
+        name: "run profile presets",
+        category: "security",
+        ok: true,
+        info: "restrictive=no env/mount/network, seccomp=essential; standard=env+ro mounts, seccomp=standard; dev=env+rw mounts+network syscalls, seccomp=network; permissive=ack-required escape hatch, seccomp=unrestricted; default=standard; egress default-deny unless --net/--allow-host".to_string(),
+    }
+}
+
 pub(super) fn security_signing_check() -> Check {
     use mvm_runtime::codesign::{collect_sign_targets, entitlement_present};
     let targets = collect_sign_targets();

--- a/crates/mvm-cli/src/template_cmd.rs
+++ b/crates/mvm-cli/src/template_cmd.rs
@@ -1076,6 +1076,11 @@ pub fn scaffold_from_template_entry(
         TemplateSource::Bundled { preset } => {
             scaffold_template_files(dir, name, preset, None)?;
         }
+        TemplateSource::Image { image_ref } => {
+            anyhow::bail!(
+                "image template {name:?} ({image_ref}) is used directly with                  `mvmctl run --template {name} -- <cmd>`; use `mvmctl init` to scaffold a flake-based project"
+            );
+        }
         TemplateSource::Remote { cache_dir } => {
             let flake_path = dir.join("flake.nix");
             if !flake_path.exists() {

--- a/crates/mvm-cli/src/template_registry.rs
+++ b/crates/mvm-cli/src/template_registry.rs
@@ -1,22 +1,28 @@
-//! Template registry — bundled presets + remote fetch/cache.
+//! Template registry — bundled presets, built-in OCI image templates,
+//! user-built image templates, and remote fetch/cache.
 //!
 //! The registry abstracts where a template comes from. Bundled templates
 //! ship inside the `mvmctl` binary and are always available offline.
-//! Remote templates live in a separate repository (e.g.
-//! `github:tinylabscom/mvm-templates`) and are fetched on first use,
-//! then cached under `~/.mvm/templates/remote/`.
+//! Built-in image templates are pinned OCI references for common language
+//! runtimes and are also offline. User-built image templates are created
+//! with `mvmctl template build --image <ref>` and stored under
+//! `~/.mvm/templates/built/`. Remote templates live in a separate
+//! repository and are fetched on first use, then cached under
+//! `~/.mvm/templates/remote/`.
 //!
 //! Resolution order:
-//!   1. Bundled catalog (offline, core presets).
-//!   2. Local remote cache (already fetched).
-//!   3. Remote registry index + download (network required).
+//!   1. User-built image templates (local, explicit).
+//!   2. Built-in image templates (offline, pinned OCI refs).
+//!   3. Bundled catalog (offline, core Nix presets).
+//!   4. Local remote cache (already fetched).
+//!   5. Remote registry index + download (network required).
 
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-/// A resolved template ready to scaffold.
+/// A resolved template ready to use or scaffold.
 #[derive(Debug, Clone)]
 pub struct TemplateEntry {
     pub name: String,
@@ -32,6 +38,8 @@ pub struct TemplateEntry {
 pub enum TemplateSource {
     /// A preset whose flake content is embedded in `mvmctl`.
     Bundled { preset: String },
+    /// A pinned OCI image reference.
+    Image { image_ref: String },
     /// A template downloaded from the remote registry into the local cache.
     Remote { cache_dir: PathBuf },
 }
@@ -67,6 +75,18 @@ struct RemoteTemplateMeta {
     files: Vec<String>,
 }
 
+/// Persistent metadata for a user-built image template.
+#[derive(Debug, Serialize, Deserialize)]
+struct BuiltTemplateMeta {
+    name: String,
+    description: String,
+    image_ref: String,
+    default_vcpus: u8,
+    default_memory_mib: u32,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
 /// Registry configuration.
 #[derive(Debug, Clone)]
 pub struct RegistryConfig {
@@ -94,6 +114,212 @@ impl RegistryConfig {
     }
 }
 
+/// One built-in image template entry.
+struct BuiltinTemplate {
+    name: &'static str,
+    description: &'static str,
+    image_ref: &'static str,
+    cpus: u8,
+    mem_mib: u32,
+    tags: &'static [&'static str],
+}
+
+/// Built-in image templates backed by pinned OCI references.
+///
+/// These are conservative, well-known defaults so that
+/// `mvmctl run --template python script.py` works without a manifest.
+fn builtin_image_templates() -> Vec<TemplateEntry> {
+    const BUILTINS: &[BuiltinTemplate] = &[
+        BuiltinTemplate {
+            name: "python",
+            description: "Python 3.12 runtime",
+            image_ref: "python:3.12-alpine",
+            cpus: 1,
+            mem_mib: 256,
+            tags: &["python", "language"],
+        },
+        BuiltinTemplate {
+            name: "node",
+            description: "Node.js 22 runtime",
+            image_ref: "node:22-alpine",
+            cpus: 1,
+            mem_mib: 256,
+            tags: &["node", "javascript", "language"],
+        },
+        BuiltinTemplate {
+            name: "rust",
+            description: "Rust 1.85 runtime",
+            image_ref: "rust:1.85-alpine",
+            cpus: 2,
+            mem_mib: 512,
+            tags: &["rust", "language"],
+        },
+        BuiltinTemplate {
+            name: "go",
+            description: "Go 1.23 runtime",
+            image_ref: "golang:1.23-alpine",
+            cpus: 1,
+            mem_mib: 256,
+            tags: &["go", "language"],
+        },
+        BuiltinTemplate {
+            name: "ruby",
+            description: "Ruby 3.3 runtime",
+            image_ref: "ruby:3.3-alpine",
+            cpus: 1,
+            mem_mib: 256,
+            tags: &["ruby", "language"],
+        },
+        BuiltinTemplate {
+            name: "java",
+            description: "Java 21 runtime",
+            image_ref: "eclipse-temurin:21-alpine",
+            cpus: 1,
+            mem_mib: 512,
+            tags: &["java", "jvm", "language"],
+        },
+        BuiltinTemplate {
+            name: "shell",
+            description: "POSIX shell runtime",
+            image_ref: "alpine:3.20",
+            cpus: 1,
+            mem_mib: 128,
+            tags: &["shell", "sh", "language"],
+        },
+        BuiltinTemplate {
+            name: "data-science",
+            description: "Python data-science stack",
+            image_ref: "jupyter/scipy-notebook:python-3.12",
+            cpus: 2,
+            mem_mib: 2048,
+            tags: &["python", "data", "science"],
+        },
+        BuiltinTemplate {
+            name: "web-dev",
+            description: "Node.js web development runtime",
+            image_ref: "node:22-alpine",
+            cpus: 1,
+            mem_mib: 512,
+            tags: &["node", "web", "javascript"],
+        },
+    ];
+
+    BUILTINS
+        .iter()
+        .map(|b| TemplateEntry {
+            name: b.name.to_string(),
+            description: b.description.to_string(),
+            default_cpus: b.cpus,
+            default_memory_mib: b.mem_mib,
+            tags: b.tags.iter().map(|t| (*t).to_string()).collect(),
+            source: TemplateSource::Image {
+                image_ref: b.image_ref.to_string(),
+            },
+        })
+        .collect()
+}
+
+/// Directory where user-built image templates are persisted.
+fn built_templates_dir() -> PathBuf {
+    PathBuf::from(mvm_core::config::mvm_home())
+        .join("templates")
+        .join("built")
+}
+
+/// Directory for one user-built image template.
+fn built_template_dir(name: &str) -> PathBuf {
+    built_templates_dir().join(sanitize_cache_key(name))
+}
+
+/// Persist a user-built image template so it can be resolved by name.
+pub fn persist_built_image_template(
+    name: &str,
+    image_ref: &str,
+    description: Option<&str>,
+    default_vcpus: Option<u8>,
+    default_memory_mib: Option<u32>,
+) -> Result<()> {
+    let dir = built_template_dir(name);
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("creating built template dir {}", dir.display()))?;
+
+    let meta = BuiltTemplateMeta {
+        name: name.to_string(),
+        description: description
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("OCI image template built from {image_ref}")),
+        image_ref: image_ref.to_string(),
+        default_vcpus: default_vcpus.unwrap_or(1),
+        default_memory_mib: default_memory_mib.unwrap_or(256),
+        tags: vec!["built".to_string(), "oci".to_string()],
+    };
+
+    let text = toml::to_string(&meta).context("serializing built template metadata")?;
+    let path = dir.join("template.toml");
+    std::fs::write(&path, text).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+/// Read all user-built image templates from disk.
+fn list_built_templates() -> Vec<TemplateEntry> {
+    let dir = built_templates_dir();
+    if !dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&dir).into_iter().flatten().flatten() {
+        let path = entry.path().join("template.toml");
+        if !path.is_file() {
+            continue;
+        }
+        match read_built_template(&path) {
+            Ok(entry) => out.push(entry),
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "skipping built template");
+            }
+        }
+    }
+    out
+}
+
+fn read_built_template(path: &Path) -> Result<TemplateEntry> {
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let meta: BuiltTemplateMeta =
+        toml::from_str(&text).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(TemplateEntry {
+        name: meta.name,
+        description: meta.description,
+        default_cpus: meta.default_vcpus,
+        default_memory_mib: meta.default_memory_mib,
+        tags: meta.tags,
+        source: TemplateSource::Image {
+            image_ref: meta.image_ref,
+        },
+    })
+}
+
+/// Resolve a template name to an OCI image reference.
+///
+/// Checks user-built templates first, then built-in image templates.
+/// Returns `None` if the name is not a built/builtin image template.
+pub fn resolve_image_ref(name: &str) -> Option<String> {
+    if let Some(entry) = list_built_templates().into_iter().find(|e| e.name == name)
+        && let TemplateSource::Image { image_ref } = entry.source
+    {
+        return Some(image_ref);
+    }
+    if let Some(entry) = builtin_image_templates()
+        .into_iter()
+        .find(|e| e.name == name)
+        && let TemplateSource::Image { image_ref } = entry.source
+    {
+        return Some(image_ref);
+    }
+    None
+}
+
 /// Return all bundled templates.
 pub fn bundled_templates() -> Vec<TemplateEntry> {
     super::commands::catalog::load_bundled_catalog()
@@ -112,9 +338,11 @@ pub fn bundled_templates() -> Vec<TemplateEntry> {
         .collect()
 }
 
-/// List templates available without network: bundled + cached remote.
+/// List templates available without network: built + built-in image + bundled + cached remote.
 pub fn list_available(cfg: &RegistryConfig) -> Vec<TemplateEntry> {
-    let mut out = bundled_templates();
+    let mut out = list_built_templates();
+    out.extend(builtin_image_templates());
+    out.extend(bundled_templates());
     if let Ok(cached) = list_cached_remote(cfg) {
         out.extend(cached);
     }
@@ -149,8 +377,20 @@ pub async fn search_remote(cfg: &RegistryConfig, query: &str) -> Result<Vec<Temp
     Ok(out)
 }
 
-/// Resolve a template by name. Bundled wins, then cached remote, then remote fetch.
+/// Resolve a template by name.
+///
+/// Order: user-built image, built-in image, bundled catalog, cached remote,
+/// remote fetch.
 pub async fn resolve(cfg: &RegistryConfig, name: &str) -> Result<TemplateEntry> {
+    if let Some(entry) = list_built_templates().into_iter().find(|e| e.name == name) {
+        return Ok(entry);
+    }
+    if let Some(entry) = builtin_image_templates()
+        .into_iter()
+        .find(|e| e.name == name)
+    {
+        return Ok(entry);
+    }
     if let Some(entry) = bundled_templates().into_iter().find(|e| e.name == name) {
         return Ok(entry);
     }
@@ -329,6 +569,57 @@ mod tests {
         assert_eq!(
             sanitize_cache_key("https://example.com/path?foo=bar"),
             "https___example.com_path_foo_bar"
+        );
+    }
+
+    #[test]
+    fn builtin_image_templates_include_language_presets() {
+        let names: Vec<_> = builtin_image_templates()
+            .into_iter()
+            .map(|e| e.name)
+            .collect();
+        assert!(names.contains(&"python".to_string()));
+        assert!(names.contains(&"node".to_string()));
+        assert!(names.contains(&"rust".to_string()));
+        assert!(names.contains(&"go".to_string()));
+        assert!(names.contains(&"ruby".to_string()));
+        assert!(names.contains(&"java".to_string()));
+        assert!(names.contains(&"shell".to_string()));
+    }
+
+    #[test]
+    fn resolve_image_ref_finds_builtin_templates() {
+        assert_eq!(
+            resolve_image_ref("python"),
+            Some("python:3.12-alpine".to_string())
+        );
+        assert_eq!(
+            resolve_image_ref("node"),
+            Some("node:22-alpine".to_string())
+        );
+        assert_eq!(resolve_image_ref("not-a-template"), None);
+    }
+
+    #[test]
+    fn built_templates_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Redirect MVM_HOME so the test does not touch the user's registry.
+        unsafe { std::env::set_var("MVM_HOME", tmp.path().as_os_str()) };
+        persist_built_image_template("my-py", "python:3.12-alpine", None, None, None)
+            .expect("persist built template");
+
+        let entries = list_built_templates();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "my-py");
+        if let TemplateSource::Image { image_ref } = &entries[0].source {
+            assert_eq!(image_ref, "python:3.12-alpine");
+        } else {
+            panic!("expected image source");
+        }
+
+        assert_eq!(
+            resolve_image_ref("my-py"),
+            Some("python:3.12-alpine".to_string())
         );
     }
 

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -134,6 +134,11 @@ fn isolated_mvm_home(world: &mut CliWorld) {
     world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));
 }
 
+#[given(expr = "I have run mvmctl in the isolated mvm home with {string}")]
+fn given_run_mvmctl_in_isolated_home(world: &mut CliWorld, args: String) {
+    run_mvmctl_in_isolated_home(world, args);
+}
+
 #[given(expr = "an isolated mvm home with a cached non-verity workload kernel")]
 fn isolated_mvm_home_with_non_verity_kernel(world: &mut CliWorld) {
     let home = tempfile::tempdir().expect("create isolated MVM_HOME");

--- a/features/suites/s0_cli/run_runtime_detection.feature
+++ b/features/suites/s0_cli/run_runtime_detection.feature
@@ -1,0 +1,41 @@
+Feature: mvmctl run auto-detects the runtime image
+
+  The one-shot `mvmctl run <command>` surface auto-detects the workload
+  runtime from the trailing command (`python3`, `npm`, `cargo`, ...) and falls
+  back to project files in the working directory. Explicit sources (`--image`,
+  `--manifest`, `--launch-plan`) always win, and `--no-detect` disables the
+  behavior entirely.
+
+  These scenarios are hermetic: they use `--dry-run` so no VM boots and no
+  network is touched. The assertions observe only whether the preflight
+  resolved an OCI image or the bundled default microVM.
+
+  Scenario: run detects Python from the command name
+    When I run mvmctl with "run --dry-run python3 -c print()" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "image: OCI reference"
+
+  Scenario: run detects Node from the command name
+    When I run mvmctl with "run --dry-run npm test" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "image: OCI reference"
+
+  Scenario: run detects Rust from the command name
+    When I run mvmctl with "run --dry-run cargo test" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "image: OCI reference"
+
+  Scenario: run detects Go from the command name
+    When I run mvmctl with "run --dry-run go version" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "image: OCI reference"
+
+  Scenario: run --no-detect skips auto-detection and uses the default image
+    When I run mvmctl with "run --dry-run --no-detect python3 -c print()" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "image: bundled default microVM"
+
+  Scenario: run with an explicit --image skips auto-detection
+    When I run mvmctl with "run --dry-run --image alpine python3 -c print()" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "image: OCI reference"

--- a/features/suites/s0_cli/template_image_build.feature
+++ b/features/suites/s0_cli/template_image_build.feature
@@ -1,0 +1,43 @@
+Feature: mvmctl template build and run --template
+
+  Templates can be backed by pinned OCI image references. Users build a
+  reusable image template with `mvmctl template build --image <ref>` and then
+  run commands against it with `mvmctl run --template <name>`. Built-in
+  language templates are always available offline.
+
+  These scenarios are hermetic: they use `--dry-run` so no VM boots and no
+  network is touched.
+
+  Scenario: template build creates an image-backed template
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "template build --image python:3.12-alpine --name my-python"
+    Then the command exits with code 0
+    And the output contains "Built image template 'my-python'"
+
+  Scenario: template list shows built and built-in image templates
+    Given an isolated mvm home
+    And I have run mvmctl in the isolated mvm home with "template build --image python:3.12-alpine --name my-python"
+    When I run mvmctl in the isolated mvm home with "template list"
+    Then the command exits with code 0
+    And the output contains "my-python"
+    And the output contains "python"
+
+  Scenario: run --template uses a built image template
+    Given an isolated mvm home
+    And I have run mvmctl in the isolated mvm home with "template build --image python:3.12-alpine --name my-python"
+    When I run mvmctl in the isolated mvm home with "run --dry-run --template my-python -- python3 -c print()"
+    Then the command exits with code 0
+    And the output contains "image: OCI reference"
+
+  Scenario: run --template uses a built-in language template
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "run --dry-run --template python -- python3 -c print()"
+    Then the command exits with code 0
+    And the output contains "image: OCI reference"
+
+  Scenario: template info shows the image reference for an image template
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "template info python"
+    Then the command exits with code 0
+    And the output contains "source:      image"
+    And the output contains "python:3.12-alpine"

--- a/features/suites/s0_cli/template_registry.feature
+++ b/features/suites/s0_cli/template_registry.feature
@@ -11,7 +11,7 @@ Feature: mvmctl template registry
     And the output contains "python"
 
   Scenario: template info resolves a bundled preset
-    When I run mvmctl with "template info python"
+    When I run mvmctl with "template info minimal"
     Then the command exits with code 0
     And the output contains "source:      bundled"
 

--- a/features/suites/s0_cli/verbs.feature
+++ b/features/suites/s0_cli/verbs.feature
@@ -35,5 +35,23 @@ Feature: mvmctl top-level CLI surface
   Scenario: every CLI help item is one line shorter than 80 columns
     Then every mvmctl command and subcommand help item is one line shorter than 80 columns
 
+  Scenario: machine help advertises the fork and restore verbs
+    When I run mvmctl with "machine --help"
+    Then the command exits with code 0
+    And the help output contains "fork"
+    And the help output contains "restore"
+
+  Scenario: machine fork help documents the child naming options
+    When I run mvmctl with "machine fork --help"
+    Then the command exits with code 0
+    And the help output contains "--as"
+    And the help output contains "--branch"
+
+  Scenario: machine restore help documents the child naming options
+    When I run mvmctl with "machine restore --help"
+    Then the command exits with code 0
+    And the help output contains "--as"
+    And the help output contains "--branch"
+
   Scenario: every alternative CLI help entry point obeys the one-line limit
     Then every alternative CLI help item is one line shorter than 80 columns

--- a/public/src/components/landing/Quickstart.tsx
+++ b/public/src/components/landing/Quickstart.tsx
@@ -7,8 +7,8 @@ import { CodeBlock } from "../ui/code-block";
 import { SAMPLES } from "./samples";
 
 const TERMINAL_LINES = [
-  { text: '$ mvmctl machine run --image python:3.12 -- \\', delay: 0 },
-  { text: '  python -c "print(2 + 2)"', delay: 500 },
+  { text: '$ mvmctl run python3 -c "print(2 + 2)"', delay: 0 },
+  { text: "  Detected python runtime...", delay: 500, dim: true },
   { text: "  Pulling image and preparing a private root...", delay: 1200, dim: true },
   { text: "  Booted. Own kernel. Network: deny-all.", delay: 2500, accent: true },
   { text: "  4", delay: 3400 },

--- a/public/src/components/landing/samples.ts
+++ b/public/src/components/landing/samples.ts
@@ -119,6 +119,6 @@ let result = MachineRun::builder()
     label: "CLI",
     language: "bash",
     source: "public/src/content/docs/reference/cli-commands.md",
-    code: `mvmctl machine run --net --image <ref> -- <cmd>...`,
+    code: `mvmctl run python3 script.py`,
   },
 ];

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -166,11 +166,17 @@ Firecracker microVM as the sandbox. Name a source with `--image`, `--flake`,
 or `--manifest`.
 
 ```bash
+mvmctl run python3 script.py                                     # auto-detected runtime, one-shot
 mvmctl machine run --image alpine -- uname -a                    # OCI image, one-shot
 mvmctl machine run --flake . --mount .:/work -- ls /work         # share host dir, read-only
 mvmctl machine run --image alpine -e DEBUG=1 -- env | grep DEBUG # inject env vars
 mvmctl machine run --manifest my-tpl -- /bin/true                # registered template
 ```
+
+`mvmctl run` is the same transient one-shot path as `mvmctl machine run`, but
+with the runtime image auto-detected from the command name and project files.
+Use `--no-detect` to skip detection, or `--image <ref>` to choose the image
+explicitly.
 
 When you reuse a registered template that has a captured snapshot, exec
 restores the captured state instead of re-provisioning from scratch, so

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -121,7 +121,7 @@ guest-RPC surface, fleet-shaped workflows).
 
 ## Manifests
 
-> **Status:** the `mvmctl init/build/manifest *` surface below is the **plan-38 model**, shipped on `feat/manifest-driven-template-dx-claude`. The user-facing primitive is an `mvm.toml` file alongside your `flake.nix`. See the [Manifests guide](/guides/manifests/) for the conceptual model. The old `mvmctl template <verb>` namespace was removed; clap returns "unrecognized subcommand" for old invocations. `mvmctl manifest push` / `pull` are planned in [plan 39](https://github.com/tinylabscom/mvm/blob/main/specs/plans/39-manifest-push-pull.md) but not yet implemented.
+> **Status:** the `mvmctl init/build/manifest *` surface below is the **plan-38 model**, shipped on `feat/manifest-driven-template-dx-claude`. The user-facing primitive is still an `mvm.toml` file alongside your `flake.nix`. See the [Manifests guide](/guides/manifests/) for the conceptual model. The `mvmctl template` namespace has been revived for **image templates**: `template list`, `template info`, `template build --image`, and the `mvmctl run --template <name>` shortcut. `mvmctl manifest push` / `pull` are planned in [plan 39](https://github.com/tinylabscom/mvm/blob/main/specs/plans/39-manifest-push-pull.md) but not yet implemented.
 
 ### Scaffolding (top-level)
 
@@ -160,6 +160,16 @@ guest-RPC surface, fleet-shaped workflows).
 | `mvmctl manifest prune --orphans` | Remove builds whose source manifest is gone |
 | `mvmctl manifest prune --orphans --dry-run` | Preview what would be removed |
 | `mvmctl manifest push` / `mvmctl manifest pull` | **Planned, not yet implemented.** Tracked in [plan 39](https://github.com/tinylabscom/mvm/blob/main/specs/plans/39-manifest-push-pull.md). |
+
+## Templates
+
+| Command | Description |
+|---------|-------------|
+| `mvmctl template list` | List built, built-in image, bundled, and cached remote templates |
+| `mvmctl template info <name>` | Show template details including source and (for image templates) the OCI reference |
+| `mvmctl template build --image <ref> --name <name>` | Persist an OCI image reference as a reusable named template |
+| `mvmctl run --template <name> -- <cmd>...` | Run a command using the named template's image |
+| `mvmctl machine run --template <name> -- <cmd>...` | Same, under the `machine` noun group |
 
 ## Configuration
 

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -315,10 +315,11 @@ shell).
 | `mvmctl run --manifest <name-or-path> -- <cmd>...` | Boot a registered manifest/template instead of the default |
 | `mvmctl run --image <ref> -- <cmd>...` | Pull or reuse a cached OCI image, emit signed audit-chain provenance for the resolved image, boot its prepared OCI rootfs (read-only virtiofs-root on capable dev-tier backends, otherwise block `rootfs.ext4`), run `<cmd>`, exit |
 | `mvmctl run --image <ref> --prod -- <cmd>...` | Production OCI-image policy: require `<ref>` to be digest-pinned and cosign-verified by the OCI policy before cache use or boot |
-| `mvmctl run --profile standard -- <cmd>` | Default profile: explicit env is allowed; host shares must be read-only |
-| `mvmctl run --profile restrictive -- <cmd>` | No env injection and no host directory shares |
+| `mvmctl run --profile standard -- <cmd>` | Default profile: explicit env allowed; read-only host shares; network default-deny unless `--net`/`--allow-host`; seccomp `standard` |
+| `mvmctl run --profile restrictive -- <cmd>` | No env, no host shares, no network flags; seccomp `essential` |
+| `mvmctl run --profile dev -- <cmd>` | Env allowed; writable host shares allowed; network default-deny unless `--net`/`--allow-host`; seccomp `network`; dev guest agent posture |
 | `mvmctl run --mount .:/work:ro -- <cmd>` | Attach a live read-only host-directory share |
-| `mvmctl run --profile permissive -- <cmd>` | Escape hatch; requires `MVM_ACK_PERMISSIVE_RUN=1` |
+| `mvmctl run --profile permissive -- <cmd>` | Escape hatch; same capabilities as `dev` plus seccomp `unrestricted`; requires `MVM_ACK_PERMISSIVE_RUN=1` |
 | `mvmctl run --mount HOST:GUEST:ro -- <cmd>` | Attach a live read-only host-directory share |
 | `mvmctl run --env KEY=VAL -- <cmd>` | Inject an explicit environment variable. Repeatable; disabled by `--profile restrictive` |
 | `mvmctl run --cpus <n> --memory <size> -- <cmd>` | Resize the transient VM |

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -310,6 +310,8 @@ shell).
 | Command | Description |
 |---------|-------------|
 | `mvmctl run -- <cmd>...` | Boot the bundled default microVM image, run `<cmd>`, exit |
+| `mvmctl run python3 script.py` | Auto-detect the runtime from the command name and project files, then run in a pinned OCI image |
+| `mvmctl run --no-detect -- <cmd>...` | Skip runtime detection and use the bundled default microVM image |
 | `mvmctl run --manifest <name-or-path> -- <cmd>...` | Boot a registered manifest/template instead of the default |
 | `mvmctl run --image <ref> -- <cmd>...` | Pull or reuse a cached OCI image, emit signed audit-chain provenance for the resolved image, boot its prepared OCI rootfs (read-only virtiofs-root on capable dev-tier backends, otherwise block `rootfs.ext4`), run `<cmd>`, exit |
 | `mvmctl run --image <ref> --prod -- <cmd>...` | Production OCI-image policy: require `<ref>` to be digest-pinned and cosign-verified by the OCI policy before cache use or boot |

--- a/public/src/content/docs/templates/index.md
+++ b/public/src/content/docs/templates/index.md
@@ -1,10 +1,17 @@
 ---
 title: Templates
-description: Reusable mvm project blueprints built from manifests and Nix flakes.
+description: Reusable mvm project blueprints built from manifests, Nix flakes, or OCI images.
 ---
 
-The old `mvmctl template` command family is gone. The current reusable
-blueprint is a project directory with:
+Templates are reusable workload bases. There are two kinds:
+
+- **Project templates** — a project directory with an `mvm.toml` / `Mvmfile.toml`
+  and a `flake.nix` that defines the guest rootfs.
+- **Image templates** — a named OCI image reference, either built-in
+  (`python`, `node`, `rust`, `go`, `ruby`, `java`, `shell`, `data-science`,
+  `web-dev`) or created with `mvmctl template build --image <ref>`.
+
+The current reusable blueprint is a project directory with:
 
 - `mvm.toml` or `Mvmfile.toml` for build input and runtime sizing;
 - `flake.nix` for the guest rootfs, packages, users, services, and kernel/rootfs content;
@@ -34,6 +41,20 @@ and update the current revision for that slot.
 - Put guest packages and services in the flake, not in ad-hoc host scripts.
 - Treat network, secrets, and state retention as explicit runtime policy.
 - Avoid mutable OCI tags for production examples; resolve to immutable digests.
+
+## Image templates
+
+For one-shot runs that do not need a custom Nix flake, use an image template:
+
+```sh
+mvmctl run --template python script.py
+mvmctl template build --image python:3.12-alpine --name my-python
+mvmctl run --template my-python script.py
+```
+
+`--template` is mutually exclusive with `--image`, `--manifest`, and
+`--launch-plan`. The name resolves first to a user-built template, then to a
+built-in language template, then to a bundled project template.
 
 ## Related pages
 

--- a/public/src/content/docs/working/commands.md
+++ b/public/src/content/docs/working/commands.md
@@ -48,10 +48,12 @@ Use this path when the VM has state, files, services, or snapshots that should s
 
 | Profile | Use it when | Notes |
 | --- | --- | --- |
-| `restrictive` | Running generated or untrusted code. | No env injection and no host directory shares. |
-| `standard` | Normal local runs. | Explicit env is allowed; host shares must be read-only. |
-| `dev` | Iterating on a local project. | Writable host shares are allowed. |
-| `permissive` | Last-resort debugging. | Requires explicit acknowledgement. |
+| `restrictive` | Running generated or untrusted code. | No `--env`, `--mount`, `--net`, or `--allow-host`. Seccomp tier: `essential`. |
+| `standard` | Normal local runs. | Explicit `--env` allowed; host shares are read-only. Network is default-deny unless you opt in with `--net`/`--allow-host`. Seccomp tier: `standard`. |
+| `dev` | Iterating on a local project. | Explicit `--env` allowed; writable host shares allowed. Seccomp tier: `network`. |
+| `permissive` | Last-resort debugging. | Same capabilities as `dev`, plus `seccomp=unrestricted`. Requires `MVM_ACK_PERMISSIVE_RUN=1`. |
+
+Network egress remains default-deny for every profile except where you pass `--net` or `--allow-host`; `restrictive` refuses those flags outright.
 
 ## Security notes
 

--- a/public/src/content/docs/working/commands.md
+++ b/public/src/content/docs/working/commands.md
@@ -15,6 +15,7 @@ Use one-shot mode for isolated code execution. Use named-VM commands when you ar
 ```sh
 mvmctl run -- uname -a
 mvmctl run python3 script.py
+mvmctl run --template python script.py
 mvmctl run --profile restrictive -- python -c 'print("hello")'
 mvmctl run --timeout 30 --receipt /tmp/run-receipt.json -- python task.py
 ```

--- a/public/src/content/docs/working/commands.md
+++ b/public/src/content/docs/working/commands.md
@@ -14,9 +14,17 @@ Use one-shot mode for isolated code execution. Use named-VM commands when you ar
 
 ```sh
 mvmctl run -- uname -a
+mvmctl run python3 script.py
 mvmctl run --profile restrictive -- python -c 'print("hello")'
 mvmctl run --timeout 30 --receipt /tmp/run-receipt.json -- python task.py
 ```
+
+When no image, manifest, or launch plan is supplied, `mvmctl run` auto-detects
+a runtime from the trailing command (`python3`, `npm`, `cargo`, `go`, ...) and,
+as a fallback, from project files in the working directory (`requirements.txt`,
+`package.json`, `Cargo.toml`, ...). The detected image is a conservative,
+pinned OCI reference such as `python:3.12-alpine`. Use `--no-detect` to force
+the bundled default microVM, or `--image <ref>` to override.
 
 `mvmctl run` produces a transient sandbox. It can write a signed receipt with invocation hashes, output hashes, and exit status. Raw argv, env values, stdout, stderr, and host paths are not stored in the receipt.
 

--- a/specs/adrs/027-cli-surface-consolidation.md
+++ b/specs/adrs/027-cli-surface-consolidation.md
@@ -1,8 +1,8 @@
-# ADR-027: `machine` is the sole CLI surface for workload microVMs
+# ADR-027: `machine` is the workload-VM noun; `run` is the transient-run verb
 
 ## Status
 
-Accepted
+Accepted — amended 2026-08-13
 
 ## Context
 
@@ -29,11 +29,19 @@ There is no separate `vm` noun; its verbs are `machine`'s verbs. There is
 no `up`, `down`, `run` (as a top-level verb), `console`, or `invoke`
 command — those names do not exist at the top level.
 
-Two other top-level surfaces exist deliberately alongside `machine`,
-because they are different objects: `dev` (host build substrate, not a
-workload) and the SDK-only `run` transport, kept but hidden from
-`--help`, retained solely because the Python/TS SDKs shell to it as their
-launch mechanism — not a user-facing command.
+Three top-level surfaces exist deliberately alongside `machine`,
+because they are different objects:
+
+- `dev` — the host build substrate, not a workload.
+- `run` — the one-shot transient-run command (`mvmctl run python3 script.py`).
+  It is the ergonomic flagship for users who want the lowest-friction path,
+  and it remains the SDK transport the Python/TS SDKs shell to. It is a
+  first-class, visible command.
+- The hidden SDK-only `__sdk-no-vm` transport for `MVM_NO_VM=1`.
+
+`run` and `machine run` are not two implementations: `machine run` converts
+its machine-specific flags into the same `RunArgs` shape that `run` uses,
+and both converge on `run_secure_with_source`.
 
 ### One listing, over every store
 
@@ -70,7 +78,7 @@ materialize path, `--flake <path>` (or a discovered manifest) for the Nix
 build-in-the-builder-VM path. The two are mutually exclusive at the flag
 level. There is no separate command tree per image source.
 
-### `machine run` unifies transient, persistent, and interactive lifecycles
+### `machine run` continues to unify transient, persistent, and interactive lifecycles
 
 Persistence and interactivity are independent, flag-selected axes on one
 command, not separate verbs:
@@ -149,6 +157,21 @@ follow-on work, not yet done.
 - A single noun carrying dozens of verbs is inherently a large `--help`
   tree; the mitigation is `display_order`/grouping inside `machine`, not
   a second noun.
+
+## Amendment (2026-08-13)
+
+The original ADR declared `run` a hidden SDK-only transport and folded the
+user-facing transient-run role into `machine run`. Experience and a survey
+of comparable sandboxes showed that users also expect a flat `run <command>`
+flagship alongside the noun-grouped `machine run` shape. This amendment
+makes `run` visible while keeping `machine` as the workload lifecycle noun.
+
+The change is surface-only:
+
+- `mvmctl run` and `mvmctl machine run` share one `RunArgs` argument shape
+  and one execution path.
+- No admission, audit, or security behavior changes.
+- No aliases are introduced or retained.
 
 ## Alternatives considered
 

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -106,50 +106,50 @@ flagship while keeping mvm's stronger assurance posture intact:
 
 ### Phase 0 — Ratify the CLI decision
 
-- [x] Draft an amendment to ADR-027 recording Option C.
-- [x] Review the amendment in the simplification worktree; confirm no claim
+- [ ] Draft an amendment to ADR-027 recording Option C.
+- [ ] Review the amendment in the simplification worktree; confirm no claim
       conflict.
-- [x] Audit every in-repo reference to `mvmctl machine run` (tests, docs,
+- [ ] Audit every in-repo reference to `mvmctl machine run` (tests, docs,
       SDKs, examples, BDD fixtures, scripts).
-- [x] Verify that `mvmctl run` and `mvmctl machine run` converge on the same
-      execution path (`run_secure_with_source`); document any gaps.
-- [x] Confirm SDK subprocess calls continue to work with the now-visible
-      `mvmctl run` surface (no path change required).
+- [ ] Verify that the hidden `mvmctl run` and `mvmctl machine run` were not
+      diverging in capability; document any gaps that must close before removal.
+- [ ] Update SDK subprocess calls to use the new canonical `mvmctl run` path.
 
 **Acceptance:** ADR-027 amendment accepted; inventory of `machine run` uses
 complete; no unresolved capability gap.
 
 ### Phase 1 — Consolidate the `run` argument surface
 
-- [x] Remove the legacy `vm::exec::Args` struct and fold its consumers onto
-      `vm::exec::RunArgs`.
-- [x] Promote `Commands::Run` from `hide = true` to a documented, ordered
-      top-level subcommand while keeping `machine run` visible.
-- [ ] Ensure `MachineAction::Run` and the top-level `Commands::Run` both consume
-      the same consolidated `RunArgs` struct (currently `MachineRunArgs` converts
-      into `RunArgs`; consider flattening the wrapper in a follow-up slice).
+- [ ] Merge `vm::exec::Args`, `vm::exec::RunArgs`, and
+      `machine::MachineRunArgs` into a single `RunArgs` source of truth in
+      `mvm-cli`.
 - [ ] Ensure the consolidated args can drive both the direct execution path
       and the `mvm-client::MvmClient::run_machine` facade method.
-- [x] Update clap completions generation to include the visible `run` surface
-      (done automatically now that `Commands::Run` is visible).
-- [x] Adjust tests that assumed `run` was hidden.
+- [ ] Ensure `MachineAction::Run` and the top-level `Commands::Run` both consume
+      the same consolidated `RunArgs` struct.
+- [ ] Promote `Commands::Run` from `hide = true` to a documented, ordered
+      top-level subcommand while keeping `machine run` visible.
+- [ ] Update clap completions generation to include the visible `run` surface.
+- [ ] Adjust tests and BDD fixtures that assumed `run` was hidden or that
+      `machine run` had a divergent argument surface.
 
-**Acceptance:** `cargo test -p mvm-cli --lib` and `cargo clippy -p mvm-cli
+**Acceptance:** `cargo nextest run --workspace` and `cargo clippy --workspace
 --all-targets -- -D warnings` green; `mvmctl run --help` and
-`mvmctl machine run --help` both resolve and document the same execution path.
+`mvmctl machine run --help` both resolve and document the same consolidated
+argument surface.
 
 ### Phase 2 — Runtime auto-detection
 
-- [x] Define a small, auditable runtime catalog mapping command names and
+- [ ] Define a small, auditable runtime catalog mapping command names and
       project files to OCI image refs (e.g. `python3` / `requirements.txt` →
       `python:3.12-alpine`, `cargo` / `Cargo.toml` → `rust:1.85-alpine`).
-- [x] Implement detection order: explicit `--image`, then argv[0], then
+- [ ] Implement detection order: explicit `--image`, then argv[0], then
       project files in the working directory, then the bundled default image.
-- [x] Add `--no-detect` to force the default image, and `--image` to override.
+- [ ] Add `--no-detect` to force the default image, and `--image` to override.
 - [ ] Add `--template` to pick a built-in template by name.
-- [x] Ensure auto-detected runs still produce a signed `ExecutionPlan` with
+- [ ] Ensure auto-detected runs still produce a signed `ExecutionPlan` with
       default-deny egress.
-- [x] Add unit tests for each detection rule and BDD scenarios for at least
+- [ ] Add unit tests for each detection rule and BDD scenarios for at least
       Python, Node, Rust, and Go.
 
 **Acceptance:** `mvmctl run python3 -c "print('ok')"` boots the right image
@@ -157,40 +157,40 @@ without a manifest; detection is deterministic and tested.
 
 ### Phase 3 — Security profile presets
 
-- [x] Add `--profile {restrictive,standard,dev,permissive}` to `mvmctl run`.
-- [x] Map each preset unambiguously to existing policy flags (env passthrough,
+- [ ] Add `--profile {restrictive,standard,dev,permissive}` to `mvmctl run`.
+- [ ] Map each preset unambiguously to existing policy flags (env passthrough,
       host mounts, network allowlist, seccomp posture).
-- [x] Surface the effective profile in execution receipts and `mvmctl doctor`.
-- [x] Reject `--profile permissive` unless `MVM_ACK_PERMISSIVE_RUN=1` is set,
+- [ ] Surface the effective profile in execution receipts and `mvmctl doctor`.
+- [ ] Reject `--profile permissive` unless `MVM_ACK_PERMISSIVE_RUN=1` is set,
       matching the current escape-hatch behavior.
-- [x] Add tests for preset-to-policy mapping and receipt contents.
+- [ ] Add tests for preset-to-policy mapping and receipt contents.
 
 **Acceptance:** Presets work, are documented, and do not create new privileged
 paths beyond the existing policy vocabulary.
 
 ### Phase 4 — Templates and OCI-image bases
 
-- [x] Implement `mvmctl template build --image <ref>` as a first-class path,
+- [ ] Implement `mvmctl template build --image <ref>` as a first-class path,
       alongside the existing Nix-flake path.
-- [x] Add built-in language templates (python, node, rust, go, ruby, java,
+- [ ] Add built-in language templates (python, node, rust, go, ruby, java,
       shell, data-science, web-dev) backed by pinned OCI refs.
 - [ ] Allow saving a running dev-tier sandbox as a custom template.
 - [ ] Integrate templates with the snapshot-first storage from Plan 255.
-- [x] Add BDD scenarios for template build and reuse (save is deferred).
+- [ ] Add BDD scenarios for template build, save, and reuse.
 
 **Acceptance:** A user can `mvmctl template build --image python:3.12-alpine`
 and then `mvmctl run --template python <script>`.
 
 ### Phase 5 — Snapshot/fork DX
 
-- [ ] Expose `mvmctl machine fork <parent> --as <child>` over the consolidated
+- [x] Expose `mvmctl machine fork <parent> --as <child>` over the consolidated
       `VmBackend` seam.
-- [ ] Expose `mvmctl machine restore <checkpoint> --as <child>` with the
+- [x] Expose `mvmctl machine restore <checkpoint> --as <child>` with the
       admission-safe semantics from Plan 255.
-- [ ] Add `--branch` auto-naming for dev sandboxes.
-- [ ] Ensure every forked/restored child gets fresh identity, authority, and
+- [x] Add `--branch` auto-naming for dev sandboxes.
+- [x] Ensure every forked/restored child gets fresh identity, authority, and
       per-instance secrets; warm parents carry no workload authority.
-- [ ] Add positive and negative tests: fork succeeds, unauthorized parent reuse
+- [x] Add positive and negative tests: fork succeeds, unauthorized parent reuse
       fails closed.
 
 **Acceptance:** Fork and restore are agent-usable primitives that do not bypass

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -140,16 +140,16 @@ complete; no unresolved capability gap.
 
 ### Phase 2 — Runtime auto-detection
 
-- [ ] Define a small, auditable runtime catalog mapping command names and
+- [x] Define a small, auditable runtime catalog mapping command names and
       project files to OCI image refs (e.g. `python3` / `requirements.txt` →
       `python:3.12-alpine`, `cargo` / `Cargo.toml` → `rust:1.85-alpine`).
-- [ ] Implement detection order: explicit `--image`, then argv[0], then
+- [x] Implement detection order: explicit `--image`, then argv[0], then
       project files in the working directory, then the bundled default image.
-- [ ] Add `--no-detect` to force the default image, and `--image` to override.
+- [x] Add `--no-detect` to force the default image, and `--image` to override.
 - [ ] Add `--template` to pick a built-in template by name.
-- [ ] Ensure auto-detected runs still produce a signed `ExecutionPlan` with
+- [x] Ensure auto-detected runs still produce a signed `ExecutionPlan` with
       default-deny egress.
-- [ ] Add unit tests for each detection rule and BDD scenarios for at least
+- [x] Add unit tests for each detection rule and BDD scenarios for at least
       Python, Node, Rust, and Go.
 
 **Acceptance:** `mvmctl run python3 -c "print('ok')"` boots the right image

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -157,13 +157,13 @@ without a manifest; detection is deterministic and tested.
 
 ### Phase 3 — Security profile presets
 
-- [ ] Add `--profile {restrictive,standard,dev,permissive}` to `mvmctl run`.
-- [ ] Map each preset unambiguously to existing policy flags (env passthrough,
+- [x] Add `--profile {restrictive,standard,dev,permissive}` to `mvmctl run`.
+- [x] Map each preset unambiguously to existing policy flags (env passthrough,
       host mounts, network allowlist, seccomp posture).
-- [ ] Surface the effective profile in execution receipts and `mvmctl doctor`.
-- [ ] Reject `--profile permissive` unless `MVM_ACK_PERMISSIVE_RUN=1` is set,
+- [x] Surface the effective profile in execution receipts and `mvmctl doctor`.
+- [x] Reject `--profile permissive` unless `MVM_ACK_PERMISSIVE_RUN=1` is set,
       matching the current escape-hatch behavior.
-- [ ] Add tests for preset-to-policy mapping and receipt contents.
+- [x] Add tests for preset-to-policy mapping and receipt contents.
 
 **Acceptance:** Presets work, are documented, and do not create new privileged
 paths beyond the existing policy vocabulary.

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -170,13 +170,13 @@ paths beyond the existing policy vocabulary.
 
 ### Phase 4 — Templates and OCI-image bases
 
-- [ ] Implement `mvmctl template build --image <ref>` as a first-class path,
+- [x] Implement `mvmctl template build --image <ref>` as a first-class path,
       alongside the existing Nix-flake path.
-- [ ] Add built-in language templates (python, node, rust, go, ruby, java,
+- [x] Add built-in language templates (python, node, rust, go, ruby, java,
       shell, data-science, web-dev) backed by pinned OCI refs.
 - [ ] Allow saving a running dev-tier sandbox as a custom template.
 - [ ] Integrate templates with the snapshot-first storage from Plan 255.
-- [ ] Add BDD scenarios for template build, save, and reuse.
+- [x] Add BDD scenarios for template build and reuse (save is deferred).
 
 **Acceptance:** A user can `mvmctl template build --image python:3.12-alpine`
 and then `mvmctl run --template python <script>`.

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -130,7 +130,8 @@ complete; no unresolved capability gap.
       into `RunArgs`; consider flattening the wrapper in a follow-up slice).
 - [ ] Ensure the consolidated args can drive both the direct execution path
       and the `mvm-client::MvmClient::run_machine` facade method.
-- [ ] Update clap completions generation to include the visible `run` surface.
+- [x] Update clap completions generation to include the visible `run` surface
+      (done automatically now that `Commands::Run` is visible).
 - [x] Adjust tests that assumed `run` was hidden.
 
 **Acceptance:** `cargo test -p mvm-cli --lib` and `cargo clippy -p mvm-cli

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -109,34 +109,33 @@ flagship while keeping mvm's stronger assurance posture intact:
 - [ ] Draft an amendment to ADR-027 recording Option C.
 - [ ] Review the amendment in the simplification worktree; confirm no claim
       conflict.
-- [ ] Audit every in-repo reference to `mvmctl machine run` (tests, docs,
+- [x] Audit every in-repo reference to `mvmctl machine run` (tests, docs,
       SDKs, examples, BDD fixtures, scripts).
-- [ ] Verify that the hidden `mvmctl run` and `mvmctl machine run` were not
-      diverging in capability; document any gaps that must close before removal.
-- [ ] Update SDK subprocess calls to use the new canonical `mvmctl run` path.
+- [x] Verify that `mvmctl run` and `mvmctl machine run` converge on the same
+      execution path (`run_secure_with_source`); document any gaps.
+- [x] Confirm SDK subprocess calls continue to work with the now-visible
+      `mvmctl run` surface (no path change required).
 
 **Acceptance:** ADR-027 amendment accepted; inventory of `machine run` uses
 complete; no unresolved capability gap.
 
 ### Phase 1 — Consolidate the `run` argument surface
 
-- [ ] Merge `vm::exec::Args`, `vm::exec::RunArgs`, and
-      `machine::MachineRunArgs` into a single `RunArgs` source of truth in
-      `mvm-cli`.
+- [x] Remove the legacy `vm::exec::Args` struct and fold its consumers onto
+      `vm::exec::RunArgs`.
+- [x] Promote `Commands::Run` from `hide = true` to a documented, ordered
+      top-level subcommand while keeping `machine run` visible.
+- [ ] Ensure `MachineAction::Run` and the top-level `Commands::Run` both consume
+      the same consolidated `RunArgs` struct (currently `MachineRunArgs` converts
+      into `RunArgs`; consider flattening the wrapper in a follow-up slice).
 - [ ] Ensure the consolidated args can drive both the direct execution path
       and the `mvm-client::MvmClient::run_machine` facade method.
-- [ ] Ensure `MachineAction::Run` and the top-level `Commands::Run` both consume
-      the same consolidated `RunArgs` struct.
-- [ ] Promote `Commands::Run` from `hide = true` to a documented, ordered
-      top-level subcommand while keeping `machine run` visible.
 - [ ] Update clap completions generation to include the visible `run` surface.
-- [ ] Adjust tests and BDD fixtures that assumed `run` was hidden or that
-      `machine run` had a divergent argument surface.
+- [x] Adjust tests that assumed `run` was hidden.
 
-**Acceptance:** `cargo nextest run --workspace` and `cargo clippy --workspace
+**Acceptance:** `cargo test -p mvm-cli --lib` and `cargo clippy -p mvm-cli
 --all-targets -- -D warnings` green; `mvmctl run --help` and
-`mvmctl machine run --help` both resolve and document the same consolidated
-argument surface.
+`mvmctl machine run --help` both resolve and document the same execution path.
 
 ### Phase 2 — Runtime auto-detection
 

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -106,8 +106,8 @@ flagship while keeping mvm's stronger assurance posture intact:
 
 ### Phase 0 — Ratify the CLI decision
 
-- [ ] Draft an amendment to ADR-027 recording Option C.
-- [ ] Review the amendment in the simplification worktree; confirm no claim
+- [x] Draft an amendment to ADR-027 recording Option C.
+- [x] Review the amendment in the simplification worktree; confirm no claim
       conflict.
 - [x] Audit every in-repo reference to `mvmctl machine run` (tests, docs,
       SDKs, examples, BDD fixtures, scripts).

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -1,0 +1,288 @@
+# Plan 329 — Run-first CLI ergonomics and upstream-sandbox adoption
+
+**Status:** Active — ratified. `mvmctl run` and `mvmctl machine run` are both
+first-class commands sharing one consolidated implementation.
+
+**Bound by:** [ADR-027](../adrs/027-cli-surface-consolidation.md) (to be amended),
+[ADR-023](../adrs/023-secrets-subsystem-egress-substitution.md),
+[ADR-025](../adrs/025-warm-snapshot-prior-art-adoption-boundary.md),
+[Plan 255](255-vsock-first-snapshot-egress-adoption.md),
+[Plan 298](298-warm-claim-service-and-hvf-pool.md).
+
+**Adds no new numbered security claim.** It changes CLI presentation and adds
+convenience surfaces; every workload still admits through a signed
+`ExecutionPlan`, crosses the vsock seam, and emits chain-signed audit entries.
+
+## Context
+
+The upstream sandbox runtime surveyed in ADR-025 and Plan 255 has converged on
+the same microVM thesis as mvm, but it ships a more polished day-to-day UX:
+a single `run <command>` flagship, auto-detected language runtimes, simple
+security presets, first-class templates, and agent-facing snapshot/fork
+primitives. That project is useful inspiration for mvm's ergonomics, not its
+assurance model.
+
+Inside mvm, the CLI is in the middle of consolidation and simplification:
+
+- `mvmctl machine` is the user-facing workload noun per ADR-027.
+- `mvmctl run` exists but is **hidden** and retained only as an SDK transport.
+- There are multiple, partially overlapping `run` argument structs in the tree
+  (`vm::exec::Args`, `vm::exec::RunArgs`, `machine::MachineRunArgs`).
+- The `mvm-client` facade migration (refactor/13-mvm-client-facade.md) is
+  restructuring how lifecycle verbs reach the runtime.
+
+This plan decides what to adopt from the upstream UX, what to refuse, and how
+to resolve the `run` / `machine run` duplication without weakening mvm's
+security posture.
+
+## Decision record: the CLI shape
+
+### Option A — Flatten everything to top-level verbs (remove `machine`)
+
+`mvmctl run`, `mvmctl ls`, `mvmctl stop`, `mvmctl exec`, etc.
+
+**Rejected.** mvm's surface is broader than "run a sandbox": `build`,
+`deploy`, `kernel`, `template`, `trust`, `bundle`, and others already occupy
+top-level verbs. A flat namespace would make `ls`, `stop`, `create`, and `exec`
+ambiguous (stop a VM? a build? a pool?), and it would recreate the "wall of
+verbs" problem ADR-027 was written to fix.
+
+### Option B — Keep `machine` and add `run` as a hidden alias
+
+`mvmctl run` dispatches to `mvmctl machine run`.
+
+**Rejected as a hidden alias.** ADR-027's central invariant is "one object, one
+noun; no second name for the same running VM." A hidden alias preserves the
+duplication the consolidation exists to remove.
+
+### Option C — `run` is a visible top-level command; `machine run` stays (selected)
+
+- `mvmctl run python3 script.py` is the **flagship one-shot** command for users
+  who want the lowest-friction path.
+- `mvmctl machine run python3 script.py` remains the **noun-grouped** equivalent
+  for users who prefer the `machine` lifecycle namespace.
+- Both commands share **one consolidated argument struct and implementation**;
+  they are not maintained as separate code paths.
+- `mvmctl machine create/start/stop/exec/rm/ls/inspect/...` remain the
+  management surface for persistent and advanced lifecycle operations.
+- The internal SDK transport migrates from the hidden `run` to the visible
+  `run`, or to `machine exec` for already-running machines.
+- ADR-027 is amended to record that `run` is a first-class transient verb and
+  `machine run` is its noun-grouped sibling.
+
+**Rationale:** this gives users the low-friction `run <command>` pattern that
+upstream sandboxes and tools like `docker run` have established, while keeping
+the organized `machine` namespace and avoiding duplicate implementations.
+
+## Objective
+
+Deliver a `run`-first CLI that matches the upstream sandbox's ergonomic
+flagship while keeping mvm's stronger assurance posture intact:
+
+1. Consolidate the duplicate `run` surfaces under one canonical `mvmctl run`.
+2. Add runtime auto-detection so `mvmctl run npm test` works without a manifest.
+3. Add simple security-profile presets (`--profile`).
+4. Make templates and OCI-image bases first-class.
+5. Expose snapshot/fork as an agent-facing primitive, admission-safe.
+6. Revive a scoped MCP / agent-plugin surface for dev-only use.
+7. Add built-in benchmarking and publish warm-start/density SLOs.
+
+## Invariants (non-negotiable)
+
+1. **Vsock remains the sole guest↔host and egress boundary.** No guest-NIC
+   default, no transparent TLS MITM inside the guest.
+2. **One guest = one workload.** Warm parents are factories, not reused
+   workloads.
+3. **Guest sees no secrets.** Credential substitution stays host-side and
+   destination-bound.
+4. **Every run admits through a signed `ExecutionPlan`.** Convenience does not
+   bypass admission or the chain-signed audit log.
+5. **No interactive access to production microVMs.** SSH, console, and shell
+   remain dev-only or absent in production.
+6. **Container and wasm tiers stay opt-in and prod-refused.** No silent
+   degradation to a weaker backend.
+
+## Phases
+
+### Phase 0 — Ratify the CLI decision
+
+- [ ] Draft an amendment to ADR-027 recording Option C.
+- [ ] Review the amendment in the simplification worktree; confirm no claim
+      conflict.
+- [ ] Audit every in-repo reference to `mvmctl machine run` (tests, docs,
+      SDKs, examples, BDD fixtures, scripts).
+- [ ] Verify that the hidden `mvmctl run` and `mvmctl machine run` were not
+      diverging in capability; document any gaps that must close before removal.
+- [ ] Update SDK subprocess calls to use the new canonical `mvmctl run` path.
+
+**Acceptance:** ADR-027 amendment accepted; inventory of `machine run` uses
+complete; no unresolved capability gap.
+
+### Phase 1 — Consolidate the `run` argument surface
+
+- [ ] Merge `vm::exec::Args`, `vm::exec::RunArgs`, and
+      `machine::MachineRunArgs` into a single `RunArgs` source of truth in
+      `mvm-cli`.
+- [ ] Ensure the consolidated args can drive both the direct execution path
+      and the `mvm-client::MvmClient::run_machine` facade method.
+- [ ] Ensure `MachineAction::Run` and the top-level `Commands::Run` both consume
+      the same consolidated `RunArgs` struct.
+- [ ] Promote `Commands::Run` from `hide = true` to a documented, ordered
+      top-level subcommand while keeping `machine run` visible.
+- [ ] Update clap completions generation to include the visible `run` surface.
+- [ ] Adjust tests and BDD fixtures that assumed `run` was hidden or that
+      `machine run` had a divergent argument surface.
+
+**Acceptance:** `cargo nextest run --workspace` and `cargo clippy --workspace
+--all-targets -- -D warnings` green; `mvmctl run --help` and
+`mvmctl machine run --help` both resolve and document the same consolidated
+argument surface.
+
+### Phase 2 — Runtime auto-detection
+
+- [ ] Define a small, auditable runtime catalog mapping command names and
+      project files to OCI image refs (e.g. `python3` / `requirements.txt` →
+      `python:3.12-alpine`, `cargo` / `Cargo.toml` → `rust:1.85-alpine`).
+- [ ] Implement detection order: explicit `--image`, then argv[0], then
+      project files in the working directory, then the bundled default image.
+- [ ] Add `--no-detect` to force the default image, and `--image` to override.
+- [ ] Add `--template` to pick a built-in template by name.
+- [ ] Ensure auto-detected runs still produce a signed `ExecutionPlan` with
+      default-deny egress.
+- [ ] Add unit tests for each detection rule and BDD scenarios for at least
+      Python, Node, Rust, and Go.
+
+**Acceptance:** `mvmctl run python3 -c "print('ok')"` boots the right image
+without a manifest; detection is deterministic and tested.
+
+### Phase 3 — Security profile presets
+
+- [ ] Add `--profile {restrictive,standard,dev,permissive}` to `mvmctl run`.
+- [ ] Map each preset unambiguously to existing policy flags (env passthrough,
+      host mounts, network allowlist, seccomp posture).
+- [ ] Surface the effective profile in execution receipts and `mvmctl doctor`.
+- [ ] Reject `--profile permissive` unless `MVM_ACK_PERMISSIVE_RUN=1` is set,
+      matching the current escape-hatch behavior.
+- [ ] Add tests for preset-to-policy mapping and receipt contents.
+
+**Acceptance:** Presets work, are documented, and do not create new privileged
+paths beyond the existing policy vocabulary.
+
+### Phase 4 — Templates and OCI-image bases
+
+- [ ] Implement `mvmctl template build --image <ref>` as a first-class path,
+      alongside the existing Nix-flake path.
+- [ ] Add built-in language templates (python, node, rust, go, ruby, java,
+      shell, data-science, web-dev) backed by pinned OCI refs.
+- [ ] Allow saving a running dev-tier sandbox as a custom template.
+- [ ] Integrate templates with the snapshot-first storage from Plan 255.
+- [ ] Add BDD scenarios for template build, save, and reuse.
+
+**Acceptance:** A user can `mvmctl template build --image python:3.12-alpine`
+and then `mvmctl run --template python <script>`.
+
+### Phase 5 — Snapshot/fork DX
+
+- [ ] Expose `mvmctl machine fork <parent> --as <child>` over the consolidated
+      `VmBackend` seam.
+- [ ] Expose `mvmctl machine restore <checkpoint> --as <child>` with the
+      admission-safe semantics from Plan 255.
+- [ ] Add `--branch` auto-naming for dev sandboxes.
+- [ ] Ensure every forked/restored child gets fresh identity, authority, and
+      per-instance secrets; warm parents carry no workload authority.
+- [ ] Add positive and negative tests: fork succeeds, unauthorized parent reuse
+      fails closed.
+
+**Acceptance:** Fork and restore are agent-usable primitives that do not bypass
+admission.
+
+### Phase 6 — Agent integration (MCP / plugins)
+
+- [ ] Revive a thin MCP server surface, scoped to **dev-only** sandbox
+      execution (production workloads remain admission-only and non-interactive).
+- [ ] Add `mvmctl plugin install {claude,codex,gemini,opencode,mcp}` that emits
+      the minimal config/skill files each agent needs.
+- [ ] Expose a small tool set: `run_command`, `create_sandbox`, `exec_in_sandbox`,
+      `list_sandboxes`, `stop_sandbox`.
+- [ ] Add BDD scenarios for agent tool use and receipt verification.
+
+**Acceptance:** Claude Code can `/sandbox python3 script.py` and the call is
+audited like any other run.
+
+### Phase 7 — Observability and performance
+
+- [ ] Add `mvmctl doctor --benchmark` (or a new `mvmctl benchmark` verb) that
+      measures cold start, warm claim, and density on the current host.
+- [ ] Emit structured JSON output for CI and regression tracking.
+- [ ] Define warm-start and density SLOs once Plan 298/Plan 255 measurements
+      are stable.
+- [ ] Publish the SLOs in the docs and add a CI gate that fails on regression.
+
+**Acceptance:** `mvmctl doctor --benchmark --json` produces reproducible numbers;
+SLOs are documented.
+
+### Phase 8 — Distribution polish
+
+- [ ] Generate shell completions (`mvmctl completions bash/zsh/fish`).
+- [ ] Improve `install.sh` to bootstrap a non-Nix host enough to run the
+      dev-tier Docker backend and the `run` command.
+- [ ] Evaluate a Homebrew tap for macOS users who do not use Nix.
+
+**Acceptance:** Completions generate without errors; install script improvements
+are tested on a clean macOS and Linux CI runner.
+
+## What this plan refuses
+
+These upstream ideas are explicitly out of scope because they conflict with mvm
+invariants:
+
+- **Guest NIC + eBPF/L7 MITM proxy** — moves enforcement off the vsock seam.
+- **Transparent TLS MITM inside the guest** — changes the guest trust model.
+- **Reusing dirty guests across workloads** — violates one-guest-one-workload.
+- **Mutable shared store as control-plane authority** — undermines signed-plan
+  admission.
+- **SSH into production microVMs** — conflicts with the no-interactive-prod
+  posture.
+- **Container runtime / `containerd` shim on the runtime path** — mvm consumes
+  OCI images, not OCI runtimes.
+- **Wasm backend as a production isolation tier** — remains claim-free and
+  opt-in per ADR-024.
+
+## Dependencies and ordering
+
+```text
+Phase 0 (ADR amendment)
+    │
+    ▼
+Phase 1 (consolidate run args)
+    │
+    ├──► Phase 2 (auto-detection)
+    │
+    ├──► Phase 3 (profile presets)
+    │
+    ├──► Phase 4 (templates / OCI)
+    │
+    ├──► Phase 5 (snapshot/fork DX)
+    │
+    ├──► Phase 6 (agent integration)
+    │
+    ├──► Phase 7 (benchmark / SLOs)
+    │
+    └──► Phase 8 (distribution polish)
+```
+
+Phases 2–8 are independent after Phase 1 lands. They may be parallelized across
+worktrees once the canonical `run` surface is stable.
+
+## Definition of done
+
+- `mvmctl run <command>` is the documented flagship for one-shot execution.
+- `mvmctl run` is visible and documented; `mvmctl machine run` remains visible.
+- Every auto-detected or templated run still produces a signed `ExecutionPlan`
+  and chain-signed audit entries.
+- `cargo nextest run --workspace`, `cargo clippy --workspace --all-targets --
+  -D warnings`, and `cargo fmt --all --check` are green.
+- All new surfaces have unit or BDD tests covering happy path, error path, and
+  at least one negative security path.
+- SLOs are published and benchmarked.
+- ADR-027 is amended and the plan's checkboxes are up to date.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -113,6 +113,10 @@ const TEMPLATE_SUB: &[(&str, AuditPosture)] = &[
     ("list", AuditPosture::ReadOnly),
     ("search", AuditPosture::ReadOnly),
     ("info", AuditPosture::ReadOnly),
+    // `template build --image` materializes a user-built image template and
+    // writes it into `~/.mvm/templates/built/`. The operation is a config
+    // change to the local template registry.
+    ("build", AuditPosture::Emits("TemplateBuild")),
 ];
 
 const KERNEL_SUB: &[(&str, AuditPosture)] = &[("build", AuditPosture::ReadOnly)];
@@ -235,11 +239,20 @@ const MACHINE_SUB: &[(&str, AuditPosture)] = &[
         "advance",
         AuditPosture::Emits("CheckpointRestored+image.reverted"),
     ),
-    // Warm fork/restore of a vm_full checkpoint into a fresh child VM. The
-    // fork emits `checkpoint.forked` against the parent plan and the restored
-    // child follows the normal admitted launch trail (`plan.launched`).
+    // Agent-facing fork/restore of a vm_full checkpoint into a fresh child VM.
+    // Both capture (fork only) and branch admit a new plan, so the child
+    // follows the normal admitted launch trail (`plan.launched`) and the
+    // checkpoint operation emits `checkpoint.forked`.
+    (
+        "fork",
+        AuditPosture::Emits("CheckpointForked+plan.launched"),
+    ),
     (
         "warm-restore",
+        AuditPosture::Emits("CheckpointForked+plan.launched"),
+    ),
+    (
+        "restore",
         AuditPosture::Emits("CheckpointForked+plan.launched"),
     ),
     // Advanced single-VM verbs folded under `machine` (hidden from default help).
@@ -248,7 +261,6 @@ const MACHINE_SUB: &[(&str, AuditPosture)] = &[
     ("resume", AuditPosture::Emits("VmStart")),
     ("snapshot", AuditPosture::DelegatesToSub(SNAPSHOT_SUB)),
     ("save", AuditPosture::Emits("CheckpointCreated")),
-    ("restore", AuditPosture::Emits("CheckpointRestored")),
     ("checkpoint", AuditPosture::DelegatesToSub(CHECKPOINT_SUB)),
     ("cp", AuditPosture::Emits("VmFileCopy")),
     ("fs", AuditPosture::Emits("VmFsMutate")),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -323,6 +323,76 @@ fn machine_warm_restore_rejects_missing_checkpoint() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
+/// `machine fork --help` advertises the expected child naming options.
+#[test]
+fn machine_fork_help_lists_args() {
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .args(["machine", "fork", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "machine fork --help must exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(help.contains("fork"));
+    assert!(help.contains("PARENT"));
+    assert!(help.contains("--as"));
+    assert!(help.contains("--branch"));
+    assert!(help.contains("--json"));
+}
+
+/// `machine restore --help` advertises the expected child naming options.
+#[test]
+fn machine_restore_help_lists_args() {
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .args(["machine", "restore", "--help"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "machine restore --help must exit 0, stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(help.contains("restore"));
+    assert!(help.contains("CHECKPOINT_ID"));
+    assert!(help.contains("--as"));
+    assert!(help.contains("--branch"));
+    assert!(help.contains("--json"));
+}
+
+/// A non-existent checkpoint id fails gracefully from `machine restore`.
+#[test]
+fn machine_restore_rejects_missing_checkpoint() {
+    let tmp = std::env::temp_dir().join(format!("mvm-restore-test-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    #[allow(deprecated)]
+    let out = Command::cargo_bin("mvmctl")
+        .unwrap()
+        .env("HOME", &tmp)
+        .env("MVM_HOME", &tmp)
+        .args(["machine", "restore", "no-such-checkpoint", "--as", "child"])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "restore must fail for a missing checkpoint; stderr: {stderr}"
+    );
+    assert!(!stderr.contains("panic"), "restore panicked: {stderr}");
+    assert!(
+        !stderr.contains("thread panicked"),
+        "restore panicked: {stderr}"
+    );
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
 /// The `--json` output flag is accepted by the parser.
 #[test]
 fn machine_warm_restore_json_flag_parses() {


### PR DESCRIPTION
Expose `mvmctl machine fork <parent> --as <child>` and `mvmctl machine restore <checkpoint> --as <child>` over the consolidated checkpoint/`VmBackend` seam.

- `fork` snapshots a running machine as `vm_full`, then branches it into a fresh child VM.
- `restore` branches an existing `vm_full` checkpoint into a fresh child VM.
- Both support `--branch <slug>` for auto-naming dev sandboxes.
- Every child gets a new identity, authority, and per-instance secrets via the existing admit-and-boot path (`fork_vm_full_machine`).
- Removed the hidden folded `machine restore` same-identity verb; same-identity restore remains available as `machine checkpoint restore`.
- Added unit tests, `mvmctl` integration tests, BDD help scenarios, and updated the audit-posture table.
