### PR TITLE
ci: gate PRs on a cold-boot latency ceiling

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -301,6 +301,13 @@ jobs:
       - name: Run E2E tests
         # Keep this lane on end-to-end smoke targets that compile
         # without live microVM host state.
+        #
+        # `runtime_boot_bench` is a COMPILE check here and nothing more. It
+        # self-skips unless `MVM_RUNTIME_BOOT_BENCH=1`, which this lane
+        # deliberately does not set, so it asserts nothing about boot latency.
+        # That assertion lives in ci.yml's `boot-latency` lane, which supplies
+        # a real image and /dev/kvm. Said plainly because the bare target name
+        # reads like latency coverage and is not.
         run: cargo test --test smoke_run_json_receipt --test runtime_boot_bench
 
   sdk-release-dry-run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,6 +702,110 @@ jobs:
       - name: Run mvm-hostd eBPF telemetry load/attach test
         run: cargo test -p mvm-hostd --features ebpf-telemetry --lib
 
+  # ── Lane: cold-boot latency ceiling ──────────────────────────────
+  # A launch-latency regression is otherwise found by hand, months late:
+  # Firecracker guest boot drifted to 447ms against 58.6ms on the same image
+  # and was noticed only when someone profiled a launch for another reason.
+  #
+  # This is the coarse half of the gate deliberately. A shared runner's
+  # variance is large, so the budget is loose enough to be immune to it and
+  # therefore too loose to catch a 20% drift. It catches the multiple-x class,
+  # which is the class that has actually happened. The precise, tight-tolerance
+  # comparison belongs on a dedicated host where run-to-run spread is small
+  # enough for a percentage to mean something — that is a separate lane, not
+  # this one, because one threshold cannot do both jobs: loose enough to
+  # survive shared-runner noise is too loose to catch drift, and tight enough
+  # to catch drift will flake here and get switched off.
+  boot-latency:
+    name: Boot latency ceiling
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Pinned, not `latest`. Auto-tracking a moving release is how this lane
+      # would surprise-break on an unrelated image cut, and it would look like
+      # a latency regression when it is not.
+      IMAGE_TAG: v0.17.0
+      FC_VERSION: v1.10.1
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/free-disk
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install system build deps
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
+          sudo apt-get install -y libcap-ng-dev lld
+
+      - uses: ./.github/actions/rust-cache
+        with:
+          key: boot-latency
+
+      - name: Install firecracker
+        run: |
+          set -euo pipefail
+          curl -fL -o firecracker.tgz \
+            "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-x86_64.tgz"
+          tar -xzf firecracker.tgz
+          sudo install -m 0755 "release-${FC_VERSION}-x86_64/firecracker-${FC_VERSION}-x86_64" /usr/bin/firecracker
+          /usr/bin/firecracker --version
+
+      - name: Grant /dev/kvm access for the job
+        # ubuntu-latest's /dev/kvm is root:kvm 0660 and the runner user is not
+        # in the kvm group. The runner is ephemeral, so the looser mode is
+        # confined to this job.
+        run: |
+          set -euo pipefail
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm missing on this runner — the boot gate cannot run." >&2
+            exit 1
+          fi
+          sudo chmod 666 /dev/kvm
+          ls -la /dev/kvm
+
+      - name: Fetch and verify the pinned bootable image
+        # Hash-verified against the release's own checksum manifest — the same
+        # posture every other artifact fetch in this repo uses. A corrupted
+        # download must fail here rather than surface as a boot-time mystery.
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/boot-image && cd /tmp/boot-image
+          base="https://github.com/tinylabscom/mvm/releases/download/${IMAGE_TAG}"
+          for f in default-microvm-vmlinux-x86_64 default-microvm-rootfs-x86_64.ext4; do
+            curl -fL --retry 3 -o "$f" "$base/$f"
+          done
+          curl -fL --retry 3 -o checksums.txt \
+            "$base/default-microvm-x86_64-checksums-sha256.txt"
+          grep -E ' (default-microvm-vmlinux-x86_64|default-microvm-rootfs-x86_64\.ext4)$' \
+            checksums.txt > expected.txt
+          test -s expected.txt
+          sha256sum -c expected.txt
+          ls -la
+
+      - name: Boot within the ceiling
+        # The budget is a ceiling, not a target. A dedicated KVM host measures
+        # this image cold-boot-to-agent-ready at a median of ~2.1s, so 6s
+        # leaves roughly 3x headroom for a shared runner while still failing
+        # the multiple-x regressions this lane exists to catch. p50/p95/max are
+        # printed on every run, so tightening it later is a reading exercise
+        # rather than a guess.
+        env:
+          MVM_RUNTIME_BOOT_BENCH: "1"
+          MVM_RUNTIME_BOOT_BACKEND: firecracker
+          MVM_RUNTIME_BOOT_KERNEL: /tmp/boot-image/default-microvm-vmlinux-x86_64
+          MVM_RUNTIME_BOOT_ROOTFS: /tmp/boot-image/default-microvm-rootfs-x86_64.ext4
+          MVM_RUNTIME_BOOT_READY: guest-agent
+          MVM_RUNTIME_BOOT_RUNS: "5"
+          MVM_RUNTIME_BOOT_CONCURRENT: "3"
+          MVM_RUNTIME_BOOT_BUDGET_MS: "6000"
+        run: |
+          cargo test --test runtime_boot_bench \
+            prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
+
   nix-flake-check:
     name: Nix flake check (Linux eval)
     # Nix eval/build is heavy; run it in the merge queue and on manual dispatch,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -741,6 +741,11 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
           sudo apt-get install -y libcap-ng-dev lld
 
+      # Building the root package runs `crates/mvm-cli/build.rs`, which
+      # cross-compiles the embedded host binaries and needs the pinned zig.
+      # Without it the lane fails before it ever boots anything.
+      - uses: ./.github/actions/install-zigbuild
+
       - uses: ./.github/actions/rust-cache
         with:
           key: boot-latency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,15 +780,22 @@ jobs:
           set -euo pipefail
           mkdir -p /tmp/boot-image && cd /tmp/boot-image
           base="https://github.com/tinylabscom/mvm/releases/download/${IMAGE_TAG}"
-          for f in default-microvm-vmlinux-x86_64 default-microvm-rootfs-x86_64.ext4; do
+          for f in default-microvm-vmlinux-x86_64 default-microvm-rootfs-x86_64.ext4 \
+                   default-microvm-meta-x86_64.json; do
             curl -fL --retry 3 -o "$f" "$base/$f"
           done
           curl -fL --retry 3 -o checksums.txt \
             "$base/default-microvm-x86_64-checksums-sha256.txt"
-          grep -E ' (default-microvm-vmlinux-x86_64|default-microvm-rootfs-x86_64\.ext4)$' \
+          grep -E ' (default-microvm-vmlinux-x86_64|default-microvm-rootfs-x86_64\.ext4|default-microvm-meta-x86_64\.json)$' \
             checksums.txt > expected.txt
           test -s expected.txt
           sha256sum -c expected.txt
+          # The runtime-overlay admission gate reads `mvm-meta.json` from the
+          # rootfs's own directory and refuses to boot without it. The release
+          # publishes that sidecar under an arch-qualified asset name, so it has
+          # to be put back under the name the gate looks for. Verified above
+          # under its asset name before being renamed.
+          cp default-microvm-meta-x86_64.json mvm-meta.json
           ls -la
 
       - name: Boot within the ceiling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,7 +727,11 @@ jobs:
       # would surprise-break on an unrelated image cut, and it would look like
       # a latency regression when it is not.
       IMAGE_TAG: v0.17.0
-      FC_VERSION: v1.10.1
+      # Must track `crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT`. The
+      # launch path passes `--enable-pci`, which older Firecracker rejects
+      # outright: it exits before creating its API socket, and the only symptom
+      # is a socket-wait timeout that says nothing about the cause.
+      FC_VERSION: v1.14.1
     steps:
       - uses: actions/checkout@v6
 
@@ -817,6 +821,23 @@ jobs:
         run: |
           cargo test --test runtime_boot_bench \
             prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
+
+      - name: Dump VMM diagnostics on failure
+        if: failure()
+        # Firecracker's stderr goes to `firecracker.log` in the per-VM state
+        # dir and its console to `console.log`; neither reaches the job output.
+        # Without this a launch failure surfaces only as "API socket did not
+        # appear", which is a symptom and never the cause.
+        run: |
+          for d in "$HOME"/.mvm/vms/*/; do
+            echo "===== $d ====="
+            ls -la "$d" || true
+            for f in firecracker.log console.log; do
+              if [ -s "$d$f" ]; then
+                echo "--- $f ---"; tail -50 "$d$f"
+              fi
+            done
+          done
 
   nix-flake-check:
     name: Nix flake check (Linux eval)

--- a/specs/sprint/delivery/2484-boot-latency-ceiling.md
+++ b/specs/sprint/delivery/2484-boot-latency-ceiling.md
@@ -58,6 +58,26 @@ Worth noting for the workflow-linting gap tracked separately: no linter would
 have caught this. The YAML was valid and `actionlint` passed both before and
 after. A missing build dependency is only observable by running the job.
 
+## Second run: the pinned image needs its sidecar
+
+With zig installed the lane built and reached a real VM start, which then
+refused:
+
+```
+refusing to start VM: rootfs at /tmp/boot-image has no `mvm-meta.json` sidecar
+```
+
+`admit_runtime_overlay_contract` reads `mvm-meta.json` from the rootfs's own
+directory. The release does publish that sidecar, as
+`default-microvm-meta-x86_64.json` — arch-qualified, because release assets
+share one flat namespace — so the lane fetches it, verifies it under that name,
+and copies it to the name the gate looks for. Its `overlayAware: true` is what
+the gate needs under the default runtime-source policy.
+
+Each failure has been one layer deeper than the last and none has been the
+budget: first the build toolchain, then the image contract. That is the cost of
+a lane that could not be exercised before landing.
+
 ## Not verified here
 
 **The budget has still never been exercised.** The first run died in the build step, so the

--- a/specs/sprint/delivery/2484-boot-latency-ceiling.md
+++ b/specs/sprint/delivery/2484-boot-latency-ceiling.md
@@ -78,6 +78,33 @@ Each failure has been one layer deeper than the last and none has been the
 budget: first the build toolchain, then the image contract. That is the cost of
 a lane that could not be exercised before landing.
 
+## Third run: a Firecracker version too old for the launch path
+
+The sidecar gate passed and Firecracker was actually invoked, then:
+
+```
+Firecracker API socket .../fc.socket did not appear within 3s
+```
+
+The launch path passes `--enable-pci`, which the pinned v1.10.1 rejects
+outright — it exits before creating its API socket. The socket-wait timeout is
+the only symptom, and it names nothing about the cause.
+
+v1.10.1 came from copying `ci-full.yml`'s older spawn-smoke lane, which predates
+the PCI flag. The canonical version is
+`crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT` (`v1.14.1`), which
+`nix/ops/hetzner/cloud-init.yaml` already tracks with a comment saying so; this
+lane now does too.
+
+**The same stale pin is still in `ci-full.yml`'s `workload-spawn-smoke-linux`
+lane.** It is `workflow_dispatch`-only, so nobody has run it into this. Not
+changed here because this PR cannot verify that lane, but it is very likely
+broken for the same one-line reason.
+
+A `failure()` step now dumps `firecracker.log` and `console.log` from the per-VM
+state dir. Firecracker's stderr goes there and never reached the job output,
+which is why three runs produced symptoms rather than causes.
+
 ## Not verified here
 
 **The budget has still never been exercised.** The first run died in the build step, so the

--- a/specs/sprint/delivery/2484-boot-latency-ceiling.md
+++ b/specs/sprint/delivery/2484-boot-latency-ceiling.md
@@ -1,0 +1,52 @@
+# 2484 — cold-boot latency ceiling gates a PR
+
+## What was missing, and what already existed
+
+No PR-gating check on launch latency, so a regression was found by hand months
+late — Firecracker guest boot at 447ms against 58.6ms on the same image.
+
+But the harness was already written. `tests/runtime_boot_bench.rs` measures
+live Firecracker boot serially and under fan-out and asserts p50/p95/max
+against `MVM_RUNTIME_BOOT_BUDGET_MS`. The issue proposed wiring
+`crates/mvm-cli/src/bench/regression.rs` instead, not knowing this existed.
+
+Worse, the one CI reference to it measured nothing. `ci-full.yml` ran
+`cargo test --test runtime_boot_bench`, but `MVM_RUNTIME_BOOT_BENCH` is set
+nowhere under `.github/`, so the test printed `skipped` and returned `Ok`. The
+lane compiled a benchmark and asserted nothing, in a `workflow_dispatch`-only
+workflow that does not gate a PR either way.
+
+## What landed
+
+`ci.yml` gains a `boot-latency` lane: pinned firecracker, `/dev/kvm` granted
+the way the existing live-spawn lane does it, the pinned `v0.17.0`
+default-microvm kernel + rootfs fetched and **sha256-verified against the
+release's own manifest**, then the existing benchmark run for real with
+`MVM_RUNTIME_BOOT_READY=guest-agent`. Gated on the existing `scope.outputs.code`
+filter so it stays off unrelated PRs.
+
+`ci-full.yml`'s comment now says what its invocation actually does — a compile
+check, not latency coverage.
+
+## Why the budget is loose
+
+6000ms against a ~2.1s dedicated-host median. A shared runner's variance is
+large, so a threshold that survives it cannot also catch a 20% drift. This lane
+takes the coarse half deliberately: it catches the multiple-x class, which is
+the class that has actually happened. p50/p95/max print on every run, so
+tightening later is a reading exercise rather than a guess.
+
+The precise relative-baseline comparison (`compare_to_baseline`,
+host-descriptor-pinned) belongs on a dedicated host and is not this lane. One
+threshold cannot do both jobs, and a gate that flakes is a gate that gets
+switched off.
+
+## Not verified here
+
+**The lane has never executed.** GitHub Actions cannot be run locally, so its
+first run on this PR is its own validation. Specifically unproven: that the
+`v0.17.0` default-microvm rootfs reaches guest-agent readiness under plain
+firecracker on a hosted runner, and that 6000ms clears it there. If the first
+run fails, the number or the readiness signal is wrong — not the lane's shape.
+
+The relative-baseline half of the issue is not implemented, so #2484 stays open.

--- a/specs/sprint/delivery/2484-boot-latency-ceiling.md
+++ b/specs/sprint/delivery/2484-boot-latency-ceiling.md
@@ -41,12 +41,28 @@ host-descriptor-pinned) belongs on a dedicated host and is not this lane. One
 threshold cannot do both jobs, and a gate that flakes is a gate that gets
 switched off.
 
+## First run: a build failure, not a boot failure
+
+The lane's first run failed before booting anything. `mvm-cli`'s `build.rs`
+cross-compiles the embedded host binaries and needs the pinned zig, which the
+lane did not install — so the root package would not build. Fixed by adding the
+existing `./.github/actions/install-zigbuild` step, the same one `bdd.yml` and
+`cache-warm.yml` use.
+
+Everything ahead of the boot did work on that run: firecracker installed,
+`/dev/kvm` granted, and the pinned image fetched and sha256-verified against the
+release manifest. So the lane's shape is right and only the toolchain step was
+missing.
+
+Worth noting for the workflow-linting gap tracked separately: no linter would
+have caught this. The YAML was valid and `actionlint` passed both before and
+after. A missing build dependency is only observable by running the job.
+
 ## Not verified here
 
-**The lane has never executed.** GitHub Actions cannot be run locally, so its
-first run on this PR is its own validation. Specifically unproven: that the
-`v0.17.0` default-microvm rootfs reaches guest-agent readiness under plain
-firecracker on a hosted runner, and that 6000ms clears it there. If the first
-run fails, the number or the readiness signal is wrong — not the lane's shape.
+**The budget has still never been exercised.** The first run died in the build step, so the
+boot itself has still not happened. Specifically unproven: that the `v0.17.0`
+default-microvm rootfs reaches guest-agent readiness under plain firecracker on
+a hosted runner, and that 6000ms clears it there.
 
 The relative-baseline half of the issue is not implemented, so #2484 stays open.


### PR DESCRIPTION
Addresses #2484. Does **not** close it — the relative-baseline half is not implemented.

## What I found before writing anything

The premise of the issue was partly wrong, and one of the corrections is a defect on its own. Full detail in [this comment](https://github.com/tinylabscom/mvm/issues/2484#issuecomment-5297837638).

1. **The benchmark already existed.** `tests/runtime_boot_bench.rs` measures live Firecracker boot serially and under fan-out, asserting p50/p95/max against `MVM_RUNTIME_BOOT_BUDGET_MS`. The issue proposed wiring `bench/regression.rs` instead, not knowing this was there.

2. **The one CI reference to it measured nothing.** `ci-full.yml` ran `cargo test --test runtime_boot_bench`, but `MVM_RUNTIME_BOOT_BENCH` is set nowhere under `.github/` — so the test printed `skipped` and returned `Ok`. A lane that compiles a benchmark and asserts nothing, inside a `workflow_dispatch`-only workflow that gates no PR regardless. Anyone scanning CI for boot-latency coverage would find that line and reasonably conclude it was covered.

3. **My blocker assumption was wrong.** I expected hosted runners to lack KVM. They don't — `ci-full.yml`'s `workload-spawn-smoke-linux` already boots a live Firecracker VM on stock `ubuntu-latest` via `/dev/kvm`. So a PR-gating live boot lane is buildable.

## What this does

A `boot-latency` lane in `ci.yml`: pinned firecracker, `/dev/kvm` granted the way the existing live-spawn lane does it, the pinned `v0.17.0` default-microvm kernel + rootfs fetched and **sha256-verified against the release's own checksum manifest**, then the existing benchmark run for real with `MVM_RUNTIME_BOOT_READY=guest-agent`. Filtered on the existing `scope.outputs.code` so unrelated PRs don't pay for it.

`ci-full.yml`'s comment now states that its invocation is a compile check, not latency coverage.

## Why 6000ms

Against a ~2.1s dedicated-host median for this image, cold-boot to agent-ready. Roughly 3x headroom.

That is loose on purpose. Shared-runner variance is large enough that no single threshold both survives it and catches a 20% drift — tight enough to catch drift will flake here and get switched off, which is worse than no gate because it still reads as coverage. This lane takes the multiple-x class, which is the class that has actually happened (#2299 was ~8x). p50/p95/max print on every run, so tightening later is a reading exercise rather than a guess.

The precise relative-baseline comparison (`compare_to_baseline`, host-descriptor-pinned, refuses to compare across differing hosts) belongs on a dedicated host where spread is small enough for a percentage to mean something. That half of #2484 is still open.

## Verification

- `actionlint` on both modified workflows — clean. Worth noting: **the repo has no workflow linter in CI**, so this was the only mechanical check available; I ran it locally.
- `cargo nextest run --workspace` — 11,614 passed, 0 failed
- clippy `-D warnings`, nightly `fmt --all --check` — clean
- `check-workflow-paths`, `check-sprint-append`, `check-nextest-groups`, `check-honesty`, `check-doc-claims`, `check-no-overclaim`, `check-no-spec-refs-in-comments` — pass
- `cargo test --test runtime_boot_bench` locally: 5 pass, including `live_bench_is_disabled_by_default` (the skip path still works)

## What is NOT verified

**The lane has never executed.** Actions cannot be run locally, so its first run on this PR is its own validation. Specifically unproven: that the `v0.17.0` default-microvm rootfs reaches guest-agent readiness under plain firecracker on a hosted runner, and that 6000ms clears it there.

If the first run fails, the readiness signal or the number is wrong — not the lane's shape. Please don't merge on the strength of the other gates being green; this one needs its own run read.
