### PR TITLE
feat(audit): mirror chain-signed audit appends to tracing (#2107)

### DIFF
--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -42,7 +42,7 @@ use crate::audit::decisions::DecisionStore;
 use crate::audit::receipt_export::audit_entry_to_receipt;
 use crate::audit::receipt_store::ReceiptStore;
 use crate::supervisor::{
-    AuditSigner, FileAuditSigner, PlanAuditEntry, for_plan, transcript_sealed,
+    AuditSigner, FileAuditSigner, PlanAuditEntry, audit_mirror, for_plan, transcript_sealed,
 };
 use anyhow::{Context, Result};
 use base64::Engine;
@@ -1156,6 +1156,7 @@ impl AuditEmitter {
                 "emit: signer"
             );
         }
+        audit_mirror::emit_mirror_event(entry);
         let t_r = std::time::Instant::now();
         self.emit_receipt_for_entry(entry);
         tracing::debug!(ms = t_r.elapsed().as_secs_f64() * 1000.0, "emit: receipt");

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -302,7 +302,7 @@ impl AuditSigner for CapturingAuditSigner {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use chrono::TimeZone;
     use mvm_core::plan::{
@@ -315,7 +315,7 @@ mod tests {
     };
     use std::collections::BTreeMap;
 
-    fn sample_plan() -> ExecutionPlan {
+    pub(crate) fn sample_plan() -> ExecutionPlan {
         ExecutionPlan {
             grants: None,
             environment: None,

--- a/crates/mvm-hostd/src/supervisor/audit_mirror.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_mirror.rs
@@ -1,0 +1,170 @@
+//! Fire-and-forget tracing mirror for chain-signed audit appends.
+//!
+//! Every successful chain append also emits one diagnostic `tracing` event at
+//! the dedicated target `mvm::audit`. The mirror carries only the fixed,
+//! non-sensitive envelope fields of the audit entry; the free-form `labels`
+//! map is deliberately omitted because it may contain secrets, environment
+//! values, credentials, host paths, or raw policy payloads.
+//!
+//! The mirror is isolated from the chain write: a missing, slow, or panicking
+//! subscriber cannot block, reorder, or fail a chain append, and cannot
+//! change what is signed.
+
+use crate::supervisor::audit::PlanAuditEntry;
+
+/// Tracing target used for all audit-mirror events.
+pub const TARGET: &str = "mvm::audit";
+
+/// Emit a single diagnostic tracing event for `entry`.
+///
+/// This function is intentionally isolated from chain signing. It catches any
+/// subscriber panic so that a misbehaving observability layer can never
+/// propagate into the audit path.
+pub fn emit_mirror_event(entry: &PlanAuditEntry) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tracing::info!(
+            target: TARGET,
+            tenant = %entry.tenant.0,
+            plan_id = %entry.plan_id.0,
+            plan_version = %entry.plan_version,
+            image_name = %entry.image_name,
+            image_sha256 = %entry.image_sha256,
+            event = %entry.event,
+            timestamp = %entry.timestamp,
+            "audit entry appended to chain",
+        );
+    }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::layer::{Context, Layer};
+    use tracing_subscriber::prelude::*;
+
+    #[derive(Default)]
+    struct FieldCapture(BTreeMap<String, String>);
+
+    impl Visit for FieldCapture {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.0
+                .insert(field.name().to_string(), format!("{:?}", value));
+        }
+    }
+
+    type CapturedEvents = Arc<Mutex<Vec<(String, BTreeMap<String, String>)>>>;
+
+    struct CaptureLayer {
+        events: CapturedEvents,
+    }
+
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let mut capture = FieldCapture::default();
+            event.record(&mut capture);
+            self.events
+                .lock()
+                .expect("capture mutex poisoned")
+                .push((event.metadata().target().to_string(), capture.0));
+        }
+    }
+
+    fn sample_entry(event: &str) -> PlanAuditEntry {
+        PlanAuditEntry {
+            timestamp: chrono::Utc::now(),
+            tenant: mvm_contract::plan::TenantId("tenant-a".to_string()),
+            plan_id: mvm_contract::plan::PlanId("plan-123".to_string()),
+            plan_version: 7,
+            bundle_id: None,
+            bundle_version: None,
+            image_name: "alpine".into(),
+            image_sha256: "deadbeef".into(),
+            event: event.into(),
+            labels: BTreeMap::from([("secret_key".into(), "secret_value".into())]),
+        }
+    }
+
+    #[test]
+    fn mirror_event_carries_non_sensitive_envelope_fields() {
+        let events: CapturedEvents = Arc::new(Mutex::new(Vec::new()));
+        let layer = CaptureLayer {
+            events: events.clone(),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        let entry = sample_entry("plan.admitted");
+        tracing::subscriber::with_default(subscriber, || {
+            emit_mirror_event(&entry);
+        });
+
+        let captured = events.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let (target, fields) = &captured[0];
+        assert_eq!(target, TARGET);
+        assert_eq!(fields.get("tenant"), Some(&"tenant-a".to_string()));
+        assert_eq!(fields.get("plan_id"), Some(&"plan-123".to_string()));
+        assert_eq!(fields.get("plan_version"), Some(&"7".to_string()));
+        assert_eq!(fields.get("image_name"), Some(&"alpine".to_string()));
+        assert_eq!(fields.get("image_sha256"), Some(&"deadbeef".to_string()));
+        assert_eq!(fields.get("event"), Some(&"plan.admitted".to_string()));
+        assert!(fields.contains_key("timestamp"));
+        assert!(
+            !fields.contains_key("labels"),
+            "free-form labels must not appear in the mirror"
+        );
+        assert!(
+            !fields.values().any(|v| v.contains("secret_value")),
+            "mirror must not leak sensitive label values"
+        );
+    }
+
+    #[test]
+    fn panicking_subscriber_does_not_block_chain_write() {
+        struct PanicLayer;
+        impl<S> Layer<S> for PanicLayer
+        where
+            S: tracing::Subscriber,
+        {
+            fn on_event(&self, _event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                panic!("hostile subscriber");
+            }
+        }
+
+        let signer: Arc<crate::supervisor::audit::CapturingAuditSigner> =
+            Arc::new(crate::supervisor::audit::CapturingAuditSigner::new());
+        let recorder = crate::supervisor::audit_recorder::Recorder::new(
+            signer.clone(),
+            mvm_contract::plan::TenantId("tenant-a".to_string()),
+        );
+
+        let subscriber = tracing_subscriber::registry().with(PanicLayer);
+        let result = tracing::subscriber::with_default(subscriber, || {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap()
+                    .block_on(recorder.record_plan_bound(
+                        crate::supervisor::audit_recorder::EventCategory::Plan,
+                        "plan.launched",
+                        &crate::supervisor::audit::tests::sample_plan(),
+                        None,
+                        [],
+                    ))
+            }))
+        });
+
+        // The chain write itself must succeed; only the mirror may panic.
+        assert!(
+            result.is_ok(),
+            "chain append must survive a panicking subscriber"
+        );
+        assert_eq!(signer.entries().len(), 1);
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/audit_recorder.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_recorder.rs
@@ -55,6 +55,7 @@ use mvm_core::plan::{ExecutionPlan, PlanId, TenantId};
 use mvm_core::policy::PolicyBundle;
 
 use crate::supervisor::audit::{AuditError, AuditSigner, PlanAuditEntry, for_plan};
+use crate::supervisor::audit_mirror;
 
 /// Canonical audit-event categories. The string form (the
 /// `event_name` field's prefix) is the wire-stable identifier
@@ -248,6 +249,7 @@ impl Recorder {
         let merged = merge_extras(category, extras);
         let entry = for_plan(plan, bundle, event_name, merged);
         self.signer.sign_and_emit(&entry).await?;
+        audit_mirror::emit_mirror_event(&entry);
         self.bump_metric(category);
         Ok(())
     }
@@ -359,7 +361,7 @@ fn merge_extras(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::supervisor::audit::CapturingAuditSigner;
 

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -32,6 +32,7 @@ pub mod audit;
 pub mod audit_checkpoint;
 pub mod audit_dedup;
 pub mod audit_file;
+pub mod audit_mirror;
 pub mod audit_recorder;
 pub mod audit_segment;
 pub mod audit_set;


### PR DESCRIPTION
Closes #2107.

Adds a fire-and-forget `tracing` mirror so operators can observe audit activity through standard subscribers without the signed chain depending on them.

What changed:
- New `mvm-hostd::supervisor::audit_mirror` module emits one `tracing::info!` event at target `mvm::audit` per successful chain append.
- The mirror carries only fixed non-sensitive envelope fields (tenant, plan_id, plan_version, image_name, image_sha256, event, timestamp); free-form labels are omitted to avoid leaking secrets, credentials, host paths, or raw policy payloads.
- Isolated from the chain write via `catch_unwind`/`AssertUnwindSafe`, so a panicking or slow subscriber cannot block, reorder, or fail a chain append.
- Wired into both production append paths: `Recorder::record_plan_bound` / `record_unbound` and `AuditEmitter::emit_entry_blocking`.
- Tests verify field capture, sensitive-label exclusion, and that a panicking subscriber leaves the chain write intact.

Verification:
- `cargo test -p mvm-hostd --lib supervisor::audit_mirror` passes.
- `cargo clippy -p mvm-hostd --all-targets -- -D warnings` passes on macOS.