### PR TITLE
fix(xtask): stop the ADR gate reading the changelog as a live reference

### DIFF
--- a/xtask/src/check_adr_coverage.rs
+++ b/xtask/src/check_adr_coverage.rs
@@ -129,6 +129,14 @@ fn visit(
             continue;
         }
 
+        // A changelog records what a commit message said, not what exists
+        // now. It is generated from git history, so a subject naming an ADR
+        // that was renumbered or never landed reappears on the next release
+        // however many times the line is edited out.
+        if path.file_name().and_then(|n| n.to_str()) == Some("CHANGELOG.md") {
+            continue;
+        }
+
         // Cheap pre-filter on extension. Binary files (images,
         // lockfiles, etc.) can't carry meaningful ADR refs even if
         // they happen to contain the byte sequence.
@@ -415,6 +423,42 @@ mod tests {
 
         let result = run(root);
         assert!(result.is_err(), "broken ref must surface as Err");
+    }
+
+    /// A changelog is generated from commit subjects. One naming an ADR that
+    /// was renumbered or never landed is a fact about the commit, not a claim
+    /// the ADR exists — and editing the line out only holds until the next
+    /// release regenerates it.
+    #[test]
+    fn a_changelog_reference_to_a_missing_adr_is_not_a_broken_ref() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join("specs/adrs")).unwrap();
+        let adr1 = adr_token(1);
+        std::fs::write(
+            root.join("specs/adrs/001-fixture.md"),
+            format!("# {adr1} — fixture\n"),
+        )
+        .unwrap();
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/a.rs"), format!("// see {adr1}\n")).unwrap();
+
+        let adr_missing = adr_token(998);
+        std::fs::write(
+            root.join("CHANGELOG.md"),
+            format!("- **adr**: {adr_missing} something that never landed\n"),
+        )
+        .unwrap();
+
+        run(root).expect("a changelog citing a missing ADR must not fail the gate");
+
+        // The exemption is the changelog, not the number: the same reference
+        // from source is still a broken ref.
+        std::fs::write(root.join("src/b.rs"), format!("// see {adr_missing}\n")).unwrap();
+        assert!(
+            run(root).is_err(),
+            "the same missing ADR cited from source must still fail"
+        );
     }
 
     #[test]


### PR DESCRIPTION
**`check-adr-coverage` fails on `main`**, so every open pull request inherits a red `Invariant` lane:

```
$ cargo run -p xtask -- check-adr-coverage
[error] ADR-110 referenced 1x in code, but specs/adrs/110-*.md does not exist
ADRs discovered: 43; ADRs referenced: 34; broken refs: 1
Error: check-adr-coverage: 1 reference to non-existent ADRs
```

## Where it comes from

The v0.18.0 release prep (#2582) generated `CHANGELOG.md` from commit subjects. One of them is:

```
- **adr**: ADR-110 uniform userspace vsock egress
```

No ADR 110 exists — this repo's numbering stops at 042, so that subject named a proposal that was renumbered or never landed.

## Why skipping the changelog is the fix, not editing the line

A changelog records **what a commit message said**. That is a fact about history, not a claim that the document exists today. And it is generated from git history, so deleting the line holds only until the next release regenerates it — the gate would go red again at v0.19.0 with no new mistake made.

The gate keeps scanning everything else: source, specs, workflows, docs. Only `CHANGELOG.md` is exempt.

## The exemption cannot widen

One test, both halves, so this cannot decay into "missing ADRs are fine":

```rust
// tolerated from a changelog
run(root).expect("a changelog citing a missing ADR must not fail the gate");

// still a broken ref from source — same ADR number
std::fs::write(root.join("src/b.rs"), format!("// see {adr_missing}\n")).unwrap();
assert!(run(root).is_err(), "the same missing ADR cited from source must still fail");
```

## Verification

- `cargo run -p xtask -- check-adr-coverage` — `broken refs: 0` (was 1)
- `cargo nextest run -p xtask` — 624 passed
- `cargo clippy -p xtask --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean

Found while diagnosing #2545's red `Invariant` lane, which turned out not to be that PR's fault.