### PR TITLE
fix(release): read the bytes the kernel execs, not just their checksum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           # Anything that can change a compiled target, generated artifact, or
           # the commands used by a Rust lane keeps the full compiler/test
           # matrix. Prose, site assets, and process-only specs do not.
-          if grep -zE '^(crates/|src/|tests/|xtask/|scripts/|features/|schema/|model/|assets/|\.cargo/|\.config/|\.github/actions/|\.github/workflows/|nix/packaging/release/verify-release-assets[^/]*\.sh$|Cargo\.(toml|lock)$|rust-toolchain\.toml$|build\.rs$|install\.sh$|[Jj]ustfile$)' "$CHANGED_FILE" >/dev/null; then
+          if grep -zE '^(crates/|src/|tests/|xtask/|scripts/|features/|schema/|model/|assets/|\.cargo/|\.config/|\.github/actions/|\.github/workflows/|nix/packaging/release/[^/]*\.sh$|Cargo\.(toml|lock)$|rust-toolchain\.toml$|build\.rs$|install\.sh$|[Jj]ustfile$)' "$CHANGED_FILE" >/dev/null; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"
@@ -176,7 +176,8 @@ jobs:
           sudo apt-get install -y shellcheck
           shellcheck -S warning install.sh
           shellcheck nix/packaging/release/verify-release-assets.sh \
-                     nix/packaging/release/verify-release-assets.test.sh
+                     nix/packaging/release/verify-release-assets.test.sh \
+                     nix/packaging/release/assert-init-shebang.sh
 
       - name: Release-asset verifier gate tests
         run: bash nix/packaging/release/verify-release-assets.test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -591,7 +591,12 @@ jobs:
           # is the only step that opens the rootfs and reads the bytes the
           # kernel will exec. Runs before the image is uploaded, so a rootfs
           # that cannot boot never becomes a release asset.
-          sudo apt-get update && sudo apt-get install -y e2fsprogs
+          # debugfs ships in e2fsprogs, preinstalled on both runner images.
+          # Install only if that ever stops being true: an apt round-trip on
+          # the release critical path is a flake that fails the publish for a
+          # reason having nothing to do with the image.
+          command -v debugfs >/dev/null 2>&1 \
+            || { sudo apt-get update && sudo apt-get install -y e2fsprogs; }
           bash nix/packaging/release/assert-init-shebang.sh \
             "staging/default-microvm-rootfs-${ARCH}.ext4" "staged ${ARCH}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -582,6 +582,19 @@ jobs:
           cp -L "$STORE_PATH/rootfs.roothash" "staging/default-microvm-rootfs-${ARCH}.roothash"
           cp -L "$STORE_PATH/mvm-meta.json"   "staging/default-microvm-meta-${ARCH}.json"
 
+      - name: Assert the staged rootfs has an exec'able /init
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          # The publish path is checksums all the way down, and a checksum
+          # cannot tell a good image from a faithfully-copied broken one. This
+          # is the only step that opens the rootfs and reads the bytes the
+          # kernel will exec. Runs before the image is uploaded, so a rootfs
+          # that cannot boot never becomes a release asset.
+          sudo apt-get update && sudo apt-get install -y e2fsprogs
+          bash nix/packaging/release/assert-init-shebang.sh \
+            "staging/default-microvm-rootfs-${ARCH}.ext4" "staged ${ARCH}"
+
       - name: Generate default microVM SBOM
         env:
           ARCH: ${{ matrix.arch }}

--- a/nix/packaging/release/assert-init-shebang.sh
+++ b/nix/packaging/release/assert-init-shebang.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Assert a default-microvm rootfs carries a /init the kernel can exec.
+#
+# The kernel exec()s /init directly, so `#!` must be the first two bytes of the
+# file. Shift them by even one column and the boot dies with ENOEXEC before any
+# userspace runs, leaving a kernel panic as the only symptom — which is what
+# v0.17.0 published. Checksums cannot catch it: a faithful copy of a broken
+# image is still faithful.
+#
+# Reads the bytes straight out of the unmounted ext4 with debugfs: no mount, no
+# loop device, no root. Called twice — once on the staged image before it is
+# uploaded (release.yml `default-microvm`), once on the published image after it
+# is downloaded again (verify-release-assets.sh).
+#
+# Usage: assert-init-shebang.sh ROOTFS_EXT4 [LABEL]
+set -euo pipefail
+
+INIT_SHEBANG='#!/bin/sh'
+
+rootfs="${1:-}"
+[ -n "$rootfs" ] || { echo "usage: assert-init-shebang.sh ROOTFS_EXT4 [LABEL]" >&2; exit 2; }
+label="${2:-$(basename "$rootfs")}"
+
+[ -f "$rootfs" ] || { echo "::error::[$label] rootfs not found: $rootfs" >&2; exit 1; }
+command -v debugfs >/dev/null 2>&1 || {
+  echo "::error::[$label] debugfs (e2fsprogs) not on PATH — cannot read /init out of the rootfs" >&2
+  exit 1
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+if ! debugfs -R "dump /init $tmp/init" "$rootfs" >/dev/null 2>&1 || [ ! -s "$tmp/init" ]; then
+  echo "::error::[$label] could not read /init out of $(basename "$rootfs")" >&2
+  exit 1
+fi
+
+init_head=$(head -c "${#INIT_SHEBANG}" "$tmp/init")
+if [ "$init_head" != "$INIT_SHEBANG" ]; then
+  echo "::error::[$label] /init does not begin with '$INIT_SHEBANG' (got '$init_head') — the kernel panics with ENOEXEC before userspace" >&2
+  exit 1
+fi
+
+echo "ok: [$label] /init begins with '$INIT_SHEBANG' at byte 0"

--- a/nix/packaging/release/verify-release-assets.sh
+++ b/nix/packaging/release/verify-release-assets.sh
@@ -22,6 +22,8 @@ TARGETS="aarch64-apple-darwin x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu
 BUILDER_ARCHES="aarch64 x86_64"
 KERNEL_ARCHES="aarch64 x86_64"
 RUNTIME_ARCHES="aarch64 x86_64"
+# Keep in lockstep with the release.yml `default-microvm` matrix.
+BOOT_ARCHES="aarch64 x86_64"
 DO_COSIGN=0
 EXPECT_VERSION=""
 
@@ -32,6 +34,9 @@ while [ $# -gt 0 ]; do
     --builder-arches) BUILDER_ARCHES="$2"; shift 2 ;;
     --kernel-arches)  KERNEL_ARCHES="$2"; shift 2 ;;
     --runtime-arches) RUNTIME_ARCHES="$2"; shift 2 ;;
+    # Empty disables the boot-asset checks. Only for a host without
+    # e2fsprogs, where /init cannot be read out of the rootfs at all.
+    --boot-arches)    BOOT_ARCHES="$2"; shift 2 ;;
     --cosign)         DO_COSIGN=1; shift ;;
     # Assert the packaged binary reports this version. Only the target that
     # matches the host can be executed; cross-arch targets are skipped (their
@@ -86,6 +91,15 @@ require_signed_manifest() {
     ${COSIGN_OIDC_ISSUER:+--certificate-oidc-issuer "$COSIGN_OIDC_ISSUER"} \
     "$manifest" >/dev/null 2>&1 \
     || fail "$label cosign verify-blob failed"
+}
+
+# Whether a rootfs can be exec'd by the kernel is asserted by one script, used
+# both here (published artifact, re-downloaded) and by release.yml before the
+# staged image is ever uploaded. It prints its own ::error:: diagnosis.
+INIT_SHEBANG_CHECK="$(dirname "$0")/assert-init-shebang.sh"
+assert_init_shebang() {
+  "$INIT_SHEBANG_CHECK" "$1" "$2" >/dev/null || FAILED=1
+  return 0
 }
 
 required_bins_for_target() {
@@ -182,6 +196,53 @@ for arch in $KERNEL_ARCHES; do
   fi
   got=$(sha256_of "$workload_kernel")
   [ "$want" = "$got" ] || fail "[$arch] workload kernel sha256 mismatch: recorded=$want actual=$got"
+done
+
+# The rootfs, kernel and metadata sidecar under `default-microvm-*` are the
+# artifacts mvmctl actually boots, and nothing here used to open them: the
+# runtime-pack loop below checks only the pack sidecars. v0.17.0 shipped a
+# rootfs whose /init carries its `#!` at byte 1, and every checksum in this file
+# still verified, because a faithful copy of a broken image is still faithful.
+#
+# Same COMPLETE-or-ABSENT contract as the packs, and for the same reason: the
+# `release` job publishes under `!cancelled()`, so an image job that failed
+# leaves these absent on purpose and that is not an error here. A partial set,
+# or a rootfs whose /init the kernel cannot exec, is.
+for arch in $BOOT_ARCHES; do
+  boot_rootfs="default-microvm-rootfs-${arch}.ext4"
+  boot_kernel="default-microvm-vmlinux-${arch}"
+  boot_meta="default-microvm-meta-${arch}.json"
+  boot_checks="$ASSETS_DIR/default-microvm-${arch}-checksums-sha256.txt"
+
+  present=0
+  for f in "$boot_rootfs" "$boot_kernel" "$boot_meta"; do
+    [ -f "$ASSETS_DIR/$f" ] && present=$((present + 1))
+  done
+
+  if [ "$present" -eq 0 ]; then
+    echo "note: [$arch] no default-microvm boot assets published (image job did not ship) — ok"
+    continue
+  fi
+  if [ "$present" -ne 3 ]; then
+    fail "[$arch] partial default-microvm boot assets: rootfs=$([ -f "$ASSETS_DIR/$boot_rootfs" ] && echo y || echo n) kernel=$([ -f "$ASSETS_DIR/$boot_kernel" ] && echo y || echo n) meta=$([ -f "$ASSETS_DIR/$boot_meta" ] && echo y || echo n)"
+    continue
+  fi
+
+  [ -f "$boot_checks" ] || { fail "[$arch] default-microvm checksums manifest missing: default-microvm-${arch}-checksums-sha256.txt"; continue; }
+  require_signed_manifest "$boot_checks" "[$arch] default-microvm checksums manifest"
+  for f in "$boot_rootfs" "$boot_kernel" "$boot_meta"; do
+    want=$(awk -v n="$f" '$2 == n { print $1 }' "$boot_checks" | head -1)
+    if [ -z "$want" ]; then
+      fail "[$arch] $f not listed in default-microvm-${arch}-checksums-sha256.txt"
+      continue
+    fi
+    got=$(sha256_of "$ASSETS_DIR/$f")
+    [ "$want" = "$got" ] || fail "[$arch] $f sha256 mismatch: recorded=$want actual=$got"
+  done
+
+  # The checksums above prove the bytes are the ones we published. This proves
+  # the ones we published can boot.
+  assert_init_shebang "$ASSETS_DIR/$boot_rootfs" "$arch"
 done
 
 # The SBOM ships signed alongside the binaries on every release.

--- a/nix/packaging/release/verify-release-assets.test.sh
+++ b/nix/packaging/release/verify-release-assets.test.sh
@@ -19,6 +19,26 @@ sha256_of() {
   else shasum -a 256 "$1" | awk '{print $1}'; fi
 }
 
+# The boot-asset gate reads /init out of the rootfs with debugfs, so a
+# placeholder file cannot exercise it — these fixtures need a real ext4.
+# `mkfs.ext4 -d` builds one from a directory with no root and no loop device.
+# Absent that tooling (macOS), the boot checks are switched off via
+# --boot-arches and their scenarios are skipped rather than faked green.
+BOOT_TOOLS=0
+if command -v mkfs.ext4 >/dev/null 2>&1 && command -v debugfs >/dev/null 2>&1; then
+  BOOT_TOOLS=1
+fi
+BOOT_ARCHES="aarch64 x86_64"
+
+# Write an ext4 at $1 whose /init has $2 as its first line.
+make_rootfs() {
+  root="$(mktemp -d)"
+  printf '%s\n# mvm /init fixture\nexit 0\n' "$2" > "$root/init"
+  chmod 0500 "$root/init"
+  mkfs.ext4 -F -q -d "$root" "$1" 2M >/dev/null 2>&1
+  rm -rf "$root"
+}
+
 bins_for() {
   case "$1" in
     *apple-darwin) echo "mvmctl mvm-hvf-supervisor mvm-libkrun-supervisor mvm-network-endpoint" ;;
@@ -69,10 +89,28 @@ build_valid_fixture() {
     done
     printf 'bundle\n' > "$dir/default-microvm-$arch-checksums-sha256.txt.bundle"
   done
+  if [ "$BOOT_TOOLS" = 1 ]; then
+    for arch in $BOOT_ARCHES; do
+      make_rootfs "$dir/default-microvm-rootfs-$arch.ext4" '#!/bin/sh'
+      printf 'vmlinux-%s\n' "$arch"   > "$dir/default-microvm-vmlinux-$arch"
+      printf '{"meta":"%s"}\n' "$arch" > "$dir/default-microvm-meta-$arch.json"
+      for f in "default-microvm-rootfs-$arch.ext4" "default-microvm-vmlinux-$arch" \
+               "default-microvm-meta-$arch.json"; do
+        echo "$(sha256_of "$dir/$f")  $f" >> "$dir/default-microvm-$arch-checksums-sha256.txt"
+      done
+    done
+  fi
   echo "$dir"
 }
 
-run() { bash "$SCRIPT" --assets-dir "$1" >/dev/null 2>&1; }  # returns the script's exit code
+# Returns the script's exit code.
+run() {
+  if [ "$BOOT_TOOLS" = 1 ]; then
+    bash "$SCRIPT" --assets-dir "$1" >/dev/null 2>&1
+  else
+    bash "$SCRIPT" --assets-dir "$1" --boot-arches "" >/dev/null 2>&1
+  fi
+}
 
 PASS=0; FAILN=0
 ok()   { PASS=$((PASS+1)); echo "  ok: $1"; }
@@ -115,9 +153,14 @@ if run "$d"; then bad "partial runtime pack (missing bundle) must fail"; else ok
 rm -rf "$d"
 
 # 7. Absent runtime pack (all three gone) → pass (accelerator absent).
+# The per-arch manifest covers the boot assets too, and the job that writes it
+# writes both, so "no manifest" only ever means "the whole image job shipped
+# nothing" — drop the boot assets with it rather than fixture an impossible state.
 d="$(build_valid_fixture)"
 rm -f "$d/default-microvm-x86_64.pack-manifest.json" "$d/default-microvm-x86_64.pack-manifest.json.bundle" \
-      "$d/default-microvm-x86_64.sbom.txt" "$d/default-microvm-x86_64-checksums-sha256.txt"
+      "$d/default-microvm-x86_64.sbom.txt" "$d/default-microvm-x86_64-checksums-sha256.txt" \
+      "$d/default-microvm-rootfs-x86_64.ext4" "$d/default-microvm-vmlinux-x86_64" \
+      "$d/default-microvm-meta-x86_64.json"
 if run "$d"; then ok "absent runtime pack is accepted"; else bad "absent runtime pack should be accepted"; fi
 rm -rf "$d"
 
@@ -160,6 +203,48 @@ d="$(build_valid_fixture)"
 printf 'tampered-kernel\n' > "$d/vmlinux-aarch64-workload"
 if run "$d"; then bad "checksum-mismatched workload kernel must fail"; else ok "checksum-mismatched workload kernel fails closed"; fi
 rm -rf "$d"
+
+# 13-16. The boot-asset gate. These need a real ext4 (see make_rootfs), so they
+# are skipped where e2fsprogs is absent — which is also where `run` switches the
+# gate off, so the suite stays honest rather than reporting checks it never ran.
+if [ "$BOOT_TOOLS" = 1 ]; then
+  # 13. THE REGRESSION. A rootfs whose /init has its `#!` one column right of
+  # byte 0 — byte-for-byte what v0.17.0 published. Every checksum still matches;
+  # only reading /init catches it.
+  d="$(build_valid_fixture)"
+  make_rootfs "$d/default-microvm-rootfs-aarch64.ext4" ' #!/bin/sh'
+  # Re-record the hash, so the image is a *faithful* copy of a broken build and
+  # the checksum layer has nothing to say about it.
+  grep -v ' default-microvm-rootfs-aarch64.ext4$' \
+    "$d/default-microvm-aarch64-checksums-sha256.txt" > "$d/.checks.tmp"
+  mv "$d/.checks.tmp" "$d/default-microvm-aarch64-checksums-sha256.txt"
+  echo "$(sha256_of "$d/default-microvm-rootfs-aarch64.ext4")  default-microvm-rootfs-aarch64.ext4" \
+    >> "$d/default-microvm-aarch64-checksums-sha256.txt"
+  if run "$d"; then bad "a /init shebang off byte 0 must fail"; else ok "/init shebang off byte 0 fails closed"; fi
+  rm -rf "$d"
+
+  # 14. Partial boot assets (rootfs gone, kernel + meta still there) → fail.
+  d="$(build_valid_fixture)"
+  rm -f "$d/default-microvm-rootfs-aarch64.ext4"
+  if run "$d"; then bad "partial boot assets must fail"; else ok "partial boot assets fail closed"; fi
+  rm -rf "$d"
+
+  # 15. Boot assets entirely absent → pass (image job did not ship; `release`
+  # publishes the binary download regardless).
+  d="$(build_valid_fixture)"
+  rm -f "$d/default-microvm-rootfs-x86_64.ext4" "$d/default-microvm-vmlinux-x86_64" \
+        "$d/default-microvm-meta-x86_64.json"
+  if run "$d"; then ok "absent boot assets are accepted"; else bad "absent boot assets should be accepted"; fi
+  rm -rf "$d"
+
+  # 16. Rootfs bytes do not match the recorded hash → fail closed.
+  d="$(build_valid_fixture)"
+  printf 'tampered-rootfs\n' > "$d/default-microvm-rootfs-aarch64.ext4"
+  if run "$d"; then bad "checksum-mismatched rootfs must fail"; else ok "checksum-mismatched rootfs fails closed"; fi
+  rm -rf "$d"
+else
+  echo "  skip: boot-asset gate (mkfs.ext4/debugfs not on PATH)"
+fi
 
 # 12. Every binary the verifier REQUIRES must be one release.yml actually
 # bundles. The fixtures above cannot catch a stale name: build_valid_fixture

--- a/specs/sprint/delivery/2539-init-shebang-artifact-gate.md
+++ b/specs/sprint/delivery/2539-init-shebang-artifact-gate.md
@@ -1,0 +1,61 @@
+# 2539 — gate the bytes the kernel execs, not just their checksum
+
+## What shipped
+
+An artifact-level assertion that a `default-microvm` rootfs carries a `/init`
+the kernel can exec, wired into both ends of the release path.
+
+- `nix/packaging/release/assert-init-shebang.sh` — reads `/init` out of an
+  unmounted ext4 with `debugfs` (no mount, no loop device, no root) and refuses
+  a rootfs whose first bytes are not `#!/bin/sh`.
+- `.github/workflows/release.yml` — runs it on the staged image in the
+  `default-microvm` job, before the upload. A rootfs that cannot boot never
+  becomes a release asset.
+- `nix/packaging/release/verify-release-assets.sh` — a new boot-asset section
+  requires the `default-microvm` rootfs/kernel/meta trio to be present, listed
+  in and matching the signed per-arch checksums manifest, and runs the same
+  assertion on the published, re-downloaded image.
+- `.github/workflows/ci.yml` — shellchecks the new script, and widens the
+  scope regex from `verify-release-assets*.sh` to every `.sh` under
+  `nix/packaging/release/`, so a change to the new file is not invisible to CI.
+
+## Why the existing gates could not catch it
+
+Three source-level guards inspect the *generator* (`mk-guest.nix`'s
+`lib.throwIf`, `mk_guest_init_shebang_lands_at_byte_zero`, and the substring
+test that #2538 removed). Nothing between `nix build` and `gh release create`
+opened the ext4, and `verify-release-assets.sh` re-downloaded the published
+assets without looking inside them — it checked only the pack sidecars, never
+the rootfs itself. A checksum cannot separate a good image from a faithfully
+copied broken one, which is why v0.17.0 verified clean for five weeks.
+
+## COMPLETE-or-ABSENT, deliberately
+
+The boot-asset section follows the same contract as the builder and runtime
+pack checks. The `release` job publishes under `!cancelled()`, so an image job
+that failed leaves these assets absent *on purpose* and the binary download
+still ships. Absent is fine; partial, or present-and-unbootable, is not.
+
+## Evidence
+
+Run on Linux (e2fsprogs 1.47.0, matching `ubuntu-latest`):
+
+- `verify-release-assets.test.sh` — 20 passed, 0 failed, including four new
+  boot-asset scenarios. The regression case builds a real ext4 whose `/init`
+  shebang sits at byte 1 and **re-records its hash**, so the checksum layer has
+  nothing to say and only reading `/init` catches it.
+- Pointed at the actually-published `v0.17.0` `default-microvm-rootfs-x86_64.ext4`:
+  `sha256sum -c` reports `OK`, `/init` reads
+  `20 23 21 2f 62 69 6e 2f 73 68 0a`, and the gate rejects it. That is the
+  defect and the blind spot demonstrated on one artifact.
+- The scenarios are skipped, loudly, where `mkfs.ext4`/`debugfs` are absent
+  (macOS), and `--boot-arches ""` switches the gate off there rather than
+  reporting a check that never ran.
+
+## Not done here
+
+Booting the staged image before publishing — strictly stronger than a byte
+check on x86_64 — is WS1 of the boot-image-lifecycle spec (#2547). This gate
+composes with it rather than replacing it: WS1's own stated gap is that the
+`aarch64` leg gets a header check rather than a boot, and this is that check,
+on both arches.


### PR DESCRIPTION
Closes part of #2539.

`v0.17.0` published a `default-microvm` rootfs whose `/init` carries its `#!` at
byte 1. The kernel `exec()`s `/init` directly, so the guest panics with `ENOEXEC`
before userspace — and every checksum verified clean for five weeks, because a
faithful copy of a broken image is still faithful.

#2538 fixed the generator. This closes the gap that let it ship.

## The gap

Three guards inspect the *generator* (`mk-guest.nix`'s `lib.throwIf`,
`mk_guest_init_shebang_lands_at_byte_zero`, and the substring test #2538
removed). Nothing between `nix build` and `gh release create` ever opened the
ext4, and `verify-release-assets.sh` re-downloads the published assets while
checking only the *pack sidecars* — never the rootfs itself.

## What this adds

- **`nix/packaging/release/assert-init-shebang.sh`** — dumps `/init` out of the
  unmounted ext4 with `debugfs` (no mount, no loop device, no root) and refuses
  a rootfs that does not begin with `#!/bin/sh`.
- **`release.yml`** calls it on the *staged* image in `default-microvm`, before
  the upload, so an unbootable rootfs never becomes a release asset.
- **`verify-release-assets.sh`** calls the same script on the *published,
  re-downloaded* image, and now also requires the rootfs/kernel/meta trio to be
  present, listed in and matching the signed per-arch manifest.

One implementation, two callers — the byte comparison is not duplicated in YAML.

## COMPLETE-or-ABSENT

The new section follows the contract the pack checks already use. `release`
publishes under `!cancelled()`, so an image job that failed leaves these assets
absent *on purpose* and the binary download still ships. Absent is fine.
Partial, or present-and-unbootable, is not.

## Evidence

Run on Linux with e2fsprogs 1.47.0, the same version `ubuntu-latest` carries:

- `verify-release-assets.test.sh` — **20 passed, 0 failed**, including four new
  boot-asset scenarios. The regression case builds a real ext4 whose `/init`
  shebang sits at byte 1 **and re-records its hash**, so the checksum layer has
  nothing to say and only reading `/init` catches it.
- Pointed at the actually-published `v0.17.0` rootfs: `sha256sum -c` reports
  `OK`, `/init` reads `20 23 21 2f 62 69 6e 2f 73 68 0a`, and the gate rejects
  it. The defect and the blind spot, demonstrated on one artifact.
- Where `mkfs.ext4`/`debugfs` are absent (macOS) the scenarios skip **loudly**
  and `--boot-arches ""` switches the gate off, rather than reporting a check
  that never ran.

`shellcheck` and `actionlint` clean; `check-workflow-paths`,
`check-declared-backing`, `check-no-overclaim`, `check-honesty`,
`check-doc-claims`, `check-no-spec-refs-in-comments`, `check-sprint-append`,
`check-mutation-witnesses`, `check-claim-catalog`, `check-plan-names` all pass.

## Relationship to #2547

WS1 of the boot-image-lifecycle spec proposes *booting* the staged image before
publishing — strictly stronger on x86_64. These compose rather than compete:
that spec's own stated gap is that the `aarch64` leg gets a header check rather
than a boot, and this is that check, on both arches.

## Still open on #2539

Cutting a release from a tree carrying #2538, and restoring the `boot-latency`
gate to `needs: [scope]`. Both follow separately.