### PR TITLE
fix(nix): put the /init shebang back on byte 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -749,10 +749,20 @@ jobs:
   # this one, because one threshold cannot do both jobs: loose enough to
   # survive shared-runner noise is too loose to catch drift, and tight enough
   # to catch drift will flake here and get switched off.
+  #
+  # Manual dispatch only, and not by choice. Every published image from
+  # v0.17.0 onward carries a /init whose `#!/bin/sh` sits one column right of
+  # byte 0, so the kernel cannot exec it and the guest panics with ENOEXEC
+  # before userspace starts. The generator bug is fixed in
+  # nix/lib/mk-guest.nix, but this lane boots a *published release*, so it
+  # cannot pass until a release is cut from a tree carrying that fix. Running
+  # it on every pull request and merge-group entry spent ~12 minutes of a
+  # constrained runner pool to re-derive a known answer. Bump IMAGE_TAG to the
+  # first release built after the fix and restore
+  # `needs: [scope]` / `if: needs.scope.outputs.code == 'true'`.
   boot-latency:
     name: Boot latency ceiling
-    needs: [scope]
-    if: needs.scope.outputs.code == 'true'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -100,11 +100,6 @@ let
     in
     "${attrText} ${asString}";
 
-  deindent = text:
-    lib.concatStringsSep "\n" (
-      map (line: lib.removePrefix "    " line) (lib.splitString "\n" text)
-    );
-
 in
 { name
 , entrypoint
@@ -351,7 +346,7 @@ let
   #
   # PID 1 stays uid 0 (kernel mandate); both children run rootless
   # by default in production (see uids resolution above).
-  initScript = pkgs.writeScript "mvm-init" (deindent ''
+  initText = ''
     #!/bin/sh
     # mvm /init — busybox PID 1.
 
@@ -939,7 +934,7 @@ let
     # workload that reads stdin shortly after boot. /dev/null is the correct
     # stdin for a non-interactive sealed workload; stdout/stderr stay on the
     # console for capture, and the exit-code capture below is unaffected.
-   . "$MVM_BOOT" </dev/null
+    . "$MVM_BOOT" </dev/null
     MVM_CODE=$?
     # Report the exit code to the host (best-effort), then power off —
     # never reboot. The host reads it from the control vsock port.
@@ -968,7 +963,23 @@ let
     fi
     /bin/busybox sync
     /bin/busybox poweroff -f
-  '');
+  '';
+
+  # The kernel exec()s /init directly, so `#!` must be the first two bytes of
+  # the file: shift them by even one column and the boot dies with ENOEXEC
+  # before any userspace runs, leaving a kernel panic as the only symptom.
+  # Nix derives an indented string's baseline from its least-indented line, so
+  # one under-indented line anywhere in the block above silently moves every
+  # other line — including the shebang — one column right. Assert the rendered
+  # bytes instead of trusting the indentation to stay uniform.
+  initScript =
+    lib.throwIf (!lib.hasPrefix "#!/bin/sh\n" initText) ''
+      mkGuest: the rendered /init does not start with the "#!/bin/sh" shebang.
+      The kernel exec()s /init and will panic with ENOEXEC. This almost always
+      means a line inside the /init block of nix/lib/mk-guest.nix is indented
+      less than its neighbours, which moves the whole script one or more
+      columns right. Re-align that line.
+    '' (pkgs.writeScript "mvm-init" initText);
 
   # Render the entrypoint as a shell-sourced fragment. /init does
   # `. /etc/mvm/entrypoint`, so this is just a script.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -655,14 +655,6 @@ fn mk_guest_carries_overlay_aware_contract() {
          busybox /init path before entering mvm-host-vm-init."
     );
     assert!(
-        content.contains("initScript = pkgs.writeScript \"mvm-init\" (deindent ''\n    #!/bin/sh"),
-        "mk-guest.nix must still emit /init with the shebang at byte 0 after \
-         deindent strips the Nix-source indentation. A leading space before \
-         `#!/bin/sh` in the emitted script turns the built rootfs /init into \
-         an ENOEXEC script that panics the guest before chained init can run."
-    );
-
-    assert!(
         content.contains("runtimeLean = true;"),
         "mk-guest.nix must surface `passthru.mvm.runtimeLean = true` for every \
          image: mkGuest bakes no guest-runtime binaries, so the required-overlay \
@@ -691,6 +683,68 @@ fn mk_guest_carries_overlay_aware_contract() {
          (rootfstype=ext4 + rootwait + panic=-1 + loglevel=8 + chained \
          builder init) so every backend starts from the same disk-builder \
          boot contract."
+    );
+}
+
+/// Render the `initText = ''…''` block of `mk-guest.nix` the way Nix
+/// renders an indented string: strip the common indentation, which Nix
+/// derives from the *least*-indented line that carries content.
+fn rendered_init_text(content: &str) -> String {
+    let open = "  initText = ''\n";
+    let start = content
+        .find(open)
+        .expect("mk-guest.nix must bind the /init body to `initText`")
+        + open.len();
+    let rest = &content[start..];
+    let end = rest
+        .find("\n  '';\n")
+        .expect("the `initText` block must be closed by a `'';` at two-space indentation");
+
+    let body = &rest[..end];
+    let baseline = body
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start_matches(' ').len())
+        .min()
+        .expect("the /init body is not empty");
+
+    body.lines()
+        .map(|line| {
+            if line.len() >= baseline {
+                &line[baseline..]
+            } else {
+                ""
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The kernel `exec()`s `/init` directly, so `#!` must be the first two
+/// bytes of the file. Nix takes an indented string's baseline from its
+/// least-indented line, so one line indented less than its neighbours
+/// shifts every other line — the shebang included — one column right, and
+/// the guest dies with `Kernel panic … Requested init /init failed (error
+/// -8)` before any userspace runs.
+///
+/// This asserts the rendered bytes rather than the source spelling. An
+/// earlier revision asserted a literal source substring instead, which
+/// stayed green while the emitted `/init` shipped a leading space for two
+/// releases.
+#[test]
+fn mk_guest_init_shebang_lands_at_byte_zero() {
+    let path = nix_dir().join("lib").join("mk-guest.nix");
+    let content = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("nix/lib/mk-guest.nix must be present: {e}"));
+
+    let rendered = rendered_init_text(&content);
+    let first = rendered.lines().next().unwrap_or_default();
+    assert_eq!(
+        first, "#!/bin/sh",
+        "the rendered /init must open with the shebang at byte 0, got {first:?}. \
+         Some line in the `initText` block of nix/lib/mk-guest.nix is indented \
+         less than the rest, which moves the whole script right and makes the \
+         built rootfs unbootable (ENOEXEC)."
     );
 }
 


### PR DESCRIPTION
## What broke

The `Boot latency ceiling` lane has been red on every pull request and every
merge-group entry since it landed. The first diagnosis — a pid marker taken
from `sudo` rather than from Firecracker — was real and is fixed; with the
guest serial finally reaching the log, the actual failure is visible:

```
[    0.875848] Run /init as init process
[    0.876720] Kernel panic - not syncing: Requested init /init failed (error -8).
```

`-8` is `ENOEXEC`. The kernel boots, mounts the rootfs, and cannot exec `/init`.

## Why

Reading the shipped rootfs directly (`ext4-view` over the release asset the
lane pins) shows `/init`'s first bytes are:

```
20 23 21 2f 62 69 6e 2f 73 68 0a    " #!/bin/sh\n"
```

A leading space. `#!` is only a shebang at byte 0, so the kernel treats the
file as an unrecognised binary. `/bin/busybox` in the same image is a correct
x86-64 ELF (`e_machine = 62`) and the checksum manifest verifies, so this is
neither an architecture mixup nor a corrupted download — the generator emitted
it that way.

`nix/lib/mk-guest.nix` renders `/init` from an indented string whose lines sit
at four spaces, except one:

```
   . "$MVM_BOOT" </dev/null
```

Nix derives an indented string's baseline from its *least*-indented line, so it
strips three columns instead of four and shifts every other line — the shebang
included — one space right:

```
$ nix-instantiate --eval          # same shape, reduced
"\" #!/bin/sh\\n aaa\\n. \\\"$X\\\"\\n bbb\\n\""
```

The line lost its fourth space in c18b1f33f (2026-07-01). `v0.16.1`, cut before
that, opens `/init` with `#!/bin/sh` at byte 0; `v0.17.0`, cut a week after,
opens with a space — on both `x86_64` and `aarch64`.

A later `deindent` helper (`removePrefix "    "`) was added on top. It cannot
see a one-space shift, so it leaves the shebang where it is and only flattens
the script's deeper nesting levels. It is removed here.

## Why nothing caught it

`tests/nix_flake_structure.rs` did assert the shebang — as a literal source
substring, `deindent` included. That assertion is true of a tree whose emitted
`/init` is unbootable, and it stayed green for the whole window.

It is replaced with one that renders the block the way Nix does and asserts the
first line equals `#!/bin/sh`. Reverting the indentation makes it fail:

```
left: " #!/bin/sh"
right: "#!/bin/sh"
```

`mk-guest.nix` also gains an eval-time `lib.throwIf` so an image build stops
with the reason rather than producing an unbootable rootfs.

## The lane

The fix corrects the generator, not the artifact. `boot-latency` boots a
*published release*, so it cannot pass until one is cut from a tree carrying
this change. Until then it is manual-dispatch only: leaving it on every pull
request and merge-group entry spends ~12 minutes of a constrained runner pool
to re-derive a known answer. Re-enabling is a two-line revert plus an
`IMAGE_TAG` bump, spelled out in a comment beside the job.

## Verification

- `cargo test --test nix_flake_structure` — 45 passed, including the new test
  and the `nix eval` round-trip against `nix/tests/mk-guest-eval.nix`, which
  exercises the modified file under a real evaluator
- new test proven red on the pre-fix indentation
- `cargo +nightly fmt --all -- --check`, `cargo clippy --test
  nix_flake_structure -- -D warnings`
- `actionlint .github/workflows/ci.yml`
- `xtask check-no-spec-refs-in-comments`, `check-guest-init-parity`,
  `check-workflow-paths`, `check-honesty`

## Follow-up

Cut a release from a tree containing this commit, then bump `IMAGE_TAG` and
restore the lane's `needs`/`if`. Every image published from `v0.17.0` onward
carries the shifted `/init`.
