### PR TITLE
chore(deps): re-resolve Cargo.lock against the manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3019,7 +3019,7 @@ dependencies = [
  "mvm-sdk",
  "mvm-vmm",
  "nix 0.29.0",
- "rand 0.8.6",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -4201,22 +4201,11 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -4229,16 +4218,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.1",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4256,9 +4235,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"


### PR DESCRIPTION
## The drift

`origin/main` fails `cargo metadata --locked`:

```
error: cannot update the lock file /.../Cargo.lock because --locked was passed to prevent this
```

The rand unification bumped `mvm-build` to `rand 0.10` in its manifest but left the lock naming `rand 0.8.6` for that package. The lock therefore still carried `rand 0.8.6`, `rand_chacha 0.3.1` and `rand_core 0.6.4` with nothing depending on them.

## Why no lane caught it

The PR and merge-queue lanes build before the `--locked` gates run, and that build rewrites the lock on disk — so by the time `xtask check-core-runtime-free` / `check-closure-budget` / `check-feature-closure-budget` / `check-content-address-determinism` shell out to `cargo tree --locked`, the file already matches. Verified: `Lint policy` is green on the current merge-queue runs.

What does not get that free rewrite:

- `security.yml`'s `cargo build --release --locked` and `cargo zigbuild --release --locked` — no preceding unlocked build.
- Any local `cargo` invocation, which silently dirties a contributor's tree with lock churn that then rides along in an unrelated commit.

## The change

`Cargo.lock` only — the resolution the manifests already ask for. No dependency changes; three orphaned packages drop out.

Deliberately scoped to the lock: `xtask check-duplicate-majors` now reports `rand` and `rand_core` as stale ALLOWLIST entries, but #2516 and #2530 are both in the merge queue editing `xtask/src/check_duplicate_majors.rs`, so touching it here would conflict with them. Worth a follow-up sweep once those land.

## Verification

- `cargo metadata --locked` — exit 0 (was 101)
- `cargo tree -p mvm-core -e no-dev --prefix none --locked` — exit 0 (was 101)
- `cargo run -p xtask -- check-duplicate-majors` — clean, 9 known duplicate-major crates