### PR TITLE
fix: the guest agent could not spawn itself — capability bounding set, wrong order

### DIFF
--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -31,6 +31,10 @@ pub const CAP_KILL: u32 = 5;
 pub const CAP_NET_BIND_SERVICE: u32 = 10;
 /// Linux capability used by the guest agent to correct a restored wall clock.
 pub const CAP_SYS_TIME: u32 = 25;
+/// Linux capability `PR_CAPBSET_DROP` itself requires. Never retained — which
+/// is exactly why the bounding set has to be narrowed before the capability
+/// sets are, and not after.
+pub const CAP_SETPCAP: u32 = 8;
 /// Capabilities explicitly retained by the guest agent after boot setup.
 pub const RESTORE_AGENT_CAPABILITIES: u32 = (1u32 << CAP_KILL) | (1u32 << CAP_SYS_TIME);
 
@@ -540,11 +544,19 @@ pub fn drop_privilege_raw(uid: u32, gid: u32) -> std::io::Result<()> {
 
 /// Drop to the guest-agent identity while retaining only the fixed capabilities
 /// required for authenticated restore handling.
+///
+/// The bounding set is narrowed first, before the identity change, because
+/// `PR_CAPBSET_DROP` needs `CAP_SETPCAP` and [`set_capabilities`] below removes
+/// it: narrowing afterwards fails `EPERM`, and on the spawn path that errno
+/// leaves the `pre_exec` hook and kills the agent before it ever runs. The
+/// bounding set is inherited across fork and exec and can only shrink, so
+/// applying it here binds the agent and everything under it just as firmly.
 #[cfg(target_os = "linux")]
 pub fn drop_guest_agent_privilege_raw(uid: u32, gid: u32) -> std::io::Result<()> {
     if unsafe { libc::prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0) } != 0 {
         return Err(std::io::Error::last_os_error());
     }
+    narrow_bounding_set_where_enforceable(RESTORE_AGENT_CAPABILITIES)?;
     if unsafe { libc::setgroups(0, std::ptr::null::<libc::gid_t>()) } != 0 {
         return Err(std::io::Error::last_os_error());
     }
@@ -556,7 +568,6 @@ pub fn drop_guest_agent_privilege_raw(uid: u32, gid: u32) -> std::io::Result<()>
     }
     set_capabilities(RESTORE_AGENT_CAPABILITIES)?;
     raise_ambient_capabilities(RESTORE_AGENT_CAPABILITIES)?;
-    drop_capability_bounding_set_to(RESTORE_AGENT_CAPABILITIES)?;
     set_no_new_privileges()?;
     if unsafe { libc::getuid() } == 0 {
         return Err(std::io::Error::from_raw_os_error(libc::EPERM));
@@ -690,7 +701,19 @@ pub fn harden_init_process() -> std::io::Result<()> {
 #[cfg(target_os = "linux")]
 pub fn drop_workload_capability_bounding_set() -> std::io::Result<()> {
     set_no_new_privileges()?;
-    match drop_capability_bounding_set_to(0) {
+    narrow_bounding_set_where_enforceable(0)
+}
+
+/// Narrow the bounding set to `keep`, skipping the drop when this caller could
+/// never have performed it.
+///
+/// Shared by the agent identity drop and the workload spawn, which need the
+/// same "enforce where possible, fail closed on a real error" rule with
+/// different masks. See [`bounding_drop_is_unenforceable`] for why `EPERM`
+/// alone is a skip.
+#[cfg(target_os = "linux")]
+fn narrow_bounding_set_where_enforceable(keep: u32) -> std::io::Result<()> {
+    match drop_capability_bounding_set_to(keep) {
         Err(err) if bounding_drop_is_unenforceable(&err) => Ok(()),
         result => result,
     }
@@ -1777,6 +1800,26 @@ mod privilege_tests {
         )));
     }
 
+    /// The ordering constraint the agent privilege drop is built around, as an
+    /// assertion rather than a comment.
+    ///
+    /// `PR_CAPBSET_DROP` requires `CAP_SETPCAP`, and the agent does not retain
+    /// it. So the bounding-set narrowing can only ever succeed *before*
+    /// `set_capabilities` runs — afterwards the syscall returns `EPERM`, and on
+    /// the spawn path that errno escapes the `pre_exec` hook and the agent
+    /// never starts. Anyone widening the retained mask to include
+    /// `CAP_SETPCAP`, or reordering the drop back after the capability sets,
+    /// should land here first.
+    #[test]
+    fn the_agent_never_retains_the_capability_its_bounding_drop_requires() {
+        assert!(
+            !bounding_set_retains(RESTORE_AGENT_CAPABILITIES, CAP_SETPCAP),
+            "the agent must not retain CAP_SETPCAP; if it ever does, the \
+             narrow-before-you-drop ordering stops being load-bearing and this \
+             test should be replaced rather than relaxed"
+        );
+    }
+
     /// Mirrors `CAPABILITY_SLOTS` so the test compiles off Linux, where the
     /// real constant is `cfg`-gated out along with the syscall loop.
     const CAPABILITY_SLOTS_FOR_TEST: std::ops::RangeInclusive<u32> = 0..=63;
@@ -1803,6 +1846,44 @@ mod privilege_tests {
         );
         // Narrowed to the agent's set, not emptied. The workload gets the
         // empty set separately, at spawn.
+        assert!(
+            status.contains("CapBnd:\t0000000002000020"),
+            "CapBnd must be exactly CAP_KILL|CAP_SYS_TIME; got:\n{status}"
+        );
+    }
+
+    /// Live witness for the agent identity drop itself.
+    ///
+    /// The regression this pins returned `EPERM` from the bounding-set drop,
+    /// which on the spawn path never reached a log — it surfaced only as
+    /// `spawn guest-agent: Operation not permitted` in the guest console and a
+    /// host-side 30s agent-readiness timeout. Asserting `Ok` here is the whole
+    /// point; the state assertions confirm it succeeded for the right reason.
+    ///
+    /// Irreversible: it drops the calling process to uid 901 for good. It needs
+    /// a process per test, which is what nextest gives it, and is gated behind
+    /// the same explicit env var and root check as the test above.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn drop_guest_agent_privilege_reaches_the_agent_identity_from_root() {
+        if std::env::var("MVM_GUEST_PRIVILEGED_TESTS").as_deref() != Ok("1") {
+            return;
+        }
+        if unsafe { libc::getuid() } != 0 {
+            return;
+        }
+        super::drop_guest_agent_privilege_raw(WORKLOAD_UID, WORKLOAD_GID)
+            .expect("the agent privilege drop must succeed as root");
+        assert_eq!(
+            unsafe { libc::getuid() },
+            WORKLOAD_UID,
+            "the drop must land on the workload uid"
+        );
+        let status = std::fs::read_to_string("/proc/self/status").expect("read status");
+        assert!(
+            status.contains("NoNewPrivs:\t1"),
+            "NoNewPrivs must be 1 after the drop; got:\n{status}"
+        );
         assert!(
             status.contains("CapBnd:\t0000000002000020"),
             "CapBnd must be exactly CAP_KILL|CAP_SYS_TIME; got:\n{status}"

--- a/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
@@ -354,6 +354,11 @@ fn main() -> anyhow::Result<()> {
                     .iter()
                     .map(|share| (share.tag.clone(), share.path.clone()))
                     .collect(),
+                // Streamed as the guest emits it, so the log is readable while
+                // the VM is still running — which is when a boot that never
+                // reaches the agent has to be diagnosed. The authoritative
+                // rewrite after the run loop returns is unchanged.
+                console_log: Some(cfg.console_log.clone()),
                 pause_state: cfg.pause_state.clone(),
                 snapshot_request: cfg.snapshot_request.clone(),
                 snapshot_ram: cfg.snapshot_ram.clone(),

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -229,6 +229,15 @@ pub struct HostChannels {
     pub virtiofs_root: Option<PathBuf>,
     /// Read-only live host-directory shares as `(virtio-fs tag, host path)`.
     pub virtiofs_shares: Vec<(String, PathBuf)>,
+    /// Host console log to mirror guest output into as the guest emits it.
+    ///
+    /// The whole-run transcript comes back in [`KernelBootResult::console`]
+    /// either way; this is what makes it readable *before* the run loop
+    /// returns, so a guest that never finishes booting can be diagnosed while
+    /// it is still hung instead of only once it has been stopped. Opened
+    /// write-only: the console carries guest output to the host and never the
+    /// other way.
+    pub console_log: Option<PathBuf>,
     /// Optional host-visible marker acknowledged after the run loop enters its
     /// pause hold. It is removed when resume is observed.
     pub pause_state: Option<PathBuf>,
@@ -649,6 +658,7 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
                 builder_control_sockets: channels.builder_control_sockets,
                 virtiofs_root: channels.virtiofs_root,
                 virtiofs_shares: channels.virtiofs_shares,
+                console_log: channels.console_log,
                 pause_state: channels.pause_state,
                 snapshot_request: channels.snapshot_request,
                 snapshot_ram: channels.snapshot_ram,
@@ -710,6 +720,8 @@ struct RunInputs {
     /// When set, serve this host dir to the guest as a read-only virtiofs root.
     virtiofs_root: Option<PathBuf>,
     virtiofs_shares: Vec<(String, PathBuf)>,
+    /// Host console log the PL011 mirrors guest output into as it arrives.
+    console_log: Option<PathBuf>,
     pause_state: Option<PathBuf>,
     snapshot_request: Option<PathBuf>,
     snapshot_ram: Option<PathBuf>,
@@ -748,6 +760,7 @@ unsafe fn run(
         builder_control_sockets,
         virtiofs_root,
         virtiofs_shares,
+        console_log,
         pause_state,
         snapshot_request,
         snapshot_ram,
@@ -900,6 +913,14 @@ unsafe fn run(
         });
 
         let mut uart = Pl011::new(UART_BASE);
+        // Mirror guest output to the host log as it arrives. Write-only, and
+        // best-effort: a console log that cannot be opened costs a diagnostic,
+        // never the boot. The full transcript still comes back in the result.
+        if let Some(path) = console_log.as_deref()
+            && let Ok(file) = mvm_vmm::host::console_capture::open_console_capture(path)
+        {
+            uart.stream_to(Box::new(file));
+        }
         // One virtio-blk per disk image (`/dev/vda`, `/dev/vdb`, …) at its window.
         let mut virtio_disks: Vec<VirtioBlk> = disks
             .into_iter()

--- a/crates/mvm-vmm/src/vmm/device.rs
+++ b/crates/mvm-vmm/src/vmm/device.rs
@@ -5,6 +5,8 @@
 //! here. Today that is just enough of a PL011 UART for a kernel's `earlycon` to
 //! emit bytes — the first guest output beyond the boot proof.
 
+use std::io::Write;
+
 use super::device_state::{
     DeviceKind, DeviceStateError, SnapshotDeviceState, StateReader, StateWriter,
 };
@@ -25,9 +27,56 @@ pub trait MmioDevice {
 /// ARM PL011 UART, cut down to what `earlycon=pl011` needs: writes to the data
 /// register emit a byte; the flag register always reports "ready to transmit"
 /// so the guest never spins waiting on us. Emitted bytes accumulate in `output`.
+///
+/// A caller may also attach a sink with [`Pl011::stream_to`], in which case
+/// every byte is additionally written through as the guest emits it. `output`
+/// stays authoritative for the whole-run transcript; the sink is what makes a
+/// guest that never finishes booting observable while it is still hung.
 pub struct Pl011 {
     base: u64,
     pub output: Vec<u8>,
+    stream: Option<ConsoleStream>,
+}
+
+/// Write-through tail for [`Pl011`], flushed a line at a time.
+///
+/// Line granularity is the whole point: a per-byte flush is a syscall per
+/// character, and a flush only at drop is what left a hung guest's console
+/// empty for the entire time anyone was looking at it.
+struct ConsoleStream {
+    sink: Box<dyn Write + Send>,
+    pending: Vec<u8>,
+    /// Set after the first failed write. A console log that cannot be written
+    /// is a lost diagnostic, never a reason to fault the guest, so the device
+    /// stops trying rather than retrying on every byte.
+    failed: bool,
+}
+
+impl ConsoleStream {
+    /// Flush threshold for a line that never ends. A guest that hangs
+    /// mid-write still surfaces what it managed to emit.
+    const MAX_PENDING: usize = 512;
+
+    fn push(&mut self, byte: u8) {
+        if self.failed {
+            return;
+        }
+        self.pending.push(byte);
+        if byte == b'\n' || self.pending.len() >= Self::MAX_PENDING {
+            self.flush();
+        }
+    }
+
+    fn flush(&mut self) {
+        if self.failed || self.pending.is_empty() {
+            return;
+        }
+        if self.sink.write_all(&self.pending).is_err() || self.sink.flush().is_err() {
+            self.failed = true;
+            return;
+        }
+        self.pending.clear();
+    }
 }
 
 impl Pl011 {
@@ -48,7 +97,21 @@ impl Pl011 {
         Self {
             base,
             output: Vec::new(),
+            stream: None,
         }
+    }
+
+    /// Mirror guest output into `sink` as it arrives, in addition to `output`.
+    ///
+    /// The device never opens the sink itself: the caller owns where the
+    /// transcript goes and, for the host console log, that it is opened
+    /// write-only.
+    pub fn stream_to(&mut self, sink: Box<dyn Write + Send>) {
+        self.stream = Some(ConsoleStream {
+            sink,
+            pending: Vec::new(),
+            failed: false,
+        });
     }
 
     /// PL011 occupies a 4 KiB MMIO page.
@@ -65,7 +128,11 @@ impl MmioDevice for Pl011 {
 
     fn write(&mut self, offset: u64, value: u64, _size: u8) {
         if offset == Self::DR {
-            self.output.push((value & 0xff) as u8);
+            let byte = (value & 0xff) as u8;
+            self.output.push(byte);
+            if let Some(stream) = self.stream.as_mut() {
+                stream.push(byte);
+            }
         }
         // All other registers are write-ignored for earlycon's purposes.
     }
@@ -104,6 +171,13 @@ impl SnapshotDeviceState for Pl011 {
         }
         reader.finish()?;
         self.output.clear();
+        // Same reason the transcript is not replayed: a partial parent line
+        // still sitting in the write-through buffer is the parent's output,
+        // and must not appear in the child's console log. The sink itself
+        // stays attached — it is the child's own log file.
+        if let Some(stream) = self.stream.as_mut() {
+            stream.pending.clear();
+        }
         Ok(())
     }
 }
@@ -153,5 +227,112 @@ mod tests {
         uart.output.extend_from_slice(b"child output");
         uart.restore_state(&state).unwrap();
         assert!(uart.output.is_empty());
+    }
+
+    /// Writes a byte at a time into `uart`, as the guest does.
+    fn emit(uart: &mut Pl011, bytes: &[u8]) {
+        for b in bytes {
+            uart.write(Pl011::DR, u64::from(*b), 4);
+        }
+    }
+
+    fn streaming_uart(path: &std::path::Path) -> Pl011 {
+        let mut uart = Pl011::new(0x0900_0000);
+        uart.stream_to(Box::new(std::fs::File::create(path).expect("create sink")));
+        uart
+    }
+
+    /// The property whose absence hid a boot failure: output is readable from
+    /// the sink while the device is still live, not only once it is dropped.
+    #[test]
+    fn a_completed_line_reaches_the_sink_before_the_device_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("console.log");
+        let mut uart = streaming_uart(&path);
+
+        emit(&mut uart, b"mvm-verity-init: switching to /init\n");
+
+        // Deliberately no drop, no flush call: the guest is still running.
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            b"mvm-verity-init: switching to /init\n"
+        );
+    }
+
+    /// A guest that hangs part-way through a line still surfaces it.
+    #[test]
+    fn an_unterminated_line_flushes_once_it_exceeds_the_pending_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("console.log");
+        let mut uart = streaming_uart(&path);
+
+        emit(&mut uart, &vec![b'x'; ConsoleStream::MAX_PENDING - 1]);
+        assert!(
+            std::fs::read(&path).unwrap().is_empty(),
+            "below the cap and with no newline, nothing needs to have been written yet"
+        );
+
+        emit(&mut uart, b"x");
+        assert_eq!(
+            std::fs::read(&path).unwrap().len(),
+            ConsoleStream::MAX_PENDING,
+            "reaching the cap must flush what is pending"
+        );
+    }
+
+    /// Streaming is additive. The in-memory transcript is unchanged, so the
+    /// exit-time consumers of it see exactly what they saw before.
+    #[test]
+    fn streaming_does_not_change_the_in_memory_transcript() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut streamed = streaming_uart(&dir.path().join("console.log"));
+        let mut plain = Pl011::new(0x0900_0000);
+
+        for uart in [&mut streamed, &mut plain] {
+            emit(uart, b"line one\nline two, unterminated");
+        }
+
+        assert_eq!(streamed.output, plain.output);
+    }
+
+    /// A sink that cannot be written must not fault the guest, and must not be
+    /// retried on every subsequent byte.
+    #[test]
+    fn a_failing_sink_is_abandoned_rather_than_propagated() {
+        struct Broken;
+        impl std::io::Write for Broken {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("sink is gone"))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut uart = Pl011::new(0x0900_0000);
+        uart.stream_to(Box::new(Broken));
+        emit(&mut uart, b"first\nsecond\n");
+
+        assert_eq!(uart.output, b"first\nsecond\n", "the guest keeps emitting");
+        assert!(
+            uart.stream.as_ref().is_some_and(|s| s.failed),
+            "the stream must latch failed rather than retry per byte"
+        );
+    }
+
+    /// A restored child must not inherit a partial parent line through the
+    /// write-through buffer, but keeps its own sink attached.
+    #[test]
+    fn restore_clears_pending_output_without_detaching_the_sink() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("console.log");
+        let mut uart = streaming_uart(&path);
+
+        emit(&mut uart, b"parent partial line");
+        let state = uart.snapshot_state().unwrap();
+        uart.restore_state(&state).unwrap();
+        emit(&mut uart, b"child line\n");
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"child line\n");
     }
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-13
+Last updated: 2026-08-14
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -320,6 +320,14 @@ for detailed scope and acceptance criteria.
         unprivileged spawn failed outright, and because it ran first the
         failure also skipped `NoNewPrivs` — the load-bearing control. The
         privileged init path still fails closed
+  - [x] Issue #2522 — the `EPERM` tolerance above covered the workload spawn
+        but not the agent's own drop, which ran the same bounding-set narrowing
+        *after* `set_capabilities` had already removed `CAP_SETPCAP`. Every
+        `machine run --image` failed: the errno left the `pre_exec` hook, the
+        agent never started, and the host timed out waiting for it. The
+        narrowing now runs before the identity change, while the caller still
+        holds the capability the syscall needs, and both call sites share one
+        helper. Bisected against the parent commit and witnessed live on HVF
   - [ ] Re-run the adversarial probe on HVF **and** Firecracker — the closure
         gate, not yet run; no Linux/KVM host available
   - [ ] Record the ADR-001 claims 1/2 scope decision (owner call; determines

--- a/specs/sprint/delivery/2522-agent-spawn-capability-bounding-set.md
+++ b/specs/sprint/delivery/2522-agent-spawn-capability-bounding-set.md
@@ -100,6 +100,25 @@ not fixed here.
 `bounding_drop_is_unenforceable`, which is already tested on every host; it is
 Linux-gated and needs root, so it has no separate unit test.
 
-The end-to-end witness is the live boot: `machine run --image alpine` and
-`--image python:3.12` both succeed on macOS 26 / HVF, against the pre-#2478
-binary as the known-good baseline.
+The end-to-end witness is the live boot, against the pre-#2478 binary as the
+known-good baseline:
+
+| backend | broken `main` | fixed |
+| --- | --- | --- |
+| HVF (macOS 26) | agent unreachable after 30s | `alpine` → `hi`, `python:3.12` → `4` |
+| libkrun (macOS) | agent unreachable after 30s | `alpine` → `hi` |
+| Firecracker (Linux/KVM) | not witnessed — see below | not witnessed |
+
+libkrun matters as the second witness because it shares nothing with HVF except
+the guest, which is where the bug is. It also printed the failing line straight
+to the terminal — it hands the console fd to the VMM — so on that backend the
+diagnostic worked all along.
+
+Firecracker could not be witnessed either way. That host fails earlier, at vCPU
+resume, with the Firecracker process exiting before the guest emits anything;
+this branch fails identically there. That is #2510, a distinct defect this does
+not fix — the agent-spawn `EPERM` cannot make a VMM exit, because
+`mvm-oci-init` logs the failure and falls through to `idle_forever()`, leaving
+the VM alive. Firecracker reaches the same privilege drop through the same code,
+so it is affected by construction; it just cannot be observed there until #2510
+is resolved.

--- a/specs/sprint/delivery/2522-agent-spawn-capability-bounding-set.md
+++ b/specs/sprint/delivery/2522-agent-spawn-capability-bounding-set.md
@@ -1,0 +1,105 @@
+# The guest agent could not spawn itself — capability bounding set, wrong order
+
+**Issue:** #2522
+**Branch:** `fix/2522-agent-spawn-capbset`
+**Regressed by:** #2478 (issue #2101, `specs/plans/300-open-issue-closeout.md` Phase 1)
+
+Every `mvmctl machine run --image <ref>` on `main` failed with `guest agent did
+not become reachable within 30s`. Bisected on one host, one `~/.mvm`, one set of
+caches — only the binary differed:
+
+| build | result |
+| --- | --- |
+| `69a2e581b` (= `a6599e1cb^`) | `hi`, exit 0 |
+| `ae8f576d9` | agent unreachable, exit 1 |
+
+## What was wrong
+
+`drop_guest_agent_privilege_raw` narrowed the capability bounding set *after*
+`set_capabilities` had reduced the process to `CAP_KILL|CAP_SYS_TIME`.
+`PR_CAPBSET_DROP` requires `CAP_SETPCAP`, which is not in that set, so the
+syscall returned `EPERM` every time. On the OCI route the function runs inside
+`spawn_one_as`'s `pre_exec`, so the errno came back out of `Command::spawn()`
+and the agent was never started:
+
+```
+mvm-verity-init: switching to /init
+mvm-guest-init: spawn guest-agent at /mvm/runtime/agent: Operation not permitted (os error 1)
+```
+
+The nix route reaches the same function from PID 1 (`bin/mvm-guest-agent/init.rs`),
+so it was broken identically. Nothing about the failure was backend-specific.
+
+#2478 diagnosed this exact interaction for the *workload* spawn and fixed it
+there, by tolerating `EPERM` in `drop_workload_capability_bounding_set`. The
+agent's own drop kept the broken ordering, and there were two copies of the
+same three-line `match` rather than one.
+
+## What changed
+
+- `guest_mount::drop_guest_agent_privilege_raw` narrows the bounding set
+  immediately after `PR_SET_KEEPCAPS` and before `setgroups`/`setgid`/`setuid`,
+  while the caller still holds `CAP_SETPCAP`. This enforces the narrowing rather
+  than skipping it; the bounding set is inherited across fork and exec, so it
+  binds the agent and everything under it exactly as before. `set_capabilities`,
+  `raise_ambient_capabilities`, `set_no_new_privileges` and the `getuid() == 0`
+  paranoia check are unmoved. `CAP_KILL` and `CAP_SYS_TIME` are retained by the
+  mask, so the ambient raise is unaffected by the earlier narrowing.
+- `narrow_bounding_set_where_enforceable` is now the single implementation of
+  "enforce where possible, fail closed on any other errno", shared with
+  `drop_workload_capability_bounding_set`. A future fix to one cannot miss the
+  other.
+- `harden_init_process` is untouched. It still runs as root in init, orders
+  `NoNewPrivs` first and fails closed, and remains the load-bearing control on
+  the OCI path.
+
+## Why it was invisible
+
+On HVF the guest console accumulated in `Pl011.output` and reached
+`console.log` only after the run loop returned. For the whole 30s the host
+spends waiting for the agent the file is 0 bytes, so the CLI's
+`emit_guest_console_diagnostic` — the diagnostic that exists specifically for a
+boot that never comes up — could only ever report "Guest console … was empty".
+The console above was recovered by booting detached, letting it fail, stopping
+the VM, and only then reading the file.
+
+`Pl011` now takes an optional write-through sink (`Pl011::stream_to`), flushed
+per line and at a 512-byte cap so an unterminated line still surfaces. The
+supervisor passes `console_log` through `HostChannels`, and the device opens it
+with the existing `open_console_capture` — write-only, which is what keeps
+claim 15's "no host input fd" true. The change is additive: `output` still
+accumulates identically and the supervisor's authoritative rewrite after the run
+loop returns is unchanged, so every consumer of `KernelBootResult.console` sees
+what it saw before. What changed is that the log is readable *during* the run,
+and survives a `SIGKILL`.
+
+## Why CI did not catch it
+
+`oci-image-runner-smoke` and the live-VM lanes live in `ci-full.yml`, which is
+`workflow_dispatch:`-only. No PR-gating lane boots a guest, so a change that
+makes every guest fail to boot passes every required check. Worth a follow-up;
+not fixed here.
+
+## Tests
+
+- `the_agent_never_retains_the_capability_its_bounding_drop_requires` — pins the
+  invariant the ordering rests on (`CAP_SETPCAP` ∉ `RESTORE_AGENT_CAPABILITIES`),
+  and runs on every host.
+- `drop_guest_agent_privilege_reaches_the_agent_identity_from_root` — live
+  witness behind `MVM_GUEST_PRIVILEGED_TESTS=1` + root, matching the existing
+  `harden_init_process_*` idiom. Asserts the drop returns `Ok` — which is the
+  whole regression — and lands on uid 901 with `CapBnd` = `CAP_KILL|CAP_SYS_TIME`
+  and `NoNewPrivs: 1`.
+- Five `Pl011` tests: a completed line reaches the sink before the device is
+  dropped (the property whose absence hid this bug), an unterminated line
+  flushes at the cap, streaming leaves the in-memory transcript byte-identical,
+  a failing sink latches instead of faulting the guest or retrying per byte, and
+  restore clears pending parent output without detaching the child's sink.
+
+`narrow_bounding_set_where_enforceable` has no logic of its own beyond
+`bounding_drop_is_unenforceable`, which is already tested on every host; it is
+Linux-gated and needs root, so it has no separate unit test.
+
+The end-to-end witness is the live boot: `machine run --image alpine` and
+`--image python:3.12` both succeed on macOS 26 / HVF, against the pre-#2478
+binary as the known-good baseline.


### PR DESCRIPTION
Fixes #2522.

`mvmctl machine run --image <anything>` has been broken on `main` since #2478
merged. Bisected on one host, one `~/.mvm`, one set of caches — only the binary
differed:

| build | result |
| --- | --- |
| `69a2e581b` (= `a6599e1cb^`) | `hi`, exit 0 |
| `ae8f576d9` | agent unreachable, exit 1 |

## The bug

`drop_guest_agent_privilege_raw` narrowed the capability bounding set *after*
`set_capabilities` had reduced the process to `CAP_KILL|CAP_SYS_TIME`.
`PR_CAPBSET_DROP` requires `CAP_SETPCAP`, which is not in that set, so it
returned `EPERM` every time. On the OCI route the function runs inside
`spawn_one_as`'s `pre_exec`, so the errno came back out of `Command::spawn()`
and the agent was never started:

```
mvm-verity-init: switching to /init
mvm-guest-init: spawn guest-agent at /mvm/runtime/agent: Operation not permitted (os error 1)
```

The nix route reaches the same function from PID 1, so it was broken
identically — this was never OCI- or backend-specific.

#2478 diagnosed this exact interaction for the *workload* spawn and fixed it
there by tolerating `EPERM`. The agent's own drop kept the broken ordering, and
the rule lived in two copies of the same `match`.

The narrowing now runs before the identity change, while the caller still holds
the capability the syscall needs — which enforces it rather than skipping it —
and both call sites share one helper.

## Second commit: why this took a session to find

On HVF the guest console accumulated in `Pl011.output` and reached `console.log`
only after the run loop returned. For the entire 30s the host waits for the
agent the file is 0 bytes, so `emit_guest_console_diagnostic` — the diagnostic
that exists specifically for a boot that never comes up — could only report
"Guest console … was empty". The transcript above had to be recovered by booting
detached, letting it fail, stopping the VM, and only then reading the file.

`Pl011` now takes an optional write-through sink, flushed per line and at a
512-byte cap. Additive: `output` still accumulates identically and the
supervisor's authoritative rewrite at exit is unchanged, so every consumer of
`KernelBootResult.console` sees what it saw before. Opened with the existing
`open_console_capture`, so it stays write-only and the sealed guest keeps its
"no host input fd" property. libkrun was never affected — it is handed the fd.

## Verification

Gates: `just lint` (fmt + clippy + clippy-bdd + xtask policy gates), `cargo
nextest run --workspace` (11690 passed), doctests, `just check-linux`, and a
`zigbuild --all-targets` for the touched crates — `guest_mount.rs` is entirely
`#[cfg(target_os = "linux")]`, so a macOS-only check compiles none of it.

Live on macOS 26 / HVF, against the pre-#2478 binary as the known-good baseline:

- `machine run --image alpine -- /bin/echo hi` → `hi`
- `machine run --image python:3.12 -- python -c "print(2 + 2)"` → `4`
- `machine run -d --name … --image alpine -- /bin/echo hi` → `hi`
- console.log is 13698 bytes **while the VM is still running** (0 before)

## Noted, not fixed here

- No PR-gating lane boots a guest: `oci-image-runner-smoke` and the live-VM
  lanes live in `ci-full.yml`, which is `workflow_dispatch:`-only. A change that
  makes every guest fail to boot passes every required check.
- A long-running detached exec (`machine run -d … -- /bin/sleep 120`) fails with
  `failed to fill whole buffer`. Reproduces identically on the pre-#2478 binary,
  so it is pre-existing and unrelated.
