### PR TITLE
fix(docs,contract): correct claim 10 and pin the egress refusal direction (Plan 306 WS5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,9 +322,22 @@ ADR-001 §"Appendix: Cardoso minimum-viable-policy checklist".
 10. **No untrusted workload reaches the network unless explicitly
     admitted by policy.** Sprint 52 W3. `policy_default_is_deny_all`
     and `run_net_default_is_deny_all` (the ADR-001 row's witnesses)
-    assert the default-deny posture; `mvmctl up` emits an opt-in warning when
-    the resolved policy is `unrestricted` (escape hatch is
-    `MVM_ACK_UNRESTRICTED_NETWORK=1`, never set in CI). Cardoso-flavoured
+    assert the default-deny posture. An unrecognised preset name refuses
+    rather than falling through to a permissive default, at the CLI and on
+    the wire alike (`crates/mvm-contract/tests/egress_predicate_algebra.rs`).
+
+    This bullet used to claim that "`mvmctl up` emits an opt-in warning when
+    the resolved policy is `unrestricted`", with an escape hatch of
+    `MVM_ACK_UNRESTRICTED_NETWORK=1`. **None of that exists.** `up` is not a
+    dispatched verb — `up::Args` is not a `Commands` variant, so its
+    `--network-preset` and `--network-allow` fields are unreachable CLI
+    surface. `MVM_ACK_UNRESTRICTED_NETWORK` is read nowhere in the workspace;
+    its only occurrence is a doc comment in `mvm-contract::stream::edge`
+    saying another mechanism is "shaped after" it. There is no unrestricted
+    acknowledgement, so nothing is being bypassed — but nothing warns either,
+    and `specs/plans/296` cites the non-existent hatch as prior art for its
+    E7 redaction opt-out. Building the acknowledgement is Plan 306 WS5.
+    Cardoso-flavoured
     audit of DNS / vsock control-plane carve-out / Plan 104 broker
     channels as covert egress is tracked in Plan 111 Workstream A.
 11. **Every application-dep volume is hash-locked, attestation-checked,

--- a/crates/mvm-contract/tests/egress_predicate_algebra.rs
+++ b/crates/mvm-contract/tests/egress_predicate_algebra.rs
@@ -1,0 +1,119 @@
+//! What the egress policy algebra actually is, pinned.
+//!
+//! Three properties are worth stating in one place with tests: deny-wins
+//! within a grant, union across grants, and default-deny absent any admitting
+//! grant. Two of those describe a grammar this repository does not have — `NetworkPolicy` is `Preset | AllowList`, with no negation
+//! and no multi-grant composition, and `policy::resolver`'s own documentation
+//! says deny-wins "comes online once the sub-policy types grow allow/deny
+//! pairs". There is nothing to pin there yet.
+//!
+//! What *is* real, and was unpinned, is the third property and the one that
+//! matters most: **an input the parser does not recognise must refuse, never
+//! fall through to a permissive default.** That is the direction a policy
+//! parser fails badly in, and the direction nothing was testing.
+//!
+//! These pin the decision, not merely today's behaviour. An implementation
+//! that resolves an unknown preset to anything other than an error is wrong,
+//! however reasonable the fallback looks.
+
+use mvm_contract::policy::network_policy::{NetworkPolicy, NetworkPreset};
+use std::str::FromStr;
+
+/// An unrecognised preset name raises. It does not fall through to
+/// `Unrestricted`, which is the first-declared variant and the one a
+/// careless `Default` derive would select.
+#[test]
+fn an_unknown_preset_refuses_rather_than_falling_through_to_allow() {
+    for unknown in ["wide-open", "", "UNRESTRICTED", "all", "default", "any"] {
+        let parsed = NetworkPreset::from_str(unknown);
+        assert!(
+            parsed.is_err(),
+            "preset {unknown:?} is not recognised and must refuse, not resolve to a default"
+        );
+    }
+}
+
+/// The same holds through serde, which is the path a signed plan or a policy
+/// bundle actually arrives on. A parser that is strict at the CLI and lenient
+/// on the wire is strict nowhere that matters.
+#[test]
+fn serde_also_refuses_an_unknown_preset() {
+    for unknown in ["\"wide-open\"", "\"all\"", "\"\""] {
+        let parsed: Result<NetworkPreset, _> = serde_json::from_str(unknown);
+        assert!(
+            parsed.is_err(),
+            "preset {unknown} must be refused on the wire as well as at the CLI"
+        );
+    }
+}
+
+/// Case matters. `UNRESTRICTED` is not `unrestricted`; accepting it would mean
+/// the set of names that grant network access is larger than the set written
+/// down.
+#[test]
+fn preset_names_are_case_sensitive() {
+    assert!(NetworkPreset::from_str("Unrestricted").is_err());
+    assert!(NetworkPreset::from_str("None").is_err());
+    assert!(NetworkPreset::from_str("unrestricted").is_ok());
+    assert!(NetworkPreset::from_str("none").is_ok());
+}
+
+/// Every recognised name still resolves, so the refusals above are about an
+/// input being unrecognised rather than a parser that rejects everything.
+#[test]
+fn every_declared_preset_round_trips() {
+    for (name, expected) in [
+        ("unrestricted", NetworkPreset::Unrestricted),
+        ("none", NetworkPreset::None),
+        ("registries", NetworkPreset::Registries),
+        ("dev", NetworkPreset::Dev),
+        ("agent", NetworkPreset::Agent),
+    ] {
+        assert_eq!(NetworkPreset::from_str(name).unwrap(), expected);
+        assert_eq!(
+            expected.to_string(),
+            name,
+            "Display must round-trip FromStr"
+        );
+    }
+}
+
+/// Default-deny, stated as a property of the constructors rather than of a
+/// call site. `deny_all` is the safe default and `unrestricted` is not
+/// reachable by accident: there is no `Default` impl that could select it.
+#[test]
+fn deny_all_is_the_restrictive_constructor_and_unrestricted_is_explicit() {
+    let deny = NetworkPolicy::deny_all();
+    assert!(!deny.is_unrestricted(), "deny_all must not be unrestricted");
+
+    let open = NetworkPolicy::unrestricted();
+    assert!(
+        open.is_unrestricted(),
+        "unrestricted must report itself as such, so a caller can gate on it"
+    );
+
+    // An empty allow-list admits nothing. This is the case where a
+    // "union across grants" implementation would be tempted to treat the
+    // empty set as "unconstrained".
+    let empty = NetworkPolicy::allow_list(vec![]);
+    assert!(
+        !empty.is_unrestricted(),
+        "an empty allow-list admits nothing; it is not an absent constraint"
+    );
+}
+
+/// `trusted_build_egress` is unrestricted, and that is deliberate — but it is
+/// a *separate named constructor* so every broad-egress grant is greppable and
+/// cannot be confused with a workload policy.
+///
+/// Pinned because the two being the same value is exactly what would let the
+/// distinction quietly disappear in a refactor.
+#[test]
+fn trusted_build_egress_is_unrestricted_but_separately_named() {
+    assert!(NetworkPolicy::trusted_build_egress().is_unrestricted());
+    assert_eq!(
+        NetworkPolicy::trusted_build_egress(),
+        NetworkPolicy::unrestricted(),
+        "if these diverge, every caller of the build constructor changes meaning"
+    );
+}

--- a/specs/plans/306-declared-backing-and-tier-honesty.md
+++ b/specs/plans/306-declared-backing-and-tier-honesty.md
@@ -122,6 +122,41 @@ What we already have, and therefore what this plan does **not** redo:
       the point is that the vocabulary admits the case the product will need
       without shipping an env var that turns enforcement off.
 
+      **Partially landed, and the premise needs correcting.** Three findings
+      from auditing this against the tree:
+
+      1. **There is no escape hatch to replace.**
+         `MVM_ACK_UNRESTRICTED_NETWORK` is read nowhere in the workspace; its
+         only occurrence is a doc comment in `mvm-contract::stream::edge`
+         saying another mechanism is "shaped after" it. Neither is there the
+         unrestricted warning CLAUDE.md claimed — `mvmctl up` is not a
+         dispatched verb (`up::Args` is not a `Commands` variant, so its
+         `--network-preset` and `--network-allow` are unreachable CLI
+         surface). Nothing is bypassing enforcement, but nothing warns
+         either. CLAUDE.md's claim 10 is corrected.
+      2. **`specs/plans/296` E7 rests on that fiction**, citing
+         "unrestricted egress requires `MVM_ACK_UNRESTRICTED_NETWORK=1`" as
+         prior art for the stream-edge redaction opt-out. The design may
+         still be right; the precedent it names is not there.
+      3. **The predicate algebra has no grammar to pin.** `NetworkPolicy` is
+         `Preset | AllowList` with no negation and no multi-grant
+         composition, and `policy::resolver`'s own docs say deny-wins "comes
+         online once the sub-policy types grow allow/deny pairs". Deny-wins
+         and union cannot be tested into existence.
+
+      Landed: `crates/mvm-contract/tests/egress_predicate_algebra.rs` pins the
+      part that is real and was untested — an unrecognised preset **refuses**
+      rather than falling through to `Unrestricted` (the first-declared
+      variant, and what a careless `Default` derive would select), at the CLI
+      and through serde alike; names are case-sensitive; an empty allow-list
+      admits nothing rather than reading as an absent constraint; and
+      `trusted_build_egress` stays a separately named constructor so a
+      broad-egress grant remains greppable.
+
+      Remaining before WS5 closes: build the enumerated deny-loud verdict
+      (not replace one), and either grow the allow/deny grammar or record that
+      deny-wins/union are not applicable to the current policy shape.
+
 - [x] **WS6 — Replay vectors for the audit chain's signed bytes.**
       `address_vectors.rs` covers `ir_hash` and Merkle; the audit chain's
       `CanonicalEntry` JCS bytes — the thing a third party verifies — has no

--- a/xtask/src/check_build_egress_callers.rs
+++ b/xtask/src/check_build_egress_callers.rs
@@ -49,6 +49,18 @@ const ALLOWED_CALLERS: &[&str] = &[
 /// in the sense this gate polices.
 const DEFINING_FILE: &str = "crates/mvm-contract/src/policy/network_policy.rs";
 
+/// Tests that assert properties *of* the constructor, from outside the
+/// defining file. Same reasoning as [`DEFINING_FILE`]: naming the symbol in
+/// order to pin its behaviour is the opposite of routing a workload through
+/// it, and a gate that forbids testing the thing it polices would push the
+/// property out of the suite entirely.
+const PROPERTY_TEST_FILES: &[&str] = &[
+    // Pins that `trusted_build_egress` stays a *separately named* constructor
+    // rather than an alias of `unrestricted()` — the distinction this gate
+    // exists to keep greppable.
+    "crates/mvm-contract/tests/egress_predicate_algebra.rs",
+];
+
 pub fn run(workspace: &Path) -> Result<()> {
     let mut offenders: Vec<String> = Vec::new();
     let mut allowed_hits = 0usize;
@@ -66,7 +78,7 @@ pub fn run(workspace: &Path) -> Result<()> {
     })?;
 
     for (rel, text) in files {
-        if rel == DEFINING_FILE {
+        if rel == DEFINING_FILE || PROPERTY_TEST_FILES.contains(&rel.as_str()) {
             continue;
         }
         if ALLOWED_CALLERS.contains(&rel.as_str()) {


### PR DESCRIPTION
Plan 306 **WS5** for #2256. **It cannot be completed as written** — two of its four items rest on machinery that is not there. The audit is the deliverable.

## Finding 1 — claim 10 described a control that has never run

CLAUDE.md said:

> `mvmctl up` emits an opt-in warning when the resolved policy is `unrestricted` (escape hatch is `MVM_ACK_UNRESTRICTED_NETWORK=1`, never set in CI)

**None of that exists.**

- **`up` is not a dispatched verb.** `up::Args` is not a `Commands` variant and is never constructed outside `up/`, so its `--network-preset` and `--network-allow` fields are unreachable CLI surface.
- **`MVM_ACK_UNRESTRICTED_NETWORK` is read nowhere in the workspace.** Its only occurrence is a doc comment in `mvm-contract::stream::edge` saying another mechanism is *"shaped after"* it.

To be precise about severity: **nothing is bypassing enforcement**, because there is no acknowledgement to bypass. But nothing warns either, and claim 10 asserted a control that has never existed. Corrected to what actually holds.

## Finding 2 — a plan rests on the fiction

`specs/plans/296` E7 cites *"this repository already has the right shape for it: unrestricted egress requires `MVM_ACK_UNRESTRICTED_NETWORK=1`"* as prior art for the stream-edge redaction opt-out. The design may still be right; the precedent it names is not there. Recorded in Plan 306 so it is not inherited a third time.

## Finding 3 — the algebra has no grammar to pin

`NetworkPolicy` is `Preset | AllowList` — no negation, no multi-grant composition. `policy::resolver`'s own docs say deny-wins *"comes online once the sub-policy types grow allow/deny pairs"*. **Deny-wins and union cannot be tested into existence**, so WS5's first item is not actionable against the current policy shape.

## What did land

The part that is real and was untested: **the direction a policy parser fails badly in.** An unrecognised input must refuse, never fall through to a permissive default.

| Pinned | Why it matters |
|---|---|
| Unknown preset refuses | It would otherwise fall to `Unrestricted` — the first-declared variant, and what a careless `Default` derive selects |
| Refuses through serde too | A parser strict at the CLI and lenient on the wire is strict nowhere that matters — the wire is how signed plans arrive |
| Names are case-sensitive | The set of names granting network access must be no larger than the set written down |
| Empty allow-list admits nothing | The case a "union across grants" implementation is tempted to read as an absent constraint |
| `trusted_build_egress` separately named | Keeps every broad-egress grant greppable; if it and `unrestricted()` silently converge, the distinction disappears in a refactor |

## Remaining before WS5 closes

- [ ] Build the enumerated deny-loud verdict — **build**, not replace.
- [ ] Either grow the allow/deny grammar, or record that deny-wins/union are not applicable to the current policy shape.

## Verification

`cargo nextest run -p mvm-contract` — 884 passed (6 new). `check-doc-claims`, `check-honesty`, `check-no-overclaim`, `check-witness-citations`, `check-claim-catalog`, `check-no-spec-refs-in-comments` green. `cargo fmt --all -- --check`, workspace all-target Clippy.
