### PR TITLE
fix(hostd): retry the accept errors that describe a pending connection

### DIFF
--- a/crates/mvm-hostd/src/supervisor/accept_loop.rs
+++ b/crates/mvm-hostd/src/supervisor/accept_loop.rs
@@ -51,9 +51,29 @@ pub fn classify_accept_error(err: &io::Error, consecutive: u32) -> AcceptAction 
         | io::ErrorKind::OutOfMemory => true,
         // EMFILE/ENFILE/ENOBUFS have no stable `ErrorKind`, so they only ever
         // arrive as a raw errno.
+        //
+        // The second group is what `accept(2)` reports about the *pending
+        // connection* rather than about the listener. Linux passes errors
+        // already pending on the new socket back through the accept call, and
+        // the man page is explicit that an application should treat them like
+        // EAGAIN and retry. Omitting them is not neutral: the terminator loop
+        // is bound to a real TcpListener, so a single EPROTO there would end
+        // transparent egress for that VM permanently — the exact failure this
+        // module exists to prevent, arriving through a different errno.
         _ => matches!(
             err.raw_os_error(),
-            Some(libc::EMFILE) | Some(libc::ENFILE) | Some(libc::ENOBUFS) | Some(libc::ENOMEM)
+            Some(libc::EMFILE)
+                | Some(libc::ENFILE)
+                | Some(libc::ENOBUFS)
+                | Some(libc::ENOMEM)
+                | Some(libc::EPROTO)
+                | Some(libc::EPERM)
+                | Some(libc::ENOSR)
+                | Some(libc::ETIMEDOUT)
+                | Some(libc::ENETDOWN)
+                | Some(libc::ENETUNREACH)
+                | Some(libc::EHOSTUNREACH)
+                | Some(libc::EOPNOTSUPP)
         ),
     };
     if transient {
@@ -145,9 +165,42 @@ mod tests {
     }
 
     #[test]
+    fn a_pending_connections_network_error_retries_rather_than_ending_the_terminator() {
+        // Linux `accept()` reports errors already pending on the *new* socket
+        // through the accept call. The man page is explicit that these should be
+        // treated like EAGAIN and retried — they describe one dead connection
+        // attempt, never the listener. This matters for `serve_terminator`,
+        // which is the one loop bound to a real TcpListener: without this, a
+        // single EPROTO permanently ends transparent egress for that VM.
+        for code in [
+            libc::EPROTO,
+            libc::EPERM,
+            libc::ENETDOWN,
+            libc::ENETUNREACH,
+            libc::EHOSTUNREACH,
+            libc::ETIMEDOUT,
+            libc::EOPNOTSUPP,
+        ] {
+            assert!(
+                matches!(
+                    classify_accept_error(&errno(code), 0),
+                    AcceptAction::Retry(_)
+                ),
+                "errno {code} is a pending connection's error, not the listener's"
+            );
+        }
+    }
+
+    #[test]
     fn unrecognised_errors_are_fatal_rather_than_spinning() {
+        // Pinned to an errno `accept(2)` can genuinely produce but that says
+        // nothing characterised about the listener. The earlier pin was `EDOM`,
+        // which `accept` cannot return at all — so the assertion held for every
+        // errno that mattered and the missing pending-connection family went
+        // unnoticed. A fatal-by-default policy is only honest if its test uses
+        // an error the syscall can actually raise.
         assert_eq!(
-            classify_accept_error(&errno(libc::EDOM), 0),
+            classify_accept_error(&errno(libc::EFAULT), 0),
             AcceptAction::Fatal
         );
     }


### PR DESCRIPTION
Closes #2526. Follow-up to #2485 / #2492 — this was raised in review on #2492 before merge; that PR merged without it, so the gap is on `main`.

## The gap

#2492 gave every egress accept loop a shared classifier, which fixed the original defect. But it makes **unrecognised errno fatal**, and `accept(2)` on Linux reports errors already pending on the *new* socket through the accept call:

> Linux `accept()` passes already-pending network errors on the new socket as an error code from `accept()`. **For reliable operation the application should detect the network errors defined for the protocol after `accept()` and treat them like `EAGAIN` by retrying.**

So `EPROTO`, `EPERM` (firewall), `ENOSR`, `ETIMEDOUT`, `ENETDOWN`, `ENETUNREACH`, `EHOSTUNREACH` and `EOPNOTSUPP` were all `Fatal`.

For the UDS and vsock loops that is theoretical. For `serve_terminator` it is not — `network_endpoint_proxy.rs:892` takes a real `tokio::net::TcpListener`, exactly the socket family the man page describes. One `EPROTO` from a single pending connection permanently ended the transparent egress redirect path for that VM: the failure #2485 exists to prevent, arriving through a different errno.

## The change

Add that family to the transient arm. Deliberately unchanged:

- **unknown-is-fatal** stays — the author's reasoning is right for a listener that failed in a way we have not characterised.
- **`EBADF` / `EINVAL` / `ENOTSOCK` stay fatal** — the listener itself is dead there, and retrying would be an infinite hot spin.

Chosen over inverting to an explicit fatal set so one policy still covers all six call sites and the justification stays next to each errno. The existing `FREE_RETRIES` streak cap bounds the spin risk either way.

## Why review missed it

`unrecognised_errors_are_fatal_rather_than_spinning` pinned `EDOM` — an errno `accept(2)` cannot return — so the assertion held for every errno that actually mattered. Repinned to `EFAULT`, which `accept` can raise. A fatal-by-default policy is only honest if its test uses an error the syscall can produce.

## Verification

The new test was confirmed **red against `main` first**: errno 100 is `ENETDOWN` on macOS and classified `Fatal`, so the case failed before the classifier change and passes after.

- `cargo nextest run --workspace` — **11,708 passed**, 26 skipped
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all` — clean
- `cargo run -p xtask -- check-nextest-groups` — all override filters match
- `cargo-zigbuild check --target x86_64-unknown-linux-gnu --workspace --all-targets` — clean (the linux-gated targets a macOS `--all-targets` cannot reach)
- `cargo check -p mvm-conformance --all-targets --features bdd` — clean (the `required-features` target `--all-targets` silently skips)

The last two are the lanes that caught #2513 twice; running them here up front rather than learning from CI again.