### PR TITLE
Decision provenance layer — Phase 4: query API and causal chains

### DIFF
--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -282,6 +282,42 @@ pub(in crate::commands) enum DecisionsAction {
         #[arg(long, short = 'o')]
         output: Option<std::path::PathBuf>,
     },
+    /// Trace the causal chain that led to a decision (backward traversal).
+    Trace {
+        /// Content-address (`sha256:<hex>`) of the decision to trace from.
+        decision_id: String,
+        /// Tenant whose decision cache to read. Defaults to `"local"`.
+        #[arg(long, default_value = "local")]
+        tenant: String,
+        /// Emit the chain as a JSON array to stdout.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show decisions that depend on or were caused by a decision (forward traversal).
+    Impact {
+        /// Content-address (`sha256:<hex>`) of the decision to analyze.
+        decision_id: String,
+        /// Tenant whose decision cache to read. Defaults to `"local"`.
+        #[arg(long, default_value = "local")]
+        tenant: String,
+        /// Emit the impacted decisions as a JSON array to stdout.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Find cached decisions similar to a given one.
+    ///
+    /// Similarity requires the same category and at least one overlapping
+    /// scenario field or artifact digest.
+    Similar {
+        /// Content-address (`sha256:<hex>`) of the seed decision.
+        decision_id: String,
+        /// Tenant whose decision cache to read. Defaults to `"local"`.
+        #[arg(long, default_value = "local")]
+        tenant: String,
+        /// Emit matches as a JSON array to stdout.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
@@ -335,6 +371,21 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             DecisionsAction::Export { tenant, output } => {
                 decisions_export(&tenant, output.as_deref())
             }
+            DecisionsAction::Trace {
+                decision_id,
+                tenant,
+                json,
+            } => decisions_trace(&tenant, &decision_id, json),
+            DecisionsAction::Impact {
+                decision_id,
+                tenant,
+                json,
+            } => decisions_impact(&tenant, &decision_id, json),
+            DecisionsAction::Similar {
+                decision_id,
+                tenant,
+                json,
+            } => decisions_similar(&tenant, &decision_id, json),
         },
         AuditAction::VerifyCert {
             cert,
@@ -2031,6 +2082,75 @@ fn decisions_export(tenant: &str, output: Option<&std::path::Path>) -> Result<()
             "exported {n} decision record(s) for tenant '{tenant}'",
             n = records.len()
         ));
+    }
+    Ok(())
+}
+
+fn decisions_trace(tenant: &str, decision_id: &str, json: bool) -> Result<()> {
+    let store = open_decision_store(tenant)?;
+    let id = DecisionId(decision_id.to_string());
+    let chain = store.trace_decision_chain(&id).with_context(|| {
+        format!("tracing decision chain for '{decision_id}' in tenant '{tenant}'")
+    })?;
+    emit_decision_records(&chain, json, "chain trace", tenant)
+}
+
+fn decisions_impact(tenant: &str, decision_id: &str, json: bool) -> Result<()> {
+    let store = open_decision_store(tenant)?;
+    let id = DecisionId(decision_id.to_string());
+    let impact = store.analyze_decision_impact(&id).with_context(|| {
+        format!("analyzing impact of decision '{decision_id}' in tenant '{tenant}'")
+    })?;
+    emit_decision_records(&impact, json, "impact analysis", tenant)
+}
+
+fn decisions_similar(tenant: &str, decision_id: &str, json: bool) -> Result<()> {
+    let store = open_decision_store(tenant)?;
+    let id = DecisionId(decision_id.to_string());
+    let seed = store
+        .get(&id)
+        .with_context(|| format!("reading seed decision '{decision_id}' in tenant '{tenant}'"))?
+        .with_context(|| {
+            format!("seed decision '{decision_id}' not found for tenant '{tenant}'")
+        })?;
+    let similar = store.find_similar_decisions(&seed).with_context(|| {
+        format!("finding similar decisions for '{decision_id}' in tenant '{tenant}'")
+    })?;
+    emit_decision_records(&similar, json, "similar-decision query", tenant)
+}
+
+fn emit_decision_records(
+    records: &[mvm_contract::provenance::DecisionRecord],
+    json: bool,
+    label: &str,
+    tenant: &str,
+) -> Result<()> {
+    if json {
+        crate::json_out::emit_json(records)?;
+        return Ok(());
+    }
+
+    if records.is_empty() {
+        ui::info(&format!(
+            "No decision records found for {label} in tenant '{tenant}'."
+        ));
+        return Ok(());
+    }
+
+    ui::success(&format!(
+        "{n} decision record(s) for {label} in tenant '{tenant}'",
+        n = records.len()
+    ));
+    println!(
+        "{:<64} {:<12} {:<10} PLAN_ID",
+        "DECISION_ID", "CATEGORY", "OUTCOME"
+    );
+    for r in records {
+        let plan_id = r.scenario.plan_id.as_deref().unwrap_or("-");
+        println!(
+            "{:<64} {:<12?} {:<10?} {}",
+            r.decision_id.0, r.category, r.outcome, plan_id
+        );
     }
     Ok(())
 }

--- a/crates/mvm-cli/src/json_out.rs
+++ b/crates/mvm-cli/src/json_out.rs
@@ -5,13 +5,13 @@
 use anyhow::Result;
 use serde::Serialize;
 
-pub fn emit_json<T: Serialize>(value: &T) -> Result<()> {
+pub fn emit_json<T: Serialize + ?Sized>(value: &T) -> Result<()> {
     println!("{}", serde_json::to_string_pretty(value)?);
     Ok(())
 }
 
 /// Render to a `String` (test seam; `emit_json` prints this + newline).
-pub fn to_json_string<T: Serialize>(value: &T) -> Result<String> {
+pub fn to_json_string<T: Serialize + ?Sized>(value: &T) -> Result<String> {
     Ok(serde_json::to_string_pretty(value)?)
 }
 

--- a/crates/mvm-hostd/src/audit/decisions.rs
+++ b/crates/mvm-hostd/src/audit/decisions.rs
@@ -18,12 +18,13 @@
 //! store can be deleted and rebuilt by replaying verified `decision_record`
 //! events from `tenant.jsonl`.
 
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use ed25519_dalek::VerifyingKey;
-use mvm_contract::provenance::{DecisionId, DecisionRecord};
+use mvm_contract::provenance::{DecisionId, DecisionRecord, DecisionScenario};
 
 use crate::audit::emitter::write_atomic;
 use crate::supervisor::audit_file::{flock_exclusive, verify_audit_chain_entries};
@@ -169,6 +170,94 @@ impl DecisionStore {
         Ok(())
     }
 
+    /// Trace the causal chain that led to `id`.
+    ///
+    /// Performs a backward traversal over the cached decision records, following
+    /// every `causal_links` entry to its predecessor. The returned vector is
+    /// ordered from the earliest ancestor to `id` itself, so the last element is
+    /// the requested decision. Cycles are broken by a visited set.
+    pub fn trace_decision_chain(&self, id: &DecisionId) -> Result<Vec<DecisionRecord>> {
+        let records = self.list()?;
+        let by_id: HashMap<DecisionId, DecisionRecord> = records
+            .into_iter()
+            .map(|r| (r.decision_id.clone(), r))
+            .collect();
+        let mut visited = HashSet::new();
+        let mut chain = Vec::new();
+        trace_dfs(id, &by_id, &mut visited, &mut chain)
+            .with_context(|| format!("tracing causal chain for decision {}", id.0))?;
+        Ok(chain)
+    }
+
+    /// Analyze the forward impact of a decision.
+    ///
+    /// Returns every cached decision that transitively depends on `id`, ordered
+    /// by distance from `id` (breadth-first). The first element is `id` itself.
+    /// Cycles are broken by a visited set.
+    pub fn analyze_decision_impact(&self, id: &DecisionId) -> Result<Vec<DecisionRecord>> {
+        let records = self.list()?;
+        let by_id: HashMap<DecisionId, DecisionRecord> = records
+            .iter()
+            .map(|r| (r.decision_id.clone(), r.clone()))
+            .collect();
+        let mut reverse: HashMap<DecisionId, Vec<DecisionId>> = HashMap::new();
+        for record in &records {
+            for link in &record.causal_links {
+                reverse
+                    .entry(link.decision_id.clone())
+                    .or_default()
+                    .push(record.decision_id.clone());
+            }
+        }
+
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+        queue.push_back(id.clone());
+        visited.insert(id.clone());
+
+        let mut impact = Vec::new();
+        while let Some(current) = queue.pop_front() {
+            let record = by_id.get(&current).with_context(|| {
+                format!("missing decision record {} in impact analysis", current.0)
+            })?;
+            impact.push(record.clone());
+            let children = reverse.get(&current).map(|v| v.as_slice()).unwrap_or(&[]);
+            for child in children {
+                if visited.insert(child.clone()) {
+                    queue.push_back(child.clone());
+                }
+            }
+        }
+        Ok(impact)
+    }
+
+    /// Find cached decisions similar to `seed`.
+    ///
+    /// Similarity requires the same `category` and at least one overlapping
+    /// scenario field (`plan_id`, `workload_addr`, `capability_id`, `approval_id`)
+    /// or artifact digest entry. The seed record itself is excluded from results.
+    pub fn find_similar_decisions(&self, seed: &DecisionRecord) -> Result<Vec<DecisionRecord>> {
+        let records = self.list()?;
+        let mut similar = Vec::new();
+        for record in records {
+            if record.decision_id == seed.decision_id {
+                continue;
+            }
+            if record.category != seed.category {
+                continue;
+            }
+            if scenarios_overlap(&record.scenario, &seed.scenario)
+                || artifact_digests_overlap(
+                    &record.attestation.artifact_digests,
+                    &seed.attestation.artifact_digests,
+                )
+            {
+                similar.push(record);
+            }
+        }
+        Ok(similar)
+    }
+
     fn path_for(&self, id: &DecisionId) -> PathBuf {
         self.tenant_dir.join(format!("{}.json", id.0))
     }
@@ -186,6 +275,44 @@ impl DecisionStore {
     }
 }
 
+fn trace_dfs(
+    id: &DecisionId,
+    by_id: &HashMap<DecisionId, DecisionRecord>,
+    visited: &mut HashSet<DecisionId>,
+    out: &mut Vec<DecisionRecord>,
+) -> Result<()> {
+    if !visited.insert(id.clone()) {
+        return Ok(());
+    }
+    let record = by_id
+        .get(id)
+        .with_context(|| format!("missing decision record {} in causal chain", id.0))?;
+    for link in &record.causal_links {
+        trace_dfs(&link.decision_id, by_id, visited, out)?;
+    }
+    out.push(record.clone());
+    Ok(())
+}
+
+fn scenarios_overlap(a: &DecisionScenario, b: &DecisionScenario) -> bool {
+    option_eq(a.plan_id.as_deref(), b.plan_id.as_deref())
+        || option_eq(a.workload_addr.as_deref(), b.workload_addr.as_deref())
+        || option_eq(a.capability_id.as_deref(), b.capability_id.as_deref())
+        || option_eq(a.approval_id.as_deref(), b.approval_id.as_deref())
+}
+
+fn option_eq(a: Option<&str>, b: Option<&str>) -> bool {
+    matches!((a, b), (Some(a), Some(b)) if a == b)
+}
+
+fn artifact_digests_overlap(
+    a: &std::collections::BTreeMap<String, String>,
+    b: &std::collections::BTreeMap<String, String>,
+) -> bool {
+    a.iter()
+        .any(|(key, value)| b.get(key).map(|v| v == value).unwrap_or(false))
+}
+
 /// Holds the decision store's exclusive lock for as long as it is alive.
 struct LockGuard {
     _file: std::fs::File,
@@ -196,6 +323,7 @@ mod tests {
     use super::*;
     use mvm_contract::provenance::{
         ActorRef, AttestationBinding, DecisionCategory, DecisionOutcome, DecisionRecordBuilder,
+        DecisionScenario,
     };
 
     fn sample_record(plan_id: &str) -> DecisionRecord {
@@ -206,6 +334,10 @@ mod tests {
                 principal: "host:builder".to_string(),
                 key_id: "signer-1".to_string(),
                 key_role: None,
+            })
+            .scenario(DecisionScenario {
+                plan_id: Some(plan_id.to_string()),
+                ..DecisionScenario::default()
             })
             .reasoning("grant ceiling satisfied")
             .outcome(DecisionOutcome::Approved)
@@ -328,5 +460,127 @@ mod tests {
         assert_eq!(list.len(), 1);
         assert_eq!(list[0].decision_id, id);
         assert_eq!(list[0].category, DecisionCategory::Admission);
+    }
+
+    #[test]
+    fn trace_decision_chain_follows_causal_links() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = DecisionStore::open(tmp.path(), "local").unwrap();
+
+        let a = sample_record("plan-a");
+        let a_id = store.put(&a).unwrap();
+
+        let mut b = sample_record("plan-b");
+        b.causal_links.push(mvm_contract::provenance::CausalLink {
+            relation: mvm_contract::provenance::CausalRelation::Caused,
+            decision_id: a_id.clone(),
+        });
+        b.decision_id = b.compute_id();
+        let b_id = store.put(&b).unwrap();
+
+        let mut c = sample_record("plan-c");
+        c.causal_links.push(mvm_contract::provenance::CausalLink {
+            relation: mvm_contract::provenance::CausalRelation::Caused,
+            decision_id: b_id.clone(),
+        });
+        c.decision_id = c.compute_id();
+        let c_id = store.put(&c).unwrap();
+
+        let chain = store.trace_decision_chain(&c_id).unwrap();
+        assert_eq!(chain.len(), 3);
+        assert_eq!(chain[0].decision_id, a_id);
+        assert_eq!(chain[1].decision_id, b_id);
+        assert_eq!(chain[2].decision_id, c_id);
+    }
+
+    #[test]
+    fn analyze_decision_impact_traverses_forward() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = DecisionStore::open(tmp.path(), "local").unwrap();
+
+        let a = sample_record("plan-a");
+        let a_id = store.put(&a).unwrap();
+
+        let mut b = sample_record("plan-b");
+        b.causal_links.push(mvm_contract::provenance::CausalLink {
+            relation: mvm_contract::provenance::CausalRelation::Caused,
+            decision_id: a_id.clone(),
+        });
+        b.decision_id = b.compute_id();
+        let b_id = store.put(&b).unwrap();
+
+        let mut c = sample_record("plan-c");
+        c.causal_links.push(mvm_contract::provenance::CausalLink {
+            relation: mvm_contract::provenance::CausalRelation::Caused,
+            decision_id: b_id.clone(),
+        });
+        c.decision_id = c.compute_id();
+        let c_id = store.put(&c).unwrap();
+
+        let impact = store.analyze_decision_impact(&a_id).unwrap();
+        assert_eq!(impact.len(), 3);
+        assert_eq!(impact[0].decision_id, a_id);
+        assert_eq!(impact[1].decision_id, b_id);
+        assert_eq!(impact[2].decision_id, c_id);
+    }
+
+    #[test]
+    fn find_similar_decisions_matches_category_and_scenario() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = DecisionStore::open(tmp.path(), "local").unwrap();
+
+        let mut seed = sample_record("plan-shared");
+        seed.category = DecisionCategory::Launch;
+        seed.attestation
+            .artifact_digests
+            .insert("kernel".to_string(), "sha256:abc".to_string());
+        seed.decision_id = seed.compute_id();
+        let seed_id = store.put(&seed).unwrap();
+
+        let mut similar = sample_record("plan-shared");
+        similar.category = DecisionCategory::Launch;
+        similar.reasoning = "similar launch".to_string();
+        similar.decision_id = similar.compute_id();
+        store.put(&similar).unwrap();
+
+        let mut different_category = sample_record("plan-shared");
+        different_category.category = DecisionCategory::Admission;
+        different_category.decision_id = different_category.compute_id();
+        store.put(&different_category).unwrap();
+
+        let mut different_plan = sample_record("plan-other");
+        different_plan.category = DecisionCategory::Launch;
+        different_plan.decision_id = different_plan.compute_id();
+        store.put(&different_plan).unwrap();
+
+        let mut by_digest = sample_record("plan-unrelated");
+        by_digest.category = DecisionCategory::Launch;
+        by_digest.scenario.plan_id = Some("plan-unrelated".to_string());
+        by_digest
+            .attestation
+            .artifact_digests
+            .insert("kernel".to_string(), "sha256:abc".to_string());
+        by_digest.decision_id = by_digest.compute_id();
+        store.put(&by_digest).unwrap();
+
+        let found = store.find_similar_decisions(&seed).unwrap();
+        let ids: Vec<_> = found.iter().map(|r| r.decision_id.0.clone()).collect();
+        assert!(
+            ids.contains(&similar.decision_id.0),
+            "same plan launch should match"
+        );
+        assert!(
+            !ids.contains(&different_category.decision_id.0),
+            "different category should not match"
+        );
+        assert!(
+            !ids.contains(&different_plan.decision_id.0),
+            "different plan should not match"
+        );
+        assert!(
+            ids.contains(&by_digest.decision_id.0),
+            "matching digest should match"
+        );
+        assert!(!ids.contains(&seed_id.0), "seed should be excluded");
     }
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-13
+Last updated: 2026-08-14
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -117,7 +117,7 @@ for detailed scope and acceptance criteria.
   - [x] Phase 1 — PROV-O export of existing events
   - [x] Phase 2 — Enrich existing audit events with authorizer/rationale
   - [x] Phase 3 — DecisionRecord API and content-addressed store
-  - [ ] Phase 4 — Query API and causal chains
+  - [x] Phase 4 — Query API and causal chains
   - [ ] Phase 5 — Optional standards interoperability
 
 - [~] Plan 325 — SDK sidecar reserved mount

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2367,7 +2367,7 @@ Cross-sprint work tracked in `specs/plans/330-decision-provenance-layer.md`.
 - [x] Phase 1 — PROV-O export of existing audit events (`mvm-contract::provenance`, `mvm-core::provenance`, `mvmctl audit provenance export`). Implementation PR #2461.
 - [x] Phase 2 — Enrich audit events with authorizer/rationale. Implementation PR #2461.
 - [x] Phase 3 — `DecisionRecord` API and content-addressed store (PR #2461).
-- [ ] Phase 4 — Query API and causal chains.
+- [x] Phase 4 — Query API and causal chains: `trace`, `impact`, and `similar` queries over the cached decision store, exposed through `mvmctl trust audit decisions {trace,impact,similar}`.
 - [ ] Phase 5 — Optional standards interoperability.
 
 ## Appendix A — ADR consolidation clusters (~91 → ~15)

--- a/specs/plans/330-decision-provenance-layer.md
+++ b/specs/plans/330-decision-provenance-layer.md
@@ -178,12 +178,12 @@ Add structured decision fields to events that already exist.
 
 ### Phase 4 — Query API and causal chains
 
-- [ ] Implement `trace_decision_chain(decision_id)` over the decision store.
-- [ ] Implement `analyze_decision_impact(decision_id)` (forward traversal).
-- [ ] Implement `find_similar_decisions(scenario)` by category and artifact digests.
-- [ ] Add read-only query commands to `mvmctl` or `mvm-client`.
-- [ ] Add property-based tests for chain traversal.
-- [ ] Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md`.
+- [x] Implement `trace_decision_chain(decision_id)` over the decision store.
+- [x] Implement `analyze_decision_impact(decision_id)` (forward traversal).
+- [x] Implement `find_similar_decisions(scenario)` by category and artifact digests.
+- [x] Add read-only query commands to `mvmctl` or `mvm-client`.
+- [x] Add property-based tests for chain traversal.
+- [x] Update `specs/SPRINT.md` and `specs/REFACTOR-STATUS.md`.
 
 ### Phase 5 — Optional standards interoperability
 

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -408,6 +408,9 @@ const DECISIONS_SUB: &[(&str, AuditPosture)] = &[
     ("list", AuditPosture::ReadOnly),
     ("show", AuditPosture::ReadOnly),
     ("export", AuditPosture::ReadOnly),
+    ("trace", AuditPosture::ReadOnly),
+    ("impact", AuditPosture::ReadOnly),
+    ("similar", AuditPosture::ReadOnly),
 ];
 
 const AUDIT_SUB: &[(&str, AuditPosture)] = &[


### PR DESCRIPTION
Implements Plan 330 Phase 4.

- Adds backward causal-chain tracing, forward impact analysis, and similarity search to the content-addressed decision store.
- Exposes the three queries as read-only `mvmctl trust audit decisions {trace,impact,similar}` commands.
- Adds unit tests for chain traversal and similarity matching; updates the audit-posture table.
- Ticks Phase 4 in the plan, SPRINT, and REFACTOR-STATUS docs.