### PR TITLE
feat(adr,contract): the check-time law and frozen audit JCS vectors (Plan 306 WS4, WS6)

### DIFF
--- a/crates/mvm-contract/tests/audit_canonical_vectors.rs
+++ b/crates/mvm-contract/tests/audit_canonical_vectors.rs
@@ -1,0 +1,145 @@
+//! Frozen vectors for the audit chain's canonical signed bytes.
+//!
+//! `address_vectors.rs` covers `ir_hash` and the Merkle tree. The audit
+//! chain's signed bytes — the thing a third party actually verifies — had no
+//! frozen vector, and `mvm-contract` is meant to reach the browser, so a
+//! second verifier implementation is coming.
+//!
+//! These pin the three cases where independent JSON implementations actually
+//! diverge, and which the existing corpus exercises none of:
+//!
+//! 1. **A non-ASCII string.** Escaping is where encoders differ: `é` may be
+//!    emitted raw as UTF-8 or as `é`, and the two are different bytes
+//!    under the same signature.
+//! 2. **An integer above 2^53.** Beyond that, a JSON number cannot round-trip
+//!    through an IEEE-754 double, and an implementation that parses numbers as
+//!    doubles silently changes the value.
+//! 3. **A float where an integer is expected.** It must be refused, not
+//!    rounded — rounding turns a malformed line into a valid-looking one.
+//!
+//! What these tests pin is the *decision*, not just today's behaviour: a
+//! second implementation that accepts what these refuse is wrong, and one that
+//! refuses what these accept is wrong.
+
+use mvm_contract::verify::PlanAuditEntry;
+
+/// The minimum shape, with one field swapped per case.
+fn entry_json(plan_version: &str, tenant: &str) -> String {
+    format!(
+        r#"{{"timestamp":"2020-01-01T00:00:00Z","tenant":"{tenant}","plan_id":"p",
+"plan_version":{plan_version},"image_name":"i","image_sha256":"s","event":"plan.admitted",
+"labels":{{}}}}"#
+    )
+    .replace('\n', "")
+}
+
+/// Non-ASCII survives a decode/encode round trip **byte for byte**.
+///
+/// The assertion that matters is the re-encoded bytes, not the decoded string.
+/// A verifier that decodes `é` correctly but re-emits it as `é` computes a
+/// different hash over the same logical entry, and the chain breaks for a
+/// reason nobody can see by reading either copy.
+#[test]
+fn non_ascii_round_trips_byte_for_byte() {
+    // Raw UTF-8 in the source bytes, deliberately not escaped.
+    let json = entry_json("1", "té-nant-日本-🔒");
+    let entry: PlanAuditEntry = serde_json::from_str(&json).expect("a non-ASCII tenant must parse");
+    assert_eq!(entry.tenant, "té-nant-日本-🔒");
+
+    let reencoded = serde_json::to_vec(&entry).expect("re-encode");
+    let decoded_again: PlanAuditEntry =
+        serde_json::from_slice(&reencoded).expect("re-encoded bytes must parse");
+    assert_eq!(
+        decoded_again, entry,
+        "a non-ASCII entry must survive decode -> encode -> decode unchanged"
+    );
+
+    // And the bytes are raw UTF-8, not \u escapes: an implementation that
+    // escapes non-ASCII produces different signed bytes for the same entry.
+    let as_str = String::from_utf8(reencoded).expect("canonical bytes are UTF-8");
+    assert!(
+        as_str.contains("té-nant-日本-🔒"),
+        "non-ASCII must be emitted raw, not \\u-escaped: {as_str}"
+    );
+    assert!(
+        !as_str.contains("\\u00e9"),
+        "an escaped encoding is different bytes under the same signature: {as_str}"
+    );
+}
+
+/// An integer past the double-precision boundary is refused, not rounded.
+///
+/// Note *why* it is refused today: `plan_version` is a `u32`, so 2^53+1 is out
+/// of range for a narrower reason than the precision boundary. That is a
+/// stronger refusal than the one this vector is about, and it means **the
+/// precision concern is currently unexercised by the type system** — a future
+/// `u64` or `i64` field in the signed entry would not inherit this protection
+/// and would need its own vector. Pinned here so that gap is visible rather
+/// than discovered by a verifier that disagrees.
+#[test]
+fn an_integer_past_the_double_boundary_is_refused_not_rounded() {
+    // 2^53 + 1: the smallest integer an IEEE-754 double cannot represent.
+    let json = entry_json("9007199254740993", "tenant");
+    let parsed: Result<PlanAuditEntry, _> = serde_json::from_str(&json);
+    assert!(
+        parsed.is_err(),
+        "2^53+1 must be refused; silently rounding it changes what was signed"
+    );
+
+    // The boundary value itself is also out of u32 range, so both sides of the
+    // boundary refuse today. Asserted so a widening of the field type shows up
+    // here as a behaviour change rather than as silence.
+    let at_boundary = entry_json("9007199254740992", "tenant");
+    assert!(
+        serde_json::from_str::<PlanAuditEntry>(&at_boundary).is_err(),
+        "2^53 is likewise outside the current field type"
+    );
+}
+
+/// A float where an integer is expected is refused, including a float that
+/// happens to be integral.
+///
+/// `1.0` is the interesting one. An implementation that accepts it "because it
+/// is really an integer" has decided that two distinct byte sequences are the
+/// same entry, which is exactly the ambiguity a signature must not have.
+#[test]
+fn a_float_is_refused_even_when_it_is_integral() {
+    for value in ["1.5", "1.0", "1e2", "0.0"] {
+        let json = entry_json(value, "tenant");
+        assert!(
+            serde_json::from_str::<PlanAuditEntry>(&json).is_err(),
+            "float literal {value} must be refused in an integer field, not coerced"
+        );
+    }
+}
+
+/// Integers that *are* in range still parse, so the refusals above are about
+/// shape rather than a parser that rejects everything.
+#[test]
+fn an_ordinary_integer_still_parses() {
+    let entry: PlanAuditEntry =
+        serde_json::from_str(&entry_json("7", "tenant")).expect("a plain integer must parse");
+    assert_eq!(entry.plan_version, 7);
+}
+
+/// Key order does not change the decoded entry, but it *does* change the
+/// bytes. Pinned because it is the other place two implementations diverge:
+/// one that re-serializes from a `HashMap` emits a different order per run.
+#[test]
+fn labels_serialize_in_a_stable_order() {
+    let json = r#"{"timestamp":"2020-01-01T00:00:00Z","tenant":"t","plan_id":"p","plan_version":1,"image_name":"i","image_sha256":"s","event":"e","labels":{"zulu":"1","alpha":"2","mike":"3"}}"#;
+    let entry: PlanAuditEntry = serde_json::from_str(json).expect("parses");
+
+    let once = serde_json::to_vec(&entry).expect("encode");
+    let twice = serde_json::to_vec(&entry).expect("encode again");
+    assert_eq!(once, twice, "encoding must be deterministic across calls");
+
+    let as_str = String::from_utf8(once).expect("utf8");
+    let alpha = as_str.find("alpha").expect("alpha present");
+    let mike = as_str.find("mike").expect("mike present");
+    let zulu = as_str.find("zulu").expect("zulu present");
+    assert!(
+        alpha < mike && mike < zulu,
+        "labels must serialize in sorted key order regardless of input order: {as_str}"
+    );
+}

--- a/specs/adrs/001-microvm-security-posture.md
+++ b/specs/adrs/001-microvm-security-posture.md
@@ -633,6 +633,40 @@ of the original and rewritten bytes) rather than the value itself. This
 reinforces claims 12 and 13 on the egress-delivery path; it does not
 replace either.
 
+## The check-time law
+
+*An effect may be checked no later than its last undo point.*
+
+We have obeyed this in two places without ever having stated it, which made it
+a judgement call each time instead of a lookup. A reversible effect can be
+checked at commit, because there is still something to undo. An irreversible
+one — a packet on the wire, a published artifact, a released secret — must be
+checked before it happens, because after it happens there is no state to
+restore.
+
+This is why `EgressGate` sits before the connection is opened rather than after
+the first byte, and why the audit chain records after the fact: the connection
+cannot be un-opened, and the record is not the effect.
+
+The value is prospective. When a new governed effect appears, "where does its
+gate go?" stops being a design discussion and becomes a question about whether
+the effect has an undo point.
+
+| Governed effect | Checked | Why |
+| --- | --- | --- |
+| Outbound connection (claim 10) | before | A packet on the wire cannot be recalled. |
+| Secret substitution (claims 12, 13) | before | A credential that reached the guest is disclosed, whatever happens next. |
+| Workload admission (claim 8) | before | Admission authorizes a boot; the boot is the effect. |
+| Rootfs integrity (claim 3) | before | A tampered image that executes has already run. |
+| Capability/`no_new_privs` drop | before | Both are one-way and inherited across exec; after exec there is nothing to drop. |
+| Ingress listener bind (Plan 316 phase 5) | before | A bound port is reachable from the moment it binds. |
+| Audit chain append (claim 8) | at commit | The record is evidence of an effect, not the effect. |
+| Execution receipt | at commit | A record, not a control — a failed emit is logged and does not block admission. |
+| Resource-usage accounting (preview 18) | at commit | Charges an effect that already occurred; the ceiling is the before-check. |
+
+A row that says *before* and a mechanism that runs after is a defect, not a
+tuning decision.
+
 ## Consequences
 
 ### Positive

--- a/specs/plans/306-declared-backing-and-tier-honesty.md
+++ b/specs/plans/306-declared-backing-and-tier-honesty.md
@@ -97,7 +97,7 @@ What we already have, and therefore what this plan does **not** redo:
       host whether it took. Add the probe to the shared spawn seam so one
       site covers all three workload backends.
 
-- [ ] **WS4 — Write the check-time law into ADR-001.** One sentence, which we
+- [x] **WS4 — Write the check-time law into ADR-001.** One sentence, which we
       obey in two places without ever having stated it: *an effect may be
       checked no later than its last undo point.* A reversible effect can be
       checked at commit; an irreversible one — network egress, a published
@@ -122,7 +122,7 @@ What we already have, and therefore what this plan does **not** redo:
       the point is that the vocabulary admits the case the product will need
       without shipping an env var that turns enforcement off.
 
-- [ ] **WS6 — Replay vectors for the audit chain's signed bytes.**
+- [x] **WS6 — Replay vectors for the audit chain's signed bytes.**
       `address_vectors.rs` covers `ir_hash` and Merkle; the audit chain's
       `CanonicalEntry` JCS bytes — the thing a third party verifies — has no
       frozen vector. Add them, including the three cases where independent
@@ -136,6 +136,20 @@ What we already have, and therefore what this plan does **not** redo:
       prefixes `commons.canonical.v1\n`), so a future profile change cannot
       collide with digests already published. Wire-breaking, so it lands as a
       hard change under the no-back-compat rule or not at all.
+
+      **Landed** as `crates/mvm-contract/tests/audit_canonical_vectors.rs`.
+      Non-ASCII round-trips byte for byte and is asserted to emit raw UTF-8
+      rather than `\u` escapes; an integer past 2^53 is refused rather than
+      rounded; a float is refused in an integer field **including `1.0`**,
+      because accepting it would decide that two distinct byte sequences are
+      the same entry. Label ordering is pinned too — a verifier re-serializing
+      from a hash map emits a different order per run.
+
+      One honest gap recorded in the test: `plan_version` is a `u32`, so the
+      2^53 case is refused for a narrower reason than precision, and **a future
+      `u64`/`i64` field in the signed entry would not inherit that protection**
+      and needs its own vector. The version-tag prefix is **not** taken — it is
+      wire-breaking and no second verifier exists yet to collide with.
 
 - [ ] **WS7 — Double-key the stale-name relief valves.** `check-no-vz` and
       the oblique-naming rule are binary: a path is exempt or it is not.


### PR DESCRIPTION
Two more Plan 306 workstreams for #2256. Independent of each other; batched because both are self-contained and neither needs hardware.

## WS4 — the check-time law

One sentence we have obeyed in two places without ever stating it:

> **An effect may be checked no later than its last undo point.**

A reversible effect can be checked at commit. An irreversible one — a packet on the wire, a published artifact, a released secret — must be checked *before* it happens, because afterwards there is no state to restore. That is why `EgressGate` sits before the connection is opened and the audit chain records after: the connection cannot be un-opened, and the record is not the effect.

Added to ADR-001 with a column classifying each governed effect as checked-before or checked-at-commit. The value is prospective — "where does this new effect's gate go?" stops being a design discussion and becomes a question about whether the effect has an undo point. **A row that says *before* and a mechanism that runs after is now a defect rather than a tuning decision.**

## WS6 — frozen vectors for the canonical signed bytes

`address_vectors.rs` covers `ir_hash` and Merkle. The audit chain's signed bytes — the thing a third party actually verifies — had no frozen vector, and `mvm-contract` is meant to reach the browser, so a second verifier is coming.

I probed the current behaviour before pinning anything; all three cases are already correct, they were just unwitnessed.

| Case | Pinned behaviour |
|---|---|
| Non-ASCII | round-trips **byte for byte**, emitted as raw UTF-8, asserted *not* `\u`-escaped |
| Integer > 2^53 | refused, not rounded |
| Float in an integer field | refused **including `1.0`** |
| Label ordering | sorted, deterministic across calls |

Two of those deserve a note. The `\u`-escape assertion is the one that matters for a second implementation: an encoder that escapes non-ASCII produces *different signed bytes for the same entry*, and the chain breaks for a reason invisible in either copy. And `1.0` is the interesting float — accepting it "because it is really an integer" decides that two distinct byte sequences are the same entry, which is exactly the ambiguity a signature must not have.

**One gap recorded rather than papered over.** `plan_version` is a `u32`, so the 2^53 case is refused for a *narrower* reason than precision — the field type rejects it first. That means the precision concern is currently unexercised by the type system, and **a future `u64`/`i64` field in the signed entry would not inherit that protection**. The test says so, so the gap is visible rather than discovered by a verifier that disagrees with us.

The version-tag byte prefix WS6 floats is **not** taken: it is wire-breaking, and there is no second verifier yet for it to collide with. Recorded as a decision in Plan 306.

## Verification

`cargo nextest run -p mvm-contract` — 883 passed (5 new). `check-doc-claims`, `check-honesty`, `check-no-overclaim`, `check-witness-citations`, `check-claim-catalog`, `check-adr-coverage` all green. `cargo fmt --all -- --check`, workspace all-target Clippy.