### PR TITLE
docs(deps): say which graph each duplicate-major list measures

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -105,6 +105,14 @@ highlight = "all"
 # regress. Entries are grouped by why they duplicate; shrink the list
 # as upstream majors converge or a dep is replaced — never grow it
 # without a recorded reason.
+#
+# This list describes cargo-deny's *filtered* graph: dev-only edges and
+# unenabled optional deps are not in it. `xtask check-duplicate-majors`
+# ratchets the same property over `cargo metadata --locked`, which is the
+# full graph — all targets, all features, dev-dependencies included — so its
+# ALLOWLIST is strictly larger and the two are expected to differ. A crate
+# there and absent here is not drift; it is a duplication only the wider
+# graph can see. Compare them by that rule, not entry for entry.
 skip = [
     # Windows host-target shim umbrellas. `windows-sys` and `windows-core`
     # still coexist at two majors across the graph; they are host/build only

--- a/xtask/src/check_duplicate_majors.rs
+++ b/xtask/src/check_duplicate_majors.rs
@@ -25,6 +25,14 @@ use std::process::Command;
 /// Remove an entry freely once the duplication is gone (the gate flags stale
 /// entries); adding one must be justified in the PR that does — it admits a
 /// new duplicate major into the build.
+///
+/// This list is measured over `cargo metadata --locked`: the full graph, all
+/// targets and features, dev-dependencies included. `deny.toml`'s `skip` list
+/// ratchets the same property over cargo-deny's *filtered* graph, which drops
+/// dev-only edges and unenabled optional deps — so this list is strictly the
+/// larger of the two. An entry here with no counterpart there is expected
+/// whenever the duplication is dev-only or sits behind an optional dep nobody
+/// enables; it is not evidence that either list has rotted.
 const ALLOWLIST: &[&str] = &[
     "bitflags",
     // Neither defmt major is compiled: both are optional dependencies nobody


### PR DESCRIPTION
## What

`deny.toml`'s `skip` list and `xtask check-duplicate-majors`'s `ALLOWLIST` ratchet
the same property — "crates allowed to resolve at two majors" — over **different
graphs**, and neither file said so.

| | graph | entries |
|---|---|---|
| `deny.toml` | cargo-deny's filtered graph (drops dev-only edges and unenabled optional deps) | 7 |
| `xtask check-duplicate-majors` | `cargo metadata --locked` — all targets, all features, dev-dependencies included | 11 |

xtask's list is strictly the larger by construction. The four it carries alone —
`defmt` (both optional, neither enabled), `hashbrown`, `itertools` (criterion,
dev-only), `nom` (cargo-fuzz tooling, dev-only) — are duplicated only in the
wider graph, so cargo-deny cannot see them and correctly does not list them.

Both lists are right. Nothing needed reconciling. But an entry-for-entry compare
reads the gap as rot, which is exactly what happened while auditing the
`bitflags` entry in #2516 — time spent looking for a bug that was not there.

## The change

Comments only. Each list now names the other and states the graph it measures,
so the next audit reads the difference as expected rather than as drift.

## Verification

- `cargo run -p xtask -- check-duplicate-majors` — clean, 11 known crates
- `cargo deny check bans` — `bans ok`

Closes #2517.