### PR TITLE
perf(build): reuse prebuilt musl host binaries in dev builds

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -211,6 +211,14 @@ build-supervisors:
     cargo build -p mvm-hostd --bin mvm-network-endpoint --bin mvm-hvf-supervisor
     cargo build -p mvm-hostd --bin mvm-libkrun-supervisor --features libkrun-sys
 
+# Drop the cached cross-compiled host binaries so the next build rebuilds them.
+# Dev builds reuse these instead of re-running cargo-zigbuild, which is ~93% of
+# mvm-cli's build-script wall time. Run this after editing anything they link
+# (mvm-build, mvm-core, ...) when you are about to boot a real VM; ordinary
+# check/test/clippy runs never need it. Release builds always rebuild.
+embed-refresh:
+    rm -rf target/*/build/mvm-cli-nested-target/host-vm-target
+
 # Build the dm-verity-capable workload kernel into the local mvm cache.
 # Set MVM_KERNEL_SOURCE=download to use the hash-verified release artifact, or
 

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -79,8 +79,49 @@ fn main() {
     // plain-`cargo build` fast-path was once tried on the false premise that
     // the bins are C-free; it broke CI, which has no musl-gcc.)
 
+    // The musl cross-compile is ~93% of this build script's wall time (measured:
+    // 105s for one binary, ~163s for the set, against 13s for the whole native
+    // aux-helper leg). Every one of these binaries links `mvm-build` ->
+    // `mvm-core`, so any edit under `mvm-core/src` invalidates all six and a
+    // one-line change costs ~176s before a single test runs.
+    //
+    // Outside `--release`, reuse an already-cross-compiled binary instead of
+    // rebuilding it. The embedded set still exists and still hashes, so the
+    // extraction tests and the manifest gate keep passing on their real bytes;
+    // they assert the *name set*, the *SHA match* and *idempotency*, none of
+    // which require the bytes to be freshly compiled. A release build never
+    // takes this path, so shipped binaries are always rebuilt from source.
+    //
+    // The native per-VM helpers deliberately do NOT get this treatment: they
+    // are the supervisors where a stale binary silently produces a running
+    // guest that ignores your edit, and rebuilding them costs 13s.
+    // Explicitly opt IN only the plain debug profile. Cargo reports PROFILE as
+    // "debug"/"release"; keying on `!= "release"` would silently take the reuse
+    // path for any custom profile (e.g. `release-witness`) that reports
+    // something else, which is exactly the case where fresh bytes matter.
+    let reuse_prebuilt_embedded = std::env::var("PROFILE").unwrap_or_default() == "debug";
+    let mut reused_any = false;
+
     for binary in &manifest {
         let out_file = bins_out.join(&binary.name);
+        let prebuilt = host_target_dir
+            .join(strip_glibc(&pin.target))
+            .join("release")
+            .join(&binary.name);
+        if reuse_prebuilt_embedded && prebuilt.is_file() {
+            eprintln!(
+                "[build.rs] reusing prebuilt {} (dev profile; `cargo build --release` \
+                 or `just embed-refresh` rebuilds it)",
+                binary.name
+            );
+            std::fs::copy(&prebuilt, &out_file).unwrap_or_else(|e| {
+                panic!("copy {} -> {}: {e}", prebuilt.display(), out_file.display())
+            });
+            reused_any = true;
+            let sha = sha256_hex(&out_file);
+            entries.push((binary.name.clone(), out_file.clone(), sha));
+            continue;
+        }
         run_cargo_zigbuild(
             ZigbuildRequest::default()
                 .with_root(&workspace_root)
@@ -100,6 +141,14 @@ fn main() {
             workspace_root.join("crates/mvm-build/src/bin").display()
         );
     }
+
+    // Loud, not silent: the runtime can tell the user their embedded set was
+    // reused rather than rebuilt, which is the difference between a confusing
+    // "my edit did nothing" boot and an actionable message.
+    println!(
+        "cargo:rustc-env=MVM_EMBEDDED_BINS_REUSED={}",
+        if reused_any { "1" } else { "0" }
+    );
 
     build_native_aux_helpers(&workspace_root, &nested_target_dir);
 

--- a/specs/plans/334-build-critical-path.md
+++ b/specs/plans/334-build-critical-path.md
@@ -1,0 +1,94 @@
+# Plan 334 — Cut `mvm-cli`'s build script off the inner loop
+
+**Status:** DELIVERED
+**Date:** 2026-08-14
+**Owner:** mvm
+
+## Summary
+
+A one-line edit to `crates/mvm-core/src/lib.rs` cost **288s**. Of a 178.9s
+instrumented rebuild, **175.9s (98%) was `mvm-cli`'s build script**, and ~93% of
+that was the `cargo-zigbuild` musl cross-compile of the embedded host binaries.
+
+Fixed by reusing already-cross-compiled musl binaries in the **debug profile
+only**. Measured **288s -> 15s**.
+
+## Measurements (2026-08-14, aarch64 macOS, 16 cores)
+
+`cargo build -p mvm-cli --timings` after a whitespace edit to `mvm-core`:
+
+| Unit | Time |
+|---|---|
+| total build | 178.9s |
+| `mvm-cli` build script (`run-custom-build`) | **175.9s** |
+| every library crate (`core`,`agentd`,`vmm`,`backends`,`runtime`,`hostd`,`client`) | finished by **6.9s** |
+| `mvm-cli` crate itself | 2.8s |
+
+Build-script leg split, after an `mvm-core` edit:
+
+| Leg | Time |
+|---|---|
+| musl `cargo-zigbuild` (1 of 6 bins) | **105s** |
+| musl leg, whole set | ~163s |
+| native aux-helper leg (4 bins) | **13s** |
+
+Inner loops, at `jobs=6`:
+
+| Edit | Before | After |
+|---|---|---|
+| `mvm-core` | 288s, 13 crates | **15s** |
+| `mvm-hostd` | 27s, 6 crates | unchanged |
+| `mvm-cli` | 2s, 1 crate | unchanged |
+
+## Fix
+
+`crates/mvm-cli/build.rs`: when `PROFILE == "debug"`, copy an existing
+cross-compiled binary out of the shared nested target dir instead of re-running
+`cargo-zigbuild`. Anything else — including `--release` and custom profiles —
+rebuilds from source, so shipped bytes are always freshly compiled and the
+single-download property is untouched.
+
+Deliberate choices:
+
+- **Explicit `== "debug"`, not `!= "release"`.** Cargo reports PROFILE as
+  `debug`/`release`; keying on the negative would silently reuse under a custom
+  profile such as `release-witness`, which is exactly where fresh bytes matter.
+- **Native per-VM helpers still always rebuild** (13s). Those are the
+  supervisors where a stale binary silently yields a guest that ignores your
+  edit (#2058, "stale supervisor makes a fixed build look broken"). The 93% win
+  is entirely in the musl leg, so that risk is not worth taking for 13s.
+- **`MVM_EMBEDDED_BINS_REUSED` is exported** so a reused set is observable
+  rather than silently assumed.
+- **`just embed-refresh`** drops the cache when fresh bytes are wanted in dev.
+
+Tests keep passing because the four files asserting `EMBEDDED` is populated
+check the *name set*, the *SHA match* and *idempotency* — none require freshly
+compiled bytes, and the embedded set still hashes its real contents.
+
+## Hypotheses measured and REFUTED
+
+Recorded so they are not re-proposed. Five of six failed:
+
+- **Nested-build feature ping-pong** (`libkrun-sys` flip across a shared target
+  dir): rebuild after the flip compiled **0** crates.
+- **Cross-invocation fingerprint thrash** (`cargo check --workspace
+  --all-targets` vs `cargo build -p mvm-cli`): **0** crates.
+- **Dependency count.** Deps are cached and do not recompile on an inner-loop
+  edit. Cut them for *security surface*, not build time.
+- **tree-sitter `opt-level = 3`** on ~24MB of generated C: forced full C rebuild
+  measured **15s**. Dropping the override saves seconds, not minutes.
+- **The 9-deep serial critical path.** Extracting `mvm-agentd/src/vsock/` to let
+  agentd build in parallel targets a segment worth **1.9s of 178.9s (1%)**. The
+  LOC-derived "~30%" estimate was wrong by ~30x. **Parked.**
+  (The seam itself is real and clean if ever needed: `vsock/` + `probes.rs` +
+  `integrations.rs` = ~11K LOC, reverse edges are wire types only.)
+
+## Out of scope / follow-ups
+
+- **Host oversubscription.** ~30 worktrees x default `jobs`=16 on a 16-core box
+  gave load average 73–114 with 11.5M pageouts. Addressed out-of-band with
+  `[build] jobs = 6` in `~/.cargo/config.toml` (global, not the repo's
+  `.cargo/config.toml`, which would throttle CI and other contributors). Running
+  fewer concurrent worktrees remains the largest available lever.
+- `mvm-observability` split and `mvm-core` dep trimming are justified by
+  **security surface**, not build time.

--- a/specs/sprint/delivery/334-build-script-embed-reuse.md
+++ b/specs/sprint/delivery/334-build-script-embed-reuse.md
@@ -1,0 +1,18 @@
+# 334 — `mvm-cli` build script off the inner loop
+
+Reuse already-cross-compiled musl host binaries in the debug profile instead of
+re-running `cargo-zigbuild` on every edit that touches their transitive sources.
+
+**Measured:** an `mvm-core` one-line edit went **288s -> 15s**. The build script
+was 175.9s of a 178.9s rebuild (98%); the musl leg was ~93% of that.
+
+Release and every non-debug profile rebuild from source unchanged, so shipped
+binaries and the single-download property are unaffected. The native per-VM
+supervisors still rebuild every time (13s) because that is the class where stale
+binaries fail silently.
+
+Added `just embed-refresh` to drop the cache on demand, and exported
+`MVM_EMBEDDED_BINS_REUSED` so a reused set is observable.
+
+Full measurement log, including five refuted hypotheses, in
+`specs/plans/334-build-critical-path.md`.


### PR DESCRIPTION
## What

`mvm-cli`'s build script was **175.9s of a 178.9s rebuild (98%)** after a one-line edit to `mvm-core`. Every embedded host binary links `mvm-build` → `mvm-core`, so any edit there invalidated all six and re-ran `cargo-zigbuild` for each.

Reuse an already-cross-compiled binary when `PROFILE == "debug"`.

## Measured

| Edit | Before | After |
|---|---|---|
| `mvm-core` one-line | 288s | **15s** |

Build-script leg split after an `mvm-core` edit: musl `cargo-zigbuild` **105s for one binary** (~163s for the set) vs **13s** for the whole native aux-helper leg.

`cargo build -p mvm-cli --timings` showed every library crate (`core`, `agentd`, `vmm`, `backends`, `runtime`, `hostd`, `client`) finishing by **6.9s** — the cost was never the crate graph.

## Design notes

- **Explicit `== "debug"`, not `!= "release"`.** Cargo reports PROFILE as debug/release; the negative form would silently reuse under a custom profile such as `release-witness`, which is exactly where fresh bytes matter. Release and all custom profiles rebuild from source, so shipped binaries and the single-download property are unchanged.
- **Native per-VM helpers still rebuild every time** (13s). Those are the supervisors where a stale binary silently yields a guest that ignores your edit. The 93% win is entirely in the musl leg, so that risk isn't worth taking.
- **Tests keep passing on real bytes.** The four files asserting `EMBEDDED` is populated check the name set, the SHA match and idempotency — none require freshly compiled bytes.
- Adds `just embed-refresh`; exports `MVM_EMBEDDED_BINS_REUSED` so a reused set is observable rather than silently assumed.

## Verification

```
cargo +nightly fmt --all -- --check      OK
cargo clippy --workspace --all-targets   exit 0  (pre-commit hook)
cargo nextest run -p mvm-cli             1753 passed, 3 skipped
check-mvm-host-binaries-sync             clean
check-no-spec-refs-in-comments           clean
check-honesty / check-no-overclaim       clean
check-sprint-append                      clean
check-duplicate-majors                   clean
```

Behaviour proven with `-vv`: six musl binaries reused, zero `cargo zigbuild` invocations, six per-VM supervisors still rebuilt.

## Reviewer attention

The trade is freshness-for-speed in dev, so the boundary matters more than the speedup:

- `MVM_EMBEDDED_BINS_REUSED` is exported but **nothing consumes it yet** — wiring a runtime warning is the obvious follow-up.
- Keeping the native supervisors always-fresh was a judgement call; caching those too is defensible if 13s matters.

`specs/plans/334-build-critical-path.md` records the full measurement log, including **five refuted hypotheses** (feature ping-pong, cross-invocation thrash, dependency count, tree-sitter `-O3`, and the serial critical path) so they don't get re-derived.