### PR TITLE
fix(hostd): survive transient accept errors on every egress listener

### DIFF
--- a/crates/mvm-hostd/src/supervisor/accept_loop.rs
+++ b/crates/mvm-hostd/src/supervisor/accept_loop.rs
@@ -1,0 +1,198 @@
+//! Accept-error policy shared by every guest-facing listener.
+//!
+//! `accept(2)` reports two very different things through one error channel.
+//! Some errors mean the listener is dead and the loop must stop (`EBADF`,
+//! `EINVAL`, `ENOTSOCK`). Others are about the *pending connection* or about
+//! transient host pressure — a peer that reset between SYN and accept, a signal,
+//! or exhausted file descriptors — and the listener is still perfectly good.
+//!
+//! Treating the second class as fatal ends egress for a VM that did nothing
+//! wrong, for the rest of its life: fd exhaustion is usually host-wide, so the
+//! process that caused it is typically not the one that dies, and the VM does
+//! not recover when the host does.
+
+use std::io;
+use std::time::Duration;
+
+use crate::supervisor::audit_recorder::{EventCategory, Recorder};
+
+/// Ceiling on the retry delay. Fd exhaustion clears on a human timescale, so a
+/// second between probes is cheap; the cap exists to stop the shift growing
+/// without bound, not because a longer wait would hurt.
+const MAX_RETRY_DELAY: Duration = Duration::from_secs(1);
+
+/// Consecutive transient errors tolerated before backing off at all. A lone
+/// `ECONNABORTED` is one dead connection attempt and the next accept should be
+/// immediate; only a *sustained* streak indicates pressure worth pausing for.
+const FREE_RETRIES: u32 = 4;
+
+/// What the caller should do about an accept error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcceptAction {
+    /// The listener is still usable. Sleep this long, then accept again.
+    Retry(Duration),
+    /// The listener cannot recover. Stop the loop.
+    Fatal,
+}
+
+/// Classify an accept error, given how many transient errors have arrived
+/// back-to-back (0 for the first).
+///
+/// Unrecognised errno values are treated as fatal. A listener failing in a way
+/// we have not characterised should surface loudly rather than spin forever on
+/// an error nothing will clear.
+#[must_use]
+pub fn classify_accept_error(err: &io::Error, consecutive: u32) -> AcceptAction {
+    let transient = match err.kind() {
+        io::ErrorKind::Interrupted
+        | io::ErrorKind::ConnectionAborted
+        | io::ErrorKind::ConnectionReset
+        | io::ErrorKind::WouldBlock
+        | io::ErrorKind::OutOfMemory => true,
+        // EMFILE/ENFILE/ENOBUFS have no stable `ErrorKind`, so they only ever
+        // arrive as a raw errno.
+        _ => matches!(
+            err.raw_os_error(),
+            Some(libc::EMFILE) | Some(libc::ENFILE) | Some(libc::ENOBUFS) | Some(libc::ENOMEM)
+        ),
+    };
+    if transient {
+        AcceptAction::Retry(retry_delay(consecutive))
+    } else {
+        AcceptAction::Fatal
+    }
+}
+
+/// Delay before retry `consecutive` (0-based): free for the first few, then
+/// 1 ms doubling to the ceiling.
+fn retry_delay(consecutive: u32) -> Duration {
+    let Some(over) = consecutive.checked_sub(FREE_RETRIES) else {
+        return Duration::ZERO;
+    };
+    // Saturating shift: a listener wedged for a very long time must not
+    // overflow its way back to a zero delay.
+    let ms = 1u64.saturating_mul(1u64 << over.min(16));
+    Duration::from_millis(ms).min(MAX_RETRY_DELAY)
+}
+
+/// Record a guest-facing listener giving up.
+///
+/// A VM that loses egress goes quiet rather than failing loudly — the workload
+/// keeps running and its connections simply stop working. Without an entry in
+/// the chain the only trace is a line on this process's stderr, and for the
+/// terminator (a spawned task the primary loop does not join) not even the
+/// process exit signals it.
+pub async fn record_listener_stopped(recorder: Option<&Recorder>, listener: &str, reason: &str) {
+    let Some(recorder) = recorder else {
+        tracing::warn!(
+            listener,
+            reason,
+            "listener stopped with no recorder to audit it"
+        );
+        return;
+    };
+    let labels = [
+        ("listener".to_string(), listener.to_string()),
+        ("reason".to_string(), reason.to_string()),
+    ];
+    if let Err(error) = recorder
+        .record_unbound(EventCategory::Host, "host.listener_stopped", labels)
+        .await
+    {
+        tracing::warn!(%error, listener, "listener-stop audit emit failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn errno(code: i32) -> io::Error {
+        io::Error::from_raw_os_error(code)
+    }
+
+    #[test]
+    fn peer_and_signal_errors_retry_immediately() {
+        for code in [libc::EINTR, libc::ECONNABORTED, libc::ECONNRESET] {
+            assert_eq!(
+                classify_accept_error(&errno(code), 0),
+                AcceptAction::Retry(Duration::ZERO),
+                "errno {code} is about one pending connection, not the listener"
+            );
+        }
+    }
+
+    #[test]
+    fn fd_exhaustion_retries_rather_than_killing_the_listener() {
+        for code in [libc::EMFILE, libc::ENFILE, libc::ENOBUFS, libc::ENOMEM] {
+            assert_eq!(
+                classify_accept_error(&errno(code), 0),
+                AcceptAction::Retry(Duration::ZERO),
+                "errno {code} is host pressure; the listener is still good"
+            );
+        }
+    }
+
+    #[test]
+    fn dead_listener_errors_are_fatal() {
+        for code in [libc::EBADF, libc::EINVAL, libc::ENOTSOCK] {
+            assert_eq!(
+                classify_accept_error(&errno(code), 0),
+                AcceptAction::Fatal,
+                "errno {code} means the listener cannot serve again"
+            );
+        }
+    }
+
+    #[test]
+    fn unrecognised_errors_are_fatal_rather_than_spinning() {
+        assert_eq!(
+            classify_accept_error(&errno(libc::EDOM), 0),
+            AcceptAction::Fatal
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stopped_listener_lands_in_the_chain() {
+        use crate::supervisor::audit::CapturingAuditSigner;
+        use mvm_core::plan::TenantId;
+        use std::sync::Arc;
+
+        let signer = Arc::new(CapturingAuditSigner::new());
+        let recorder = Recorder::new(signer.clone(), TenantId("local".into()));
+        record_listener_stopped(Some(&recorder), "terminator", "bad file descriptor").await;
+
+        let entries = signer.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].event, "host.listener_stopped");
+        assert_eq!(
+            entries[0].labels.get("listener").map(String::as_str),
+            Some("terminator")
+        );
+        assert_eq!(
+            entries[0].labels.get("reason").map(String::as_str),
+            Some("bad file descriptor")
+        );
+    }
+
+    #[test]
+    fn a_sustained_streak_backs_off_and_caps() {
+        let delay = |n: u32| match classify_accept_error(&errno(libc::EMFILE), n) {
+            AcceptAction::Retry(d) => d,
+            AcceptAction::Fatal => panic!("EMFILE must retry"),
+        };
+        assert_eq!(
+            delay(FREE_RETRIES - 1),
+            Duration::ZERO,
+            "first few are free"
+        );
+        assert_eq!(delay(FREE_RETRIES), Duration::from_millis(1));
+        assert_eq!(delay(FREE_RETRIES + 1), Duration::from_millis(2));
+        assert_eq!(delay(FREE_RETRIES + 4), Duration::from_millis(16));
+        assert_eq!(
+            delay(1_000),
+            MAX_RETRY_DELAY,
+            "and never grows past the cap"
+        );
+    }
+}

--- a/crates/mvm-hostd/src/supervisor/mod.rs
+++ b/crates/mvm-hostd/src/supervisor/mod.rs
@@ -27,6 +27,7 @@
 //! - `artifact` — `ArtifactCollector` trait + `NoopArtifactCollector`.
 //! - `supervisor` — `Supervisor` aggregate that owns the slots.
 
+pub mod accept_loop;
 pub mod artifact;
 pub mod audit;
 pub mod audit_checkpoint;

--- a/crates/mvm-hostd/src/supervisor/network_endpoint_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/network_endpoint_proxy.rs
@@ -31,6 +31,9 @@ use crate::keyholder::{
     SignDispatchError, SigningInput, SubstituteError, SubstitutionRegistry, assemble_registry,
     build_sigv4_input, find_placeholder,
 };
+use crate::supervisor::accept_loop::{
+    AcceptAction, classify_accept_error, record_listener_stopped,
+};
 use crate::supervisor::audit_recorder::Recorder;
 use crate::supervisor::network::stages::{RedactingSubstitution, RedactionHits};
 use crate::supervisor::reversible_replacement::{ReplacementEngine, ReplacementFlow};
@@ -775,11 +778,14 @@ impl SubstitutionService {
     }
 
     /// Accept loop: one routed request per connection, framed JSON, a task per
-    /// connection. Runs until the listener errors.
+    /// connection. Runs until the listener fails in a way it cannot recover from;
+    /// transient accept errors are retried.
     pub async fn serve(self: Arc<Self>, listener: UnixListener) {
+        let mut transient = 0u32;
         loop {
             match listener.accept().await {
                 Ok((stream, _)) => {
+                    transient = 0;
                     let me = Arc::clone(&self);
                     tokio::spawn(async move {
                         if let Err(e) = me.handle_connection(stream).await {
@@ -787,10 +793,23 @@ impl SubstitutionService {
                         }
                     });
                 }
-                Err(e) => {
-                    tracing::warn!(error = %e, "substitution endpoint accept failed; stopping");
-                    return;
-                }
+                Err(e) => match classify_accept_error(&e, transient) {
+                    AcceptAction::Retry(delay) => {
+                        tracing::warn!(error = %e, "substitution endpoint accept failed; retrying");
+                        transient = transient.saturating_add(1);
+                        tokio::time::sleep(delay).await;
+                    }
+                    AcceptAction::Fatal => {
+                        tracing::error!(error = %e, "substitution endpoint accept failed; stopping");
+                        record_listener_stopped(
+                            self.recorder.as_ref(),
+                            "substitution-uds",
+                            &e.to_string(),
+                        )
+                        .await;
+                        return;
+                    }
+                },
             }
         }
     }
@@ -803,17 +822,43 @@ impl SubstitutionService {
     /// the async forward leg is driven via `Handle::block_on`. No new dep.
     #[cfg(target_os = "linux")]
     pub async fn serve_vsock(self: Arc<Self>, listener: vsock::VsockListener) {
+        let mut transient = 0u32;
         loop {
             let listen_fd = listener.raw_fd();
             let accepted = tokio::task::spawn_blocking(move || vsock::accept(listen_fd)).await;
             let conn_fd = match accepted {
-                Ok(Ok(fd)) => fd,
-                Ok(Err(e)) => {
-                    tracing::warn!(error = %e, "vsock substitution accept failed; stopping");
-                    return;
+                Ok(Ok(fd)) => {
+                    transient = 0;
+                    fd
                 }
+                Ok(Err(e)) => match classify_accept_error(&e, transient) {
+                    AcceptAction::Retry(delay) => {
+                        tracing::warn!(error = %e, "vsock substitution accept failed; retrying");
+                        transient = transient.saturating_add(1);
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    AcceptAction::Fatal => {
+                        tracing::error!(error = %e, "vsock substitution accept failed; stopping");
+                        record_listener_stopped(
+                            self.recorder.as_ref(),
+                            "substitution-vsock",
+                            &e.to_string(),
+                        )
+                        .await;
+                        return;
+                    }
+                },
+                // A panic in the accept task is a bug in this process, not host
+                // pressure that will clear. Retrying would hide it.
                 Err(e) => {
-                    tracing::warn!(error = %e, "vsock accept task panicked; stopping");
+                    tracing::error!(error = %e, "vsock accept task panicked; stopping");
+                    record_listener_stopped(
+                        self.recorder.as_ref(),
+                        "substitution-vsock",
+                        &e.to_string(),
+                    )
+                    .await;
                     return;
                 }
             };
@@ -849,9 +894,11 @@ impl SubstitutionService {
         listener: tokio::net::TcpListener,
         timeout: std::time::Duration,
     ) {
+        let mut transient = 0u32;
         loop {
             match listener.accept().await {
                 Ok((stream, _)) => {
+                    transient = 0;
                     let me = Arc::clone(&self);
                     tokio::spawn(async move {
                         if let Err(e) = me.handle_terminator_connection(stream, timeout).await {
@@ -859,10 +906,23 @@ impl SubstitutionService {
                         }
                     });
                 }
-                Err(e) => {
-                    tracing::warn!(error = %e, "terminator accept failed; stopping");
-                    return;
-                }
+                Err(e) => match classify_accept_error(&e, transient) {
+                    AcceptAction::Retry(delay) => {
+                        tracing::warn!(error = %e, "terminator accept failed; retrying");
+                        transient = transient.saturating_add(1);
+                        tokio::time::sleep(delay).await;
+                    }
+                    AcceptAction::Fatal => {
+                        tracing::error!(error = %e, "terminator accept failed; stopping");
+                        record_listener_stopped(
+                            self.recorder.as_ref(),
+                            "terminator",
+                            &e.to_string(),
+                        )
+                        .await;
+                        return;
+                    }
+                },
             }
         }
     }

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -31,6 +31,9 @@ use hickory_proto::rr::{Name, RData, RecordType};
 use hickory_proto::serialize::binary::{BinDecodable, BinEncodable, BinEncoder};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+use crate::supervisor::accept_loop::{
+    AcceptAction, classify_accept_error, record_listener_stopped,
+};
 use crate::supervisor::audit_recorder::Recorder;
 use crate::supervisor::{
     dns_handler, egress_rate, http_forward, icmp_echo, icmp_handler, socks5_udp,
@@ -51,7 +54,8 @@ const DNS_QUERY_TIMEOUT: Duration = Duration::from_secs(2);
 const RESOLV_CONF_PATH: &str = "/etc/resolv.conf";
 
 /// Serve raw-TCP egress over a bound UDS listener: one tokio task per guest
-/// connection, each gated then spliced. Runs until the listener errors.
+/// connection, each gated then spliced. Runs until the listener fails in a way it cannot recover from;
+/// transient accept errors are retried.
 pub async fn serve_raw_egress(
     listener: tokio::net::UnixListener,
     gate: Arc<EgressGate>,
@@ -59,9 +63,11 @@ pub async fn serve_raw_egress(
     timeout: Duration,
 ) {
     let rate_guard = Arc::new(egress_rate::EgressRateGuard::default());
+    let mut transient = 0u32;
     loop {
         match listener.accept().await {
             Ok((stream, _)) => {
+                transient = 0;
                 let gate = Arc::clone(&gate);
                 let recorder = recorder.clone();
                 let rate_guard = Arc::clone(&rate_guard);
@@ -73,10 +79,19 @@ pub async fn serve_raw_egress(
                     }
                 });
             }
-            Err(e) => {
-                tracing::warn!(error = %e, "raw egress accept failed; stopping");
-                return;
-            }
+            Err(e) => match classify_accept_error(&e, transient) {
+                AcceptAction::Retry(delay) => {
+                    tracing::warn!(error = %e, "raw egress accept failed; retrying");
+                    transient = transient.saturating_add(1);
+                    tokio::time::sleep(delay).await;
+                }
+                AcceptAction::Fatal => {
+                    tracing::error!(error = %e, "raw egress accept failed; stopping");
+                    record_listener_stopped(recorder.as_deref(), "raw-egress-uds", &e.to_string())
+                        .await;
+                    return;
+                }
+            },
         }
     }
 }
@@ -271,14 +286,32 @@ pub async fn serve_raw_egress_vsock(
 ) {
     use crate::supervisor::network_endpoint_proxy::vsock;
     let rate_guard = Arc::new(egress_rate::EgressRateGuard::default());
+    let mut transient = 0u32;
     loop {
         let listen_fd = listener.raw_fd();
         let conn_fd = match vsock::accept(listen_fd) {
-            Ok(fd) => fd,
-            Err(e) => {
-                tracing::warn!(error = %e, "raw egress vsock accept failed; stopping");
-                return;
+            Ok(fd) => {
+                transient = 0;
+                fd
             }
+            Err(e) => match classify_accept_error(&e, transient) {
+                AcceptAction::Retry(delay) => {
+                    tracing::warn!(error = %e, "raw egress vsock accept failed; retrying");
+                    transient = transient.saturating_add(1);
+                    tokio::time::sleep(delay).await;
+                    continue;
+                }
+                AcceptAction::Fatal => {
+                    tracing::error!(error = %e, "raw egress vsock accept failed; stopping");
+                    record_listener_stopped(
+                        recorder.as_deref(),
+                        "raw-egress-vsock",
+                        &e.to_string(),
+                    )
+                    .await;
+                    return;
+                }
+            },
         };
         let gate = Arc::clone(&gate);
         let recorder = recorder.clone();

--- a/specs/sprint/delivery/2485-accept-loop-transient-errors.md
+++ b/specs/sprint/delivery/2485-accept-loop-transient-errors.md
@@ -1,0 +1,57 @@
+# 2485 — production egress accept loops survive transient accept errors
+
+## What was wrong
+
+Every guest-facing listener treated any `accept(2)` error as fatal: log a
+`warn!`, `return` out of the loop. Six sites, all the same shape — raw egress
+(UDS + vsock), the substitution endpoint (UDS + vsock, plus the accept-task
+panic arm), and the transparent terminator.
+
+`accept(2)` reports two unrelated things through one channel. `EBADF`,
+`EINVAL` and `ENOTSOCK` mean the listener is dead. `EINTR`, `ECONNABORTED`,
+`ECONNRESET`, `EMFILE`, `ENFILE`, `ENOBUFS` and `ENOMEM` are about the pending
+connection or about transient host pressure, and the listener is still good.
+
+There is no restart wrapper — `bin/mvm-network-endpoint.rs` awaits the primary
+loop directly — so the second class ended egress for that VM for the rest of
+its life. Fd exhaustion is usually host-wide, so the VM that died was typically
+not the one that caused it, and it did not recover when the host did.
+
+The terminator case was worse because it is a spawned task the primary loop
+does not join: it could die while the VM kept running, leaving the redirect
+path silently gone.
+
+Fail-closed throughout, so no claim was violated. Availability and
+observability defect, not a security one.
+
+## What landed
+
+`crates/mvm-hostd/src/supervisor/accept_loop.rs` — a pure classifier
+(`classify_accept_error`) returning `Retry(Duration)` or `Fatal`, one delay
+policy (first four retries free, then 1 ms doubling to a 1 s cap), and
+`record_listener_stopped`, which emits `host.listener_stopped` through the
+chain signer so a VM losing egress is visible in the audit log rather than only
+on the endpoint's stderr.
+
+Unrecognised errno values classify as `Fatal`. A listener failing in a way
+nobody characterised should surface loudly rather than spin forever on
+something that will not clear.
+
+All six sites now share it. The accept-task panic arm stays fatal — a panic is
+a bug in this process, not pressure that clears — but is now audited.
+
+## Verification
+
+`cargo nextest run --workspace` 11,609 passed. Clippy clean. `cargo +nightly
+fmt --all -- --check`, doctests, and `check-no-spec-refs-in-comments`,
+`check-honesty`, `check-doc-claims`, `check-no-overclaim`,
+`check-uniform-vsock-egress`, `check-vsock-only-egress` all pass.
+`just check-linux` passes — the two vsock sites are `cfg(target_os = "linux")`
+and a macOS-only check would not have compiled them.
+
+## Not addressed here
+
+The audit that found this also confirmed a hard 16 MiB ceiling
+(`MAX_FRAME_BYTES`) on any request or response through the substitution path.
+It is enforced cleanly rather than truncating or hanging, but it is not stated
+in user-facing docs. Left open on the issue.


### PR DESCRIPTION
Closes #2485.

Found by auditing the production egress path. Two premises in the original issue were wrong and are corrected in [a comment there](https://github.com/tinylabscom/mvm/issues/2485#issuecomment-5296588176); this PR fixes the defect that audit actually turned up.

## The defect

Every guest-facing accept loop treated any `accept(2)` error as fatal — log a `warn!`, `return`. Six sites: raw egress (UDS + vsock), the substitution endpoint (UDS + vsock, plus its accept-task panic arm), and the transparent terminator.

`accept(2)` reports two unrelated things through one channel. `EBADF` / `EINVAL` / `ENOTSOCK` mean the listener is dead. `EINTR`, `ECONNABORTED`, `ECONNRESET`, `EMFILE`, `ENFILE`, `ENOBUFS`, `ENOMEM` are about the pending connection or transient host pressure, and the listener is still fine.

There is no restart wrapper — `bin/mvm-network-endpoint.rs` awaits the primary loop directly — so the second class ended egress for that VM for the rest of its life. Two consequences, the second worse:

- **Collateral.** Fd exhaustion is usually host-wide, so the VM that lost egress was typically not the one that caused it, and it did not recover when the host did.
- **Silent.** The terminator is a spawned task the primary loop never joins. It could die while the VM kept running, leaving the redirect path gone with only a `warn!` on the endpoint's stderr as evidence.

Fail-closed throughout — no egress is safer than ungated egress — so **no claim is affected**. This is an availability and observability defect.

## The change

New `supervisor/accept_loop.rs`:

- `classify_accept_error(&io::Error, consecutive) -> Retry(Duration) | Fatal` — pure, so the policy is testable without a socket
- one delay policy: first four retries free (a lone `ECONNABORTED` is one dead connection attempt and the next accept should be immediate), then 1 ms doubling to a 1 s cap
- `record_listener_stopped` emits `host.listener_stopped` through the chain signer, so a VM losing egress is visible in the audit log and not only on stderr

All six sites route through it. Unrecognised errno values classify as `Fatal` — a listener failing in a way nobody characterised should surface loudly rather than spin forever on something that will not clear. The accept-task panic arm stays fatal (a panic is a bug in this process, not pressure that clears) but is now audited.

## Verification

- `cargo nextest run --workspace` — 11,609 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check`, `cargo test --workspace --doc` — clean
- `check-no-spec-refs-in-comments`, `check-honesty`, `check-doc-claims`, `check-no-overclaim`, `check-uniform-vsock-egress`, `check-vsock-only-egress` — pass
- `just check-linux` — passes. Two of the six sites are `cfg(target_os = "linux")`; a macOS-only check would not have compiled them.

## Left open on the issue

The audit also confirmed a hard 16 MiB ceiling (`MAX_FRAME_BYTES`) on any request or response through the substitution path. It is enforced cleanly rather than truncating or hanging, but I could not find it stated in user-facing docs. Not touched here.
