### PR TITLE
fix(fc): take the pid marker from the process that becomes Firecracker

### DIFF
--- a/crates/mvm-backends/src/fc/daemon.rs
+++ b/crates/mvm-backends/src/fc/daemon.rs
@@ -123,10 +123,18 @@ fn start_vm_firecracker_inner(
 ///
 /// Privilege justification: Firecracker is launched through `sudo` because, on
 /// the reference builder-VM host, the invoking user does not have direct access
-/// to `/dev/kvm` and the TAP/vsock network plumbing it configures. The launch
-/// no longer uses an intermediate `bash -c`: `sudo` execs `setsid` directly,
-/// which then execs Firecracker, so the only extra process is the one required
-/// for elevation.
+/// to `/dev/kvm` and the TAP/vsock network plumbing it configures.
+///
+/// The pid marker is written by the launched process itself (`echo $$`) and not
+/// by the caller (`echo $!`), because `$!` does not reliably name Firecracker.
+/// `sudo` with `use_pty` — the default since sudo 1.9.14, which is what Ubuntu
+/// 24.04 ships — forks a monitor and runs the command as its child rather than
+/// exec'ing it, so `$!` names a process whose `comm` is `sudo`. Liveness is
+/// probed by comparing `/proc/<pid>/comm` against `firecracker`, so on such a
+/// host every boot read as "the VMM exited" on the first poll while the guest
+/// was in fact booting normally. Writing `$$` from inside is correct whichever
+/// of `sudo`/`setsid` forks, since the `exec` makes that same pid Firecracker.
+/// The `sh -c` costs no surviving process for the same reason.
 fn firecracker_launch_script(
     abs_dir: &str,
     abs_socket: &str,
@@ -145,17 +153,18 @@ fn firecracker_launch_script(
     };
     let q_dir = shell_quote(abs_dir);
     let q_socket = shell_quote(abs_socket);
+    let q_pid = shell_quote(&format!("{abs_dir}/fc.pid"));
     format!(
         r#"
         mkdir -p {q_dir}
         sudo rm -f {q_socket}
         {vsock_cleanup}
         touch {q_dir}/console.log {q_dir}/firecracker.log
-        {cpu_scope}sudo setsid nohup firecracker --api-sock {q_socket} --enable-pci \
+        {cpu_scope}sudo setsid nohup sh -c 'echo $$ > "$0"; exec firecracker --api-sock "$1" --enable-pci' {q_pid} {q_socket} \
             </dev/null >{q_dir}/console.log 2>{q_dir}/firecracker.log &
-        echo $! > {q_dir}/fc.pid
         "#,
         q_dir = q_dir,
+        q_pid = q_pid,
         q_socket = q_socket,
         vsock_cleanup = vsock_cleanup,
         cpu_scope = cpu_scope,
@@ -390,7 +399,7 @@ mod tests {
         );
         let scope_at = script.find("systemd-run").expect("prefix present");
         let launch_at = script
-            .find("sudo setsid nohup firecracker")
+            .find("sudo setsid nohup sh -c")
             .expect("launch present");
         assert!(scope_at < launch_at, "{script}");
     }
@@ -399,11 +408,39 @@ mod tests {
     fn an_ungranted_launch_line_carries_no_scope() {
         let script = firecracker_launch_script("/tmp/vm", "/tmp/vm/fc.socket", true, "");
         assert!(!script.contains("systemd-run"), "{script}");
-        assert!(script.contains("sudo setsid nohup firecracker"), "{script}");
+        assert!(script.contains("sudo setsid nohup sh -c"), "{script}");
         assert!(
-            !script.contains("bash -c"),
-            "launch must not spawn an intermediate bash: {script}"
+            script.contains("exec firecracker"),
+            "the shell must exec Firecracker, never leave one behind: {script}"
         );
+    }
+
+    /// The regression this exists for: `$!` names Firecracker only when every
+    /// wrapper in the launch chain execs. `sudo` with `use_pty` (the default
+    /// since 1.9.14, and what Ubuntu 24.04 ships) forks a monitor instead, so
+    /// `$!` was the `sudo` pid and the `/proc/<pid>/comm == firecracker`
+    /// liveness probe read every boot as an immediate VMM exit.
+    #[test]
+    fn the_pid_marker_is_written_by_the_launched_process_not_the_caller() {
+        let script = firecracker_launch_script("/tmp/vm", "/tmp/vm/fc.socket", true, "");
+
+        assert!(
+            !script.contains("echo $!"),
+            "$! does not survive a forking sudo/setsid: {script}"
+        );
+        assert!(
+            script.contains(r#"echo $$ > "$0""#),
+            "the pid must come from the process that becomes Firecracker: {script}"
+        );
+
+        // Written before the exec, so the marker is in place by the time the
+        // API socket exists and the caller starts probing liveness.
+        let write_at = script.find("echo $$").expect("pid write present");
+        let exec_at = script.find("exec firecracker").expect("exec present");
+        assert!(write_at < exec_at, "{script}");
+
+        // And it names the path the rest of the tree reads.
+        assert!(script.contains("/tmp/vm/fc.pid"), "{script}");
     }
 
     #[test]


### PR DESCRIPTION
## What was wrong

The Firecracker launch line records the VMM's pid with `$!`:

```sh
sudo setsid nohup firecracker --api-sock ... --enable-pci &
echo $! > fc.pid
```

`$!` is Firecracker only if every wrapper in that chain *execs*. `sudo` with
`use_pty` — the default since sudo 1.9.14, which is what Ubuntu 24.04 ships —
forks a monitor and runs the command as its **child** instead. Measured on the
KVM box (sudo 1.9.15p5, `Defaults use_pty` in `/etc/sudoers`):

```
captured pid=2715264   comm=sudo
2715264  1        sudo
2715266  2715264  sleep      <- the real command
```

Liveness is `/proc/<pid>/comm == "firecracker"` (`fc/host.rs:280`), so it
answered *no* on the first poll after `InstanceStart` and the driver concluded
the VMM had died (`fc/driver/fc.rs:930`).

## Why it looked like a VMM crash

Firecracker was healthy. From the failing run on that box:

```
fc boot: InstanceStart  ms=867
WARN FirecrackerGuard: killing orphaned Firecracker process dir=/root/.mvm/vms/probe2510
Error: Firecracker process for 'probe2510' exited before its guest agent came up
```

`firecracker.log` for the same run ends with `event_end: boot microvm` and both
vCPUs resuming normally — no error, no panic. `dmesg` is clean: no seccomp kill,
no OOM. **We killed it ourselves**, ~7 ms into the guest's boot, which is why
the reported symptom was "the process exits with no guest serial at all":
nothing had been printed yet. `fc.pid` was gone too, removed by the guard on
the way out.

This is why it reproduced on two unrelated hosts (the KVM box and GitHub's
`ubuntu-24.04` runners, both Ubuntu 24.04) while the same kernel and initrd
booted fine when Firecracker was driven directly.

## The fix

The launched process writes its own pid and then execs:

```sh
sudo setsid nohup sh -c 'echo $$ > "$0"; exec firecracker --api-sock "$1" --enable-pci' <pidfile> <socket> &
```

`$$` is correct whichever of `sudo`/`setsid` forks, because the `exec` makes
that same pid Firecracker. The `sh -c` leaves no surviving process for the same
reason, so the "no intermediate shell" property the previous line was written
for still holds — the test now asserts `exec firecracker` rather than the
absence of `bash -c`.

Ordering is safe: the marker is written before the exec, so it is in place well
before the API socket appears and the caller starts probing.

## Tests

`the_pid_marker_is_written_by_the_launched_process_not_the_caller` — asserts the
line carries no `echo $!`, writes `$$` to the marker path, and does so before
the exec. **Proven red** against the pre-fix launch line:

```
$! does not survive a forking sudo/setsid:
        sudo setsid nohup firecracker --api-sock '/tmp/vm/fc.socket' --enable-pci \
        echo $! > '/tmp/vm'/fc.pid
test result: FAILED. 0 passed; 1 failed
```

Full `mvm-backends` `fc::` suite (81 tests) and `cargo clippy --workspace
--all-targets -- -D warnings` are clean.

## Knock-on

This is also what makes the `Boot latency ceiling` lane on #2505 red — that job
fails with the identical "exited before its guest agent came up" on an
`ubuntu-24.04` runner.

Closes #2510.