### PR TITLE
fix(runtime): call the network-endpoint stub by the name it has

### DIFF
--- a/crates/mvm-runtime/src/wasm_backend.rs
+++ b/crates/mvm-runtime/src/wasm_backend.rs
@@ -2849,7 +2849,7 @@ mod tests {
                     headers: vec![],
                     body_b64: B64.encode(b"pong"),
                 };
-                let server = spawn_stub_substitution_endpoint(socket_path.clone(), canned_response);
+                let server = spawn_stub_network_endpoint(socket_path.clone(), canned_response);
                 let wat = r#"(module
   (import "mvm" "egress" (func $mvm_egress (param i32 i32 i32 i32 i32 i32 i32) (result i32)))
   (memory (export "memory") 2)


### PR DESCRIPTION
`main` does not compile with this crate's features on:

```
$ cargo check -p mvm-runtime --all-features --tests
error[E0425]: cannot find function `spawn_stub_substitution_endpoint` in this scope
    --> crates/mvm-runtime/src/wasm_backend.rs:2852:30
error: could not compile `mvm-runtime` (lib test) due to 1 previous error
```

## Cause

The helper was renamed `spawn_stub_substitution_endpoint` → `spawn_stub_network_endpoint` when the shared authenticated session was extracted (#2443). It has two call sites inside the same test function; one was updated and one was not. Both the definition and the missed call live inside `activation_preopens_and_env_are_exactly_what_the_module_sees`, so scope was never the issue — just the name.

What made the rename read as finished: the surviving helper's own doc comment still calls it *"the stub substitution endpoint the P3a gate proves the wasm round-trip against."* The old name stayed visible in the prose next to the new one.

## Consequence

The enclosing test has not run since that rename — it could not be built. With the name corrected it passes:

```
PASS [0.037s] mvm-runtime wasm_backend::tests::wasm_backend_engine_tests::
              activation_preopens_and_env_are_exactly_what_the_module_sees
```

## Why no lane caught it

`Lint feature coverage` runs exactly two feature combinations:

```
cargo clippy   -p mvm-client --all-targets --features tracing-bridge
cargo nextest run -p mvm-core   --features hostd-transport
```

`mvm-runtime` with its features on is not built anywhere. I have **not** added a lane for it here — `--all-features` pulls the wasm engine in, and adding that to every PR is a real cost on a runner pool that is already the binding constraint. Worth a deliberate decision rather than a drive-by, so flagging rather than deciding.

## Verification

- `cargo check -p mvm-runtime --all-features --tests` — clean (was E0425)
- `cargo nextest run -p mvm-runtime --all-features -E 'test(activation_preopens)'` — 1 passed
- `cargo clippy -p mvm-runtime --all-features --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean

Found while reviewing #2552.