### PR TITLE
ci: lint the workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,10 +167,22 @@ jobs:
       # because a changed job can break a reference in a file it did not touch.
       # Placed after shellcheck is installed (actionlint shells out to it) but
       # before the slow toolchain steps, so a workflow error fails fast.
+      # Pinned + checksum-verified rather than an installer action: actionlint
+      # is a Go binary, so `install-action` has no recipe for it and its
+      # cargo-binstall fallback looks for a crate that does not exist.
       - name: Install actionlint
-        uses: taiki-e/install-action@v2
-        with:
-          tool: actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -fL --retry 3 -o "$tarball" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
+          echo "${ACTIONLINT_SHA256}  ${tarball}" | sha256sum -c -
+          tar -xzf "$tarball" actionlint
+          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint --version
 
       - name: Lint workflow files
         run: actionlint .github/workflows/*.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           # Anything that can change a compiled target, generated artifact, or
           # the commands used by a Rust lane keeps the full compiler/test
           # matrix. Prose, site assets, and process-only specs do not.
-          if grep -zE '^(crates/|src/|tests/|xtask/|scripts/|features/|schema/|model/|assets/|\.cargo/|\.config/|\.github/actions/|\.github/workflows/ci\.yml$|nix/packaging/release/verify-release-assets[^/]*\.sh$|Cargo\.(toml|lock)$|rust-toolchain\.toml$|build\.rs$|install\.sh$|[Jj]ustfile$)' "$CHANGED_FILE" >/dev/null; then
+          if grep -zE '^(crates/|src/|tests/|xtask/|scripts/|features/|schema/|model/|assets/|\.cargo/|\.config/|\.github/actions/|\.github/workflows/|nix/packaging/release/verify-release-assets[^/]*\.sh$|Cargo\.(toml|lock)$|rust-toolchain\.toml$|build\.rs$|install\.sh$|[Jj]ustfile$)' "$CHANGED_FILE" >/dev/null; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"
@@ -159,6 +159,21 @@ jobs:
       # compiler lint lane, so start them on their own runner.
       - name: Install system build deps
         run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld shellcheck
+
+      # Nothing else validates the workflow files. A wrong `if:`, a typo'd
+      # `needs:` job name, or a bad `${{ }}` reference does not fail a PR — it
+      # silently disables the lane, which still reads as covered to anyone
+      # auditing the file. Runs over every workflow, not just changed ones,
+      # because a changed job can break a reference in a file it did not touch.
+      # Placed after shellcheck is installed (actionlint shells out to it) but
+      # before the slow toolchain steps, so a workflow error fails fast.
+      - name: Install actionlint
+        uses: taiki-e/install-action@v2
+        with:
+          tool: actionlint
+
+      - name: Lint workflow files
+        run: actionlint .github/workflows/*.yml
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -191,10 +191,10 @@ jobs:
           printf '{"arch":"%s","y_symbol_count":%d,"vmlinux_bytes":%d,"vmlinux_gz_bytes":%d}\n' \
             "$ARCH" "$Y_COUNT" "$RAW_BYTES" "$GZ_BYTES" > "staging/kernel-metrics-${ARCH}.json"
           cd staging
-          sha256sum vmlinux-${ARCH}-* > "kernel-${ARCH}-checksums-sha256.txt"
+          sha256sum vmlinux-"${ARCH}"-* > "kernel-${ARCH}-checksums-sha256.txt"
           echo "=== kernel artifacts (${ARCH}) ==="
           cat "kernel-${ARCH}-checksums-sha256.txt" "kernel-${ARCH}.json" "kernel-metrics-${ARCH}.json"
-          du -h vmlinux-${ARCH}-*
+          du -h vmlinux-"${ARCH}"-*
 
       - name: Upload kernel artifacts (CI visibility)
         # `always()` because the budget gate above exits non-zero on a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,15 +373,18 @@ jobs:
           cd staging
           # Build the checksums list dynamically — sidecars are
           # optional, so only include what's actually present.
-          FILES="builder-vm-vmlinux-${ARCH} builder-vm-rootfs-${ARCH}.ext4"
-          [ -f "builder-vm-${ARCH}.cmdline.txt" ]   && FILES="$FILES builder-vm-${ARCH}.cmdline.txt"
-          [ -f "builder-vm-${ARCH}.manifest.json" ] && FILES="$FILES builder-vm-${ARCH}.manifest.json"
+          # An array, not a space-joined string: the string form relies on word
+          # splitting to become arguments, so a name containing a space would
+          # split into two paths that do not exist.
+          FILES=("builder-vm-vmlinux-${ARCH}" "builder-vm-rootfs-${ARCH}.ext4")
+          [ -f "builder-vm-${ARCH}.cmdline.txt" ]   && FILES+=("builder-vm-${ARCH}.cmdline.txt")
+          [ -f "builder-vm-${ARCH}.manifest.json" ] && FILES+=("builder-vm-${ARCH}.manifest.json")
           # The attested pack is optional (signing may be skipped or fail); only
           # checksum its files when they are actually present.
           if [ -f "builder-vm-${ARCH}.pack-manifest.json.bundle" ]; then
-            FILES="$FILES builder-vm-${ARCH}.pack-manifest.json builder-vm-${ARCH}.pack-manifest.json.bundle builder-vm-${ARCH}.sbom.txt"
+            FILES+=("builder-vm-${ARCH}.pack-manifest.json" "builder-vm-${ARCH}.pack-manifest.json.bundle" "builder-vm-${ARCH}.sbom.txt")
           fi
-          sha256sum $FILES > "builder-vm-${ARCH}-checksums-sha256.txt"
+          sha256sum "${FILES[@]}" > "builder-vm-${ARCH}-checksums-sha256.txt"
 
       - name: Upload builder VM image artifacts
         uses: actions/upload-artifact@v7
@@ -647,17 +650,19 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           cd staging
-          FILES="default-microvm-vmlinux-${ARCH} \
-                 default-microvm-rootfs-${ARCH}.ext4 \
-                 default-microvm-rootfs-${ARCH}.verity \
-                 default-microvm-rootfs-${ARCH}.roothash \
-                 default-microvm-meta-${ARCH}.json"
+          FILES=(
+            "default-microvm-vmlinux-${ARCH}"
+            "default-microvm-rootfs-${ARCH}.ext4"
+            "default-microvm-rootfs-${ARCH}.verity"
+            "default-microvm-rootfs-${ARCH}.roothash"
+            "default-microvm-meta-${ARCH}.json"
+          )
           # The attested pack is optional (signing may be skipped or fail); only
           # checksum its files when they are actually present.
           if [ -f "default-microvm-${ARCH}.pack-manifest.json.bundle" ]; then
-            FILES="$FILES default-microvm-${ARCH}.pack-manifest.json default-microvm-${ARCH}.pack-manifest.json.bundle default-microvm-${ARCH}.sbom.txt"
+            FILES+=("default-microvm-${ARCH}.pack-manifest.json" "default-microvm-${ARCH}.pack-manifest.json.bundle" "default-microvm-${ARCH}.sbom.txt")
           fi
-          sha256sum $FILES > "default-microvm-${ARCH}-checksums-sha256.txt"
+          sha256sum "${FILES[@]}" > "default-microvm-${ARCH}-checksums-sha256.txt"
 
       - name: Upload default microVM image artifacts
         uses: actions/upload-artifact@v7
@@ -713,7 +718,8 @@ jobs:
         run: |
           cd artifacts
           # Combine per-platform checksums into one file
-          cat *.sha256 > checksums-sha256.txt
+          # ./ prefix: a file named like an option must stay a filename.
+          cat ./*.sha256 > checksums-sha256.txt
           echo "Combined checksums:"
           cat checksums-sha256.txt
 

--- a/.github/workflows/security-lane-watch.yml
+++ b/.github/workflows/security-lane-watch.yml
@@ -71,6 +71,8 @@ jobs:
 
           if [ ! -s failing.md ]; then
             if [ -n "$EXISTING" ]; then
+              # Backticks here are markdown, not command substitution; %s carries the values.
+              # shellcheck disable=SC2016
               printf 'Security run [%s](%s) on `%s` is green again — closing.\n' \
                 "$RUN_ID" "$RUN_URL" "$HEAD_SHA" > body.md
               gh issue comment "$EXISTING" --repo "$REPO" --body-file body.md
@@ -81,12 +83,16 @@ jobs:
           fi
 
           {
+            # Backticks here are markdown, not command substitution; %s carries the values.
+            # shellcheck disable=SC2016
             printf 'The `Security` workflow (%s) failed on `%s`.\n\n' "$RUN_EVENT" "$HEAD_SHA"
             printf 'Run: %s\n\n' "$RUN_URL"
             printf 'Failing jobs:\n\n'
             cat failing.md
             printf '\nThese lanes do not run on pull requests, so a failure here is\n'
             printf 'invisible until someone reads run history. Several of them are the\n'
+            # Backticks here are markdown, not command substitution; %s carries the values.
+            # shellcheck disable=SC2016
             printf 'only witness for a numbered claim in `specs/adrs/001-microvm-security-posture.md`\n'
             printf '— while a lane is red, that claim has no live evidence behind it.\n'
           } > body.md

--- a/specs/sprint/delivery/2508-actionlint-gate.md
+++ b/specs/sprint/delivery/2508-actionlint-gate.md
@@ -1,0 +1,67 @@
+# 2508 — the workflow files are now linted
+
+23 workflow files, 6,712 lines, previously unchecked until a run failed. The
+failure mode that matters is silent: a wrong `if:`, a typo'd `needs:` job name,
+or a bad `${{ }}` reference does not fail a PR — it disables the lane, which
+still reads as covered to anyone auditing the file.
+
+## Baseline
+
+The first full run surfaced 8 findings, all shellcheck `info` inside `run:`
+blocks, and **zero** workflow-syntax, expression, or `needs:` errors. The class
+the issue is most concerned about was already clean; what existed was shell
+nits, three of which were false positives whose suggested fix is a bug.
+
+| Finding | Disposition |
+| --- | --- |
+| `kernel-build.yml` ×2 SC2086 | Fixed — quote the variable, keep the glob unquoted so it still expands |
+| `release.yml:713` SC2035 | Fixed — `./*.sha256`, so a file named like an option stays a filename |
+| `release.yml` ×2 SC2086 on `$FILES` | Fixed by converting the accumulator to an array |
+| `security-lane-watch.yml` ×3 SC2016 | Suppressed per line, with the reason |
+
+The `$FILES` pair relied on word splitting to turn a space-joined string into
+arguments, so a filename containing a space would have split into two paths
+that do not exist. An array removes the class rather than silencing it.
+
+The three SC2016 hits are `printf` *format* strings whose values arrive as
+`%s` arguments; the literal backticks are markdown for a GitHub issue body.
+Double-quoting them — shellcheck's suggestion — would make the shell run
+command substitution on the backticks, and one would try to execute a path
+under `specs/adrs/`. Suppressed per line with that reason rather than fixed.
+
+A file-wide `# shellcheck disable=` directive is not honoured by actionlint's
+shellcheck integration; per-line directives are.
+
+## The gate
+
+`actionlint` runs in `lint-policy`, which is the only lint job with no
+`if: needs.scope.outputs.code == 'true'` condition — so it runs on every PR,
+including a workflow-only change that the scope filter might otherwise classify
+as non-code. It is placed after the step that installs `shellcheck` (actionlint
+shells out to it, and without it the eight findings above would not have been
+seen) but before the uv/Node/zigbuild/cache steps, so a workflow error fails
+fast.
+
+It runs over `.github/workflows/*.yml`, not changed files: a changed job can
+break a `needs:` reference in a file it did not touch.
+
+The CI scope filter entry widened from `\.github/workflows/ci\.yml$` to
+`\.github/workflows/`, so a change to any workflow keeps the full matrix. A
+workflow defines what every lane does, so editing one can change any result.
+
+## Witnesses
+
+Both failure modes named in the issue were injected and confirmed caught:
+
+- typo'd `needs:` → `job "lint" needs job "lint-polcy" which does not exist in
+  this workflow [job-needs]`, plus a second error on the dependent expression.
+- bad `${{ }}` property → `property "kode" is not defined in object type
+  {code: string} [expression]`.
+
+Both restored afterwards; all 23 files lint clean.
+
+## Out of scope
+
+`actionlint` cannot tell that a lane asserts nothing — the `runtime_boot_bench`
+instance in the issue would still pass it. That class needs separate thinking
+and is not addressed here.


### PR DESCRIPTION
Closes #2508.

23 workflow files, 6,712 lines, unchecked until a run failed. The failure mode is silent: a wrong `if:`, a typo'd `needs:` job name, or a bad `${{ }}` reference does not fail a PR — it disables the lane. A disabled lane still appears in the file, so a reader auditing coverage concludes it is covered.

## Baseline: 8 findings, none of them the scary class

The first full run surfaced 8 shellcheck `info` findings inside `run:` blocks and **zero** workflow-syntax, expression, or `needs:` errors. Worth stating plainly — the class this gate exists to catch was already clean; what existed was shell nits, three of which are false positives whose suggested fix is a bug.

| Finding | Disposition |
| --- | --- |
| `kernel-build.yml` ×2 SC2086 | Fixed — quote the variable, leave the glob unquoted so it still expands |
| `release.yml:713` SC2035 | Fixed — `./*.sha256`, so a file named like an option stays a filename |
| `release.yml` ×2 SC2086 on `$FILES` | Fixed by converting the accumulator to an array |
| `security-lane-watch.yml` ×3 SC2016 | Suppressed per line, with the reason |

The `$FILES` pair relied on word splitting to turn a space-joined string into arguments, so a filename containing a space would have split into two paths that do not exist. An array removes the class rather than silencing it.

The three SC2016 hits are `printf` **format** strings whose values arrive as `%s` arguments, and whose literal backticks are markdown for a GitHub issue body. Double-quoting them — shellcheck's suggestion — would make the shell run command substitution on the backticks, and one would try to execute a path under `specs/adrs/`. Suppressed per line with that reason. (A file-wide `# shellcheck disable=` is not honoured by actionlint's shellcheck integration; per-line is.)

## The gate

`actionlint` runs in **`lint-policy`** — the only lint job with no `if: needs.scope.outputs.code == 'true'`, so it runs on every PR including a workflow-only change the scope filter might classify as non-code.

Placed **after** the step installing `shellcheck` (actionlint shells out to it; without it none of the 8 findings above are visible) but **before** the uv/Node/zigbuild/cache steps, so a workflow error fails fast rather than after a toolchain install.

Runs over `.github/workflows/*.yml`, not changed files — a changed job can break a `needs:` reference in a file it did not touch.

Scope filter widened from `\.github/workflows/ci\.yml$` to `\.github/workflows/`, per the issue: a workflow defines what every lane does, so editing one can change any result.

## Witnesses — both failure modes injected and confirmed caught

Typo'd `needs:`:
```
ci.yml:451:3: job "lint" needs job "lint-polcy" which does not exist in this workflow [job-needs]
ci.yml:463:30: property "lint-policy" is not defined in object type {...} [expression]
```

Bad `${{ }}` property:
```
ci.yml:102:9: property "kode" is not defined in object type {code: string} [expression]
```

Both reverted; all 23 files lint clean, including this PR's own edits.

## Out of scope

`actionlint` cannot tell that a lane asserts nothing — the `runtime_boot_bench` instance in the issue would still have passed it. That class needs separate thinking and is deliberately not addressed here.