### PR TITLE
test(sec): kill two substitution mutants; delete an unreachable wasm guard

### DIFF
--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -131,12 +131,10 @@ pub fn resolve_manifest_arg(arg: &str) -> Result<ManifestArgRef> {
                 });
             }
         }
-        if !module_path.is_file() {
-            anyhow::bail!(
-                "Manifest wasm module '{}' does not exist",
-                module_path.display()
-            );
-        }
+        // No existence check here. `Manifest::read_file` already refuses a
+        // manifest whose `wasm` field does not point to an existing file, so
+        // by this line the module is known to exist — a second check was
+        // unreachable, which is why mutating it away changed no test.
         return Ok(ManifestArgRef::WasmModule {
             manifest_path: canonical,
             module_path: module_path.to_path_buf(),
@@ -357,6 +355,32 @@ mod tests {
         // manifest. The point is that it was not silently taken for a name.
         if let Ok(ManifestArgRef::Name(n)) = resolved {
             panic!("a directory was misclassified as the registry name {n:?}");
+        }
+    }
+
+    /// A relative wasm module resolves against the manifest's own directory.
+    ///
+    /// The guard is `if !module_path.is_absolute()`. Deleting the `!` inverts
+    /// it: a relative path skips the join and is then looked up against the
+    /// process working directory instead of the manifest's, which resolves to
+    /// a different file or to nothing at all depending on where mvmctl was
+    /// invoked from.
+    #[test]
+    fn a_relative_wasm_module_resolves_against_the_manifest_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let manifest = dir.path().join("mvm.toml");
+        std::fs::write(dir.path().join("app.wasm"), b"\0asm").expect("write module");
+        std::fs::write(&manifest, "wasm = \"app.wasm\"\n").expect("write manifest");
+
+        let resolved = resolve_manifest_arg(manifest.to_str().expect("utf8 path"))
+            .expect("a manifest naming a module beside it must resolve");
+        match resolved {
+            ManifestArgRef::WasmModule { module_path, .. } => assert_eq!(
+                module_path.canonicalize().ok(),
+                dir.path().join("app.wasm").canonicalize().ok(),
+                "the module must resolve beside the manifest, not against the cwd"
+            ),
+            other => panic!("expected a WasmModule, got {other:?}"),
         }
     }
 

--- a/crates/mvm-contract/src/substitution.rs
+++ b/crates/mvm-contract/src/substitution.rs
@@ -118,6 +118,27 @@ mod tests {
         assert_eq!(find_placeholder("mvm-managed:OPENAI_API_KEY"), None);
     }
 
+    /// `is_empty` is session bookkeeping, but it is bookkeeping the keyholder
+    /// reads to decide whether a session has any substitution to do at all. A
+    /// constant-`true` version makes a populated session look empty; a
+    /// constant-`false` one makes an empty session look populated. Neither
+    /// direction had a test, so both survived mutation.
+    #[test]
+    fn is_empty_tracks_whether_the_session_holds_any_placeholder() {
+        let mut map = PlaceholderMap::new();
+        assert!(map.is_empty(), "a fresh map holds nothing");
+        assert_eq!(map.len(), 0);
+
+        let ph = Placeholder::new(format!("{SECRET_PLACEHOLDER_PREFIX}deadbeef"));
+        map.insert(ph, secret_ref("token", &["api.example.com"]));
+
+        assert!(
+            !map.is_empty(),
+            "a map holding a placeholder must not report empty"
+        );
+        assert_eq!(map.len(), 1);
+    }
+
     fn secret_ref(name: &str, hosts: &[&str]) -> SecretRef {
         use crate::ir::{AuthType, SecretMount};
         use alloc::string::ToString;


### PR DESCRIPTION
Three of the twelve mutants that survived Security run `31839663209`. Landing what is solid rather than holding it behind the eight I have not done.

**The lane is still red.** This does not fix it.

## Killed, verified red-first

**`PlaceholderMap::is_empty`** had no test at all, so both the constant-`true` and constant-`false` mutants survived. It is session bookkeeping — but bookkeeping the keyholder reads to decide whether a session has any substitution to do, and constant-`true` makes a populated session look empty. Both mutants confirmed to fail the new test before it was kept.

## Deleted rather than witnessed

**`resolve_manifest_arg`'s `if !module_path.is_file()` bail is unreachable.** `Manifest::read_file` already refuses a manifest whose `wasm` field does not name an existing file, so by that line the module is known to exist.

That unreachability is *why* mutating the guard away changed no test — there was no reachable behaviour to change. Deleting the code removes the mutant instead of papering over it with a test that cannot exist. I found this by writing the obvious test, watching it fail for the wrong reason, and probing `read_file` directly.

## What this does NOT do

The added test — a relative wasm module resolves against the manifest's directory — is a genuine behavioural test, but it **does not kill the `delete !` mutant on `is_absolute`**. I verified that by applying the mutation and watching the test still pass. That survivor stands.

## Remaining survivors (9)

| Crate | Site |
|---|---|
| mvm-cli | `resolve.rs` `is_absolute` — `delete !` |
| mvm-hostd | `admission_budget.rs:104` `committed` → `Default::default()` |
| mvm-hostd | `keyholder/substitution.rs:78` `as_map` → empty map |
| mvm-hostd | `plan_admission.rs:363` `admit_within_host_budget` — `delete !` |
| mvm-hostd | `plan_admission.rs:627` `*` → `+` (×2) |
| mvm-hostd | `plan_admission.rs:1166/1173` delete `plan_id` field (×2) |
| mvm-hostd | `audit_file.rs:91` `RotationPolicy::never` → `Default::default()` |

Several are claim-bearing: the budget ones are preview claim 18, `as_map` is on the claim-13 substitution path, and the `plan_id` field deletions are the claim-8 binding.

**Separately, the mvm-hostd shard did not finish** — it ended `Error: interrupted` after 73m and 55m shards. That is an infrastructure problem independent of the survivors, and it means that shard's list may be incomplete.

## Verification

`cargo nextest run -p mvm-contract -p mvm-cli` — 2,677 passed. Workspace all-target Clippy and fmt clean via the pre-commit gate.
