### PR TITLE
chore(build): drop mvm-build's unused tokio dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3025,7 +3025,6 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.18",
- "tokio",
  "toml 0.8.23",
  "tracing",
  "uuid",

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -105,7 +105,6 @@ tempfile.workspace = true
 thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
 # `builder_protocol::{HostVmRequest,HostVmResponse}`
 # carry a `JobId(Uuid)` to disambiguate concurrent dispatches over
 # the persistent VM channel. Existing mvm-core / mvm-cli call sites


### PR DESCRIPTION
## What

`mvm-build` declared `tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }` but has no async code at all — **zero** `async fn`, **zero** `.await`, and no `tokio::` call site anywhere in the crate.

The only other mentions of tokio in `mvm-build` are three comments, two of which assert the opposite of what the manifest said:

- `src/egress_proxy/proxy.rs:27` — "so the thread count never explodes. No tokio dep — std::net + …"
- `src/guest_agent_build.rs:631` — "so the sealed agent's default build stays tokio-free."

Unlike every neighbouring entry in that dependency table, the line carried no comment justifying it, which is what a leftover looks like rather than a choice.

## Effect

One edge out of `Cargo.lock`. `tokio` itself stays — `mvm-hostd`, `mvm-agentd`, `mvm-http`, `mvm-fs`, `mvm-cli`, `mvm-client` and `mvm-runtime` all still use it. The shipped closure is unchanged at 243.

```diff
 dependencies = [
   "tar",
   "tempfile",
   "thiserror 2.0.18",
-  "tokio",
   "toml 0.8.23",
```

## Why it's safe

The real risk in dropping a direct dep is feature unification: another crate may have been compiling only because this one activated `tokio/sync` or `tokio/rt-multi-thread`. `cargo check --workspace --all-targets` is clean, so nothing was.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `xtask check-core-runtime-free` — clean
- `xtask check-closure-budget` — 243 crates (at budget)
- `cargo nextest run --workspace` — 11612/11616 pass. The 4 failures are `mvm-hostd::host_agent_restart` daemon-lifecycle tests timing out at exactly 10.0s under full parallel load; all 4 pass in ~1s when re-run isolated (`-j 1`). Unrelated to a manifest-only change.