### PR TITLE
test(egress): witness the blocking vsock leg's raw tunnel bound

### DIFF
--- a/crates/mvm-hostd/src/supervisor/raw_egress.rs
+++ b/crates/mvm-hostd/src/supervisor/raw_egress.rs
@@ -394,6 +394,27 @@ fn handle_raw_conn_blocking(
     rate_guard: Arc<egress_rate::EgressRateGuard>,
     timeout: Duration,
 ) -> std::io::Result<()> {
+    handle_raw_conn_blocking_with_resolver(conn_fd, gate, recorder, rate_guard, timeout, |host| {
+        resolve_hostname_ips_pure(host, timeout)
+    })
+}
+
+/// [`handle_raw_conn_blocking`] with the hostname resolver injected, for the same
+/// reason as [`handle_raw_conn_with_resolver`]: the tunnel-limit refusal is a
+/// one-byte nack indistinguishable on the wire from a policy refusal, so "the
+/// target was never resolved" is the only hermetic way to witness the bound.
+#[cfg(target_os = "linux")]
+fn handle_raw_conn_blocking_with_resolver<F>(
+    conn_fd: std::os::fd::RawFd,
+    gate: &EgressGate,
+    recorder: Option<Arc<Recorder>>,
+    rate_guard: Arc<egress_rate::EgressRateGuard>,
+    timeout: Duration,
+    resolve: F,
+) -> std::io::Result<()>
+where
+    F: Fn(&str) -> std::io::Result<Vec<IpAddr>>,
+{
     let owned = unsafe { OwnedFd::from_raw_fd(conn_fd) };
     let mut guest = std::fs::File::from(owned);
 
@@ -431,22 +452,21 @@ fn handle_raw_conn_blocking(
         write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
         return Ok(());
     };
-    let (ips, port) =
-        match gate.decide_request_with(&target, |host| resolve_hostname_ips_pure(host, timeout)) {
-            EgressVerdict::Allow { ips, port } => (ips, port),
-            // As on the async path: a raw tunnel answers with a one-byte nack,
-            // so the reason is logged host-side rather than discarded.
-            verdict @ (EgressVerdict::Deny(_) | EgressVerdict::Malformed) => {
-                match verdict {
-                    EgressVerdict::Deny(reason) => {
-                        eprintln!("raw-egress: refusing target {target}: {reason}")
-                    }
-                    _ => eprintln!("raw-egress: refusing malformed target {target}"),
+    let (ips, port) = match gate.decide_request_with(&target, &resolve) {
+        EgressVerdict::Allow { ips, port } => (ips, port),
+        // As on the async path: a raw tunnel answers with a one-byte nack,
+        // so the reason is logged host-side rather than discarded.
+        verdict @ (EgressVerdict::Deny(_) | EgressVerdict::Malformed) => {
+            match verdict {
+                EgressVerdict::Deny(reason) => {
+                    eprintln!("raw-egress: refusing target {target}: {reason}")
                 }
-                write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
-                return Ok(());
+                _ => eprintln!("raw-egress: refusing malformed target {target}"),
             }
-        };
+            write_connect_ack_blocking(&mut guest, ConnectAck::Fail)?;
+            return Ok(());
+        }
+    };
 
     let upstream = match connect_first_admitted_blocking(&ips, port, timeout) {
         Some(stream) => stream,
@@ -1361,6 +1381,91 @@ mod tests {
         assert!(
             guard.try_admit_tunnel().is_some(),
             "the refused connection must have released its tunnel slot"
+        );
+    }
+
+    /// The vsock leg of the same bound. Identical trap: the nack byte is also
+    /// what a policy refusal and a failed upstream connect send, so the witness
+    /// is that a full pool never reached the resolver.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg() {
+        let lookups = Arc::new(AtomicUsize::new(0));
+        let probe = Arc::clone(&lookups);
+        let (mut client, server) = UnixStream::pair().unwrap();
+        let guard = Arc::new(
+            egress_rate::EgressRateGuard::builder()
+                .max_tunnels(0)
+                .build(),
+        );
+        let handler = std::thread::spawn(move || {
+            handle_raw_conn_blocking_with_resolver(
+                server.into_raw_fd(),
+                &unrestricted_gate(),
+                None,
+                guard,
+                Duration::from_secs(1),
+                move |_host| {
+                    probe.fetch_add(1, Ordering::Relaxed);
+                    Ok(Vec::new())
+                },
+            )
+        });
+        client.write_all(b"blocked.test:80\n").unwrap();
+
+        let mut ack = [0_u8; 1];
+        client.read_exact(&mut ack).unwrap();
+        assert_eq!(ack[0], ConnectAck::Fail.as_byte());
+        handler.join().unwrap().unwrap();
+        let mut rest = Vec::new();
+        client.read_to_end(&mut rest).unwrap();
+        assert!(rest.is_empty(), "no tunnel bytes after a Fail ack");
+
+        assert_eq!(
+            lookups.load(Ordering::Relaxed),
+            0,
+            "a full tunnel pool must refuse before the host does any DNS work"
+        );
+    }
+
+    /// Companion to the test above: with a slot free the same input does reach
+    /// the resolver, so the zero there is the limiter and not a fixture that
+    /// never resolves anything.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_available_tunnel_slot_reaches_the_resolver_on_the_vsock_leg() {
+        let lookups = Arc::new(AtomicUsize::new(0));
+        let probe = Arc::clone(&lookups);
+        let (mut client, server) = UnixStream::pair().unwrap();
+        let guard = Arc::new(
+            egress_rate::EgressRateGuard::builder()
+                .max_tunnels(1)
+                .build(),
+        );
+        let handler = std::thread::spawn(move || {
+            handle_raw_conn_blocking_with_resolver(
+                server.into_raw_fd(),
+                &unrestricted_gate(),
+                None,
+                guard,
+                Duration::from_secs(1),
+                move |_host| {
+                    probe.fetch_add(1, Ordering::Relaxed);
+                    Ok(Vec::new())
+                },
+            )
+        });
+        client.write_all(b"blocked.test:80\n").unwrap();
+
+        let mut ack = [0_u8; 1];
+        client.read_exact(&mut ack).unwrap();
+        assert_eq!(ack[0], ConnectAck::Fail.as_byte());
+        handler.join().unwrap().unwrap();
+
+        assert_eq!(
+            lookups.load(Ordering::Relaxed),
+            1,
+            "an admitted tunnel resolves its target"
         );
     }
 

--- a/specs/sprint/delivery/2519-blocking-vsock-tunnel-witness.md
+++ b/specs/sprint/delivery/2519-blocking-vsock-tunnel-witness.md
@@ -1,0 +1,90 @@
+# 2519 — the blocking vsock leg of the raw-egress tunnel bound gets a witness
+
+## What was missing
+
+The per-workload cap on simultaneous raw TCP tunnels lives on two legs of
+`crates/mvm-hostd/src/supervisor/raw_egress.rs`:
+
+- async UDS — `handle_raw_conn_with_resolver`, witnessed by
+  `an_exhausted_tunnel_pool_refuses_before_resolving_the_target`.
+- blocking vsock — `handle_raw_conn_blocking`, `#[cfg(target_os = "linux")]`.
+  Identical `rate_guard.try_admit_tunnel()` call, no test.
+
+The vsock leg was compile-checked only. Deleting its admission left the whole
+suite green on every host, Linux included.
+
+## Why the obvious test does not work
+
+A refused tunnel's only tell on the wire is a one-byte `ConnectAck::Fail`. So is
+a policy `Deny`, so is a `Malformed` target, so is an admitted target whose
+upstream connect fails. Four outcomes, one byte.
+
+A test that writes a target and asserts `Fail` therefore passes whether or not
+the bound exists — measured below, not assumed. The async leg's first witness
+made exactly this mistake and was only caught by reverting the fix.
+
+The assertion has to be behavioural. A refused tunnel is refused *before* the
+target is resolved, so the observable is how many times the resolver was
+reached: zero.
+
+## What landed
+
+`handle_raw_conn_blocking` becomes a pure delegator over
+`handle_raw_conn_blocking_with_resolver<F: Fn(&str) -> io::Result<Vec<IpAddr>>>`
+— the same split, with the same synchronous one-arg resolver bound, that the
+async leg already has. `spawn_raw_egress_connection` and every production caller
+are untouched. `dns_handler::serve_dns_blocking` is deliberately not the model:
+it hardcodes `resolve_hostname_ips_pure` and offers no seam.
+
+Two Linux-gated tests, reusing the `UnixStream::pair()` + `into_raw_fd()` idiom
+from `raw_vsock_handlers_run_concurrently` and the existing `unrestricted_gate()`
+fixture:
+
+- `an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg` —
+  `max_tunnels(0)`, asserts the injected resolver was reached **0** times.
+- `an_available_tunnel_slot_reaches_the_resolver_on_the_vsock_leg` —
+  `max_tunnels(1)`, asserts **1**. Without it the first assertion could hold
+  because the fixture never resolves anything under any condition.
+
+Neither test asserts anything load-bearing on the ack byte.
+
+## Evidence
+
+Both tests are `#[cfg(target_os = "linux")]`, so the red-proof was run on the
+x86_64 Linux box, not the macOS dev host. Green first — `cargo nextest run -p
+mvm-hostd raw_egress`:
+
+```
+        PASS [   0.011s] ( 1/16) mvm-hostd supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg
+        PASS [   0.011s] ( 2/16) mvm-hostd supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_the_target
+        PASS [   0.011s] ( 5/16) mvm-hostd supervisor::raw_egress::tests::an_available_tunnel_slot_reaches_the_resolver_on_the_vsock_leg
+        PASS [   0.011s] ( 6/16) mvm-hostd supervisor::raw_egress::tests::an_available_tunnel_slot_reaches_the_resolver
+     Summary [   3.019s] 16 tests run: 16 passed, 1920 skipped
+```
+
+Then the `rate_guard.try_admit_tunnel()` block deleted from
+`handle_raw_conn_blocking_with_resolver`, nothing else changed:
+
+```
+        FAIL [   0.010s] ( 5/16) mvm-hostd supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg
+
+  stderr ───
+    raw-egress: refusing target blocked.test:80: blocked.test is not admitted; no hosts are admitted
+
+    thread 'supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg' (2775281) panicked at crates/mvm-hostd/src/supervisor/raw_egress.rs:1417:9:
+    assertion `left == right` failed: a full tunnel pool must refuse before the host does any DNS work
+      left: 1
+     right: 0
+
+     Summary [   3.018s] 16 tests run: 15 passed, 1 failed, 1920 skipped
+```
+
+That stderr line is the trap made visible. With the bound gone the guest still
+received its `Fail` byte — the gate produced it a few lines further down, off the
+resolved-but-unadmitted address — and the test sailed past its `assert_eq!(ack[0],
+Fail)` before dying on the resolver count. An ack-byte assertion would have stayed
+green.
+
+The companion test passing in the red run is the correct result; it is not the
+witness. Restored, both green again. Full `cargo nextest run -p mvm-hostd`: 1926 passed
+on Linux, 1891 passed on macOS with the Linux-gated pair skipped.


### PR DESCRIPTION
Closes #2519.

#2518 bounded simultaneous raw TCP tunnels per workload on both legs of
`crates/mvm-hostd/src/supervisor/raw_egress.rs`, but only the async UDS leg got a
witness. The blocking vsock leg (`handle_raw_conn_blocking`,
`#[cfg(target_os = "linux")]`) carried the identical `try_admit_tunnel` call with
nothing asserting its behaviour — compile-checked only. Deleting its admission
left the whole suite green, on Linux included.

## Why an ack-byte assertion is worthless here

A refused tunnel's only tell on the wire is a one-byte `ConnectAck::Fail`. So is a
policy `Deny`, so is a `Malformed` target, so is an admitted target whose upstream
connect fails. Four outcomes, one byte. The async leg's first witness made exactly
this mistake and passed with the fix reverted.

So the assertion is behavioural instead: a refused tunnel is refused *before* the
target is resolved, so the observable is that the injected resolver was never
reached.

## Change

`handle_raw_conn_blocking` becomes a pure delegator over
`handle_raw_conn_blocking_with_resolver<F: Fn(&str) -> io::Result<Vec<IpAddr>>>`
— the same split, with the same synchronous one-arg resolver bound, that
`handle_raw_conn` / `handle_raw_conn_with_resolver` already have next door.
`spawn_raw_egress_connection` and every production caller are untouched. No
behaviour change on any path. `dns_handler::serve_dns_blocking` is deliberately
not the model: it hardcodes `resolve_hostname_ips_pure` and offers no seam.

Two Linux-gated tests, reusing the `UnixStream::pair()` + `into_raw_fd()` idiom
from `raw_vsock_handlers_run_concurrently` and the existing `unrestricted_gate()`
fixture:

- `an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg` —
  `max_tunnels(0)`, asserts the resolver was reached **0** times.
- `an_available_tunnel_slot_reaches_the_resolver_on_the_vsock_leg` —
  `max_tunnels(1)`, asserts **1**, so the zero above is the limiter and not a
  fixture that never resolves anything.

Neither test asserts anything load-bearing on the ack byte.

## Red proof

Both tests are `#[cfg(target_os = "linux")]`, so this was run on an x86_64 Linux
host, not the macOS dev box.

Green — `cargo nextest run -p mvm-hostd raw_egress`:

```
        PASS [   0.011s] ( 1/16) mvm-hostd supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg
        PASS [   0.011s] ( 2/16) mvm-hostd supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_the_target
        PASS [   0.011s] ( 3/16) mvm-hostd supervisor::raw_egress::tests::denied_target_sends_fail_ack_then_closes
        PASS [   0.011s] ( 4/16) mvm-hostd supervisor::raw_egress::tests::connect_first_admitted_falls_over_from_unreachable_ipv6_to_ipv4
        PASS [   0.011s] ( 5/16) mvm-hostd supervisor::raw_egress::tests::an_available_tunnel_slot_reaches_the_resolver_on_the_vsock_leg
        PASS [   0.011s] ( 6/16) mvm-hostd supervisor::raw_egress::tests::an_available_tunnel_slot_reaches_the_resolver
        PASS [   0.011s] ( 7/16) mvm-hostd supervisor::raw_egress::tests::a_gate_refusal_returns_the_tunnel_slot
        PASS [   0.008s] ( 8/16) mvm-hostd supervisor::raw_egress::tests::malformed_or_unterminated_first_line_fails_closed
        PASS [   0.009s] ( 9/16) mvm-hostd supervisor::raw_egress::tests::load_upstreams_from_resolv_conf_parses_nameservers
        PASS [   0.009s] (10/16) mvm-hostd supervisor::raw_egress::tests::parse_dns_response_extracts_ip_answers
        PASS [   0.010s] (11/16) mvm-hostd supervisor::raw_egress::tests::splice_sends_fail_ack_when_no_admitted_ip_is_reachable
        PASS [   0.011s] (12/16) mvm-hostd supervisor::raw_egress::tests::dns_marker_dispatches_to_policy_gated_handler
        PASS [   0.010s] (13/16) mvm-hostd supervisor::raw_egress::tests::raw_vsock_handlers_run_concurrently
        PASS [   0.010s] (14/16) mvm-hostd supervisor::raw_egress::tests::splice_proxies_both_directions
        PASS [   0.008s] (15/16) mvm-hostd supervisor::raw_egress::tests::splice_sends_ok_ack_before_tunneling
        PASS [   3.015s] (16/16) mvm-hostd supervisor::raw_egress::tests::connect_first_admitted_skips_unreachable_then_uses_reachable
────────────
     Summary [   3.019s] 16 tests run: 16 passed, 1920 skipped
```

Then the `rate_guard.try_admit_tunnel()` block deleted from
`handle_raw_conn_blocking_with_resolver`, nothing else changed:

```
        PASS [   0.010s] ( 2/16) mvm-hostd supervisor::raw_egress::tests::connect_first_admitted_falls_over_from_unreachable_ipv6_to_ipv4
        PASS [   0.010s] ( 3/16) mvm-hostd supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_the_target
        PASS [   0.010s] ( 4/16) mvm-hostd supervisor::raw_egress::tests::an_available_tunnel_slot_reaches_the_resolver_on_the_vsock_leg
        FAIL [   0.010s] ( 5/16) mvm-hostd supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg

  stdout ───

    running 1 test
    test supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg ... FAILED

    failures:

    failures:
        supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1763 filtered out; finished in 0.00s

  stderr ───
    raw-egress: refusing target blocked.test:80: blocked.test is not admitted; no hosts are admitted

    thread 'supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg' (2775281) panicked at crates/mvm-hostd/src/supervisor/raw_egress.rs:1417:9:
    assertion `left == right` failed: a full tunnel pool must refuse before the host does any DNS work
      left: 1
     right: 0
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

        PASS [   0.011s] ( 6/16) mvm-hostd supervisor::raw_egress::tests::an_available_tunnel_slot_reaches_the_resolver
        PASS [   0.014s] ( 7/16) mvm-hostd supervisor::raw_egress::tests::a_gate_refusal_returns_the_tunnel_slot
        PASS [   0.008s] ( 8/16) mvm-hostd supervisor::raw_egress::tests::parse_dns_response_extracts_ip_answers
        PASS [   0.009s] ( 9/16) mvm-hostd supervisor::raw_egress::tests::load_upstreams_from_resolv_conf_parses_nameservers
        PASS [   0.010s] (10/16) mvm-hostd supervisor::raw_egress::tests::raw_vsock_handlers_run_concurrently
        PASS [   0.010s] (11/16) mvm-hostd supervisor::raw_egress::tests::malformed_or_unterminated_first_line_fails_closed
        PASS [   0.011s] (12/16) mvm-hostd supervisor::raw_egress::tests::dns_marker_dispatches_to_policy_gated_handler
        PASS [   0.010s] (13/16) mvm-hostd supervisor::raw_egress::tests::splice_proxies_both_directions
        PASS [   0.010s] (14/16) mvm-hostd supervisor::raw_egress::tests::splice_sends_fail_ack_when_no_admitted_ip_is_reachable
        PASS [   0.008s] (15/16) mvm-hostd supervisor::raw_egress::tests::splice_sends_ok_ack_before_tunneling
        PASS [   3.014s] (16/16) mvm-hostd supervisor::raw_egress::tests::connect_first_admitted_skips_unreachable_then_uses_reachable
────────────
     Summary [   3.018s] 16 tests run: 15 passed, 1 failed, 1920 skipped
        FAIL [   0.010s] ( 5/16) mvm-hostd supervisor::raw_egress::tests::an_exhausted_tunnel_pool_refuses_before_resolving_on_the_vsock_leg
error: test run failed
```

That stderr line is the trap made visible: with the bound gone the guest still got
its `Fail` byte — the gate produced it a few lines further down, off the
resolved-but-unadmitted address — and the test sailed past its `assert_eq!(ack[0],
Fail)` before dying on the resolver count. An ack-byte assertion would have stayed
green. The companion passing in the red run is the correct result; it is not the
witness.

Code restored, both green again.

## Other verification

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run -p mvm-hostd` — 1891 passed on macOS (Linux-gated pair skipped), 1926 passed on Linux
- `cargo zigbuild -p mvm-hostd --all-targets --target x86_64-unknown-linux-gnu` — clean
- xtask: `check-no-spec-refs-in-comments`, `check-uniform-vsock-egress`, `check-vsock-only-egress`, `check-honesty`, `check-witness-citations`, `check-sprint-append` — all clean
