### PR TITLE
chore(justfile): correct what test-cached actually adds over a global sccache

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -161,12 +161,24 @@ test:
 test-doc:
     cargo test --workspace --doc
 
-# Run tests with sccache wrapping rustc — caches compilation across
-# worktrees/branches (a content cache, not a build lock, so parallel
-# sessions don't serialize on it). Incremental is OFF because sccache and
-# incremental compilation are mutually exclusive: this trades inner-loop
-
-# incremental for cross-worktree cache hits. Needs `cargo install sccache`.
+# Run tests with sccache also caching the workspace crates.
+#
+# The wrapper itself is not what this recipe adds. `RUSTC_WRAPPER = "sccache"`
+# belongs in a contributor's own `~/.cargo/config.toml` (a fact about a host
+# that runs many worktrees, not about the project), and there it already caches
+# every third-party dependency, because cargo compiles dependencies
+# non-incrementally regardless of this setting.
+#
+# What `CARGO_INCREMENTAL=0` adds is the *workspace* crates, which are the ones
+# incremental compilation otherwise keeps out of the cache. That is a good
+# trade for a full-suite run — incremental buys nothing when everything is
+# being compiled anyway — and a bad one for the inner loop, which is why it is
+# scoped to this recipe instead of being set globally.
+#
+# A content cache, not a build lock, so parallel sessions don't serialize on it.
+# Needs `cargo install sccache`. For cross-worktree hits the host config also
+# needs `basedirs`; without it every worktree is a private cache and the
+# measured hit rate is 0%.
 test-cached:
     @command -v sccache >/dev/null || { echo "sccache not found — install with: cargo install sccache"; exit 1; }
     RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 cargo nextest run --workspace


### PR DESCRIPTION
Follow-up to #2405, whose closing note deferred "promoting `RUSTC_WRAPPER` to the user-level cargo config" as a separate decision. I took that decision, measured it, and this is the one repo-side change it needs.

## The comment was wrong

`test-cached` asserted that *"sccache and incremental compilation are mutually exclusive"*. That belief is what kept the wrapper scoped to a single recipe nobody runs — sccache had **0 lifetime compile requests** on this machine.

`CARGO_INCREMENTAL` only governs **workspace members**. Cargo already compiles dependencies non-incrementally, which is exactly what sccache caches. So a plain `RUSTC_WRAPPER` in a contributor's own `~/.cargo/config.toml` caches all ~650 third-party crates *with no inner-loop cost at all*.

## Measured

| | Before | After |
|---|---|---|
| Cold dep build, second worktree | 37.35s | **18.46s** |
| Inner loop (one-line `mvm-core` edit) | 1.83–1.93s | **1.59–1.80s** |
| First build after enabling (all misses) | — | 42.25s |

`target/debug/incremental/` still carries the workspace units afterwards, so incremental is genuinely intact rather than merely appearing so.

## The part that is easy to miss

Cross-worktree hits need **`basedirs`** in the sccache config. sccache hashes the compiler command line, which carries absolute source and `--extern` paths — so without it every worktree is a private cache. I measured exactly that: **0 hits, 0.00% hit rate** across two worktrees before setting it, 56% cumulative after.

Worth stating loudly because the failure is silent: sccache reports healthy stats, zero errors, and simply never hits. The config key is `basedirs` (a list); `base_dir` is rejected at load and breaks every cargo build on the machine until removed.

## Scope

Comment-only — the recipe body is unchanged, and it keeps `CARGO_INCREMENTAL=0` because adding the workspace crates to the cache is a good trade for a full-suite run and a bad one for the inner loop. The wrapper itself is host config and is deliberately **not** checked in, for the same reason `[build] jobs` is not: it is a fact about a machine running many worktrees, and a checked-in value would hit CI runners and other contributors.

`just --list` parses clean.