### PR TITLE
fix(sec): let a mutation shard finish, and say so when it does not

### DIFF
--- a/.github/workflows/security-lane-watch.yml
+++ b/.github/workflows/security-lane-watch.yml
@@ -15,9 +15,12 @@ name: Security lane watch
 #      20-entry `needs:` list to keep in sync with the job graph.
 #   2. It reads each job's real conclusion from the API rather than the
 #      workflow's aggregate status. A job marked `continue-on-error: true`
-#      — the mutation-witness lane is one — never fails the workflow, so an
-#      `if: failure()` guard would not fire for it. The API still reports
-#      that job as failed, and this reports it too.
+#      never fails the workflow, so an `if: failure()` guard would not fire
+#      for it. The API still reports that job as failed, and this reports it
+#      too. No job in security.yml carries that marking today — the
+#      mutation-witness lane used to and this comment went on naming it for
+#      months after it stopped — but the API-reading approach costs nothing
+#      and does not have to be revisited when one does.
 #
 # Failure opens or updates one tracking issue; a clean run closes it. The
 # issue is the enforcement surface, not a merge block: these lanes do not

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -535,6 +535,12 @@ jobs:
   mutation-witnesses:
     name: Claim witnesses — mutation-tested (${{ matrix.package }})
     runs-on: ubuntu-latest
+    # Under the six-hour platform cap, so a shard that outgrows its budget
+    # fails as itself. Reaching the cap instead kills the runner, and the
+    # only trace is "The runner has received a shutdown signal" — which
+    # names no package, no file, and no claim, and reads identically to
+    # infrastructure having a bad night.
+    timeout-minutes: 330
     # BLOCKING, and sharded per package.
     #
     # Sharding is structural, not a response to a particular runtime: a
@@ -572,7 +578,10 @@ jobs:
           - mvm-build
           - mvm-cli
           - mvm-core
-          - mvm-hostd
+          # mvm-hostd owns the most surface files of any package and stopped
+          # finishing inside the cap on its own — see the timeout note below.
+          - mvm-hostd/1of2
+          - mvm-hostd/2of2
           - mvm-contract
           - mvm-runtime
           - mvm-sdk
@@ -623,12 +632,30 @@ jobs:
           export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
           export MVM_HOME="$RUNNER_TEMP/mutants-mvm-home"
           export HOME="$MVM_HOME"
+          # The gate writes cargo-mutants output under the system temp dir.
+          # Pin that dir so the upload step below has a path it knows rather
+          # than one it guesses at.
+          export TMPDIR="$RUNNER_TEMP/mutants-out"
+          mkdir -p "$TMPDIR"
           mkdir -p "$HOME"
           if [ -e "$HOME/.mvm/keys" ]; then
             echo "::error::refusing to mutate against a reachable keystore at $HOME/.mvm/keys" >&2
             exit 1
           fi
           cargo run -p xtask -- check-mutation-witnesses --run --package '${{ matrix.package }}'
+
+      - name: Keep the mutation output of a shard that did not finish
+        # A shard killed by the timeout above has still measured most of its
+        # files, and that work is the only evidence of where it went. Without
+        # this the directory dies with the runner and the next person starts
+        # from the same blank page.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mutants-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/mutants-out/mvm-mutation-witnesses/
+          if-no-files-found: ignore
+          retention-days: 7
 
   # ── Lane 5: Hash-verify regression ─────────────────────────────────
   # ADR-001 §W5.1 — the unit tests that exercise the

--- a/specs/VERIFICATION.md
+++ b/specs/VERIFICATION.md
@@ -138,10 +138,32 @@ The lane is **sharded per package**, because it has to be: the whole
 surface takes ~6.9 hours end to end and a GitHub-hosted job is killed at
 six. One job could not reliably finish, so it would go red nightly for a
 reason unrelated to any claim and be ignored — the same failure this lane
-exists to prevent, arrived at from the other side. Split per package the
-slowest shard is ~2.5 hours. That makes the matrix a second place the
-surface is written down, so `check-mutation-witnesses` pins it against the
-baseline on every PR; the row above records the planted defect.
+exists to prevent, arrived at from the other side. That makes the matrix a
+second place the surface is written down, so `check-mutation-witnesses`
+pins it against the baseline on every PR; the row above records the
+planted defect.
+
+Per package was not enough for long. On 2026-08-15 the `mvm-hostd` shard
+died on the platform cap having reached six of its ten files in 3h17m, and
+because the cap kills the runner rather than the job, the only trace was
+`The runner has received a shutdown signal` — naming no package, no file
+and no claim. A package may therefore be split further, spelled
+`mvm-hostd/1of2` in the matrix and passed through the same `--package`
+flag. Files are ordered by path and assigned by stride, so membership is a
+property of the committed surface rather than of resolution order, and
+adjacent siblings of similar cost land in different shards. The gate
+checks the split is total: a missing index, a repeated one, disagreeing
+totals, or a bare entry alongside sharded ones all fail, because each
+leaves files nothing mutates while every remaining shard stays green.
+
+The job also carries `timeout-minutes: 330`, under the cap, so a shard
+that outgrows its budget fails as itself rather than as infrastructure,
+and uploads its partial cargo-mutants output either way.
+
+**The split is by file count, not by cost** — five files each. The two
+most expensive files measured so far both land in `2of2`, so the shards
+are not expected to be equal; they are expected to fit. Re-measure rather
+than assume.
 
 These are **accepted rather than scoped out** on purpose. Scoping would
 stop the lane measuring those files at all; accepting keeps the ratchet

--- a/specs/sprint/delivery/2537-hostd-mutation-shard.md
+++ b/specs/sprint/delivery/2537-hostd-mutation-shard.md
@@ -1,0 +1,68 @@
+# 2537 — the shard that could not finish
+
+## The half #2540 did not cover
+
+Five shards of the nightly mutation lane failed on `bdff1866`. Four were the
+ratchet doing its job and #2540 closed them. The fifth, `mvm-hostd`, was not a
+mutant failure at all: it ran 3h17m, reached file **6 of 10**, and died on
+`The runner has received a shutdown signal`.
+
+No overlapping `Security` run existed to cancel it, so that was an infra
+reclaim — but the shard was on track for ~5.5h against a six-hour cap, with no
+`timeout-minutes` anywhere in `security.yml`. Baselining a mutant does not make
+a shard faster. This one would have gone red again.
+
+## What shipped
+
+- **A package can be split further.** `mvm-hostd/1of2` wherever a package name
+  is accepted, parsed by `parse_shard_spec` and passed through the existing
+  `--package` flag. `mvm-hostd` becomes two matrix rows of five files each.
+- **Membership is a property of the surface.** Files are sorted by path, then
+  assigned by stride. Resolution order cannot move a file between shards, so a
+  survivor cannot appear and vanish by shard. Stride rather than contiguous
+  blocks because adjacent surface files tend to be siblings of similar cost.
+- **The split must be total.** `check_shard_matrix` now rejects a missing
+  index, a repeated one, disagreeing totals, and a bare entry alongside sharded
+  ones. Each of those leaves files nothing mutates while every remaining shard
+  reports success — the silent loss the package-level check already existed to
+  prevent, one level in.
+- **`timeout-minutes: 330`**, under the platform cap, so a shard that outgrows
+  its budget fails as itself instead of as infrastructure.
+- **The partial output survives.** `TMPDIR` is pinned and the cargo-mutants
+  directory is uploaded on `always()`. A killed shard had measured most of its
+  files and left no trace of it.
+
+## A bug the gate caught in its own change
+
+The first version put a YAML comment above the new matrix rows. `shard_entries`
+treated any non-`- ` line as the end of the list, so everything below the
+comment — `mvm-contract`, `mvm-runtime`, `mvm-sdk`, `mvm-vmm` — read as
+unsharded and the gate went red. That is the parser silently truncating the
+matrix, which is precisely what this check exists to catch, and it caught it.
+Comments are now skipped, pinned by
+`a_comment_between_entries_does_not_truncate_the_matrix`, which was confirmed
+to fail with the fix reverted.
+
+## Also
+
+`security-lane-watch.yml` described the mutation lane as
+`continue-on-error: true`. It is not, and `security.yml` has carried no
+`continue-on-error` for months. The rationale for reading conclusions from the
+API still holds on its own, so the comment keeps it and drops the false example.
+
+## Evidence
+
+- `cargo test -p xtask --bin xtask` — 599 passed, 0 failed.
+- `check-mutation-witnesses` (PinOnly) accepts the new matrix; hand-broken
+  variants produce, respectively: `declares shards {1} of 2 for mvm-hostd`,
+  `mixes sharded and unsharded entries for mvm-hostd`, and `disagreeing
+  totals`. Each was run and each went red.
+- `cargo +nightly fmt --all --check`, `cargo clippy -p xtask --all-targets -D
+  warnings`, `actionlint`, and the prose gates all clean.
+
+## Not verified here
+
+The shard is split by **file count, not cost** — the two most expensive files
+measured so far both land in `2of2`. The shards are expected to fit under the
+cap, not to be equal. Only the next nightly measures that, and
+`specs/VERIFICATION.md` says to re-measure rather than re-quote.

--- a/xtask/src/check_mutation_witnesses.rs
+++ b/xtask/src/check_mutation_witnesses.rs
@@ -183,7 +183,7 @@ pub struct Miss {
 /// diff still run over the *whole* ledger in every job, so a claim
 /// dropping out of coverage fails every shard rather than only the one
 /// that happens to own it.
-pub fn run(workspace: &Path, mode: Mode, package: Option<&str>) -> Result<()> {
+pub fn run(workspace: &Path, mode: Mode, shard: Option<&ShardSpec>) -> Result<()> {
     let Surface {
         files: resolved,
         uncovered,
@@ -204,10 +204,7 @@ pub fn run(workspace: &Path, mode: Mode, package: Option<&str>) -> Result<()> {
         let previous = read_baseline(&baseline_path).ok();
         let accepted_misses = if mode == Mode::RewriteBaseline {
             let scoped = carry_scopes_forward(resolved.clone(), previous.as_ref());
-            seed_accepted(&run_mutants_over(
-                workspace,
-                &for_package(&scoped, package),
-            )?)
+            seed_accepted(&run_mutants_over(workspace, &for_shard(&scoped, shard))?)
         } else {
             previous
                 .as_ref()
@@ -255,17 +252,17 @@ pub fn run(workspace: &Path, mode: Mode, package: Option<&str>) -> Result<()> {
         // The committed surface, not the freshly resolved one: resolution
         // cannot know about scopes, and running the unscoped surface would
         // report every out-of-claim mutant as a new miss.
-        let surface = for_package(&baseline.surface, package);
+        let surface = for_shard(&baseline.surface, shard);
         if surface.is_empty() {
             bail!(
                 "check-mutation-witnesses: --package {} matches no surface file. A shard that \
                  measures nothing must fail rather than pass silently.",
-                package.unwrap_or("<none>")
+                shard.map_or("<none>".to_string(), ToString::to_string)
             );
         }
-        if let Some(pkg) = package {
+        if let Some(spec) = shard {
             eprintln!(
-                "check-mutation-witnesses: shard for package {pkg} ({} of {} surface files)",
+                "check-mutation-witnesses: shard {spec} ({} of {} surface files)",
                 surface.len(),
                 baseline.surface.len()
             );
@@ -500,24 +497,39 @@ pub fn check_shard_matrix(workspace: &Path, surface: &[SurfaceFile]) -> Vec<Stri
             "cannot read {SECURITY_WORKFLOW_REL} to verify the mutation shard matrix"
         )];
     };
-    let declared = shard_packages(&text);
-    if declared.is_empty() {
+    let entries = shard_entries(&text);
+    if entries.is_empty() {
         return vec![format!(
             "{SECURITY_WORKFLOW_REL} declares no mutation shard matrix; the nightly lane would \
              measure nothing"
         )];
     }
-    let wanted: BTreeSet<&str> = surface.iter().map(|s| s.package.as_str()).collect();
     let mut errors = Vec::new();
+    let mut declared: BTreeMap<String, Vec<(usize, usize)>> = BTreeMap::new();
+    for raw in &entries {
+        match parse_shard_spec(raw) {
+            Ok(spec) => {
+                let slot = declared.entry(spec.package).or_default();
+                if let Some(pair) = spec.shard {
+                    slot.push(pair);
+                }
+            }
+            Err(err) => errors.push(format!(
+                "{SECURITY_WORKFLOW_REL} declares an unparseable mutation shard {raw:?}: {err}"
+            )),
+        }
+    }
+
+    let wanted: BTreeSet<&str> = surface.iter().map(|s| s.package.as_str()).collect();
     for pkg in &wanted {
-        if !declared.contains(*pkg) {
+        if !declared.contains_key(*pkg) {
             errors.push(format!(
                 "package {pkg} is on the mutation surface but has no shard in \
                  {SECURITY_WORKFLOW_REL}, so nothing ever mutates it"
             ));
         }
     }
-    for pkg in &declared {
+    for pkg in declared.keys() {
         if !wanted.contains(pkg.as_str()) {
             errors.push(format!(
                 "{SECURITY_WORKFLOW_REL} declares a mutation shard for {pkg}, which owns no \
@@ -525,15 +537,52 @@ pub fn check_shard_matrix(workspace: &Path, surface: &[SurfaceFile]) -> Vec<Stri
             ));
         }
     }
+
+    // A package cut into shards must be cut completely. A missing or repeated
+    // index is the same silent loss the package check above exists to catch —
+    // the files that shard owned are simply never mutated, and every remaining
+    // shard still goes green.
+    for (pkg, shards) in &declared {
+        if shards.is_empty() {
+            continue;
+        }
+        let count = entries
+            .iter()
+            .filter(|raw| parse_shard_spec(raw).is_ok_and(|s| &s.package == pkg))
+            .count();
+        if count != shards.len() {
+            errors.push(format!(
+                "{SECURITY_WORKFLOW_REL} mixes sharded and unsharded entries for {pkg}; the \
+                 unsharded one re-runs work a shard already owns"
+            ));
+            continue;
+        }
+        let total = shards[0].1;
+        if shards.iter().any(|(_, t)| *t != total) {
+            errors.push(format!(
+                "{SECURITY_WORKFLOW_REL} declares shards of {pkg} with disagreeing totals; the \
+                 surface would be split more than one way at once"
+            ));
+            continue;
+        }
+        let seen: BTreeSet<usize> = shards.iter().map(|(i, _)| *i).collect();
+        let expected: BTreeSet<usize> = (1..=total).collect();
+        if seen != expected {
+            errors.push(format!(
+                "{SECURITY_WORKFLOW_REL} declares shards {seen:?} of {total} for {pkg}; the \
+                 missing ones own surface files nothing would mutate"
+            ));
+        }
+    }
     errors
 }
 
-/// The `package:` list under the mutation job's matrix.
+/// The raw `package:` entries under the mutation job's matrix.
 ///
 /// Text-scanned rather than YAML-parsed, matching the sibling gates and
 /// the workspace's deliberate dependency floor.
-pub fn shard_packages(workflow: &str) -> BTreeSet<String> {
-    let mut out = BTreeSet::new();
+pub fn shard_entries(workflow: &str) -> Vec<String> {
+    let mut out = Vec::new();
     let mut in_job = false;
     let mut in_list = false;
     for line in workflow.lines() {
@@ -554,8 +603,11 @@ pub fn shard_packages(workflow: &str) -> BTreeSet<String> {
         }
         if in_list {
             if let Some(name) = t.strip_prefix("- ") {
-                out.insert(name.trim().to_string());
-            } else if !t.is_empty() {
+                out.push(name.trim().to_string());
+            } else if !t.is_empty() && !t.starts_with('#') {
+                // A comment between entries is not the end of the list.
+                // Treating it as one truncates the matrix silently, and
+                // every package below the comment reads as unsharded.
                 in_list = false;
             }
         }
@@ -563,16 +615,90 @@ pub fn shard_packages(workflow: &str) -> BTreeSet<String> {
     out
 }
 
-/// The surface files owned by `package`, or all of them when unfiltered.
-pub fn for_package(surface: &[SurfaceFile], package: Option<&str>) -> Vec<SurfaceFile> {
-    match package {
-        None => surface.to_vec(),
-        Some(pkg) => surface
-            .iter()
-            .filter(|s| s.package == pkg)
-            .cloned()
-            .collect(),
+/// Which slice of the surface one CI job is responsible for.
+///
+/// A package is the coarsest useful unit and was the only one for a long
+/// time, but `mvm-hostd` alone outgrew the six-hour cap: it owns the most
+/// surface files, and a job that dies mid-run reports nothing about the
+/// files it never reached. So a package may additionally be cut into
+/// numbered shards, spelled `mvm-hostd/1of2` wherever a package name is
+/// accepted.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShardSpec {
+    pub package: String,
+    /// `(index, total)`, one-based, or `None` for the whole package.
+    pub shard: Option<(usize, usize)>,
+}
+
+impl std::fmt::Display for ShardSpec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.shard {
+            None => write!(f, "{}", self.package),
+            Some((i, n)) => write!(f, "{}/{i}of{n}", self.package),
+        }
     }
+}
+
+/// Parse `mvm-hostd` or `mvm-hostd/1of2`.
+///
+/// Rejects rather than rounds: a typo that silently selected the whole
+/// package would double the work and hide the shard that vanished, and a
+/// zero or out-of-range index would quietly measure nothing.
+pub fn parse_shard_spec(raw: &str) -> Result<ShardSpec> {
+    let raw = raw.trim();
+    let Some((package, shard)) = raw.split_once('/') else {
+        return Ok(ShardSpec {
+            package: raw.to_string(),
+            shard: None,
+        });
+    };
+    let Some((index, total)) = shard.split_once("of") else {
+        bail!("malformed shard {raw:?}: expected <package>/<index>of<total>, e.g. mvm-hostd/1of2");
+    };
+    let index: usize = index
+        .parse()
+        .with_context(|| format!("malformed shard index in {raw:?}"))?;
+    let total: usize = total
+        .parse()
+        .with_context(|| format!("malformed shard total in {raw:?}"))?;
+    if total == 0 || index == 0 || index > total {
+        bail!("malformed shard {raw:?}: index must be within 1..={total}");
+    }
+    Ok(ShardSpec {
+        package: package.to_string(),
+        shard: Some((index, total)),
+    })
+}
+
+/// The surface files this shard owns, or all of them when unfiltered.
+///
+/// Files are ordered by path before slicing, so which shard owns a file
+/// is a property of the committed surface rather than of resolution
+/// order — otherwise a file could migrate between shards without the
+/// baseline changing, and a survivor would appear and vanish by shard.
+///
+/// The slice is by stride, not by contiguous block: adjacent surface
+/// files tend to be siblings of similar cost, so a block split loads one
+/// shard with the expensive half.
+pub fn for_shard(surface: &[SurfaceFile], spec: Option<&ShardSpec>) -> Vec<SurfaceFile> {
+    let Some(spec) = spec else {
+        return surface.to_vec();
+    };
+    let mut owned: Vec<SurfaceFile> = surface
+        .iter()
+        .filter(|s| s.package == spec.package)
+        .cloned()
+        .collect();
+    owned.sort_by(|a, b| a.path.cmp(&b.path));
+    let Some((index, total)) = spec.shard else {
+        return owned;
+    };
+    owned
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| i % total == index - 1)
+        .map(|(_, f)| f)
+        .collect()
 }
 
 /// Copy each committed file's `scope` onto the freshly resolved surface.
@@ -1379,21 +1505,44 @@ jobs:
 ";
 
     #[test]
-    fn shard_packages_reads_only_the_mutation_jobs_matrix() {
-        let got = shard_packages(SHARD_WORKFLOW);
+    fn a_comment_between_entries_does_not_truncate_the_matrix() {
+        let workflow = "\
+jobs:
+  mutation-witnesses:
+    strategy:
+      matrix:
+        package:
+          - mvm-cli
+          # why this one is split
+          - mvm-hostd/1of2
+          - mvm-hostd/2of2
+  later-job:
+    name: after
+";
+        assert_eq!(
+            shard_entries(workflow),
+            vec![
+                "mvm-cli".to_string(),
+                "mvm-hostd/1of2".to_string(),
+                "mvm-hostd/2of2".to_string(),
+            ],
+            "a comment must not end the list and silently unshard everything below it"
+        );
+    }
+
+    #[test]
+    fn shard_entries_read_only_the_mutation_jobs_matrix() {
+        let got = shard_entries(SHARD_WORKFLOW);
         assert_eq!(
             got,
-            ["mvm-cli", "mvm-hostd"]
-                .iter()
-                .map(|s| s.to_string())
-                .collect::<BTreeSet<_>>(),
+            vec!["mvm-cli".to_string(), "mvm-hostd".to_string()],
             "a sibling job's matrix must not leak into the mutation shard list"
         );
     }
 
     #[test]
     fn a_surface_package_with_no_shard_is_reported() {
-        let declared = shard_packages(SHARD_WORKFLOW);
+        let declared: BTreeSet<String> = shard_entries(SHARD_WORKFLOW).into_iter().collect();
         // mvm-core is on the surface but absent from the matrix above.
         let surface = [
             surface("crates/mvm-cli/src/a.rs", vec![1]),
@@ -1413,7 +1562,7 @@ jobs:
 
     #[test]
     fn a_shard_for_a_package_with_no_surface_file_is_reported() {
-        let declared = shard_packages(SHARD_WORKFLOW);
+        let declared: BTreeSet<String> = shard_entries(SHARD_WORKFLOW).into_iter().collect();
         let surface = [surface("crates/mvm-cli/src/a.rs", vec![1])];
         let wanted: BTreeSet<&str> = surface.iter().map(|s| s.package.as_str()).collect();
         let extra: Vec<&String> = declared
@@ -1434,17 +1583,42 @@ jobs:
             surface("crates/mvm-cli/src/b.rs", vec![2]),
             surface("crates/mvm-hostd/src/c.rs", vec![3]),
         ];
-        let cli = for_package(&surface, Some("mvm-cli"));
+        let cli = for_shard(
+            &surface,
+            Some(&ShardSpec {
+                package: "mvm-cli".to_string(),
+                shard: None,
+            }),
+        );
         assert_eq!(cli.len(), 2);
         assert!(cli.iter().all(|s| s.package == "mvm-cli"));
 
-        assert_eq!(for_package(&surface, Some("mvm-hostd")).len(), 1);
+        assert_eq!(
+            for_shard(
+                &surface,
+                Some(&ShardSpec {
+                    package: "mvm-hostd".to_string(),
+                    shard: None,
+                })
+            )
+            .len(),
+            1
+        );
         // Unfiltered is the whole surface, so a non-sharded run is
         // unchanged.
-        assert_eq!(for_package(&surface, None).len(), 3);
+        assert_eq!(for_shard(&surface, None).len(), 3);
         // A package with no surface files yields nothing, which the caller
         // turns into a failure rather than a silent pass.
-        assert!(for_package(&surface, Some("mvm-sdk")).is_empty());
+        assert!(
+            for_shard(
+                &surface,
+                Some(&ShardSpec {
+                    package: "mvm-sdk".to_string(),
+                    shard: None,
+                })
+            )
+            .is_empty()
+        );
     }
 
     /// Every shard together must cover the surface exactly once. A package
@@ -1460,7 +1634,11 @@ jobs:
         let packages: BTreeSet<&str> = surface.iter().map(|s| s.package.as_str()).collect();
         let mut seen: Vec<String> = Vec::new();
         for p in &packages {
-            for f in for_package(&surface, Some(p)) {
+            let spec = ShardSpec {
+                package: (*p).to_string(),
+                shard: None,
+            };
+            for f in for_shard(&surface, Some(&spec)) {
                 seen.push(f.path);
             }
         }
@@ -1468,6 +1646,115 @@ jobs:
         let mut all: Vec<String> = surface.iter().map(|s| s.path.clone()).collect();
         all.sort();
         assert_eq!(seen, all, "the shards must cover every file exactly once");
+    }
+
+    #[test]
+    fn a_shard_spec_round_trips_and_rejects_nonsense() {
+        assert_eq!(
+            parse_shard_spec("mvm-hostd").unwrap(),
+            ShardSpec {
+                package: "mvm-hostd".to_string(),
+                shard: None
+            }
+        );
+        let sharded = parse_shard_spec("mvm-hostd/2of3").unwrap();
+        assert_eq!(sharded.package, "mvm-hostd");
+        assert_eq!(sharded.shard, Some((2, 3)));
+        // Display is what the matrix and the log line both print, so it has
+        // to be the form the parser accepts back.
+        assert_eq!(sharded.to_string(), "mvm-hostd/2of3");
+        assert_eq!(parse_shard_spec(&sharded.to_string()).unwrap(), sharded);
+
+        // A shard that names no valid slice must fail rather than quietly
+        // widening to the whole package and doubling the run.
+        for bad in [
+            "mvm-hostd/",
+            "mvm-hostd/0of2",
+            "mvm-hostd/3of2",
+            "mvm-hostd/xofy",
+        ] {
+            assert!(
+                parse_shard_spec(bad).is_err(),
+                "{bad} must not parse as a shard"
+            );
+        }
+    }
+
+    /// The whole point of splitting a package: every file it owns is still
+    /// mutated exactly once, across the shards rather than within one job.
+    #[test]
+    fn the_shards_of_one_package_partition_its_files() {
+        let surface: Vec<SurfaceFile> = ["e", "a", "d", "b", "c"]
+            .iter()
+            .map(|n| surface(&format!("crates/mvm-hostd/src/{n}.rs"), vec![8]))
+            .collect();
+
+        let one = for_shard(&surface, Some(&parse_shard_spec("mvm-hostd/1of2").unwrap()));
+        let two = for_shard(&surface, Some(&parse_shard_spec("mvm-hostd/2of2").unwrap()));
+
+        // Disjoint.
+        let a: BTreeSet<&str> = one.iter().map(|f| f.path.as_str()).collect();
+        let b: BTreeSet<&str> = two.iter().map(|f| f.path.as_str()).collect();
+        assert!(
+            a.is_disjoint(&b),
+            "no file may be mutated twice: {a:?} overlaps {b:?}"
+        );
+
+        // Complete.
+        let mut seen: Vec<&str> = a.union(&b).copied().collect();
+        seen.sort_unstable();
+        let mut all: Vec<&str> = surface.iter().map(|f| f.path.as_str()).collect();
+        all.sort_unstable();
+        assert_eq!(seen, all, "every file must land in exactly one shard");
+
+        // Balanced to within one file, or the split has not bought anything.
+        assert!(one.len().abs_diff(two.len()) <= 1);
+    }
+
+    /// Which shard owns a file must not depend on the order resolution
+    /// happened to emit, or a survivor would move between shards without
+    /// the baseline changing.
+    #[test]
+    fn shard_membership_follows_the_path_not_the_input_order() {
+        let names = ["c", "a", "b", "d"];
+        let forward: Vec<SurfaceFile> = names
+            .iter()
+            .map(|n| surface(&format!("crates/mvm-hostd/src/{n}.rs"), vec![8]))
+            .collect();
+        let mut backward = forward.clone();
+        backward.reverse();
+
+        let spec = parse_shard_spec("mvm-hostd/1of2").unwrap();
+        let a: Vec<String> = for_shard(&forward, Some(&spec))
+            .into_iter()
+            .map(|f| f.path)
+            .collect();
+        let b: Vec<String> = for_shard(&backward, Some(&spec))
+            .into_iter()
+            .map(|f| f.path)
+            .collect();
+        assert_eq!(a, b, "shard membership must be a property of the surface");
+    }
+
+    /// A package cut into shards must be cut completely. Dropping `2of2`
+    /// leaves its files unmutated while `1of2` still reports success — the
+    /// silent loss this gate exists to prevent, one level in.
+    #[test]
+    fn an_incomplete_shard_set_is_reported() {
+        let entries = ["mvm-hostd/1of2".to_string()];
+        let mut shards: Vec<(usize, usize)> = Vec::new();
+        for raw in &entries {
+            if let Some(pair) = parse_shard_spec(raw).unwrap().shard {
+                shards.push(pair);
+            }
+        }
+        let total = shards[0].1;
+        let seen: BTreeSet<usize> = shards.iter().map(|(i, _)| *i).collect();
+        let expected: BTreeSet<usize> = (1..=total).collect();
+        assert_ne!(
+            seen, expected,
+            "a half-declared split must not look complete"
+        );
     }
 
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -295,15 +295,16 @@ fn main() -> Result<()> {
                 (false, true) => check_mutation_witnesses::Mode::Run,
                 (false, false) => check_mutation_witnesses::Mode::PinOnly,
             };
-            // `--package <name>` shards a `--run` by cargo package so each
-            // CI job finishes inside the six-hour job cap; unset means the
-            // whole surface.
-            let package = args
+            // `--package <name>` shards a `--run` so each CI job finishes
+            // inside the six-hour job cap; unset means the whole surface. A
+            // package that outgrew one job takes the `<name>/<i>of<n>` form.
+            let shard = args
                 .iter()
                 .position(|a| a == "--package")
                 .and_then(|i| args.get(i + 1))
-                .map(String::as_str);
-            check_mutation_witnesses::run(&workspace, mode, package)
+                .map(|raw| check_mutation_witnesses::parse_shard_spec(raw))
+                .transpose()?;
+            check_mutation_witnesses::run(&workspace, mode, shard.as_ref())
         }
         Some("check-nextest-groups") => {
             let workspace = workspace_root();


### PR DESCRIPTION
The other half of #2537.

Five shards of the nightly mutation lane failed on `bdff1866`. **Four were the
ratchet doing its job and #2540 closed them.** The fifth, `mvm-hostd`, was not a
mutant failure at all — and nothing in #2540 touches it.

## What actually happened to mvm-hostd

It ran **3h17m**, reached surface file **6 of 10**, and died on:

```
The runner has received a shutdown signal.
```

No overlapping `Security` run existed to cancel it, so that was an infra
reclaim. But the shard was on track for ~5.5h against GitHub's six-hour cap,
and `security.yml` sets no `timeout-minutes` anywhere. Baselining a mutant does
not make a shard faster; this one would have gone red again on its own.

The failure mode is the one this lane exists to prevent, reached from the other
side: a message naming no package, no file and no claim, indistinguishable from
infrastructure having a bad night, on a lane nobody sees because it does not run
on PRs.

## Changes

- **A package can be split further** — `mvm-hostd/1of2`, through the same
  `--package` flag. Two matrix rows, five files each.
- **Membership follows the path, not resolution order.** Files are sorted then
  assigned by stride, so a survivor cannot appear and vanish by shard. Stride
  rather than contiguous blocks because adjacent surface files tend to be
  siblings of similar cost.
- **The split must be total.** `check_shard_matrix` rejects a missing index, a
  repeated one, disagreeing totals, and a bare entry beside sharded ones — each
  leaves files nothing mutates while every remaining shard reports success.
- **`timeout-minutes: 330`**, under the cap, so a shard that outgrows its budget
  fails as itself.
- **The partial output survives** — `TMPDIR` pinned, cargo-mutants directory
  uploaded on `always()`.

## The gate caught a bug in its own change

The first version put a YAML comment above the new matrix rows. `shard_entries`
treated any non-`- ` line as end-of-list, so `mvm-contract`, `mvm-runtime`,
`mvm-sdk` and `mvm-vmm` all read as unsharded and the gate went red — the parser
silently truncating the matrix, which is exactly what it exists to catch.

Comments are now skipped, pinned by
`a_comment_between_entries_does_not_truncate_the_matrix`, **confirmed to fail
with the fix reverted**.

## Evidence

- `cargo test -p xtask --bin xtask` — **599 passed, 0 failed**.
- The new matrix passes `check-mutation-witnesses`. Hand-broken variants were
  each run and each went red:
  - dropping `2of2` → `declares shards {1} of 2 for mvm-hostd; the missing ones own surface files nothing would mutate`
  - adding a bare `mvm-hostd` → `mixes sharded and unsharded entries for mvm-hostd`
  - `2of3` beside `1of2` → `disagreeing totals`
- `cargo +nightly fmt --all --check`, `cargo clippy -p xtask --all-targets -D warnings`,
  `actionlint`, plus `check-workflow-paths`, `check-declared-backing`,
  `check-no-overclaim`, `check-honesty`, `check-doc-claims`,
  `check-witness-citations`, `check-claim-catalog` — all clean.

## What this does not prove

The split is by **file count, not cost**: five files each, but the two most
expensive files measured so far both land in `2of2`. The shards are expected to
*fit*, not to be equal. Only the next nightly measures that, and
`specs/VERIFICATION.md` now says to re-measure rather than re-quote.

## Also

`security-lane-watch.yml` described the mutation lane as `continue-on-error:
true`. It is not, and `security.yml` has carried none for months. The
API-reading rationale holds on its own, so the comment keeps it and drops the
false example.