### PR TITLE
fix(build): stop reporting a slow endpoint exec as an unresponsive builder

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -64,6 +64,9 @@ use std::time::{Duration, Instant};
 use std::{fs, io};
 
 use libkrun_sys::{KernelFormat, KrunContext, SupervisorConfig};
+use mvm_vmm::host::network_endpoint_spawn::{
+    HandshakeContext, handshake_timeout, read_handshake_line,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -368,7 +371,20 @@ impl BuilderVsockEgressEndpoint {
                 "builder egress endpoint stdout was not piped".to_string(),
             )
         })?;
-        read_builder_endpoint_handshake(stdout, child.id(), Duration::from_secs(10))?;
+        // The shared reader, not a local copy: the builder's own version
+        // accepted any non-empty line as a handshake and reported a bare
+        // duration on timeout, which is not enough to tell a slow endpoint from
+        // a dead one.
+        read_handshake_line(
+            stdout,
+            child.id(),
+            handshake_timeout(),
+            &HandshakeContext {
+                endpoint: &endpoint_path,
+                stderr_log: Some(&stderr_log_path),
+            },
+        )
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("{e:#}")))?;
 
         let pid_file = state_dir.join(BUILDER_SUBST_PID_FILE);
         std::fs::write(&pid_file, child.id().to_string()).map_err(|e| {
@@ -496,43 +512,6 @@ fn resolve_network_endpoint_path() -> Result<PathBuf, BuilderVmError> {
             .collect::<Vec<_>>()
             .join(", ")
     )))
-}
-
-fn read_builder_endpoint_handshake(
-    stdout: std::process::ChildStdout,
-    pid: u32,
-    timeout: Duration,
-) -> Result<(), BuilderVmError> {
-    use std::io::{BufRead, BufReader};
-
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let mut line = String::new();
-        let res = BufReader::new(stdout).read_line(&mut line).map(|_| line);
-        let _ = tx.send(res);
-    });
-
-    match rx.recv_timeout(timeout) {
-        Ok(Ok(line)) if !line.trim().is_empty() => Ok(()),
-        Ok(Ok(_)) => {
-            kill_pid(pid as libc::pid_t, libc::SIGKILL);
-            Err(BuilderVmError::ExtractionFailed(
-                "builder egress endpoint closed stdout without a ready handshake".to_string(),
-            ))
-        }
-        Ok(Err(e)) => {
-            kill_pid(pid as libc::pid_t, libc::SIGKILL);
-            Err(BuilderVmError::ExtractionFailed(format!(
-                "read builder egress endpoint handshake: {e}"
-            )))
-        }
-        Err(_) => {
-            kill_pid(pid as libc::pid_t, libc::SIGKILL);
-            Err(BuilderVmError::ExtractionFailed(format!(
-                "builder egress endpoint handshake timed out after {timeout:?}"
-            )))
-        }
-    }
 }
 
 fn reap_builder_vsock_egress_endpoint(state_dir: &Path) {

--- a/crates/mvm-vmm/src/host/network_endpoint_spawn.rs
+++ b/crates/mvm-vmm/src/host/network_endpoint_spawn.rs
@@ -179,9 +179,79 @@ pub fn build_egress_tls_delivery(bound_hosts: &[&str], ca_dir: &Path) -> Result<
 /// path reads this to inject `HTTP_PROXY` + placeholder vars). Spawned only when
 /// the admitted plan carries secret bindings.
 pub const SUBST_PID_FILE: &str = "substitution.pid";
-/// How long the endpoint gets to bind its listener + write the ready handshake
-/// line before the caller declares the spawn failed.
-pub const SUBST_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Default bound on the endpoint's ready handshake.
+///
+/// This is not a budget for the endpoint's work — binding a listener and
+/// writing one line is microseconds. It is a budget for the process *starting*,
+/// and the callers put a lot in front of that: the Stage 0 builder packs a
+/// multi-gigabyte, non-sparse `work.ext4` immediately before spawning, so a
+/// cold helper binary competes with that flush for I/O and can take tens of
+/// seconds to reach `main`. A tight bound turns a slow exec into a spurious
+/// "endpoint unresponsive" and sends the operator hunting a hang that is really
+/// a queue. Nothing is lost by being generous: an endpoint that dies closes
+/// stdout, and that is reported the moment it happens rather than at this bound.
+const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Env var overriding [`DEFAULT_HANDSHAKE_TIMEOUT`], in whole seconds.
+pub const HANDSHAKE_TIMEOUT_ENV: &str = "MVM_ENDPOINT_HANDSHAKE_TIMEOUT_SECS";
+
+/// The handshake bound in force, honouring [`HANDSHAKE_TIMEOUT_ENV`].
+pub fn handshake_timeout() -> Duration {
+    std::env::var(HANDSHAKE_TIMEOUT_ENV)
+        .ok()
+        .and_then(|raw| parse_handshake_timeout(&raw))
+        .unwrap_or(DEFAULT_HANDSHAKE_TIMEOUT)
+}
+
+/// Parse an override. Split out so "junk and zero fall back to the default"
+/// is testable without mutating the environment. Zero is rejected rather than
+/// honoured: a zero bound fails every spawn before the endpoint can answer.
+fn parse_handshake_timeout(raw: &str) -> Option<Duration> {
+    let secs: u64 = raw.trim().parse().ok()?;
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+/// How much of the endpoint's stderr a failed handshake quotes back.
+const STDERR_TAIL_BYTES: usize = 2048;
+
+/// What a failed handshake names, so the failure is actionable from the error
+/// text alone. Without it the caller reports a bare duration while the
+/// endpoint's own stderr — which says exactly what went wrong — sits unread in
+/// a file the operator has no reason to know exists.
+pub struct HandshakeContext<'a> {
+    /// The endpoint binary that was spawned.
+    pub endpoint: &'a Path,
+    /// Where that process's stderr was redirected, when the caller redirected it.
+    pub stderr_log: Option<&'a Path>,
+}
+
+impl HandshakeContext<'_> {
+    /// Append which binary was run and what it said before it stopped talking.
+    fn describe(&self, what: &str) -> String {
+        let mut msg = format!("{what} (endpoint {})", self.endpoint.display());
+        let Some(log) = self.stderr_log else {
+            return msg;
+        };
+        match stderr_tail(log, STDERR_TAIL_BYTES) {
+            Some(tail) => msg.push_str(&format!("; its stderr said: {tail}")),
+            None => msg.push_str(&format!("; it wrote nothing to {}", log.display())),
+        }
+        msg
+    }
+}
+
+/// Last `max_bytes` of `path`, collapsed onto one line so it survives an error
+/// chain. `None` when the file is missing or empty — a silent endpoint is
+/// itself a finding, so the caller reports that rather than an empty quote.
+fn stderr_tail(path: &Path, max_bytes: usize) -> Option<String> {
+    let raw = std::fs::read(path).ok()?;
+    let start = raw.len().saturating_sub(max_bytes);
+    let collapsed = String::from_utf8_lossy(&raw[start..])
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!collapsed.is_empty()).then_some(collapsed)
+}
 
 /// Locate the `mvm-network-endpoint` binary. Compiled by mvmctl's build
 /// script; see [`mvm_vmm::host::aux_bin`] for the search order.
@@ -690,7 +760,15 @@ pub fn spawn_network_endpoint(mut params: SubstitutionSpawnParams<'_>) -> Result
         .stdout
         .take()
         .ok_or_else(|| anyhow!("substitution endpoint stdout was not piped"))?;
-    let handshake = read_handshake_line(stdout, child.id(), SUBST_HANDSHAKE_TIMEOUT)?;
+    let handshake = read_handshake_line(
+        stdout,
+        child.id(),
+        handshake_timeout(),
+        &HandshakeContext {
+            endpoint: &bin,
+            stderr_log: Some(&stderr_log),
+        },
+    )?;
 
     std::fs::write(&pid_file, child.id().to_string())
         .map_err(|e| anyhow!("write {}: {e}", pid_file.display()))?;
@@ -769,10 +847,15 @@ impl Drop for SpawnedEndpointGuard {
 /// a helper thread and bound the wait; on timeout / EOF-without-line / a line
 /// that is not a handshake, SIGKILL the endpoint and fail (the caller rolls
 /// back the VM — fail closed).
-fn read_handshake_line(
+///
+/// Shared by every spawner of this binary. The builder path used to carry its
+/// own copy that accepted *any* non-empty line as a handshake, so stray chrome
+/// on a shared stdout read as success there and as a parse failure here.
+pub fn read_handshake_line(
     stdout: std::process::ChildStdout,
     pid: u32,
     timeout: Duration,
+    ctx: &HandshakeContext<'_>,
 ) -> Result<EndpointHandshake> {
     use std::io::{BufRead, BufReader};
     let (tx, rx) = std::sync::mpsc::channel();
@@ -784,19 +867,34 @@ fn read_handshake_line(
     match rx.recv_timeout(timeout) {
         Ok(Ok(line)) if !line.trim().is_empty() => serde_json::from_str(line.trim()).map_err(|e| {
             kill(pid as libc::pid_t, libc::SIGKILL);
-            anyhow!("parse substitution endpoint handshake: {e}")
+            anyhow!(
+                "{}",
+                ctx.describe(&format!("parse substitution endpoint handshake: {e}"))
+            )
         }),
         Ok(Ok(_)) => {
             kill(pid as libc::pid_t, libc::SIGKILL);
-            bail!("substitution endpoint closed stdout without a ready handshake")
+            bail!(
+                "{}",
+                ctx.describe("substitution endpoint closed stdout without a ready handshake")
+            )
         }
         Ok(Err(e)) => {
             kill(pid as libc::pid_t, libc::SIGKILL);
-            bail!("read substitution endpoint handshake: {e}")
+            bail!(
+                "{}",
+                ctx.describe(&format!("read substitution endpoint handshake: {e}"))
+            )
         }
         Err(_) => {
             kill(pid as libc::pid_t, libc::SIGKILL);
-            bail!("substitution endpoint handshake timed out after {timeout:?}")
+            bail!(
+                "{}",
+                ctx.describe(&format!(
+                    "substitution endpoint handshake timed out after {timeout:?} \
+                     (override with {HANDSHAKE_TIMEOUT_ENV})"
+                ))
+            )
         }
     }
 }
@@ -938,12 +1036,195 @@ mod tests {
             .spawn()
             .unwrap();
         let stdout = child.stdout.take().expect("child stdout is piped");
-        let err = read_handshake_line(stdout, child.id(), Duration::from_secs(1))
-            .expect_err("an empty handshake line must fail");
+        let err = read_handshake_line(
+            stdout,
+            child.id(),
+            Duration::from_secs(1),
+            &HandshakeContext {
+                endpoint: std::path::Path::new("/bin/sh"),
+                stderr_log: None,
+            },
+        )
+        .expect_err("an empty handshake line must fail");
         assert!(
             err.to_string()
                 .contains("closed stdout without a ready handshake")
         );
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn handshake_timeout_override_rejects_zero_and_junk() {
+        assert_eq!(parse_handshake_timeout("90"), Some(Duration::from_secs(90)));
+        assert_eq!(
+            parse_handshake_timeout("  90 "),
+            Some(Duration::from_secs(90))
+        );
+        // Zero would fail every spawn before the endpoint could answer.
+        assert_eq!(parse_handshake_timeout("0"), None);
+        assert_eq!(parse_handshake_timeout("soon"), None);
+        assert_eq!(parse_handshake_timeout(""), None);
+        assert_eq!(parse_handshake_timeout("-5"), None);
+    }
+
+    #[test]
+    fn handshake_timeout_defaults_well_clear_of_a_cold_exec() {
+        // The bound this replaced was 10s, which a cold helper exec behind a
+        // multi-gigabyte disk write does not reliably meet.
+        assert!(DEFAULT_HANDSHAKE_TIMEOUT >= Duration::from_secs(30));
+    }
+
+    #[test]
+    fn stderr_tail_reports_none_for_missing_and_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.log");
+        assert_eq!(stderr_tail(&missing, 512), None);
+
+        let empty = dir.path().join("empty.log");
+        std::fs::write(&empty, b"").unwrap();
+        assert_eq!(stderr_tail(&empty, 512), None);
+
+        // Whitespace only is "wrote nothing" too — quoting it back is noise.
+        let blank = dir.path().join("blank.log");
+        std::fs::write(&blank, b"\n\n   \n").unwrap();
+        assert_eq!(stderr_tail(&blank, 512), None);
+    }
+
+    #[test]
+    fn stderr_tail_keeps_the_end_and_collapses_onto_one_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("e.log");
+        std::fs::write(&log, b"first line\nsecond line\n").unwrap();
+        assert_eq!(
+            stderr_tail(&log, 4096).as_deref(),
+            Some("first line second line")
+        );
+        // Bounded: the tail is what matters, the head is dropped. `"second
+        // line\n"` is the last 12 bytes of the file.
+        let tail = stderr_tail(&log, 12).expect("a bounded read still yields the tail");
+        assert_eq!(tail, "second line");
+    }
+
+    #[test]
+    fn timed_out_handshake_names_the_endpoint_and_quotes_its_stderr() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("endpoint.stderr.log");
+        std::fs::write(&log, b"bind failed: Address already in use\n").unwrap();
+
+        let mut child = Command::new("sh")
+            .args(["-c", "exec sleep 30"])
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdout = child.stdout.take().expect("child stdout is piped");
+        let err = read_handshake_line(
+            stdout,
+            child.id(),
+            Duration::from_millis(200),
+            &HandshakeContext {
+                endpoint: Path::new("/opt/mvm/mvm-network-endpoint"),
+                stderr_log: Some(&log),
+            },
+        )
+        .expect_err("a silent endpoint must time out");
+        let msg = err.to_string();
+        assert!(msg.contains("timed out"), "{msg}");
+        // The three things the operator needs and used to have to guess.
+        assert!(msg.contains("/opt/mvm/mvm-network-endpoint"), "{msg}");
+        assert!(msg.contains("Address already in use"), "{msg}");
+        assert!(msg.contains(HANDSHAKE_TIMEOUT_ENV), "{msg}");
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn a_silent_endpoint_is_reported_as_silent_not_quoted_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("endpoint.stderr.log");
+        std::fs::write(&log, b"").unwrap();
+
+        let mut child = Command::new("sh")
+            .args(["-c", "exec sleep 30"])
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdout = child.stdout.take().expect("child stdout is piped");
+        let err = read_handshake_line(
+            stdout,
+            child.id(),
+            Duration::from_millis(200),
+            &HandshakeContext {
+                endpoint: Path::new("/opt/mvm/mvm-network-endpoint"),
+                stderr_log: Some(&log),
+            },
+        )
+        .expect_err("a silent endpoint must time out");
+        let msg = err.to_string();
+        assert!(msg.contains("wrote nothing to"), "{msg}");
+        assert!(msg.contains(&log.display().to_string()), "{msg}");
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn a_non_handshake_line_is_refused() {
+        // The builder path used to accept any non-empty line, so stray chrome
+        // on a shared stdout read as a successful handshake there.
+        let mut child = Command::new("sh")
+            .args([
+                "-c",
+                "printf 'Preparing the builder VM...\\n'; exec sleep 30",
+            ])
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdout = child.stdout.take().expect("child stdout is piped");
+        let err = read_handshake_line(
+            stdout,
+            child.id(),
+            Duration::from_secs(5),
+            &HandshakeContext {
+                endpoint: Path::new("/opt/mvm/mvm-network-endpoint"),
+                stderr_log: None,
+            },
+        )
+        .expect_err("chrome is not a handshake");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("parse substitution endpoint handshake"),
+            "{msg}"
+        );
+        assert!(msg.contains("/opt/mvm/mvm-network-endpoint"), "{msg}");
+        // `read_handshake_line` already SIGKILLed it; reap so nextest sees no leak.
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn a_well_formed_handshake_line_is_accepted() {
+        let mut child = Command::new("sh")
+            .args([
+                "-c",
+                &format!("printf '%s\\n' '{READY_HANDSHAKE}'; exec sleep 30"),
+            ])
+            .stdout(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdout = child.stdout.take().expect("child stdout is piped");
+        let handshake = read_handshake_line(
+            stdout,
+            child.id(),
+            Duration::from_secs(5),
+            &HandshakeContext {
+                endpoint: Path::new("/opt/mvm/mvm-network-endpoint"),
+                stderr_log: None,
+            },
+        )
+        .expect("a well-formed handshake must parse");
+        assert_eq!(handshake.env.len(), 1);
+        assert_eq!(handshake.input_fingerprints.len(), 1);
+        assert_eq!(
+            handshake.input_fingerprints[0].category(),
+            SecretCategory::HostSecret
+        );
+        let _ = child.kill();
         let _ = child.wait();
     }
 

--- a/specs/plans/2026-08-15-aux-helper-binary-freshness.md
+++ b/specs/plans/2026-08-15-aux-helper-binary-freshness.md
@@ -1,0 +1,71 @@
+# Aux helper binaries drift from `mvmctl`, and two resolvers disagree about which one to run
+
+Backing: shipped-source
+Validation: none
+
+Every path below was read on `main` at `0c9ef804d`. The two-divergent-binaries
+observation is from a developer machine and reproduces by building two branches
+through one shared `CARGO_TARGET_DIR`. Nothing here is gated yet — the checkboxes
+are the work, not a record of it.
+
+Deferred out of the builder-egress handshake fix. Neither item caused that
+failure — the handshake timeout did — but both were found while diagnosing it,
+and both make a future occurrence harder to diagnose than it needs to be.
+
+## 1. Two resolvers for `mvm-network-endpoint`, with opposite precedence
+
+`mvm_vmm::host::aux_bin::resolve` (`crates/mvm-vmm/src/host/aux_bin.rs`) is the
+canonical resolver. Its order is `$<ENV_VAR>` → `$MVM_AUX_BIN_DIR` → next to
+`current_exe` → workspace `target/{release,debug}`, and its doc comment says why
+the build script's dir must come first: so a freshly built helper there is not
+shadowed by a stale copy sitting next to a dev `cargo run` exe.
+
+`resolve_network_endpoint_path` in `crates/mvm-build/src/libkrun_builder.rs`
+reimplements that search and **omits `$MVM_AUX_BIN_DIR`**, so the builder path
+picks exactly the copy the canonical resolver exists to avoid. `mvm-build`
+already depends on `mvm-vmm` (`crates/mvm-build/Cargo.toml`), so it can call
+`aux_bin::resolve` directly.
+
+- [ ] Delete `resolve_network_endpoint_path` and call `aux_bin::resolve`.
+- [ ] Note that this also drops the run-time `cargo build -p mvm-hostd`
+      fallback, which is the intended behaviour: `aux_bin::resolve`
+      deliberately never builds and errors with a `just build-supervisors` hint.
+- [ ] Test: the builder path prefers `$MVM_AUX_BIN_DIR` over a decoy copy
+      beside the exe.
+
+## 2. The build script's watch list has two holes
+
+`build_native_aux_helpers` in `crates/mvm-cli/build.rs` watches
+`crates/mvm-hostd/src` and `crates/mvm-core/src` with a bare directory-level
+`rerun-if-changed`. The same file's own comment on `emit_rerun_for_tree` states
+that cargo does not reliably re-trigger a directory watch on a content edit to
+an existing file, which is why `crates/mvm-runtime/src` and
+`crates/mvm-build/src` get the file-by-file walk instead.
+
+`crates/mvm-vmm/src` is not watched at all, though `mvm-network-endpoint` links
+it (`cargo tree -p mvm-hostd --depth 1`).
+
+Observed consequence: two `mvm-network-endpoint` binaries coexisting under one
+shared target dir, built from different commits — one linking `rand 0.10` and
+`crates/mvm-http/src/proxy.rs`, the other `rand 0.8` with no `proxy.rs`.
+
+- [ ] Switch the `mvm-hostd/src` and `mvm-core/src` entries to
+      `emit_rerun_for_tree`.
+- [ ] Add `crates/mvm-vmm/src`.
+- [ ] Extend the existing freshness guard rather than adding a second one:
+      `supervisor_needs_rebuild` / `LIBKRUN_SUPERVISOR_INPUT_ROOTS` in
+      `crates/mvm-build/src/libkrun_builder.rs` today covers only
+      `mvm-libkrun-supervisor`. Add `crates/mvm-vmm/{Cargo.toml,src}` to its
+      roots and apply it to `mvm-network-endpoint` too.
+
+## 3. The deeper cause behind the handshake timeout
+
+The handshake fix raises and bounds the budget and makes the failure legible. It
+does not remove what made the budget tight: `pack_stage0_work_disk`
+(`crates/mvm-build/src/libkrun_builder.rs`) writes a multi-gigabyte, non-sparse
+`work.ext4` immediately before `BuilderVsockEgressEndpoint::spawn`, so the
+endpoint's first exec competes with that flush.
+
+- [ ] Consider spawning the egress endpoint *before* packing the work disk. The
+      endpoint would then be alive across a long pack, which the parent-death
+      watchdog and the RAII reaper already cover — confirm that before moving it.


### PR DESCRIPTION
`mvmctl bootstrap` intermittently failed with:

    Stage 0 root-dir build: extracting artifacts from builder sandbox:
    builder egress endpoint handshake timed out after 10s

with a hint pointing at `mvmctl cache repair`, which is not the problem.

## What was happening

The endpoint's stderr log was zero bytes in every failure. Its first `info!`
fires immediately after the config parse, so an empty log proves the process
never reached `main` — it was still being exec'd. Nothing was hung: the same
binary handshakes in ~45ms once its pages are warm, and three consecutive
failures were followed by a clean pass with no rebuild in between.

`pack_stage0_work_disk` writes a multi-gigabyte, non-sparse `work.ext4`
immediately before `BuilderVsockEgressEndpoint::spawn`, so the endpoint's first
exec competes with that flush for I/O. Ten seconds is a fine budget for the
endpoint's work — bind a listener, write a line — and a poor one for a cold
28 MB helper starting behind a 2.5 GB write.

## The fix

Bound the process *starting*, not its work: 60s by default, overridable with
`MVM_ENDPOINT_HANDSHAKE_TIMEOUT_SECS`. Nothing is lost by being generous — an
endpoint that dies closes stdout, and that is still reported the moment it
happens rather than at the bound.

Then make the failure legible, because a bare duration is why this took a full
diagnosis pass. A failed handshake now names the endpoint binary and quotes the
tail of the stderr log the caller already opened for it and never read:

    substitution endpoint handshake timed out after 3s
    (override with MVM_ENDPOINT_HANDSHAKE_TIMEOUT_SECS)
    (endpoint /tmp/stub-endpoint.sh); its stderr said: bind failed: ...

A silent endpoint is reported as silent rather than quoted empty — that it wrote
nothing is itself the finding.

## One reader, not two

The builder carried its own copy of the handshake read that accepted **any**
non-empty line as success, so stray chrome on a shared stdout read as a
completed handshake there while the workload path rejected it. Deleted; both
paths now use `read_handshake_line`, which parses the line as an
`EndpointHandshake` or fails.

Deferred findings from the same diagnosis — the builder's second resolver for
`mvm-network-endpoint` that skips `$MVM_AUX_BIN_DIR`, the build script's
directory-level watches and its missing `crates/mvm-vmm/src` — are written up in
`specs/plans/2026-08-15-aux-helper-binary-freshness.md`. Neither caused this.

## Verification

- `cargo nextest run --workspace` — 11790 passed
- `cargo test --workspace --doc`, `just check-gated`, `cargo clippy --workspace
  --all-targets -- -D warnings`, `cargo +nightly fmt --all -- --check` — clean
- xtask gates incl. check-declared-backing / check-claim-catalog / check-honesty
  / check-no-spec-refs-in-comments / check-uniform-vsock-egress — clean
- End to end: a stub endpoint that writes to stderr and never handshakes now
  produces the message above; a real `mvmctl bootstrap` gets past the handshake
  and boots the guest, where it hits the separate egress defect in #2543.