### PR TITLE
feat(cli): auto-create persistent machines on mvmctl machine start

### DIFF
--- a/crates/mvm-cli/src/commands/machine/lifecycle.rs
+++ b/crates/mvm-cli/src/commands/machine/lifecycle.rs
@@ -54,8 +54,68 @@ pub(super) fn run_restart(cmd: MachineStartCmd) -> Result<()> {
     Ok(())
 }
 
+/// Resolve the spec for `machine start`. If the machine does not exist and a
+/// source is provided (`--image` or `--manifest`), the spec is created on
+/// demand. If it exists and flags are provided, the configs are reconciled.
+pub(super) fn resolve_start_spec(args: &MachineStartArgs) -> Result<(MachineSpec, SpecReconcile)> {
+    let existing = load_machine_spec(&args.name).ok();
+    let has_source = args.create_flags.image.is_some() || args.create_flags.manifest.is_some();
+    if !has_source {
+        return match existing {
+            Some(spec) => Ok((spec, SpecReconcile::Reuse)),
+            None => anyhow::bail!(
+                "machine {name:?} does not exist.
+                 Run `mvmctl machine ls` to list machines,
+                 or `mvmctl machine start {name} --image <ref>` to create and start one.",
+                name = args.name
+            ),
+        };
+    }
+    let manifest_source = args
+        .create_flags
+        .manifest
+        .as_deref()
+        .map(|arg| load_machine_manifest_source(Path::new(arg)))
+        .transpose()?;
+    let workflow = manifest_source.as_ref().map(|source| &source.workflow);
+    let init = workflow
+        .map(|workflow| workflow.init.clone())
+        .unwrap_or_default();
+    let volumes = match manifest_source.as_ref() {
+        Some(source) => source
+            .workflow
+            .volumes
+            .iter()
+            .map(|spec| absolutize_manifest_volume_spec(spec, &source.base_dir))
+            .collect::<Result<Vec<_>>>()?,
+        None => Vec::new(),
+    };
+    let desired = build_machine_spec(MachineSpecInputs {
+        name: &args.name,
+        image: args.create_flags.image.as_deref(),
+        net: args.create_flags.net,
+        allow_host: &args.create_flags.allow_host,
+        cpus: args.create_flags.cpus,
+        cpu_limit: args.create_flags.cpu_limit,
+        timeout: args.create_flags.timeout,
+        grants_file: args.create_flags.grants_file.as_deref(),
+        memory: args.create_flags.memory.as_deref(),
+        mem_initial: args.create_flags.mem_initial.as_deref(),
+        profile: args.create_flags.profile,
+        workflow,
+        volumes: &volumes,
+        init: &init,
+    })?;
+    let action = reconcile_machine_spec(existing.as_ref(), &desired, args.create_flags.force)?;
+    let spec = match action {
+        SpecReconcile::Reuse => existing.expect("reuse implies an existing spec"),
+        SpecReconcile::Create | SpecReconcile::Recreate { .. } => desired,
+    };
+    Ok((spec, action))
+}
+
 pub(super) fn start_machine(args: MachineStartArgs) -> Result<()> {
-    let mut spec = ensure_machine_spec_exists(&args.name)?;
+    let (mut spec, action) = resolve_start_spec(&args)?;
     if args.dry_run {
         let summary = machine_start_preflight_summary(
             &spec,
@@ -70,8 +130,27 @@ pub(super) fn start_machine(args: MachineStartArgs) -> Result<()> {
         return Ok(());
     }
     if machine_is_running(&args.name) {
-        println!("{}", already_running_notice(&args.name, args.json));
-        return Ok(());
+        match action {
+            SpecReconcile::Reuse => {
+                println!("{}", already_running_notice(&args.name, args.json));
+                return Ok(());
+            }
+            SpecReconcile::Recreate { ref changed } => {
+                eprintln!(
+                    "machine {:?}: config changed ({changed}) — stopping the old instance and recreating it",
+                    args.name
+                );
+                stop_running_machine(&args.name);
+            }
+            SpecReconcile::Create => {
+                // A freshly-created spec cannot already be running; proceed to save and boot.
+            }
+        }
+    }
+    match action {
+        SpecReconcile::Create => save_machine_spec(&spec, false)?,
+        SpecReconcile::Recreate { .. } => overwrite_machine_spec(&spec)?,
+        SpecReconcile::Reuse => {}
     }
     enforce_dev_init_profile(&spec.profile, &spec.init)?;
     let effective_hypervisor = args
@@ -218,7 +297,7 @@ pub(super) fn start_machine(args: MachineStartArgs) -> Result<()> {
 }
 
 pub(super) fn exec_machine(cli: &Cli, args: MachineExecArgs, cfg: &MvmConfig) -> Result<()> {
-    ensure_machine_spec_exists(&args.name)?;
+    let _ = load_machine_spec(&args.name)?;
     let command = if args.argv.is_empty() {
         None
     } else {
@@ -249,7 +328,7 @@ pub(super) fn exec_machine(cli: &Cli, args: MachineExecArgs, cfg: &MvmConfig) ->
 }
 
 pub(super) fn shell_machine(cli: &Cli, args: MachineShellArgs, cfg: &MvmConfig) -> Result<()> {
-    ensure_machine_spec_exists(&args.name)?;
+    let _ = load_machine_spec(&args.name)?;
     console::run(
         cli,
         console::Args {

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -883,11 +883,55 @@ pub(in crate::commands) struct MachineRemoveArgs {
     pub json: bool,
 }
 
+/// Optional source/config flags for `machine start`. When a persistent machine
+/// does not already exist, these flags are used to create it on demand.
+#[derive(ClapArgs, Debug, Clone, Default)]
+pub(in crate::commands) struct MachineStartCreateFlags {
+    /// OCI image reference to boot when creating the machine.
+    #[arg(long, value_name = "REF", conflicts_with = "manifest")]
+    pub image: Option<String>,
+    /// Image-backed machine manifest to source defaults from.
+    #[arg(long, value_name = "PATH", conflicts_with = "image")]
+    pub manifest: Option<String>,
+    /// Enable dev-tier outbound networking for the created machine.
+    #[arg(long)]
+    pub net: bool,
+    /// Allow egress only to these hosts: `HOST[:PORT]` (repeatable).
+    #[arg(long = "allow-host", value_name = "HOST[:PORT]")]
+    pub allow_host: Vec<String>,
+    /// vCPU cores the guest sees on lifecycle starts (not a host CPU share).
+    #[arg(long)]
+    pub cpus: Option<u32>,
+    /// Cap host CPU time in millicores (1500 = 1.5 cores); not `--cpus`.
+    #[arg(long = "cpu-limit", value_name = "MILLICORES")]
+    pub cpu_limit: Option<u32>,
+    /// Bound each start's wall-clock runtime in seconds.
+    #[arg(long, value_name = "SECS")]
+    pub timeout: Option<u64>,
+    /// Read grants (CPU, wall clock, egress) from a JSON file.
+    #[arg(long = "grants-file", value_name = "PATH")]
+    pub grants_file: Option<PathBuf>,
+    /// Memory for lifecycle starts (supports human-readable: 512M, 1G, ...).
+    #[arg(long)]
+    pub memory: Option<String>,
+    /// Optional initial host memory commitment for lifecycle starts.
+    #[arg(long, value_name = "SIZE")]
+    pub mem_initial: Option<String>,
+    /// Security profile for lifecycle starts.
+    #[arg(long, value_enum)]
+    pub profile: Option<RunProfile>,
+    /// Overwrite an existing machine spec if the config changed.
+    #[arg(long)]
+    pub force: bool,
+}
+
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineStartArgs {
     /// Persistent machine name.
     #[arg(value_name = "NAME")]
     pub name: String,
+    #[command(flatten)]
+    pub create_flags: MachineStartCreateFlags,
     /// Write a signed machine-start receipt to this path.
     #[arg(long, value_name = "PATH")]
     pub receipt: Option<PathBuf>,
@@ -933,6 +977,8 @@ pub(in crate::commands) struct MachineStartCmd {
     /// Persistent machine name(s) to boot.
     #[arg(value_name = "NAME", required = true)]
     pub names: Vec<String>,
+    #[command(flatten)]
+    pub create_flags: MachineStartCreateFlags,
     /// Write a signed machine-start receipt to this path (single machine only).
     #[arg(long, value_name = "PATH")]
     pub receipt: Option<PathBuf>,
@@ -966,6 +1012,7 @@ impl MachineStartCmd {
     fn start_args_for(&self, name: &str) -> MachineStartArgs {
         MachineStartArgs {
             name: name.to_string(),
+            create_flags: self.create_flags.clone(),
             receipt: self.receipt.clone(),
             json: self.json,
             dry_run: self.dry_run,
@@ -1124,6 +1171,107 @@ struct MachineManifestSource {
     base_dir: PathBuf,
 }
 
+/// Inputs required to build a persistent [`MachineSpec`]. Extracted so both
+/// `machine create` and `machine start --image ...` share one
+/// validation/construction path.
+struct MachineSpecInputs<'a> {
+    name: &'a str,
+    image: Option<&'a str>,
+    net: bool,
+    allow_host: &'a [String],
+    cpus: Option<u32>,
+    cpu_limit: Option<u32>,
+    timeout: Option<u64>,
+    grants_file: Option<&'a Path>,
+    memory: Option<&'a str>,
+    mem_initial: Option<&'a str>,
+    profile: Option<RunProfile>,
+    workflow: Option<&'a ManifestMachineWorkflow>,
+    volumes: &'a [String],
+    init: &'a [String],
+}
+
+fn build_machine_spec(inputs: MachineSpecInputs<'_>) -> Result<MachineSpec> {
+    validate_machine_name(inputs.name)?;
+    let workflow = inputs.workflow;
+    let image = match (inputs.image, workflow) {
+        (Some(image), _) => image.to_string(),
+        (None, Some(workflow)) => workflow.image.clone(),
+        (None, None) => {
+            bail!(
+                "machine {} requires either --image <ref> or --manifest <path>",
+                inputs.name
+            )
+        }
+    };
+    let net = inputs.net || workflow.is_some_and(|workflow| workflow.net);
+    let allow_host = if inputs.allow_host.is_empty() {
+        workflow
+            .map(|workflow| workflow.allow_hosts.clone())
+            .unwrap_or_default()
+    } else {
+        inputs.allow_host.to_vec()
+    };
+    // Resolving grants also settles the egress policy, so validating it
+    // here validates the same policy the machine will actually boot under.
+    let config = mvm_core::user_config::load(None);
+    let resolved = super::shared::resolve_run_grants(super::shared::GrantInputs {
+        cpu_limit_millicores: inputs.cpu_limit,
+        timeout_secs: inputs.timeout,
+        allow_host: &allow_host,
+        net,
+        grants_file: inputs.grants_file,
+        manifest: workflow.map(|workflow| &workflow.grants),
+        config: &config,
+    })?;
+    let cpus = inputs
+        .cpus
+        .or_else(|| workflow.map(|workflow| workflow.cpus))
+        .unwrap_or(2);
+    if cpus == 0 {
+        bail!("machine CPUs must be >= 1");
+    }
+    let memory = inputs
+        .memory
+        .map(String::from)
+        .or_else(|| workflow.map(|workflow| workflow.mem.clone()))
+        .unwrap_or_else(|| "512M".to_string());
+    let mem_initial = inputs
+        .mem_initial
+        .map(String::from)
+        .or_else(|| workflow.and_then(|workflow| workflow.mem_initial.clone()));
+    let _ = validate_machine_memory(&memory, mem_initial.as_deref())?;
+    // CLI-created machines are development workloads unless the caller
+    // explicitly opts into a stricter profile. The daemon is the only
+    // producer that should supply a non-dev production profile by policy.
+    let profile = inputs.profile.unwrap_or(RunProfile::Dev);
+    let profile_name = run_profile_name(profile).to_string();
+    enforce_dev_init_profile(&profile_name, inputs.init)?;
+    Ok(MachineSpec {
+        schema_version: MACHINE_SPEC_SCHEMA_VERSION,
+        name: inputs.name.to_string(),
+        image: Some(image),
+        manifest: None,
+        deployment: None,
+        resolved_digest: None,
+        runtime_pack: false,
+        net,
+        allow_host,
+        ports: Vec::new(),
+        cpus,
+        memory,
+        mem_initial,
+        profile: profile_name,
+        volumes: inputs.volumes.to_vec(),
+        init: inputs.init.to_vec(),
+        agent_verb: Vec::new(),
+        created_at: Some(mvm_core::time::utc_now()),
+        last_started_at: None,
+        health_check: None,
+        grants: resolved.plan_grants,
+    })
+}
+
 impl MachineCreateArgs {
     fn into_spec(self) -> Result<MachineSpec> {
         // Auto-generate a name when `NAME` is omitted, mirroring `machine run
@@ -1145,59 +1293,8 @@ impl MachineCreateArgs {
             (false, None) => None,
         };
         let workflow = manifest_source.as_ref().map(|source| &source.workflow);
-        let image = match (self.image, workflow) {
-            (Some(image), _) => image,
-            (None, Some(workflow)) => workflow.image.clone(),
-            (None, None) => {
-                bail!("machine create requires either --image <ref> or --manifest <path>")
-            }
-        };
-        let net = self.net || workflow.is_some_and(|workflow| workflow.net);
-        let allow_host = if self.allow_host.is_empty() {
-            workflow
-                .map(|workflow| workflow.allow_hosts.clone())
-                .unwrap_or_default()
-        } else {
-            self.allow_host
-        };
-        // Resolving grants also settles the egress policy, so validating it
-        // here validates the same policy the machine will actually boot under.
-        let config = mvm_core::user_config::load(None);
-        let resolved = super::shared::resolve_run_grants(super::shared::GrantInputs {
-            cpu_limit_millicores: self.cpu_limit,
-            timeout_secs: self.timeout,
-            allow_host: &allow_host,
-            net,
-            grants_file: self.grants_file.as_deref(),
-            manifest: workflow.map(|workflow| &workflow.grants),
-            config: &config,
-        })?;
-        let cpus = self
-            .cpus
-            .or_else(|| workflow.map(|workflow| workflow.cpus))
-            .unwrap_or(2);
-        if cpus == 0 {
-            bail!("machine CPUs must be >= 1");
-        }
-        let memory = self
-            .memory
-            .or_else(|| workflow.map(|workflow| workflow.mem.clone()))
-            .unwrap_or_else(|| "512M".to_string());
-        let mem_initial = self
-            .mem_initial
-            .or_else(|| workflow.and_then(|workflow| workflow.mem_initial.clone()));
-        let _ = validate_machine_memory(&memory, mem_initial.as_deref())?;
-        // CLI-created machines are development workloads unless the caller
-        // explicitly opts into a stricter profile. The daemon is the only
-        // producer that should supply a non-dev production profile by policy.
-        let profile = self.profile.unwrap_or(RunProfile::Dev);
-        let profile_name = run_profile_name(profile).to_string();
         let init = workflow
             .map(|workflow| workflow.init.clone())
-            .unwrap_or_default();
-        enforce_dev_init_profile(&profile_name, &init)?;
-        let volumes = workflow
-            .map(|workflow| workflow.volumes.clone())
             .unwrap_or_default();
         let volumes = match manifest_source.as_ref() {
             Some(source) => source
@@ -1206,30 +1303,23 @@ impl MachineCreateArgs {
                 .iter()
                 .map(|spec| absolutize_manifest_volume_spec(spec, &source.base_dir))
                 .collect::<Result<Vec<_>>>()?,
-            None => volumes,
+            None => Vec::new(),
         };
-        Ok(MachineSpec {
-            schema_version: MACHINE_SPEC_SCHEMA_VERSION,
-            name,
-            image: Some(image),
-            manifest: None,
-            deployment: None,
-            resolved_digest: None,
-            runtime_pack: false,
-            net,
-            allow_host,
-            ports: Vec::new(),
-            cpus,
-            memory,
-            mem_initial,
-            profile: profile_name,
-            volumes,
-            init,
-            agent_verb: Vec::new(),
-            created_at: Some(mvm_core::time::utc_now()),
-            last_started_at: None,
-            health_check: None,
-            grants: resolved.plan_grants,
+        build_machine_spec(MachineSpecInputs {
+            name: &name,
+            image: self.image.as_deref(),
+            net: self.net,
+            allow_host: &self.allow_host,
+            cpus: self.cpus,
+            cpu_limit: self.cpu_limit,
+            timeout: self.timeout,
+            grants_file: self.grants_file.as_deref(),
+            memory: self.memory.as_deref(),
+            mem_initial: self.mem_initial.as_deref(),
+            profile: self.profile,
+            workflow,
+            volumes: &volumes,
+            init: &init,
         })
     }
 }
@@ -1421,12 +1511,6 @@ fn rm_running_refusal(running: &[String]) -> Option<String> {
         running.join(", "),
         running.join(" ")
     ))
-}
-
-fn ensure_machine_spec_exists(name: &str) -> Result<MachineSpec> {
-    // `load_machine_spec` already emits an actionable "does not exist" message
-    // for a missing spec, so no extra context wrapper is needed here.
-    load_machine_spec(name)
 }
 
 fn mark_machine_started(spec: &mut MachineSpec, resolved_digest: String) {

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -69,6 +69,7 @@ fn run_persistent(
         action,
         MachineStartArgs {
             name: name.clone(),
+            create_flags: MachineStartCreateFlags::default(),
             receipt: args.receipt.clone(),
             json: args.json,
             dry_run: false,

--- a/crates/mvm-cli/src/commands/machine/spec_ops.rs
+++ b/crates/mvm-cli/src/commands/machine/spec_ops.rs
@@ -201,6 +201,7 @@ pub(super) fn run_reconfigure(args: MachineReconfigureArgs) -> Result<()> {
         lifecycle::stop_running_machine(&args.name);
         lifecycle::start_machine(MachineStartArgs {
             name: args.name.clone(),
+            create_flags: MachineStartCreateFlags::default(),
             receipt: None,
             json: false,
             dry_run: false,

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -2248,7 +2248,7 @@ fn resolve_remove_targets_dedupes_named_and_enumerates_all() {
 #[test]
 fn running_vm_wrappers_require_a_persisted_machine_spec() {
     let _state = IsolatedMachineState::new();
-    let err = ensure_machine_spec_exists("web").expect_err("missing spec rejected");
+    let err = load_machine_spec("web").expect_err("missing spec rejected");
     let msg = format!("{err:#}");
     // Actionable not-found: names the machine and points at the recovery verbs.
     assert!(msg.contains("machine \"web\" does not exist"), "msg: {msg}");
@@ -3207,4 +3207,129 @@ fn machine_inspect_marks_an_unenforced_tier_as_not_bounded() {
 #[test]
 fn machine_inspect_says_nothing_when_no_boot_recorded_a_tier() {
     assert_eq!(super::spec_ops::enforced_cpu_line(None), None);
+}
+
+// ---------------------------------------------------------------------------
+// `machine start` auto-create / reconcile tests
+// ---------------------------------------------------------------------------
+
+fn start_args_with_create_flags(
+    name: &str,
+    create_flags: MachineStartCreateFlags,
+) -> MachineStartArgs {
+    MachineStartArgs {
+        name: name.to_string(),
+        create_flags,
+        receipt: None,
+        json: false,
+        dry_run: false,
+        quiet: false,
+        hypervisor: None,
+        no_supervisor: false,
+        kernel_pin: None,
+        has_ad_hoc_argv: false,
+    }
+}
+
+#[test]
+fn start_parser_accepts_source_and_config_flags() {
+    let action = parse(&[
+        "start", "web", "--image", "nginx", "--cpus", "2", "--memory", "512M",
+    ])
+    .expect("parse start with flags");
+    let MachineAction::Start(cmd) = action else {
+        panic!("expected start action");
+    };
+    assert_eq!(cmd.names, vec!["web"]);
+    assert_eq!(cmd.create_flags.image.as_deref(), Some("nginx"));
+    assert_eq!(cmd.create_flags.cpus, Some(2));
+    assert_eq!(cmd.create_flags.memory.as_deref(), Some("512M"));
+}
+
+#[test]
+fn start_parser_rejects_image_and_manifest_together() {
+    let err = parse(&["start", "web", "--image", "nginx", "--manifest", "mvm.toml"])
+        .expect_err("image and manifest must conflict");
+    assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn start_resolver_creates_missing_machine_when_source_given() {
+    let _state = IsolatedMachineState::new();
+    let args = start_args_with_create_flags(
+        "web",
+        MachineStartCreateFlags {
+            image: Some("nginx".to_string()),
+            cpus: Some(2),
+            memory: Some("512M".to_string()),
+            ..MachineStartCreateFlags::default()
+        },
+    );
+    let (spec, action) = super::lifecycle::resolve_start_spec(&args).expect("create on start");
+    assert_eq!(action, super::SpecReconcile::Create);
+    assert_eq!(spec.name, "web");
+    assert_eq!(spec.image.as_deref(), Some("nginx"));
+    assert_eq!(spec.cpus, 2);
+    assert_eq!(spec.memory, "512M");
+}
+
+#[test]
+fn start_resolver_reuses_existing_machine_without_source_flags() {
+    let _state = IsolatedMachineState::new();
+    let existing = spec_fixture("web");
+    save_machine_spec(&existing, false).expect("save existing");
+    let args = start_args_with_create_flags("web", MachineStartCreateFlags::default());
+    let (spec, action) = super::lifecycle::resolve_start_spec(&args).expect("reuse existing");
+    assert_eq!(action, super::SpecReconcile::Reuse);
+    assert_eq!(spec, existing);
+}
+
+#[test]
+fn start_resolver_errors_when_missing_and_no_source() {
+    let _state = IsolatedMachineState::new();
+    let args = start_args_with_create_flags("web", MachineStartCreateFlags::default());
+    let err = super::lifecycle::resolve_start_spec(&args).expect_err("missing machine errors");
+    let msg = err.to_string();
+    assert!(msg.contains("does not exist"), "msg: {msg}");
+    assert!(msg.contains("--image"), "msg: {msg}");
+}
+
+#[test]
+fn start_resolver_errors_on_changed_config_without_force() {
+    let _state = IsolatedMachineState::new();
+    let existing = spec_fixture("web");
+    save_machine_spec(&existing, false).expect("save existing");
+    let args = start_args_with_create_flags(
+        "web",
+        MachineStartCreateFlags {
+            image: Some("ubuntu:24.04".to_string()),
+            ..MachineStartCreateFlags::default()
+        },
+    );
+    let err = super::lifecycle::resolve_start_spec(&args)
+        .expect_err("changed config without force errors");
+    assert!(err.to_string().contains("different config"), "msg: {err}");
+}
+
+#[test]
+fn start_resolver_recreates_with_force() {
+    let _state = IsolatedMachineState::new();
+    let existing = spec_fixture("web");
+    save_machine_spec(&existing, false).expect("save existing");
+    let args = start_args_with_create_flags(
+        "web",
+        MachineStartCreateFlags {
+            image: Some("ubuntu:24.04".to_string()),
+            force: true,
+            ..MachineStartCreateFlags::default()
+        },
+    );
+    let (spec, action) = super::lifecycle::resolve_start_spec(&args).expect("force recreate");
+    match action {
+        super::SpecReconcile::Recreate { changed } => {
+            assert!(changed.contains("source"), "changed: {changed}");
+        }
+        other => panic!("expected Recreate, got {other:?}"),
+    }
+    assert_eq!(spec.image.as_deref(), Some("ubuntu:24.04"));
 }

--- a/crates/mvm-sdk/src/machine.rs
+++ b/crates/mvm-sdk/src/machine.rs
@@ -607,6 +607,9 @@ impl MachineCreateBuilder {
 #[derive(Debug, Clone)]
 pub struct MachineStartBuilder {
     name: String,
+    image: Option<String>,
+    cpus: Option<u32>,
+    memory: Option<String>,
     receipt: Option<String>,
     json: bool,
     dry_run: bool,
@@ -616,10 +619,31 @@ impl MachineStartBuilder {
     fn new(name: String) -> Self {
         Self {
             name,
+            image: None,
+            cpus: None,
+            memory: None,
             receipt: None,
             json: false,
             dry_run: false,
         }
+    }
+
+    /// OCI image reference to use when the machine must be created on start.
+    pub fn image(mut self, image: impl Into<String>) -> Self {
+        self.image = Some(image.into());
+        self
+    }
+
+    /// vCPU cores for a machine created on start.
+    pub fn cpus(mut self, cpus: u32) -> Self {
+        self.cpus = Some(cpus);
+        self
+    }
+
+    /// Memory for a machine created on start.
+    pub fn memory(mut self, memory: impl Into<String>) -> Self {
+        self.memory = Some(memory.into());
+        self
     }
 
     /// Write a machine-start receipt to `path`.
@@ -645,6 +669,13 @@ impl MachineStartBuilder {
         let name = require_non_empty(self.name.clone(), "name")?;
         // `machine start` takes a positional name, not `--name`.
         let mut args = vec!["start".to_string(), name];
+        append_optional(&mut args, "--image", self.image.as_deref())?;
+        append_optional(
+            &mut args,
+            "--cpus",
+            self.cpus.map(|c| c.to_string()).as_deref(),
+        )?;
+        append_optional(&mut args, "--memory", self.memory.as_deref())?;
         append_optional(&mut args, "--receipt", self.receipt.as_deref())?;
         if self.json {
             args.push("--json".to_string());

--- a/crates/mvm-sdk/tests/machine_verb_conformance.rs
+++ b/crates/mvm-sdk/tests/machine_verb_conformance.rs
@@ -130,6 +130,19 @@ fn start_matches_shared_fixture() {
 }
 
 #[test]
+fn start_image_matches_shared_fixture() {
+    let argv = Machine::named("web")
+        .unwrap()
+        .start()
+        .image("nginx")
+        .cpus(2)
+        .memory("512M")
+        .machine_args()
+        .expect("start-image argv");
+    assert_eq!(argv, fixture("start-image"));
+}
+
+#[test]
 fn exec_matches_shared_fixture() {
     let argv = Machine::named("web")
         .unwrap()
@@ -252,6 +265,7 @@ fn fixture_coverage_is_accounted_for() {
         "run-default",
         "shell",
         "start",
+        "start-image",
         "stop",
     ];
     assert_eq!(

--- a/tests/machine-fixtures/start-image.argv
+++ b/tests/machine-fixtures/start-image.argv
@@ -1,0 +1,8 @@
+start
+web
+--image
+nginx
+--cpus
+2
+--memory
+512M


### PR DESCRIPTION
feat(cli): auto-create persistent machines on mvmctl machine start

mvmctl machine start NAME previously failed when the persistent
machine spec did not exist. It now accepts the same source/config flags
as machine create and will create the spec on demand:

  mvmctl machine start web --image nginx --cpus 2 --memory 512M

If the machine already exists and no source flags are given, the
existing spec is reused. If source flags are given and the config
differs, the command errors unless --force is passed, in which case
the old instance is stopped and the spec recreated (matching the
reconcile semantics already used by machine run --name).

Changes:
- Extract MachineSpecInputs + build_machine_spec() helper shared by
  machine create and the new machine start auto-create path.
- Add MachineStartCreateFlags (flattened into MachineStartArgs and
  MachineStartCmd) with --image, --manifest, --net, --allow-host,
  --cpus, --cpu-limit, --timeout, --grants-file, --memory,
  --mem-initial, --profile, and --force.
- Implement resolve_start_spec() in lifecycle.rs to load, create, or
  reconcile the spec before boot.
- Add unit tests for parser acceptance, conflicts, create-on-missing,
  reuse, missing-without-source errors, and force-recreate.
- Add SDK argv fixture for start --image.

Workspace clippy and the mvm-cli test suite pass.
