### PR TITLE
fix(seccomp-audit): follow clones and track syscall state per tracee

### DIFF
--- a/crates/mvm-cli/src/commands/seccomp_audit.rs
+++ b/crates/mvm-cli/src/commands/seccomp_audit.rs
@@ -7,11 +7,17 @@
 //! It does not boot a microVM and does not install a seccomp filter, so
 //! the workload runs normally while being observed.
 //!
-//! The current implementation traces the main process only; forked children
-//! and spawned threads are not audited. That is enough to discover the
-//! baseline syscall surface of most single-process build scripts and CLI
-//! tools. Multi-threaded/multi-process workloads may need to be audited
-//! piecemeal or inside a guest VM with `mvm-seccomp-apply`.
+//! The tracer follows clones, forks and vforks, so a multi-threaded or
+//! multi-process workload is audited whole. This matters for deriving a real
+//! allowlist: every host role that would consume one builds a multi-threaded
+//! tokio runtime, and an allowlist derived from the main thread alone is
+//! incomplete by construction — the failure mode being SIGSYS under load,
+//! after the filter is already installed.
+//!
+//! Syscall entry/exit state is tracked per tracee. It cannot be one flag for
+//! the session: entry and exit are separate stops, sibling threads interleave
+//! them freely, and a shared flag would pair one thread's entry with
+//! another's exit and record the wrong half.
 //!
 //! Linux-only: ptrace is not available on macOS, and the seccomp tiers
 //! are defined for Linux guests.
@@ -81,13 +87,30 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args) -> Result<()> {
     }
 }
 
+/// Whether a stop is a new tracee halting at birth rather than a signal the
+/// workload sent itself.
+///
+/// Asking to follow clones means every new thread stops with `SIGSTOP` the
+/// moment it exists. That stop is an artefact of attachment; forwarding it with
+/// `ptrace::syscall(pid, Some(sig))` would deliver a stop the workload never
+/// raised and can wedge a thread before it runs its first instruction. A
+/// genuine `SIGSTOP` to an already-known tracee still has to be delivered.
+/// Takes the raw signal number rather than `nix`'s `Signal` so it stays
+/// testable on hosts where `nix` is not linked; `nix` is a Linux-only
+/// dependency here but this decision is worth a witness anywhere.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn is_new_tracee_birth_stop(first_sighting: bool, signal: i32) -> bool {
+    first_sighting && signal == libc::SIGSTOP
+}
+
 #[cfg(target_os = "linux")]
 fn run_linux(args: Args) -> Result<()> {
     use anyhow::Context;
     use nix::sys::ptrace::{self, Options};
     use nix::sys::signal::Signal;
-    use nix::sys::wait::{WaitStatus, waitpid};
-    use std::collections::HashSet;
+    use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
+    use nix::unistd::Pid;
+    use std::collections::{HashMap, HashSet};
 
     use mvm_core::crypto::seccomp::syscall_table;
 
@@ -143,45 +166,101 @@ fn run_linux(args: Args) -> Result<()> {
         other => bail!("unexpected initial wait status: {other:?}"),
     }
 
-    let options = Options::PTRACE_O_TRACESYSGOOD | Options::PTRACE_O_TRACEEXEC;
+    // TRACECLONE/FORK/VFORK make every new thread and child a tracee of ours,
+    // stopped at birth, so none of them runs a syscall we fail to see.
+    let options = Options::PTRACE_O_TRACESYSGOOD
+        | Options::PTRACE_O_TRACEEXEC
+        | Options::PTRACE_O_TRACECLONE
+        | Options::PTRACE_O_TRACEFORK
+        | Options::PTRACE_O_TRACEVFORK;
     ptrace::setoptions(main_pid, options).context("failed to set ptrace options")?;
 
     // Start the tracee; from here on we use PTRACE_SYSCALL to stop at every entry/exit.
     ptrace::syscall(main_pid, None).context("failed to resume tracee")?;
 
     let mut observed = HashSet::new();
-    // Tracks whether the tracee is currently inside a syscall, so we only record on entry.
-    let mut in_syscall = false;
+    // Per-tracee syscall-entry state. A tracee alternates entry/exit stops, but
+    // siblings interleave, so this cannot collapse to one flag for the session.
+    let mut in_syscall: HashMap<Pid, bool> = HashMap::new();
+    // Tracees we have seen. A clone event and the new child's own SIGSTOP race,
+    // so whichever arrives first registers it and the other is a no-op.
+    let mut live: HashSet<Pid> = HashSet::new();
+    live.insert(main_pid);
 
-    let main_exit_code = loop {
-        let status = waitpid(main_pid, None)?;
+    let mut main_exit_code = None;
+
+    // __WALL: without it waitpid ignores clone()d threads, which is most of
+    // what we are here to observe.
+    let wait_flags = Some(WaitPidFlag::__WALL);
+
+    while !live.is_empty() {
+        let status = match waitpid(Pid::from_raw(-1), wait_flags) {
+            Ok(status) => status,
+            // No children left to reap.
+            Err(nix::errno::Errno::ECHILD) => break,
+            Err(e) => return Err(e).context("waitpid failed"),
+        };
+
+        let pid = match status.pid() {
+            Some(pid) => pid,
+            None => continue,
+        };
 
         match status {
-            WaitStatus::Exited(_, code) => break Some(code),
+            WaitStatus::Exited(_, code) => {
+                live.remove(&pid);
+                in_syscall.remove(&pid);
+                if pid == main_pid {
+                    main_exit_code = Some(code);
+                }
+                continue;
+            }
             WaitStatus::Signaled(_, sig, _) => {
-                bail!("audited command killed by signal {sig:?}");
+                live.remove(&pid);
+                in_syscall.remove(&pid);
+                // Only the main process dying by signal invalidates the audit;
+                // a worker thread killed by design does not.
+                if pid == main_pid {
+                    bail!("audited command killed by signal {sig:?}");
+                }
+                continue;
             }
             WaitStatus::PtraceSyscall(_) => {
-                let regs = ptrace::getregs(main_pid).context("failed to read tracee registers")?;
+                let regs = ptrace::getregs(pid).context("failed to read tracee registers")?;
                 let nr = extract_syscall_number(&regs);
 
-                in_syscall = !in_syscall;
-                if in_syscall {
+                let entering = in_syscall.entry(pid).or_insert(false);
+                *entering = !*entering;
+                if *entering {
                     observed.insert(nr);
                 }
 
-                ptrace::syscall(main_pid, None).context("failed to resume after syscall")?;
+                ptrace::syscall(pid, None).context("failed to resume after syscall")?;
             }
             WaitStatus::PtraceEvent(_, _, _) => {
-                ptrace::syscall(main_pid, None).context("failed to resume after ptrace event")?;
+                // A clone/fork/vfork event carries the new tracee's pid. Register
+                // it here; it is already stopped and gets resumed on its own stop.
+                if let Ok(new) = ptrace::getevent(pid) {
+                    let new_pid = Pid::from_raw(new as i32);
+                    if new > 0 {
+                        live.insert(new_pid);
+                    }
+                }
+                ptrace::syscall(pid, None).context("failed to resume after ptrace event")?;
             }
             WaitStatus::Stopped(_, sig) => {
-                // A genuine signal stop (not a syscall stop). Deliver it.
-                ptrace::syscall(main_pid, Some(sig)).context("failed to deliver signal")?;
+                // A tracee we have not seen yet is a new thread stopping at
+                // birth; its SIGSTOP is an artefact of attachment, not a signal
+                // the workload sent, so it must not be delivered onward.
+                if is_new_tracee_birth_stop(live.insert(pid), sig as i32) {
+                    ptrace::syscall(pid, None).context("failed to resume new tracee")?;
+                } else {
+                    ptrace::syscall(pid, Some(sig)).context("failed to deliver signal")?;
+                }
             }
             _ => {}
         }
-    };
+    }
 
     // The main child has already been reaped by the waitpid loop above.
     let _child_pid = main_pid;
@@ -329,5 +408,30 @@ mod tests {
         assert_eq!(next_tier(&SeccompTier::Standard), "network");
         assert_eq!(next_tier(&SeccompTier::Network), "unrestricted");
         assert_eq!(next_tier(&SeccompTier::Unrestricted), "unrestricted");
+    }
+}
+
+#[cfg(test)]
+mod traceclone_tests {
+    use super::is_new_tracee_birth_stop;
+
+    #[test]
+    fn a_new_tracees_birth_sigstop_is_not_forwarded() {
+        assert!(is_new_tracee_birth_stop(true, libc::SIGSTOP));
+    }
+
+    #[test]
+    fn a_known_tracees_sigstop_is_still_delivered() {
+        // The workload really did stop itself; swallowing this would change
+        // the behaviour of the program under audit.
+        assert!(!is_new_tracee_birth_stop(false, libc::SIGSTOP));
+    }
+
+    #[test]
+    fn a_new_tracees_other_signal_is_still_delivered() {
+        // Only SIGSTOP is the attachment artefact. A first-sighting SIGSEGV is
+        // real and must reach the tracee.
+        assert!(!is_new_tracee_birth_stop(true, libc::SIGSEGV));
+        assert!(!is_new_tracee_birth_stop(true, libc::SIGTERM));
     }
 }

--- a/specs/plans/305-delete-dead-gateway-stack.md
+++ b/specs/plans/305-delete-dead-gateway-stack.md
@@ -180,7 +180,13 @@ roles build `tokio::runtime::Builder::new_multi_thread()`, so any allowlist it
 produces today is incomplete by construction and the failure mode is SIGSYS
 under load. Extend the tracer with `PTRACE_O_TRACECLONE` first.
 
-- [ ] Extend `seccomp-audit` to follow clones/threads
+- [x] Extend `seccomp-audit` to follow clones/threads. Two defects, not one:
+      the tracer set neither `PTRACE_O_TRACECLONE`/`FORK`/`VFORK` nor `__WALL`
+      and waited only on the main pid, and its syscall entry/exit state was a
+      single flag for the whole session — which pairs one thread's entry with
+      another's exit once siblings interleave. Fixing the option without the
+      per-tracee state would have produced a plausible but wrong allowlist,
+      which is worse than the honest limitation it replaced.
 - [ ] Derive the four allowlists on the live Linux box
 - [ ] One PR per role
 

--- a/specs/sprint/delivery/305-ws4-traceclone.md
+++ b/specs/sprint/delivery/305-ws4-traceclone.md
@@ -1,0 +1,52 @@
+# Plan 305 WS4 — seccomp-audit now follows clones and threads
+
+WS4 (confine the four unconfined signer/broker roles) was blocked on the
+tracer: `mvmctl seccomp-audit` observed only the main thread, and all four
+roles build a multi-threaded tokio runtime, so any allowlist derived from it
+was incomplete by construction. The failure mode is SIGSYS under load, after
+the filter is already installed.
+
+## What was actually wrong
+
+Two defects, and the second is the dangerous one.
+
+1. The tracer set neither `PTRACE_O_TRACECLONE`, `PTRACE_O_TRACEFORK` nor
+   `PTRACE_O_TRACEVFORK`, and its `waitpid` named `main_pid` without `__WALL` —
+   so cloned threads were invisible twice over.
+
+2. Syscall entry/exit state was a single `bool` for the whole session. Entry
+   and exit are separate stops and siblings interleave them freely, so a shared
+   flag pairs one thread's entry with another's exit and records the wrong half.
+
+Adding the ptrace options alone would have started delivering thread data
+through the broken state machine — a plausible but wrong allowlist, which is
+worse than the honest "main process only" limitation it replaced.
+
+## Delivered
+
+- Follow clone/fork/vfork; wait on any tracee with `__WALL`.
+- Per-tracee entry/exit state (`HashMap<Pid, bool>`).
+- Handle the clone-event/SIGSTOP race: whichever arrives first registers the
+  tracee, the other is a no-op.
+- A new tracee's birth `SIGSTOP` is an attachment artefact and is not forwarded;
+  a known tracee's `SIGSTOP` still is. That decision is extracted as
+  `is_new_tracee_birth_stop` and witnessed by three tests.
+- Only the main process dying by signal fails the audit; a worker thread killed
+  by design does not.
+- Module docs corrected — they advertised the limitation this removes.
+
+## Validation
+
+`cargo nextest run -p mvm-cli -E 'test(traceclone)'` — 3 passed. The helper
+takes a raw signal number rather than `nix`'s `Signal` so it is testable on
+macOS, where `nix` is not linked.
+
+`cargo zigbuild --target aarch64-unknown-linux-gnu -p mvm-cli --lib` — clean,
+no warnings. The tracer itself is `#[cfg(target_os = "linux")]` and cannot be
+exercised on this host.
+
+## Still open in WS4
+
+Deriving the four allowlists needs a live Linux box and a running instance of
+each role; confining them is one PR per role afterwards. This change unblocks
+that work rather than performing it.


### PR DESCRIPTION
Unblocks Plan 305 WS4. All four unconfined roles (`mvm-host-signer`, `mvm-audit-signer`, `mvm-signer-helper`, `mvm-broker`) build a multi-threaded tokio runtime, and the tracer observed only the main thread — so any allowlist derived from it was incomplete by construction. The failure mode is SIGSYS under load, after the filter is already installed.

## Two defects, and the second is why this is more than a flag

**1. The tracer could not see other threads.** It set neither `PTRACE_O_TRACECLONE`, `PTRACE_O_TRACEFORK` nor `PTRACE_O_TRACEVFORK`, and its `waitpid` named `main_pid` without `__WALL`. Cloned threads were invisible twice over.

**2. Syscall entry/exit state was a single `bool` for the whole session.** Entry and exit are separate stops, and siblings interleave them freely, so one flag pairs one thread's entry with another's exit and records the wrong half.

Adding the ptrace options *alone* would have started feeding thread data through that broken state machine and produced a **plausible but wrong allowlist** — strictly worse than the honest "main process only" limitation it replaced, because a wrong allowlist gets installed and then SIGSYSes in production. State is now per-tracee (`HashMap<Pid, bool>`).

## Also handled

- The clone event and the new child's own `SIGSTOP` race; whichever arrives first registers the tracee and the other is a no-op.
- A new tracee's birth `SIGSTOP` is an artefact of attachment, not a signal the workload raised, so it is not forwarded — forwarding it can wedge a thread before its first instruction. A *known* tracee's `SIGSTOP` still is delivered, because the workload really did stop itself.
- Only the main process dying by signal fails the audit; a worker thread killed by design does not.
- Module docs corrected — they advertised the limitation this removes.

## Tests

The signal decision is the easiest part to get subtly wrong, so it is extracted as `is_new_tracee_birth_stop` and witnessed by three tests covering birth-SIGSTOP, known-tracee SIGSTOP, and first-sighting non-SIGSTOP.

It takes a raw signal number rather than `nix`'s `Signal` deliberately: `nix` is a Linux-only dependency of this crate, and taking `i32` means the decision is testable on any host rather than only where the tracer runs.

```
cargo nextest run -p mvm-cli -E 'test(traceclone)'   # 3 passed
cargo zigbuild --target aarch64-unknown-linux-gnu -p mvm-cli --lib   # clean, no warnings
```

The tracer itself is `#[cfg(target_os = "linux")]` and cannot be exercised on the authoring host; the cross-compile is what confirms it builds.

## Scope

This unblocks WS4 rather than completing it. Deriving the four allowlists needs a live Linux host with each role running, and confining them is one PR per role afterwards. Plan 305 and the delivery note both say so rather than ticking WS4 done.