### PR TITLE
fix(stage0): gate persistent-store reuse on a clean ext4 superblock

### DIFF
--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -111,7 +111,7 @@ mod linux {
             // hang; the absence of /out artifacts is the failure signal.
             return power_off();
         }
-        match build_and_copy() {
+        match build_and_copy().and_then(|()| finalize_persistent_nix_store()) {
             Ok(()) => {
                 eprintln!("stage0-init: done; halting");
                 power_off()
@@ -600,6 +600,45 @@ mod linux {
         eprintln!("stage0-init: seeded persistent store: {n_src} -> {n_dst} entries");
         bind_mount(STAGE0_NIX_STORE_MOUNT, NIX_TARGET)?;
         Ok(())
+    }
+
+    /// Flush and cleanly unmount the persistent store before reporting Stage 0
+    /// success. `reboot(RB_POWER_OFF)` alone can surface delayed ext4 failures
+    /// only after the success marker has reached the console, which makes the
+    /// host accept a corrupt cache. The explicit unmount moves all filesystem
+    /// writeback ahead of that marker and makes kernel error accounting part of
+    /// the guest result.
+    fn finalize_persistent_nix_store() -> Result<(), String> {
+        if is_qemu() {
+            return Ok(());
+        }
+
+        // SAFETY: sync() takes no arguments and only flushes filesystem state.
+        unsafe {
+            libc::sync();
+        }
+        reject_ext4_errors(Path::new("/sys/fs/ext4/vda/errors_count"))?;
+        unmount(NIX_TARGET)?;
+        unmount(STAGE0_NIX_STORE_MOUNT)?;
+        Ok(())
+    }
+
+    fn reject_ext4_errors(errors_count_path: &Path) -> Result<(), String> {
+        let raw = std::fs::read_to_string(errors_count_path)
+            .map_err(|e| format!("read {}: {e}", errors_count_path.display()))?;
+        let count = raw.trim().parse::<u64>().map_err(|e| {
+            format!(
+                "parse {} value {raw:?} as an ext4 error count: {e}",
+                errors_count_path.display()
+            )
+        })?;
+        if count == 0 {
+            Ok(())
+        } else {
+            Err(format!(
+                "persistent Stage 0 ext4 store reported {count} filesystem error(s)"
+            ))
+        }
     }
 
     fn mount_stage0_nix_store(device: &str) -> Result<(), String> {
@@ -1176,6 +1215,10 @@ mod linux {
         .map_err(|e| format!("bind {source} -> {target}: {e}"))
     }
 
+    fn unmount(target: &str) -> Result<(), String> {
+        nix::mount::umount(target).map_err(|e| format!("unmount {target}: {e}"))
+    }
+
     fn is_mountpoint(target: &str) -> bool {
         // A path is a mountpoint when its st_dev differs from its parent's.
         let (Ok(here), Some(parent)) = (std::fs::metadata(target), Path::new(target).parent())
@@ -1436,6 +1479,18 @@ mod linux {
             std::fs::write(home.join(".cargo/config"), b"stale").expect("seed leftover file");
             super::purge_stale_nix_builder_home(root.path()).expect("removes leftover");
             assert!(!home.exists(), "stale nix builder home must be gone");
+        }
+
+        #[test]
+        fn ext4_error_count_must_be_zero_before_success() {
+            let root = tempfile::tempdir().expect("tempdir");
+            let errors = root.path().join("errors_count");
+            std::fs::write(&errors, "0\n").expect("write zero count");
+            super::reject_ext4_errors(&errors).expect("zero errors are clean");
+
+            std::fs::write(&errors, "7\n").expect("write nonzero count");
+            let error = super::reject_ext4_errors(&errors).expect_err("errors must fail");
+            assert!(error.contains("7 filesystem error(s)"), "{error}");
         }
 
         #[test]

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2637,8 +2637,20 @@ pub(crate) fn prepopulate_stage0_nix_store_image(
 
     let marker = stage0_nix_store_host_marker(&seed_store)?;
     let marker_path = stage0_nix_store_host_marker_path(store_image);
-    if std::fs::read_to_string(&marker_path).is_ok_and(|existing| existing == marker) {
+    if std::fs::read_to_string(&marker_path).is_ok_and(|existing| existing == marker)
+        && stage0_store_superblock_is_clean(store_image)?
+    {
         return Ok(());
+    }
+
+    // The marker binds the image to the seed closure, but it is deliberately
+    // outside the filesystem and therefore cannot attest filesystem health.
+    // Drop it before rebuilding so an interrupted format can never make a
+    // damaged image look reusable on the next invocation.
+    if marker_path.exists() {
+        std::fs::remove_file(&marker_path).map_err(|e| {
+            BuilderVmError::ExtractionFailed(format!("remove {}: {e}", marker_path.display()))
+        })?;
     }
 
     let Some(mkfs) = find_host_mkfs_ext4() else {
@@ -2702,6 +2714,22 @@ fn format_stage0_store_empty_in_process(store_image: &Path) -> Result<(), Builde
         .map_err(|e| {
             BuilderVmError::ExtractionFailed(format!("open {}: {e}", store_image.display()))
         })?;
+    let device_size = file
+        .metadata()
+        .map_err(|e| {
+            BuilderVmError::ExtractionFailed(format!("stat {}: {e}", store_image.display()))
+        })?
+        .len();
+    // `format_empty_ext4` writes only filesystem metadata so a large sparse
+    // backing file stays sparse. Reset the file first: every inode table the
+    // formatter advertises as zeroed must actually be zero even when this is a
+    // recovery reformat of an image containing an older Nix store.
+    file.set_len(0).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("truncate {}: {e}", store_image.display()))
+    })?;
+    file.set_len(device_size).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("resize {}: {e}", store_image.display()))
+    })?;
     let summary = mvm_fs::ext4::mkfs::format_empty_ext4(&mut file, size_bytes).map_err(|e| {
         BuilderVmError::ExtractionFailed(format!(
             "pure-Rust ext4 format of {}: {e}",
@@ -2761,6 +2789,34 @@ fn host_file_4k_blocks_for_ext4(store_image: &Path) -> Result<u64, BuilderVmErro
 
 fn stage0_nix_store_host_marker_path(store_image: &Path) -> PathBuf {
     store_image.with_extension("stage0-seed")
+}
+
+const EXT4_SUPERBLOCK_MAGIC_OFFSET: u64 = 1024 + 0x38;
+const EXT4_SUPERBLOCK_MAGIC: u16 = 0xEF53;
+const EXT4_VALID_FS: u16 = 0x0001;
+
+/// The external seed marker is only reusable when ext4 itself reports a clean
+/// unmount. A zero/dirty/error state forces a fresh sparse format before boot.
+fn stage0_store_superblock_is_clean(store_image: &Path) -> Result<bool, BuilderVmError> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut file = std::fs::File::open(store_image).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!("open {}: {e}", store_image.display()))
+    })?;
+    file.seek(SeekFrom::Start(EXT4_SUPERBLOCK_MAGIC_OFFSET))
+        .map_err(|e| {
+            BuilderVmError::ExtractionFailed(format!("seek {}: {e}", store_image.display()))
+        })?;
+    let mut fields = [0u8; 4];
+    file.read_exact(&mut fields).map_err(|e| {
+        BuilderVmError::ExtractionFailed(format!(
+            "read ext4 state from {}: {e}",
+            store_image.display()
+        ))
+    })?;
+    let magic = u16::from_le_bytes([fields[0], fields[1]]);
+    let state = u16::from_le_bytes([fields[2], fields[3]]);
+    Ok(magic == EXT4_SUPERBLOCK_MAGIC && state == EXT4_VALID_FS)
 }
 
 fn stage0_nix_store_host_marker(seed_store: &Path) -> Result<String, BuilderVmError> {
@@ -5321,14 +5377,13 @@ mod tests {
         );
     }
 
-    /// A second prepopulation of an already-prepared store must be a no-op — it
-    /// records the host marker on the first pass and honours it on the second,
-    /// so the guest-seeded, grown store survives instead of being reformatted
-    /// (which would wipe every persisted build result). Discriminated by
-    /// corrupting the superblock after pass one: a reformat would restore it.
+    /// A matching external marker must not hide filesystem corruption. The
+    /// second prepopulation pass reformats an image whose ext4 error-state bit
+    /// is set, restoring a usable sparse store instead of handing it back to
+    /// Stage 0.
     #[cfg(feature = "pure-mkfs")]
     #[test]
-    fn stage0_store_prepopulate_is_idempotent_and_preserves_store() {
+    fn stage0_store_prepopulate_repairs_corrupt_marked_store() {
         use std::io::{Read, Seek, SeekFrom, Write};
 
         let scratch = TempDir::new().unwrap();
@@ -5360,29 +5415,76 @@ mod tests {
             f.read_exact(&mut b).unwrap();
             u16::from_le_bytes(b)
         };
+        let read_state = |p: &Path| {
+            let mut f = std::fs::File::open(p).unwrap();
+            f.seek(SeekFrom::Start(magic_off + 2)).unwrap();
+            let mut b = [0u8; 2];
+            f.read_exact(&mut b).unwrap();
+            u16::from_le_bytes(b)
+        };
         assert_eq!(
             read_magic(&store_image),
             0xEF53,
             "pass 1 wrote a valid ext4"
         );
 
-        // Corrupt the superblock magic; only a reformat would restore it.
+        // Set EXT4_ERROR_FS in the superblock state; only a reformat restores
+        // the valid-filesystem state.
         {
             let mut f = std::fs::OpenOptions::new()
                 .write(true)
                 .open(&store_image)
                 .unwrap();
-            f.seek(SeekFrom::Start(magic_off)).unwrap();
-            f.write_all(&[0, 0]).unwrap();
+            f.seek(SeekFrom::Start(magic_off + 2)).unwrap();
+            f.write_all(&0x0002_u16.to_le_bytes()).unwrap();
         }
 
-        // Pass 2: marker matches → early return, no reformat.
+        // Pass 2: marker matches, but filesystem health does not → reformat.
         prepopulate_stage0_nix_store_image(&image, &store_image).unwrap();
         assert_eq!(
-            read_magic(&store_image),
-            0,
-            "second prepopulate must preserve the store, not reformat it"
+            read_state(&store_image),
+            EXT4_VALID_FS,
+            "a corrupt marked store must be reformatted"
         );
+    }
+
+    #[cfg(feature = "pure-mkfs")]
+    #[test]
+    fn stage0_store_prepopulate_preserves_clean_marked_store() {
+        use std::io::{Read, Seek, SeekFrom, Write};
+
+        let scratch = TempDir::new().unwrap();
+        let root_dir = scratch.path().join("root");
+        let seed_store = root_dir.join("nix").join("store");
+        std::fs::create_dir_all(&seed_store).unwrap();
+        std::fs::write(seed_store.join("aaa-seed-pkg"), b"x").unwrap();
+        let image = BuilderVmImage::RootDir {
+            root_dir,
+            entry_path: "init".into(),
+        };
+        let store_image = scratch.path().join("nix-store-stage0-test.img");
+        std::fs::File::create(&store_image)
+            .unwrap()
+            .set_len(64 * 1024 * 1024)
+            .unwrap();
+
+        prepopulate_stage0_nix_store_image(&image, &store_image).unwrap();
+        let sentinel_offset = 8 * 1024 * 1024;
+        let mut file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&store_image)
+            .unwrap();
+        file.seek(SeekFrom::Start(sentinel_offset)).unwrap();
+        file.write_all(b"warm-cache").unwrap();
+        drop(file);
+
+        prepopulate_stage0_nix_store_image(&image, &store_image).unwrap();
+        let mut file = std::fs::File::open(&store_image).unwrap();
+        file.seek(SeekFrom::Start(sentinel_offset)).unwrap();
+        let mut sentinel = [0u8; 10];
+        file.read_exact(&mut sentinel).unwrap();
+        assert_eq!(&sentinel, b"warm-cache");
     }
 
     // `read_job_result_*`, `extract_nix_store_hash_*`,

--- a/crates/mvm-fs/src/ext4/mkfs.rs
+++ b/crates/mvm-fs/src/ext4/mkfs.rs
@@ -102,6 +102,10 @@ struct Geometry {
 /// The reserved inodes (1..=10) are all marked used; root is inode 2 among
 /// them. We create no `lost+found` — the kernel mounts and writes without it.
 const RESERVED_INODES: u32 = 10;
+/// The inode tables written by this formatter are fully zeroed. Advertising
+/// that fact prevents the kernel's lazy inode-table initializer from rewriting
+/// group descriptors behind a busy, unjournaled filesystem.
+const BG_INODE_ZEROED: u16 = 0x0004;
 
 impl Geometry {
     fn plan(size_bytes: u64) -> Result<Self, MkfsError> {
@@ -322,6 +326,7 @@ fn build_gdt(geom: &Geometry) -> Vec<u8> {
         };
         put_u16(&mut gdt, d + 0x0E, free_inodes as u16); // bg_free_inodes_count_lo
         put_u16(&mut gdt, d + 0x10, if g == 0 { 1 } else { 0 }); // bg_used_dirs_count_lo (root)
+        put_u16(&mut gdt, d + 0x12, BG_INODE_ZEROED); // bg_flags
     }
     gdt
 }
@@ -457,6 +462,17 @@ mod tests {
         let geom = Geometry::plan(160 * 1024 * 1024).unwrap();
         let per_group: u32 = (0..geom.groups).map(|g| geom.group_free_blocks(g)).sum();
         assert_eq!(per_group, s.free_blocks);
+    }
+
+    #[test]
+    fn every_group_descriptor_marks_its_inode_table_zeroed() {
+        let (img, summary) = format_buf(160 * 1024 * 1024);
+        let descriptor_table = BLOCK_SIZE as usize;
+        for group in 0..summary.groups as usize {
+            let flags_offset = descriptor_table + group * 32 + 0x12;
+            let flags = u16::from_le_bytes([img[flags_offset], img[flags_offset + 1]]);
+            assert_eq!(flags, BG_INODE_ZEROED, "group {group}");
+        }
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -167,6 +167,10 @@ for detailed scope and acceptance criteria.
         the 461-test `xtask --features man` CI lane, and 172 BDD scenarios pass;
         KVM-backed ARM64 cold bootstrap, kernel publication, persistent Stage 0
         reuse, and two fully warm Alpine runs complete without a second Stage 0
+  - [x] Persistent Stage 0 ext4 reuse requires clean filesystem state; cold
+        repair and warm reuse pass live ARM64 builder runs without ext4 errors
+  - [~] Workspace tests expose unrelated non-deterministic `mvm-hostd` failures;
+        Linux all-target Clippy remains for CI or a supported builder entry point
 
 - [x] Plan 316 — website and docs redesign (agent design review completed and maintainer sign-off received; merged via #2438)
       (`specs/plans/316-website-redesign.md`)

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -54,6 +54,12 @@
       scenarios pass. A KVM-backed ARM64 acceptance run completed cold
       bootstrap and kernel publication, then ran Alpine twice from a fully warm
       cache without launching Stage 0.
+      Store reuse additionally requires a clean ext4 superblock alongside the
+      external seed marker; the in-process formatter prevents lazy inode-table
+      races, and Stage 0 flushes, checks, and unmounts the store before
+      reporting success. A live ARM64 cold repair and warm-cache rerun both
+      completed without ext4 errors. The Linux all-target Clippy rerun for this
+      change remains for CI or a supported builder-VM entry point.
 
 - [x] HVF large-response integrity — **plan 315**. Restored bounded
       virtio-vsock host-to-guest credit accounting that had been removed while

--- a/specs/plans/315-bootstrap-machine-readiness.md
+++ b/specs/plans/315-bootstrap-machine-readiness.md
@@ -15,7 +15,9 @@ byte-marker probe falsely rejected the valid KALLSYMS-free ARM64 kernel.
 machine path. It prepares host tooling, the builder VM, and the verified workload kernel.
 An interrupted producer never replaces a usable cache entry or leaves a partial
 entry that can be served, and the next retry explains that its persistent Nix
-store remains reusable.
+store remains reusable. Stage 0 reuses that store only while its ext4
+superblock reports a clean unmount, and it flushes, checks, and unmounts the
+store before publishing guest success.
 
 ## Work
 
@@ -49,9 +51,18 @@ store remains reusable.
 - [x] Follow only bounded, HTTPS OCI blob redirects to the exact trusted Docker
       CDN origins, stripping registry authorization at the origin boundary and
       refusing redirects for manifests.
+- [x] Prevent kernel lazy inode-table initialization from racing allocations in
+      the in-process ext4 image, and clear prior contents before a recovery
+      reformat advertises zeroed inode tables.
+- [x] Require both the external seed marker and a clean ext4 superblock before
+      reusing the persistent store; flush, reject recorded ext4 errors, and
+      unmount the store before Stage 0 emits its success marker.
 - [x] Cover bootstrap ordering/failure, verified resolution, incompatible-cache
       eviction, KALLSYMS-free acceptance, config rejection, atomic publication,
-      interrupted-staging cleanup, buffered symlink copy, and Ctrl-C messaging.
+      interrupted-staging cleanup, buffered symlink copy, Ctrl-C messaging,
+      marked-store corruption recovery, clean-store preservation, group
+      descriptor initialization, and the guest error-count gate. Prove cold
+      recovery and warm reuse with live ARM64 Stage 0 builds.
 - [x] Close repository-wide verification. Formatting, focused tests, `cargo
       check --workspace`, host `cargo clippy --workspace --all-targets -- -D
       warnings`, the complete serialized workspace suite including doctests,
@@ -60,6 +71,15 @@ store remains reusable.
       bootstrap, reused the persistent Stage 0 Nix store, rebuilt and published
       the workload kernel with dm-verity plus 8250 console support, and then ran
       Alpine twice from the fully warm cache without launching Stage 0.
+- [ ] Close repository-wide verification exceptions. Formatting, focused tests,
+      `cargo check --workspace`, host `cargo clippy --workspace --all-targets --
+      -D warnings`, and all 172 BDD scenarios pass. The full workspace test run
+      passes the changed crates but remains red in untouched `mvm-hostd`
+      shared-state/timing tests; isolated reruns produce a different telemetry
+      failure and a hanging UDS test. The Linux all-target Clippy rerun remains
+      for CI or a supported builder-VM execution entry point; the shipped
+      builder is headless and this macOS session must not run Linux tooling
+      outside it.
 
 ## Security properties
 


### PR DESCRIPTION
Two related defects in the Stage 0 persistent Nix store, found while triaging idle work.

## Store reuse trusted a marker alone

Stage 0 decided the persistent store was reusable from an external seed marker. A store left dirty by an interrupted producer therefore got served as usable. Reuse now additionally requires a clean ext4 superblock, and `finalize_persistent_nix_store` flushes, checks the kernel's ext4 error accounting, and unmounts before the success marker reaches the console.

Ordering is the point: `reboot(RB_POWER_OFF)` alone can surface delayed ext4 failures *after* the marker is already out, which makes the host accept a corrupt cache. Moving writeback and the error check ahead of the marker makes the guest result honest.

## The formatter never advertised its zeroed inode tables

`crates/mvm-fs/src/ext4/mkfs.rs` left `bg_flags` at zero in every group descriptor. The inode tables it writes *are* fully zeroed, but without `BG_INODE_ZEROED` the kernel's lazy inode-table initializer is entitled to rewrite group descriptors behind a busy, unjournaled filesystem — racing allocations in the in-process image.

`bg_flags` on `main` today is unset, so this is live, not theoretical.

## Validation

- `cargo nextest run -p mvm-fs -p mvm-build` — **1067 passed**, 1 skipped.
- Full workspace `cargo clippy --workspace --all-targets -- -D warnings` green (pre-commit hook, run against current main after rebase).
- Rebased onto `37c38b93c`; zero commits behind.

The Linux all-target Clippy rerun is left for CI: the shipped builder is headless and this macOS session must not run Linux tooling outside it. That exception is recorded as an open item in Plan 315 rather than claimed as done.

## Conflict resolution note

`main` had changed `mount_stage0_nix_store` to take a `device` parameter while this branch added two functions above it; both sides are kept. In Plan 315, SPRINT, and REFACTOR-STATUS the landed entries are preserved and the new ones appended — in particular `main`'s closed verification item was **not** downgraded, since it was true for its own scope; this change's outstanding verification is a separate open item.