### PR TITLE
fix(client): type the rootfs declaration instead of probing for it

### DIFF
--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -256,7 +256,8 @@ async fn transient_failed_launch_rolls_back_session_state() {
         .expect("request");
     let err = client.launch(request).await.unwrap_err();
     assert!(
-        err.to_string().contains("parse image reference"),
+        matches!(err, mvm_core::client::MvmError::InvalidSpec { .. })
+            && err.to_string().contains("not a usable OCI reference"),
         "got: {err}"
     );
 

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -26,6 +26,7 @@ use mvm_fs::oci::{
     UnpackOptions, UnpackReport, current_linux_platform, unpack_layer_with_prior_paths,
 };
 use mvm_runtime::AnyBackend;
+use mvm_runtime::artifacts::spec::RootfsSource;
 
 use mvm_core::client::BackendCapabilityReport;
 use mvm_core::client::dto::{
@@ -385,28 +386,75 @@ pub(crate) fn backend_err(e: impl std::fmt::Display) -> MvmError {
     }
 }
 
-/// How a `spec.image` string is interpreted.
+/// The work a declared rootfs source implies. One variant per verification
+/// path: a materialized blob is booted as-is, a tree is injected and
+/// materialized, and a reference is fetched from a registry first.
 #[derive(Debug, PartialEq, Eq)]
-enum ImageSource {
-    /// A path to an already-materialized `rootfs.ext4` — boot it directly.
+enum RootfsPlan {
+    /// An already-materialized `rootfs.ext4` — boot it directly.
     Materialized(PathBuf),
-    /// A path to an unpacked OCI rootfs directory — inject runtime + materialize.
+    /// An unpacked OCI rootfs directory — inject runtime + materialize.
     UnpackedDir(PathBuf),
-    /// Anything else is treated as an OCI registry reference — pull + unpack +
-    /// inject + materialize.
-    Registry(String),
+    /// A registry reference — pull + unpack + inject + materialize.
+    Pull(ImageReference),
 }
 
-/// Classify a `spec.image`: an existing file is a materialized rootfs, an
-/// existing directory is an unpacked tree, everything else is a registry ref.
-fn classify_image(image: &str) -> ImageSource {
-    let path = Path::new(image);
-    if path.is_file() {
-        ImageSource::Materialized(path.to_path_buf())
-    } else if path.is_dir() {
-        ImageSource::UnpackedDir(path.to_path_buf())
+/// Turn a caller-declared `spec.image` into the work it implies.
+///
+/// The declaration is parsed before anything is looked up, so a mistyped path
+/// stops here instead of falling through to the registry arm: the arms
+/// differ in how the bytes they produce are verified, and which one runs must
+/// not depend on the caller's working directory.
+fn plan_rootfs(image: &str) -> Result<RootfsPlan> {
+    let source: RootfsSource = image.parse().map_err(|e| MvmError::InvalidSpec {
+        reason: format!("{e}"),
+    })?;
+    plan_rootfs_source(source)
+}
+
+/// The declaration-to-work half of [`plan_rootfs`], split out so each arm is
+/// reachable in a test without going through the string grammar.
+fn plan_rootfs_source(source: RootfsSource) -> Result<RootfsPlan> {
+    match source {
+        // The filesystem is consulted only to tell a blob from a tree, and
+        // only once the caller has declared the source local.
+        RootfsSource::LocalPath(path) if path.is_file() => Ok(RootfsPlan::Materialized(path)),
+        RootfsSource::LocalPath(path) if path.is_dir() => Ok(RootfsPlan::UnpackedDir(path)),
+        RootfsSource::LocalPath(path) => Err(MvmError::InvalidSpec {
+            reason: format!(
+                "declared local rootfs path does not exist: {} — no registry fetch was \
+                 attempted; write `oci:<reference>` to boot a registry image instead",
+                path.display()
+            ),
+        }),
+        RootfsSource::Oci { image_ref } => image_ref
+            .parse::<ImageReference>()
+            .map(RootfsPlan::Pull)
+            .map_err(|e| MvmError::InvalidSpec {
+                reason: format!(
+                    "not a usable OCI reference: {image_ref:?}: {e}{}",
+                    path_collision_hint(&image_ref)
+                ),
+            }),
+        RootfsSource::Flake { flake_ref, attr } => Err(MvmError::InvalidSpec {
+            reason: format!(
+                "a flake source is built, not booted: build {flake_ref}#{attr} first, then \
+                 declare the resulting rootfs path"
+            ),
+        }),
+    }
+}
+
+/// A bare name is a registry reference by declaration, so a same-named file in
+/// the caller's working directory is not silently preferred — but it is almost
+/// certainly what they meant, so say so once the reference has failed to parse.
+fn path_collision_hint(image_ref: &str) -> String {
+    if Path::new(image_ref).exists() {
+        format!(
+            " (a filesystem entry named {image_ref:?} exists — write `./{image_ref}` or `path:{image_ref}` to boot it)"
+        )
     } else {
-        ImageSource::Registry(image.to_string())
+        String::new()
     }
 }
 
@@ -414,14 +462,14 @@ fn classify_image(image: &str) -> ImageSource {
 /// as needed (no subprocess, no CLI). Registry pulls are async; the dir +
 /// pre-materialized cases are synchronous.
 pub(crate) async fn resolve_local_rootfs(image: &str, name: &str) -> Result<PathBuf> {
-    match classify_image(image) {
-        ImageSource::Materialized(path) => Ok(path),
+    match plan_rootfs(image)? {
+        RootfsPlan::Materialized(path) => Ok(path),
         // An already-unpacked tree carries no unpack report, so there is
         // nothing the host filesystem deferred to merge back in.
-        ImageSource::UnpackedDir(dir) => materialize_from_dir(&dir, name, Vec::new()),
-        ImageSource::Registry(reference) => {
+        RootfsPlan::UnpackedDir(dir) => materialize_from_dir(&dir, name, Vec::new()),
+        RootfsPlan::Pull(image_ref) => {
             let staging = tempfile::tempdir().map_err(backend_err)?;
-            let deferred_nodes = pull_image_to_dir(&reference, staging.path()).await?;
+            let deferred_nodes = pull_image_to_dir(&image_ref, staging.path()).await?;
             materialize_from_dir(staging.path(), name, deferred_nodes)
         }
     }
@@ -464,13 +512,14 @@ fn materialize_from_dir(
 /// Pull a public OCI registry reference and unpack every layer into `dest`,
 /// reusing mvm-oci's fetch + hardened unpacker (gzip is decoded here, at the
 /// crate boundary, keeping mvm-oci decompressor-free by design).
-async fn pull_image_to_dir(reference: &str, dest: &Path) -> Result<Vec<mvm_fs::ext4::Node>> {
-    let image_ref: ImageReference = reference
-        .parse()
-        .map_err(|e| backend_err(format!("parse image reference {reference:?}: {e}")))?;
+async fn pull_image_to_dir(
+    image_ref: &ImageReference,
+    dest: &Path,
+) -> Result<Vec<mvm_fs::ext4::Node>> {
+    let reference = image_ref.canonical();
     let manifest_fetcher = OciManifestFetcher::new();
     let manifest = manifest_fetcher
-        .fetch_linux_platform_manifest(&image_ref, &current_linux_platform())
+        .fetch_linux_platform_manifest(image_ref, &current_linux_platform())
         .await
         .map_err(|e| backend_err(format!("fetch manifest for {reference}: {e}")))?;
     let layers = manifest
@@ -486,7 +535,7 @@ async fn pull_image_to_dir(reference: &str, dest: &Path) -> Result<Vec<mvm_fs::e
     for layer in &layers {
         let mut bytes = Vec::new();
         layer_fetcher
-            .fetch_layer(&image_ref, layer, &mut bytes)
+            .fetch_layer(image_ref, layer, &mut bytes)
             .await
             .map_err(|e| backend_err(format!("fetch layer {}: {e}", layer.digest)))?;
         let report = unpack_one_layer(layer, &bytes, dest, &prior_layer_paths)?;
@@ -1013,27 +1062,134 @@ mod tests {
         assert!(none.len() <= machines.len());
     }
 
+    /// `std::env::set_current_dir` is process-wide; this Mutex stops
+    /// `cargo test`'s thread pool from racing between two cwd-mutating tests.
+    /// The lock is held for the lifetime of [`CwdGuard`].
+    static CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct CwdGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        prev: PathBuf,
+    }
+
+    impl CwdGuard {
+        fn enter(dir: &Path) -> Self {
+            let guard = CWD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::current_dir().expect("cwd");
+            std::env::set_current_dir(dir).expect("chdir");
+            CwdGuard {
+                _guard: guard,
+                prev,
+            }
+        }
+    }
+
+    impl Drop for CwdGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.prev);
+        }
+    }
+
+    fn reference(s: &str) -> ImageReference {
+        s.parse().expect("parses as an OCI reference")
+    }
+
     #[test]
-    fn classify_image_routes_file_dir_and_registry() {
+    fn plan_rootfs_routes_file_dir_and_registry() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("rootfs.ext4");
         std::fs::write(&file, b"x").unwrap();
 
         // An existing file → a materialized rootfs.
         assert_eq!(
-            classify_image(&file.to_string_lossy()),
-            ImageSource::Materialized(file.clone())
+            plan_rootfs(&file.to_string_lossy()).unwrap(),
+            RootfsPlan::Materialized(file.clone())
         );
         // An existing directory → an unpacked tree.
         assert_eq!(
-            classify_image(&dir.path().to_string_lossy()),
-            ImageSource::UnpackedDir(dir.path().to_path_buf())
+            plan_rootfs(&dir.path().to_string_lossy()).unwrap(),
+            RootfsPlan::UnpackedDir(dir.path().to_path_buf())
         );
-        // Anything else → a registry reference (no network touched here).
+        // A reference → a pull (no network touched here).
         assert_eq!(
-            classify_image("docker.io/library/alpine:3.20"),
-            ImageSource::Registry("docker.io/library/alpine:3.20".into())
+            plan_rootfs("docker.io/library/alpine:3.20").unwrap(),
+            RootfsPlan::Pull(reference("docker.io/library/alpine:3.20"))
         );
+    }
+
+    #[test]
+    fn a_mistyped_local_path_is_refused_and_never_planned_as_a_pull() {
+        let dir = tempfile::tempdir().unwrap();
+        // The user meant `rootfs.ext4`; nothing exists at what they typed.
+        let typo = dir.path().join("rootfs.ext5");
+
+        let planned = plan_rootfs(&typo.to_string_lossy());
+
+        // `Pull` is the only variant that reaches a registry, so refusing to
+        // produce one is what "no fetch was attempted" means here.
+        assert!(
+            !matches!(planned, Ok(RootfsPlan::Pull(_))),
+            "a typo'd local path must not be planned as a registry pull: {planned:?}"
+        );
+        let err = planned.expect_err("an absent declared path is an error");
+        assert!(
+            matches!(err, MvmError::InvalidSpec { .. }),
+            "expected a spec error naming the path, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains(&typo.display().to_string()),
+            "the error must name the path the caller typed: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_local_rootfs_refuses_a_mistyped_path_before_any_fetch() {
+        let dir = tempfile::tempdir().unwrap();
+        let typo = dir.path().join("rootfs.ext5");
+
+        let err = crate::local::resolve_local_rootfs(&typo.to_string_lossy(), "m")
+            .await
+            .expect_err("an absent declared path is an error");
+
+        assert!(matches!(err, MvmError::InvalidSpec { .. }), "got {err:?}");
+        assert!(err.to_string().contains(&typo.display().to_string()));
+    }
+
+    #[test]
+    fn a_registry_reference_survives_a_colliding_working_directory_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("alpine:3.20"), b"decoy").unwrap();
+        std::fs::create_dir(dir.path().join("busybox")).unwrap();
+        let _cwd = CwdGuard::enter(dir.path());
+
+        // Both names exist in the cwd; neither is a declared path, so both
+        // stay references.
+        assert_eq!(
+            plan_rootfs("alpine:3.20").unwrap(),
+            RootfsPlan::Pull(reference("alpine:3.20"))
+        );
+        assert_eq!(
+            plan_rootfs("busybox").unwrap(),
+            RootfsPlan::Pull(reference("busybox"))
+        );
+        // The explicitly-relative form is how the caller asks for the file.
+        assert_eq!(
+            plan_rootfs("./alpine:3.20").unwrap(),
+            RootfsPlan::Materialized(PathBuf::from("./alpine:3.20"))
+        );
+    }
+
+    #[test]
+    fn an_unbootable_declaration_names_what_is_wrong() {
+        let empty = plan_rootfs("").expect_err("empty is not a source");
+        assert!(matches!(empty, MvmError::InvalidSpec { .. }), "{empty:?}");
+
+        let flake = plan_rootfs_source(RootfsSource::Flake {
+            flake_ref: "./nix".into(),
+            attr: "rootfs".into(),
+        })
+        .expect_err("a flake is built, not booted");
+        assert!(flake.to_string().contains("./nix#rootfs"), "{flake}");
     }
 
     #[test]

--- a/crates/mvm-core/src/client/dto.rs
+++ b/crates/mvm-core/src/client/dto.rs
@@ -54,6 +54,14 @@ impl MachineStatus {
 #[serde(deny_unknown_fields)]
 pub struct MachineSpec {
     pub name: String,
+    /// What to boot, as a declaration rather than something to be guessed at:
+    /// an absolute, `./`-relative or `~/`-relative path (or an explicit
+    /// `path:<p>`) is a local rootfs — a materialized `rootfs.ext4` or an
+    /// unpacked tree — and anything else (or an explicit `oci:<ref>`) is an
+    /// OCI reference. A declared path that is absent is refused by name; it is
+    /// never retried as a registry pull, because the two take different
+    /// verification routes and which one runs must not depend on the caller's
+    /// working directory.
     pub image: String,
     pub cpus: u32,
     pub memory_mib: u32,

--- a/crates/mvm-runtime/src/artifacts/spec.rs
+++ b/crates/mvm-runtime/src/artifacts/spec.rs
@@ -72,3 +72,158 @@ pub struct MicrovmBuildSpec {
     /// Optional tenant scope for the resulting manifest.
     pub tenant_id: Option<String>,
 }
+
+/// Scheme prefixes that let a caller state which kind of source a string is,
+/// overriding the shape heuristic below.
+const PATH_SCHEME: &str = "path:";
+const OCI_SCHEME: &str = "oci:";
+
+/// Why a caller-supplied string is not a rootfs source at all.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RootfsSourceParseError {
+    #[error("empty rootfs source")]
+    Empty,
+    #[error("`{scheme}` prefix with no value")]
+    EmptyPayload { scheme: &'static str },
+}
+
+impl RootfsSource {
+    /// True for strings whose *shape* declares a filesystem location: an
+    /// absolute path, an explicitly-relative one, or a home-relative one. An
+    /// OCI reference can take none of these forms, so the two spaces do not
+    /// overlap and the answer needs no filesystem lookup.
+    fn is_path_shaped(s: &str) -> bool {
+        s.starts_with('/')
+            || s.starts_with("./")
+            || s.starts_with("../")
+            || s == "."
+            || s == ".."
+            || s.starts_with("~/")
+    }
+}
+
+impl std::str::FromStr for RootfsSource {
+    type Err = RootfsSourceParseError;
+
+    /// Classify a caller-declared rootfs string **without consulting the
+    /// filesystem**. What a string means is what the caller declared, not a
+    /// function of what happens to exist in their working directory — probing
+    /// makes a typo fall through to a different arm, and the arms differ in
+    /// how the resulting bytes are verified.
+    ///
+    /// `Flake` is not reachable from a string: a flake source carries an
+    /// attribute alongside the reference and is constructed by the build side.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Command substitution and file reads routinely carry a trailing
+        // newline; the surrounding whitespace is never part of the intent.
+        let s = s.trim();
+        if s.is_empty() {
+            return Err(RootfsSourceParseError::Empty);
+        }
+        if let Some(rest) = s.strip_prefix(PATH_SCHEME) {
+            return non_empty(rest, PATH_SCHEME).map(|v| Self::LocalPath(PathBuf::from(v)));
+        }
+        if let Some(rest) = s.strip_prefix(OCI_SCHEME) {
+            return non_empty(rest, OCI_SCHEME).map(|v| Self::Oci {
+                image_ref: v.to_string(),
+            });
+        }
+        if Self::is_path_shaped(s) {
+            Ok(Self::LocalPath(PathBuf::from(s)))
+        } else {
+            Ok(Self::Oci {
+                image_ref: s.to_string(),
+            })
+        }
+    }
+}
+
+fn non_empty<'a>(value: &'a str, scheme: &'static str) -> Result<&'a str, RootfsSourceParseError> {
+    if value.is_empty() {
+        Err(RootfsSourceParseError::EmptyPayload { scheme })
+    } else {
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod rootfs_source_parse_tests {
+    use super::*;
+
+    fn parse(s: &str) -> Result<RootfsSource, RootfsSourceParseError> {
+        s.parse()
+    }
+
+    fn local(p: &str) -> RootfsSource {
+        RootfsSource::LocalPath(PathBuf::from(p))
+    }
+
+    fn oci(r: &str) -> RootfsSource {
+        RootfsSource::Oci {
+            image_ref: r.to_string(),
+        }
+    }
+
+    #[test]
+    fn path_shapes_parse_as_local_paths() {
+        assert_eq!(
+            parse("/var/lib/rootfs.ext4").unwrap(),
+            local("/var/lib/rootfs.ext4")
+        );
+        assert_eq!(parse("./rootfs.ext4").unwrap(), local("./rootfs.ext4"));
+        assert_eq!(
+            parse("../out/rootfs.ext4").unwrap(),
+            local("../out/rootfs.ext4")
+        );
+        assert_eq!(
+            parse("~/images/rootfs.ext4").unwrap(),
+            local("~/images/rootfs.ext4")
+        );
+        assert_eq!(parse(".").unwrap(), local("."));
+    }
+
+    #[test]
+    fn registry_shapes_parse_as_oci_references() {
+        assert_eq!(parse("alpine:3.20").unwrap(), oci("alpine:3.20"));
+        assert_eq!(
+            parse("docker.io/library/alpine:3.20").unwrap(),
+            oci("docker.io/library/alpine:3.20")
+        );
+        // A bare name that could name a file in someone's cwd is still a
+        // reference — nothing here looks at the filesystem.
+        assert_eq!(parse("rootfs.ext4").unwrap(), oci("rootfs.ext4"));
+    }
+
+    #[test]
+    fn schemes_override_the_shape_heuristic() {
+        assert_eq!(parse("path:rootfs.ext4").unwrap(), local("rootfs.ext4"));
+        assert_eq!(
+            parse("oci:/weird/repo:tag").unwrap(),
+            oci("/weird/repo:tag")
+        );
+    }
+
+    #[test]
+    fn empty_and_valueless_schemes_are_errors() {
+        assert_eq!(parse("").unwrap_err(), RootfsSourceParseError::Empty);
+        assert_eq!(parse("   \n").unwrap_err(), RootfsSourceParseError::Empty);
+        assert_eq!(
+            parse("path:").unwrap_err(),
+            RootfsSourceParseError::EmptyPayload {
+                scheme: PATH_SCHEME
+            }
+        );
+        assert_eq!(
+            parse("oci:").unwrap_err(),
+            RootfsSourceParseError::EmptyPayload { scheme: OCI_SCHEME }
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_not_part_of_the_declaration() {
+        assert_eq!(
+            parse("  /var/rootfs.ext4\n").unwrap(),
+            local("/var/rootfs.ext4")
+        );
+    }
+}

--- a/specs/sprint/delivery/2544-typed-rootfs-declaration.md
+++ b/specs/sprint/delivery/2544-typed-rootfs-declaration.md
@@ -1,0 +1,33 @@
+# 2544 — the boot path reads a declared rootfs source, not a probed one
+
+`classify_image` decided what a `spec.image` string meant by asking the
+filesystem: `is_file()` → materialized rootfs, `is_dir()` → unpacked tree,
+anything else → registry reference. The fallthrough arm answered two different
+questions with one variant — "this is a reference" and "I could not classify
+this" — so a mistyped path (`rootfs.ext5`) left the local arm entirely and was
+handed to the OCI client, which turned it into a live registry GET whose 404
+named neither the typo nor the path. The mirror case followed from the same
+probe: a relative reference colliding with a cwd entry was silently
+reinterpreted as a local file.
+
+The three arms take different verification routes, so probing made the route a
+function of the caller's working directory rather than of what they declared.
+
+`RootfsSource` (`mvm-runtime`, already the build side's typed answer to this
+question) gained a filesystem-free `FromStr`: an absolute / `./` / `../` / `~/`
+path — or an explicit `path:` — is `LocalPath`, and everything else — or an
+explicit `oci:` — is `Oci`. `mvm-client`'s duplicate `ImageSource` is gone; the
+boot path now parses the declaration, then plans the work
+(`RootfsPlan::{Materialized, UnpackedDir, Pull}`). The filesystem is consulted
+only to tell a blob from a tree, and only after the caller declared the source
+local; an absent declared path is an `InvalidSpec` naming the path, and `Pull`
+— the only variant that reaches a registry — is unreachable from it. A bad
+reference is also parsed at plan time, before the staging dir, and hints at the
+`./` form when a same-named entry exists.
+
+Left alone deliberately: `mvm-cli::exec::ImageSource` shares the name but not
+the question — its variants are resolved boot artifacts (template, pinned
+revision, prebuilt kernel+rootfs paths, wasm module), downstream of this
+decision. Folding it in would conflate declaration with resolution. Typing
+`MachineSpec.image` itself is the remaining step and needs `RootfsSource`
+hoisted below `mvm-client`; tracked separately.


### PR DESCRIPTION
## What

`classify_image` in `crates/mvm-client/src/local.rs` decided what a `spec.image` string *meant* by probing the filesystem: `is_file()` → materialized rootfs, `is_dir()` → unpacked tree, anything else → registry reference. The fallthrough arm answered two different questions with one variant — "this is a reference" and "I could not classify this" — with two silent consequences: a mistyped local path became a network fetch against a garbage reference, and a relative reference colliding with a cwd entry became a local path.

The three arms verify their bytes differently, so probing made the verification route a function of the caller's working directory rather than of what they declared.

## The fix

`RootfsSource` (`crates/mvm-runtime/src/artifacts/spec.rs`) — the build side's existing typed answer to this same question — gains a **filesystem-free** `FromStr`:

- absolute / `./` / `../` / `~/`, or an explicit `path:<p>` → `LocalPath`
- everything else, or an explicit `oci:<ref>` → `Oci`
- empty (or a valueless scheme) → a parse error, not a guess

mvm-client's duplicate `ImageSource` is deleted. `resolve_local_rootfs` now parses the declaration, then plans the work as `RootfsPlan::{Materialized, UnpackedDir, Pull}`:

- the filesystem is consulted **only** to tell a blob from a tree, and only after the caller declared the source local;
- an absent declared path is an `InvalidSpec` naming the path, and `Pull` — the only variant that reaches a registry — is unreachable from that arm;
- a bad reference is parsed at plan time as well, before the staging dir, and hints at the `./` form when a same-named filesystem entry exists.

`RootfsPlan::Pull` carries a parsed `ImageReference` rather than a string, so an unparseable reference cannot reach the fetcher at all.

## On converging the three types

Two of the three converged: `mvm-client::local::ImageSource` is gone, replaced by `RootfsSource` + the plan enum.

`mvm-cli::exec::ImageSource` is deliberately left alone. It shares the name but not the question — its variants (`Template`, `PinnedTemplate`, `Prebuilt { kernel_path, rootfs_path, … }`, `WasmModule`) are *resolved boot artifacts*, downstream of the declaration this issue is about. Folding it into `RootfsSource` would conflate declaration with resolution and lose the template/pinned-revision cases, which have no rootfs string at all. With the client's copy gone, there is now exactly one `ImageSource` in the tree and it names a different concept.

Remaining and not done here: `MachineSpec.image` is still `String` on the wire. Typing the DTO field needs `RootfsSource` hoisted from `mvm-runtime` down to `mvm-core`, which is a wider move than this bug warrants. The grammar is documented on the field, and the parse now happens at the boundary, so the declaration is authoritative from there inward. Filed as #2553.

## Red proof

Each new test was run against the unfixed behaviour by restoring the old probing logic under the new signature (same function name, old body), leaving the tests untouched. 4 of 4 fail, verbatim:

```
     Summary [   0.341s] 7 tests run: 3 passed, 4 failed, 215 skipped
        FAIL [   0.024s] (1/7) mvm-client local::tests::an_unbootable_declaration_names_what_is_wrong
        FAIL [   0.027s] (3/7) mvm-client local::tests::a_registry_reference_survives_a_colliding_working_directory_entry
        FAIL [   0.028s] (5/7) mvm-client local::tests::a_mistyped_local_path_is_refused_and_never_planned_as_a_pull
        FAIL [   0.339s] (7/7) mvm-client local::tests::resolve_local_rootfs_refuses_a_mistyped_path_before_any_fetch
```

The typo'd path is planned as a pull — asserting on "no registry call happened", not merely "an error occurred":

```
thread 'local::tests::a_mistyped_local_path_is_refused_and_never_planned_as_a_pull' panicked at crates/mvm-client/src/local.rs:1135:9:
a typo'd local path must not be planned as a registry pull: Ok(Pull(ImageReference { registry: "docker.io", repository: "/var/folders/y5/_5yhtyx939bdw3qgt8bv5x6c0000gn/t/.tmpx2hhyv/rootfs.ext5", tag: Some("latest"), digest: None }))
```

...and end to end, the typo really does leave the machine:

```
thread 'local::tests::resolve_local_rootfs_refuses_a_mistyped_path_before_any_fetch' panicked at crates/mvm-client/src/local.rs:1159:9:
got Backend { reason: "fetch manifest for docker.io//var/folders/y5/_5yhtyx939bdw3qgt8bv5x6c0000gn/t/.tmpemrrpl/rootfs.ext5:latest: registry error: GET https://registry-1.docker.io/v2//var/folders/y5/_5yhtyx939bdw3qgt8bv5x6c0000gn/t/.tmpemrrpl/rootfs.ext5/manifests/latest failed with 404 Not Found: 404 page not found\n" }
```

The cwd-collision case, with a file named `alpine:3.20` and a directory named `busybox` in the working directory:

```
thread 'local::tests::a_registry_reference_survives_a_colliding_working_directory_entry' panicked at crates/mvm-client/src/local.rs:1172:9:
assertion `left == right` failed
  left: Materialized("alpine:3.20")
 right: Pull(ImageReference { registry: "docker.io", repository: "library/alpine", tag: Some("3.20"), digest: None })
```

One existing test changed: `launch::tests::transient_failed_launch_rolls_back_session_state` asserted on the old `"parse image reference"` message, which is now raised at plan time as `InvalidSpec`. Same refusal, same rollback, earlier and typed.

## Verification

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 11791 passed, 0 failed
- `cargo test --workspace --doc` — clean
- `just check-gated` equivalent: `cargo-zigbuild check --target x86_64-unknown-linux-gnu --workspace --all-targets` and `cargo check -p mvm-conformance --all-targets --features bdd` — both clean
- every `xtask check-*` gate the Lint job runs — clean

Pre-existing and untouched: `cargo nextest run -p mvm-runtime --all-features` fails to compile on `main` (`wasm_backend.rs:2852` calls `spawn_stub_substitution_endpoint`, which exists nowhere in the tree). Not reachable from any lane this PR changes.

Closes #2544
