### PR TITLE
fix(ci): stop the test aggregate asserting a conclusion the kernel lane no longer has

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,9 +627,14 @@ jobs:
             echo "BDD conformance did not match scope $SCOPE_BDD: $BDD_RESULT"
             exit 1
           fi
+          # The kernel lane runs on every event and gates its own steps, so
+          # that it ran says nothing about scope and `skipped` is no longer a
+          # reachable conclusion. What still has to hold is that it did not
+          # fail. That the lane actually built when its scope demanded it is
+          # asserted inside the job, against the artifacts, which is a stronger
+          # statement than a job conclusion could make.
           case "$KERNEL_SCOPE" in
-            true) kernel_required=success ;;
-            false) kernel_required=skipped ;;
+            true|false) kernel_required=success ;;
             *) echo "Invalid kernel scope: $KERNEL_SCOPE"; exit 1 ;;
           esac
           if [ "$KERNEL_RESULT" != "$kernel_required" ]; then
@@ -1029,6 +1034,23 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}
         run: bash scripts/build-kernel-artifacts.sh "$ARCH"
+
+      - name: Assert the lane built what its scope demanded
+        # Replaces what the `test` aggregate used to get from the job's own
+        # conclusion. Gating the steps rather than the job means a
+        # mis-gated step would leave the job green and empty, so the check
+        # has to look at the bytes.
+        if: needs.scope.outputs.kernel == 'true'
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          for f in "staging/vmlinux-${ARCH}-builder" "staging/vmlinux-${ARCH}-workload"; do
+            if [ ! -s "$f" ]; then
+              echo "::error::kernel scope is true but $f is missing or empty" >&2
+              exit 1
+            fi
+          done
 
       - name: Upload kernel artifacts
         if: ${{ always() && needs.scope.outputs.kernel == 'true' }}


### PR DESCRIPTION
**Every pull request that touches no kernel path is failing `Test`.** This is a regression from #2548 and it blocks the queue again.

```
KERNEL_SCOPE: false
KERNEL_RESULT: success
Kernel validation did not match scope false: success
```

## Cause

#2548 removed the kernel job's job-level `if:` so a skipped matrix job could not swallow the two required `Build kernels (…)` contexts. That fix is correct and confirmed — PRs now report `Build kernels (aarch64)` / `(x86_64)` under their expanded names.

But it changed the job's conclusion. The lane now **runs on every event** and gates its own steps, so it reports `success` whether or not it built anything. The `test` aggregate still asserted the old shape:

```
false) kernel_required=skipped ;;
```

`skipped` is no longer a conclusion that lane can reach, so the assertion could only ever fail.

## Fix, in two parts

**1. The aggregate asks what it can still answer.** Scope no longer predicts the conclusion, so the check is that the lane did not fail. The invalid-scope guard stays — a malformed scope value is still an error.

**2. The property the old assertion carried moves into the job, and gets stronger.** The aggregate was really asking "did the lane do its work when scope demanded it". Gating steps rather than the job means a mis-gated step would leave the job **green and empty** — something a job conclusion cannot detect at all. The new check looks for the kernel images:

```yaml
- name: Assert the lane built what its scope demanded
  if: needs.scope.outputs.kernel == 'true'
  run: |
    for f in "staging/vmlinux-${ARCH}-builder" "staging/vmlinux-${ARCH}-workload"; do
      [ -s "$f" ] || { echo "::error::kernel scope is true but $f is missing or empty"; exit 1; }
    done
```

Net: coverage goes up, not down. Before #2548 the aggregate could only see whether a job ran; now the lane proves it produced bytes.

## Verification

- `actionlint .github/workflows/ci.yml` — clean
- `cargo run -p xtask -- check-workflow-paths` — clean
- `cargo nextest run -p xtask -E 'test(workflow)'` — 20 passed

This PR touches `ci.yml`, so its own kernel scope is **true** — it exercises the new artifact assertion on itself, and both `Build kernels (…)` contexts must report expanded.