### PR TITLE
perf(test): stop the credit-exhaustion test spending 30s proving a timeout

### DIFF
--- a/crates/mvm-hostd/src/supervisor/flowmux.rs
+++ b/crates/mvm-hostd/src/supervisor/flowmux.rs
@@ -779,6 +779,7 @@ impl FlowMuxSession {
         let writer = Arc::clone(&self.writer);
         let registry = Arc::clone(&self.registry);
         let validator = Arc::clone(&self.validator);
+        let credit_wait = self.limits.credit_wait;
 
         std::thread::Builder::new()
             .name(format!("flowmux-tcp-{stream_id}"))
@@ -792,6 +793,7 @@ impl FlowMuxSession {
                     validator,
                     host_half_closed: relay_flag,
                     retired: retired_flag,
+                    credit_wait,
                 })
             })
             .map_err(FlowMuxError::Transport)?;
@@ -1112,10 +1114,6 @@ fn lock_registry(registry: &Mutex<StreamRegistry>) -> std::sync::MutexGuard<'_, 
     registry.lock().unwrap_or_else(|e| e.into_inner())
 }
 
-/// How long a relay waits for the guest to return credit before giving up on
-/// the stream. Generous: a slow guest is still a working guest, and the only
-/// thing this bounds is a stream whose peer has stopped reading entirely.
-const HOST_CREDIT_WAIT: Duration = Duration::from_secs(30);
 /// How often the wait re-checks. The relay thread is blocked either way, so
 /// this trades a little latency for not needing a condvar in the registry.
 const HOST_CREDIT_POLL: Duration = Duration::from_millis(2);
@@ -1128,14 +1126,15 @@ const HOST_CREDIT_POLL: Duration = Duration::from_millis(2);
 /// stream instead truncates a transfer that was working, which surfaces to the
 /// caller as a corrupt download rather than as flow control. Only two things
 /// end the wait: the stream going away, or a peer that has stopped reading for
-/// [`HOST_CREDIT_WAIT`].
+/// `wait`, which comes from `RegistryLimits::credit_wait`.
 fn await_host_credit(
     registry: &Mutex<StreamRegistry>,
     stream_id: u32,
     len: u32,
     retired: &AtomicBool,
+    wait: Duration,
 ) -> Result<(), RegistryError> {
-    let deadline = Instant::now() + HOST_CREDIT_WAIT;
+    let deadline = Instant::now() + wait;
     loop {
         let err = match lock_registry(registry).consume_host_credit(stream_id, len) {
             Ok(()) => return Ok(()),
@@ -1224,6 +1223,8 @@ struct TcpRelayParams {
     validator: Arc<Mutex<SessionValidator>>,
     host_half_closed: Arc<AtomicBool>,
     retired: Arc<AtomicBool>,
+    /// How long to wait for the guest to return credit before giving up.
+    credit_wait: Duration,
 }
 
 fn run_tcp_relay(params: TcpRelayParams) {
@@ -1236,6 +1237,7 @@ fn run_tcp_relay(params: TcpRelayParams) {
         validator,
         host_half_closed,
         retired,
+        credit_wait,
     } = params;
     let mut buf = [0u8; 16 * 1024];
     loop {
@@ -1250,7 +1252,9 @@ fn run_tcp_relay(params: TcpRelayParams) {
                 break;
             }
             Ok(n) => {
-                if let Err(e) = await_host_credit(&registry, stream_id, n as u32, &retired) {
+                if let Err(e) =
+                    await_host_credit(&registry, stream_id, n as u32, &retired, credit_wait)
+                {
                     warn!(stream_id, error = %e, "FlowMux host credit exhausted");
                     let _ = write_frame_to(
                         &session,
@@ -2556,6 +2560,10 @@ mod tests {
         let addr = tcp_banner_server();
         let limits = RegistryLimits {
             initial_credit: 0,
+            // A guest that never grants credit is exactly what the wait exists
+            // to tolerate, so shrink it here rather than spending the whole
+            // production bound proving the give-up path still fires.
+            credit_wait: Duration::from_millis(200),
             ..Default::default()
         };
         let (mut guest, mut guest_session, host) =

--- a/crates/mvm-hostd/src/supervisor/flowmux/registry.rs
+++ b/crates/mvm-hostd/src/supervisor/flowmux/registry.rs
@@ -89,6 +89,11 @@ pub struct RegistryLimits {
     pub udp_open_rate: u32,
     /// DNS resolve requests per second (burst == rate). Zero disables.
     pub dns_resolve_rate: u32,
+    /// How long a relay waits for the guest to return credit before giving up
+    /// on the stream. Sits beside `initial_credit` because it is the other half
+    /// of the same window: one says how much room the guest starts with, this
+    /// says how long the host will wait to get it back.
+    pub credit_wait: Duration,
 }
 
 impl Default for RegistryLimits {
@@ -103,6 +108,7 @@ impl Default for RegistryLimits {
             tcp_connect_rate: 0,
             udp_open_rate: 0,
             dns_resolve_rate: 0,
+            credit_wait: Duration::from_secs(30),
         }
     }
 }


### PR DESCRIPTION
`await_host_credit` waits out a hardcoded 30s before giving up on a stream whose
guest has stopped returning credit. That bound is right for production — a slow
guest is still a working guest — but `host_credit_exhaustion_sends_reset` sets
`initial_credit: 0`, so it deliberately provokes the give-up path and then pays
the full production bound to watch it fire. One test, 30s of wall clock, on
every workspace run and every PR.

The bound moves onto `RegistryLimits` beside `initial_credit`. They are two
halves of the same window: one says how much room the guest starts with, the
other how long the host will wait to get it back, and a test that overrides the
first has an obvious reason to override the second. Production keeps 30s via
`Default`; the test asks for 200ms and asserts exactly what it did before.

    host_credit_exhaustion_sends_reset   30.015s -> 0.212s

`a_download_past_the_credit_cap_is_not_torn_down` still passes on the default
bound, so the wait is still doing its job for a guest that does grant credit.

## Verification

- `cargo nextest run -p mvm-hostd -p mvm-agentd --features mvm-agentd/addons`
  — 2744 passed
- `cargo clippy -p mvm-hostd --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean