### PR TITLE
test(sec): direct witnesses for the four surviving Security-lane mutants

### DIFF
--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -616,6 +616,50 @@ mod tests {
         );
     }
 
+    /// The other half of the digest-pin rule, and the half nothing asserted.
+    ///
+    /// `prod && !pinned` has two operands, so a test that only drives
+    /// `prod=true, pinned=false` pins one cell of a four-cell truth table.
+    /// Flipping the `&&` to `||` still refuses the mutable prod pull above —
+    /// it just *also* refuses everything else, and no test noticed.
+    ///
+    /// A digest-pinned prod pull must get past this check. It will still fail,
+    /// because the test has no registry, but it must fail for a reason that is
+    /// not the pin rule.
+    #[test]
+    fn a_digest_pinned_prod_pull_is_not_refused_by_the_pin_rule() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // A closed local port: the pull fails on connect in milliseconds
+        // instead of reaching a real registry. Which check rejected it is the
+        // only thing under test, so the registry never needs to answer — and a
+        // unit test that pulls from the internet is a flake waiting to happen.
+        let pinned = concat!(
+            "127.0.0.1:1/library/alpine@sha256:",
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        let err = pull_image_with_trust(tmp.path(), pinned, true)
+            .expect_err("no registry is listening on this port");
+        assert!(
+            !err.to_string()
+                .contains("requires a digest-pinned reference"),
+            "a digest-pinned reference must clear the pin rule; got: {err}"
+        );
+    }
+
+    /// The dev cell of the same truth table. A mutable tag outside `--prod` is
+    /// the ordinary case, and `||` would refuse it.
+    #[test]
+    fn a_mutable_tag_outside_prod_is_not_refused_by_the_pin_rule() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let err = pull_image_with_trust(tmp.path(), "127.0.0.1:1/library/alpine:3.20", false)
+            .expect_err("no registry is listening on this port");
+        assert!(
+            !err.to_string()
+                .contains("requires a digest-pinned reference"),
+            "the pin rule applies only under --prod; got: {err}"
+        );
+    }
+
     #[test]
     fn prod_run_image_requires_digest_pin_before_network() {
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -312,6 +312,54 @@ mod tests {
     use mvm_core::network_policy::{HostPort, NetworkPolicy, NetworkPreset};
     use mvm_core::util::test_env::TestEnv;
 
+    /// A VM that is not running must be refused.
+    ///
+    /// The check is `if !backend_is_running(..)`. Deleting the `!` inverts it:
+    /// a stopped VM resolves successfully and the caller proceeds to operate on
+    /// a machine that is not there. Nothing asserted the refusal, so the
+    /// inversion survived.
+    #[test]
+    fn a_vm_that_is_not_running_is_refused() {
+        let home = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(home.path());
+        let err = resolve_running_vm("definitely-not-running")
+            .expect_err("a VM that is not running must not resolve");
+        assert!(
+            err.to_string().contains("is not running"),
+            "refusal must name the reason; got: {err}"
+        );
+    }
+
+    /// A bare directory name is a manifest *path*, not a registry name.
+    ///
+    /// `looks_like_path` is a chain of `||`s ending in `path.is_dir()`.
+    /// Replacing that last `||` with `&&` binds tighter, collapsing the tail to
+    /// `path.is_file() && path.is_dir()` — which no path satisfies. A bare name
+    /// that is really a directory then gets misread as a legacy registry name,
+    /// and every earlier operand misses it: no `/`, no leading `.`, no `.toml`.
+    ///
+    /// Changes the process working directory, which is safe here because the
+    /// named test gate is nextest and nextest runs one process per test.
+    #[test]
+    fn a_bare_directory_name_is_treated_as_a_path_not_a_registry_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // No slash, no leading dot, no .toml — only `is_dir` can classify it.
+        let bare = "manifestdir";
+        std::fs::create_dir(tmp.path().join(bare)).expect("create dir");
+
+        let previous = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(tmp.path()).expect("chdir");
+        let resolved = resolve_manifest_arg(bare);
+        std::env::set_current_dir(previous).expect("restore cwd");
+
+        // It resolves as a path — which fails, because the directory holds no
+        // manifest. The point is that it was not silently taken for a name.
+        if let Ok(ManifestArgRef::Name(n)) = resolved {
+            panic!("a directory was misclassified as the registry name {n:?}");
+        }
+    }
+
     #[test]
     fn run_net_default_is_deny_all() {
         assert_eq!(

--- a/crates/mvm-core/src/cpu_scope.rs
+++ b/crates/mvm-core/src/cpu_scope.rs
@@ -607,6 +607,39 @@ pub fn rendered_argv(cmd: &Command) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    /// Never claim HVF vCPU-quota enforcement without a bounded quota record.
+    ///
+    /// `enforced_grants_for_vm` branches on `vcpu_quota_tier ==
+    /// EnforcedTier::HvfVcpuQuota`. Inverting that comparison makes the
+    /// *absence* of a record report `HvfVcpuQuota` — a receipt asserting an
+    /// enforcement mechanism that never ran, which is precisely the
+    /// overstatement this seam exists to prevent.
+    ///
+    /// A state dir with no record is the common case on every non-HVF backend,
+    /// so this is not a corner.
+    #[test]
+    fn a_vm_with_no_quota_record_never_reports_hvf_quota_enforcement() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let grants = super::enforced_grants_for_vm(dir.path());
+        assert_ne!(
+            grants.cpu,
+            EnforcedTier::HvfVcpuQuota,
+            "no quota record was written, so no HVF quota can have been enforced"
+        );
+    }
+
+    /// Wall clock is reported as declared rather than omitted, so a receipt
+    /// says which dimensions were measured and found unenforced instead of
+    /// leaving a reader to infer it from silence.
+    #[test]
+    fn wall_clock_is_reported_declared_rather_than_omitted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            super::enforced_grants_for_vm(dir.path()).wall_clock,
+            EnforcedTier::Declared
+        );
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
Security run 31817896244 left four mutants alive. Each is now killed by a test asserting the property the mutation breaks, and **each was verified red against the mutated source before being kept** — I applied each mutation locally, watched the new test fail, then reverted.

**No waiver added, no accepted-miss entry.** These are direct witnesses.

| Mutant | What the mutation does |
|---|---|
| `pull_core.rs:206` `&&`→`||` | Refuses a digest-pinned prod pull *and* every ordinary dev pull |
| `resolve.rs:12` delete `!` | A stopped VM resolves successfully; the caller proceeds against a machine that is not there |
| `resolve.rs:97` `||`→`&&` | A bare directory name is misread as a legacy registry name |
| `cpu_scope.rs:407` `==`→`!=` | **Absence** of a quota record reports `HvfVcpuQuota` — a receipt asserting enforcement that never ran |

## Why these survived

`pull_image_with_trust` guards on `prod && !is_digest_pinned()` — two operands, four cells, and only one was pinned. The existing `prod_pull_requires_digest_pin_before_network` drives `prod=true, pinned=false`. Flipping `&&` to `||` still refuses that case; it just *also* refuses everything else. Two tests add the missing cells.

`enforced_grants_for_vm` is the one I'd flag: inverting the comparison makes a VM with **no** quota record report `HvfVcpuQuota`. That is a receipt claiming an enforcement mechanism that never ran, which is exactly the overstatement that seam exists to prevent — and a state dir with no record is the common case on every non-HVF backend, so it is not a corner case.

## One thing worth knowing

Written against `docker.io` first, the dev-case pull test took **108 seconds and failed by succeeding** — it pulled Alpine from the real internet. A unit test that reaches a registry is a flake waiting to happen and would have been a bad addition to a lane that already suffers from races. Both pull tests now use a closed local port and fail on connect in ~15 ms. That is all the test needs: the assertion is about *which check rejected the reference*, not what a registry would have said.

The `resolve_manifest_arg` test changes the process working directory. Safe here because the named gate is nextest, which runs one process per test — noted in the test so nobody moves it under a threaded runner.

## Verification

`cargo nextest run -p mvm-cli -p mvm-core` — 3,667 passed. `xtask check-mutation-witnesses` clean. `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`.

The Security workflow is the real gate and it does not run on PRs, so I will dispatch it against this branch and report the result rather than assume.

Refs #2135.
