### PR TITLE
perf(ci): resolve the test-support features once instead of five times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,13 +530,17 @@ jobs:
         run: cargo test -p mvm-build --features pure-mkfs --lib rootfs::tests::pure
 
       - name: test-support feature tests (mock backend)
+        # One invocation, not one per package. Cargo resolves features per
+        # invocation, so selecting a different package each time produced
+        # different fingerprints and rebuilt most of the same graph seven
+        # times over — 28 of this job's 35 minutes, and the critical path for
+        # every pull request. These packages form one feature subtree
+        # (mvm-cli -> mvm-runtime -> mvm-backends, mvm-vmm -> mvm-core), so a
+        # single resolution covers all of them and compiles once.
         run: |
-          cargo nextest run -p mvm-backends --features test-support --lib
-          cargo nextest run -p mvm-runtime --features test-support --lib
-          cargo nextest run -p mvm-client --features test-support --lib
-          cargo nextest run -p mvm-cli --features test-support --lib
+          cargo nextest run --features test-support --lib \
+            -p mvm-backends -p mvm-runtime -p mvm-client -p mvm-cli -p mvm-vmm
           cargo nextest run -p mvmctl --features test-support --test audit_emissions_live
-          cargo nextest run -p mvm-vmm --features test-support --lib
           cargo check -p mvm-cli --features test-support --example verification_loop
 
   lint:

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -454,11 +454,13 @@ mod tests {
         assert!(lint_policy.contains("bash scripts/check-no-orchestration-server.sh"));
         assert!(lint_policy.contains("cargo run -p xtask -- check-conformance"));
         let lint_features = job_block(&workflow, "lint-features");
+        // One invocation covering the whole test-support subtree. Selecting a
+        // package at a time made cargo resolve features once per package and
+        // rebuild most of the same graph each time; the packages are listed
+        // together so a single resolution serves all of them.
         for expected in [
-            "cargo nextest run -p mvm-backends --features test-support --lib",
-            "cargo nextest run -p mvm-runtime --features test-support --lib",
-            "cargo nextest run -p mvm-client --features test-support --lib",
-            "cargo nextest run -p mvm-cli --features test-support --lib",
+            "cargo nextest run --features test-support --lib",
+            "-p mvm-backends -p mvm-runtime -p mvm-client -p mvm-cli -p mvm-vmm",
             "cargo nextest run -p mvmctl --features test-support --test audit_emissions_live",
             "cargo check -p mvm-cli --features test-support --example verification_loop",
         ] {
@@ -469,11 +471,22 @@ mod tests {
         }
         assert_eq!(
             lint_features
-                .matches("cargo nextest run -p mvm-backends --features test-support --lib")
+                .matches("cargo nextest run --features test-support --lib")
                 .count(),
             1,
-            "feature coverage must not repeat the same mvm-backends test command"
+            "feature coverage must not repeat the test-support run"
         );
+        // The per-package shape is what made this lane the critical path, so
+        // its return is an error rather than a silent regression.
+        for regressed in [
+            "cargo nextest run -p mvm-backends --features test-support --lib",
+            "cargo nextest run -p mvm-runtime --features test-support --lib",
+        ] {
+            assert!(
+                !lint_features.contains(regressed),
+                "feature coverage must not go back to one invocation per package: {regressed:?}"
+            );
+        }
 
         let test = job_block(&workflow, "test");
         assert!(test.contains("name: Test"));


### PR DESCRIPTION
## Where the time goes

Job durations on a recent completed pull-request run:

| Job | Time |
|---|---|
| **Lint feature coverage** | **35.2m** ← critical path |
| Test workspace | 24.7m |
| Test Linux and conformance | 23.7m |
| Lint core (fmt + clippy) | 12.3m |
| Test release profile | 11.6m |
| Invariant | 5.6m |
| Build kernels (aarch64) / (x86_64) | 0m — correctly scoped out |

**28.5m of that 35.2m job is one step.** Every other step in it takes one to two minutes.

## Cause

The step ran one cargo invocation per package. Cargo resolves features per invocation, so each package selection produced its own fingerprints and rebuilt much of the same graph again. These packages are a single feature subtree — `mvm-cli → mvm-runtime → mvm-backends`, `mvm-vmm → mvm-core` — so it was largely the same code compiled five times.

## Measured, not estimated

Cold target dir, build only, same machine:

```
OLD (5 per-package invocations):  7m39s
NEW (1 combined invocation):      5m55s     23% faster
```

I had guessed a far bigger win before measuring. Cargo shares more across invocations than that guess assumed, so the honest expectation is this step landing near **22m** and the job near **28m** — not the single-digit figure the raw step time might suggest.

## Coverage is identical

The saving must not come from running fewer tests. `cargo nextest list` under both shapes:

```
OLD unique tests: 3512
NEW unique tests: 3512
in OLD but not NEW:  (empty)
in NEW but not OLD:  (empty)
```

## The ceiling, stated

`Test workspace` is 24.7m. Trimming this lane below that yields **no** wall-clock gain on the critical path — the next improvement has to come from elsewhere (scoping this lane by path, or splitting its three one-minute checks out so they report early instead of queueing behind the slow one). Worth doing separately; not folded in here.

## Verification

- `actionlint .github/workflows/ci.yml` — clean
- test-set equality as above
- timings from a cold `CARGO_TARGET_DIR` per shape