### PR TITLE
feat(sec): sign the checksum manifests that gate boot bytes

### DIFF
--- a/.github/workflows/kernel-build.yml
+++ b/.github/workflows/kernel-build.yml
@@ -38,6 +38,13 @@ jobs:
           - arch: x86_64
             runner: ubuntu-latest
     runs-on: ${{ matrix.runner }}
+    # Narrowed to this job rather than the workflow, so the reusable bdd call
+    # above does not also inherit an OIDC token it has no use for. A job-level
+    # block replaces the inherited set outright, hence contents: write is
+    # repeated here for the release upload.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -69,6 +76,13 @@ jobs:
             staging/kernel-metrics-${{ matrix.arch }}.json
             staging/workload-config-${{ matrix.arch }}
 
+      # Only on the publish path: a non-tag diagnostic run has nothing to sign,
+      # and keyless signing would write that run into the public transparency
+      # log for no reason.
+      - name: Install cosign
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: sigstore/cosign-installer@v3
+
       - name: Publish to release
         if: startsWith(github.ref, 'refs/tags/v')
         env:
@@ -78,12 +92,28 @@ jobs:
         # `mvmctl kernel build --source download` resolves these by the
         # mvmctl release tag + arch + variant, then SHA-256-verifies each
         # against the checksums manifest before admitting it to the cache.
+        #
+        # That makes the manifest, not the vmlinux blobs, the thing an attacker
+        # has to beat: swap a kernel and its recorded hash together and the
+        # download-side check still passes. So the manifest is cosign-signed
+        # here and its bundle published beside it, giving the verifier
+        # something to anchor on that is not itself swappable.
+        #
+        # --new-bundle-format is not optional: it is the one Sigstore bundle
+        # shape the in-binary Rust verifier parses, and every other signed blob
+        # in this project's releases uses it.
         run: |
           set -euo pipefail
           cd staging
+          cosign sign-blob \
+            --yes \
+            --new-bundle-format \
+            --bundle "kernel-${ARCH}-checksums-sha256.txt.bundle" \
+            "kernel-${ARCH}-checksums-sha256.txt"
           gh release upload "$TAG" \
             "vmlinux-${ARCH}-builder" \
             "vmlinux-${ARCH}-workload" \
             "kernel-${ARCH}-checksums-sha256.txt" \
+            "kernel-${ARCH}-checksums-sha256.txt.bundle" \
             "kernel-${ARCH}.json" \
             --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -723,7 +723,7 @@ jobs:
           echo "Combined checksums:"
           cat checksums-sha256.txt
 
-      - name: Sign release tarballs and SBOM
+      - name: Sign release tarballs, checksum manifests, and SBOM
         shell: bash
         run: |
           set -euo pipefail
@@ -739,7 +739,27 @@ jobs:
           #
           # Requires cosign >= v2.4 on any host that verifies by hand; that is
           # the floor this project targets and there is no legacy fallback.
-          for blob in artifacts/*.tar.gz sbom.cdx.json; do
+          #
+          # The checksum manifests are in this list because they are what
+          # actually gates boot bytes: every downloader hashes the artifact and
+          # compares it against the manifest, so an unsigned manifest lets
+          # whoever can swap an artifact swap its recorded hash too and the
+          # comparison still passes. Signing the tarball alone does not close
+          # that — the image blobs (kernel, rootfs, verity sidecar) are not
+          # tarballs and carry no per-file signature of their own; the manifest
+          # is their only integrity anchor.
+          #
+          # The two image manifests are globs, so nullglob drops them when the
+          # image job that would have produced them failed — image signing stays
+          # best-effort exactly as image publication is. The combined binary
+          # manifest is a literal because the preceding step always writes it
+          # and this job hard-gates on the binary build.
+          for blob in \
+            artifacts/*.tar.gz \
+            artifacts/builder-vm-*-checksums-sha256.txt \
+            artifacts/default-microvm-*-checksums-sha256.txt \
+            artifacts/checksums-sha256.txt \
+            sbom.cdx.json; do
             cosign sign-blob \
               --yes \
               --new-bundle-format \
@@ -857,6 +877,7 @@ jobs:
             artifacts/*.tar.gz
             artifacts/*.tar.gz.bundle
             artifacts/checksums-sha256.txt
+            artifacts/checksums-sha256.txt.bundle
             artifacts/builder-vm-vmlinux-*
             artifacts/builder-vm-rootfs-*
             artifacts/builder-vm-*.cmdline.txt
@@ -865,6 +886,7 @@ jobs:
             artifacts/builder-vm-*.pack-manifest.json.bundle
             artifacts/builder-vm-*.sbom.txt
             artifacts/builder-vm-*-checksums-sha256.txt
+            artifacts/builder-vm-*-checksums-sha256.txt.bundle
             artifacts/runtime-overlay-*.tar.gz
             artifacts/runtime-overlay-*.tar.gz.sha256
             artifacts/sdk-sidecar-*.tar.gz
@@ -878,6 +900,7 @@ jobs:
             artifacts/default-microvm-*.pack-manifest.json.bundle
             artifacts/default-microvm-*.sbom.txt
             artifacts/default-microvm-*-checksums-sha256.txt
+            artifacts/default-microvm-*-checksums-sha256.txt.bundle
             sbom.cdx.json
             sbom.cdx.json.bundle
           )

--- a/crates/mvm-cli/src/commands/env/artifact_verify.rs
+++ b/crates/mvm-cli/src/commands/env/artifact_verify.rs
@@ -5,6 +5,10 @@
 //! published checksum manifest" helpers that back hash-verified downloads;
 //! the dev-image and builder-VM download orchestration in
 //! `builder_vm.rs` calls them.
+//!
+//! The manifest is itself signature-verified before it is parsed, so the
+//! digests every artifact is held to come from the publisher rather than from
+//! whoever answered the request.
 
 use anyhow::{Context, Result};
 
@@ -47,35 +51,61 @@ pub(super) fn bump_verify_outcome(outcome: &str) {
     }
 }
 
-/// Download the per-release `sha256sum`-format checksum file and parse it
-/// into a `name -> hex-digest` map for the artifacts we plan to download.
+/// A published checksum manifest, named the way the signature rung needs it.
 ///
-/// The checksum file is the trust anchor for the hash-verified download.
-/// It is fetched from the same GitHub release URL as the artifacts, over
-/// TLS. Anyone
-/// who can swap the artifact can also swap the checksum file, so the
-/// real defence is end-to-end signing (cosign on the .tar.gz / SBOM
-/// today, on the checksum file itself in a future iteration). What we
-/// gain *now* is detection of mid-flight corruption and operator-error
-/// substitution at the URL level — both of which are ruled out by a
-/// matching hash.
+/// The verifier fetches the Sigstore bundle from `<base_url>/<asset>.bundle`
+/// and accepts only the identity bound to `version`'s tag, so a single joined
+/// URL is not enough — splitting one back apart would have to guess where the
+/// asset name starts. A params struct also stops three same-typed strings from
+/// being transposed silently.
+pub(super) struct ChecksumManifest<'a> {
+    /// Per-version release base URL, no trailing slash.
+    pub base_url: &'a str,
+    /// The manifest's published asset name, e.g. `kernel-aarch64-checksums-sha256.txt`.
+    pub asset: &'a str,
+    /// Release version whose signing identity is accepted for this manifest.
+    pub version: &'a str,
+}
+
+impl ChecksumManifest<'_> {
+    fn url(&self) -> String {
+        format!("{}/{}", self.base_url, self.asset)
+    }
+}
+
+/// Download the per-release `sha256sum`-format checksum file, prove it against
+/// the release's Sigstore bundle, and parse it into a `name -> hex-digest` map
+/// for the artifacts we plan to download.
+///
+/// The manifest is the trust anchor for every artifact digest beneath it, and
+/// TLS authenticates only the transport: whoever can swap an artifact can swap
+/// the digest published beside it. So the bytes are verified against the
+/// release signing identity *before* a line of them is parsed — an unsigned,
+/// mis-signed, or foreign-signed manifest is refused with nothing read out of
+/// it.
+///
+/// `MVM_SKIP_HASH_VERIFY` does not reach this rung. Bypassing the publisher
+/// check takes `MVM_SKIP_COSIGN_VERIFY`, a deliberately separate switch, since
+/// waiving *who* published is a bigger concession than waiving *what* the bytes
+/// hash to.
 ///
 /// Returns only entries for the artifacts in `wanted`; missing names
 /// short-circuit to a clear error.
 pub(super) fn fetch_expected_hashes(
-    checksums_url: &str,
+    manifest: &ChecksumManifest<'_>,
     wanted: &[&str],
 ) -> Result<std::collections::HashMap<String, String>> {
+    let checksums_url = manifest.url();
     let tmp = tempfile::NamedTempFile::new().context("Failed to create temp file")?;
     let tmp_path = tmp.path().to_string_lossy().to_string();
-    download_file(checksums_url, &tmp_path).with_context(|| {
+    download_file(&checksums_url, &tmp_path).with_context(|| {
         format!(
             "Failed to download checksum manifest from {checksums_url}.\n\
              ADR-002 §W5.1 requires a hash-verified download; refusing to\n\
-             proceed without the checksum file. To bypass for an emergency\n\
-             rotation, set MVM_SKIP_HASH_VERIFY=1."
+             proceed without the checksum file."
         )
     })?;
+    verify_manifest_signature(manifest, tmp.path())?;
     let body = std::fs::read_to_string(&tmp_path)
         .with_context(|| format!("Failed to read checksum file at {tmp_path}"))?;
 
@@ -103,6 +133,34 @@ pub(super) fn fetch_expected_hashes(
         }
     }
     Ok(map)
+}
+
+/// Verify the downloaded manifest at `staged` against the release signing
+/// identity, using the one shared release verifier.
+///
+/// A refusal here is attack-shaped, so it feeds the same counter and audit
+/// line as a bad artifact signature rather than looking like a network blip.
+pub(super) fn verify_manifest_signature(
+    manifest: &ChecksumManifest<'_>,
+    staged: &std::path::Path,
+) -> Result<()> {
+    mvm_build::release_signature::verify_release_archive_signature(
+        &mvm_build::release_signature::ReleaseSignatureRequest {
+            base_url: manifest.base_url,
+            asset: manifest.asset,
+            archive_path: staged,
+            version: manifest.version,
+        },
+    )
+    .map_err(|error| {
+        bump_verify_outcome("sig_invalid");
+        anyhow::Error::new(error).context(format!(
+            "Refusing to parse an unauthenticated checksum manifest \
+             ({}). Every artifact digest below it would inherit the \
+             manifest's trust. ADR-002 §W5.1.",
+            manifest.asset
+        ))
+    })
 }
 
 /// Stream `path` through SHA-256 and compare to `expected` (lowercase
@@ -223,7 +281,6 @@ mod tests {
     use super::*;
     use mvm_core::util::test_env::TestEnv;
     use sha2::{Digest, Sha256};
-    use std::io::Write;
 
     #[test]
     fn curl_download_args_request_resume() {
@@ -316,46 +373,135 @@ mod tests {
         assert!(result.is_ok(), "skip-env should bypass check: {result:?}");
     }
 
+    /// Stage a `sha256sum` manifest in its own dir and return the manifest
+    /// params pointing at it. `file://` keeps the download path real — curl
+    /// copies the bytes — without a network or a live release.
+    fn stage_manifest(body: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(MANIFEST_ASSET), body).unwrap();
+        let base_url = format!("file://{}", dir.path().display());
+        (dir, base_url)
+    }
+
+    const MANIFEST_ASSET: &str = "checksums.txt";
+    const MANIFEST_VERSION: &str = "9.9.9";
+
+    fn manifest<'a>(base_url: &'a str) -> ChecksumManifest<'a> {
+        ChecksumManifest {
+            base_url,
+            asset: MANIFEST_ASSET,
+            version: MANIFEST_VERSION,
+        }
+    }
+
     #[test]
     fn fetch_expected_hashes_parses_sha256sum_format() {
-        // Run a tiny in-process HTTP server? Overkill — the function
-        // takes a URL and shells out to curl. Instead, we test the
-        // parser by exercising it directly via a file:// URL: curl
-        // accepts file:// and just copies the bytes.
-        let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("checksums.txt");
-        let mut f = std::fs::File::create(&manifest_path).unwrap();
+        let mut env = TestEnv::new();
+        // This test is about the parser, so waive the publisher rung the way
+        // an operator would; the rung itself has its own witnesses below.
+        env.set("MVM_SKIP_COSIGN_VERIFY", "1");
         // Two-space gap is canonical sha256sum output. Mix in a leading
         // '*' on one line (binary mode) to confirm we strip it.
-        writeln!(f, "{}  dev-vmlinux-x86_64", "a".repeat(64)).unwrap();
-        writeln!(f, "{} *dev-rootfs-x86_64.ext4", "b".repeat(64)).unwrap();
-        writeln!(f, "garbage line that is not a hash").unwrap();
-        drop(f);
+        let body = format!(
+            "{}  dev-vmlinux-x86_64\n{} *dev-rootfs-x86_64.ext4\ngarbage line that is not a hash\n",
+            "a".repeat(64),
+            "b".repeat(64)
+        );
+        let (_dir, base_url) = stage_manifest(&body);
 
-        let url = format!("file://{}", manifest_path.display());
-        let map = fetch_expected_hashes(&url, &["dev-vmlinux-x86_64", "dev-rootfs-x86_64.ext4"])
-            .expect("manifest should parse");
+        let map = fetch_expected_hashes(
+            &manifest(&base_url),
+            &["dev-vmlinux-x86_64", "dev-rootfs-x86_64.ext4"],
+        )
+        .expect("manifest should parse");
         assert_eq!(map.get("dev-vmlinux-x86_64").unwrap(), &"a".repeat(64));
         assert_eq!(map.get("dev-rootfs-x86_64.ext4").unwrap(), &"b".repeat(64));
     }
 
     #[test]
     fn fetch_expected_hashes_errors_when_artifact_missing_from_manifest() {
-        let dir = tempfile::tempdir().unwrap();
-        let manifest_path = dir.path().join("checksums.txt");
-        std::fs::write(
-            &manifest_path,
-            format!("{}  some-other-file\n", "c".repeat(64)),
-        )
-        .unwrap();
+        let mut env = TestEnv::new();
+        env.set("MVM_SKIP_COSIGN_VERIFY", "1");
+        let (_dir, base_url) = stage_manifest(&format!("{}  some-other-file\n", "c".repeat(64)));
 
-        let url = format!("file://{}", manifest_path.display());
-        let err = fetch_expected_hashes(&url, &["dev-vmlinux-x86_64"])
+        let err = fetch_expected_hashes(&manifest(&base_url), &["dev-vmlinux-x86_64"])
             .unwrap_err()
             .to_string();
         assert!(
             err.contains("did not include") && err.contains("dev-vmlinux-x86_64"),
             "expected missing-entry error, got: {err}"
         );
+    }
+
+    /// The manifest is the trust anchor for every digest under it, so an
+    /// unsigned one must be refused with nothing read out of it. The staged
+    /// manifest is also missing the wanted entry: if the signature rung ever
+    /// moves after the parse, this fails with a "did not include" error and
+    /// says so.
+    #[test]
+    fn fetch_expected_hashes_refuses_an_unsigned_manifest_before_parsing() {
+        let mut env = TestEnv::new();
+        env.remove("MVM_SKIP_COSIGN_VERIFY");
+        let (_dir, base_url) = stage_manifest(&format!("{}  some-other-file\n", "d".repeat(64)));
+
+        let err = fetch_expected_hashes(&manifest(&base_url), &["dev-vmlinux-x86_64"])
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            !err.contains("did not include"),
+            "the signature rung must refuse before the manifest is parsed: {err}"
+        );
+        assert!(
+            err.contains("unauthenticated checksum manifest"),
+            "the refusal must name the reason: {err}"
+        );
+    }
+
+    /// The two hatches are independent by design: waiving the digest check is
+    /// a smaller concession than waiving the publisher check, so it must not
+    /// silently grant the larger one.
+    #[test]
+    fn skip_hash_verify_does_not_waive_the_manifest_signature() {
+        let mut env = TestEnv::new();
+        env.set("MVM_SKIP_HASH_VERIFY", "1");
+        env.remove("MVM_SKIP_COSIGN_VERIFY");
+        let (_dir, base_url) = stage_manifest(&format!("{}  dev-vmlinux-x86_64\n", "e".repeat(64)));
+
+        let err = fetch_expected_hashes(&manifest(&base_url), &["dev-vmlinux-x86_64"])
+            .expect_err("an unsigned manifest must be refused whatever the hash hatch says")
+            .to_string();
+
+        assert!(
+            err.contains("unauthenticated checksum manifest"),
+            "MVM_SKIP_HASH_VERIFY must not reach the signature rung: {err}"
+        );
+    }
+
+    /// The converse: waiving the publisher check admits the manifest but
+    /// leaves every digest in it binding.
+    #[test]
+    fn skip_cosign_verify_admits_the_manifest_but_keeps_the_hash_pin() {
+        let mut env = TestEnv::new();
+        env.set("MVM_SKIP_COSIGN_VERIFY", "1");
+        env.remove("MVM_SKIP_HASH_VERIFY");
+        let artifact_name = "dev-vmlinux-x86_64";
+        let pinned = hex_sha256(b"the published bytes");
+        let (_dir, base_url) = stage_manifest(&format!("{pinned}  {artifact_name}\n"));
+
+        let expected = fetch_expected_hashes(&manifest(&base_url), &[artifact_name])
+            .expect("the escape hatch must admit an unsigned manifest");
+
+        let local = tempfile::tempdir().unwrap();
+        let path = local.path().join(artifact_name);
+        std::fs::write(&path, b"substituted bytes").unwrap();
+        let err = verify_artifact_hash(
+            path.to_str().unwrap(),
+            artifact_name,
+            expected.get(artifact_name),
+        )
+        .expect_err("the digest pin must still bind")
+        .to_string();
+        assert!(err.contains("Integrity check failed"), "{err}");
     }
 }

--- a/crates/mvm-cli/src/commands/env/builder_vm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm.rs
@@ -24,7 +24,9 @@ use sha2::{Digest, Sha256};
 
 #[cfg(feature = "release-artifact-bootstrap")]
 use super::artifact_verify::bump_verify_outcome;
-use super::artifact_verify::{download_file, fetch_expected_hashes, verify_artifact_hash};
+use super::artifact_verify::{
+    ChecksumManifest, download_file, fetch_expected_hashes, verify_artifact_hash,
+};
 use crate::ui;
 #[cfg(all(test, feature = "builder-vm"))]
 use bootstrap::BuildHeartbeat;

--- a/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
@@ -496,14 +496,20 @@ fn download_default_microvm_image(
 
     let assets = default_microvm_assets(cache_dir, arch);
     let checksums_name = format!("default-microvm-{arch}-checksums-sha256.txt");
-    let checksums_url = format!("{base_url}/{checksums_name}");
 
     ui::info(&format!(
         "Downloading default microVM image (v{version})..."
     ));
 
     let asset_names: Vec<&str> = assets.iter().map(|(n, _)| n.as_str()).collect();
-    let expected = fetch_expected_hashes(&checksums_url, &asset_names)?;
+    let expected = fetch_expected_hashes(
+        &ChecksumManifest {
+            base_url: &base_url,
+            asset: &checksums_name,
+            version,
+        },
+        &asset_names,
+    )?;
 
     for (name, dest) in &assets {
         ui::info(&format!("  Fetching {name}..."));

--- a/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
@@ -899,9 +899,9 @@ pub(super) fn promote_builder_vm_stage0_cache(
 /// `builder-vm-image` release-workflow job into the local cache dir,
 /// SHA-256-verified.
 ///
-/// Mirrors `download_dev_image_inner` for the interactive image, minus
-/// cosign signing (the signed-manifest path extends to builder-vm
-/// artifacts as a follow-up). The required artifacts are `vmlinux`,
+/// Mirrors `download_dev_image_inner` for the interactive image: the checksum
+/// manifest is signature-verified before it is parsed, and every artifact is
+/// then held to the digest it pins. The required artifacts are `vmlinux`,
 /// `rootfs.ext4`, `cmdline.txt`, and `manifest.json`; the runtime
 /// builder-image loader rejects caches that do not carry the full
 /// contract.
@@ -920,13 +920,16 @@ pub(super) fn download_builder_vm_image(arch: &str, cache_dir: &str) -> Result<(
     let rootfs_url = format!("{base_url}/{}", names.rootfs);
     let cmdline_url = format!("{base_url}/{}", names.cmdline);
     let manifest_url = format!("{base_url}/{}", names.manifest);
-    let checksums_url = format!("{base_url}/{}", names.checksums);
 
     // The builder-image cache contract is fail-closed: every artifact
     // the runtime loader consumes must be listed in checksums and
     // downloaded here before the cache is considered usable.
     let expected = fetch_expected_hashes(
-        &checksums_url,
+        &ChecksumManifest {
+            base_url: &base_url,
+            asset: &names.checksums,
+            version,
+        },
         &[
             &names.kernel,
             &names.rootfs,

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -100,6 +100,30 @@ fn strip_v_prefix(tag: &str) -> &str {
     tag.strip_prefix('v').unwrap_or(tag)
 }
 
+/// Download a release checksum manifest and prove the publisher signed it
+/// before any of its bytes are read.
+///
+/// The manifest decides which artifact bytes are acceptable, so whoever can
+/// serve one picks the artifact; TLS says nothing about who wrote it. Refuses
+/// on a missing, unparseable, or foreign-signed bundle — the shared release
+/// verifier does the deciding.
+fn fetch_signed_checksum_manifest(base_url: &str, asset: &str, version: &str) -> Result<String> {
+    let staged = tempfile::NamedTempFile::new()
+        .with_context(|| format!("creating staging file for {asset}"))?;
+    http::download_file(&format!("{base_url}/{asset}"), staged.path())
+        .with_context(|| format!("downloading {asset} — cannot verify integrity"))?;
+    mvm_build::release_signature::verify_release_archive_signature(
+        &mvm_build::release_signature::ReleaseSignatureRequest {
+            base_url,
+            asset,
+            archive_path: staged.path(),
+            version,
+        },
+    )
+    .with_context(|| format!("refusing to parse an unauthenticated checksum manifest ({asset})"))?;
+    std::fs::read_to_string(staged.path()).with_context(|| format!("reading {asset}"))
+}
+
 /// Parse a hex-encoded SHA256 digest from a `checksums-sha256.txt` entry.
 ///
 /// Each line is: `<64 hex chars>  <filename>`  (two spaces, shasum format).
@@ -206,11 +230,16 @@ fn download_release(version: &str, target: &str, tmp_dir: &Path) -> Result<()> {
 /// release's `kernel-<arch>-checksums-sha256.txt`, and write it to
 /// `dest`. The `--source download` arm of `mvmctl kernel build`.
 ///
+/// That manifest is itself signature-verified against the release identity
+/// before it is read, so the digest the kernel is held to comes from the
+/// publisher rather than from whoever answered the request.
+///
 /// Keyed by the mvmctl release tag: a given mvmctl can only ever fetch
 /// the kernel that shipped with it — never a substitute for an in-tree
 /// config edit (a source checkout compiles instead).
-/// `MVM_SKIP_HASH_VERIFY` is the documented emergency escape — never
-/// set it in CI.
+/// `MVM_SKIP_HASH_VERIFY` is the documented emergency escape for the digest
+/// comparison — never set it in CI. It does not waive the manifest signature;
+/// `MVM_SKIP_COSIGN_VERIFY` is that separate, larger concession.
 ///
 /// Available without `builder-vm`: lean clients cannot compile kernels
 /// locally, so downloading the release-matched kernel is their supported
@@ -226,7 +255,8 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
             .with_context(|| format!("creating kernel cache dir {}", parent.display()))?;
     }
 
-    let asset_url = format!("{base}/{GITHUB_REPO}/releases/download/{tag}/{asset}");
+    let release_base = format!("{base}/{GITHUB_REPO}/releases/download/{tag}");
+    let asset_url = format!("{release_base}/{asset}");
     let parent = dest
         .parent()
         .with_context(|| format!("kernel destination has no parent: {}", dest.display()))?;
@@ -248,15 +278,19 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
         )
     })?;
 
+    // The signature rung runs even under MVM_SKIP_HASH_VERIFY: that hatch
+    // waives comparing the digest, not the question of who published the
+    // manifest the digest comes from. Waiving the publisher takes the separate
+    // MVM_SKIP_COSIGN_VERIFY.
+    let manifest = fetch_signed_checksum_manifest(&release_base, &checksums, current_version())?;
+
     if std::env::var("MVM_SKIP_HASH_VERIFY").is_ok() {
         ui::warn("MVM_SKIP_HASH_VERIFY set — skipping kernel checksum verification (never in CI).");
         publish_downloaded_kernel(download, dest)?;
         return Ok(());
     }
 
-    let checksum_url = format!("{base}/{GITHUB_REPO}/releases/download/{tag}/{checksums}");
-    let expected = http::fetch_text(&checksum_url)
-        .context("downloading kernel checksums — cannot verify integrity")?
+    let expected = manifest
         .lines()
         .find(|l| l.contains(&asset))
         .with_context(|| format!("{asset} not found in {checksums}"))

--- a/nix/packaging/release/verify-release-assets.sh
+++ b/nix/packaging/release/verify-release-assets.sh
@@ -64,6 +64,27 @@ sha256_of() {
   else shasum -a 256 "$1" | awk '{print $1}'; fi
 }
 
+# Every downloader anchors on a checksum manifest: it hashes the artifact and
+# compares against this file. That makes an unsigned manifest the weak link —
+# whoever can swap an artifact can swap its recorded hash too, and the
+# comparison still passes. So each manifest ships a cosign bundle beside it,
+# and a release that skipped signing one is a packaging bug worth failing on
+# here: the download would still succeed and still "verify", which is precisely
+# the silent failure this catches.
+require_signed_manifest() {
+  manifest="$1"; label="$2"
+  bundle="$manifest.bundle"
+  [ -f "$bundle" ] || { fail "$label signature bundle missing: $(basename "$bundle")"; return; }
+  [ "$DO_COSIGN" = 1 ] || return
+  command -v cosign >/dev/null 2>&1 || { fail "--cosign given but cosign not on PATH"; return; }
+  cosign verify-blob --bundle "$bundle" \
+    ${COSIGN_IDENTITY_REGEXP:+--certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP"} \
+    ${COSIGN_IDENTITY:+--certificate-identity "$COSIGN_IDENTITY"} \
+    ${COSIGN_OIDC_ISSUER:+--certificate-oidc-issuer "$COSIGN_OIDC_ISSUER"} \
+    "$manifest" >/dev/null 2>&1 \
+    || fail "$label cosign verify-blob failed"
+}
+
 required_bins_for_target() {
   case "$1" in
     *apple-darwin)
@@ -77,6 +98,7 @@ required_bins_for_target() {
 
 COMBINED="$ASSETS_DIR/checksums-sha256.txt"
 [ -f "$COMBINED" ] || fail "combined checksums manifest missing: checksums-sha256.txt"
+require_signed_manifest "$COMBINED" "combined checksums manifest"
 
 for target in $TARGETS; do
   tarball="$ASSETS_DIR/mvmctl-${target}.tar.gz"
@@ -148,6 +170,7 @@ for arch in $KERNEL_ARCHES; do
 
   [ -f "$workload_kernel" ] || { fail "[$arch] workload kernel missing: vmlinux-${arch}-workload"; continue; }
   [ -f "$kernel_checks" ] || { fail "[$arch] kernel checksums manifest missing: kernel-${arch}-checksums-sha256.txt"; continue; }
+  require_signed_manifest "$kernel_checks" "[$arch] kernel checksums manifest"
 
   want=$(awk -v n="vmlinux-${arch}-workload" '$2 == n { print $1 }' "$kernel_checks" | head -1)
   if [ -z "$want" ]; then
@@ -189,6 +212,7 @@ for arch in $BUILDER_ARCHES; do
   fi
 
   [ -f "$bp_checks" ] || { fail "[$arch] builder checksums manifest missing: builder-vm-${arch}-checksums-sha256.txt"; continue; }
+  require_signed_manifest "$bp_checks" "[$arch] builder checksums manifest"
   for f in "$bp_manifest" "$bp_bundle" "$bp_sbom"; do
     want=$(awk -v n="$f" '$2 == n { print $1 }' "$bp_checks" | head -1)
     if [ -z "$want" ]; then
@@ -227,6 +251,7 @@ for arch in $RUNTIME_ARCHES; do
   fi
 
   [ -f "$rp_checks" ] || { fail "[$arch] default-microvm checksums manifest missing: default-microvm-${arch}-checksums-sha256.txt"; continue; }
+  require_signed_manifest "$rp_checks" "[$arch] default-microvm checksums manifest"
   for f in "$rp_manifest" "$rp_bundle" "$rp_sbom"; do
     want=$(awk -v n="$f" '$2 == n { print $1 }' "$rp_checks" | head -1)
     if [ -z "$want" ]; then

--- a/nix/packaging/release/verify-release-assets.sh
+++ b/nix/packaging/release/verify-release-assets.sh
@@ -74,9 +74,12 @@ sha256_of() {
 require_signed_manifest() {
   manifest="$1"; label="$2"
   bundle="$manifest.bundle"
-  [ -f "$bundle" ] || { fail "$label signature bundle missing: $(basename "$bundle")"; return; }
-  [ "$DO_COSIGN" = 1 ] || return
-  command -v cosign >/dev/null 2>&1 || { fail "--cosign given but cosign not on PATH"; return; }
+  # Every return is explicit: the script runs under `set -e`, so a bare `return`
+  # after a failed test propagates that failure and aborts the whole run instead
+  # of recording one problem and carrying on.
+  [ -f "$bundle" ] || { fail "$label signature bundle missing: $(basename "$bundle")"; return 0; }
+  [ "$DO_COSIGN" = 1 ] || return 0
+  command -v cosign >/dev/null 2>&1 || { fail "--cosign given but cosign not on PATH"; return 0; }
   cosign verify-blob --bundle "$bundle" \
     ${COSIGN_IDENTITY_REGEXP:+--certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP"} \
     ${COSIGN_IDENTITY:+--certificate-identity "$COSIGN_IDENTITY"} \

--- a/nix/packaging/release/verify-release-assets.test.sh
+++ b/nix/packaging/release/verify-release-assets.test.sh
@@ -40,10 +40,12 @@ build_valid_fixture() {
     printf 'bundle\n' > "$dir/mvmctl-$t.tar.gz.bundle"
     echo "$(sha256_of "$dir/mvmctl-$t.tar.gz")  mvmctl-$t.tar.gz" >> "$dir/checksums-sha256.txt"
   done
+  printf 'bundle\n' > "$dir/checksums-sha256.txt.bundle"
   for arch in $KERNEL_ARCHES; do
     printf 'kernel-%s-workload\n' "$arch" > "$dir/vmlinux-$arch-workload"
     : > "$dir/kernel-$arch-checksums-sha256.txt"
     echo "$(sha256_of "$dir/vmlinux-$arch-workload")  vmlinux-$arch-workload" >> "$dir/kernel-$arch-checksums-sha256.txt"
+    printf 'bundle\n' > "$dir/kernel-$arch-checksums-sha256.txt.bundle"
   done
   printf '{"sbom":true}\n' > "$dir/sbom.cdx.json"
   printf 'bundle\n' > "$dir/sbom.cdx.json.bundle"
@@ -55,6 +57,7 @@ build_valid_fixture() {
     for f in "builder-vm-$arch.pack-manifest.json" "builder-vm-$arch.pack-manifest.json.bundle" "builder-vm-$arch.sbom.txt"; do
       echo "$(sha256_of "$dir/$f")  $f" >> "$dir/builder-vm-$arch-checksums-sha256.txt"
     done
+    printf 'bundle\n' > "$dir/builder-vm-$arch-checksums-sha256.txt.bundle"
   done
   for arch in $RUNTIME_ARCHES; do
     printf '{"pack":"runtime-%s"}\n' "$arch" > "$dir/default-microvm-$arch.pack-manifest.json"
@@ -64,6 +67,7 @@ build_valid_fixture() {
     for f in "default-microvm-$arch.pack-manifest.json" "default-microvm-$arch.pack-manifest.json.bundle" "default-microvm-$arch.sbom.txt"; do
       echo "$(sha256_of "$dir/$f")  $f" >> "$dir/default-microvm-$arch-checksums-sha256.txt"
     done
+    printf 'bundle\n' > "$dir/default-microvm-$arch-checksums-sha256.txt.bundle"
   done
   echo "$dir"
 }
@@ -128,6 +132,22 @@ d="$(build_valid_fixture)"
 rm -f "$d/kernel-aarch64-checksums-sha256.txt"
 if run "$d"; then bad "missing kernel checksums manifest must fail"; else ok "missing kernel checksums manifest fails closed"; fi
 rm -rf "$d"
+
+# 9b. A checksum manifest without its signature bundle → fail closed.
+#
+# The manifest is what every downloader anchors on, so an unsigned one lets
+# whoever can swap an artifact swap its recorded digest too. Each of these
+# deletes only the bundle, leaving a manifest that still parses and still
+# matches its artifacts — the failure mode that is otherwise invisible until a
+# release ships.
+for manifest in checksums-sha256.txt kernel-aarch64-checksums-sha256.txt \
+                builder-vm-aarch64-checksums-sha256.txt \
+                default-microvm-aarch64-checksums-sha256.txt; do
+  d="$(build_valid_fixture)"
+  rm -f "$d/$manifest.bundle"
+  if run "$d"; then bad "unsigned $manifest must fail"; else ok "unsigned $manifest fails closed"; fi
+  rm -rf "$d"
+done
 
 # 10. Workload kernel present but absent from per-arch kernel manifest → fail.
 d="$(build_valid_fixture)"

--- a/specs/plans/2026-08-15-kernel-artifacts-own-release-cadence.md
+++ b/specs/plans/2026-08-15-kernel-artifacts-own-release-cadence.md
@@ -1,0 +1,69 @@
+# Kernel artifacts on their own release cadence
+
+Backing: preview
+Validation: none
+
+**Status: DEFERRED — recorded so the tradeoff is not re-derived from scratch.**
+
+## The question
+
+Should the guest kernel build move out of this repository into its own, so it can
+be patched on a CVE cadence independent of `mvmctl` releases?
+
+Today `nix/images/kernel/flake.nix` is already a standalone publishable flake —
+it emits per-arch `vmlinux`, `configfile`, `metrics`, `resolved-configs`, and an
+`artifact-manifest` carrying `kernel_version` / `config_hash` / `artifact_hash` —
+and `.github/workflows/kernel-build.yml` publishes it on `v*` tags. So the kernel
+is *already* a separately-built artifact. What it is not is separately
+*versioned*: a kernel CVE fix can only reach users attached to an `mvmctl`
+release tag.
+
+## The shape it would take
+
+The pattern worth copying, if we do this, is the split — not the extraction:
+
+- **Out:** build, sign, publish. A small repo holding the flake, the signer, and
+  two workflows (build-on-PR, build-sign-publish-on-tag). Per-arch `vmlinux` +
+  `.sha256` + signature as release assets.
+- **In:** boot validation. It stays here, because the boot test needs the VMM,
+  and the VMM is here. The consumer repo references the kernel flake and boots a
+  guest on a KVM runner against it.
+
+Getting that backwards — trying to boot-test in the kernel repo — is the failure
+mode, since it would drag the whole VMM into a repo whose job is to produce one
+ELF file.
+
+## Why it is deferred
+
+The gain is CVE cadence alone, and it is bought with real cost:
+
+- Every contributor build gains a cross-repo flake reference, against the
+  standing invariant that a source checkout builds every image locally from
+  in-repo flakes with no release-pipeline round-trip. A kernel that lives
+  elsewhere is either vendored back in (defeating the point) or fetched
+  (violating the invariant).
+- Two repos to keep in lockstep for any change that touches both the kernel
+  config and the code that boots it — which is most kernel changes we actually
+  make.
+- `check-kernel-config-budget` and `check-kernel-pin-freshness` currently gate
+  the kernel in the same run as its consumer. Splitting means either duplicating
+  them or letting the pin drift between repos.
+
+The cadence problem is also not yet biting: we have not had a kernel CVE that
+needed to ship faster than the next release.
+
+## What would change the answer
+
+- [ ] A kernel CVE we need to ship out-of-band, i.e. the cadence cost becomes
+      concrete rather than hypothetical.
+- [ ] The kernel gaining consumers outside this repository.
+- [ ] Kernel build time becoming a large enough share of release wall-clock that
+      decoupling pays for itself on that alone.
+
+## Adjacent work that landed instead
+
+Signing the checksum manifests (this branch) closes the more urgent half of the
+same supply-chain question: the artifacts were hash-pinned but the hash manifest
+itself was unsigned, so whoever could swap an artifact could swap its checksum
+file. That gap did not need a repo split to fix, and fixing it does not depend on
+one.

--- a/specs/sprint/delivery/signed-checksum-manifests.md
+++ b/specs/sprint/delivery/signed-checksum-manifests.md
@@ -1,0 +1,82 @@
+# Signed checksum manifests
+
+Every prebuilt artifact download — builder VM, default microVM, kernel, release
+tarballs — hashes the file and compares it against a `sha256sum`-format manifest
+fetched from the same release URL. The manifest itself was unsigned. TLS
+authenticates the transport, not the publisher, so whoever could serve a swapped
+artifact could serve a matching manifest beside it and the comparison would still
+pass. The manifest was the weak link precisely because everything below it
+inherited its trust.
+
+The gap was known and written down. `artifact_verify.rs` said the real defence
+was "signing … on the checksum file itself in a future iteration", and
+`stage0_cache.rs` said the builder VM download was the tarball treatment "minus
+cosign signing … as a follow-up". Neither follow-up had happened. This is it.
+
+## Producer
+
+`release.yml` signs three more blobs in the existing `cosign sign-blob
+--new-bundle-format` loop — `builder-vm-*-checksums-sha256.txt`,
+`default-microvm-*-checksums-sha256.txt`, and the combined
+`checksums-sha256.txt` — and publishes each `.bundle` beside its manifest. The
+image manifests stay globs so `nullglob` drops them when the image job that
+would have produced them failed; image signing is best-effort exactly as image
+publication already is.
+
+`kernel-build.yml` did no signing at all. It now signs
+`kernel-<arch>-checksums-sha256.txt` on the tag path. `id-token: write` is scoped
+to the job rather than the workflow, because the workflow calls the BDD suite as
+a reusable workflow and that call would otherwise inherit an OIDC token it has no
+use for.
+
+## Consumer
+
+`fetch_expected_hashes` takes a `ChecksumManifest { base_url, asset, version }`
+instead of a joined URL — the verifier needs the pieces separately to locate the
+bundle and to pin the tag-bound signing identity, and both call sites already
+held them separately, so the struct removed a line at each rather than adding
+one. Order is download → verify → parse: a manifest that fails the signature is
+refused with nothing read out of it.
+
+Verification reuses `mvm_build::release_signature::verify_release_archive_signature`,
+the same identity-pinned Sigstore path the runtime overlay and SDK sidecar
+already go through. No second verifier, no second bundle-name helper, no new
+dependency. A refusal bumps the existing `sig_invalid` counter, which also emits
+the `ImageVerifyFailed` audit line — a bad signature is attack-shaped, not a
+network blip.
+
+`update.rs::download_kernel` gets the same treatment.
+
+## The two escape hatches are now actually independent
+
+`MVM_SKIP_HASH_VERIFY` and `MVM_SKIP_COSIGN_VERIFY` were already documented as
+deliberately separate — waiving *who published* is a strictly larger concession
+than waiving *what the bytes hash to*. Wiring the signature rung in is what makes
+that real: the hash hatch no longer disables publisher verification, because the
+publisher check now sits above it.
+
+**Behaviour change worth knowing.** On the kernel path, `MVM_SKIP_HASH_VERIFY=1`
+previously skipped the manifest fetch outright, so it also happened to work when
+the manifest 404'd. It no longer does — a missing manifest is fatal regardless of
+that hatch. This makes the kernel path consistent with the image path, which has
+always fetched the manifest unconditionally and only ever let the hatch waive the
+digest comparison. The kernel path was the outlier.
+
+## The release gate could not see any of this
+
+`verify-release-assets.sh` asserted each manifest *exists* but never that it was
+signed, so a release that silently skipped signing would still have passed
+`verify-release` — the exact failure this work exists to prevent, invisible to the
+check meant to catch it. Added `require_signed_manifest`: the bundle must exist,
+and under `--cosign` it must verify.
+
+## Not done
+
+- `mvm-build` carries a second, separate `fetch_expected_hashes` used by
+  `initramfs.rs` and `runtime_overlay.rs`. It is untouched here. Those paths
+  fetch archive checksums for artifacts whose tarballs are already independently
+  cosign-verified, so the anchor is not missing the way it was for the image
+  blobs — but the duplication itself is worth collapsing.
+- `runtime-overlay-*.tar.gz.sha256` and `sdk-sidecar-*.tar.gz.sha256` stay
+  unsigned: single-line sidecars for a tarball that already carries its own
+  signature, so swapping one gains nothing.

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -141,8 +141,10 @@ fn the_release_consumes_its_own_artifacts_before_publishing_them() {
     let verify = workflow
         .find("- name: Verify the published artifacts survive the consumer path")
         .expect("release.yml must consume its artifacts before publishing them");
+    // Matched on a stable prefix: the step's name grows as blobs join the loop,
+    // and the ordering property this asserts does not depend on that wording.
     let sign = workflow
-        .find("- name: Sign release tarballs and SBOM")
+        .find("- name: Sign release tarballs")
         .expect("release.yml must sign the tarballs");
     let publish = workflow
         .find("- name: Create GitHub Release")
@@ -176,4 +178,68 @@ fn the_sdk_sidecar_job_builds_both_published_arches() {
             "the sdk-sidecar-image matrix must build {arch}"
         );
     }
+}
+
+fn kernel_build_workflow() -> String {
+    let path = Path::new(".github/workflows/kernel-build.yml");
+    fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+/// Every published checksum manifest must be signed, and its bundle published.
+///
+/// A manifest is what each downloader anchors on: it hashes the artifact and
+/// compares against the manifest, so an unsigned one lets whoever can swap an
+/// artifact swap its recorded digest too and the comparison still passes. The
+/// image blobs (kernel, rootfs, verity sidecar) are not tarballs and carry no
+/// signature of their own, so the manifest is their only anchor.
+///
+/// Dropping a manifest from the signing loop, or signing it and forgetting to
+/// attach the bundle, both fail the same way: the download still succeeds, still
+/// "verifies", and nothing surfaces it until a real release ships. Hence a gate.
+#[test]
+fn every_published_checksum_manifest_is_signed_and_its_bundle_attached() {
+    let workflow = release_workflow();
+    let sign_step = workflow
+        .split("- name: Sign release tarballs")
+        .nth(1)
+        .expect("release.yml must have a signing step");
+    let sign_loop = sign_step
+        .split("done")
+        .next()
+        .expect("the signing loop is non-empty");
+    let assets = workflow
+        .split("assets=(")
+        .nth(1)
+        .expect("release.yml must list release assets")
+        .split(')')
+        .next()
+        .expect("the asset list is non-empty");
+
+    for manifest in [
+        "artifacts/checksums-sha256.txt",
+        "artifacts/builder-vm-*-checksums-sha256.txt",
+        "artifacts/default-microvm-*-checksums-sha256.txt",
+    ] {
+        assert!(
+            sign_loop.contains(manifest),
+            "{manifest} must be cosign-signed; every artifact digest below it inherits its trust"
+        );
+        assert!(
+            assets.contains(&format!("{manifest}.bundle")),
+            "{manifest}.bundle must be attached to the release, or the verifier 404s"
+        );
+    }
+
+    // The kernel manifest ships from its own workflow and is just as load-bearing.
+    let kernel = kernel_build_workflow();
+    let manifest = "kernel-${ARCH}-checksums-sha256.txt";
+    assert!(
+        kernel.contains(&format!("--bundle \"{manifest}.bundle\"")),
+        "kernel-build.yml must cosign-sign {manifest}"
+    );
+    assert!(
+        kernel.contains(&format!("\"{manifest}.bundle\" \\")),
+        "kernel-build.yml must upload {manifest}.bundle beside the manifest"
+    );
 }


### PR DESCRIPTION
## The gap

Every prebuilt artifact download — builder VM, default microVM, kernel, release tarballs — hashes the file and compares it against a `sha256sum` manifest fetched from the same release URL. **The manifest itself was unsigned.** TLS authenticates the transport, not the publisher, so whoever could serve a swapped artifact could serve a matching manifest beside it and the comparison would still pass.

The manifest was the weak link precisely because everything below it inherited its trust — and for the image blobs (kernel, rootfs, verity sidecar) it is the *only* anchor, since they are not tarballs and carry no signature of their own.

This was known and written down in two places, and neither follow-up had happened:

- `artifact_verify.rs` — "the real defence is end-to-end signing (cosign on the .tar.gz / SBOM today, **on the checksum file itself in a future iteration**)"
- `stage0_cache.rs` — the builder VM download is the tarball treatment "**minus cosign signing** (the signed-manifest path extends to builder-vm artifacts as a follow-up)"

## Producer

- `release.yml` — `builder-vm-*-checksums-sha256.txt`, `default-microvm-*-checksums-sha256.txt`, and the combined `checksums-sha256.txt` join the existing `cosign sign-blob --new-bundle-format` loop; each `.bundle` is published beside its manifest. The image manifests stay globs, so `nullglob` drops them when the image job that would have produced them failed — image signing stays best-effort exactly as image publication already is.
- `kernel-build.yml` — did no signing at all. Now signs `kernel-<arch>-checksums-sha256.txt` on the tag path. `id-token: write` is scoped to the **job**, not the workflow, because this workflow calls the BDD suite as a reusable workflow and that call would otherwise inherit an OIDC token it has no use for.

## Consumer

`fetch_expected_hashes` takes a `ChecksumManifest { base_url, asset, version }` instead of a joined URL — the verifier needs the pieces separately to locate the bundle and pin the tag-bound signing identity, and both call sites already held them separately, so the struct removed a line at each rather than adding one. Order is **download → verify → parse**: a manifest that fails the signature is refused with nothing read out of it.

Verification reuses `mvm_build::release_signature::verify_release_archive_signature` — the same identity-pinned Sigstore path the runtime overlay and SDK sidecar already take. No second verifier, no second bundle-name helper, no new dependency. `update.rs::download_kernel` gets the same treatment. A refusal bumps the existing `sig_invalid` counter, which also emits the `ImageVerifyFailed` audit line, since a bad signature is attack-shaped rather than a network blip.

## The two escape hatches are now independent in practice

`MVM_SKIP_HASH_VERIFY` and `MVM_SKIP_COSIGN_VERIFY` were already documented as deliberately separate — waiving *who published* is a strictly larger concession than waiving *what the bytes hash to*. Wiring the signature rung in is what makes that real: the hash hatch no longer disables publisher verification, because the publisher check now sits above it.

## ⚠️ Behaviour change

On the kernel path, `MVM_SKIP_HASH_VERIFY=1` previously skipped the manifest fetch outright, so it also happened to work when the manifest 404'd. **It no longer does** — a missing manifest is fatal regardless of that hatch.

Kept deliberately: the image path has always fetched the manifest unconditionally and only ever let the hatch waive the digest comparison, so the kernel path was the outlier and is now consistent. Flagging it because it narrows a documented emergency escape.

## The release gate could not see any of this

`verify-release-assets.sh` asserted each manifest *exists* but never that it was signed — so a release that silently skipped signing would still have passed `verify-release`. That is the exact failure this work exists to prevent, invisible to the check meant to catch it. Added `require_signed_manifest` (bundle must exist; under `--cosign` it must verify), plus a `release_assets` test that fails if any manifest leaves the signing loop or its bundle goes unattached.

## Verification

- **Red-first, and it genuinely went red.** Against unmodified code, `fetch_expected_hashes_refuses_an_unsigned_manifest_before_parsing` failed with `did not include an entry for 'dev-vmlinux-x86_64'` — the old code parsed the unsigned manifest and only complained afterwards. The test asserts the *absence* of that parse-stage error, so it fails again if the rung ever moves back after the parse.
- **Mutation-tested the new CI gate**, three mutants, each killed with the correct message: dropping a manifest from the sign loop, dropping a published `.bundle`, and kernel-build.yml ceasing to sign. Workflows restored byte-identically afterwards.
- **`require_signed_manifest`** red/green proven against a fixture harness.
- Three new `TestEnv`-isolated tests; the two pre-existing parser tests ported and still asserting what they asserted before.
- `cargo nextest run --workspace` → **11786 passed, 0 failed**; `cargo test --workspace --doc`; `cargo clippy --workspace --all-targets -- -D warnings` exit 0; nightly `cargo fmt --all -- --check`; `just check-gated`; and `check-no-spec-refs-in-comments`, `check-test-home-isolation`, `check-plan-names`, `check-sprint-append`, `check-workflow-paths`, `check-honesty`, `check-no-overclaim`, `check-declared-backing`.

## Not done

- `mvm-build` carries a second `fetch_expected_hashes` used by `initramfs.rs` / `runtime_overlay.rs`, untouched here — those fetch checksums for artifacts whose tarballs are already independently cosign-verified, so the anchor is not missing the way it was for image blobs. The duplication is still worth collapsing.
- `runtime-overlay-*.tar.gz.sha256` and `sdk-sidecar-*.tar.gz.sha256` stay unsigned: single-line sidecars for a tarball that already carries its own signature.