### PR TITLE
docs+test: machine start auto-create follow-up

### DIFF
--- a/features/suites/s0_cli/machine_lifecycle_contract.feature
+++ b/features/suites/s0_cli/machine_lifecycle_contract.feature
@@ -49,3 +49,43 @@ Feature: machine lifecycle request contract
     Then the command exits with code 1
     And the error output contains "does not exist"
     And the error output contains "machine create ghost"
+
+  # `machine start` can create the spec on demand, so the request-contract
+  # behavior is testable without booting a guest.
+  Scenario: start with a source creates the spec without booting when dry-run
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "machine start bdd-start-create --image alpine --dry-run"
+    Then the command exits with code 0
+    And the output contains "no VM will be booted"
+    And the output contains "image: OCI reference"
+
+  Scenario: start without a source on a missing machine suggests creating it
+    When I run mvmctl with "machine start bdd-missing" and an isolated mvm home
+    Then the command exits with code 1
+    And the error output contains "does not exist"
+    And the error output contains "--image"
+
+  Scenario: start with the same config reuses an existing machine
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "machine create bdd-reuse --image alpine"
+    Then the command exits with code 0
+    When I run mvmctl in the isolated mvm home with "machine start bdd-reuse --image alpine --dry-run"
+    Then the command exits with code 0
+    And the output contains "no VM will be booted"
+
+  Scenario: start with a changed config refuses to recreate without force
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "machine create bdd-change --image alpine"
+    Then the command exits with code 0
+    When I run mvmctl in the isolated mvm home with "machine start bdd-change --image ubuntu --dry-run"
+    Then the command exits with code 1
+    And the error output contains "different config"
+    And the error output contains "--force"
+
+  Scenario: start with a changed config and force recreates the machine
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "machine create bdd-force --image alpine"
+    Then the command exits with code 0
+    When I run mvmctl in the isolated mvm home with "machine start bdd-force --image ubuntu --force --dry-run"
+    Then the command exits with code 0
+    And the output contains "no VM will be booted"

--- a/public/src/content/docs/getting-started/quickstart.md
+++ b/public/src/content/docs/getting-started/quickstart.md
@@ -35,8 +35,13 @@ capability, read [Machine limitations](/guides/machine-limitations/).
 For a named machine that survives across starts:
 
 ```bash
+# Create the spec, then start it
 mvmctl machine create alpine-dev --image alpine
 mvmctl machine start alpine-dev
+
+# Or create and start in one command
+mvmctl machine start alpine-dev --image alpine
+
 mvmctl machine exec alpine-dev -- uname -a
 mvmctl machine stop alpine-dev
 ```

--- a/public/src/content/docs/guides/machine-use-cases.md
+++ b/public/src/content/docs/guides/machine-use-cases.md
@@ -19,6 +19,7 @@ boundary only when a workflow actually needs Linux build or evaluation work.
 | Run a command in an OCI image | `mvmctl machine run --image ghcr.io/org/app:tag -- <cmd>` | OCI provenance, cache reuse, admission, receipts, and audit. |
 | Use a local image archive | `mvmctl machine run --image-archive ./image.tar -- <cmd>` | Offline-friendly image input through the same hardened unpack/admission path. |
 | Keep a dev machine around | `mvmctl machine create dev --image alpine` | Durable spec plus `start`, `exec`, `shell`, `stop`, `inspect`, and `rm`. |
+| Start a machine, creating it if missing | `mvmctl machine start dev --image alpine` | Combines `create` + `start`; useful for scripts and idempotent workflows. |
 | Declare a repeatable machine | `mvmctl machine create dev --manifest ./mvm.toml` | TOML-backed image, sizing, network, volume, and dev-init settings. |
 | Branch a running machine | `mvmctl machine fork dev --as dev-branch` | Snapshot a running VM and boot a fresh child with new identity and secrets. |
 | Branch a saved checkpoint | `mvmctl machine restore ckpt-dev-123 --as dev-restore` | Restore a `vm_full` checkpoint into a fresh child VM with new identity and secrets. |
@@ -56,8 +57,13 @@ Use digest-pinned image references for production or repeatable environments.
 Use named machines when you want state across starts:
 
 ```bash
+# Create and start as separate steps
 mvmctl machine create alpine-dev --image alpine:3.20 --net
 mvmctl machine start alpine-dev
+
+# Or combine them: start creates the spec if it does not exist
+mvmctl machine start alpine-dev --image alpine:3.20 --net
+
 mvmctl machine exec alpine-dev -- apk add jq
 mvmctl machine shell alpine-dev
 mvmctl machine stop alpine-dev

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -448,6 +448,11 @@ guest, on any tier.
 | `mvmctl machine start <name> --dry-run --json` | Print the machine-start preflight summary as redacted JSON |
 | `mvmctl machine start <name> --json` | Print a redacted JSON start summary instead of plain text |
 | `mvmctl machine start <name> --receipt <path>` | Write a signed machine-start receipt with effective policy plus the resolved digest and start timestamp |
+| `mvmctl machine start <name> --image <ref>` | Start a persisted machine, creating its spec on demand if it does not exist. Combines `machine create <name> --image <ref>` and `machine start <name>` into one command |
+| `mvmctl machine start <name> --manifest <path>` | When auto-creating, source defaults (image, sizing, network, volumes, dev-init) from an image-backed `mvm.toml` / `Mvmfile.toml` |
+| `mvmctl machine start <name> --image <ref> --cpus N --memory SIZE` | Size the machine when auto-creating it (same defaults as `machine create`) |
+| `mvmctl machine start <name> --image <ref> --net --allow-host <host[:port]>` | Set egress policy when auto-creating the machine |
+| `mvmctl machine start <name> --image <ref> --force` | If the machine exists with a different config, stop the old instance, overwrite the spec, and start. Without `--force` a config mismatch errors |
 | `mvmctl machine restart <name>...` | Restart one or more named machines: stop if running, then start (same stop→start as a config-change recreate). This is also how a running machine picks up a newer version-matched runtime overlay. |
 | `mvmctl machine ls` (alias `ps`) | List persisted named machine specs |
 | `mvmctl machine ls --json` | Print persisted named machine specs as JSON |


### PR DESCRIPTION
Follow-up to #2469 (already merged), adding the docs and BDD coverage for
the new `mvmctl machine start --image` auto-create behavior.

Changes:
- docs: document `machine start --image` and related flags in the CLI
  reference, machine use-cases guide, and quickstart.
- test(bdd): five hermetic scenarios covering create-on-start, missing
  machine suggestion, config reuse, config-change refusal, and
  `--force` recreate.

All scenarios in `machine_lifecycle_contract.feature` pass (10 scenarios,
56 steps).
