### PR TITLE
fix(sec): delete the dead wasm branch, witness the launch plan binding, baseline three equivalences

### DIFF
--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -117,27 +117,19 @@ pub fn resolve_manifest_arg(arg: &str) -> Result<ManifestArgRef> {
 
     // A manifest that selects a wasm module bypasses the build/slot system
     // entirely: the module exists at the declared path and is run directly.
+    //
+    // Neither half of that is re-derived here. `read_file` resolves a relative
+    // `wasm` against the manifest's own directory before it returns, and
+    // `canonical` is absolute, so what arrives is always an absolute path;
+    // and its `validate` refuses a manifest whose module is not an existing
+    // file, on that same resolved path. A second copy of either rule would be
+    // free to drift from the one that ran.
     let manifest = mvm_core::domain::manifest::Manifest::read_file(&canonical)
         .with_context(|| format!("Reading manifest {} for wasm source", canonical.display()))?;
     if let Some(wasm) = manifest.wasm.as_deref() {
-        let module_path = std::path::Path::new(wasm);
-        if !module_path.is_absolute() {
-            let base = canonical.parent().expect("manifest has a parent directory");
-            let joined = base.join(module_path);
-            if joined.is_file() {
-                return Ok(ManifestArgRef::WasmModule {
-                    manifest_path: canonical,
-                    module_path: joined,
-                });
-            }
-        }
-        // No existence check here. `Manifest::read_file` already refuses a
-        // manifest whose `wasm` field does not point to an existing file, so
-        // by this line the module is known to exist — a second check was
-        // unreachable, which is why mutating it away changed no test.
         return Ok(ManifestArgRef::WasmModule {
             manifest_path: canonical,
-            module_path: module_path.to_path_buf(),
+            module_path: std::path::PathBuf::from(wasm),
         });
     }
 
@@ -360,11 +352,11 @@ mod tests {
 
     /// A relative wasm module resolves against the manifest's own directory.
     ///
-    /// The guard is `if !module_path.is_absolute()`. Deleting the `!` inverts
-    /// it: a relative path skips the join and is then looked up against the
-    /// process working directory instead of the manifest's, which resolves to
-    /// a different file or to nothing at all depending on where mvmctl was
-    /// invoked from.
+    /// `Manifest::read_file` is what does that, before this function sees the
+    /// path. The `if !module_path.is_absolute()` join that used to sit here
+    /// re-derived the same rule and could not change the outcome either way,
+    /// which is why deleting its `!` left every test passing; it is gone, and
+    /// this asserts the resolution the caller actually depends on.
     #[test]
     fn a_relative_wasm_module_resolves_against_the_manifest_directory() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -520,6 +512,81 @@ mod tests {
         env.remove("MVM_HYPERVISOR");
         env.remove("MVM_BACKEND");
         assert_eq!(resolve_effective_hypervisor("firecracker"), "hvf");
+    }
+
+    /// The module path handed on is absolute either way the manifest names it,
+    /// and the manifest may be given as its directory rather than its file.
+    ///
+    /// The absolute form is the arm the deleted `is_absolute` join used to
+    /// skip, so nothing covered it; the relative form re-confirms through the
+    /// directory entry point that `Manifest::read_file` is doing the
+    /// resolution. Absoluteness is asserted because callers hand this straight
+    /// to the wasm backend, which never sees the manifest's directory.
+    #[test]
+    fn a_wasm_manifest_resolves_to_the_absolute_module_path() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let module = tmp.path().join("app.wasm");
+        std::fs::write(&module, b"\0asm").expect("write module");
+        let canonical_module = std::fs::canonicalize(&module).expect("canonicalize module");
+
+        // The relative form: resolved against the manifest's directory.
+        let relative_dir = tmp.path().join("relative");
+        std::fs::create_dir(&relative_dir).expect("create dir");
+        std::fs::write(
+            relative_dir.join("mvm.toml"),
+            b"name = \"wasm-app\"\nwasm = \"../app.wasm\"\n",
+        )
+        .expect("write manifest");
+
+        // The absolute form: taken as written.
+        let absolute_dir = tmp.path().join("absolute");
+        std::fs::create_dir(&absolute_dir).expect("create dir");
+        std::fs::write(
+            absolute_dir.join("mvm.toml"),
+            format!("name = \"wasm-app\"\nwasm = \"{}\"\n", module.display()).as_bytes(),
+        )
+        .expect("write manifest");
+
+        for dir in [&relative_dir, &absolute_dir] {
+            match resolve_manifest_arg(&dir.to_string_lossy()).unwrap_or_else(|e| {
+                panic!("a wasm manifest in {} must resolve: {e}", dir.display())
+            }) {
+                ManifestArgRef::WasmModule { module_path, .. } => {
+                    assert!(
+                        module_path.is_absolute(),
+                        "the module path handed on must be absolute: {}",
+                        module_path.display()
+                    );
+                    assert_eq!(
+                        std::fs::canonicalize(&module_path).expect("canonicalize resolved module"),
+                        canonical_module,
+                        "resolved to a different module than the manifest named"
+                    );
+                }
+                other => panic!("a wasm manifest must resolve to WasmModule, got {other:?}"),
+            }
+        }
+    }
+
+    /// A manifest whose wasm module is missing is refused, not booted.
+    #[test]
+    fn a_wasm_manifest_naming_a_missing_module_is_refused() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("mvm.toml"),
+            b"name = \"wasm-app\"\nwasm = \"absent.wasm\"\n",
+        )
+        .expect("write manifest");
+
+        let err = resolve_manifest_arg(&tmp.path().to_string_lossy())
+            .expect_err("a manifest naming a module that is not there must not resolve");
+        // The refusal comes from the manifest read, which validates the module
+        // exists before this function sees the path -- the reason there is no
+        // second existence check here.
+        assert!(
+            format!("{err:#}").contains("existing file"),
+            "refusal must name the missing module; got: {err:#}"
+        );
     }
 
     /// `looks_like_path` is a five-way disjunction deciding whether a

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -3721,3 +3721,37 @@ mod admit_and_start_params_builder_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod launch_decision_record_tests {
+    use super::*;
+
+    /// The launch decision record names the plan it launched — in the
+    /// scenario it describes and in the attestation it binds to.
+    ///
+    /// Deleting either `plan_id` leaves a record that says a workload was
+    /// launched but not which signed plan authorized it, and the scenario's
+    /// `plan_id` is part of the record's content address, so dropping it also
+    /// re-addresses the decision. Both deletions survived mutation because
+    /// nothing read the fields back.
+    #[test]
+    fn a_launch_decision_record_binds_the_plan_it_launched() {
+        let plan = mvm_core::plan::test_support::PlanFixture::new()
+            .plan_id("plan-under-launch")
+            .build();
+
+        let record = launch_decision_record(&plan, "firecracker");
+
+        assert_eq!(record.category, DecisionCategory::Launch);
+        assert_eq!(
+            record.scenario.plan_id.as_deref(),
+            Some("plan-under-launch"),
+            "the scenario must name the launched plan"
+        );
+        assert_eq!(
+            record.attestation.plan_id.as_deref(),
+            Some("plan-under-launch"),
+            "the attestation binding must name the launched plan"
+        );
+    }
+}

--- a/specs/sprint/delivery/2537-mutation-witness-lane-repair.md
+++ b/specs/sprint/delivery/2537-mutation-witness-lane-repair.md
@@ -1,0 +1,100 @@
+# 2537 — Mutation-witness lane repair
+
+## What was red
+
+Five shards of the nightly `Security` workflow's `Claim witnesses —
+mutation-tested` lane failed on `bdff1866`: `mvm-cli`, `mvm-core`, `mvm-vmm`,
+`mvm-hostd`, `mvm-contract`. Nothing about the lane's tooling was broken. Every
+failure was the ratchet doing its job — seven mutants of claim-enforcement code
+that no witness detected, none of them in
+`xtask/mutation-witness-baseline.json`.
+
+They fall into two groups.
+
+## Group 1 — four real holes, now closed by tests
+
+| file | mutant | claim |
+| --- | --- | --- |
+| `crates/mvm-contract/src/substitution.rs` | `PlaceholderMap::is_empty -> true` / `-> false` | 13 |
+| `crates/mvm-cli/src/commands/shared/resolve.rs` | `delete !` in `resolve_manifest_arg` | 10 |
+| `crates/mvm-hostd/src/plan_admission.rs` | `delete field plan_id` from `DecisionScenario` and from `AttestationBinding` in `launch_decision_record` | 1, 8, 18 |
+
+`PlaceholderMap::is_empty` could be pinned to either constant unnoticed:
+nothing asserted the map's own answer to "did this session mint anything"
+before an insert or after one. That one landed separately in #2532 while this
+was in flight, so it is not in this change; it is listed because it is one of
+the seven the lane reported.
+
+`launch_decision_record` names the plan it launched twice — once in the
+scenario it describes, once in the attestation it binds to. Either could be
+deleted and the record still emitted, leaving an audit entry that says a
+workload was launched but not which signed plan authorized it. The scenario's
+`plan_id` is inside the record's content address, so the deletion also
+re-addressed the decision. Nothing read either field back.
+
+`resolve_manifest_arg` is the more interesting one. The ratchet keys on the
+mutant's description, so `delete ! in resolve_manifest_arg` covered two sites,
+and they were not the same kind of problem:
+
+- `if !module_path.is_file()` — reachable. Inverting it refuses every wasm
+  manifest as a module that "does not exist". But the check is a verbatim
+  duplicate of `Manifest::validate`, which runs the same `path.is_file()` on
+  the same already-resolved path a few lines earlier.
+- `if !module_path.is_absolute()` — unreachable. `Manifest::read_file` resolves
+  a relative `wasm` against the manifest's own directory before returning, and
+  the path handed to it is canonicalized, so what arrives is always absolute.
+  With the `!` deleted the branch runs, `base.join(absolute)` returns the
+  absolute path unchanged, and the function returns the same value.
+
+Both are deleted rather than witnessed. Baselining was not an option for
+either: the two share one identity, so a waiver for the dead branch would have
+suppressed the live one with it. What they encoded is asserted directly instead
+— a wasm manifest resolves to its module by absolute path whether the manifest
+names it relatively or absolutely, and a manifest naming an absent module is
+refused.
+
+## Group 2 — three provably equivalent mutants, baselined
+
+`replace X::builder -> XBuilder with Default::default()` on `SynthesisInput`,
+`SubstitutionSpawnParams` and `AdmitAndStartParams`. In all three,
+`builder()` is a one-line alias for `XBuilder::new()` and the file's
+`impl Default for XBuilder` returns `Self::new()` — `Default::default()`
+evaluates the identical expression. No test can distinguish them.
+
+This class will recur: the builder pattern is the house rule for structs with
+several optional fields, `clippy::new_without_default` requires the `Default`
+impl that makes the mutant viable, and every new builder on a claim-surface
+file arrives with one. Each is one baseline line with the equivalence written
+out; if a fourth appears, that is what to add.
+
+## What is not proven
+
+The `mvm-hostd` shard was killed by a runner shutdown after 3h22m, having
+mutated 6 of its 10 surface files. The three new misses above are from the
+files it reached. The four it never reached — `supervisor/dns_audit.rs`,
+`supervisor/network/stages.rs`, `supervisor/network_endpoint.rs`,
+`supervisor/network_endpoint_proxy.rs` (claims 10, 13, 17, 13) — carry no
+evidence either way, from that run or from this change. A local sweep of them
+was started and abandoned: `network/stages.rs` alone generates 152 mutants, and
+at the rate a laptop retires them the four files are a multi-hour run. What it
+did cover — 18 of `stages.rs`'s 152 — came back with nothing missed, which is
+weak evidence and is offered as nothing more. The next nightly is what measures
+them, and it may find more.
+
+The `mvm-cli` shard also reported eleven baseline entries in `pull_core.rs` and
+`resolve.rs` as now caught. Dropping stale entries tightens the ratchet, but
+`pull_core.rs` needs its own half-hour run to confirm, so they are left in
+place rather than dropped on one observation.
+
+## Overlap with #2532
+
+\#2532 landed first, mid-flight, and reached the same conclusion that one of
+the two wasm branches is dead — but removed the other one, and said in its own
+body that the surviving `is_absolute` mutant stands and the lane is still red.
+That is correct: the branch it kept is the dead one.
+
+This change rebases onto it rather than around it. Its `is_empty` test stands
+and the duplicate written here was dropped; its `resolve.rs` test stands, with
+its doc comment corrected, because the mutation it claimed to witness is one no
+test can catch. What remains is the deletion of the dead branch, the coverage
+the deletion needs, and the other four crates.

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -1007,6 +1007,11 @@
       "reason": "the discriminating input is a bare relative name that exists as a file or directory in the process's current directory. A test cannot create one without writing into the repo working tree or mutating process-global CWD shared by parallel tests under the documented cargo test fallback."
     },
     {
+      "file": "crates/mvm-core/src/plan/synthesis.rs",
+      "mutant": "replace SynthesisInput<'a>::builder -> SynthesisInputBuilder<'a> with Default::default()",
+      "reason": "provably equivalent: `SynthesisInput::builder` is a one-line alias for `SynthesisInputBuilder::new()`, and this file's `impl Default for SynthesisInputBuilder` returns `Self::new()`, so `Default::default()` evaluates the identical expression. No test can distinguish the two, and the builder's own required-field refusal is asserted directly by the empty-builder test beside it."
+    },
+    {
       "file": "crates/mvm-hostd/src/admission_budget.rs",
       "mutant": "replace committed -> MachineCharge with Default::default()",
       "reason": "committed aggregates persisted MachineCharge records from disk; the aggregation logic is covered by integration tests that write and read back real records."
@@ -1030,6 +1035,11 @@
       "file": "crates/mvm-hostd/src/plan_admission.rs",
       "mutant": "replace * with + in admit_within_host_budget",
       "reason": "The BUNDLE_JSON_MAX_BYTES cap is fail-closed; shrinking it refuses strictly more input. Catching the mutation needs a fixture between the two sizes, which the existing boundary test deliberately avoids as a tautology."
+    },
+    {
+      "file": "crates/mvm-hostd/src/plan_admission.rs",
+      "mutant": "replace AdmitAndStartParams<'a>::builder -> AdmitAndStartParamsBuilder<'a> with Default::default()",
+      "reason": "provably equivalent: `AdmitAndStartParams::builder` is a one-line alias for `AdmitAndStartParamsBuilder::new()`, and this file's `impl Default for AdmitAndStartParamsBuilder` returns `Self::new()`, so `Default::default()` evaluates the identical expression. No test can distinguish the two, and the builder's own required-field refusal is asserted directly by the empty-builder test beside it."
     },
     {
       "file": "crates/mvm-hostd/src/supervisor/audit_file.rs",
@@ -1180,6 +1190,11 @@
       "file": "crates/mvm-sdk/src/compile/deps_audit.rs",
       "mutant": "replace * with + in hash_file_raw",
       "reason": "equivalent: the mutated expression is the read-buffer size (64 * 1024 versus 64 + 1024). It changes how many bytes are read per iteration and nothing else; the resulting SHA-256 is identical, so no assertion on behaviour can separate them."
+    },
+    {
+      "file": "crates/mvm-vmm/src/host/network_endpoint_spawn.rs",
+      "mutant": "replace SubstitutionSpawnParams<'a>::builder -> SubstitutionSpawnParamsBuilder<'a> with Default::default()",
+      "reason": "provably equivalent: `SubstitutionSpawnParams::builder` is a one-line alias for `SubstitutionSpawnParamsBuilder::new()`, and this file's `impl Default for SubstitutionSpawnParamsBuilder` returns `Self::new()`, so `Default::default()` evaluates the identical expression. No test can distinguish the two, and the builder's own required-field refusal is asserted directly by the empty-builder test beside it."
     }
   ]
 }


### PR DESCRIPTION
Five shards of the nightly `Security` workflow's `Claim witnesses — mutation-tested`
lane failed on `bdff1866` (run 31865236109): `mvm-cli`, `mvm-core`, `mvm-vmm`,
`mvm-hostd`, `mvm-contract`.

**Nothing about the lane's tooling is broken.** Every failure is the ratchet doing
its job: seven mutants of claim-enforcement code that no witness detects, none of
them in `xtask/mutation-witness-baseline.json`. #2532 closed one of them
(`PlaceholderMap::is_empty`) while this was in flight; this is the rest.

## The two `delete !` mutants in `resolve_manifest_arg` (claim 10)

They shared one ratchet identity but were different problems, and #2532 removed
the wrong one of the pair — as its own body says: *"the added test does not kill
the `delete !` mutant on `is_absolute`… That survivor stands"* and *"The lane is
still red."*

- **`!module_path.is_file()`** — reachable. Inverting it refuses every wasm
  manifest. Removable because it is a verbatim duplicate of `Manifest::validate`,
  which runs the same `path.is_file()` on the same resolved path a few lines
  earlier. #2532 removed this one.
- **`!module_path.is_absolute()`** — dead, and the survivor. `Manifest::read_file`
  resolves a relative `wasm` against the manifest's own directory before returning,
  and the path handed to it is canonicalized, so the module path is always
  absolute; with the `!` deleted the branch runs, `base.join(absolute)` returns it
  unchanged, and the function produces the same value. **Equivalent — no test can
  ever catch it.** This PR deletes it.

Deleting was the only move available. A baseline waiver keys on the description,
so a waiver for the dead branch would have suppressed the reachable one with it.

The absolute form is the arm that `join` used to skip, so nothing covered it; it
is covered now, along with the refusal a manifest naming an absent module must
produce. **#2532's test stands** — its doc comment is corrected, because it
described the mutation it does not catch, which is the one now deleted.

## `launch_decision_record` (claims 1, 8, 18)

`delete field plan_id` from `DecisionScenario` **and** from `AttestationBinding`.
The launch record names the plan twice. Either field could be deleted and the
record still emitted, leaving an audit entry that says a workload launched but not
which signed plan authorized it. The scenario's `plan_id` is inside the record's
content address, so the deletion also re-addresses the decision. Nothing read
either field back.

## Three provably equivalent mutants, baselined

`replace X::builder -> XBuilder with Default::default()` on `SynthesisInput`,
`SubstitutionSpawnParams` and `AdmitAndStartParams`. In all three, `builder()` is a
one-line alias for `XBuilder::new()` and the file's `impl Default for XBuilder`
returns `Self::new()` — `Default::default()` evaluates the identical expression.
Each is one baseline line with the equivalence written out.

This class will recur: the builder pattern is the house rule for structs with
several optional fields, `clippy::new_without_default` requires the `Default` impl
that makes the mutant viable, and every new builder on a claim-surface file arrives
with one.

## Evidence

`cargo mutants` run locally per file with the lane's own invocation
(`-p <pkg> --file <path> --test-tool nextest --timeout-multiplier 5
--minimum-test-timeout 60`) against an isolated `HOME`/`MVM_HOME`:

```
crates/mvm-hostd/src/plan_admission.rs  --re launch_decision_record
    3 mutants: 2 caught, 1 unviable, 0 missed
    caught: delete field plan_id from struct DecisionScenario expression in launch_decision_record
    caught: delete field plan_id from struct AttestationBinding expression in launch_decision_record
crates/mvm-cli/src/commands/shared/resolve.rs  (whole file)
    25 mutants: 23 caught, 2 unviable, 0 missed
```

Both `plan_id` mutants were `MISSED` in run 31865236109 against unchanged source.
An intermediate run against the source that kept `!is_file` and dropped only
`is_absolute` came back 26 mutants / 24 caught / 2 unviable / 0 missed, with
`delete !` on the surviving guard among the caught — so the reachable half is
witnessed either way, and removing the duplicate does not reopen it.

`cargo nextest run -p mvm-contract -p mvm-hostd` — 2,792 passed.

Gates: `cargo +nightly fmt --all -- --check`, `cargo clippy --workspace
--all-targets -- -D warnings`, `cargo run -p xtask -- check-mutation-witnesses`
(surface pinned and clean), plus `check-claim-catalog`, `check-witness-citations`,
`check-claim-witness-freshness`, `check-no-overclaim`, `check-honesty`,
`check-no-spec-refs-in-comments`, `check-test-home-isolation`, `check-file-size`,
`check-sprint-append`.

## What this PR does not prove

The `mvm-hostd` shard died to a runner shutdown after 3h22m, 6 of 10 files in.
That is an infrastructure failure independent of the survivors and is not addressed
here.

**Its four unreached files carry no evidence either way** —
`supervisor/dns_audit.rs`, `supervisor/network/stages.rs`,
`supervisor/network_endpoint.rs`, `supervisor/network_endpoint_proxy.rs`, claims
10/13/17/13. A local sweep was started and abandoned: `stages.rs` alone generates
152 mutants. The 18 it retired came back with nothing missed — weak evidence,
offered as nothing more. If the next nightly finds a survivor there, that is a hole
this PR did not know about, not a regression from it.

Eleven baseline entries in `pull_core.rs` and `resolve.rs` were reported as now
caught. Dropping stale entries tightens the ratchet, but one observation is thin
evidence for deleting a waiver, so they are left in place.

The `Boot latency ceiling` failure on this PR is pre-existing and repo-wide: the
same job is red on the merge-queue runs for #2532, #2534, #2533, #2515 and #2501.
#2538 fixes it (`/init` shebang not at byte 0 → `ENOEXEC`).

Closes #2537
