### PR TITLE
specs: ADR-043 — frame the client-interface conformance decision

### DIFF
--- a/specs/adrs/043-client-interface-conformance.md
+++ b/specs/adrs/043-client-interface-conformance.md
@@ -1,0 +1,142 @@
+# ADR-043: Conforming to a client interface mvm did not invent
+
+Backing: preview
+Validation: none — this ADR proposes a decision and is enforced by nothing
+
+## Status
+
+**Proposed.** This ADR frames a decision; it does not take one. Nothing in it
+is implemented, and the recommendation at the end is to build the narrow
+variant and refuse the broad one.
+
+## Context
+
+Every verb mvm exposes is a verb mvm invented. `mvmctl machine run`,
+`mvmctl build image`, `mvmctl template build` are coherent and
+self-documenting, and they are also entirely unfamiliar: a team evaluating mvm
+must learn a new noun set before they can run anything, and none of their
+existing tooling can drive it at all.
+
+The prompt for writing this down was an outside read of an edge-inference
+runtime whose CLI serves an HTTP API it did not design. Because that API is the
+one clients in its domain already speak, every existing client works against it
+unmodified and the adoption cost of the runtime is approximately zero. The
+runtime kept its own engine and conformed only at the wire.
+
+The analogous move for mvm is to speak an interface that orchestrators and
+developer tooling already emit, while continuing to boot exactly the microVMs
+it boots today. The engine does not change; only the protocol at the edge does.
+
+This is worth stating precisely because it is *not* the decision the project
+already made and reversed.
+
+## What this is not
+
+**ADR-034 introduced a Docker-backed dev tier. Plan 329 retired it and removed
+the implementation.** The retirement rationale is directly relevant here:
+
+> The existence of a Docker-backed tier created brand confusion between
+> containers and microVMs, carried a large host-privileged code path, and
+> diluted MVM's core value proposition of hardware-isolated per-workload
+> kernels.
+
+That decision was about a **backend** — where the workload actually runs. A
+shared-kernel container is not a microVM, cannot carry the hardware-isolation
+claims, and had to go.
+
+What this ADR raises is a **client interface**, not a backend. The workload
+would still boot on Firecracker, libkrun, or HVF, behind a hardware boundary,
+under a signed `ExecutionPlan`, with the same claims intact. Only the shape of
+the request arriving at the front door changes.
+
+That distinction is real. It is also **not a complete answer to ADR-034**, and
+this ADR should not pretend otherwise: the brand-confusion half of the
+retirement rationale partially survives the distinction. An interface whose
+vocabulary is containers invites the reader to conclude mvm is a container
+runtime — which is exactly the confusion Plan 329 paid code deletion to remove.
+A compatibility surface can be technically honest and still be positioned
+badly.
+
+## Constraints any implementation inherits
+
+These are not negotiable and are the reason this needs an ADR rather than a
+plan.
+
+1. **One admission path.** Claim 8 holds because every workload boots from a
+   signed, audited `ExecutionPlan` through `admit_for_run`. A conformance
+   surface must *synthesize a plan and go through that admission*, not around
+   it. A second entry point that reaches a backend without admission does not
+   weaken claim 8, it voids it.
+
+2. **One egress decision point.** Claim 10 holds because the per-VM
+   substitution endpoint's shared `EgressGate` is the sole decision point, and
+   `xtask check-uniform-vsock-egress` pins Firecracker, libkrun, and HVF to one
+   spawn site so a backend cannot grow a second gate. A conformance surface
+   must inherit that seam verbatim. Any request field that appears to configure
+   networking must resolve to a policy the existing gate evaluates, or be
+   refused.
+
+3. **The funnel is `AnyBackend::as_workload_backend`.** It returns `Some` for
+   Firecracker, libkrun, HVF, Wasm, and Apple Container, and `None` for QEMU.
+   A conformance surface routes through it and inherits that refusal rather
+   than reimplementing backend selection. (Note for readers working from
+   `CLAUDE.md`: that file still lists Wasm among the barred tiers. It is not —
+   Wasm is a real workload backend, claim-free, mediating egress to the same
+   substitution endpoint. The code is right and the prose is stale.)
+
+4. **Unmappable fields fail closed.** A foreign interface carries a large
+   surface mvm has no equivalent for — privileged mode, host mounts, host
+   networking, capability grants, device passthrough. Every one of those must
+   be refused with a named reason. Silently ignoring a security-relevant field
+   because mvm "doesn't do that anyway" produces a caller who believes they
+   requested an isolation posture they did not get. This is the single largest
+   source of risk in the whole idea and it is a *specification* problem, not an
+   implementation one: the refusal list has to be enumerated up front.
+
+5. **No claim inherits by proximity.** The surface documents which claims hold
+   for workloads admitted through it. It does not restate the claims ledger.
+
+## Options
+
+**A — Full container-API compatibility.** Broad surface, immediate familiarity,
+existing tooling drives mvm unmodified. Largest refusal list, largest ongoing
+compatibility burden, and it walks straight into ADR-034's brand-confusion
+objection with the word "container" in the interface name.
+
+**B — Narrow, explicitly-scoped run surface.** A small HTTP or socket API
+covering exactly the operations mvm already performs — admit a workload from an
+image reference, stream its output, stop it, report status — using the
+vocabulary of the thing mvm actually is. Conforms to the *shape* callers expect
+(an API rather than a CLI) without borrowing a vocabulary that misdescribes the
+boundary. Much smaller refusal list because the surface never offers the fields
+that would have to be refused.
+
+**C — Do nothing.** The CLI stays the only entry point. Zero risk, and the
+adoption cost stays where it is.
+
+## Recommendation
+
+**Option B, and an explicit refusal of Option A.**
+
+Option A's value is real but it is borrowed familiarity, and the thing being
+borrowed is a vocabulary that describes a weaker boundary than the one mvm
+provides. mvm spent a plan removing that confusion. Reintroducing it at the API
+layer weeks later, for adoption convenience, trades the project's clearest
+differentiator for a shortcut.
+
+Option B captures most of the adoption benefit — the complaint is usually "I
+can't drive this from my service" rather than "I can't drive this with one
+specific client" — while keeping the refusal list small enough to enumerate
+honestly.
+
+If Option A is later chosen anyway, it must arrive as its own ADR that
+confronts Plan 329 directly, not as an extension of this one.
+
+## Consequences
+
+- No implementation begins until this ADR is Accepted with an option chosen.
+- Whichever option is chosen, constraint 4's refusal list is written and
+  reviewed **before** any endpoint exists, because it is where the security
+  argument lives.
+- If Option C, the adoption gap should be closed by documentation and SDK reach
+  instead, which is cheaper and carries none of this risk.


### PR DESCRIPTION
## Why this is an ADR and not a plan

Every verb mvm exposes is one mvm invented. Coherent, and also unfamiliar — evaluating mvm means learning a new noun set before running anything, and no existing tooling can drive it. Conforming at the wire to an interface clients already speak is the standard fix and costs nothing in the engine: the workload still boots on Firecracker/libkrun/HVF under a signed plan.

It needs an ADR because it runs adjacent to a decision the project **already made and reversed**.

## The ADR-034 problem, stated rather than dodged

ADR-034 added a Docker-backed dev tier. **Plan 329 retired it and deleted the implementation**, partly because it "created brand confusion between containers and microVMs [and] diluted MVM's core value proposition."

That was about a **backend** — where the workload runs. This is about a **client interface** — the workload still boots behind a hardware boundary under a signed `ExecutionPlan`, with the claims intact. That distinction is real.

It is also **not a complete answer**, and the ADR says so instead of leaning on it: the brand-confusion half of the rationale survives the distinction. An interface whose vocabulary is containers invites the reader to conclude mvm is a container runtime — the exact confusion Plan 329 paid code deletion to remove.

## Constraints any implementation inherits

1. **One admission path** — synthesize a plan and go *through* `admit_for_run`, not around it. A second entry point reaching a backend without admission doesn't weaken claim 8, it voids it.
2. **One egress decision point** — inherit the `EgressGate` seam verbatim; `check-uniform-vsock-egress` exists to stop a second gate growing.
3. **Route through `AnyBackend::as_workload_backend`** and inherit its refusals rather than reimplementing backend selection.
4. **Unmappable fields fail closed, by name.** Privileged mode, host mounts, host networking, capability grants, device passthrough. Silently ignoring a security-relevant field because "mvm doesn't do that anyway" leaves a caller believing they requested an isolation posture they did not get. This is the largest risk in the idea and it's a *specification* problem — the refusal list gets enumerated before any endpoint exists.

## Recommendation

**The narrow surface, and an explicit refusal of full container-API compatibility.** The familiarity being borrowed in the broad option is a vocabulary that describes a weaker boundary than the one mvm has. If that option is ever chosen it needs its own ADR confronting Plan 329 directly.

**Status: Proposed.** Nothing is implemented and no implementation begins until an option is chosen.

## Incidental fix

Corrects a stale line readers hit on the way in: `CLAUDE.md` lists Wasm among the tiers barred from the workload funnel. It isn't — `as_workload_backend` returns `Some` for Wasm (claim-free, but a real workload backend). Only QEMU is barred. Noted inline in the ADR rather than silently relied upon.

## Verification

Docs-only. `check-adr-coverage`, `check-declared-backing`, `check-doc-claims`, `check-honesty`, `check-no-overclaim`, `check-deferrals`, `check-witness-citations` all pass.