### PR TITLE
docs(bench): publish the launch budgets, and gate the page against them

### DIFF
--- a/crates/mvm-cli/src/bench/cold_launch.rs
+++ b/crates/mvm-cli/src/bench/cold_launch.rs
@@ -54,6 +54,32 @@ pub const WARM_CLAIM_P50_BUDGET_MS: f64 = 30.0;
 /// Warm-claim dispatch-window p99 budget, in milliseconds.
 pub const WARM_CLAIM_P99_BUDGET_MS: f64 = 50.0;
 
+/// The dispatch-window budgets one lane publishes, by percentile.
+///
+/// `None` is "this lane deliberately publishes no budget at this percentile",
+/// never "zero". The acquisition lanes measure work whose cost is dominated by
+/// a registry and a disk, so holding them to a latency ceiling would gate mvm
+/// on someone else's network.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LaneBudgets {
+    pub p50_ms: Option<f64>,
+    pub p95_ms: Option<f64>,
+    pub p99_ms: Option<f64>,
+}
+
+impl LaneBudgets {
+    /// The published budgets in contract order, paired with the percentile
+    /// label the violation and the doc table both use.
+    #[must_use]
+    pub const fn by_percentile(self) -> [(&'static str, Option<f64>); 3] {
+        [
+            ("p50", self.p50_ms),
+            ("p95", self.p95_ms),
+            ("p99", self.p99_ms),
+        ]
+    }
+}
+
 /// The measurement lanes the cold-launch contract reports independently.
 ///
 /// They are reported separately rather than averaged because they measure
@@ -94,6 +120,51 @@ impl LaunchLane {
             Self::MountMiss => "mount_miss",
             Self::ArtifactMiss => "artifact_miss",
             Self::WarmClaim => "warm_claim",
+        }
+    }
+
+    /// What this lane measures, in one sentence, for a reader who has not read
+    /// the enum. The published table and the gate name the same thing because
+    /// they read the same string.
+    #[must_use]
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::PreparedCold => {
+                "Cached artifacts, no mount image, new VMM and new guest identity."
+            }
+            Self::PreparedColdMountHit => {
+                "The same launch with an unchanged cached read-only mount image."
+            }
+            Self::MountMiss => "Directory fingerprint plus first mount-image materialization.",
+            Self::ArtifactMiss => "Image acquisition, unpack, verification, and preparation.",
+            Self::WarmClaim => {
+                "A claimed warm standby — a comparison point, never folded into a cold number."
+            }
+        }
+    }
+
+    /// The dispatch-window budgets this lane is published and gated against.
+    ///
+    /// [`validate_matrix_report`] and the published budget table both read
+    /// this, so a budget cannot be changed in one and stale in the other.
+    #[must_use]
+    pub const fn budgets(self) -> LaneBudgets {
+        match self {
+            Self::PreparedCold | Self::PreparedColdMountHit => LaneBudgets {
+                p50_ms: Some(PREPARED_COLD_P50_BUDGET_MS),
+                p95_ms: Some(PREPARED_COLD_P95_BUDGET_MS),
+                p99_ms: Some(PREPARED_COLD_P99_BUDGET_MS),
+            },
+            Self::WarmClaim => LaneBudgets {
+                p50_ms: Some(WARM_CLAIM_P50_BUDGET_MS),
+                p95_ms: None,
+                p99_ms: Some(WARM_CLAIM_P99_BUDGET_MS),
+            },
+            Self::MountMiss | Self::ArtifactMiss => LaneBudgets {
+                p50_ms: None,
+                p95_ms: None,
+                p99_ms: None,
+            },
         }
     }
 }
@@ -263,42 +334,17 @@ pub fn validate_matrix_report(report: &ColdLaunchReport) -> Result<(), LaneViola
     if report.stats != canonical.stats {
         return Err(LaneViolation::NonCanonicalSummary);
     }
-    match report.lane {
-        LaunchLane::PreparedCold | LaunchLane::PreparedColdMountHit => {
-            require_budget(
-                report.lane,
-                "p50",
-                report.stats.dispatch_window_ms.p50,
-                PREPARED_COLD_P50_BUDGET_MS,
-            )?;
-            require_budget(
-                report.lane,
-                "p95",
-                report.stats.dispatch_window_ms.p95,
-                PREPARED_COLD_P95_BUDGET_MS,
-            )?;
-            require_budget(
-                report.lane,
-                "p99",
-                report.stats.dispatch_window_ms.p99,
-                PREPARED_COLD_P99_BUDGET_MS,
-            )?;
+    let measured = report.stats.dispatch_window_ms.by_percentile();
+    for ((percentile, budget_ms), (_, found)) in report
+        .lane
+        .budgets()
+        .by_percentile()
+        .into_iter()
+        .zip(measured)
+    {
+        if let Some(budget_ms) = budget_ms {
+            require_budget(report.lane, percentile, found, budget_ms)?;
         }
-        LaunchLane::WarmClaim => {
-            require_budget(
-                report.lane,
-                "p50",
-                report.stats.dispatch_window_ms.p50,
-                WARM_CLAIM_P50_BUDGET_MS,
-            )?;
-            require_budget(
-                report.lane,
-                "p99",
-                report.stats.dispatch_window_ms.p99,
-                WARM_CLAIM_P99_BUDGET_MS,
-            )?;
-        }
-        LaunchLane::MountMiss | LaunchLane::ArtifactMiss => {}
     }
     Ok(())
 }
@@ -612,6 +658,14 @@ pub struct SpanStats {
 }
 
 impl SpanStats {
+    /// The measured percentiles in the same order and with the same labels as
+    /// [`LaneBudgets::by_percentile`], so a budget and its measurement can be
+    /// zipped without either side naming a percentile as a string.
+    #[must_use]
+    pub const fn by_percentile(self) -> [(&'static str, Option<f64>); 3] {
+        [("p50", self.p50), ("p95", self.p95), ("p99", self.p99)]
+    }
+
     #[must_use]
     pub fn from_samples(samples: &[f64]) -> Self {
         if samples.is_empty() {

--- a/crates/mvm-cli/src/bench/doc_table.rs
+++ b/crates/mvm-cli/src/bench/doc_table.rs
@@ -1,0 +1,175 @@
+//! Renders the published launch-budget contract as markdown.
+//!
+//! The budget table on the public performance page is generated from
+//! [`LaunchLane::budgets`] — the same accessor
+//! [`validate_matrix_report`](super::cold_launch::validate_matrix_report)
+//! gates against — so a published number cannot drift from the number CI
+//! enforces. A doc-sync test re-renders this and compares it to the committed
+//! page; changing a budget constant without regenerating the page fails.
+//!
+//! This module renders the *contract*, not measurements. Measured percentiles
+//! come from a seeded matrix report and are published separately, because a
+//! budget is a promise and a percentile is an observation, and printing them
+//! in one column without saying which is which is how a ceiling gets read as
+//! a result.
+
+use super::cold_launch::{
+    COLD_LAUNCH_SCHEMA_VERSION, LaunchLane, MATRIX_WARMUP_SAMPLES, MIN_MATRIX_SAMPLES,
+};
+
+/// Delimiters bounding the generated region of the performance page. The text
+/// outside them is hand-written prose the generator neither reads nor rewrites.
+pub const BEGIN_MARKER: &str = "<!-- generated:launch-budgets:begin -->";
+pub const END_MARKER: &str = "<!-- generated:launch-budgets:end -->";
+
+/// Format one budget cell. An unbudgeted percentile prints as an em dash with
+/// no number, so a reader cannot mistake "not gated" for "gated at zero".
+fn cell(budget_ms: Option<f64>) -> String {
+    match budget_ms {
+        Some(ms) => format!("{ms:.0} ms"),
+        None => "—".to_string(),
+    }
+}
+
+/// The sample-count contract a lane report must satisfy to be published,
+/// stated from the constants the report-level gate enforces.
+#[must_use]
+pub fn sample_contract_sentence() -> String {
+    format!(
+        "A lane result is publishable only when it carries at least \
+         {MIN_MATRIX_SAMPLES} measured samples taken after exactly \
+         {MATRIX_WARMUP_SAMPLES} discarded warm-ups, under report schema \
+         version {COLD_LAUNCH_SCHEMA_VERSION}. A report that misses any of \
+         those is refused rather than published with a caveat."
+    )
+}
+
+/// Render the generated region: the sample contract, then one row per lane.
+///
+/// The output is bounded by [`BEGIN_MARKER`] / [`END_MARKER`] and ends with a
+/// trailing newline so it can be spliced into the page verbatim.
+#[must_use]
+pub fn render_budget_section() -> String {
+    let mut out = String::new();
+    out.push_str(BEGIN_MARKER);
+    out.push_str("\n\n");
+    out.push_str(&sample_contract_sentence());
+    out.push_str("\n\n");
+    out.push_str("| Lane | What it measures | p50 | p95 | p99 |\n");
+    out.push_str("| --- | --- | --- | --- | --- |\n");
+    for lane in LaunchLane::ALL {
+        let budgets = lane.budgets();
+        out.push_str(&format!(
+            "| `{}` | {} | {} | {} | {} |\n",
+            lane.as_str(),
+            lane.description(),
+            cell(budgets.p50_ms),
+            cell(budgets.p95_ms),
+            cell(budgets.p99_ms),
+        ));
+    }
+    out.push('\n');
+    out.push_str(END_MARKER);
+    out.push('\n');
+    out
+}
+
+/// Extract the generated region from `page`, inclusive of both markers.
+///
+/// Returns `None` when either marker is absent or they appear out of order —
+/// a page the generator cannot locate its own region in is a drift failure,
+/// not something to silently append to.
+#[must_use]
+pub fn extract_budget_section(page: &str) -> Option<&str> {
+    let begin = page.find(BEGIN_MARKER)?;
+    let end = page.find(END_MARKER)?;
+    if end < begin {
+        return None;
+    }
+    Some(&page[begin..end + END_MARKER.len()])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_lane_gets_a_row_naming_itself() {
+        let rendered = render_budget_section();
+        for lane in LaunchLane::ALL {
+            assert!(
+                rendered.contains(&format!("| `{}` |", lane.as_str())),
+                "lane {} is missing from the rendered table",
+                lane.as_str()
+            );
+            assert!(
+                rendered.contains(lane.description()),
+                "lane {} rendered without its description",
+                lane.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn budgeted_lanes_print_their_gated_numbers() {
+        let rendered = render_budget_section();
+        // The prepared-cold contract: 200/250/300 ms at p50/p95/p99.
+        assert!(rendered.contains("| 200 ms | 250 ms | 300 ms |"));
+        // The warm-claim contract publishes no p95, and says so with a dash
+        // rather than a zero.
+        assert!(rendered.contains("| 30 ms | — | 50 ms |"));
+    }
+
+    #[test]
+    fn unbudgeted_lanes_render_a_dash_and_never_a_zero() {
+        for lane in [LaunchLane::MountMiss, LaunchLane::ArtifactMiss] {
+            let budgets = lane.budgets();
+            assert_eq!(budgets.p50_ms, None);
+            assert_eq!(budgets.p95_ms, None);
+            assert_eq!(budgets.p99_ms, None);
+        }
+        let rendered = render_budget_section();
+        assert!(rendered.contains("| — | — | — |"));
+        assert!(
+            !rendered.contains("| 0 ms"),
+            "an unbudgeted percentile must never render as a zero budget"
+        );
+        assert_eq!(cell(None), "—");
+    }
+
+    #[test]
+    fn rendered_section_is_delimited_and_round_trips_through_extraction() {
+        let rendered = render_budget_section();
+        assert!(rendered.starts_with(BEGIN_MARKER));
+        assert!(rendered.trim_end().ends_with(END_MARKER));
+
+        let page = format!("# Title\n\nprose before\n\n{rendered}\nprose after\n");
+        assert_eq!(
+            extract_budget_section(&page),
+            Some(rendered.trim_end_matches('\n'))
+        );
+    }
+
+    #[test]
+    fn extraction_refuses_a_page_with_missing_or_inverted_markers() {
+        assert_eq!(extract_budget_section("no markers at all"), None);
+        assert_eq!(extract_budget_section(BEGIN_MARKER), None);
+        assert_eq!(extract_budget_section(END_MARKER), None);
+        let inverted = format!("{END_MARKER}\nrows\n{BEGIN_MARKER}");
+        assert_eq!(extract_budget_section(&inverted), None);
+    }
+
+    /// Substring assertions on a bare "5" would pass against "250 ms"; each
+    /// number is anchored to the words around it so the test fails when a
+    /// constant changes rather than matching some other cell.
+    #[test]
+    fn sample_contract_numbers_come_from_the_gate_constants() {
+        let sentence = sample_contract_sentence();
+        assert!(sentence.contains(&format!("at least {MIN_MATRIX_SAMPLES} measured samples")));
+        assert!(sentence.contains(&format!(
+            "exactly {MATRIX_WARMUP_SAMPLES} discarded warm-ups"
+        )));
+        assert!(sentence.contains(&format!("schema version {COLD_LAUNCH_SCHEMA_VERSION}")));
+        assert!(render_budget_section().contains(&sentence));
+    }
+}

--- a/crates/mvm-cli/src/bench/mod.rs
+++ b/crates/mvm-cli/src/bench/mod.rs
@@ -16,6 +16,7 @@
 
 pub mod cold_launch;
 pub mod cold_launch_runner;
+pub mod doc_table;
 pub mod harness;
 pub mod interaction;
 pub mod probe;

--- a/public/astro.config.mjs
+++ b/public/astro.config.mjs
@@ -244,6 +244,7 @@ export default defineConfig({
             { label: "Filesystem & Drives", slug: "reference/filesystem" },
             { label: "Guest Agent", slug: "reference/guest-agent" },
             { label: "Limits & Resources", slug: "reference/limits" },
+            { label: "Launch Performance", slug: "reference/performance" },
             { label: "Releases & downloads", slug: "reference/releases" },
           ],
         },

--- a/public/src/content/docs/reference/performance.md
+++ b/public/src/content/docs/reference/performance.md
@@ -1,0 +1,105 @@
+---
+title: Launch performance
+description: The dispatch-window budgets mvm gates every launch against, the lanes they are measured in, and how to reproduce a measurement.
+---
+
+mvm's launch contract is a set of budgets on the **dispatch window** — the span
+from an admitted execution plan to the guest command being dispatched. That is
+the window the contract is set against, so it is the one published here.
+
+This page states the contract. It does not state results: the budgets below are
+ceilings that CI enforces, not percentiles anyone observed. A ceiling printed in
+the same column as an observation gets read as an observation, so measured
+matrix numbers are published separately, per host, once a lane report has been
+seeded.
+
+## Lanes
+
+Launch costs are reported per lane and never averaged across them. Folding a
+first-time image acquisition into a prepared launch would make the prepared
+number meaningless and hide the acquisition cost at the same time.
+
+The acquisition lanes (`mount_miss`, `artifact_miss`) publish no budget. Their
+cost is dominated by a registry and a disk, and gating mvm on someone else's
+network would make the gate measure the wrong thing.
+
+<!-- generated:launch-budgets:begin -->
+
+A lane result is publishable only when it carries at least 20 measured samples taken after exactly 2 discarded warm-ups, under report schema version 5. A report that misses any of those is refused rather than published with a caveat.
+
+| Lane | What it measures | p50 | p95 | p99 |
+| --- | --- | --- | --- | --- |
+| `prepared_cold` | Cached artifacts, no mount image, new VMM and new guest identity. | 200 ms | 250 ms | 300 ms |
+| `prepared_cold_mount_hit` | The same launch with an unchanged cached read-only mount image. | 200 ms | 250 ms | 300 ms |
+| `mount_miss` | Directory fingerprint plus first mount-image materialization. | — | — | — |
+| `artifact_miss` | Image acquisition, unpack, verification, and preparation. | — | — | — |
+| `warm_claim` | A claimed warm standby — a comparison point, never folded into a cold number. | 30 ms | — | 50 ms |
+
+<!-- generated:launch-budgets:end -->
+
+The table between those markers is generated from the same accessor the gate
+reads. Editing it by hand fails the doc-sync test rather than changing a budget.
+
+## What disqualifies a measurement
+
+A lane refuses a sample that did work the lane forbids, rather than reporting it
+as a faster or slower version of the same thing. A launch labelled
+`prepared_cold` that quietly pulled an image, ran a build, materialized a mount
+image, or claimed a warm standby is not a prepared cold launch, and publishing it
+as one would make the number unfalsifiable.
+
+The gate reads recorded work flags, not timings. An uninstrumented phase records
+no span, so refusing on a missing span would pass exactly the contamination the
+check exists to catch.
+
+Beyond per-sample validity, a report is refused for publication when it:
+
+- carries fewer measured samples than the contract requires;
+- was produced with the wrong number of discarded warm-ups;
+- carries a summary that does not match its own raw samples;
+- was built from an unoptimised binary;
+- omits the root-filesystem strategy the launch selected;
+- omits process-memory evidence on a warm sample;
+- exceeds any published budget above.
+
+Raw per-sample vectors are kept in every report. Summary-only evidence cannot be
+re-analysed, cannot show a bimodal distribution, and cannot be checked against
+the percentiles that were published from it.
+
+## Comparability
+
+Two reports are comparable only when their host fingerprint matches — OS,
+architecture, hypervisor, VMM version, and selected root-filesystem strategy.
+A baseline from a different host or kernel is refused as incomparable rather
+than compared, because silently comparing a faster kernel's numbers against an
+older baseline masks a real regression or invents a fake one.
+
+Storage matters as much as the host tier. On a rotational disk a large,
+fixed fraction of a measured launch is `fsync` cost that disappears on NVMe.
+A number measured on spinning media is not a runtime number, and is not
+comparable to one that was not.
+
+## Reproducing a measurement
+
+The launch benchmark is a library surface driven by a live, `#[ignore]`d test,
+not a shipped CLI verb — the suite can never produce a launch number by
+accident. Run it against a release binary on a host with a prepared artifact
+cache:
+
+```sh
+export MVM_COLD_LAUNCH_MVMCTL=target/release/mvmctl
+export MVM_COLD_LAUNCH_ARGS="machine run --image alpine -- /bin/true"
+export MVM_COLD_LAUNCH_LANE=prepared_cold
+export MVM_COLD_LAUNCH_RUNS=20
+export MVM_COLD_LAUNCH_WARMUP=2
+
+cargo test --release --test cold_launch_bench -- --ignored --nocapture
+```
+
+Every knob except the counts is required. A benchmark that guesses what to
+launch measures the wrong thing, so an unset variable fails and names itself
+rather than defaulting.
+
+The run writes a JSON report under `$MVM_HOME/bench/`, alongside a
+`-latest.json` copy. The report carries the host fingerprint, the per-lane
+percentiles, and the full raw sample vector.

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -685,8 +685,15 @@ optimization backend-local and the benchmark backend-neutral.
       records physical footprint and explicitly leaves Linux-only fault counters
       unavailable. Launch-sample schema v4 and cold-launch schema v5 carry the
       evidence, and the warm-lane gate rejects a sample that omits it. The
-      real-host backend matrix and canonical budget table remain before #2280
-      can close.
+      real-host backend matrix remains before #2280 can close.
+- [x] Publish the canonical budget table. `LaunchLane::budgets()` is now the one
+      accessor both `validate_matrix_report` and the published table read, so a
+      budget cannot change in the gate and stay stale on the page.
+      `public/src/content/docs/reference/performance.md` carries the generated
+      table plus the lane and disqualification rules, and
+      `tests/perf_doc_sync.rs` fails when either side drifts. The page publishes
+      ceilings only — measured percentiles wait on a seeded real-host lane
+      report, which is the remaining half of #2280.
 - [x] Add the report-level matrix gate. A publishable lane now requires 20
       measured samples after exactly two discarded warm-ups, re-validates every
       raw sample, and enforces the prepared-cold dispatch budgets of

--- a/specs/sprint/delivery/published-launch-budgets.md
+++ b/specs/sprint/delivery/published-launch-budgets.md
@@ -1,0 +1,53 @@
+# Published launch budgets
+
+mvm's differentiator is launch latency, and the number appeared nowhere a user
+could read it. The bench harness under `crates/mvm-cli/src/bench/` already
+encoded a full publication contract — per-lane dispatch-window budgets, a
+20-sample/2-warm-up floor, a report-level gate that refuses a contaminated or
+under-sampled lane — and none of it was published. `public/src/content/docs/`
+had no performance page at all; `reference/limits.md` is a limits table, not a
+measurement or a budget.
+
+Plan 299 named this outstanding: "the real-host backend matrix and canonical
+budget table remain". This is the canonical budget table half. The real-host
+matrix still needs a seeded lane report and is not in this change.
+
+## One source for a budget
+
+`validate_matrix_report` matched on the lane and inlined each constant at the
+call site. A published table built the same way would have been a second copy
+of the budget list, free to drift from the gate silently — which is the failure
+this page exists to avoid.
+
+`LaunchLane::budgets()` is now the single accessor. It returns `LaneBudgets`
+with an `Option<f64>` per percentile, where `None` means "this lane publishes no
+budget here" and can never be confused with zero. `validate_matrix_report` zips
+it against `SpanStats::by_percentile()` — both sides expose the same
+`[(label, Option<f64>); 3]` shape, so neither names a percentile as a bare
+string. Behaviour is unchanged: the existing 92 bench tests pass untouched.
+
+The acquisition lanes (`mount_miss`, `artifact_miss`) return all-`None`. Their
+cost is dominated by a registry and a disk, and gating on that would measure
+someone else's network.
+
+## The page and its gate
+
+`bench/doc_table.rs` renders the budget section from that accessor, bounded by
+`<!-- generated:launch-budgets:begin -->` / `:end` markers. Prose outside the
+markers is hand-written and untouched by the generator.
+
+`tests/perf_doc_sync.rs` pins the committed page to the render. Both directions
+were confirmed red before being fixed: hand-editing a budget cell in the page
+fails it, and changing `PREPARED_COLD_P50_BUDGET_MS` without regenerating the
+page fails it. The failure message prints the correct section to paste.
+
+## What the page deliberately does not say
+
+It publishes budgets, labelled as ceilings CI enforces, not as percentiles
+anyone observed — with a test asserting the page keeps saying so. A ceiling in
+the same column as an observation gets read as an observation, and mvm has no
+seeded matrix report to publish observations from yet.
+
+It also states that a number measured on rotational storage is not a runtime
+number, because a large fixed fraction of such a launch is `fsync` cost that
+disappears on NVMe.

--- a/tests/perf_doc_sync.rs
+++ b/tests/perf_doc_sync.rs
@@ -1,0 +1,76 @@
+//! The published launch-budget table must equal what the gate enforces.
+//!
+//! `mvm_cli::bench::doc_table` renders the budget section from
+//! `LaunchLane::budgets()`, which is the same accessor `validate_matrix_report`
+//! reads. This test pins the committed page to that render, so changing a
+//! budget constant without regenerating the page fails here instead of leaving
+//! a public number that no longer describes the gate.
+
+use std::path::{Path, PathBuf};
+
+use mvm_cli::bench::doc_table::{
+    BEGIN_MARKER, END_MARKER, extract_budget_section, render_budget_section,
+};
+
+/// The root package's manifest dir is the repo root.
+fn performance_page() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("public/src/content/docs/reference/performance.md")
+}
+
+fn read_page() -> String {
+    let path = performance_page();
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("reading {}: {e}", path.display()))
+}
+
+#[test]
+fn published_budget_table_matches_the_gated_budgets() {
+    let page = read_page();
+    let found = extract_budget_section(&page).unwrap_or_else(|| {
+        panic!(
+            "{} is missing the generated region delimited by\n  {BEGIN_MARKER}\n  {END_MARKER}",
+            performance_page().display()
+        )
+    });
+    let expected = render_budget_section();
+    let expected = expected.trim_end_matches('\n');
+
+    assert_eq!(
+        found,
+        expected,
+        "the published launch-budget table has drifted from the budgets the \
+         matrix gate enforces.\n\nReplace the region between the markers in \
+         {} with:\n\n{expected}\n",
+        performance_page().display()
+    );
+}
+
+/// The page must keep saying that the budgets are ceilings. Without this the
+/// table reads as measured results, which is the specific misreading the page
+/// exists to prevent.
+#[test]
+fn page_distinguishes_budgets_from_measurements() {
+    let page = read_page();
+    assert!(
+        page.contains("not percentiles anyone observed"),
+        "the page must state that the published budgets are ceilings, not results"
+    );
+}
+
+/// A gate that cannot fail is not a gate: perturbing a number inside the
+/// generated region must be detected by the same comparison the real test runs.
+#[test]
+fn drifted_table_is_detected() {
+    let page = read_page();
+    let perturbed = page.replace("| 200 ms |", "| 199 ms |");
+    assert_ne!(
+        perturbed, page,
+        "expected a 200 ms budget cell in the committed page to perturb"
+    );
+
+    let found = extract_budget_section(&perturbed).expect("markers survive the perturbation");
+    assert_ne!(
+        found,
+        render_budget_section().trim_end_matches('\n'),
+        "a changed budget cell went undetected by the drift comparison"
+    );
+}


### PR DESCRIPTION
## Why

mvm's differentiator is launch latency and the number is published nowhere. `public/src/content/docs/` has no performance page; `reference/limits.md` is a limits table, not a budget or a measurement.

Meanwhile `crates/mvm-cli/src/bench/` already encodes the entire publication contract — per-lane dispatch-window budgets, a 20-sample/2-warm-up floor, and a report-level gate that refuses an under-sampled or contaminated lane. All of it was unreadable outside the source. Plan 299 names this outstanding: "the real-host backend matrix and canonical budget table remain." This is the budget-table half.

## One source for a budget

`validate_matrix_report` matched on the lane and inlined each budget constant at the call site. A published table built the same way would have been a second copy of the list, free to drift from the gate in silence — the exact failure the page exists to avoid.

`LaunchLane::budgets()` is now the single accessor. It returns `LaneBudgets` with an `Option<f64>` per percentile, so "this lane publishes no budget here" can never be read as zero. `validate_matrix_report` zips it against `SpanStats::by_percentile()` — both expose the same `[(label, Option<f64>); 3]` shape, so neither side names a percentile as a bare string.

Behaviour is unchanged: all 92 existing bench tests pass untouched, including the budget-enforcement cases.

The acquisition lanes (`mount_miss`, `artifact_miss`) return all-`None`. Their cost is dominated by a registry and a disk; gating on that would measure someone else's network.

## The page and its gate

`bench/doc_table.rs` renders the section from that accessor, bounded by `<!-- generated:launch-budgets:begin -->` / `:end`. Prose outside the markers is hand-written and untouched.

`tests/perf_doc_sync.rs` pins the committed page to the render. Both directions were confirmed red before being fixed:

- hand-editing a budget cell in the page → fails
- changing `PREPARED_COLD_P50_BUDGET_MS` without regenerating → fails

The failure message prints the correct section to paste.

## What the page deliberately does not claim

It publishes **budgets, labelled as ceilings CI enforces** — not percentiles anyone observed, with a test asserting the page keeps saying so. A ceiling in the same column as an observation gets read as an observation, and there is no seeded matrix report to publish observations from yet. That remains open, and the plan entry now says so instead of implying the whole item is done.

The page also states that a number measured on rotational storage is not a runtime number, since a large fixed fraction of such a launch is `fsync` cost that vanishes on NVMe.

## Verification

- `cargo nextest run --workspace` — 11,795 passed
- `cargo test --workspace --doc` — clean
- `cargo +nightly fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `just check-gated`; xtask `check-doc-claims`, `check-honesty`, `check-no-overclaim`, `check-file-size`, `check-no-spec-refs-in-comments`, `check-witness-citations`, `check-declared-backing`, `check-plan-names`, `check-sprint-append`, `check-deferrals` — all pass
- Docs site builds; `/reference/performance/` renders and is reachable from the Reference sidebar