### PR TITLE
refactor(316): rename the endpoint spawner and give the FlowMux port one home

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-addon-dns.rs
+++ b/crates/mvm-agentd/src/bin/mvm-addon-dns.rs
@@ -90,7 +90,6 @@ async fn main() -> Result<()> {
 }
 
 async fn build_flowmux_resolver() -> Result<FlowMuxReconnectClient> {
-    const EGRESS_VSOCK_PORT: u32 = 5253;
     let guest_signing_key = flowmux_keys::load_guest_signing_key().await?;
     let host_anchor = flowmux_keys::load_host_signer_verifying_key(Path::new(
         flowmux_keys::DEFAULT_HOST_SIGNER_PUBKEY_PATH,
@@ -98,7 +97,7 @@ async fn build_flowmux_resolver() -> Result<FlowMuxReconnectClient> {
     .context("host-signer trust anchor not provisioned")?;
     FlowMuxReconnectClient::connect(
         || async {
-            mvm_agentd::guest_vsock_session::connect_host_vsock(EGRESS_VSOCK_PORT)
+            mvm_agentd::guest_vsock_session::connect_host_vsock(mvm_agentd::vsock::EGRESS_PORT)
                 .await
                 .map_err(mvm_agentd::flowmux::FlowMuxError::Transport)
         },

--- a/crates/mvm-agentd/src/bin/mvm-egress-client.rs
+++ b/crates/mvm-agentd/src/bin/mvm-egress-client.rs
@@ -13,7 +13,7 @@
 use std::process::ExitCode;
 
 #[cfg(target_os = "linux")]
-const EGRESS_VSOCK_PORT: u32 = 5253;
+use mvm_agentd::vsock::EGRESS_PORT;
 
 fn main() -> ExitCode {
     tracing_subscriber::fmt()
@@ -73,7 +73,7 @@ fn run(addr: std::net::SocketAddr) -> ExitCode {
 
     let client = match rt.block_on(FlowMuxReconnectClient::connect(
         || async {
-            connect_host_vsock(EGRESS_VSOCK_PORT)
+            connect_host_vsock(EGRESS_PORT)
                 .await
                 .map_err(FlowMuxError::Transport)
         },

--- a/crates/mvm-agentd/src/vsock/mod.rs
+++ b/crates/mvm-agentd/src/vsock/mod.rs
@@ -117,7 +117,13 @@ pub const WORKLOAD_EXIT_PORT: u32 = 5251;
 /// host-mediated egress, formerly named `EGRESS_PORT`). Each microVM has its
 /// own vsock; this is a fixed well-known service number reused per VM, not a secret.
 /// NOTE: exposing it end-to-end needs the host-side proxy port-allowlist to admit it.
-pub const EGRESS_PORT: u32 = 5253;
+pub const EGRESS_PORT: u32 = mvm_contract::protocol::network_flow::NETWORK_FLOW_PORT;
+
+// A compile-time proof rather than a test: the guest dials this port and the
+// host binds it from `mvm_net::GuestService::NetworkFlow`. Both derive from the
+// contract constant, so drift is not expressible — this pins the value the
+// derivation must land on.
+const _: () = assert!(EGRESS_PORT == 5253);
 
 /// vsock port the host-services broker is exposed on. The in-guest broker
 /// client ([`crate::broker_client`]) dials this to reach the supervisor's

--- a/crates/mvm-conformance/Cargo.toml
+++ b/crates/mvm-conformance/Cargo.toml
@@ -61,7 +61,7 @@ mvm-build = { workspace = true, default-features = false, features = [
 # `admit_plan_for_boot` does in production.
 ed25519-dalek.workspace = true
 # Result type for the warm-claim scenario's `CheckpointChainAnchor` /
-# `EndpointSpawner` test doubles, matching the runner's own error convention.
+# `NetworkEndpointSpawner` test doubles, matching the runner's own error convention.
 anyhow.workspace = true
 tar.workspace = true
 tempfile.workspace = true

--- a/crates/mvm-conformance/tests/steps/warm_claim.rs
+++ b/crates/mvm-conformance/tests/steps/warm_claim.rs
@@ -26,8 +26,8 @@ use mvm_runtime::driver::MockDriver;
 use mvm_runtime::standby_pool::SupervisorStandbyPool;
 use mvm_runtime::workload_runner::claim::parent_rootfs_digest;
 use mvm_runtime::workload_runner::{
-    ChildGrantIssuer, ClaimContext, EndpointSpawnRequest, EndpointSpawner, RealBrokerRegistrar,
-    WorkloadRunner,
+    ChildGrantIssuer, ClaimContext, NetworkEndpointSpawnRequest, NetworkEndpointSpawner,
+    RealBrokerRegistrar, WorkloadRunner,
 };
 
 use crate::world::{CliWorld, WarmClaimOutcome, WarmClaimWitness};
@@ -158,15 +158,15 @@ impl CheckpointChainAnchor for WarmClaimAnchor {
     }
 }
 
-/// An `EndpointSpawner` double: keys its returned socket on the vm name it is
+/// An `NetworkEndpointSpawner` double: keys its returned socket on the vm name it is
 /// handed (mirroring the production spawner), with no real endpoint process.
 #[derive(Default)]
 struct WarmClaimSpawner {
     seen_vm: Mutex<Option<String>>,
 }
 
-impl EndpointSpawner for WarmClaimSpawner {
-    fn spawn(&self, req: &EndpointSpawnRequest<'_>) -> anyhow::Result<PathBuf> {
+impl NetworkEndpointSpawner for WarmClaimSpawner {
+    fn spawn(&self, req: &NetworkEndpointSpawnRequest<'_>) -> anyhow::Result<PathBuf> {
         *self.seen_vm.lock().unwrap() = Some(req.vm_name.to_string());
         Ok(mvm_core::config::vm_network_endpoint_socket(req.vm_name))
     }

--- a/crates/mvm-contract/src/protocol/network_flow/mod.rs
+++ b/crates/mvm-contract/src/protocol/network_flow/mod.rs
@@ -29,6 +29,15 @@ pub mod limits;
 pub mod opcode;
 pub mod state;
 
+/// The vsock port a workload's FlowMux session is carried on.
+///
+/// Lives here rather than in `mvm-net` because both ends need it and the
+/// guest cannot reach `mvm-net`: `mvm-agentd` links the sealed agent and
+/// depends only on this crate. `mvm_net::GuestService::NetworkFlow` maps to
+/// this constant, so host and guest name one value instead of two literals
+/// that can drift — the same arrangement `l3::L3_CONTROL_PORT` already uses.
+pub const NETWORK_FLOW_PORT: u32 = 5253;
+
 pub use frame::{
     Direction, FrameError, FrameHeader, MAGIC, ParsedFrame, SESSION_STREAM_ID, decode, encode,
     encode_into, peek_frame_len,

--- a/crates/mvm-hostd/tests/workload_stream_plane.rs
+++ b/crates/mvm-hostd/tests/workload_stream_plane.rs
@@ -32,7 +32,7 @@ use mvm_core::vm_backend::{VmBackend, VmId, VmStartConfig};
 use mvm_hostd::stream::StreamPlane;
 use mvm_runtime::driver::MockDriver;
 use mvm_runtime::workload_runner::{
-    ConsoleStreamer, EndpointSpawnRequest, EndpointSpawner, RealBrokerRegistrar,
+    ConsoleStreamer, NetworkEndpointSpawnRequest, NetworkEndpointSpawner, RealBrokerRegistrar,
     WorkloadLaunchInputs, WorkloadRunner, console_streamer_installed,
 };
 
@@ -44,13 +44,13 @@ const DEADLINE: Duration = Duration::from_secs(10);
 /// its reader before the test produces bytes it expects that reader to see.
 const ACCEPT_SETTLE: Duration = Duration::from_millis(250);
 
-/// The one gating-endpoint stand-in: `RealEndpointSpawner` would fork the
+/// The one gating-endpoint stand-in: `RealNetworkEndpointSpawner` would fork the
 /// substitution endpoint subprocess, which this test has no use for. Every
 /// other collaborator on the start path is the production one.
-struct StubEndpointSpawner;
+struct StubNetworkEndpointSpawner;
 
-impl EndpointSpawner for StubEndpointSpawner {
-    fn spawn(&self, _req: &EndpointSpawnRequest<'_>) -> Result<PathBuf> {
+impl NetworkEndpointSpawner for StubNetworkEndpointSpawner {
+    fn spawn(&self, _req: &NetworkEndpointSpawnRequest<'_>) -> Result<PathBuf> {
         Ok(PathBuf::from("/run/mvm-test-endpoint.sock"))
     }
 }
@@ -64,12 +64,12 @@ fn isolated_home() -> (TestEnv, tempfile::TempDir) {
     (env, tmp)
 }
 
-fn runner() -> WorkloadRunner<MockDriver, StubEndpointSpawner, RealBrokerRegistrar> {
+fn runner() -> WorkloadRunner<MockDriver, StubNetworkEndpointSpawner, RealBrokerRegistrar> {
     // No `with_console_streamer`: the hook has to arrive from the process
     // registration, or this test proves nothing about production.
     WorkloadRunner::new(
         MockDriver::default(),
-        StubEndpointSpawner,
+        StubNetworkEndpointSpawner,
         RealBrokerRegistrar,
     )
 }
@@ -83,10 +83,10 @@ fn runner() -> WorkloadRunner<MockDriver, StubEndpointSpawner, RealBrokerRegistr
 /// the path is the production collaborator, including the plane itself.
 fn runner_in_process(
     plane: &Arc<StreamPlane>,
-) -> WorkloadRunner<MockDriver, StubEndpointSpawner, RealBrokerRegistrar> {
+) -> WorkloadRunner<MockDriver, StubNetworkEndpointSpawner, RealBrokerRegistrar> {
     WorkloadRunner::new(
         MockDriver::default(),
-        StubEndpointSpawner,
+        StubNetworkEndpointSpawner,
         RealBrokerRegistrar,
     )
     .with_console_streamer(Arc::clone(plane) as Arc<dyn ConsoleStreamer>)
@@ -115,7 +115,10 @@ fn payloads(records: &[OutputRecord]) -> Vec<Vec<u8>> {
     records.iter().map(|r| r.payload.clone()).collect()
 }
 
-fn launch(runner: &WorkloadRunner<MockDriver, StubEndpointSpawner, RealBrokerRegistrar>, vm: &str) {
+fn launch(
+    runner: &WorkloadRunner<MockDriver, StubNetworkEndpointSpawner, RealBrokerRegistrar>,
+    vm: &str,
+) {
     let config = VmStartConfig {
         name: vm.to_string(),
         rootfs_path: "/img/rootfs.ext4".into(),

--- a/crates/mvm-net/src/channel.rs
+++ b/crates/mvm-net/src/channel.rs
@@ -70,7 +70,7 @@ impl GuestService {
         match self {
             Self::WorkloadExit => 5251,
             Self::MachineControl => 5252,
-            Self::NetworkFlow => 5253,
+            Self::NetworkFlow => mvm_contract::protocol::network_flow::NETWORK_FLOW_PORT,
             Self::NetworkControl => mvm_contract::l3::L3_CONTROL_PORT,
             Self::NetworkData { queue } => mvm_contract::l3::data_port(queue),
             Self::Broker => 5300,
@@ -317,7 +317,16 @@ mod tests {
     fn services_map_to_the_ports_both_ends_agree_on() {
         assert_eq!(GuestService::MachineControl.port(), 5252);
         assert_eq!(GuestService::WorkloadExit.port(), 5251);
+        // Pins the wire value. The constant it derives from lives in
+        // `mvm-contract` so the guest — which cannot depend on this crate —
+        // names the same number; this asserts the derivation still lands on
+        // the port deployed guests actually dial.
         assert_eq!(GuestService::NetworkFlow.port(), 5253);
+        assert_eq!(
+            GuestService::NetworkFlow.port(),
+            mvm_contract::protocol::network_flow::NETWORK_FLOW_PORT,
+            "the service mapping and the shared contract constant must not drift"
+        );
         assert_eq!(GuestService::Broker.port(), 5300);
         // Both ends of the builder control plane pin these literals: the guest
         // side in `mvm_agentd::builder_agent`, which this crate sits below.

--- a/crates/mvm-runtime/examples/hvf-workload-runner.rs
+++ b/crates/mvm-runtime/examples/hvf-workload-runner.rs
@@ -48,7 +48,9 @@ fn main() {
     use mvm_core::policy::network_policy::{HostPort, NetworkPolicy};
     use mvm_core::vm_backend::{VmBackend, VmStartConfig, VmStatus};
     use mvm_runtime::driver::HvfDriver;
-    use mvm_runtime::workload_runner::{RealBrokerRegistrar, RealEndpointSpawner, WorkloadRunner};
+    use mvm_runtime::workload_runner::{
+        RealBrokerRegistrar, RealNetworkEndpointSpawner, WorkloadRunner,
+    };
 
     let lan = discover_lan_ipv4().expect(
         "no private non-loopback IPv4 interface — this proof needs a routable LAN address \
@@ -106,7 +108,11 @@ fn main() {
         ..Default::default()
     };
 
-    let backend = WorkloadRunner::new(HvfDriver::new(), RealEndpointSpawner, RealBrokerRegistrar);
+    let backend = WorkloadRunner::new(
+        HvfDriver::new(),
+        RealNetworkEndpointSpawner,
+        RealBrokerRegistrar,
+    );
     let id = backend
         .start(&config)
         .expect("WorkloadRunner starts the hvf VM");

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -18,7 +18,7 @@ use crate::microvm::FlakeRunConfig;
 use crate::mock::MockBackend;
 use crate::wasm_backend::WasmBackend;
 use crate::workload_runner::{
-    RealBrokerRegistrar, RealEndpointSpawner, StopTiming, WorkloadRunner,
+    RealBrokerRegistrar, RealNetworkEndpointSpawner, StopTiming, WorkloadRunner,
 };
 use mvm_backends::driver::hvf::HvfDriver;
 use mvm_backends::driver::{LibkrunDriver, QemuDriver};
@@ -29,14 +29,19 @@ use mvm_vmm::host::drive_file::DriveFile;
 /// `auto_select` default). NIC-less: egress routes to the per-VM gating endpoint
 /// over vsock only; the legacy direct `HvfBackend` shim has been deleted, so
 /// this runner is the only hvf workload launch path.
-pub(crate) type HvfRunner = WorkloadRunner<HvfDriver, RealEndpointSpawner, RealBrokerRegistrar>;
+pub(crate) type HvfRunner =
+    WorkloadRunner<HvfDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;
 
 /// Construct the hvf VMM's workload runner. Like [`libkrun_runner`] and
 /// [`fc_runner`] the runner is not const-constructible, so this helper is the
 /// one construction site the enum variant, `auto_select`, the descriptor
 /// catalog, and the capability selector all call.
 pub(crate) fn hvf_runner() -> HvfRunner {
-    WorkloadRunner::new(HvfDriver::new(), RealEndpointSpawner, RealBrokerRegistrar)
+    WorkloadRunner::new(
+        HvfDriver::new(),
+        RealNetworkEndpointSpawner,
+        RealBrokerRegistrar,
+    )
 }
 
 /// libkrun driven through the same unified workload-runner role — libkrun's
@@ -44,7 +49,7 @@ pub(crate) fn hvf_runner() -> HvfRunner {
 /// Egress routes to the per-VM gating endpoint over vsock only; the legacy
 /// direct `LibkrunBackend` shim has been deleted, so this runner is the only
 /// libkrun workload launch path.
-type LibkrunRunner = WorkloadRunner<LibkrunDriver, RealEndpointSpawner, RealBrokerRegistrar>;
+type LibkrunRunner = WorkloadRunner<LibkrunDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;
 
 /// Construct libkrun's workload runner. The runner is not const-constructible,
 /// so this helper is the one construction site the enum variant, `auto_select`,
@@ -52,7 +57,7 @@ type LibkrunRunner = WorkloadRunner<LibkrunDriver, RealEndpointSpawner, RealBrok
 pub(crate) fn libkrun_runner() -> LibkrunRunner {
     WorkloadRunner::new(
         LibkrunDriver::new(),
-        RealEndpointSpawner,
+        RealNetworkEndpointSpawner,
         RealBrokerRegistrar,
     )
 }
@@ -64,28 +69,36 @@ pub(crate) fn libkrun_runner() -> LibkrunRunner {
 /// egress routes to the per-VM gating endpoint over vsock only, through the
 /// per-VM AF_VSOCK↔UNIX bridge. The legacy direct `QemuBackend`
 /// has been deleted; this runner is the only QEMU workload launch path.
-type QemuRunner = WorkloadRunner<QemuDriver, RealEndpointSpawner, RealBrokerRegistrar>;
+type QemuRunner = WorkloadRunner<QemuDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;
 
 /// Construct QEMU's workload runner. Like [`libkrun_runner`] the runner is not
 /// const-constructible, so this helper is the one construction site the enum
 /// variant, `from_build_output`, the descriptor catalog, and the capability
 /// selector all call.
 pub(crate) fn qemu_runner() -> QemuRunner {
-    WorkloadRunner::new(QemuDriver::new(), RealEndpointSpawner, RealBrokerRegistrar)
+    WorkloadRunner::new(
+        QemuDriver::new(),
+        RealNetworkEndpointSpawner,
+        RealBrokerRegistrar,
+    )
 }
 
 /// Firecracker (Linux KVM) driven through the unified workload-runner role
 /// — Firecracker's sole mvmctl-CLI workload launch path (`--hypervisor
 /// firecracker`, `default_backend`, and `auto_select`). NIC-less: egress routes
 /// to the per-VM gating endpoint over vsock only.
-type FcRunner = WorkloadRunner<FcDriver, RealEndpointSpawner, RealBrokerRegistrar>;
+type FcRunner = WorkloadRunner<FcDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;
 
 /// Construct Firecracker's workload runner. Like [`libkrun_runner`] the runner
 /// is not const-constructible, so this helper is the one construction site the
 /// enum variant, `auto_select`, the descriptor catalog, and the capability
 /// selector all call.
 pub(crate) fn fc_runner() -> FcRunner {
-    WorkloadRunner::new(FcDriver::new(), RealEndpointSpawner, RealBrokerRegistrar)
+    WorkloadRunner::new(
+        FcDriver::new(),
+        RealNetworkEndpointSpawner,
+        RealBrokerRegistrar,
+    )
 }
 
 /// Compatibility wrapper for the retired raw Firecracker configuration.

--- a/crates/mvm-runtime/src/workload_runner/claim.rs
+++ b/crates/mvm-runtime/src/workload_runner/claim.rs
@@ -18,7 +18,7 @@ use mvm_core::policy::network_policy::NetworkPolicy;
 use mvm_core::vm_backend::VmId;
 
 use crate::network_endpoint_spawn::EndpointGuard;
-use crate::workload_runner::runner::{EndpointSpawnRequest, EndpointSpawner};
+use crate::workload_runner::runner::{NetworkEndpointSpawnRequest, NetworkEndpointSpawner};
 
 #[derive(Debug, thiserror::Error)]
 pub enum ClaimRefusal {
@@ -196,11 +196,11 @@ impl EndpointHandle {
 /// substitution endpoint. Both cold boot and the warm claim call it, so the two
 /// cannot diverge to a weaker posture.
 pub struct ClaimGuards<'a> {
-    spawner: &'a dyn EndpointSpawner,
+    spawner: &'a dyn NetworkEndpointSpawner,
 }
 
 impl<'a> ClaimGuards<'a> {
-    pub fn new(spawner: &'a dyn EndpointSpawner) -> Self {
+    pub fn new(spawner: &'a dyn NetworkEndpointSpawner) -> Self {
         Self { spawner }
     }
 
@@ -245,7 +245,7 @@ impl<'a> ClaimGuards<'a> {
             });
         }
         let raw_egress = inputs.secrets.is_empty();
-        let egress_uds = self.spawner.spawn(&EndpointSpawnRequest {
+        let egress_uds = self.spawner.spawn(&NetworkEndpointSpawnRequest {
             vm_name: &vm.0,
             state_dir: inputs.state_dir,
             tenant: inputs.tenant,
@@ -325,14 +325,14 @@ mod tests {
 
     // ---- ClaimGuards: the runner-side shared host steps ----
 
-    use crate::workload_runner::runner::{EndpointSpawnRequest, EndpointSpawner};
+    use crate::workload_runner::runner::{NetworkEndpointSpawnRequest, NetworkEndpointSpawner};
     use mvm_core::policy::RedactionPolicy;
     use mvm_core::policy::network_policy::NetworkPolicy;
     use std::path::PathBuf;
     use std::sync::Mutex;
 
-    /// An `EndpointSpawner` double: records the `vm_name` it was handed and,
-    /// mirroring `RealEndpointSpawner`, returns the per-VM socket keyed on that
+    /// An `NetworkEndpointSpawner` double: records the `vm_name` it was handed and,
+    /// mirroring `RealNetworkEndpointSpawner`, returns the per-VM socket keyed on that
     /// name — so a test can prove `ClaimGuards` threads the child's own id
     /// through and never reuses a sibling's socket, with no real endpoint process.
     #[derive(Default)]
@@ -340,8 +340,8 @@ mod tests {
         seen_vm: Mutex<Option<String>>,
     }
 
-    impl EndpointSpawner for FakeSpawner {
-        fn spawn(&self, req: &EndpointSpawnRequest<'_>) -> anyhow::Result<PathBuf> {
+    impl NetworkEndpointSpawner for FakeSpawner {
+        fn spawn(&self, req: &NetworkEndpointSpawnRequest<'_>) -> anyhow::Result<PathBuf> {
             *self.seen_vm.lock().unwrap() = Some(req.vm_name.to_string());
             Ok(mvm_core::config::vm_network_endpoint_socket(req.vm_name))
         }

--- a/crates/mvm-runtime/src/workload_runner/mod.rs
+++ b/crates/mvm-runtime/src/workload_runner/mod.rs
@@ -17,9 +17,9 @@ mod standby_boot;
 
 pub use runner::{
     BrokerGuard, BrokerRegisterRequest, BrokerRegistrar, ClaimContext, ConsoleCapture,
-    ConsoleStreamer, EndpointSpawnRequest, EndpointSpawner, NoopConsoleStreamer, PreloadContext,
-    RealBrokerRegistrar, RealEndpointSpawner, SpawnContext, StopTiming, WorkloadLaunchInputs,
-    WorkloadRunner,
+    ConsoleStreamer, NetworkEndpointSpawnRequest, NetworkEndpointSpawner, NoopConsoleStreamer,
+    PreloadContext, RealBrokerRegistrar, RealNetworkEndpointSpawner, SpawnContext, StopTiming,
+    WorkloadLaunchInputs, WorkloadRunner,
 };
 pub use standby_boot::{factory_parent_config, factory_parent_spec};
 

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -2,7 +2,7 @@
 //! per-VM host-side gating endpoint, maps the admitted config onto a `VmmSpec`,
 //! and boots it through the `VmmDriver` seam — once, over the seam, instead of
 //! copied into each backend's `start`. The endpoint spawn is itself behind the
-//! `EndpointSpawner` trait so the runner is unit-testable with no real VM and no
+//! `NetworkEndpointSpawner` trait so the runner is unit-testable with no real VM and no
 //! real endpoint process.
 
 use std::path::{Path, PathBuf};
@@ -66,7 +66,7 @@ use refusal::{map_lineage_refusal, refuse, require_fresh_child_identity};
 use sockets::standing_sockets;
 
 /// What the workload runner needs to stand up the per-VM gating endpoint.
-pub struct EndpointSpawnRequest<'a> {
+pub struct NetworkEndpointSpawnRequest<'a> {
     pub vm_name: &'a str,
     pub state_dir: &'a Path,
     pub tenant: &'a str,
@@ -80,16 +80,16 @@ pub struct EndpointSpawnRequest<'a> {
 /// Stand up the per-VM gating endpoint; return the host UDS the guest's
 /// EGRESS_PORT relays to. The one host-side egress bridge (claim-10 gate +
 /// claims 12/13 substitution).
-pub trait EndpointSpawner: Send + Sync {
-    fn spawn(&self, req: &EndpointSpawnRequest<'_>) -> Result<PathBuf>;
+pub trait NetworkEndpointSpawner: Send + Sync {
+    fn spawn(&self, req: &NetworkEndpointSpawnRequest<'_>) -> Result<PathBuf>;
 }
 
-/// The production `EndpointSpawner`: spawns the real `mvm-network-endpoint`
+/// The production `NetworkEndpointSpawner`: spawns the real `mvm-network-endpoint`
 /// over the in-process-VMM UDS transport.
-pub struct RealEndpointSpawner;
+pub struct RealNetworkEndpointSpawner;
 
-impl EndpointSpawner for RealEndpointSpawner {
-    fn spawn(&self, req: &EndpointSpawnRequest<'_>) -> Result<PathBuf> {
+impl NetworkEndpointSpawner for RealNetworkEndpointSpawner {
+    fn spawn(&self, req: &NetworkEndpointSpawnRequest<'_>) -> Result<PathBuf> {
         let uds = vm_network_endpoint_socket(req.vm_name);
         spawn_network_endpoint(SubstitutionSpawnParams {
             vm_name: req.vm_name,
@@ -211,7 +211,7 @@ impl BrokerRegistrar for RealBrokerRegistrar {
 /// the resident per-tenant daemon, which sits *above* this crate in the
 /// dependency graph (the daemon depends on the runtime, never the other way
 /// around), so this crate cannot name that broker's type. Same shape as
-/// [`EndpointSpawner`] and [`BrokerRegistrar`] just above — both exist to
+/// [`NetworkEndpointSpawner`] and [`BrokerRegistrar`] just above — both exist to
 /// solve exactly this "the runtime needs the resident daemon to do
 /// something" problem — and, like the ordinary `VmBackend` methods this
 /// trait's two calls sit beside, `start`/`stop` are independent entry points
@@ -341,7 +341,7 @@ pub struct PreloadContext<'a> {
 
 /// Starts workloads over the `VmmDriver` seam: spawn the per-VM gating endpoint,
 /// map the config to a `VmmSpec`, boot via the driver.
-pub struct WorkloadRunner<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> {
+pub struct WorkloadRunner<D: VmmDriver, S: NetworkEndpointSpawner, B: BrokerRegistrar> {
     driver: D,
     spawner: S,
     broker: B,
@@ -366,7 +366,7 @@ pub struct StopTiming {
     pub driver_detail: Option<RunningVmStopTiming>,
 }
 
-impl<D: VmmDriver, S: EndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, B> {
+impl<D: VmmDriver, S: NetworkEndpointSpawner, B: BrokerRegistrar> WorkloadRunner<D, S, B> {
     /// Build a runner over the process's registered console-streaming hook.
     ///
     /// Every production construction site goes through here and none of them
@@ -1512,7 +1512,7 @@ mod tests {
     use crate::backends::hvf::HvfDriver;
     use crate::driver::MockDriver;
 
-    /// An `EndpointSpawner` test double: records the request it was handed and
+    /// An `NetworkEndpointSpawner` test double: records the request it was handed and
     /// returns a canned UDS without spawning any process. `Mutex` (not `RefCell`)
     /// so it satisfies the `Send + Sync` a `VmBackend` spawner must be.
     struct RecordingSpawner {
@@ -1536,8 +1536,8 @@ mod tests {
         }
     }
 
-    impl EndpointSpawner for RecordingSpawner {
-        fn spawn(&self, req: &EndpointSpawnRequest<'_>) -> Result<PathBuf> {
+    impl NetworkEndpointSpawner for RecordingSpawner {
+        fn spawn(&self, req: &NetworkEndpointSpawnRequest<'_>) -> Result<PathBuf> {
             *self.seen.lock().unwrap() = Some(Recorded {
                 raw_egress: req.raw_egress,
                 tenant: req.tenant.to_string(),
@@ -3317,8 +3317,8 @@ mod tests {
         }
     }
 
-    /// An `EndpointSpawner` double that keys its returned socket on the vm name it
-    /// is handed — mirroring `RealEndpointSpawner` — and records that name, so a
+    /// An `NetworkEndpointSpawner` double that keys its returned socket on the vm name it
+    /// is handed — mirroring `RealNetworkEndpointSpawner` — and records that name, so a
     /// test can prove the child endpoint is keyed on the child's own id and the
     /// parent got none, with no real endpoint process.
     #[derive(Default)]
@@ -3326,8 +3326,8 @@ mod tests {
         seen_vm: Mutex<Option<String>>,
     }
 
-    impl EndpointSpawner for KeyingSpawner {
-        fn spawn(&self, req: &EndpointSpawnRequest<'_>) -> Result<PathBuf> {
+    impl NetworkEndpointSpawner for KeyingSpawner {
+        fn spawn(&self, req: &NetworkEndpointSpawnRequest<'_>) -> Result<PathBuf> {
             *self.seen_vm.lock().unwrap() = Some(req.vm_name.to_string());
             Ok(vm_network_endpoint_socket(req.vm_name))
         }

--- a/crates/mvm-runtime/src/workload_runner/runner/backend.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner/backend.rs
@@ -3,7 +3,7 @@
 use super::*;
 use std::time::Instant;
 
-impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 'static>
+impl<D: VmmDriver + 'static, S: NetworkEndpointSpawner + 'static, B: BrokerRegistrar + 'static>
     WorkloadRunner<D, S, B>
 {
     /// Stop a VM and expose timings for each runner-owned teardown phase.
@@ -55,8 +55,8 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
 /// `VmmDriver` seam rather than being copied into each backend. State is
 /// disk-backed under the per-VM `vm_state_dir`, so a stateless CLI invocation
 /// reconstructs a handle by id.
-impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 'static> VmBackend
-    for WorkloadRunner<D, S, B>
+impl<D: VmmDriver + 'static, S: NetworkEndpointSpawner + 'static, B: BrokerRegistrar + 'static>
+    VmBackend for WorkloadRunner<D, S, B>
 {
     fn name(&self) -> &str {
         self.driver.name()
@@ -250,7 +250,7 @@ impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 
     }
 }
 
-impl<D: VmmDriver + 'static, S: EndpointSpawner + 'static, B: BrokerRegistrar + 'static>
+impl<D: VmmDriver + 'static, S: NetworkEndpointSpawner + 'static, B: BrokerRegistrar + 'static>
     WorkloadBackend for WorkloadRunner<D, S, B>
 {
     fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {

--- a/specs/plans/316-single-flow-vsock-networking.md
+++ b/specs/plans/316-single-flow-vsock-networking.md
@@ -283,20 +283,24 @@ bookkeeping lagged — see the Status section.
       `mvm-network-endpoint`, including Cargo bin declarations, release
       packaging, updater manifests, helper resolution, confinement profiles,
       scripts, process reaping, metrics labels, and operator diagnostics.
-- [~] Rename `GuestService::Substitution` to `GuestService::NetworkFlow`, retain
+- [x] Rename `GuestService::Substitution` to `GuestService::NetworkFlow`, retain
       port 5253, and delete the hand-maintained duplicate
       `EGRESS_VSOCK_PORT` constant in favor of the typed service mapping.
-      `GuestService::NetworkFlow` exists in `mvm-net/src/channel.rs` mapped to
-      5253 with a `port()` test. The duplicate constant survives in
-      `crates/mvm-agentd/src/bin/mvm-egress-client.rs:16` and
-      `crates/mvm-agentd/src/bin/mvm-addon-dns.rs:93` — `mvm-agentd` does not
-      depend on `mvm-net`, so either give the guest the typed mapping or record
-      why 5253 is pinned twice and gate the two values equal.
-- [ ] Rename `EndpointSpawner`/`RealEndpointSpawner` to
+      The port now has exactly one definition in the workspace:
+      `mvm_contract::protocol::network_flow::NETWORK_FLOW_PORT`. It lives in
+      `mvm-contract` rather than `mvm-net` because the guest cannot depend on
+      `mvm-net` — the same arrangement `l3::L3_CONTROL_PORT` already uses.
+      `mvm_net::GuestService::NetworkFlow` and `mvm_agentd::vsock::EGRESS_PORT`
+      both derive from it, so the ~80 existing `EGRESS_PORT` call sites
+      transitively name one value. A `const` assertion in `mvm-agentd` makes
+      drift a compile error; `mvm-net`'s `port()` test asserts the mapping and
+      the contract constant agree.
+- [x] Rename `EndpointSpawner`/`RealEndpointSpawner` to
       `NetworkEndpointSpawner`/`RealNetworkEndpointSpawner`; keep exactly one
-      production `spawn` implementation in `WorkloadRunner`. **Not started:**
-      `crates/mvm-hostd/tests/workload_stream_plane.rs` still imports
-      `EndpointSpawner`, and the new names appear nowhere in the workspace.
+      production `spawn` implementation in `WorkloadRunner`.
+      `EndpointSpawnRequest` moved with them, and `xtask
+      check-uniform-vsock-egress` — which pins the converged runner shape by
+      type name — was updated in the same change.
 - [ ] Make the endpoint authenticate one long-lived FlowMux session before it
       accepts any flow frame. A failed or missing session prevents workload
       readiness when the signed plan grants networking.

--- a/xtask/src/check_uniform_vsock_egress.rs
+++ b/xtask/src/check_uniform_vsock_egress.rs
@@ -2,9 +2,9 @@
 //!
 //! Uniform vsock egress: the Firecracker, libkrun, and HVF CLI workload backends
 //! are converged onto **one** launch seam — `WorkloadRunner<Driver,
-//! RealEndpointSpawner, RealBrokerRegistrar>`. The per-VM substitution endpoint
+//! RealNetworkEndpointSpawner, RealBrokerRegistrar>`. The per-VM substitution endpoint
 //! (the sole claim-10 egress gate) is spawned in exactly one place,
-//! `RealEndpointSpawner::spawn` (`workload_runner/runner.rs`), over vsock/uds; a
+//! `RealNetworkEndpointSpawner::spawn` (`workload_runner/runner.rs`), over vsock/uds; a
 //! `VmmDriver` only wires the guest port through and spawns nothing itself. This
 //! gate is that claim in executable form: it fails closed if a future edit
 //! reverts a converged variant to a raw backend, swaps the endpoint spawner off
@@ -14,8 +14,8 @@
 //!
 //! - **A — the converged CLI workload variants ARE runners.** `backend.rs` keeps
 //!   the `FcRunner`/`LibkrunRunner`/`HvfRunner` aliases at the full
-//!   `WorkloadRunner<Driver, RealEndpointSpawner, RealBrokerRegistrar>` shape
-//!   (matching the `RealEndpointSpawner, RealBrokerRegistrar` tail, so a spawner
+//!   `WorkloadRunner<Driver, RealNetworkEndpointSpawner, RealBrokerRegistrar>` shape
+//!   (matching the `RealNetworkEndpointSpawner, RealBrokerRegistrar` tail, so a spawner
 //!   swap trips the gate), and `pub enum AnyBackend` binds the runner arms
 //!   `Firecracker(FcRunner)` + `Libkrun(LibkrunRunner)` + `Hvf(HvfRunner)` —
 //!   never a raw `Firecracker(FirecrackerBackend)` / `Libkrun(LibkrunBackend)` /
@@ -62,7 +62,7 @@ const BACKEND_RS: &str = "crates/mvm-runtime/src/backend.rs";
 const APPLE_CONTAINER_RS: &str = "crates/mvm-runtime/src/apple_container_backend.rs";
 
 /// A converged runner alias and the driver it must wrap. The alias must stay at
-/// the `WorkloadRunner<Driver, RealEndpointSpawner, RealBrokerRegistrar>` shape;
+/// the `WorkloadRunner<Driver, RealNetworkEndpointSpawner, RealBrokerRegistrar>` shape;
 /// swapping the spawner or broker registrar off the tail trips Assertion A.
 struct RunnerAlias {
     alias: &'static str,
@@ -106,7 +106,7 @@ const FORBIDDEN_ENUM_ARMS: &[&str] = &[
 ///
 /// Deliberately NOT guarded (they legitimately construct or hold endpoints and
 /// sit outside the converged CLI scope): `workload_runner/runner.rs` (the one
-/// `RealEndpointSpawner`), the builder role, the raw `libkrun.rs` +
+/// `RealNetworkEndpointSpawner`), the builder role, the raw `libkrun.rs` +
 /// `microvm/egress_bridge.rs` + `egress_redirect.rs` (held live by the hostd
 /// supervisor + Firecracker standby fleet path), the endpoint definition
 /// (`network_endpoint_spawn.rs`) + the `mvm-hostd` supervisor + the substitution
@@ -114,7 +114,7 @@ const FORBIDDEN_ENUM_ARMS: &[&str] = &[
 const GUARDED_PATHS: &[&str] = &["crates/mvm-runtime/src/driver", APPLE_CONTAINER_RS];
 
 /// Raw egress-spawn tokens. Any of these on the guarded driver surface means a
-/// per-VM endpoint is being spawned outside `RealEndpointSpawner`.
+/// per-VM endpoint is being spawned outside `RealNetworkEndpointSpawner`.
 const FORBIDDEN: &[&str] = &[
     "spawn_network_endpoint",
     "EndpointTransport::Uds",
@@ -150,7 +150,7 @@ fn check_converged_runner_shape(workspace: &Path) -> Result<()> {
         if !alias_regex(alias).is_match(&text) {
             bail!(
                 "check-uniform-vsock-egress: {alias} lost its converged runner shape. \
-                 Expected `type {alias} = WorkloadRunner<{driver}, RealEndpointSpawner, \
+                 Expected `type {alias} = WorkloadRunner<{driver}, RealNetworkEndpointSpawner, \
                  RealBrokerRegistrar>`. Swapping the endpoint spawner or broker registrar \
                  off this seam breaks the uniform vsock-egress convergence — including \
                  for apple-container, which reaches the endpoint through `HvfRunner`.",
@@ -237,7 +237,7 @@ fn check_apple_container_delegates_to_runner(workspace: &Path) -> Result<()> {
         bail!(
             "check-uniform-vsock-egress: {APPLE_CONTAINER_RS}: `AppleContainerBackend` no \
              longer holds a `runner: HvfRunner`. Its claim-10 coverage is transitive — it \
-             reaches the one `RealEndpointSpawner` through the HVF runner. Holding anything \
+             reaches the one `RealNetworkEndpointSpawner` through the HVF runner. Holding anything \
              else means this workload tier needs its own egress seam, which is the \
              convergence this gate exists to prevent."
         );
@@ -298,7 +298,7 @@ fn check_no_driver_egress_spawn(workspace: &Path) -> Result<usize> {
         bail!(
             "check-uniform-vsock-egress: a per-VM egress endpoint is spawned on the \
              guarded surface. The only legal spawn site is \
-             `RealEndpointSpawner::spawn` in workload_runner/runner.rs; a driver wires \
+             `RealNetworkEndpointSpawner::spawn` in workload_runner/runner.rs; a driver wires \
              the guest port through and spawns nothing, and the apple-container backend \
              delegates rather than spawning:\n{}",
             hits.join("\n")
@@ -309,7 +309,7 @@ fn check_no_driver_egress_spawn(workspace: &Path) -> Result<usize> {
 
 fn alias_regex(alias: &RunnerAlias) -> Regex {
     let pattern = format!(
-        r"type\s+{}\s*=\s*WorkloadRunner\s*<\s*{}\s*,\s*RealEndpointSpawner\s*,\s*RealBrokerRegistrar\s*>",
+        r"type\s+{}\s*=\s*WorkloadRunner\s*<\s*{}\s*,\s*RealNetworkEndpointSpawner\s*,\s*RealBrokerRegistrar\s*>",
         alias.alias, alias.driver
     );
     Regex::new(&pattern).expect("static alias regex")
@@ -442,7 +442,7 @@ mod tests {
     fn alias_regex_requires_the_real_endpoint_spawner_tail() {
         let re = alias_regex(&REQUIRED_ALIASES[0]);
         assert!(re.is_match(
-            "type FcRunner = WorkloadRunner<FcDriver, RealEndpointSpawner, RealBrokerRegistrar>;"
+            "type FcRunner = WorkloadRunner<FcDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;"
         ));
         // A spawner swap must not match — that is the regression the tail guards.
         assert!(!re.is_match(
@@ -457,9 +457,9 @@ mod tests {
         std::fs::create_dir_all(backend.parent().expect("parent")).expect("create dirs");
         std::fs::write(
             &backend,
-            "type FcRunner = WorkloadRunner<FcDriver, RealEndpointSpawner, RealBrokerRegistrar>;\n\
-             type LibkrunRunner = WorkloadRunner<LibkrunDriver, RealEndpointSpawner, RealBrokerRegistrar>;\n\
-             type HvfRunner = WorkloadRunner<HvfDriver, RealEndpointSpawner, RealBrokerRegistrar>;\n\
+            "type FcRunner = WorkloadRunner<FcDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;\n\
+             type LibkrunRunner = WorkloadRunner<LibkrunDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;\n\
+             type HvfRunner = WorkloadRunner<HvfDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;\n\
              pub enum AnyBackend {\n    Firecracker(FirecrackerBackend),\n    Libkrun(LibkrunRunner),\n}\n",
         )
         .expect("write backend fixture");
@@ -650,9 +650,9 @@ mod tests {
         std::fs::create_dir_all(backend.parent().expect("parent")).expect("create dirs");
         std::fs::write(
             &backend,
-            "type FcRunner = WorkloadRunner<FcDriver, RealEndpointSpawner, RealBrokerRegistrar>;\n\
-             type LibkrunRunner = WorkloadRunner<LibkrunDriver, RealEndpointSpawner, RealBrokerRegistrar>;\n\
-             type HvfRunner = WorkloadRunner<HvfDriver, RealEndpointSpawner, RealBrokerRegistrar>;\n\
+            "type FcRunner = WorkloadRunner<FcDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;\n\
+             type LibkrunRunner = WorkloadRunner<LibkrunDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;\n\
+             type HvfRunner = WorkloadRunner<HvfDriver, RealNetworkEndpointSpawner, RealBrokerRegistrar>;\n\
              pub enum AnyBackend {\n    Firecracker(FcRunner),\n    Libkrun(LibkrunRunner),\n    Hvf(HvfBackend),\n}\n",
         )
         .expect("write backend fixture");


### PR DESCRIPTION
Plan 316 Phase 2 residue — two of #2371's checkboxes. They were unchecked because they were undone, not because the bookkeeping lagged; the plan simultaneously carried `Status: COMPLETE` on that phase.

## Rename

`EndpointSpawner` → `NetworkEndpointSpawner`, `RealEndpointSpawner` → `RealNetworkEndpointSpawner`, and `EndpointSpawnRequest` → `NetworkEndpointSpawnRequest`. The plan names only the first two; I moved the request type as well rather than leave `EndpointSpawnRequest` sitting beside a renamed trait — the repo's rule is hard renames with no half-states.

`xtask check-uniform-vsock-egress` pins the converged runner shape **by type name**, so it moved in the same change. Worth noting because it means a pure rename would otherwise have turned a green invariant gate red:

```
Error: check-uniform-vsock-egress: FcRunner lost its converged runner shape.
Expected `type FcRunner = WorkloadRunner<FcDriver, RealEndpointSpawner, RealBrokerRegistrar>`.
```

## The port had three definitions

`5253` was hand-maintained in `mvm-net`'s service mapping and in private consts in two guest bins, beside `mvm-agentd`'s own `EGRESS_PORT`. The duplicates existed for a real reason: **the guest cannot depend on `mvm-net`**, so it could not reach the typed service mapping.

The constant now lives in `mvm-contract`, which both ends already depend on and which `l3::L3_CONTROL_PORT` already uses exactly this way:

```rust
pub const NETWORK_FLOW_PORT: u32 = 5253;
```

`mvm_net::GuestService::NetworkFlow` and `mvm_agentd::vsock::EGRESS_PORT` both derive from it. That last part matters: `EGRESS_PORT` has ~80 call sites across the workspace, so making it *derive* rather than renaming it means all 80 transitively name one value with no 80-site churn. Renaming `EGRESS_PORT` itself is Phase 7 cleanup, not this.

Exactly one literal `5253` now defines the port. Drift is hard to express:

- a `const` assertion in `mvm-agentd` makes it a **compile error**;
- `mvm-net`'s `port()` test asserts the mapping and the contract constant agree, alongside the existing literal pin so the derivation still has to land on the port deployed guests dial.

## What this does not close

**#2371 stays open.** The remaining item is the one the phase exists for: a workload whose signed plan grants networking must **not reach ready** when the FlowMux session fails to authenticate — fail closed, not degrade. That is invariant 4, it has no witness today, and it is a behavioural change rather than a rename. Also outstanding: proving the transition adapter holds no independent connect/bind/DNS/rate/audit implementation by test rather than convention, and confirming no lock guard crosses an `.await`.

Phase 3 (#2372) is already six of seven boxes merged, *ahead* of this. The strict phase ordering was the mechanism meant to catch Phase 2 residue, so it will not be caught by a later gate — see the note on #2368.

## Verification

`cargo check --workspace`; `cargo nextest run -p mvm-net -p mvm-contract` (1,079 passed) and `-p mvm-runtime -p mvm-hostd` (2,696 passed); `cargo clippy --workspace --all-targets -- -D warnings`; `cargo nextest run -p xtask` (567 passed); and the four network invariant gates — `check-uniform-vsock-egress`, `check-vsock-only-egress`, `check-l3-expansion-freeze`, `check-honesty`.

Plan 316's two checkboxes are ticked in the same change, with the reasoning recorded rather than just the box flipped.