### PR TITLE
fix(ci): stop requiring the kernel lane to skip when it can no longer skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,13 +627,20 @@ jobs:
             echo "BDD conformance did not match scope $SCOPE_BDD: $BDD_RESULT"
             exit 1
           fi
+          # The kernel lane is matched on result alone, not against its scope.
+          # It carries no job-level `if:` — a skipped matrix job cannot expand
+          # its matrix arch, so it would report one check whose name still
+          # contains the unexpanded matrix expression — neither required
+          # context. It therefore always runs, doing nothing when out of scope,
+          # and always reports `success`. Requiring `skipped` when
+          # `KERNEL_SCOPE` was false made every pull request that touches no
+          # kernel path unmergeable with an otherwise green board.
           case "$KERNEL_SCOPE" in
-            true) kernel_required=success ;;
-            false) kernel_required=skipped ;;
+            true | false) ;;
             *) echo "Invalid kernel scope: $KERNEL_SCOPE"; exit 1 ;;
           esac
-          if [ "$KERNEL_RESULT" != "$kernel_required" ]; then
-            echo "Kernel validation did not match scope $KERNEL_SCOPE: $KERNEL_RESULT"
+          if [ "$KERNEL_RESULT" != success ]; then
+            echo "Kernel validation did not pass (scope $KERNEL_SCOPE): $KERNEL_RESULT"
             exit 1
           fi
 


### PR DESCRIPTION
**Every open pull request in the repo is currently unmergeable.** Green board, and the `Test` aggregate fails with:

```
Kernel validation did not match scope false: success
```

Verified across all of them — 2546, 2547, 2551, 2552, 2554 and both of mine (2550, 2564) show `Test=fail` with `kernels=[pass,pass]`.

## Cause

#2548 removed the `kernel` job's job-level `if:` so the matrix would expand and report both required contexts. A skipped matrix job reports a single check whose name still contains the unexpanded matrix expression, matching neither `Build kernels (aarch64)` nor `Build kernels (x86_64)` — so PRs sat waiting for contexts that never arrived. Every step kept the scope condition, so an out-of-scope run does nothing and finishes in seconds. That part works.

The consequence was missed: **the job can no longer report `skipped`.** The aggregate still required exactly that when kernel scope was false:

```sh
case "$KERNEL_SCOPE" in
  true) kernel_required=success ;;
  false) kernel_required=skipped ;;   # now unreachable
esac
```

So #2548 traded one unmergeable state for another — the previous one blocked on a missing context, this one on a failing aggregate.

## Fix

Match the kernel lane on its result alone. The scope value is still validated, so a malformed one remains an error; it just no longer selects what the result must be.

## Scope of the change

- `nix-flake-check` is unaffected — its name is static, so a skipped job still reports the context branch protection requires. It keeps its scope matching.
- `bdd-conformance` genuinely does skip when out of scope, so it keeps its scope matching too.
- Only the kernel lane changed shape in #2548, so only the kernel lane changes here.

## Verification

`actionlint .github/workflows/ci.yml` clean (note: it parses `${{ }}` inside shell comments, so the explanatory comment deliberately avoids the literal expression). YAML parses.

This change touches `ci.yml`, which puts it in kernel scope, so its own kernel lane runs and the aggregate can pass — the fix can land on its own.