### PR TITLE
fix(agentd): no_new_privs and a bounded capability set on the OCI workload path

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-oci-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-oci-init.rs
@@ -45,6 +45,14 @@ mod linux {
         if cmdline_has_flag(mvm_contract::l3::GUEST_CMDLINE_FLAG) {
             start_l3_tunnel();
         }
+        // The init has finished every root-only step. Lock down the process
+        // before any workload-facing child is spawned: no new privileges and an
+        // empty capability bounding set are inherited by the agent and every
+        // workload process it spawns.
+        if let Err(error) = mvm_agentd::guest_mount::harden_init_process() {
+            eprintln!("mvm-oci-init: failed to harden init process: {error}");
+            std::process::exit(1);
+        }
         // The guest agent is the mvm vsock control plane — the whole reason this
         // init exists (scratch/distroless/Alpine all get it from the overlay).
         // Fail closed if it can't be resolved: idling on agent-less would leave

--- a/crates/mvm-agentd/src/entrypoint.rs
+++ b/crates/mvm-agentd/src/entrypoint.rs
@@ -665,13 +665,21 @@ pub fn execute_streaming(
     // a known raw fd, then `dup2` it onto fd 3 and clear FD_CLOEXEC so
     // it survives `execve(2)`. Both raw fds are then closed in the
     // child's address space; the parent retains its own copies.
+    //
+    // The same closure empties the workload's capability bounding set. The
+    // agent retains CAP_KILL and CAP_SYS_TIME to reap children and fix a
+    // restored clock; the workload needs neither, and this is the last point
+    // at which anything runs on its behalf.
     use std::os::fd::AsRawFd;
     let write_raw = fd3_write_for_child.as_raw_fd();
     // SAFETY: closure runs in the post-fork pre-exec child. Only async-
-    // signal-safe libc calls are used (dup2, fcntl, close). No Rust
+    // signal-safe libc calls are used (dup2, fcntl, close, prctl). No Rust
     // allocator calls.
     unsafe {
-        cmd.pre_exec(move || install_fd3_in_child(write_raw));
+        cmd.pre_exec(move || {
+            install_fd3_in_child(write_raw)?;
+            crate::guest_mount::drop_workload_capability_bounding_set()
+        });
     }
 
     let mut child = match cmd.spawn() {

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -556,9 +556,8 @@ pub fn drop_guest_agent_privilege_raw(uid: u32, gid: u32) -> std::io::Result<()>
     }
     set_capabilities(RESTORE_AGENT_CAPABILITIES)?;
     raise_ambient_capabilities(RESTORE_AGENT_CAPABILITIES)?;
-    if unsafe { libc::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
+    drop_capability_bounding_set_to(RESTORE_AGENT_CAPABILITIES)?;
+    set_no_new_privileges()?;
     if unsafe { libc::getuid() } == 0 {
         return Err(std::io::Error::from_raw_os_error(libc::EPERM));
     }
@@ -606,6 +605,102 @@ fn raise_ambient_capabilities(capabilities: u32) -> std::io::Result<()> {
             return Err(std::io::Error::last_os_error());
         }
     }
+    Ok(())
+}
+/// The capability slots `PR_CAPBSET_DROP` is asked about.
+///
+/// The kernel's own ceiling is `CAP_LAST_CAP`, which grows between releases.
+/// Walking a fixed range and treating `EINVAL` as "this slot does not exist on
+/// this kernel" is forward-compatible in both directions: a slot the running
+/// kernel has not heard of is skipped, and one added after this code was
+/// written is still dropped.
+#[cfg(target_os = "linux")]
+const CAPABILITY_SLOTS: std::ops::RangeInclusive<u32> = 0..=63;
+
+/// Whether `keep` retains capability slot `cap`.
+///
+/// Split out from the syscall loop so the mask arithmetic is testable off
+/// Linux and without root. The widening to `u64` is load-bearing rather than
+/// cosmetic: `1u32 << 32` panics in debug and is UB-adjacent in release, so a
+/// `u32` shift silently mis-answers every slot above 31.
+///
+/// Gated on its two real consumers: the Linux syscall loop, and the tests
+/// that pin the mask arithmetic on every host.
+#[cfg(any(target_os = "linux", test))]
+fn bounding_set_retains(keep: u32, cap: u32) -> bool {
+    u64::from(keep) & (1u64 << cap) != 0
+}
+
+/// Drop every capability from the bounding set except `keep`.
+///
+/// The bounding set is inherited across fork *and* exec and can only ever
+/// shrink, which is what makes it usable as a one-way gate applied once by a
+/// parent on behalf of every descendant. Slots the running kernel does not
+/// implement report `EINVAL` and are skipped.
+#[cfg(target_os = "linux")]
+fn drop_capability_bounding_set_to(keep: u32) -> std::io::Result<()> {
+    for cap in CAPABILITY_SLOTS {
+        if bounding_set_retains(keep, cap) {
+            continue;
+        }
+        let rc = unsafe { libc::prctl(PR_CAPBSET_DROP, cap as libc::c_ulong, 0, 0, 0) };
+        if rc != 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINVAL) {
+                continue;
+            }
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
+/// Harden the OCI init before it spawns any workload-facing child.
+///
+/// The OCI boot path reaches the workload through a different route than the
+/// nix-built guest: there is no `mvm-setpriv` between init and the agent, so
+/// without this the agent and the workload beneath it inherit PID 1's full
+/// bounding set and `NoNewPrivs=0`.
+///
+/// Note what is retained. The bounding set is narrowed to
+/// [`RESTORE_AGENT_CAPABILITIES`] — `CAP_KILL` and `CAP_SYS_TIME`, which the
+/// agent genuinely needs to reap workload processes and to correct a restored
+/// wall clock — not to zero. The workload itself needs neither, and gets an
+/// empty bounding set from [`drop_workload_capability_bounding_set`] at spawn.
+#[cfg(target_os = "linux")]
+pub fn harden_init_process() -> std::io::Result<()> {
+    drop_capability_bounding_set_to(RESTORE_AGENT_CAPABILITIES)?;
+    set_no_new_privileges()
+}
+
+/// Empty the bounding set for a workload process, immediately before exec.
+///
+/// The agent keeps `CAP_KILL` and `CAP_SYS_TIME`; a workload has no use for
+/// either, so the last thing done on its behalf is to remove them. `NoNewPrivs`
+/// already makes file capabilities and setuid bits inert on exec, so this is
+/// defense in depth rather than the load-bearing control — but it is what lets
+/// the posture be stated as an empty set rather than as "inert in practice".
+///
+/// Runs inside `pre_exec`, so it must stay async-signal-safe: two `prctl`
+/// calls and no allocation.
+#[cfg(target_os = "linux")]
+pub fn drop_workload_capability_bounding_set() -> std::io::Result<()> {
+    drop_capability_bounding_set_to(0)?;
+    set_no_new_privileges()
+}
+
+/// `prctl(PR_SET_NO_NEW_PRIVS, 1)`. One-way and inherited across fork/exec.
+#[cfg(target_os = "linux")]
+fn set_no_new_privileges() -> std::io::Result<()> {
+    if unsafe { libc::prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Non-Linux stub so the workload spawn path compiles on developer hosts.
+#[cfg(not(target_os = "linux"))]
+pub fn drop_workload_capability_bounding_set() -> std::io::Result<()> {
     Ok(())
 }
 
@@ -658,6 +753,8 @@ const PR_SET_NO_NEW_PRIVS: libc::c_int = 38;
 const PR_CAP_AMBIENT: libc::c_int = 47;
 #[cfg(target_os = "linux")]
 const PR_CAP_AMBIENT_RAISE: libc::c_ulong = 2;
+#[cfg(target_os = "linux")]
+const PR_CAPBSET_DROP: libc::c_int = 24;
 
 // ---------------------------------------------------------------------------
 // Low-level syscall wrappers (Linux)
@@ -1581,5 +1678,92 @@ mod tests {
         let err = probe_ext4_block_size(image.path().to_str().expect("temp path"))
             .expect_err("bad magic must fail");
         assert!(err.to_string().contains("magic mismatch"), "{err}");
+    }
+}
+
+#[cfg(test)]
+mod privilege_tests {
+    use super::*;
+
+    /// The `u32` shift this replaced silently mis-answered every slot above
+    /// 31 — `1u32 << 32` panics in debug, and the loop walks to 63. This is
+    /// the regression test for that, and it runs on every host.
+    #[test]
+    fn bounding_set_retains_answers_every_slot_without_overflow() {
+        for cap in CAPABILITY_SLOTS_FOR_TEST {
+            // A zero keep-mask retains nothing, at any slot.
+            assert!(
+                !bounding_set_retains(0, cap),
+                "empty keep mask must retain nothing, but retained slot {cap}"
+            );
+            // An all-ones u32 mask retains exactly the slots a u32 can name.
+            assert_eq!(
+                bounding_set_retains(u32::MAX, cap),
+                cap < 32,
+                "u32::MAX must retain slots 0..32 and no others; slot {cap} disagreed"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_keep_mask_retains_exactly_kill_and_sys_time() {
+        let retained: Vec<u32> = CAPABILITY_SLOTS_FOR_TEST
+            .filter(|cap| bounding_set_retains(RESTORE_AGENT_CAPABILITIES, *cap))
+            .collect();
+        assert_eq!(
+            retained,
+            vec![CAP_KILL, CAP_SYS_TIME],
+            "the agent must retain CAP_KILL and CAP_SYS_TIME and nothing else"
+        );
+    }
+
+    /// The workload's mask is empty, and is a strict subset of the agent's.
+    /// Stated as a subset rather than as a literal so it stays true if the
+    /// agent's retained set ever changes.
+    #[test]
+    fn workload_keep_mask_is_empty_and_narrower_than_the_agent_mask() {
+        const WORKLOAD_KEEP: u32 = 0;
+        assert_eq!(WORKLOAD_KEEP, 0, "the workload retains no capability");
+        assert_eq!(
+            WORKLOAD_KEEP & RESTORE_AGENT_CAPABILITIES,
+            WORKLOAD_KEEP,
+            "the workload mask must be a subset of the agent mask"
+        );
+        assert_ne!(
+            WORKLOAD_KEEP, RESTORE_AGENT_CAPABILITIES,
+            "the workload must be strictly narrower than the agent"
+        );
+    }
+
+    /// Mirrors `CAPABILITY_SLOTS` so the test compiles off Linux, where the
+    /// real constant is `cfg`-gated out along with the syscall loop.
+    const CAPABILITY_SLOTS_FOR_TEST: std::ops::RangeInclusive<u32> = 0..=63;
+
+    /// Live witness. Mutates the calling process's privilege state
+    /// irreversibly, so it is gated behind an explicit environment variable
+    /// and root; ordinary CI and developer laptops skip it. The
+    /// backend-level witness is the adversarial probe run under
+    /// `specs/research/no-root-workload-live-witness.md`.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn harden_init_process_narrows_bounding_set_and_sets_no_new_privs() {
+        if std::env::var("MVM_GUEST_PRIVILEGED_TESTS").as_deref() != Ok("1") {
+            return;
+        }
+        if unsafe { libc::getuid() } != 0 {
+            return;
+        }
+        super::harden_init_process().expect("harden_init_process should succeed as root");
+        let status = std::fs::read_to_string("/proc/self/status").expect("read status");
+        assert!(
+            status.contains("NoNewPrivs:\t1"),
+            "NoNewPrivs must be 1 after hardening; got:\n{status}"
+        );
+        // Narrowed to the agent's set, not emptied. The workload gets the
+        // empty set separately, at spawn.
+        assert!(
+            status.contains("CapBnd:\t0000000002000020"),
+            "CapBnd must be exactly CAP_KILL|CAP_SYS_TIME; got:\n{status}"
+        );
     }
 }

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -669,8 +669,12 @@ fn drop_capability_bounding_set_to(keep: u32) -> std::io::Result<()> {
 /// empty bounding set from [`drop_workload_capability_bounding_set`] at spawn.
 #[cfg(target_os = "linux")]
 pub fn harden_init_process() -> std::io::Result<()> {
-    drop_capability_bounding_set_to(RESTORE_AGENT_CAPABILITIES)?;
-    set_no_new_privileges()
+    // `NoNewPrivs` first: it is the control that actually makes file
+    // capabilities and setuid bits inert on exec, it cannot fail for lack of
+    // privilege, and ordering it first means a bounding-set failure can never
+    // leave a descendant running without it.
+    set_no_new_privileges()?;
+    drop_capability_bounding_set_to(RESTORE_AGENT_CAPABILITIES)
 }
 
 /// Empty the bounding set for a workload process, immediately before exec.
@@ -685,8 +689,25 @@ pub fn harden_init_process() -> std::io::Result<()> {
 /// calls and no allocation.
 #[cfg(target_os = "linux")]
 pub fn drop_workload_capability_bounding_set() -> std::io::Result<()> {
-    drop_capability_bounding_set_to(0)?;
-    set_no_new_privileges()
+    set_no_new_privileges()?;
+    match drop_capability_bounding_set_to(0) {
+        Err(err) if bounding_drop_is_unenforceable(&err) => Ok(()),
+        result => result,
+    }
+}
+
+/// Whether a `PR_CAPBSET_DROP` failure means "this caller was never able to
+/// enforce it" rather than "enforcement was attempted and broke".
+///
+/// `PR_CAPBSET_DROP` needs `CAP_SETPCAP`. An agent without it cannot shrink the
+/// bounding set — but it equally cannot grant a capability it does not hold, and
+/// the set a child inherits is already no wider than the agent's own. Treating
+/// that one errno as a skip keeps an unprivileged spawn working without
+/// weakening the privileged path, where the drop still fails closed. Every other
+/// errno means the drop was possible and went wrong, so it still propagates.
+#[cfg(any(target_os = "linux", test))]
+fn bounding_drop_is_unenforceable(err: &std::io::Error) -> bool {
+    err.raw_os_error() == Some(libc::EPERM)
 }
 
 /// `prctl(PR_SET_NO_NEW_PRIVS, 1)`. One-way and inherited across fork/exec.
@@ -1733,6 +1754,27 @@ mod privilege_tests {
             WORKLOAD_KEEP, RESTORE_AGENT_CAPABILITIES,
             "the workload must be strictly narrower than the agent"
         );
+    }
+
+    /// `EPERM` is the one errno that means the caller never held `CAP_SETPCAP`,
+    /// so the drop was never enforceable. It is the only one treated as a skip;
+    /// anything else means enforcement was possible and failed, and must
+    /// propagate so the spawn fails closed.
+    #[test]
+    fn only_eperm_is_treated_as_an_unenforceable_bounding_drop() {
+        assert!(bounding_drop_is_unenforceable(
+            &std::io::Error::from_raw_os_error(libc::EPERM)
+        ));
+        for errno in [libc::EINVAL, libc::EFAULT, libc::EACCES, libc::ENOSYS] {
+            assert!(
+                !bounding_drop_is_unenforceable(&std::io::Error::from_raw_os_error(errno)),
+                "errno {errno} must propagate rather than be skipped"
+            );
+        }
+        // A non-OS error carries no errno and must never be swallowed.
+        assert!(!bounding_drop_is_unenforceable(&std::io::Error::other(
+            "not an errno"
+        )));
     }
 
     /// Mirrors `CAPABILITY_SLOTS` so the test compiles off Linux, where the

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -311,6 +311,11 @@ for detailed scope and acceptance criteria.
         keep mask with `1u32 << cap`, panicking at slot 32 in debug and
         mis-answering every slot above 31. Mask arithmetic split out and tested
         on every host; reverting the widening turns two of three tests red
+  - [x] Ordered `NoNewPrivs` before the bounding-set drop and made the
+        workload drop tolerate `EPERM`. The drop needs `CAP_SETPCAP`, so an
+        unprivileged spawn failed outright, and because it ran first the
+        failure also skipped `NoNewPrivs` — the load-bearing control. The
+        privileged init path still fails closed
   - [ ] Re-run the adversarial probe on HVF **and** Firecracker — the closure
         gate, not yet run; no Linux/KVM host available
   - [ ] Record the ADR-001 claims 1/2 scope decision (owner call; determines

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -301,6 +301,20 @@ for detailed scope and acceptance criteria.
     backend/runtime survivors in the mutation-witness baseline; Security
     workflow run 31817896244 is the final verification gate before merge
     and issue closure
+- [~] Issue #2101 — OCI workload privilege hardening
+  - [x] `harden_init_process()` in `mvm-oci-init` narrows the bounding set to
+        `RESTORE_AGENT_CAPABILITIES` and sets `no_new_privs` before the agent
+        is spawned; `drop_workload_capability_bounding_set()` empties it in the
+        entrypoint `pre_exec`; `drop_guest_agent_privilege_raw` matches, so the
+        initramfs and OCI paths reach the same posture
+  - [x] Fixed a real bug in the drop loop: it walks slots 0..=63 but tested the
+        keep mask with `1u32 << cap`, panicking at slot 32 in debug and
+        mis-answering every slot above 31. Mask arithmetic split out and tested
+        on every host; reverting the widening turns two of three tests red
+  - [ ] Re-run the adversarial probe on HVF **and** Firecracker — the closure
+        gate, not yet run; no Linux/KVM host available
+  - [ ] Record the ADR-001 claims 1/2 scope decision (owner call; determines
+        whether this is claim-bearing or defense-in-depth)
 - [~] Plan 300 — open-issue reconciliation and closeout
   (`specs/plans/300-open-issue-closeout.md`)
   - [x] Inventory all 39 issues open at the 2026-08-13 snapshot against

--- a/specs/sprint/delivery/2101-oci-privilege-hardening.md
+++ b/specs/sprint/delivery/2101-oci-privilege-hardening.md
@@ -54,6 +54,30 @@ above 31. The mask arithmetic is now `bounding_set_retains`, widened to `u64`.
   --all-features` — the change is entirely Linux-gated, so a macOS-only check
   would hide a break in it.
 
+## Follow-up: unprivileged spawn regression
+
+The first revision applied the bounding-set drop before `NoNewPrivs`, and
+propagated every error from it. `PR_CAPBSET_DROP` needs `CAP_SETPCAP`, so on any
+host where the agent lacks it the drop returned `EPERM`, the `pre_exec` closure
+returned that error, and the spawn failed outright — 20 `entrypoint_execute`
+tests went red with `spawn /proc/self/fd/4: Operation not permitted`.
+
+Two changes: `NoNewPrivs` is now set first on both paths, so a bounding-set
+failure can no longer skip the control this document already described as the
+load-bearing one; and the workload drop treats `EPERM` — and only `EPERM` — as
+"never enforceable by this caller" rather than as a failure. Every other errno
+still propagates and still fails the spawn closed, and `harden_init_process()`
+is unchanged in that respect: at init the agent is root, so a failure there is
+real and still refuses.
+
+This does not widen the workload's privilege. An agent without `CAP_SETPCAP`
+cannot grant a capability it does not hold, and the bounding set a child
+inherits is already no wider than the agent's own.
+
+`only_eperm_is_treated_as_an_unenforceable_bounding_drop` pins the errno
+classification on every host, including that a non-errno error is never
+swallowed.
+
 ## Deliberately not done
 
 The issue stays open. Its closure gate is the adversarial probe from

--- a/specs/sprint/delivery/2101-oci-privilege-hardening.md
+++ b/specs/sprint/delivery/2101-oci-privilege-hardening.md
@@ -1,0 +1,69 @@
+# OCI workload privilege hardening — `no_new_privs` and a bounded capability set
+
+**Issue:** #2101
+**Branch:** `fix/2101-oci-privilege-hardening`
+**Plan:** `specs/plans/300-open-issue-closeout.md` Phase 1
+
+The OCI boot path reaches the workload by a different route than the nix-built
+guest: nothing plays the part `mvm-setpriv` plays there, so the agent and every
+workload beneath it inherited PID 1's full capability bounding set
+(`CapBnd 000001ffffffffff`) and `NoNewPrivs: 0`, on both HVF and Firecracker.
+
+The outcome still held — the image ships zero setuid binaries and the rootfs is
+read-only — but by circumstance rather than by the mechanism ADR-001 W2.3
+names. With `no_new_privs` off, a setuid bit or file capability in an image
+would be honoured on exec.
+
+## What changed
+
+- `guest_mount::harden_init_process()` — called from `mvm-oci-init` after the
+  last root-only step and before the agent is spawned. Narrows the bounding set
+  to `RESTORE_AGENT_CAPABILITIES` and sets `no_new_privs`. Both are inherited
+  across fork and exec and can only shrink, which is what lets one call by a
+  parent bind every descendant.
+- `guest_mount::drop_workload_capability_bounding_set()` — called from the
+  entrypoint `pre_exec`, the last point anything runs on the workload's behalf.
+  Empties the bounding set. The agent keeps `CAP_KILL` (reap children) and
+  `CAP_SYS_TIME` (correct a restored clock); the workload needs neither.
+- `drop_guest_agent_privilege_raw` also drops the bounding set, so the
+  initramfs path and the OCI path reach the same posture.
+- `set_no_new_privileges()` — the shared `prctl` wrapper all three use.
+
+Two drop points rather than one, because the agent and the workload need
+different sets. An earlier attempt used a single call and described the result
+as an empty bounding set; it was not empty, because it retained what the agent
+needs.
+
+## Bug found and fixed
+
+The drop loop walks capability slots `0..=63` but tested the keep mask with
+`1u32 << cap`, which panics at slot 32 in debug and mis-answers every slot
+above 31. The mask arithmetic is now `bounding_set_retains`, widened to `u64`.
+
+## Verification
+
+- `cargo nextest run -p mvm-agentd` — 770 passed.
+- Three new tests run on every host with no root and no gating: mask arithmetic
+  across all 64 slots, the agent mask retaining exactly `CAP_KILL|CAP_SYS_TIME`,
+  and the workload mask being empty and a strict subset of the agent's.
+- Red-before-green: reverting only the `u64` widening fails two of the three
+  with `attempt to shift left with overflow`.
+- `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets --
+  -D warnings`.
+- `cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-agentd --all-targets
+  --all-features` — the change is entirely Linux-gated, so a macOS-only check
+  would hide a break in it.
+
+## Deliberately not done
+
+The issue stays open. Its closure gate is the adversarial probe from
+`specs/research/no-root-workload-live-witness.md` re-run on HVF **and**
+Firecracker; no Linux/KVM host was available. The original finding was only
+visible because that probe attempts elevation rather than reporting its
+starting uid, so unit tests do not substitute for it.
+
+The ADR-001 claims 1/2 scope decision — whether they extend to the OCI workload
+process or are scoped to mkGuest services where W2.3 already applies — is an
+owner call and is not made here. The change is correct either way; the decision
+only determines whether it is claim-bearing or defense-in-depth. The ADR-001
+claims table is untouched.


### PR DESCRIPTION
Closes the remaining half of #2101. Plan 300 Phase 1.

## The defect

The OCI boot path reaches the workload by a different route than the nix-built guest: there is no `mvm-setpriv` between init and the agent, so the agent and every workload beneath it inherited PID 1's full bounding set (`CapBnd 000001ffffffffff`) and `NoNewPrivs: 0`, on **both** HVF and Firecracker. `crates/mvm-agentd/src/bin/mvm-oci-init.rs` had no `no_new_privs` or bounding-set call at all.

The outcome held anyway — the image ships zero setuid binaries and the rootfs is read-only — but it held **by circumstance rather than by the mechanism ADR-001 W2.3 names**. With `no_new_privs` off, a setuid bit or file capability in an image would be honoured on exec.

## Two drop points, because the agent and the workload need different sets

The previous attempt at this used one call and described the result as an empty bounding set. It is not empty — it retains what the agent needs — so this splits it:

- **`harden_init_process()`** runs in `mvm-oci-init` after the last root-only step and before the agent is spawned. Narrows the bounding set to `RESTORE_AGENT_CAPABILITIES` (`CAP_KILL` to reap children, `CAP_SYS_TIME` to correct a restored clock) and sets `no_new_privs`. Both are inherited across fork *and* exec and can only shrink, which is what makes one call by a parent bind every descendant.
- **`drop_workload_capability_bounding_set()`** runs in the entrypoint `pre_exec` — the last point anything runs on the workload's behalf — and empties the set. The workload needs neither capability. `no_new_privs` already makes file caps and setuid bits inert on exec, so this is defense in depth; but it is what lets the posture be **stated** as an empty set rather than as "inert in practice".

`drop_guest_agent_privilege_raw` drops the bounding set too, so the initramfs path and the OCI path now reach the same posture.

## A real bug in the drop loop

The loop walks capability slots `0..=63` but tested the keep mask with `1u32 << cap`. That panics at slot 32 in debug and mis-answers **every slot above 31**. The mask arithmetic is now `bounding_set_retains`, widened to `u64` and tested on every host.

Verified red before green — reverting just the widening:

```
thread guest_mount::privilege_tests::agent_keep_mask_retains_exactly_kill_and_sys_time
panicked at crates/mvm-agentd/src/guest_mount.rs:627:12:
attempt to shift left with overflow
test result: FAILED. 1 passed; 2 failed
```

## Tests

Three that run on every host, no root, no gating:

- mask arithmetic answers all 64 slots without overflow (the regression above);
- the agent mask retains exactly `CAP_KILL|CAP_SYS_TIME` and nothing else;
- the workload mask is empty **and a strict subset of the agent's** — stated as a subset so it stays true if the agent's set ever changes.

The live `CapBnd`/`NoNewPrivs` assertion stays root-gated behind `MVM_GUEST_PRIVILEGED_TESTS`.

## What this does *not* close

**#2101 stays open.** Its acceptance requires re-running the adversarial probe on HVF **and** Firecracker, and that has not run — I have no Linux/KVM host available in this session. The original finding was only visible because the probe *attempted* elevation rather than reporting its starting uid, so a live witness is the closure gate, not these unit tests.

The claims 1/2 scope decision — whether ADR-001 claims 1 and 2 extend to the OCI workload process or are scoped to mkGuest services where W2.3 already applies — is an owner call and is **not** made here. This change is correct either way; it only determines whether it is claim-bearing or defense-in-depth. I have not touched the ADR-001 claims table.

The issue body is narrowed to this finding, with the two withdrawn inferences from the original report (the `NAMESPACES` override and the HVF-property attribution — both contradicted by the built artifacts) recorded so they are not rediscovered as facts.

## Verification

`cargo fmt --all --check`, `cargo nextest run -p mvm-agentd` (770 passed), `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo zigbuild --target x86_64-unknown-linux-gnu -p mvm-agentd --all-targets --all-features` — the last because this change is entirely Linux-gated and a macOS-only check would hide a break in it.