### PR TITLE
fix(release): stop requiring mvm-bridge, a binary Plan 305 deleted

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -673,7 +673,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: macos-latest
     # `cargo build --all-targets` builds the Rust-native per-VM host bins
-    # (workspace `[[bin]]`s in mvm-vm-host) — no Swift build step.
+    # (workspace `[[bin]]`s in mvm-hostd) — no Swift build step.
     steps:
       - uses: actions/checkout@v6
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ Persistent builder state dirs live under `~/.mvm/cache/builder-vm/vms/`, disting
 
 **Top of graph (daemons, SDK, FFI):**
 
-- `mvm-hostd` -- host-side daemon roles, one crate with separate `[[bin]]`s (the process moat): the `supervisor` + `jailer` libs, the `broker`/`host_signer`/`audit_signer` subprocess bins, and the per-VM supervisor bins `mvm-libkrun-supervisor`/`mvm-hvf-supervisor`/`mvm-bridge`. Absorbs `mvm-supervisor`/`mvm-broker`/`mvm-host-signer`/`mvm-audit-signer`/`mvm-jailer-lite`/`mvm-vm-host`.
+- `mvm-hostd` -- host-side daemon roles, one crate with separate `[[bin]]`s (the process moat): the `supervisor` + `jailer` libs, the `broker`/`host_signer`/`audit_signer` subprocess bins, and the per-VM supervisor bins `mvm-libkrun-supervisor`/`mvm-hvf-supervisor`. Absorbs `mvm-supervisor`/`mvm-broker`/`mvm-host-signer`/`mvm-audit-signer`/`mvm-jailer-lite`/`mvm-vm-host`.
 - `mvm-agentd` -- the in-guest daemon: vsock protocol (`vsock/`), console, integrations, entrypoint runtime, the `mvm-guest-agent` `[[bin]]`, and the addon/egress helper bins (`mvm-addon-dns`/`mvm-addon-vsock-bridge`, gated behind the off-by-default `addons` feature so the sealed agent stays tokio-free). Absorbs `mvm-guest` + `mvm-guest-helpers`.
 - `mvm-sdk` -- SDK: decorator parser → canonical `Workload` IR → Nix template, runtime record mode, and the in-guest host-services C-ABI cdylib (`libmvm_host_services.so`) loaded by every language SDK. Language SDK surfaces live under `crates/mvm-sdk/sdks/`.
 - `crates/deps/libkrun-sys` -- the libkrun C FFI (bindgen + `-lkrun`, gated by the `libkrun-sys` feature) **plus the safe wrapper** (`KrunContext`/`SupervisorConfig`). Was `mvm-libkrun`; lives low so `mvm-build`/`mvm-runtime` consume the wrapper.
@@ -129,7 +129,7 @@ mvm-fs: `oci/unpack/` (allow-listed unpacker), `oci/`, the ext4 writer, `overlay
 
 mvm-agentd: `vsock/`, `console.rs`, `integrations.rs`, `src/bin/mvm-guest-agent/` (the agent bin), `runner/`
 
-mvm-hostd: `supervisor/` (incl. `gateway_bridge/`), `broker/`, `host_signer/`, `audit_signer/`, `jailer/`, `src/bin/{mvm-broker,mvm-host-signer,mvm-audit-signer}.rs`, the per-VM supervisor bins
+mvm-hostd: `supervisor/`, `broker/`, `host_signer/`, `audit_signer/`, `jailer/`, `src/bin/{mvm-broker,mvm-host-signer,mvm-audit-signer}.rs`, the per-VM supervisor bins
 
 mvm-cli: `commands/` (env, build/run, `machine`, guest RPC, artifacts/trust, local ops); `doctor/`, `commands/vm/up/`, `commands/image/`, `bench/` are decomposed module trees. Tenant lifecycle + deploy-to-control-plane commands live in mvmd, not mvmctl.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,8 +54,8 @@ members = [
     # its own crate. The supervisor lifecycle + cosign-verify +
     # cgroup + seccomp + binary hardening land in W1b.2.
     # Plan 113 / ADR-003 §Decision 5 — A2 confinement helper wrapping
-    # seccompiler 0.5 + landlock 0.4. Called by the per-VM
-    # `mvm-bridge` sidecar just after startup so
+    # seccompiler 0.5 + landlock 0.4. Called by the per-VM supervisor
+    # just after startup so
     # the kernel-LSM ruleset + seccomp filter are installed before the
     # packet loop touches untrusted bytes. Linux-only at runtime; the
     # crate compiles as inert stubs on macOS / Windows so workspace
@@ -376,15 +376,6 @@ mvm-sdk = { path = "crates/mvm-sdk", version = "0.18.0" }
 # workspace. Default feature set is empty; consumers wanting real FFI
 # enable `libkrun-sys` on a host with libkrun installed.
 libkrun-sys = { path = "crates/deps/libkrun-sys", version = "0.18.0" }
-
-# Plan 113 / ADR-003 §Decision 5 — A2 confinement helper (seccompiler +
-# landlock). Consumed by the per-VM `mvm-bridge` sidecar.
-
-# Plan 113 §Task 12 / ADR-003 — per-VM Firecracker bridge sidecar binary
-# crate. Leaf entry resolved by Task 13's `FirecrackerBackend` at runtime
-# (fork+exec, never linked as a library). Linux-only at runtime; the
-# crate's `src/main.rs` cfg-gates the body so `cargo check --workspace`
-# stays green on macOS / Windows contributor hosts.
 
 # Dev dependencies
 assert_cmd = "2"

--- a/install.sh
+++ b/install.sh
@@ -134,11 +134,11 @@ $SUDO install -m 0755 "$SRC/mvmctl" "$INSTALL_DIR/mvmctl"
 # Per-VM host processes mvmctl spawns at runtime (one process per guest VM).
 # They must sit NEXT TO mvmctl so the backend's adjacent-to-exe resolver finds
 # them — installing only mvmctl strands them. copy-if-exists: the bundled set
-# differs by platform (macOS ships the supervisors + bridge + endpoint; Linux
-# ships the bridge + endpoint).
-# mvm-bridge and the substitution endpoint need no VM entitlement. The
-# supervisors are signed below before the install is reported successful.
-for hostbin in mvm-bridge mvm-hvf-supervisor mvm-libkrun-supervisor mvm-network-endpoint; do
+# differs by platform (macOS ships the supervisors + endpoint; Linux ships
+# only the endpoint).
+# The substitution endpoint needs no VM entitlement. The supervisors are
+# signed below before the install is reported successful.
+for hostbin in mvm-hvf-supervisor mvm-libkrun-supervisor mvm-network-endpoint; do
   if [ -f "$SRC/$hostbin" ]; then
     $SUDO install -m 0755 "$SRC/$hostbin" "$INSTALL_DIR/$hostbin"
     say "Installed: $INSTALL_DIR/$hostbin"

--- a/nix/packaging/homebrew/mvmctl.rb.tmpl
+++ b/nix/packaging/homebrew/mvmctl.rb.tmpl
@@ -34,7 +34,6 @@ class Mvmctl < Formula
   def install
     bin.install "mvmctl"
     %w[
-      mvm-bridge
       mvm-hvf-supervisor
       mvm-libkrun-supervisor
       mvm-network-endpoint

--- a/nix/packaging/release/verify-release-assets.sh
+++ b/nix/packaging/release/verify-release-assets.sh
@@ -67,10 +67,10 @@ sha256_of() {
 required_bins_for_target() {
   case "$1" in
     *apple-darwin)
-      echo "mvmctl mvm-bridge mvm-hvf-supervisor mvm-libkrun-supervisor mvm-network-endpoint"
+      echo "mvmctl mvm-hvf-supervisor mvm-libkrun-supervisor mvm-network-endpoint"
       ;;
     *)
-      echo "mvmctl mvm-bridge mvm-network-endpoint"
+      echo "mvmctl mvm-network-endpoint"
       ;;
   esac
 }

--- a/nix/packaging/release/verify-release-assets.test.sh
+++ b/nix/packaging/release/verify-release-assets.test.sh
@@ -21,8 +21,8 @@ sha256_of() {
 
 bins_for() {
   case "$1" in
-    *apple-darwin) echo "mvmctl mvm-bridge mvm-hvf-supervisor mvm-libkrun-supervisor mvm-network-endpoint" ;;
-    *)             echo "mvmctl mvm-bridge mvm-network-endpoint" ;;
+    *apple-darwin) echo "mvmctl mvm-hvf-supervisor mvm-libkrun-supervisor mvm-network-endpoint" ;;
+    *)             echo "mvmctl mvm-network-endpoint" ;;
   esac
 }
 
@@ -140,6 +140,24 @@ d="$(build_valid_fixture)"
 printf 'tampered-kernel\n' > "$d/vmlinux-aarch64-workload"
 if run "$d"; then bad "checksum-mismatched workload kernel must fail"; else ok "checksum-mismatched workload kernel fails closed"; fi
 rm -rf "$d"
+
+# 12. Every binary the verifier REQUIRES must be one release.yml actually
+# bundles. The fixtures above cannot catch a stale name: build_valid_fixture
+# creates whatever bins_for names, so a required-but-unbuilt binary verifies
+# green here and fails only at release time. Compare against the workflow.
+RELEASE_YML="$HERE/../../../.github/workflows/release.yml"
+shipped="mvmctl $(sed -n 's/^[[:space:]]*for hostbin in \(.*\); do$/\1/p' "$RELEASE_YML" | head -1)"
+required="$(sed -n '/^required_bins_for_target()/,/^}/p' "$SCRIPT" \
+  | sed -n 's/.*echo "\([^"]*\)".*/\1/p' | tr ' ' '\n' | sort -u)"
+drift=""
+for b in $required; do
+  case " $shipped " in *" $b "*) ;; *) drift="$drift $b" ;; esac
+done
+if [ -n "$required" ] && [ -z "$drift" ]; then
+  ok "every required bin is one release.yml ships"
+else
+  bad "verifier requires bin(s) release.yml never builds:${drift:- <none parsed>}"
+fi
 
 echo "verify-release-assets pack-gate: $PASS passed, $FAILN failed"
 [ "$FAILN" -eq 0 ]

--- a/public/src/content/docs/install/linux.md
+++ b/public/src/content/docs/install/linux.md
@@ -45,12 +45,10 @@ MVM_VERSION=v0.16.1 curl -fsSL https://raw.githubusercontent.com/tinylabscom/mvm
 git clone https://github.com/tinylabscom/mvm.git
 cd mvm
 cargo build --release --bin mvmctl
-cargo build --release -p mvm-hostd --bin mvm-bridge
-cargo build --release -p mvm-hostd --bin mvm-substitution-endpoint
+cargo build --release -p mvm-hostd --bin mvm-network-endpoint
 install -m 0755 \
   target/release/mvmctl \
-  target/release/mvm-bridge \
-  target/release/mvm-substitution-endpoint \
+  target/release/mvm-network-endpoint \
   ~/.local/bin/
 ```
 

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -38,15 +38,14 @@ git clone https://github.com/tinylabscom/mvm.git
 cd mvm
 cargo build --release --bin mvmctl
 cargo build --release -p mvm-hostd \
-  --bin mvm-bridge --bin mvm-hvf-supervisor \
+  --bin mvm-hvf-supervisor \
   --bin mvm-libkrun-supervisor --features libkrun-sys
-cargo build --release -p mvm-hostd --bin mvm-substitution-endpoint
+cargo build --release -p mvm-hostd --bin mvm-network-endpoint
 install -m 0755 \
   target/release/mvmctl \
-  target/release/mvm-bridge \
   target/release/mvm-hvf-supervisor \
   target/release/mvm-libkrun-supervisor \
-  target/release/mvm-substitution-endpoint \
+  target/release/mvm-network-endpoint \
   ~/.local/bin/
 ```
 

--- a/scripts/check-hvf-oci-allow-host-smoke.sh
+++ b/scripts/check-hvf-oci-allow-host-smoke.sh
@@ -63,7 +63,7 @@ cd "${ROOT}"
 if [[ "${SKIP_BUILD}" != "1" ]]; then
   cargo build -p mvmctl --bin mvmctl
   cargo build -p mvm-hostd --bin mvm-network-endpoint
-  cargo build -p mvm-vm-host --bin mvm-hvf-supervisor
+  cargo build -p mvm-hostd --bin mvm-hvf-supervisor
 fi
 
 MVMCTL_BIN="${MVM_HVF_ALLOW_HOST_MVMCTL:-${ROOT}/target/debug/mvmctl}"

--- a/scripts/measure-hvf-density.sh
+++ b/scripts/measure-hvf-density.sh
@@ -196,7 +196,7 @@ seed_workload_kernel
 if [[ "${SKIP_BUILD}" != "1" ]]; then
   "${run_env[@]}" cargo build -p mvmctl --bin mvmctl
   "${run_env[@]}" cargo build -p mvm-hostd --bin mvm-network-endpoint
-  "${run_env[@]}" cargo build -p mvm-vm-host --bin mvm-hvf-supervisor
+  "${run_env[@]}" cargo build -p mvm-hostd --bin mvm-hvf-supervisor
 fi
 
 MVMCTL_BIN="${MVM_HVF_DENSITY_MVMCTL:-${TARGET_DIR}/debug/mvmctl}"

--- a/specs/plans/305-delete-dead-gateway-stack.md
+++ b/specs/plans/305-delete-dead-gateway-stack.md
@@ -168,6 +168,14 @@ a cycle would not terminate.
 - [x] An orphaned doc comment in `mvm-hostd/src/lib.rs` described the deleted
       bridge module while sitting on `pub mod broker;`
 
+- [x] The packaging and install layer kept naming the deleted binary after
+      WS3 corrected the prose. `verify-release-assets.sh` required `mvm-bridge`
+      on every target while `release.yml` never builds it, so the next tagged
+      release would have failed asset verification; the test carried the same
+      stale list, so the fixture manufactured the file and the gate stayed
+      green. Fixed with a drift gate deriving the shipped set from the
+      workflow (#2497).
+
 ### WS4 — Then confine the signer roles
 
 The original plan-305 scope, deferred behind the deletion because it is a

--- a/specs/sprint/delivery/2497-bridge-release-residue.md
+++ b/specs/sprint/delivery/2497-bridge-release-residue.md
@@ -34,3 +34,21 @@ is deliberately left alone — it records measurements taken at a point in time.
 
 `shellcheck` on all three scripts, and `verify-release-assets.test.sh` at
 12 passed / 0 failed — both the lanes `ci.yml` runs for these files.
+
+## Second instance of the same bug class
+
+Generalizing the check — enumerate every real binary and crate from `cargo
+metadata`, then scan packaging, CI, scripts, and docs for names that do not
+exist — found one more live break. `-p mvm-vm-host`, a crate the Bar-A
+consolidation absorbed into `mvm-hostd`, was still being built by
+`scripts/check-hvf-oci-allow-host-smoke.sh` (wired into a `just` recipe) and
+`scripts/measure-hvf-density.sh`. Both fail on that line:
+
+```
+error: package ID specification `mvm-vm-host` did not match any packages
+```
+
+In both scripts the preceding line already said `-p mvm-hostd`, so only the
+supervisor's line was missed when the crate moved. A comment in `ci-full.yml`
+named it too. Same root cause as the bridge: the rename updated the code and
+not its callers.

--- a/specs/sprint/delivery/2497-bridge-release-residue.md
+++ b/specs/sprint/delivery/2497-bridge-release-residue.md
@@ -1,0 +1,36 @@
+# 2497 — release verification required a deleted binary
+
+Plan 305 deleted the `mvm-bridge` sidecar and corrected the prose docs, but the
+packaging and install layer kept naming it. `verify-release-assets.sh` listed
+`mvm-bridge` as a required asset for every target while `release.yml` builds and
+bundles only `mvmctl`, `mvm-network-endpoint`, and — on macOS — the two
+supervisors. Since `release.yml` runs that verifier, the next tagged release
+would have failed asset verification on every target.
+
+The gate could not have caught this. `verify-release-assets.test.sh` carried its
+own copy of the same stale list, and `build_valid_fixture` creates whatever that
+copy names — so the fixture manufactured a `mvm-bridge` file and the check went
+green. Both lists were stale in lockstep.
+
+## Delivered
+
+- Dropped `mvm-bridge` from the verifier's required-bin lists, the test's
+  fixture list, the Homebrew formula, and `install.sh`'s install loop.
+- Corrected the two live install docs, which additionally named
+  `mvm-substitution-endpoint` — not the binary's name; it is
+  `mvm-network-endpoint`.
+- Corrected `CLAUDE.md`, which listed `mvm-bridge` as a per-VM supervisor bin
+  and `supervisor/` as containing a `gateway_bridge/` module deleted with the
+  gateway stack, plus two `Cargo.toml` comments describing the sidecar.
+- Added a drift gate: the test now derives the shipped set from `release.yml`'s
+  staging loop and asserts every bin the verifier requires is one the workflow
+  actually bundles. Restoring `mvm-bridge` to the verifier turns it red with
+  `verifier requires bin(s) release.yml never builds: mvm-bridge`.
+
+`public/docs/investigations/binary-size-baseline.md` still names the binary and
+is deliberately left alone — it records measurements taken at a point in time.
+
+## Validation
+
+`shellcheck` on all three scripts, and `verify-release-assets.test.sh` at
+12 passed / 0 failed — both the lanes `ci.yml` runs for these files.


### PR DESCRIPTION
Closes #2497.

Plan 305 deleted the `mvm-bridge` sidecar and corrected the prose docs, but the packaging and install layer kept naming it.

## The break

`verify-release-assets.sh` listed `mvm-bridge` as a **required** asset for every target. No `[[bin]]` declares it, and `release.yml` builds and bundles only `mvmctl`, `mvm-network-endpoint`, and — on macOS — the two supervisors. `release.yml:929` runs that verifier, so the next tagged release would have failed asset verification on every target.

## Why the gate was blind

`verify-release-assets.test.sh` carried its own copy of the same stale list, and `build_valid_fixture` creates whatever that copy names — so the fixture manufactured a `mvm-bridge` file and the check went green. Both lists were stale in lockstep; no amount of fixture testing could catch it.

The new test #12 derives the shipped set from `release.yml`'s staging loop and asserts every bin the verifier requires is one the workflow actually bundles. Reinstating `mvm-bridge` in the verifier turns it red:

```
FAIL: verifier requires bin(s) release.yml never builds: mvm-bridge
```

## Also corrected

- `install.sh` install loop and comment; Homebrew formula.
- Both live install docs, which additionally named `mvm-substitution-endpoint` — not the binary's name either; it is `mvm-network-endpoint`.
- `CLAUDE.md`: listed `mvm-bridge` as a per-VM supervisor bin, and `supervisor/` as containing a `gateway_bridge/` module deleted with the gateway stack.
- Two `Cargo.toml` comment blocks describing the deleted sidecar, sitting above no dependency at all.

`public/docs/investigations/binary-size-baseline.md` still names it and is deliberately left alone — it records measurements taken at a point in time.

## Validation

`shellcheck` on all three scripts and `verify-release-assets.test.sh` at 12 passed / 0 failed — both lanes `ci.yml` runs for these paths. `cargo metadata` confirms the manifest still parses; no Rust changed.