### PR TITLE
fix(ci): the Test aggregate must accept a succeeding out-of-scope kernel lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,13 +627,18 @@ jobs:
             echo "BDD conformance did not match scope $SCOPE_BDD: $BDD_RESULT"
             exit 1
           fi
-          case "$KERNEL_SCOPE" in
-            true) kernel_required=success ;;
-            false) kernel_required=skipped ;;
-            *) echo "Invalid kernel scope: $KERNEL_SCOPE"; exit 1 ;;
-          esac
-          if [ "$KERNEL_RESULT" != "$kernel_required" ]; then
-            echo "Kernel validation did not match scope $KERNEL_SCOPE: $KERNEL_RESULT"
+          # The kernel job carries no job-level `if:` — a skipped matrix job
+          # cannot expand its arch, so it would report a single check still
+          # carrying the un-expanded matrix placeholder in its name, matching
+          # neither required context and leaving every PR unmergeable. It
+          # therefore always runs and always reports `success`,
+          # skipping its steps individually when out of scope. So `success` is
+          # the required result in both scopes: an out-of-scope run skips its
+          # steps and succeeds, an in-scope run actually builds. Requiring
+          # `skipped` when out of scope — as this did before the job-level `if:`
+          # was removed — failed every PR that does not touch a kernel path.
+          if [ "$KERNEL_RESULT" != success ]; then
+            echo "Kernel validation did not succeed (scope $KERNEL_SCOPE): $KERNEL_RESULT"
             exit 1
           fi
 


### PR DESCRIPTION
## What's broken

#2548 removed the kernel job's job-level `if:` — correctly, because a skipped matrix job cannot expand `matrix.arch` and would report a single check still carrying the un-expanded placeholder, matching neither required context.

But the job now **always runs**, skipping its steps individually when out of scope, so `needs.kernel.result` is `success` regardless of scope. The `Test` aggregate was never updated and still requires `skipped` when the scope is false:

```bash
case "$KERNEL_SCOPE" in
  true) kernel_required=success ;;
  false) kernel_required=skipped ;;   # never true any more
esac
```

So `Test` fails on **every PR that does not touch a kernel path**. The kernel scope matches only `nix/images/kernel/`, the builder-vm flake, `check_kernel_config_budget.rs`, and `ci.yml`/`kernel-build.yml` — so a docs-only or single-crate PR reports every lane green and is refused anyway.

Currently blocking at least #2546 (all 10 lanes green, `Test` red) and #2547 (docs-only). It is not visible on PRs that happen to touch a workflow file, which is why it got through: #2549 touched `kernel-build.yml`, putting kernel in scope.

The failure message compounds it — *"Kernel validation did not match scope false: success"* reads as though a lane misbehaved, not as gate arithmetic.

## The fix

Require `success` in both scopes, since the job always runs.

| scope | kernel result | before | after |
|---|---|---|---|
| true | success | accept | accept |
| true | failure | reject | reject |
| **false** | **success** | **reject** | **accept** |
| false | failure | reject | reject |

The only row that changes is the regression. A genuine kernel failure is still rejected in either scope, so the gate does not weaken.

## Verification

- Truth-tabled the old and new conditions against all four scope/result combinations (table above), extracting the exact shell from the workflow.
- `actionlint` clean. It caught a real hazard mid-change: my first comment wording contained a literal `${{ matrix.arch }}`, which Actions interpolates even inside a shell comment. Reworded to describe the placeholder rather than write it.
- YAML parses.
- This PR touches `ci.yml`, so its own kernel lane is in scope and it clears the gate as it currently stands — it is self-unblocking.