### PR TITLE
fix(net): make the FlowMux egress path actually carry traffic

### DIFF
--- a/crates/mvm-agentd/src/egress_client.rs
+++ b/crates/mvm-agentd/src/egress_client.rs
@@ -77,19 +77,25 @@ enum SocksRequest {
     UdpAssociate,
 }
 
+/// Finish a SOCKS5 negotiation whose version byte the caller has already
+/// consumed and matched. Only [`read_route`] may call this, and only on that
+/// branch — the stream position is the contract between them.
 async fn negotiate_request<S>(stream: &mut S) -> std::io::Result<SocksRequest>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let invalid = |m: &str| std::io::Error::new(std::io::ErrorKind::InvalidData, m.to_string());
 
-    // Greeting: VER, NMETHODS, METHODS...
-    let mut head = [0u8; 2];
-    stream.read_exact(&mut head).await?;
-    if head[0] != SOCKS5 {
-        return Err(invalid("socks: not version 5"));
-    }
-    let mut methods = vec![0u8; head[1] as usize];
+    // Greeting, resumed *after* the VER byte: NMETHODS, METHODS...
+    //
+    // `read_route` has already read and matched VER to dispatch here, so
+    // re-reading two bytes would take NMETHODS as the version and the first
+    // method as the count. For curl's `05 01 00` that reads as version 1 and
+    // rejects a perfectly good greeting — while the client, still waiting on a
+    // method reply, sees whatever comes next as a malformed SOCKS5 response.
+    let mut nmethods = [0u8; 1];
+    stream.read_exact(&mut nmethods).await?;
+    let mut methods = vec![0u8; nmethods[0] as usize];
     stream.read_exact(&mut methods).await?;
     let method = select_method(&methods);
     stream.write_all(&[SOCKS5, method]).await?;
@@ -395,6 +401,82 @@ where
 mod tests {
     use super::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// The exact bytes curl puts on the wire for `socks5h://…`: a greeting of
+    /// VER=5, NMETHODS=1, METHOD=no-auth, then a CONNECT for a domain.
+    ///
+    /// Nothing drove `read_route` with a real greeting before, which is how a
+    /// double-read of the version byte reached a builder VM: the guest logged
+    /// `socks: not version 5` and curl logged `Received invalid version in
+    /// initial SOCKS5 response`, neither of which names the offset.
+    #[tokio::test]
+    async fn read_route_accepts_a_real_socks5_connect_greeting() {
+        let (mut client, mut server) = tokio::io::duplex(256);
+        let writer = tokio::spawn(async move {
+            client
+                .write_all(&[SOCKS5, 1, METHOD_NO_AUTH])
+                .await
+                .unwrap();
+            let host = b"cache.nixos.org";
+            let mut req = vec![SOCKS5, CMD_CONNECT, 0, ATYP_DOMAIN, host.len() as u8];
+            req.extend_from_slice(host);
+            req.extend_from_slice(&443u16.to_be_bytes());
+            client.write_all(&req).await.unwrap();
+            // Read back the method reply the server owes us, so the assertion
+            // below is about a completed negotiation rather than half of one.
+            let mut method_reply = [0u8; 2];
+            client.read_exact(&mut method_reply).await.unwrap();
+            method_reply
+        });
+
+        let route = read_route(&mut server).await.expect("a valid greeting");
+        assert!(
+            matches!(&route, ProxyRoute::Socks { target } if target == "cache.nixos.org:443"),
+            "unexpected route: {route:?}"
+        );
+        assert_eq!(writer.await.unwrap(), [SOCKS5, METHOD_NO_AUTH]);
+    }
+
+    #[tokio::test]
+    async fn read_route_accepts_a_socks5_udp_associate() {
+        let (mut client, mut server) = tokio::io::duplex(256);
+        tokio::spawn(async move {
+            client
+                .write_all(&[SOCKS5, 1, METHOD_NO_AUTH])
+                .await
+                .unwrap();
+            let mut req = vec![SOCKS5, CMD_UDP_ASSOCIATE, 0, ATYP_IPV4];
+            req.extend_from_slice(&[0, 0, 0, 0]);
+            req.extend_from_slice(&0u16.to_be_bytes());
+            client.write_all(&req).await.unwrap();
+            let mut method_reply = [0u8; 2];
+            client.read_exact(&mut method_reply).await.unwrap();
+        });
+
+        let route = read_route(&mut server).await.expect("a valid greeting");
+        assert!(matches!(route, ProxyRoute::SocksUdpAssociate), "{route:?}");
+    }
+
+    /// An HTTP proxy client on the same port must still route as HTTP — the
+    /// version-byte read is a dispatch, not a filter.
+    #[tokio::test]
+    async fn read_route_still_routes_http_connect() {
+        let (mut client, mut server) = tokio::io::duplex(512);
+        tokio::spawn(async move {
+            client
+                .write_all(
+                    b"CONNECT cache.nixos.org:443 HTTP/1.1\r\nHost: cache.nixos.org:443\r\n\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let route = read_route(&mut server).await.expect("a valid CONNECT");
+        assert!(
+            matches!(&route, ProxyRoute::HttpConnect { target } if target == "cache.nixos.org:443"),
+            "unexpected route: {route:?}"
+        );
+    }
 
     #[test]
     fn select_method_prefers_no_auth() {

--- a/crates/mvm-agentd/src/flowmux.rs
+++ b/crates/mvm-agentd/src/flowmux.rs
@@ -571,12 +571,7 @@ where
         payload: Vec<u8>,
     ) -> Result<(), FlowMuxError> {
         self.validator
-            .admit(&frame_facts(
-                Direction::HostToGuest,
-                opcode,
-                stream_id,
-                payload.len() as u32,
-            ))
+            .admit(&inbound_frame_facts(opcode, stream_id, &payload))
             .map_err(|e| FlowMuxError::Frame(e.to_string()))?;
 
         match opcode {
@@ -995,6 +990,35 @@ fn frame_facts(
         .with_payload(payload_len)
 }
 
+/// Facts for a frame arriving from the host.
+///
+/// A `WindowUpdate`'s payload *is* its credit, and the validator rejects an
+/// update that carries none. Describing one by length alone therefore fails
+/// every single window update — reported as the host sending a credit-less
+/// frame, when the host sent a perfectly good one and the guest simply never
+/// looked at it. The session dies on the first replenish, which is the first
+/// byte of real traffic.
+fn inbound_frame_facts(
+    opcode: Opcode,
+    stream_id: u32,
+    payload: &[u8],
+) -> mvm_contract::protocol::network_flow::FrameFacts {
+    let facts = frame_facts(
+        Direction::HostToGuest,
+        opcode,
+        stream_id,
+        payload.len() as u32,
+    );
+    match (opcode, payload) {
+        (Opcode::WindowUpdate, [a, b, c, d]) => {
+            facts.with_credit(u32::from_be_bytes([*a, *b, *c, *d]))
+        }
+        // A malformed update keeps no credit, so the validator still refuses
+        // it — the decode is a faithful read, not a way to wave frames through.
+        _ => facts,
+    }
+}
+
 fn build_dns_query(name: &str, qtype: u16, id: u16) -> Result<Vec<u8>, FlowMuxError> {
     let mut query = Vec::with_capacity(64);
 
@@ -1234,8 +1258,13 @@ async fn reconnect_loop<S, F, Fut>(
                 break;
             }
             if state_rx.changed().await.is_err() {
-                let _ = current_tx.send(None);
-                return;
+                // The session task dropped its state sender. That is the
+                // strongest evidence the session is gone, not a signal to stop
+                // watching — a session can end without ever publishing `Dead`.
+                // Returning here drops `current_tx`, so every waiter fails with
+                // "reconnect owner gone" and the guest never gets a second
+                // session, which is indistinguishable from having no network.
+                break;
             }
         }
 

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -267,6 +267,12 @@ fn run_stage0_qemu(
         cmd.arg("-drive")
             .arg(format!("file={},if=virtio,format=raw", disk.display()));
     }
+    // Read-only, matching how the shell-job and build paths attach it.
+    #[cfg(feature = "builder-vm")]
+    cmd.arg("-drive").arg(format!(
+        "file={},if=virtio,format=raw,readonly=on",
+        identity_drive.display()
+    ));
     #[cfg(feature = "builder-vm")]
     {
         cmd.arg("-drive").arg(format!(

--- a/crates/mvm-hostd/src/supervisor/flowmux.rs
+++ b/crates/mvm-hostd/src/supervisor/flowmux.rs
@@ -845,11 +845,18 @@ impl FlowMuxSession {
         }
 
         // Replenish the consumed credit so the guest can keep sending.
-        {
-            let mut reg = lock_registry(&self.registry);
-            let _ = reg.grant_guest_credit(stream_id, payload_len);
+        //
+        // A zero-length DATA frame consumes no credit, and the protocol treats
+        // a zero-delta window update as a frame error. Sending one anyway kills
+        // the session the frame was meant to keep flowing — and it dies on the
+        // *guest's* validator, so the host log shows nothing wrong.
+        if payload_len > 0 {
+            {
+                let mut reg = lock_registry(&self.registry);
+                let _ = reg.grant_guest_credit(stream_id, payload_len);
+            }
+            self.send_window_update(stream_id, payload_len)?;
         }
-        self.send_window_update(stream_id, payload_len)?;
         Ok(())
     }
 


### PR DESCRIPTION
Stacked on `fix/one-transport-flowmux-cutover`. Five defects sat between that
branch and a builder VM that can reach the network. Each was found by running
`mvmctl bootstrap` against a real Stage 0 guest and reading how far it got;
each fix moved the failure to the next one.

## 1. The branch does not compile for Linux

`run_stage0_qemu` grew a new `let (identity_material, identity_drive) = …`
directly beneath the `#[cfg(feature = "builder-vm")]` that was gating the
`egress_endpoint` binding. An attribute gates exactly one statement, so the new
line took the gate and the old one lost it. Without the feature — which is how
`mvm-host-vm-init` cross-compiles for `aarch64-unknown-linux-musl` — that is
four hard errors.

macOS `--all-targets` cannot see it, because those use-sites are Linux-only.
This is almost certainly the red `Test` job.

## 2. The SOCKS5 version byte was read twice

`read_route` reads one byte and dispatches on it; `negotiate_request` then read
*two* more as `[VER, NMETHODS]`. For curl's `05 01 00` that reads NMETHODS as
the version and rejects a valid greeting with `socks: not version 5`, while
curl — still waiting for a method reply — reports `Received invalid version in
initial SOCKS5 response`. Neither message names the offset.

Nothing drove `read_route` with a real greeting, so nothing caught it. Added
tests for a real CONNECT greeting, UDP ASSOCIATE, and HTTP CONNECT on the same
port; the first two fail with the exact production error before this fix.

## 3. A dead session ended the reconnect owner instead of reconnecting

`reconnect_loop` waits for the session to die. When the session task dropped its
state sender — the strongest evidence it is gone — the loop `return`ed. That
drops `current_tx`, so every later open fails with `reconnect owner gone` and
the guest never gets a second session. It now breaks into the reconnect path,
which is what the surrounding loop is for.

## 4. An empty DATA frame made the host send a zero-delta window update

Credit replenish echoed `payload_len` unconditionally. A zero-length DATA frame
consumes no credit, and the protocol defines a zero-delta update as a frame
error — so the host killed the session it was trying to keep flowing, and did it
on the *guest's* validator, leaving nothing in the host log.

## 5. The guest never decoded window-update credit — the session killer

Inbound frames were described to the validator by length alone. A
`WindowUpdate`'s payload *is* its credit, and the validator refuses an update
carrying none, so **every** window update was rejected as malformed. The session
died on the first replenish, which is the first byte of real traffic. The host's
frames were correct throughout.

A malformed update still decodes to no credit and is still refused — this reads
the field, it does not wave frames through.

## Where this gets to

Before: guest cannot load its signing key, nix reaches nothing.
After: SOCKS negotiates, the tunnel authenticates, TLS completes to github.com,
and nix pulls real bytes.

It is not done. The next failure is
`frame error: opcode 0x16 names unopened stream 3` — a stream-lifecycle defect
that truncates the download mid-transfer. `bootstrap` still fails there.

## Two reasons this class of bug survives review

- `crates/mvm-cli/build.rs` does not watch `crates/mvm-agentd/src`, so editing
  the guest egress client does not re-cross-compile the embedded
  `mvm-egress-client`. The guest keeps running the old binary and the change
  appears to do nothing. Three of these fixes looked ineffective until the
  nested target dir was purged by hand.
- `egress_client` and `flowmux_egress` sit behind the off-by-default `addons`
  feature, so `cargo nextest run --workspace` never compiles the code that
  carries every builder VM's traffic.

## Verification

- `cargo nextest run -p mvm-agentd -p mvm-hostd -p mvm-build --features addons`
  — 3712 passed; same set without the feature — 3655 passed
- `cargo clippy … --all-targets --features addons -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- The Linux cross-compile of `mvm-host-vm-init` succeeds, which is what defect 1
  broke