### PR TITLE
fix(net): give FlowMux the half of flow control that was missing

### DIFF
--- a/crates/mvm-agentd/src/flowmux.rs
+++ b/crates/mvm-agentd/src/flowmux.rs
@@ -635,8 +635,25 @@ where
                 }
             }
             Opcode::Data => {
-                if let Some(state) = self.tcp_streams.get_mut(&stream_id) {
-                    let _ = state.tx.send(StreamEvent::Data(payload));
+                let consumed = u32::try_from(payload.len()).unwrap_or(u32::MAX);
+                let delivered = match self.tcp_streams.get_mut(&stream_id) {
+                    Some(state) => {
+                        let _ = state.tx.send(StreamEvent::Data(payload));
+                        true
+                    }
+                    None => false,
+                };
+                // Return the credit those bytes consumed.
+                //
+                // The host replenishes the guest's window on every DATA it
+                // relays, but nothing replenished the host's — so the host→guest
+                // window drained and the host reset the stream the moment it hit
+                // zero. That caps every download at one window (~48 KiB here) and
+                // surfaces as a truncated archive rather than as a flow-control
+                // failure. Only for a stream we still hold: replenishing one we
+                // have already retired would name a stream the host has closed.
+                if delivered && consumed > 0 {
+                    self.send_window_update(stream_id, consumed).await?;
                 }
             }
             Opcode::HalfClose => {
@@ -706,6 +723,31 @@ where
 
     async fn send_half_close(&mut self, stream_id: u32) -> Result<(), FlowMuxError> {
         self.write_frame(Opcode::HalfClose, stream_id, &[]).await
+    }
+
+    /// Grant the host `delta` more bytes of room on this stream.
+    ///
+    /// The mirror of the host's replenish. A zero delta is a frame error by
+    /// the protocol, so callers only reach here with bytes actually consumed.
+    async fn send_window_update(&mut self, stream_id: u32, delta: u32) -> Result<(), FlowMuxError> {
+        self.write_frame(Opcode::WindowUpdate, stream_id, &delta.to_be_bytes())
+            .await?;
+        // Advance our own view of the host's allowance to match what we just
+        // told it. The validator only learns of credit it admits, so a grant
+        // that goes out on the wire without this leaves the local window
+        // shrinking while the host's grows — and the guest then refuses the
+        // host's data as over-credit, on a window it granted itself.
+        // The host keeps its own view in step the same way, via `mark_sent`.
+        let _ = self.validator.admit(
+            &mvm_contract::protocol::network_flow::FrameFacts::new(
+                Direction::GuestToHost,
+                Opcode::WindowUpdate,
+                stream_id,
+            )
+            .with_payload(4)
+            .with_credit(delta),
+        );
+        Ok(())
     }
 
     async fn send_reset(&mut self, stream_id: u32, reason: &str) -> Result<(), FlowMuxError> {
@@ -1448,6 +1490,21 @@ mod tests {
                 b"pong",
             )
             .await;
+
+            // The guest returns the credit it just consumed before anything
+            // else. A real host depends on this — without it the host's window
+            // drains and it resets the stream — so the double asserts it
+            // rather than tolerating it.
+            let (opcode, wu_sid, _len, payload) = recv_frame(&mut host_stream, &mut host_session)
+                .await
+                .unwrap();
+            assert_eq!(opcode, Opcode::WindowUpdate);
+            assert_eq!(wu_sid, sid);
+            assert_eq!(
+                payload,
+                (b"pong".len() as u32).to_be_bytes(),
+                "the grant must be exactly the bytes delivered"
+            );
 
             let (opcode, hc_sid, _len, _payload) = recv_frame(&mut host_stream, &mut host_session)
                 .await

--- a/crates/mvm-hostd/src/supervisor/flowmux.rs
+++ b/crates/mvm-hostd/src/supervisor/flowmux.rs
@@ -17,7 +17,7 @@ use std::sync::{
     Arc, Mutex,
     atomic::{AtomicBool, Ordering},
 };
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use mvm_contract::protocol::dns::{MAX_DNS_MESSAGE, decode_query, encode_response};
@@ -29,7 +29,7 @@ use mvm_core::net::session::Session;
 use mvm_vmm::vsock_egress_bridge::egress_gate::{DnsVerdict, EgressGate, EgressVerdict};
 use tracing::{info, warn};
 
-use self::registry::{RegistryLimits, StreamRegistry, class_for_open};
+use self::registry::{RegistryError, RegistryLimits, StreamRegistry, class_for_open};
 
 use crate::supervisor::audit_recorder::{EventCategory, Recorder};
 use crate::supervisor::dns_resolver::resolve_hostname_ips;
@@ -329,14 +329,12 @@ impl FlowMuxSession {
                 }
             };
 
-            if let Err(e) = self.validator.admit(
-                &mvm_contract::protocol::network_flow::FrameFacts::new(
-                    Direction::GuestToHost,
-                    opcode,
-                    stream_id,
-                )
-                .with_payload(payload_len),
-            ) {
+            if let Err(e) = self.validator.admit(&Self::inbound_frame_facts(
+                &self.read_buf,
+                opcode,
+                stream_id,
+                payload_len,
+            )) {
                 warn!(error = %e, "FlowMux frame refused by session validator");
                 self.send_goaway(&e.to_string())?;
                 return Ok(());
@@ -929,6 +927,39 @@ impl FlowMuxSession {
         self.write_frame(Opcode::GoAway, 0, reason.as_bytes())
     }
 
+    /// Facts for a frame arriving from the guest.
+    ///
+    /// A `WindowUpdate`'s payload *is* its credit, and the validator refuses an
+    /// update that carries none. Describing one by length alone therefore
+    /// refuses every window update the guest sends, and the host answers a
+    /// perfectly good frame with `GoAway` — killing the session on the first
+    /// credit the guest returns. The guest-side reader has the same shape for
+    /// the same reason.
+    fn inbound_frame_facts(
+        read_buf: &[u8],
+        opcode: Opcode,
+        stream_id: u32,
+        payload_len: u32,
+    ) -> mvm_contract::protocol::network_flow::FrameFacts {
+        let facts = mvm_contract::protocol::network_flow::FrameFacts::new(
+            Direction::GuestToHost,
+            opcode,
+            stream_id,
+        )
+        .with_payload(payload_len);
+        if opcode != Opcode::WindowUpdate {
+            return facts;
+        }
+        let start = LENGTH_PREFIX_LEN + HEADER_LEN;
+        match read_buf.get(start..start + 4) {
+            // A malformed or truncated update keeps no credit, so the
+            // validator still refuses it — this reads the field, it does not
+            // wave frames through.
+            Some([a, b, c, d]) => facts.with_credit(u32::from_be_bytes([*a, *b, *c, *d])),
+            _ => facts,
+        }
+    }
+
     /// Advance the local state machine for a frame the host is about to send.
     /// Each side validates the frames it reads, but a confirming or terminal
     /// frame sent by the host still moves the host-side view of the stream.
@@ -1068,6 +1099,47 @@ fn lock_registry(registry: &Mutex<StreamRegistry>) -> std::sync::MutexGuard<'_, 
     registry.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+/// How long a relay waits for the guest to return credit before giving up on
+/// the stream. Generous: a slow guest is still a working guest, and the only
+/// thing this bounds is a stream whose peer has stopped reading entirely.
+const HOST_CREDIT_WAIT: Duration = Duration::from_secs(30);
+/// How often the wait re-checks. The relay thread is blocked either way, so
+/// this trades a little latency for not needing a condvar in the registry.
+const HOST_CREDIT_POLL: Duration = Duration::from_millis(2);
+
+/// Reserve `len` bytes of host credit on `stream_id`, waiting for the guest to
+/// replenish if the window is currently full.
+///
+/// An exhausted window is **backpressure, not an error**. The guest returns
+/// credit as it consumes, so a full window means "slow down" — resetting the
+/// stream instead truncates a transfer that was working, which surfaces to the
+/// caller as a corrupt download rather than as flow control. Only two things
+/// end the wait: the stream going away, or a peer that has stopped reading for
+/// [`HOST_CREDIT_WAIT`].
+fn await_host_credit(
+    registry: &Mutex<StreamRegistry>,
+    stream_id: u32,
+    len: u32,
+    retired: &AtomicBool,
+) -> Result<(), RegistryError> {
+    let deadline = Instant::now() + HOST_CREDIT_WAIT;
+    loop {
+        let err = match lock_registry(registry).consume_host_credit(stream_id, len) {
+            Ok(()) => return Ok(()),
+            Err(e) => e,
+        };
+        // `NotLive` means the stream is gone — waiting cannot fix that, and
+        // only `IllegalState` is the window-full case worth retrying.
+        if !matches!(err, RegistryError::IllegalState { .. })
+            || retired.load(Ordering::Relaxed)
+            || Instant::now() >= deadline
+        {
+            return Err(err);
+        }
+        std::thread::sleep(HOST_CREDIT_POLL);
+    }
+}
+
 /// Serialize and send one encrypted frame through a shared writer.
 ///
 /// Locks the session first, then the writer, so sequence numbers are assigned
@@ -1151,7 +1223,7 @@ fn run_tcp_relay(
                 break;
             }
             Ok(n) => {
-                if let Err(e) = lock_registry(&registry).consume_host_credit(stream_id, n as u32) {
+                if let Err(e) = await_host_credit(&registry, stream_id, n as u32, &retired) {
                     warn!(stream_id, error = %e, "FlowMux host credit exhausted");
                     let _ = write_frame_to(
                         &session,


### PR DESCRIPTION
Follows the SOCKS/session fixes on this branch. With those in, a builder VM
could open a connection and start a download — and then every transfer died at
about 48 KiB with a truncated archive. Five layers, each found by running
`mvmctl bootstrap` and reading how far the download got.

## The guest never returned credit at all

The host replenished the guest's window on every DATA it relayed. Nothing
replenished the host's: `send_window_update` existed exactly once in the tree,
on the host. So the host→guest window drained, the host hit zero, and it reset
the stream. One window's worth of bytes is all that ever arrived, which surfaces
as `Truncated tar archive` rather than as flow control.

The guest now grants back what it consumed, for streams it still holds.

## Both sides refused the other's window updates

A `WindowUpdate`'s payload *is* its credit, and the validator refuses an update
carrying none. Both readers described inbound frames by length alone, so both
refused every window update they were sent:

- the guest failed the session with `stream N sent a window update with no
  credit` — blaming the host for a frame the host had built correctly;
- the host answered with `GoAway` the moment the guest returned its first
  credit, which is the moment the fix above started working.

Both now decode the delta. A malformed or truncated update still carries no
credit and is still refused — this reads the field, it does not wave frames
through.

## The guest never told its own validator what it had granted

The validator only knows credit it admits. A grant that went out on the wire
without being admitted locally left the guest's view of the window shrinking
while the host's grew, until the guest refused the host's data as over-credit —
on a window the guest itself had granted. The host keeps its own view in step
via `mark_sent`; the guest now does the same.

## Credit exhaustion was treated as an error, not as backpressure

The relay reset the stream the instant the window was full. A full window means
"the guest hasn't drained this yet", and the guest replenishes as it consumes —
so the correct response is to wait. `await_host_credit` waits for the window to
open, bounded at 30s, and gives up only if the stream dies or a peer has stopped
reading entirely. `NotLive` is not retried; only the window-full case is.

## Where this gets to

Downloads went from ~48 KiB to **15.7 MB** across these fixes, and the archive
is no longer truncated by any of the above.

`bootstrap` still fails, on one remaining defect that is well characterised:

    stream 1 credit grant of 16384 exceeds the 4194304-byte window

The host's validator never sees the host's *own* outbound DATA — the relay runs
on its own thread and writes through `write_frame_to`, which does not hold the
validator — so its credit counter only ever rises, and the guest's (correct)
grants eventually push it past the cap. Fixing it means giving the relay shared
access to the validator, which is a structural change to that seam rather than
another small correction, so it is left for the owner of this branch.

## Not included, deliberately

An earlier revision also tolerated a `Reset` naming an already-retired stream,
to stop a raced teardown failing the whole session. It is dropped here: those
resets were a *symptom* of credit exhaustion and no longer occur, and the change
regressed `a_duplicate_close_is_refused`, which is a deliberate invariant. Not
worth weakening the contract for a case that no longer arises.

## Verification

- `cargo nextest run -p mvm-contract -p mvm-agentd -p mvm-hostd -p mvm-build
  --features addons` — 4611 passed
- `cargo +nightly fmt --all -- --check` — clean
- The guest-client test double now asserts the window update it receives, with
  the exact byte count delivered, instead of expecting the frame that used to
  follow. A double that tolerated the old behaviour is what let this ship.
- Live: `mvmctl bootstrap` reaches offset 15777765 with no frame errors and no
  credit exhaustion