### PR TITLE
fix(egress): bound simultaneous raw TCP tunnels per workload

### DIFF
--- a/crates/mvm-hostd/src/supervisor/dns_handler.rs
+++ b/crates/mvm-hostd/src/supervisor/dns_handler.rs
@@ -413,13 +413,19 @@ mod tests {
 
     #[tokio::test]
     async fn rate_guard_denies_when_bucket_is_empty() {
-        let guard = EgressRateGuard::new(0, 1);
+        let guard = EgressRateGuard::builder()
+            .requests_per_sec(0)
+            .max_inflight(1)
+            .build();
         assert!(guard.admit().await.is_none());
     }
 
     #[tokio::test]
     async fn rate_guard_caps_concurrent_queries() {
-        let guard = EgressRateGuard::new(10, 1);
+        let guard = EgressRateGuard::builder()
+            .requests_per_sec(10)
+            .max_inflight(1)
+            .build();
         let first = guard.admit().await.expect("first query is admitted");
         assert!(guard.admit().await.is_none());
         drop(first);
@@ -439,7 +445,10 @@ mod tests {
                 server,
                 &gate,
                 Some(&recorder),
-                &EgressRateGuard::new(0, 1),
+                &EgressRateGuard::builder()
+                    .requests_per_sec(0)
+                    .max_inflight(1)
+                    .build(),
                 Duration::from_secs(1),
                 move |_name, _timeout| {
                     handler_lookups.fetch_add(1, Ordering::Relaxed);

--- a/crates/mvm-hostd/src/supervisor/egress_rate.rs
+++ b/crates/mvm-hostd/src/supervisor/egress_rate.rs
@@ -9,6 +9,14 @@
 //!
 //! Neither limit is protocol-specific, which is why this is one type rather
 //! than a copy per verb — a copy would drift, and the drift would be silent.
+//!
+//! Raw TCP tunnels draw on the same token bucket but a **separate** simultaneity
+//! pool. A request/response verb holds its slot for one round trip; a tunnel
+//! holds one for as long as the guest keeps the connection open. Sharing one
+//! pool would let a handful of long-lived tunnels take every slot and leave the
+//! guest unable to resolve a name — a self-inflicted denial of service in the
+//! guard that exists to prevent one. The rate limit is genuinely shared: a
+//! connect storm is host work whichever verb asks for it.
 
 use std::sync::Mutex;
 
@@ -19,24 +27,24 @@ use tokio::sync::{Semaphore, SemaphorePermit};
 pub const DEFAULT_REQUESTS_PER_SEC: u32 = 100;
 /// Default number of simultaneous in-flight requests for one workload endpoint.
 pub const DEFAULT_MAX_INFLIGHT: usize = 32;
+/// Default number of simultaneous raw tunnels for one workload endpoint.
+pub const DEFAULT_MAX_TUNNELS: usize = 32;
 
 /// Shared per-workload admission guard.
 pub struct EgressRateGuard {
     bucket: Mutex<TokenBucket>,
     inflight: Semaphore,
+    tunnels: Semaphore,
 }
 
 impl EgressRateGuard {
-    /// Build a guard with an explicit sustained rate and concurrency cap.
-    pub fn new(requests_per_sec: u32, max_inflight: usize) -> Self {
-        Self {
-            bucket: Mutex::new(TokenBucket::new(requests_per_sec)),
-            inflight: Semaphore::new(max_inflight),
-        }
+    /// Start building a guard. Every knob defaults to the module constants.
+    pub fn builder() -> EgressRateGuardBuilder {
+        EgressRateGuardBuilder::default()
     }
 
-    /// Admit one request, or return `None` without waiting when either limit is
-    /// full.
+    /// Admit one request/response call, or return `None` without waiting when
+    /// either limit is full.
     pub async fn admit(&self) -> Option<SemaphorePermit<'_>> {
         self.try_admit()
     }
@@ -44,7 +52,20 @@ impl EgressRateGuard {
     /// The same decision without an async context, for the blocking accept
     /// paths. Neither limit ever waits, so this is the whole of `admit`.
     pub fn try_admit(&self) -> Option<SemaphorePermit<'_>> {
-        let permit = self.inflight.try_acquire().ok()?;
+        self.take(&self.inflight)
+    }
+
+    /// Admit one raw tunnel. The returned permit is held for the whole splice,
+    /// so this draws on the tunnel pool rather than the request pool.
+    pub fn try_admit_tunnel(&self) -> Option<SemaphorePermit<'_>> {
+        self.take(&self.tunnels)
+    }
+
+    /// Take one slot from `pool` and one token from the shared bucket. A slot
+    /// taken without a token is released again, so a full bucket never leaks
+    /// simultaneity.
+    fn take<'a>(&'a self, pool: &'a Semaphore) -> Option<SemaphorePermit<'a>> {
+        let permit = pool.try_acquire().ok()?;
         let Ok(mut bucket) = self.bucket.lock() else {
             return None;
         };
@@ -54,6 +75,110 @@ impl EgressRateGuard {
 
 impl Default for EgressRateGuard {
     fn default() -> Self {
-        Self::new(DEFAULT_REQUESTS_PER_SEC, DEFAULT_MAX_INFLIGHT)
+        Self::builder().build()
+    }
+}
+
+/// Builder for [`EgressRateGuard`].
+pub struct EgressRateGuardBuilder {
+    requests_per_sec: u32,
+    max_inflight: usize,
+    max_tunnels: usize,
+}
+
+impl Default for EgressRateGuardBuilder {
+    fn default() -> Self {
+        Self {
+            requests_per_sec: DEFAULT_REQUESTS_PER_SEC,
+            max_inflight: DEFAULT_MAX_INFLIGHT,
+            max_tunnels: DEFAULT_MAX_TUNNELS,
+        }
+    }
+}
+
+impl EgressRateGuardBuilder {
+    /// Sustained request rate across every metered verb.
+    pub fn requests_per_sec(mut self, requests_per_sec: u32) -> Self {
+        self.requests_per_sec = requests_per_sec;
+        self
+    }
+
+    /// Simultaneous request/response calls.
+    pub fn max_inflight(mut self, max_inflight: usize) -> Self {
+        self.max_inflight = max_inflight;
+        self
+    }
+
+    /// Simultaneous raw tunnels.
+    pub fn max_tunnels(mut self, max_tunnels: usize) -> Self {
+        self.max_tunnels = max_tunnels;
+        self
+    }
+
+    /// Finish the guard.
+    pub fn build(self) -> EgressRateGuard {
+        EgressRateGuard {
+            bucket: Mutex::new(TokenBucket::new(self.requests_per_sec)),
+            inflight: Semaphore::new(self.max_inflight),
+            tunnels: Semaphore::new(self.max_tunnels),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tunnels_and_requests_draw_on_separate_pools() {
+        let guard = EgressRateGuard::builder()
+            .max_inflight(1)
+            .max_tunnels(1)
+            .build();
+        let _tunnel = guard.try_admit_tunnel().expect("first tunnel is admitted");
+        assert!(
+            guard.try_admit_tunnel().is_none(),
+            "the tunnel pool is capped independently"
+        );
+        assert!(
+            guard.try_admit().is_some(),
+            "a held tunnel must not starve the request/response verbs"
+        );
+    }
+
+    #[test]
+    fn a_released_tunnel_returns_its_slot() {
+        let guard = EgressRateGuard::builder().max_tunnels(1).build();
+        let tunnel = guard.try_admit_tunnel().expect("first tunnel is admitted");
+        assert!(guard.try_admit_tunnel().is_none());
+        drop(tunnel);
+        assert!(
+            guard.try_admit_tunnel().is_some(),
+            "closing a tunnel frees its slot"
+        );
+    }
+
+    #[test]
+    fn tunnels_and_requests_share_the_rate_limit() {
+        let guard = EgressRateGuard::builder().requests_per_sec(1).build();
+        assert!(guard.try_admit_tunnel().is_some(), "the one token is spent");
+        assert!(
+            guard.try_admit().is_none(),
+            "a tunnel connect draws on the same sustained rate as a query"
+        );
+    }
+
+    #[test]
+    fn a_bucket_refusal_returns_the_tunnel_slot() {
+        let guard = EgressRateGuard::builder()
+            .requests_per_sec(0)
+            .max_tunnels(1)
+            .build();
+        assert!(guard.try_admit_tunnel().is_none(), "no tokens, no tunnel");
+        assert_eq!(
+            guard.tunnels.available_permits(),
+            1,
+            "a refusal on the bucket must hand back the slot it took"
+        );
     }
 }

--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -100,7 +100,7 @@ pub async fn serve_raw_egress(
 /// the gate, and (only on `Allow`) connect + splice. Any refusal or malformed
 /// target closes the connection without connecting — fail closed.
 async fn handle_raw_conn<S>(
-    mut guest: S,
+    guest: S,
     gate: &EgressGate,
     recorder: Option<Arc<Recorder>>,
     rate_guard: Arc<egress_rate::EgressRateGuard>,
@@ -108,6 +108,29 @@ async fn handle_raw_conn<S>(
 ) -> std::io::Result<()>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    handle_raw_conn_with_resolver(guest, gate, recorder, rate_guard, timeout, |host| {
+        resolve_hostname_ips_pure(host, timeout)
+    })
+    .await
+}
+
+/// [`handle_raw_conn`] with the hostname resolver injected, so a test can assert
+/// what the handler did *not* do — the tunnel-limit refusal has the same
+/// one-byte nack on the wire as a policy refusal, and "the target was never
+/// resolved" is the only hermetic way to tell the two apart. Mirrors the
+/// `serve_dns` / `serve_dns_with_resolver` split next door.
+async fn handle_raw_conn_with_resolver<S, F>(
+    mut guest: S,
+    gate: &EgressGate,
+    recorder: Option<Arc<Recorder>>,
+    rate_guard: Arc<egress_rate::EgressRateGuard>,
+    timeout: Duration,
+    resolve: F,
+) -> std::io::Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    F: Fn(&str) -> std::io::Result<Vec<IpAddr>>,
 {
     let Some((target, leftover)) = read_target_line(&mut guest).await? else {
         // No `\n` within the cap → fail closed, close without connecting.
@@ -133,7 +156,16 @@ where
         )
         .await;
     }
-    match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
+    // Every verb above answers one request and releases its slot; a raw tunnel
+    // holds one until the guest closes it. Take that slot before resolving the
+    // target so a connect flood is bounded at the door rather than after the
+    // host has already done the DNS work for it.
+    let Some(_tunnel) = rate_guard.try_admit_tunnel() else {
+        eprintln!("raw-egress: refusing target {target}: tunnel limit reached");
+        write_connect_ack_async(&mut guest, ConnectAck::Fail).await?;
+        return Ok(());
+    };
+    match gate.decide_request_with(&target, &resolve) {
         EgressVerdict::Allow { ips, port } => {
             splice(guest, &target, &ips, port, leftover, timeout).await
         }
@@ -392,6 +424,13 @@ fn handle_raw_conn_blocking(
     if target == socks5_udp::FRAME_LINE {
         return socks5_udp::serve_blocking(guest, gate, timeout);
     }
+    // Same bound as the async path: a tunnel's slot is held for the whole
+    // splice, so take it before the target is resolved.
+    let Some(_tunnel) = rate_guard.try_admit_tunnel() else {
+        eprintln!("raw-egress: refusing target {target}: tunnel limit reached");
+        write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
+        return Ok(());
+    };
     let (ips, port) =
         match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
             EgressVerdict::Allow { ips, port } => (ips, port),
@@ -860,8 +899,10 @@ mod tests {
     use std::os::fd::IntoRawFd;
     #[cfg(target_os = "linux")]
     use std::os::unix::net::UnixStream;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     #[cfg(target_os = "linux")]
     use tempfile::tempdir;
+
     use tokio::io::AsyncWriteExt;
 
     /// A default-deny gate + a well-formed target ⇒ the host nacks the connect and
@@ -1199,6 +1240,128 @@ mod tests {
         client.read_to_end(&mut rest).await.unwrap();
         assert!(rest.is_empty());
         splicer.await.unwrap().unwrap();
+    }
+
+    /// Build an unrestricted gate: the refusal under test must be the limiter's,
+    /// not policy's.
+    fn unrestricted_gate() -> EgressGate {
+        EgressGate::from_network_policy(
+            &NetworkPolicy::unrestricted(),
+            &mvm_core::policy::dns_pin::DnsPinRegistry::new(),
+            "2026-01-01T00:00:00Z",
+        )
+    }
+
+    /// With the tunnel pool full the handler nacks *before* resolving the
+    /// target. The nack byte alone proves nothing here — an admitted target
+    /// whose connect fails sends the same `Fail` — so the witness is that the
+    /// resolver was never reached.
+    #[tokio::test]
+    async fn an_exhausted_tunnel_pool_refuses_before_resolving_the_target() {
+        let lookups = Arc::new(AtomicUsize::new(0));
+        let probe = Arc::clone(&lookups);
+        let (mut client, server) = tokio::io::duplex(1024);
+        let guard = Arc::new(
+            egress_rate::EgressRateGuard::builder()
+                .max_tunnels(0)
+                .build(),
+        );
+        let h = tokio::spawn(async move {
+            handle_raw_conn_with_resolver(
+                server,
+                &unrestricted_gate(),
+                None,
+                guard,
+                Duration::from_secs(1),
+                move |_host| {
+                    probe.fetch_add(1, Ordering::Relaxed);
+                    Ok(Vec::new())
+                },
+            )
+            .await
+        });
+        client.write_all(b"blocked.test:80\n").await.unwrap();
+
+        let mut ack = [0u8; 1];
+        client.read_exact(&mut ack).await.unwrap();
+        assert_eq!(ack[0], ConnectAck::Fail.as_byte());
+        let mut rest = Vec::new();
+        client.read_to_end(&mut rest).await.unwrap();
+        assert!(rest.is_empty(), "no tunnel bytes after a Fail ack");
+        h.await.unwrap().unwrap();
+
+        assert_eq!(
+            lookups.load(Ordering::Relaxed),
+            0,
+            "a full tunnel pool must refuse before the host does any DNS work"
+        );
+    }
+
+    /// The companion to the test above: with a slot free the same input *does*
+    /// reach the resolver, so the assertion there is about the limiter and not
+    /// about the fixture never resolving anything.
+    #[tokio::test]
+    async fn an_available_tunnel_slot_reaches_the_resolver() {
+        let lookups = Arc::new(AtomicUsize::new(0));
+        let probe = Arc::clone(&lookups);
+        let (mut client, server) = tokio::io::duplex(1024);
+        let guard = Arc::new(
+            egress_rate::EgressRateGuard::builder()
+                .max_tunnels(1)
+                .build(),
+        );
+        let h = tokio::spawn(async move {
+            handle_raw_conn_with_resolver(
+                server,
+                &unrestricted_gate(),
+                None,
+                guard,
+                Duration::from_secs(1),
+                move |_host| {
+                    probe.fetch_add(1, Ordering::Relaxed);
+                    Ok(Vec::new())
+                },
+            )
+            .await
+        });
+        client.write_all(b"blocked.test:80\n").await.unwrap();
+        let mut ack = [0u8; 1];
+        client.read_exact(&mut ack).await.unwrap();
+        assert_eq!(ack[0], ConnectAck::Fail.as_byte());
+        h.await.unwrap().unwrap();
+
+        assert_eq!(
+            lookups.load(Ordering::Relaxed),
+            1,
+            "an admitted tunnel resolves its target"
+        );
+    }
+
+    /// A connection the gate refuses must hand its tunnel slot back, or a guest
+    /// that trips the policy repeatedly would exhaust the pool by itself.
+    #[tokio::test]
+    async fn a_gate_refusal_returns_the_tunnel_slot() {
+        let guard = Arc::new(
+            egress_rate::EgressRateGuard::builder()
+                .max_tunnels(1)
+                .build(),
+        );
+        let gate = EgressGate::default_deny();
+        let (mut client, server) = tokio::io::duplex(1024);
+        let handler_guard = Arc::clone(&guard);
+        let h = tokio::spawn(async move {
+            handle_raw_conn(server, &gate, None, handler_guard, Duration::from_secs(1)).await
+        });
+        client.write_all(b"93.184.216.34:80\n").await.unwrap();
+        let mut ack = [0u8; 1];
+        client.read_exact(&mut ack).await.unwrap();
+        assert_eq!(ack[0], ConnectAck::Fail.as_byte());
+        h.await.unwrap().unwrap();
+
+        assert!(
+            guard.try_admit_tunnel().is_some(),
+            "the refused connection must have released its tunnel slot"
+        );
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## The bug

`serve_raw_egress` spawns one task per accepted guest connection, and the raw-tunnel branch of `handle_raw_conn` never admitted against anything. A guest could hold **unlimited** simultaneous tunnels open.

`EgressRateGuard` was already threaded into `handle_raw_conn` — but it only ever reached the DNS and ICMP verbs. Its own module doc says so:

> Per-workload admission guard shared by the **metered egress verbs**. DNS and ICMP are both request/response verbs…

So the splice path took the argument and dropped it on the floor. Adjacent to `Preview` claim 18 (workload resource bounding), on a claim-10 path.

## The fix

Admit the tunnel **before resolving the target**, on both the async UDS path and the blocking vsock sibling, nacking with the existing `ConnectAck::Fail` when the pool is full. Taking the slot ahead of the gate means a connect flood is refused at the door rather than after the host has already done the DNS work for it.

### Why tunnels get their own semaphore

A request/response verb holds its slot for one round trip. A tunnel holds one for as long as the guest keeps the connection open. On a shared pool, a handful of long-lived tunnels would take every slot and leave the guest unable to resolve a name — a denial of service *inside the guard that exists to prevent one*. So: separate simultaneity pool, shared token bucket (a connect storm is host work whichever verb asks for it). `tunnels_and_requests_draw_on_separate_pools` pins that.

`EgressRateGuard::new` becomes a builder now the type carries three tunables, per the workspace's constructor guidance.

## On the tests

The first version of these tests was worthless and I want that on the record, because it passes review easily.

A refused tunnel's wire tell is `ConnectAck::Fail` — **the same byte** a policy refusal sends, and the same byte a failed upstream connect sends. My first test asserted on that byte, and it passed with the fix reverted. The gate had allowed the target and the connect had simply failed in the sandbox.

So the handler now takes its resolver as a parameter — the same `serve_dns` / `serve_dns_with_resolver` split already used next door — and the witness is behavioural: **a full pool never reaches the resolver**, with a companion test showing an available slot does, so the first isn't vacuous. Reverting the admission turns it red:

```
assertion `left == right` failed: a full tunnel pool must refuse before the host does any DNS work
  left: 1
 right: 0
```

## Known gap

The blocking vsock path carries the same admission and is compile-checked for Linux (`cargo zigbuild -p mvm-hostd --all-targets --target x86_64-unknown-linux-gnu`), but has **no dedicated witness of its own**. I did not add one I could not prove goes red from this host. Tracked separately.

## Verification

- `cargo nextest run --workspace` — 11637/11637 pass, 26 skipped
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `cargo zigbuild -p mvm-hostd --all-targets --target x86_64-unknown-linux-gnu` — clean
- Red-without-the-fix confirmed for `an_exhausted_tunnel_pool_refuses_before_resolving_the_target`