### PR TITLE
chore(deps): give the bitflags duplicate-major a reason and an exit condition

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -119,7 +119,6 @@ skip = [
     # Foundational crates mid v1->v2 ecosystem migration. mvm pins one major
     # for each it uses directly; the other is dragged in by deps that have not
     # finished migrating. Not collapsible without forking those deps.
-    "bitflags",
     "getrandom",
 
     # rand 0.8 (workspace direct) vs rand 0.10 (hickory-proto 0.26), and
@@ -135,6 +134,18 @@ skip = [
     # majors; this pair can only collapse once kvm-bindings / kvm-ioctls bump to
     # vmm-sys-util 0.15. Shrink when they do.
     "vmm-sys-util",
+
+    # bitflags 1.3.2 vs 2.x. mvm depends on neither major directly — both are
+    # wholly transitive, so there is no local pin to change. The 1.x side has
+    # two independent parents in the shipped closure: smoltcp 0.13.1 (the
+    # mvm-hostd userspace datapath) and both vmm-sys-util majors above.
+    # smoltcp 0.13.1 is the latest release and declares bitflags ^1.0
+    # non-optionally, as does vmm-sys-util 0.15.0; neither exposes a feature
+    # that selects 2.x. Collapsing this therefore needs *both* smoltcp and the
+    # rust-vmm crates to migrate — moving either one alone changes nothing,
+    # which is why no upstream request is filed against one of them in
+    # isolation. It costs exactly one crate. Drop when both have moved.
+    "bitflags",
 ]
 skip-tree = []
 

--- a/xtask/src/check_duplicate_majors.rs
+++ b/xtask/src/check_duplicate_majors.rs
@@ -26,6 +26,12 @@ use std::process::Command;
 /// entries); adding one must be justified in the PR that does — it admits a
 /// new duplicate major into the build.
 const ALLOWLIST: &[&str] = &[
+    // Both bitflags majors are transitive; mvm depends on neither directly.
+    // The 1.x side has two independent parents — smoltcp 0.13.1 (the mvm-hostd
+    // userspace datapath) and the vmm-sys-util pair below — whose latest
+    // releases both declare bitflags ^1.0 with no feature selecting 2.x.
+    // Migrating either upstream alone leaves the duplicate in place; it takes
+    // both. See deny.toml's matching entry for the full audit.
     "bitflags",
     // Neither defmt major is compiled: both are optional dependencies nobody
     // enables. smoltcp's `alloc` feature names `defmt?/alloc`, and that weak


### PR DESCRIPTION
`bitflags` resolves at two majors in the shipped `mvmctl` closure (1.3.2 and
2.13.0). Both gates that exempt it — `deny.toml`'s skip list and xtask's
`check-duplicate-majors` ALLOWLIST — recorded no reason and no exit condition.
This adds both. **Comment-only: no dependency, feature, or resolution change.**

## What the measurement found

The working assumption going in was that the 1.x copy comes solely from
`smoltcp` (via `mvm-hostd`). It does not. There are two independent parents:

```
bitflags v1.3.2
├── smoltcp v0.13.1        → mvm-hostd
├── vmm-sys-util v0.12.1   → kvm-bindings 0.11 / kvm-ioctls 0.21 → mvm-runtime   (Linux only)
└── vmm-sys-util v0.15.0   → virtio-queue 0.18 → mvm-vmm / mvm-runtime
```

- `smoltcp 0.13.1` is the latest published release and declares
  `bitflags = "^1.0"` non-optionally. There is no version to bump to and no
  feature that selects 2.x.
- `vmm-sys-util 0.15.0`, likewise latest, declares `bitflags = "^1.0"`. It is
  already a permanent duplicate-major exemption in its own right (ADR-033 §208,
  "One residual duplicate major, unavoidable today").

So no single upstream migration collapses this — `smoltcp` **and** the rust-vmm
crates would both have to move. That is why no upstream request is filed against
either in isolation: it would imply a fix that does not exist. The exemption
stays, and now says so.

`defmt` and `kqueue-sys` also declare bitflags 1, but neither is a live edge —
`defmt`'s is optional and unenabled (already documented in the xtask entry), and
`kqueue-sys` is absent from the `mvmctl` closure entirely.

## Changes

- **`deny.toml`** — `bitflags` moves out of the "foundational crates mid v1→v2"
  group into its own entry beside `vmm-sys-util`, which it cross-references. The
  old group's premise ("mvm pins one major for each it uses directly") never
  applied here: **mvm has no direct `bitflags` dependency at all**; both majors
  are wholly transitive.
- **`xtask/src/check_duplicate_majors.rs`** — the matching rationale above the
  ALLOWLIST entry, which previously had none. Both gates are updated so they
  cannot drift apart on this entry.

## Verification

```
cargo deny check bans                        → bans ok
cargo run -p xtask -- check-duplicate-majors → clean (11 known, all allowlisted)
cargo +nightly fmt --all -- --check          → clean
cargo clippy -p xtask --all-targets -D warnings → clean
```

Parent set re-confirmed on both host targets via
`cargo tree -p mvmctl -e no-dev -i bitflags@1.3.2 --locked`.

## Notes

- Touches the same `deny.toml` hunk as #2506, which is green and will likely
  land first. #2506 keeps `bitflags` in the foundational group; this moves it
  out. Happy to rebase onto it — the overlap is one comment block.
- Adjacent defect, deliberately **not** fixed here: `deny.toml`'s skip list and
  the xtask ALLOWLIST have diverged (13 entries in only one of the two), and
  `cargo deny` already warns that `thiserror-impl`, `unicode-width`, and `which`
  are stale. #2506 addresses part of this. Reconciling the rest needs its own
  audit of all entries against `cargo metadata --locked` — un-allowlisting
  something live is the risk.
