### PR TITLE
perf(fs): stop copying every file's bytes into the ext4 plan

### DIFF
--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -1380,7 +1380,7 @@ mod linux {
             }];
             let options = mvm_fs::ext4::BuildOptions::default().with_volume_name(b"mvm-work");
             let image =
-                mvm_fs::ext4::build_image_with_options(&nodes, &options).expect("build image");
+                mvm_fs::ext4::build_image_with_options(nodes, &options).expect("build image");
             assert_eq!(
                 ext4_volume_label_from_superblock(&image),
                 Some("mvm-work".to_string())

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -693,7 +693,7 @@ mod tests {
         let nodes =
             mvm_fs::rootfs::collect_nodes(src.path(), mvm_fs::rootfs::WalkOptions::default())
                 .expect("collect nodes");
-        let dense = mvm_fs::ext4::build_image(&nodes).expect("dense ext4 image");
+        let dense = mvm_fs::ext4::build_image(nodes).expect("dense ext4 image");
 
         let out = tempfile::tempdir().unwrap();
         let out_path = out.path().join("rootfs.ext4");

--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -215,7 +215,7 @@ pub fn build_runtime_overlay_from_guest_binaries(
     .collect::<Result<(), _>>()?;
     std::fs::write(root.join("VERSION"), format!("{version}\n"))?;
 
-    let image = mvm_fs::ext4::build_image(&collect_overlay_nodes(&root)?).map_err(|e| {
+    let image = mvm_fs::ext4::build_image(collect_overlay_nodes(&root)?).map_err(|e| {
         RuntimeOverlayError::DirectBuildFailed {
             reason: format!("build ext4 image: {e}"),
         }
@@ -1206,7 +1206,7 @@ mod tests {
             data: b"0.14.0\n".to_vec(),
             xattrs: Vec::new(),
         });
-        mvm_fs::ext4::build_image(&nodes).expect("build valid overlay ext4 fixture")
+        mvm_fs::ext4::build_image(nodes).expect("build valid overlay ext4 fixture")
     }
 
     #[test]

--- a/crates/mvm-build/src/sdk_sidecar.rs
+++ b/crates/mvm-build/src/sdk_sidecar.rs
@@ -321,7 +321,7 @@ mod tests {
                 xattrs: Vec::new(),
             },
         ];
-        mvm_fs::ext4::build_image(&nodes).expect("build the sidecar ext4 fixture")
+        mvm_fs::ext4::build_image(nodes).expect("build the sidecar ext4 fixture")
     }
 
     fn append_file<W: std::io::Write>(tar: &mut tar::Builder<W>, path: &str, bytes: &[u8]) {

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -503,7 +503,7 @@ mod sdk_sidecar_host_resolution_tests {
                 xattrs: Vec::new(),
             },
         ];
-        mvm_fs::ext4::build_image(&nodes).expect("build sidecar ext4 fixture")
+        mvm_fs::ext4::build_image(nodes).expect("build sidecar ext4 fixture")
     }
 
     fn seed_sidecar_cache(cache: &std::path::Path, version: &str, arch: GuestArch) {
@@ -818,7 +818,7 @@ mod runtime_overlay_attach_tests {
                 xattrs: Vec::new(),
             });
         }
-        mvm_fs::ext4::build_image(&nodes).expect("build valid overlay ext4 fixture")
+        mvm_fs::ext4::build_image(nodes).expect("build valid overlay ext4 fixture")
     }
 
     /// Stage a complete overlay cache entry (the four files the resolver

--- a/crates/mvm-conformance/tests/steps/runtime_overlay.rs
+++ b/crates/mvm-conformance/tests/steps/runtime_overlay.rs
@@ -41,7 +41,7 @@ fn build_minimal_runtime_overlay(source_dir: &Path) -> mvm_fs::overlay::RuntimeO
         })
         .collect();
 
-    let ext4_bytes = mvm_fs::ext4::build_image(&nodes).expect("build minimal overlay ext4");
+    let ext4_bytes = mvm_fs::ext4::build_image(nodes).expect("build minimal overlay ext4");
     std::fs::write(source_dir.join("overlay.ext4"), ext4_bytes).expect("write overlay.ext4");
     std::fs::write(source_dir.join("overlay.verity"), b"verity-sidecar")
         .expect("write overlay.verity");

--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -42,7 +42,7 @@ fn sidecar_ext4_bytes() -> Vec<u8> {
             xattrs: Vec::new(),
         },
     ];
-    mvm_fs::ext4::build_image(&nodes).expect("build the sidecar ext4 fixture")
+    mvm_fs::ext4::build_image(nodes).expect("build the sidecar ext4 fixture")
 }
 
 fn cache_root(world: &mut CliWorld) -> std::path::PathBuf {

--- a/crates/mvm-conformance/tests/steps/verified_boot.rs
+++ b/crates/mvm-conformance/tests/steps/verified_boot.rs
@@ -157,7 +157,7 @@ fn build_minimal_rootfs() -> Vec<u8> {
             xattrs: vec![],
         },
     ];
-    mvm_fs::ext4::build_image(&nodes).expect("build minimal ext4 rootfs")
+    mvm_fs::ext4::build_image(nodes).expect("build minimal ext4 rootfs")
 }
 
 fn verity_root_hash(image: &[u8]) -> String {

--- a/crates/mvm-fs/examples/write_extent_tree.rs
+++ b/crates/mvm-fs/examples/write_extent_tree.rs
@@ -39,7 +39,7 @@ fn main() {
         },
     ];
 
-    let image = build_image(&nodes).expect("build depth-1 extent-tree ext4 image");
+    let image = build_image(nodes).expect("build depth-1 extent-tree ext4 image");
     let one_group = 32768usize * mvm_fs::ext4::BLOCK_SIZE as usize;
     assert!(
         image.len() > 4 * one_group,

--- a/crates/mvm-fs/examples/write_multigroup.rs
+++ b/crates/mvm-fs/examples/write_multigroup.rs
@@ -40,7 +40,7 @@ fn main() {
         },
     ];
 
-    let image = build_image(&nodes).expect("build multi-group ext4 image");
+    let image = build_image(nodes).expect("build multi-group ext4 image");
     let one_group = 32768usize * mvm_fs::ext4::BLOCK_SIZE as usize;
     assert!(
         image.len() > one_group,

--- a/crates/mvm-fs/examples/write_sample.rs
+++ b/crates/mvm-fs/examples/write_sample.rs
@@ -69,7 +69,7 @@ fn main() {
             xattrs: Vec::new(),
         },
     ];
-    let image = build_image(&nodes).expect("build ext4 image");
+    let image = build_image(nodes).expect("build ext4 image");
     std::fs::write(&out, &image).expect("write image file");
     eprintln!("wrote {} bytes to {out}", image.len());
 

--- a/crates/mvm-fs/fuzz-ext4/fuzz_targets/fuzz_build_image.rs
+++ b/crates/mvm-fs/fuzz-ext4/fuzz_targets/fuzz_build_image.rs
@@ -27,7 +27,7 @@ fuzz_target!(|data: &[u8]| {
     let Ok(nodes) = gen_nodes(&mut u) else {
         return;
     };
-    if let Ok(img) = build_image(&nodes) {
+    if let Ok(img) = build_image(nodes) {
         let bs = BLOCK_SIZE as usize;
         // A real ext4 image is a whole number of blocks, has room for at least
         // the superblock block plus one more, and carries the 0xEF53 magic

--- a/crates/mvm-fs/src/ext4/mod.rs
+++ b/crates/mvm-fs/src/ext4/mod.rs
@@ -363,6 +363,18 @@ impl Image {
     }
 }
 
+// One parent→child link, recorded while the node list is consumed and wired
+// into the parent's directory entries once every inode number is known.
+struct ChildEdge {
+    parent: u32,
+    name: String,
+    child: u32,
+    ft: u8,
+    // The child's normalized path, kept for the parent-is-not-a-directory
+    // refusal so it can name the offending path rather than just the leaf.
+    path: String,
+}
+
 // A planned inode: its number, kind, and the data blocks assigned to it.
 struct Planned {
     ino: u32,
@@ -538,14 +550,14 @@ impl RegionAllocator {
 
 /// Build a deterministic read-only ext4 image containing `nodes` (plus the
 /// implicit root directory). Returns the raw image bytes.
-pub fn build_image(nodes: &[Node]) -> Result<Vec<u8>, Ext4Error> {
+pub fn build_image(nodes: Vec<Node>) -> Result<Vec<u8>, Ext4Error> {
     build_image_with_options(nodes, &BuildOptions::default())
 }
 
 /// Emit a deterministic read-only ext4 image containing `nodes` as a series of
 /// sparse `(offset, bytes)` chunks. Returns the final image length in bytes so
 /// callers can size the destination file without guessing.
-pub fn emit_image<E, F>(nodes: &[Node], emit: F) -> Result<u64, EmitImageError<E>>
+pub fn emit_image<E, F>(nodes: Vec<Node>, emit: F) -> Result<u64, EmitImageError<E>>
 where
     F: FnMut(u64, &[u8]) -> Result<(), E>,
 {
@@ -553,7 +565,7 @@ where
 }
 
 pub fn build_image_with_options(
-    nodes: &[Node],
+    nodes: Vec<Node>,
     options: &BuildOptions,
 ) -> Result<Vec<u8>, Ext4Error> {
     let mut dense = Vec::new();
@@ -575,7 +587,7 @@ pub fn build_image_with_options(
 }
 
 pub fn emit_image_with_options<E, F>(
-    nodes: &[Node],
+    nodes: Vec<Node>,
     options: &BuildOptions,
     mut emit: F,
 ) -> Result<u64, EmitImageError<E>>
@@ -583,20 +595,28 @@ where
     F: FnMut(u64, &[u8]) -> Result<(), E>,
 {
     // 1. Deterministic order: sort by path so inode numbers + block layout are
-    //    a pure function of the input set.
-    let mut sorted: Vec<&Node> = nodes.iter().collect();
-    sorted.sort_by(|a, b| a.path().cmp(b.path()));
+    //    a pure function of the input set. Normalizing once here and carrying
+    //    the result keeps a file's bytes moving through the planner exactly
+    //    once — a walked tree holds every file in memory, so a second copy
+    //    doubles the build's peak footprint.
+    let mut sorted: Vec<(String, Node)> = nodes
+        .into_iter()
+        .map(|n| normalize(n.path()).map(|p| (p, n)))
+        .collect::<Result<_, _>>()
+        .map_err(EmitImageError::Build)?;
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
 
     // 2. Assign inode numbers: root=2, then FIRST_INO.. in sorted order.
     let mut ino_of: BTreeMap<String, u32> = BTreeMap::new();
     ino_of.insert("/".to_string(), ROOT_INO);
     let mut next = FIRST_INO;
-    for n in &sorted {
-        let p = normalize(n.path()).map_err(EmitImageError::Build)?;
+    for (path, _) in &sorted {
         // `ino_of` already holds "/" → ROOT_INO, so a node re-claiming root or
         // any repeated path collides here and is refused before layout.
-        if ino_of.insert(p.clone(), next).is_some() {
-            return Err(EmitImageError::Build(Ext4Error::DuplicatePath(p)));
+        if ino_of.insert(path.clone(), next).is_some() {
+            return Err(EmitImageError::Build(Ext4Error::DuplicatePath(
+                path.clone(),
+            )));
         }
         next += 1;
     }
@@ -619,38 +639,61 @@ where
         links: 2,
         xattr_block: Vec::new(),
     });
-    for n in &sorted {
-        let p = normalize(n.path()).map_err(EmitImageError::Build)?;
-        let ino = ino_of[&p];
-        let parent_path = parent_of(&p);
+    // Collected here so step 4 can validate and wire the tree without
+    // re-walking the node list, which step 3 consumes.
+    let mut child_edges: Vec<ChildEdge> = Vec::with_capacity(sorted.len());
+    for (path, node) in sorted {
+        let ino = ino_of[&path];
         let parent_ino = *ino_of
-            .get(&parent_path)
-            .ok_or_else(|| Ext4Error::MissingParent(p.clone()))
+            .get(&parent_of(&path))
+            .ok_or_else(|| Ext4Error::MissingParent(path.clone()))
             .map_err(EmitImageError::Build)?;
-        let (kind, mode, data, symlink_target, size) = match n {
-            Node::Dir { mode, .. } => {
-                (Kind::Dir, S_IFDIR | (mode & 0o7777), Vec::new(), None, 0u64)
-            }
-            Node::File { mode, data, .. } => (
-                Kind::File,
-                S_IFREG | (mode & 0o7777),
-                data.clone(),
-                None,
-                data.len() as u64,
-            ),
-            Node::Symlink { target, .. } => (
-                Kind::Symlink,
-                S_IFLNK | 0o777,
-                Vec::new(),
-                Some(target.clone()),
-                target.len() as u64,
-            ),
-        };
         // Encode the inode's xattrs into its in-inode region now; an oversized
         // set surfaces as XattrTooLarge (a capacity limit → builder-VM fallback).
-        let xattr_block = encode_inline_xattrs(n.xattrs())
+        let xattr_block = encode_inline_xattrs(node.xattrs())
             .ok_or(Ext4Error::XattrTooLarge { ino })
             .map_err(EmitImageError::Build)?;
+        // `node` is consumed here: a file's bytes move into the plan rather
+        // than being cloned out of it.
+        let (kind, mode, data, symlink_target, size, ft) = match node {
+            Node::Dir { mode, .. } => (
+                Kind::Dir,
+                S_IFDIR | (mode & 0o7777),
+                Vec::new(),
+                None,
+                0u64,
+                FT_DIR,
+            ),
+            Node::File { mode, data, .. } => {
+                let size = data.len() as u64;
+                (
+                    Kind::File,
+                    S_IFREG | (mode & 0o7777),
+                    data,
+                    None,
+                    size,
+                    FT_FILE,
+                )
+            }
+            Node::Symlink { target, .. } => {
+                let size = target.len() as u64;
+                (
+                    Kind::Symlink,
+                    S_IFLNK | 0o777,
+                    Vec::new(),
+                    Some(target),
+                    size,
+                    FT_SYMLINK,
+                )
+            }
+        };
+        child_edges.push(ChildEdge {
+            parent: parent_ino,
+            name: leaf_name(&path),
+            child: ino,
+            ft,
+            path,
+        });
         planned.push(Planned {
             ino,
             kind,
@@ -676,30 +719,16 @@ where
         .enumerate()
         .map(|(i, p)| (p.ino, i))
         .collect();
-    // Collect (parent_ino, name, child_ino, ft) first to avoid borrow conflicts.
-    let mut child_edges: Vec<(u32, String, u32, u8)> = Vec::new();
-    for n in &sorted {
-        let p = normalize(n.path()).map_err(EmitImageError::Build)?;
-        let ino = ino_of[&p];
-        let parent_ino = *ino_of.get(&parent_of(&p)).unwrap();
+    for edge in child_edges {
         // The parent must be a directory. A file/symlink parent would leave this
         // node orphaned (no dirent references it), so refuse rather than emit an
         // unreachable inode. Root (ROOT_INO) is always a directory.
-        if planned[index[&parent_ino]].kind != Kind::Dir {
-            return Err(EmitImageError::Build(Ext4Error::NotADirectory(p.clone())));
+        let pi = index[&edge.parent];
+        if planned[pi].kind != Kind::Dir {
+            return Err(EmitImageError::Build(Ext4Error::NotADirectory(edge.path)));
         }
-        let name = leaf_name(&p);
-        let ft = match n {
-            Node::Dir { .. } => FT_DIR,
-            Node::File { .. } => FT_FILE,
-            Node::Symlink { .. } => FT_SYMLINK,
-        };
-        child_edges.push((parent_ino, name, ino, ft));
-    }
-    for (parent_ino, name, child_ino, ft) in child_edges {
-        let pi = index[&parent_ino];
-        planned[pi].children.push((name, child_ino, ft));
-        if ft == FT_DIR {
+        planned[pi].children.push((edge.name, edge.child, edge.ft));
+        if edge.ft == FT_DIR {
             planned[pi].links += 1;
         }
     }
@@ -1280,7 +1309,7 @@ mod tests {
             0xee, 0xff,
         ];
         let image = build_image_with_options(
-            &[],
+            Vec::new(),
             &BuildOptions::default()
                 .with_uuid(uuid)
                 .with_volume_name(b"mvm-rootfs"),
@@ -1317,9 +1346,10 @@ mod tests {
                 xattrs: Vec::new(),
             },
         ];
-        let dense = build_image_with_options(&nodes, &BuildOptions::default()).expect("dense");
+        let dense =
+            build_image_with_options(nodes.clone(), &BuildOptions::default()).expect("dense");
         let mut streamed = Vec::new();
-        let total = emit_image_with_options(&nodes, &BuildOptions::default(), |offset, bytes| {
+        let total = emit_image_with_options(nodes, &BuildOptions::default(), |offset, bytes| {
             let start = offset as usize;
             let end = start + bytes.len();
             if streamed.len() < end {
@@ -1341,7 +1371,7 @@ mod tests {
             data: vec![1u8; super::BLOCK_SIZE_USIZE * 2],
             xattrs: Vec::new(),
         }];
-        let err = emit_image_with_options(&nodes, &BuildOptions::default(), |_offset, _bytes| {
+        let err = emit_image_with_options(nodes, &BuildOptions::default(), |_offset, _bytes| {
             Err::<(), _>("synthetic sink failure")
         })
         .expect_err("sink error must surface");

--- a/crates/mvm-fs/src/oci_to_rootfs/ext4.rs
+++ b/crates/mvm-fs/src/oci_to_rootfs/ext4.rs
@@ -588,7 +588,7 @@ mod tests {
             .with_xattr_policy(crate::rootfs::XattrPolicy::Ignore);
         let nodes = crate::rootfs::collect_nodes(&staged.root, walk).expect("collect nodes");
         let dense =
-            crate::ext4::build_image_with_options(&nodes, &build_options).expect("dense image");
+            crate::ext4::build_image_with_options(nodes, &build_options).expect("dense image");
 
         let materialized = materialize_in_process(&staged.root, &output, &options, &build_options)
             .expect("streamed in-process materialize");

--- a/crates/mvm-fs/src/overlay.rs
+++ b/crates/mvm-fs/src/overlay.rs
@@ -663,7 +663,7 @@ mod tests {
                 xattrs: Vec::new(),
             });
         }
-        crate::ext4::build_image(&nodes).expect("build valid overlay ext4 fixture")
+        crate::ext4::build_image(nodes).expect("build valid overlay ext4 fixture")
     }
 
     #[test]

--- a/crates/mvm-fs/src/rootfs.rs
+++ b/crates/mvm-fs/src/rootfs.rs
@@ -361,7 +361,7 @@ pub fn measure_ext4_pure(
     let walk_micros = elapsed_micros(walk_started.elapsed());
 
     let build_started = Instant::now();
-    let image = crate::ext4::build_image_with_options(&nodes, &options.build)?;
+    let image = crate::ext4::build_image_with_options(nodes, &options.build)?;
     let image_size_bytes = image.len() as u64;
     let image_sha256 = hex::encode(sha2::Sha256::digest(&image));
     let build_micros = elapsed_micros(build_started.elapsed());
@@ -485,6 +485,10 @@ fn merge_extra_nodes(mut walked: Vec<Node>, extra: Vec<Node>) -> Vec<Node> {
 /// Returns the raw image bytes and the final image size. The whole tree and the
 /// assembled image are held in memory, so callers can compute content-addressed
 /// sidecars (e.g. dm-verity) from `image` before writing anything to disk.
+///
+/// Peak memory is roughly 2.5× the tree's byte size — the walked nodes plus the
+/// assembled image. The nodes are consumed by the build rather than copied into
+/// it, which is why the image does not cost a third copy.
 pub fn build_ext4_pure(
     root: &Path,
     options: &MaterializeOptions,
@@ -493,7 +497,7 @@ pub fn build_ext4_pure(
         collect_nodes(root, options.walk)?,
         options.extra_nodes.clone(),
     );
-    let image = crate::ext4::build_image_with_options(&nodes, &options.build)?;
+    let image = crate::ext4::build_image_with_options(nodes, &options.build)?;
     let size_bytes = image.len() as u64;
     Ok((image, size_bytes))
 }
@@ -504,9 +508,12 @@ pub fn build_ext4_pure(
 /// directory fails with [`MaterializeError::Walk`].
 ///
 /// The whole tree is held in memory (each file's bytes + the assembled image),
-/// which is fine for small/medium rootfs; a tree past the writer's structural
-/// limits surfaces as [`MaterializeError::Build`] with a capacity-limit
-/// classification callers can use to route to an out-of-process fallback.
+/// costing roughly 2.5× the tree's size at peak, which is fine for small/medium
+/// rootfs; a tree past the writer's structural limits surfaces as
+/// [`MaterializeError::Build`] with a capacity-limit classification callers can
+/// use to route to an out-of-process fallback. That classification is
+/// structural, not memory-based: the writer's own ceiling is 16 TiB, so a large
+/// tree exhausts host memory long before it trips.
 ///
 /// Callers that need to compute sidecars from the image bytes before any disk
 /// write should use [`build_ext4_pure`] instead and handle the write
@@ -526,7 +533,7 @@ pub fn materialize_ext4_pure(
             source,
         })?;
     }
-    let size_bytes = stream_ext4_to_file(&nodes, output, &options.build)?;
+    let size_bytes = stream_ext4_to_file(nodes, output, &options.build)?;
     Ok(MaterializedImage {
         path: output.to_path_buf(),
         size_bytes,
@@ -536,7 +543,7 @@ pub fn materialize_ext4_pure(
 /// Stream the writer's sparse ranges into a file at `output`, then extend the
 /// file to the image's full size (untouched ranges stay holes).
 fn stream_ext4_to_file(
-    nodes: &[Node],
+    nodes: Vec<Node>,
     output: &Path,
     options: &BuildOptions,
 ) -> Result<u64, MaterializeError> {
@@ -844,7 +851,7 @@ mod tests {
         std::fs::write(src.path().join("hello"), b"hi\n").unwrap();
 
         let nodes = collect_nodes(src.path(), WalkOptions::default()).expect("collect nodes");
-        let dense = crate::ext4::build_image(&nodes).expect("dense ext4 image");
+        let dense = crate::ext4::build_image(nodes).expect("dense ext4 image");
 
         let out = tempfile::tempdir().unwrap();
         let out_path = out.path().join("rootfs.ext4");

--- a/crates/mvm-fs/src/sdk_sidecar.rs
+++ b/crates/mvm-fs/src/sdk_sidecar.rs
@@ -367,7 +367,7 @@ mod tests {
             },
             payload,
         ];
-        crate::ext4::build_image(&nodes).expect("build sidecar ext4 fixture")
+        crate::ext4::build_image(nodes).expect("build sidecar ext4 fixture")
     }
 
     fn sha256_hex(bytes: &[u8]) -> String {

--- a/crates/mvm-fs/tests/adversarial.rs
+++ b/crates/mvm-fs/tests/adversarial.rs
@@ -33,7 +33,7 @@ fn parent_that_is_a_file_is_rejected() {
             xattrs: Vec::new(),
         },
     ];
-    build_image(&nodes).expect_err("a file cannot be a parent directory");
+    build_image(nodes).expect_err("a file cannot be a parent directory");
 }
 
 /// Two nodes at the same path would allocate two inodes and emit two dirents of
@@ -56,7 +56,7 @@ fn duplicate_paths_are_rejected() {
             xattrs: Vec::new(),
         },
     ];
-    build_image(&nodes).expect_err("duplicate path must be rejected");
+    build_image(nodes).expect_err("duplicate path must be rejected");
 }
 
 /// Paths with empty (`//`), dot (`.`/`..`), or NUL-bearing components are
@@ -73,7 +73,7 @@ fn malformed_path_components_are_rejected() {
             xattrs: Vec::new(),
         }];
         assert!(
-            build_image(&nodes).is_err(),
+            build_image(nodes).is_err(),
             "malformed path {bad:?} must be rejected"
         );
     }
@@ -103,7 +103,7 @@ fn deep_nesting_round_trips() {
         xattrs: Vec::new(),
     });
 
-    let fs = mount(build_image(&nodes).expect("deep valid tree builds"));
+    let fs = mount(build_image(nodes).expect("deep valid tree builds"));
     // Walk d0/d1/.../d63/leaf and read it back.
     let mut ino = 2u32; // root
     for i in 0..DEPTH {
@@ -139,7 +139,7 @@ fn symlink_cycles_are_stored_verbatim() {
             target: "/s".into(),
         },
     ];
-    let fs = mount(build_image(&nodes).expect("symlink cycle builds"));
+    let fs = mount(build_image(nodes).expect("symlink cycle builds"));
     let root = list_dir(&fs, 2);
     for (name, target) in [("a", "/b"), ("b", "/a"), ("s", "/s")] {
         let (ino, ft) = find(&root, name).unwrap_or_else(|| panic!("/{name} present"));
@@ -175,7 +175,7 @@ fn directory_over_one_block_spans_multiple_blocks() {
         });
     }
 
-    let fs = mount(build_image(&nodes).expect("over-full directory builds as multi-block"));
+    let fs = mount(build_image(nodes).expect("over-full directory builds as multi-block"));
     let (big_ino, ft) = find(&list_dir(&fs, 2), "big").expect("/big present");
     assert_eq!(ft, DirEntryType::Directory);
 

--- a/crates/mvm-fs/tests/oracle.rs
+++ b/crates/mvm-fs/tests/oracle.rs
@@ -96,7 +96,7 @@ fn read_symlink_target(fs: &Filesystem, ino: u32) -> Vec<u8> {
 
 #[test]
 fn empty_tree_mounts_with_root_dir() {
-    let fs = mount(build_image(&[]).unwrap());
+    let fs = mount(build_image(Vec::new()).unwrap());
     let (root, _) = fs.read_inode_verified(2).unwrap();
     assert_eq!(root.mode & 0o170000, 0o040000, "root must be a directory");
     let names: Vec<String> = list_dir(&fs, 2).into_iter().map(|(n, ..)| n).collect();
@@ -131,7 +131,7 @@ fn tree_round_trips_through_real_reader() {
             target: "hosts".into(),
         },
     ];
-    let fs = mount(build_image(&nodes).unwrap());
+    let fs = mount(build_image(nodes).unwrap());
 
     // Root lists /etc (dir) + /hello (file).
     let root = list_dir(&fs, 2);
@@ -192,7 +192,7 @@ fn symlink_targets_round_trip_across_fast_slow_boundary() {
         });
     }
 
-    let fs = mount(build_image(&nodes).unwrap());
+    let fs = mount(build_image(nodes).unwrap());
     let (links_ino, links_ft) = find(&list_dir(&fs, 2), "links").expect("/links present");
     assert_eq!(links_ft, DirEntryType::Directory);
     let entries = list_dir(&fs, links_ino);
@@ -264,8 +264,8 @@ fn output_is_deterministic() {
             xattrs: Vec::new(),
         },
     ];
-    let one = build_image(&nodes).unwrap();
-    let two = build_image(&nodes).unwrap();
+    let one = build_image(nodes.clone()).unwrap();
+    let two = build_image(nodes).unwrap();
     assert_eq!(one, two, "same input must produce byte-identical images");
 }
 
@@ -302,7 +302,7 @@ fn multi_group_image_round_trips_through_real_reader() {
         },
     ];
 
-    let image = build_image(&nodes).unwrap();
+    let image = build_image(nodes).unwrap();
     assert!(
         image.len() > ONE_GROUP_BYTES,
         "image ({} bytes) should span more than one block group",
@@ -346,7 +346,7 @@ fn depth1_extent_tree_file_round_trips_through_real_reader() {
         data: big,
         xattrs: Vec::new(),
     }];
-    let image = build_image(&nodes).unwrap();
+    let image = build_image(nodes).unwrap();
 
     let fs = mount(image);
     let (ino, ft) = find(&list_dir(&fs, 2), "huge").expect("/huge present");

--- a/crates/mvm-fs/tests/xattr.rs
+++ b/crates/mvm-fs/tests/xattr.rs
@@ -59,7 +59,7 @@ fn file_capability_round_trips_through_the_reader() {
             value: cap.clone(),
         }],
     }];
-    let dev = Arc::new(MemDev(build_image(&nodes).expect("build with xattr")));
+    let dev = Arc::new(MemDev(build_image(nodes).expect("build with xattr")));
     let fs = Filesystem::mount(dev.clone()).expect("mount");
 
     let (ino, ft) = root_entry(&fs, "ping");
@@ -88,7 +88,7 @@ fn xattrs_are_deterministic_and_order_independent() {
         if order {
             xattrs.reverse();
         }
-        build_image(&[Node::File {
+        build_image(vec![Node::File {
             path: "/f".into(),
             mode: 0o644,
             data: b"x".to_vec(),

--- a/crates/mvm-runtime/src/sdk_sidecar.rs
+++ b/crates/mvm-runtime/src/sdk_sidecar.rs
@@ -143,7 +143,7 @@ mod tests {
                 xattrs: Vec::new(),
             },
         ];
-        mvm_fs::ext4::build_image(&nodes).expect("build sidecar ext4 fixture")
+        mvm_fs::ext4::build_image(nodes).expect("build sidecar ext4 fixture")
     }
 
     fn seed_sidecar_cache(cache: &std::path::Path, version: &str, arch: GuestArch) {


### PR DESCRIPTION
## What

The pure in-memory ext4 build held **two full copies of the tree**. The walk produces a `Vec<Node>` carrying every file's contents; the planner then cloned those contents *again* into `Planned.data` (`crates/mvm-fs/src/ext4/mod.rs`, step 3), on top of the assembled image.

This takes the node list by value through `build_image*` / `emit_image*` and moves each file's bytes into the plan instead. Each path is normalized once up front and carried alongside its node, which also drops two redundant `normalize()` passes per node and lets step 4 wire the directory tree from recorded `ChildEdge`s rather than re-walking a list step 3 has consumed.

## Why

Measured peak RSS (`getrusage(RUSAGE_SELF).ru_maxrss`, release, macOS, generated trees, one config per process):

| tree | before | after | |
|---|---|---|---|
| 256 MiB | 4.12× | **2.67×** | |
| 512 MiB | 4.10× | **2.64×** | |
| 1 GiB | 3.83× | **2.46×** | 3,926 MiB → 2,522 MiB |

Attribution: the walk alone costs ~1.4–1.5× the tree; the emitter used to add another 2.4–2.6× and now adds 1.06–1.16×. What remains is the walked nodes plus the image itself, which is inherent to building in memory.

This matters because the capacity-limit fallback to the builder VM is **structural, not memory-based** — `Ext4Error::TooLarge` fires at the ext4 ceiling of 16 TiB — so a large-but-valid tree exhausts host memory long before anything routes it elsewhere. The docs on `build_ext4_pure` / `materialize_ext4_pure` now state the real multiplier and that limitation.

## What this deliberately does not do

Pre-sizing the dense image buffer. That was the original hypothesis for the overhead; after this change the emitter adds only ~1.06× over the walk, leaving ~0.05× of headroom — not worth the API churn to thread the planned size out to the sink.

## Behavioral note

An unnormalizable path is now rejected while the input list is consumed rather than during inode assignment, so a tree with more than one bad path reports the first in *input* order instead of *sorted* order. The refusal itself is unchanged.

## Verification

- `cargo nextest run --workspace` — 11,601 passed, 26 skipped
- `cargo test --workspace --doc` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- xtask gates: `check-no-spec-refs-in-comments`, `check-honesty`, `check-no-overclaim`, `check-content-address-determinism`, `check-closure-budget` — all OK

The byte-identity guards carry the correctness argument here: `mvm-fs::oracle`'s `output_is_deterministic`, `tree_round_trips_through_real_reader`, `multi_group_image_round_trips_through_real_reader`, and the xattr determinism tests all mount the produced image through the real ext4 reader and pass unchanged.