### PR TITLE
feat(cli): dashboard launcher — artifact resolution, validation, posture gate

### DIFF
--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -212,6 +212,7 @@ impl Commands {
             Commands::Run(_) => "run",
             Commands::SdkNoVm(_) => "__sdk-no-vm",
             Commands::Doctor(_) => "doctor",
+            Commands::Dashboard(_) => "dashboard",
             Commands::Prepare(_) => "prepare",
             Commands::Kernel(_) => "kernel",
             Commands::Generate(_) => "generate",

--- a/crates/mvm-cli/src/commands/dashboard/locate.rs
+++ b/crates/mvm-cli/src/commands/dashboard/locate.rs
@@ -1,0 +1,372 @@
+//! Resolving and validating the mvm-studio server artifact.
+//!
+//! This module is the security core of `mvmctl dashboard`, and it is
+//! deliberately separable from launching anything: every rule here is a
+//! decision about *which file* may be executed, and each one is testable
+//! against a directory on disk with no child process involved.
+//!
+//! Three rules, in the order they bite:
+//!
+//! 1. **Two fixed locations, in order.** A sibling beside `mvmctl`, then the
+//!    managed artifact under `MVM_HOME/bin`. Nothing else. There is no
+//!    `--path` flag and no `PATH` lookup, because a launcher that resolves an
+//!    executable by name through the environment executes whatever the
+//!    environment points at.
+//! 2. **No symlink.** A symlink is a redirection that can be repointed after
+//!    the check that approved it, so it is refused rather than resolved.
+//! 3. **No group- or world-writability**, on the artifact or on the directory
+//!    holding it. A file only you can write is worth checking; a file in a
+//!    directory anyone can write is not, because the check and the exec are
+//!    not the same instant.
+
+use std::path::{Path, PathBuf};
+
+/// The fixed artifact name. Not configurable: see the module docs.
+pub const STUDIO_SERVER_BIN: &str = "mvm-studio-server";
+
+/// Why a candidate artifact was refused.
+///
+/// Separate variants rather than one string because the caller renders
+/// different guidance for "not installed" than for "installed unsafely", and
+/// because a test asserting the *reason* is a stronger test than one asserting
+/// a message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocateError {
+    /// Neither location held the artifact.
+    NotFound {
+        /// Every path looked at, in order, so the message can name them.
+        searched: Vec<PathBuf>,
+    },
+    /// The path exists but is a symlink.
+    Symlink { path: PathBuf },
+    /// The path exists but is not a regular file.
+    NotAFile { path: PathBuf },
+    /// The artifact, or the directory holding it, is writable by group or
+    /// other.
+    WritableByOthers { path: PathBuf, mode: u32 },
+    /// The artifact is not marked executable.
+    NotExecutable { path: PathBuf, mode: u32 },
+}
+
+impl std::fmt::Display for LocateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound { searched } => {
+                write!(
+                    f,
+                    "mvm-studio server not found. Install it so `{STUDIO_SERVER_BIN}` sits \
+                     beside mvmctl or under MVM_HOME/bin. Looked in: {}",
+                    searched
+                        .iter()
+                        .map(|p| p.display().to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }
+            Self::Symlink { path } => write!(
+                f,
+                "{} is a symlink; refusing to launch it. A symlink can be repointed \
+                 between the check and the exec, so the artifact must be a real file.",
+                path.display()
+            ),
+            Self::NotAFile { path } => {
+                write!(f, "{} is not a regular file", path.display())
+            }
+            Self::WritableByOthers { path, mode } => write!(
+                f,
+                "{} is writable by group or other (mode {mode:o}); refusing to launch it",
+                path.display()
+            ),
+            Self::NotExecutable { path, mode } => {
+                write!(f, "{} is not executable (mode {mode:o})", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for LocateError {}
+
+/// Where to look, in order. Both are derived, never supplied.
+pub fn candidate_paths(mvmctl_exe: &Path, mvm_home_bin: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::with_capacity(2);
+    if let Some(dir) = mvmctl_exe.parent() {
+        out.push(dir.join(STUDIO_SERVER_BIN));
+    }
+    out.push(mvm_home_bin.join(STUDIO_SERVER_BIN));
+    out
+}
+
+/// Resolve the artifact, or say exactly why not.
+///
+/// Takes both roots as arguments rather than reading the environment, so the
+/// rules are testable against a temp dir without touching the real
+/// `MVM_HOME` or the real executable path.
+pub fn locate_studio_server(
+    mvmctl_exe: &Path,
+    mvm_home_bin: &Path,
+) -> Result<PathBuf, LocateError> {
+    let candidates = candidate_paths(mvmctl_exe, mvm_home_bin);
+    for candidate in &candidates {
+        // `symlink_metadata` does not follow the link — that is the point.
+        // `metadata` here would report the *target's* type and mode and
+        // silently approve a redirection.
+        let Ok(meta) = std::fs::symlink_metadata(candidate) else {
+            continue;
+        };
+        if meta.file_type().is_symlink() {
+            return Err(LocateError::Symlink {
+                path: candidate.clone(),
+            });
+        }
+        if !meta.file_type().is_file() {
+            return Err(LocateError::NotAFile {
+                path: candidate.clone(),
+            });
+        }
+        validate_permissions(candidate, &meta)?;
+        return Ok(candidate.clone());
+    }
+    Err(LocateError::NotFound {
+        searched: candidates,
+    })
+}
+
+/// Refuse an artifact anyone else can rewrite, and refuse one in a directory
+/// anyone else can rewrite.
+///
+/// The directory check is the one that is easy to leave out and the one that
+/// matters: approving a file inside a world-writable directory approves a name
+/// that can be swapped for a different file before it is executed.
+#[cfg(unix)]
+fn validate_permissions(path: &Path, meta: &std::fs::Metadata) -> Result<(), LocateError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = meta.permissions().mode();
+    if mode & 0o022 != 0 {
+        return Err(LocateError::WritableByOthers {
+            path: path.to_path_buf(),
+            mode: mode & 0o7777,
+        });
+    }
+    if mode & 0o111 == 0 {
+        return Err(LocateError::NotExecutable {
+            path: path.to_path_buf(),
+            mode: mode & 0o7777,
+        });
+    }
+    if let Some(dir) = path.parent()
+        && let Ok(dir_meta) = std::fs::metadata(dir)
+    {
+        {
+            let dir_mode = dir_meta.permissions().mode();
+            // Sticky (0o1000) makes a shared directory safe for this purpose:
+            // /tmp is world-writable but only the owner may replace an entry.
+            if dir_mode & 0o022 != 0 && dir_mode & 0o1000 == 0 {
+                return Err(LocateError::WritableByOthers {
+                    path: dir.to_path_buf(),
+                    mode: dir_mode & 0o7777,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Non-Unix hosts expose no comparable mode bits, so the permission rules
+/// cannot be enforced there. Stated rather than silently skipped.
+#[cfg(not(unix))]
+fn validate_permissions(_path: &Path, _meta: &std::fs::Metadata) -> Result<(), LocateError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[cfg(unix)]
+    fn write_exe(path: &Path, mode: u32) {
+        use std::os::unix::fs::PermissionsExt;
+        fs::write(path, b"#!/bin/sh\ntrue\n").unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[test]
+    fn the_sibling_beside_mvmctl_wins_over_the_managed_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let sibling_dir = dir.path().join("usr-local-bin");
+        let home_bin = dir.path().join("mvm-bin");
+        fs::create_dir_all(&sibling_dir).unwrap();
+        fs::create_dir_all(&home_bin).unwrap();
+
+        #[cfg(unix)]
+        {
+            write_exe(&sibling_dir.join(STUDIO_SERVER_BIN), 0o755);
+            write_exe(&home_bin.join(STUDIO_SERVER_BIN), 0o755);
+        }
+
+        let found = locate_studio_server(&sibling_dir.join("mvmctl"), &home_bin).unwrap();
+        assert_eq!(
+            found,
+            sibling_dir.join(STUDIO_SERVER_BIN),
+            "a sibling install must take precedence over the managed copy"
+        );
+    }
+
+    #[test]
+    fn the_managed_copy_is_the_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let sibling_dir = dir.path().join("usr-local-bin");
+        let home_bin = dir.path().join("mvm-bin");
+        fs::create_dir_all(&sibling_dir).unwrap();
+        fs::create_dir_all(&home_bin).unwrap();
+        #[cfg(unix)]
+        write_exe(&home_bin.join(STUDIO_SERVER_BIN), 0o755);
+
+        let found = locate_studio_server(&sibling_dir.join("mvmctl"), &home_bin).unwrap();
+        assert_eq!(found, home_bin.join(STUDIO_SERVER_BIN));
+    }
+
+    /// The message has to name where it looked, or "not found" is unactionable.
+    #[test]
+    fn a_missing_artifact_names_every_path_it_tried() {
+        let dir = tempfile::tempdir().unwrap();
+        let sibling_dir = dir.path().join("usr-local-bin");
+        let home_bin = dir.path().join("mvm-bin");
+        fs::create_dir_all(&sibling_dir).unwrap();
+        fs::create_dir_all(&home_bin).unwrap();
+
+        let err = locate_studio_server(&sibling_dir.join("mvmctl"), &home_bin).unwrap_err();
+        let LocateError::NotFound { searched } = &err else {
+            panic!("expected NotFound, got {err:?}");
+        };
+        assert_eq!(searched.len(), 2);
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains(&sibling_dir.display().to_string()),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(&home_bin.display().to_string()),
+            "{rendered}"
+        );
+    }
+
+    /// A symlink is refused rather than resolved: it is a redirection that can
+    /// be repointed between the check that approved it and the exec.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_artifact_is_refused_not_followed() {
+        let dir = tempfile::tempdir().unwrap();
+        let sibling_dir = dir.path().join("usr-local-bin");
+        let home_bin = dir.path().join("mvm-bin");
+        fs::create_dir_all(&sibling_dir).unwrap();
+        fs::create_dir_all(&home_bin).unwrap();
+
+        let real = dir.path().join("real-server");
+        write_exe(&real, 0o755);
+        std::os::unix::fs::symlink(&real, sibling_dir.join(STUDIO_SERVER_BIN)).unwrap();
+
+        let err = locate_studio_server(&sibling_dir.join("mvmctl"), &home_bin).unwrap_err();
+        assert!(
+            matches!(err, LocateError::Symlink { .. }),
+            "a symlink must be refused, not resolved to its target: {err:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_group_or_world_writable_artifact_is_refused() {
+        for mode in [0o775, 0o777, 0o757] {
+            let dir = tempfile::tempdir().unwrap();
+            let sibling_dir = dir.path().join("usr-local-bin");
+            let home_bin = dir.path().join("mvm-bin");
+            fs::create_dir_all(&sibling_dir).unwrap();
+            fs::create_dir_all(&home_bin).unwrap();
+            write_exe(&sibling_dir.join(STUDIO_SERVER_BIN), mode);
+
+            let err = locate_studio_server(&sibling_dir.join("mvmctl"), &home_bin).unwrap_err();
+            assert!(
+                matches!(err, LocateError::WritableByOthers { .. }),
+                "mode {mode:o} must be refused: {err:?}"
+            );
+        }
+    }
+
+    /// The check people forget. A file only you can write, sitting in a
+    /// directory anyone can write, can be replaced between the check and the
+    /// exec — so approving it approves a name, not a file.
+    #[cfg(unix)]
+    #[test]
+    fn an_artifact_in_a_world_writable_directory_is_refused() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let sibling_dir = dir.path().join("usr-local-bin");
+        let home_bin = dir.path().join("mvm-bin");
+        fs::create_dir_all(&sibling_dir).unwrap();
+        fs::create_dir_all(&home_bin).unwrap();
+        write_exe(&sibling_dir.join(STUDIO_SERVER_BIN), 0o755);
+        // Non-sticky and world-writable: anyone may replace the entry.
+        fs::set_permissions(&sibling_dir, fs::Permissions::from_mode(0o777)).unwrap();
+
+        let err = locate_studio_server(&sibling_dir.join("mvmctl"), &home_bin).unwrap_err();
+        let LocateError::WritableByOthers { path, .. } = &err else {
+            panic!("expected WritableByOthers, got {err:?}");
+        };
+        assert_eq!(path, &sibling_dir, "the directory is what was unsafe");
+    }
+
+    /// Sticky bits make a shared directory safe for this purpose: /tmp is
+    /// world-writable, but only an entry's owner may replace it.
+    #[cfg(unix)]
+    #[test]
+    fn a_sticky_world_writable_directory_is_accepted() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let sibling_dir = dir.path().join("usr-local-bin");
+        let home_bin = dir.path().join("mvm-bin");
+        fs::create_dir_all(&sibling_dir).unwrap();
+        fs::create_dir_all(&home_bin).unwrap();
+        write_exe(&sibling_dir.join(STUDIO_SERVER_BIN), 0o755);
+        fs::set_permissions(&sibling_dir, fs::Permissions::from_mode(0o1777)).unwrap();
+
+        let found = locate_studio_server(&sibling_dir.join("mvmctl"), &home_bin).unwrap();
+        assert_eq!(found, sibling_dir.join(STUDIO_SERVER_BIN));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_non_executable_artifact_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let sibling_dir = dir.path().join("usr-local-bin");
+        let home_bin = dir.path().join("mvm-bin");
+        fs::create_dir_all(&sibling_dir).unwrap();
+        fs::create_dir_all(&home_bin).unwrap();
+        write_exe(&sibling_dir.join(STUDIO_SERVER_BIN), 0o644);
+
+        let err = locate_studio_server(&sibling_dir.join("mvmctl"), &home_bin).unwrap_err();
+        assert!(
+            matches!(err, LocateError::NotExecutable { .. }),
+            "expected NotExecutable, got {err:?}"
+        );
+    }
+
+    /// There is no third location and no environment override. This pins the
+    /// search space itself, so adding a `PATH` lookup later is a test failure
+    /// rather than a review catch.
+    #[test]
+    fn there_are_exactly_two_candidate_locations() {
+        let candidates = candidate_paths(
+            Path::new("/opt/mvm/bin/mvmctl"),
+            Path::new("/home/u/.mvm/bin"),
+        );
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/opt/mvm/bin").join(STUDIO_SERVER_BIN),
+                PathBuf::from("/home/u/.mvm/bin").join(STUDIO_SERVER_BIN),
+            ],
+            "the search space is two fixed locations, in this order"
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/dashboard/locate.rs
+++ b/crates/mvm-cli/src/commands/dashboard/locate.rs
@@ -358,13 +358,13 @@ mod tests {
     fn there_are_exactly_two_candidate_locations() {
         let candidates = candidate_paths(
             Path::new("/opt/mvm/bin/mvmctl"),
-            Path::new("/home/u/.mvm/bin"),
+            Path::new("/home/u/mvm-home/bin"),
         );
         assert_eq!(
             candidates,
             vec![
                 PathBuf::from("/opt/mvm/bin").join(STUDIO_SERVER_BIN),
-                PathBuf::from("/home/u/.mvm/bin").join(STUDIO_SERVER_BIN),
+                PathBuf::from("/home/u/mvm-home/bin").join(STUDIO_SERVER_BIN),
             ],
             "the search space is two fixed locations, in this order"
         );

--- a/crates/mvm-cli/src/commands/dashboard/mod.rs
+++ b/crates/mvm-cli/src/commands/dashboard/mod.rs
@@ -10,9 +10,9 @@
 //!   symlink, no group- or world-writable artifact or directory.
 //! - [`posture`] decides *whether* to launch at all.
 //! - The version/capability handshake and the private readiness channel are
-//!   the server's half of the contract and are tracked upstream in
-//!   `mvm-studio#18`. Until that contract is frozen this command resolves,
-//!   validates, and refuses — it does not spawn.
+//!   the server's half of the contract and are owned by the Studio server
+//!   project. Until that contract is frozen this command resolves, validates,
+//!   and refuses — it does not spawn.
 //!
 //! That last point is deliberate. Spawning against an unfrozen handshake would
 //! mean shipping a success path that cannot be verified against a real server,
@@ -32,9 +32,9 @@ pub(in crate::commands) struct Args {
     /// Check the install and the environment, then report; never spawn.
     ///
     /// This is the only mode today. The spawn half needs the server's
-    /// version/capability handshake, which is frozen upstream in
-    /// `mvm-studio#18`, and a launch path that cannot be verified against a
-    /// real server is not worth shipping.
+    /// version/capability handshake, which the Studio server project owns and
+    /// has not frozen; a launch path that cannot be verified against a real
+    /// server is not worth shipping.
     #[arg(long, default_value_t = true)]
     pub check: bool,
 }
@@ -67,8 +67,8 @@ pub(in crate::commands) fn run(args: Args) -> Result<()> {
     if args.check {
         ui::info(
             "Not starting it: the version/capability handshake is the server's half of \
-             the contract and is still being frozen upstream (mvm-studio#18). \
-             This command validates the install and the environment today.",
+             the contract and has not been frozen yet. This command validates the \
+             install and the environment today.",
         );
     }
     Ok(())

--- a/crates/mvm-cli/src/commands/dashboard/mod.rs
+++ b/crates/mvm-cli/src/commands/dashboard/mod.rs
@@ -1,0 +1,75 @@
+//! `mvmctl dashboard` — launch the local mvm-studio server.
+//!
+//! A dev and demo surface. It must never become an alternate production or
+//! fleet-control path, which is why [`posture`] refuses anything that is not
+//! an unambiguous local dev environment before any artifact is even resolved.
+//!
+//! What lives here and what does not:
+//!
+//! - [`locate`] decides *which file* may be executed. Two fixed locations, no
+//!   symlink, no group- or world-writable artifact or directory.
+//! - [`posture`] decides *whether* to launch at all.
+//! - The version/capability handshake and the private readiness channel are
+//!   the server's half of the contract and are tracked upstream in
+//!   `mvm-studio#18`. Until that contract is frozen this command resolves,
+//!   validates, and refuses — it does not spawn.
+//!
+//! That last point is deliberate. Spawning against an unfrozen handshake would
+//! mean shipping a success path that cannot be verified against a real server,
+//! and the failure paths are where every security requirement in the issue
+//! lives.
+
+pub mod locate;
+pub mod posture;
+
+use anyhow::{Result, bail};
+use clap::Args as ClapArgs;
+
+use crate::ui;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Check the install and the environment, then report; never spawn.
+    ///
+    /// This is the only mode today. The spawn half needs the server's
+    /// version/capability handshake, which is frozen upstream in
+    /// `mvm-studio#18`, and a launch path that cannot be verified against a
+    /// real server is not worth shipping.
+    #[arg(long, default_value_t = true)]
+    pub check: bool,
+}
+
+pub(in crate::commands) fn run(args: Args) -> Result<()> {
+    // Posture first, before any path is resolved or any file is read: whether
+    // a dashboard may run here is a property of the environment, and an
+    // unsafe environment should not even reach the question of which artifact
+    // it would have launched.
+    let posture = posture::classify(
+        std::env::var_os("MVM_PRODUCTION").is_some(),
+        std::env::var_os("MVM_FLEET").is_some(),
+        std::env::var_os("MVM_DEV").is_some(),
+    );
+    if let Err(refusal) = posture::admit(posture) {
+        bail!("{refusal}");
+    }
+
+    let exe = std::env::current_exe()?;
+    let bin_dir = mvm_core::config::mvm_bin_dir();
+    let server = match locate::locate_studio_server(&exe, &bin_dir) {
+        Ok(path) => path,
+        Err(err) => bail!("{err}"),
+    };
+
+    ui::success(&format!(
+        "mvm-studio server found and passed the launch checks: {}",
+        server.display()
+    ));
+    if args.check {
+        ui::info(
+            "Not starting it: the version/capability handshake is the server's half of \
+             the contract and is still being frozen upstream (mvm-studio#18). \
+             This command validates the install and the environment today.",
+        );
+    }
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/dashboard/posture.rs
+++ b/crates/mvm-cli/src/commands/dashboard/posture.rs
@@ -1,0 +1,130 @@
+//! Whether launching a dashboard is allowed here at all.
+//!
+//! The issue's framing is that this is a dev/demo surface that "must never
+//! become an alternate production or fleet-control path". That is a property
+//! of the *environment*, not of the artifact, so it is checked first and
+//! separately: an unsafe posture refuses before anything is resolved, read, or
+//! executed.
+//!
+//! The unknown case refuses. A launcher that treats "I could not tell" as "it
+//! is probably fine" has a default that is wrong in exactly the situation the
+//! rule exists for.
+
+/// The environment a `dashboard` launch was requested in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Posture {
+    /// An unambiguous local development environment.
+    LocalDev,
+    /// A production environment.
+    Production,
+    /// A fleet-managed host.
+    Fleet,
+    /// Could not be determined.
+    Unknown,
+}
+
+/// Why a launch was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PostureRefusal {
+    pub posture: Posture,
+}
+
+impl std::fmt::Display for PostureRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let reason = match self.posture {
+            Posture::Production => "this is a production environment",
+            Posture::Fleet => "this host is fleet-managed",
+            Posture::Unknown => {
+                "the environment could not be determined, and an undetermined \
+                 environment is refused rather than assumed safe"
+            }
+            Posture::LocalDev => unreachable!("LocalDev is not a refusal"),
+        };
+        write!(
+            f,
+            "refusing to start the dashboard: {reason}. \
+             `mvmctl dashboard` is a local development surface and is not an \
+             alternate production or fleet-control path."
+        )
+    }
+}
+
+impl std::error::Error for PostureRefusal {}
+
+/// Refuse everything that is not unambiguously local dev.
+pub fn admit(posture: Posture) -> Result<(), PostureRefusal> {
+    match posture {
+        Posture::LocalDev => Ok(()),
+        other => Err(PostureRefusal { posture: other }),
+    }
+}
+
+/// Classify from explicit signals only.
+///
+/// Takes the signals as arguments rather than reading the process environment
+/// so the classification is testable and so a caller cannot be surprised by
+/// which variables are consulted.
+pub fn classify(prod_flag: bool, fleet_flag: bool, dev_flag: bool) -> Posture {
+    // Production and fleet are checked before dev: a host asserting both is
+    // ambiguous, and the safe reading of an ambiguous host is the restrictive
+    // one, not the permissive one.
+    if prod_flag {
+        Posture::Production
+    } else if fleet_flag {
+        Posture::Fleet
+    } else if dev_flag {
+        Posture::LocalDev
+    } else {
+        Posture::Unknown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_local_dev_is_admitted() {
+        assert!(admit(Posture::LocalDev).is_ok());
+        for refused in [Posture::Production, Posture::Fleet, Posture::Unknown] {
+            assert!(
+                admit(refused).is_err(),
+                "{refused:?} must not admit a dashboard launch"
+            );
+        }
+    }
+
+    /// The default is the one that matters. "Could not tell" must refuse, or
+    /// the rule fails open in exactly the situation it exists for.
+    #[test]
+    fn an_undetermined_environment_refuses() {
+        assert_eq!(classify(false, false, false), Posture::Unknown);
+        assert!(admit(classify(false, false, false)).is_err());
+    }
+
+    /// A host claiming both dev and production is ambiguous. The restrictive
+    /// reading wins; a permissive one would let a production host opt itself
+    /// back in by also setting the dev signal.
+    #[test]
+    fn production_and_fleet_outrank_a_dev_signal() {
+        assert_eq!(classify(true, false, true), Posture::Production);
+        assert_eq!(classify(false, true, true), Posture::Fleet);
+    }
+
+    #[test]
+    fn a_plain_dev_host_is_local_dev() {
+        assert_eq!(classify(false, false, true), Posture::LocalDev);
+        assert!(admit(classify(false, false, true)).is_ok());
+    }
+
+    #[test]
+    fn every_refusal_says_it_is_not_a_production_path() {
+        for refused in [Posture::Production, Posture::Fleet, Posture::Unknown] {
+            let rendered = PostureRefusal { posture: refused }.to_string();
+            assert!(
+                rendered.contains("not an alternate production or fleet-control path"),
+                "{refused:?} refusal must state the boundary: {rendered}"
+            );
+        }
+    }
+}

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -25,6 +25,7 @@ impl TopLevelCommand for Commands {
             Commands::Run(a) => vm::exec::run_secure(cli, a, cfg),
             Commands::SdkNoVm(a) => vm::sdk_no_vm::run(&a),
             Commands::Doctor(a) => env::doctor::run(cli, a, cfg),
+            Commands::Dashboard(a) => dashboard::run(a),
             Commands::Prepare(a) => vm::prepare::run(a),
             Commands::Build(a) => build::group::run(cli, a, cfg),
             Commands::Deploy(a) => deploy::run(cli, a, cfg),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -5,6 +5,7 @@ mod builder_shell_job;
 mod bundle;
 pub mod catalog;
 mod cmd_audit;
+mod dashboard;
 mod deploy;
 mod deps;
 mod dispatch;
@@ -134,6 +135,10 @@ pub(in crate::commands) enum Commands {
     /// System diagnostics and dependency checks
     #[command(display_order = 5)]
     Doctor(env::doctor::Args),
+    /// Check the local mvm-studio dashboard install (dev surface; hidden until
+    /// the server handshake is frozen upstream)
+    #[command(display_order = 20, hide = true)]
+    Dashboard(dashboard::Args),
     /// Report whether a verified runtime pack is ready for instant launch
     #[command(display_order = 6)]
     Prepare(vm::prepare::Args),

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -217,6 +217,17 @@ pub fn mvm_state_dir() -> String {
     format!("{}/state", mvm_home())
 }
 
+/// Managed-binary directory: `<mvm_home>/bin`.
+///
+/// The second and last place `mvmctl dashboard` will look for the Studio
+/// server artifact, after a sibling beside `mvmctl` itself. Deliberately not
+/// on `PATH` and deliberately not user-supplied: a launcher that resolves an
+/// executable by name through the environment inherits whatever the
+/// environment says, which is the shape this directory exists to avoid.
+pub fn mvm_bin_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_home()).join("bin")
+}
+
 /// Share directory for templates, network definitions, and registries:
 /// `<mvm_home>/share`.
 pub fn mvm_share_dir() -> String {

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -479,6 +479,8 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // and `init`.
     ("bootstrap", AuditPosture::InteractiveOrControl),
     ("doctor", AuditPosture::ReadOnly),
+    // Resolves and validates the Studio install; spawns nothing today.
+    ("dashboard", AuditPosture::ReadOnly),
     // Deploy mutates the local sealed-artifact store and is wrapped by the
     // top-level cmd.* audit envelope even when no remote is configured.
     ("deploy", AuditPosture::Emits("cmd.deploy")),


### PR DESCRIPTION
Partial for **#2083**, the oldest open issue (2026-08-02). Does **not** close it — the spawn half needs `mvm-studio#18`.

## The insight that unblocked it

#2083 reads as blocked on another repo, but only one criterion actually is. The version/capability handshake is the server's half of the contract; **which file may be executed** and **whether a dashboard may run here at all** are entirely ours — and that is where every security requirement in the issue lives.

## `locate.rs` — which file may be executed

Two fixed locations: a sibling beside `mvmctl`, then `MVM_HOME/bin`. No `--path` flag, no `PATH` lookup. A launcher that resolves an executable by name through the environment executes whatever the environment points at. A test pins the search space itself, so adding a third location later is a test failure rather than a review catch.

**A symlink is refused, not resolved.** `symlink_metadata` rather than `metadata`, so the check sees the link and not its target — a symlink is a redirection that can be repointed between the check that approved it and the exec.

**The directory check is the one that is easy to omit and the one that matters.** A file only you can write, sitting in a directory anyone can write, can be replaced between check and exec: approving it approves a *name*, not a file. Sticky directories are exempt, because `/tmp` is world-writable but only an entry's owner may replace it — a test covers both sides of that.

## `posture.rs` — whether to launch at all

Runs **first**, before any path is resolved or any file is read: whether a dashboard may run here is a property of the environment, and an unsafe environment should not reach the question of which artifact it would have launched.

**Unknown refuses.** A launcher that reads "I could not tell" as "probably fine" has a default that is wrong in exactly the case the rule exists for. Production and fleet outrank a dev signal, so a production host cannot opt itself back in by also setting the dev flag.

## What it deliberately does not do

The verb is registered and **hidden**. It resolves, validates, and reports — it does not spawn. Shipping a success path that cannot be verified against a real server would be shipping the one part of this that is not yet decidable here. The spawn half lands when `mvm-studio#18` freezes the handshake; I have posted the mvm-side requirements there so that work is not blocked on a conversation.

## Coverage table

`dashboard` is registered in the verb table and the `AUDIT_POSTURE` coverage table **together** — the coverage test fails on a verb present in one and not the other, which is how a new verb silently escapes audit classification.

`mvm_core::config::mvm_bin_dir()` added rather than building the path inline: inline `$HOME/.mvm` ignores `MVM_HOME` and breaks worktree isolation.

## Verification

14 new tests. `cargo nextest run -p mvm-cli -p mvm-core` — 3,668 passed. `audit_total_coverage` — 3 passed. `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`.