### PR TITLE
fix(ci): report both kernel contexts when the kernel lane is out of scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -993,7 +993,12 @@ jobs:
   kernel:
     name: Build kernels (${{ matrix.arch }})
     needs: [scope]
-    if: needs.scope.outputs.kernel == 'true'
+    # No job-level `if:`. A skipped matrix job cannot expand `matrix.arch`, so
+    # it reports one check literally named `Build kernels (${{ matrix.arch }})`
+    # — which matches neither required context, leaving every PR that does not
+    # touch kernel paths permanently unmergeable. Every step below carries the
+    # scope condition instead, so an out-of-scope run costs a few seconds and
+    # still reports both names.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
**Every pull request opened since the kernel lane was scoped is unmergeable, with a fully green board.**

## Symptom

| PR | kernel checks reported | state |
|---|---|---|
| #2541 (opened before the change) | `Build kernels (aarch64)` pass<br>`Build kernels (x86_64)` pass | `CLEAN` |
| #2546 (opened after) | `Build kernels (${{ matrix.arch }})` skipping | `BLOCKED` |

#2546 has every other check passing — lint, all four test lanes, invariant — and cannot merge.

## Cause

The `kernel` job gained `if: needs.scope.outputs.kernel == 'true'` at **job** level. A skipped matrix job never expands its matrix, so GitHub reports a single check under the literal, uninterpolated name. Branch protection requires:

```
Build kernels (aarch64)
Build kernels (x86_64)
```

Neither name ever arrives, so the contexts stay unsatisfied forever. Any PR touching no kernel path is affected — which is most of them.

## Fix

Drop the job-level condition. **Every step in the job already carries the same condition**, so this changes no work: an out-of-scope run checks out nothing, installs nothing, builds nothing, and finishes in seconds having reported both names. The `Report scope` step that prints "No kernel-relevant paths changed" was already written for exactly this shape.

## Why the sibling lane is fine

`nix-flake-check` is gated the same way, but its name is static — a skipped job still reports `Nix flake check (Linux eval)`, which is the name protection wants, and a skipped conclusion satisfies a required context. Only the matrix job is affected. That contrast is what identified the mechanism.

## Verification

- `actionlint .github/workflows/ci.yml` — clean
- `cargo run -p xtask -- check-workflow-paths` — clean (26 working-directory, 17 fuzz targets, 135 cargo -p packages across 23 workflows)
- `cargo nextest run -p xtask -E 'test(workflow)'` — 20 passed

The real check is this PR's own board: it touches no kernel path, so the lane is out of scope, and both `Build kernels (…)` contexts must appear under their expanded names.