### PR TITLE
fix(sec): cut mvm-hostd four ways, because two was measured to be too few

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -540,6 +540,11 @@ jobs:
     # only trace is "The runner has received a shutdown signal" — which
     # names no package, no file, and no claim, and reads identically to
     # infrastructure having a bad night.
+    #
+    # This has already earned itself: mvm-hostd/2of2 hit it on 2026-08-16 and
+    # was reported as a bounded, attributable stop with its partial output
+    # kept, which is what said the split was uneven and by how much. Note
+    # that GitHub records a timeout kill as `cancelled`, not `failure`.
     timeout-minutes: 330
     # BLOCKING, and sharded per package.
     #
@@ -578,10 +583,18 @@ jobs:
           - mvm-build
           - mvm-cli
           - mvm-core
-          # mvm-hostd owns the most surface files of any package and stopped
-          # finishing inside the cap on its own — see the timeout note below.
-          - mvm-hostd/1of2
-          - mvm-hostd/2of2
+          # Four, not two, and the number is measured rather than chosen.
+          # Two shards ran on 2026-08-16: 1of2 finished five files in 100
+          # minutes while 2of2 drew plan_admission (93 mutants), audit_file
+          # (107) and network/stages (108), spent the full 330 and never
+          # reached its fifth file. Splitting by file count does not split by
+          # cost, and this package's files differ by roughly 4x. Four shards
+          # put the two most expensive in different jobs and cut the worst
+          # known load from 335 mutants to 201.
+          - mvm-hostd/1of4
+          - mvm-hostd/2of4
+          - mvm-hostd/3of4
+          - mvm-hostd/4of4
           - mvm-contract
           - mvm-runtime
           - mvm-sdk

--- a/specs/VERIFICATION.md
+++ b/specs/VERIFICATION.md
@@ -160,10 +160,19 @@ The job also carries `timeout-minutes: 330`, under the cap, so a shard
 that outgrows its budget fails as itself rather than as infrastructure,
 and uploads its partial cargo-mutants output either way.
 
-**The split is by file count, not by cost** — five files each. The two
-most expensive files measured so far both land in `2of2`, so the shards
-are not expected to be equal; they are expected to fit. Re-measure rather
-than assume.
+**The split is by file count, and file count is not cost.** The first run
+of the two-shard split, on 2026-08-16, measured the gap: `1of2` finished
+five files in 100 minutes, while `2of2` drew `plan_admission` (93
+mutants), `supervisor/audit_file` (107) and `supervisor/network/stages`
+(108), spent its full 330 and never reached its fifth file. This
+package's files differ by roughly 4x, so an even count is an uneven job.
+
+`mvm-hostd` is therefore cut four ways, which puts the two most expensive
+files in different shards and drops the worst known load from 335 mutants
+to 201 — about 200 minutes at the ~1 min/mutant that run measured. That
+is a bound with a measurement behind it, not a guess, but it is still a
+stride over a path-sorted list: if a shard breaches again, the next step
+is assignment by measured cost rather than more shards.
 
 These are **accepted rather than scoped out** on purpose. Scoping would
 stop the lane measuring those files at all; accepting keeps the ratchet

--- a/specs/sprint/delivery/2537-hostd-four-shards.md
+++ b/specs/sprint/delivery/2537-hostd-four-shards.md
@@ -1,0 +1,59 @@
+# 2537 — two shards were not enough, and the timeout is how we know
+
+## What the first run measured
+
+The 2026-08-16 nightly ran the two-shard split for the first time:
+
+| shard | files | outcome |
+|---|---|---|
+| `mvm-hostd/1of2` | 5 | finished in **100 min** |
+| `mvm-hostd/2of2` | 5 | **330 min, stopped by `timeout-minutes`** — four files done, the fifth never started |
+
+`2of2` drew `plan_admission` (93 mutants), `supervisor/audit_file` (107),
+`supervisor/network/stages` (108) and `broker/registry` (27): 335 mutants at
+roughly a minute each. `1of2`'s five files came to a fraction of that. Splitting
+by file count does not split by cost, and this package's files differ by ~4x.
+
+The previous delivery note said the shards were "expected to fit, not to be
+equal." Half of that was wrong, and this is the correction.
+
+## The fix
+
+Four shards. Stride over the path-sorted list puts `plan_admission` and
+`network/stages` — the two most expensive — in different jobs, and drops the
+worst known load from 335 mutants to 201, about 200 minutes at the rate this
+run measured.
+
+That is a bound with a measurement behind it rather than a guess. It is still a
+stride, though: if a shard breaches again, the next step is assignment by
+measured cost, not more shards. `specs/VERIFICATION.md` says so.
+
+## The two mechanisms from #2565 both paid out
+
+Neither was hypothetical for long:
+
+- **`timeout-minutes: 330`** turned what would have been
+  `The runner has received a shutdown signal` at the six-hour cap into a
+  bounded stop attributable to one named shard. Worth recording that GitHub
+  reports a timeout kill as `cancelled`, not `failure` — reading it as
+  infrastructure noise is easy and wrong.
+- **The `always()` artifact upload** ran even on the timeout kill and produced
+  the per-file `outcomes.json` that made the imbalance measurable. Without it
+  the evidence died with the runner and the only available move would have been
+  to guess at a shard count.
+
+The same upload is what diagnosed the `mvm-vmm` failure earlier in the same run,
+while job logs were still withheld because the run had not finished.
+
+## Evidence
+
+- `cargo test -p xtask --bin xtask shard` — 10 passed.
+- `check-mutation-witnesses` accepts the four-way matrix (it is the gate that
+  would reject an incomplete split).
+- `actionlint`, `check-declared-backing`, `check-honesty`, `check-no-overclaim`,
+  `check-doc-claims` clean.
+
+## Not verified here
+
+That `4of4` fits. Only the next nightly measures that. The estimate is ~200
+minutes against a 330-minute bound, derived from this run's ~1 min/mutant.


### PR DESCRIPTION
Follow-up to #2565, part of #2537. **The first run of the two-shard split
measured itself as insufficient.**

## What happened

| shard | files | outcome |
|---|---|---|
| `mvm-hostd/1of2` | 5 | finished in **100 min** |
| `mvm-hostd/2of2` | 5 | **330 min, stopped by `timeout-minutes`** — four files done, the fifth never started |

`2of2` drew `plan_admission` (93 mutants), `supervisor/audit_file` (107),
`supervisor/network/stages` (108) and `broker/registry` (27) — 335 mutants at
roughly a minute each. `1of2`'s five came to a fraction of that.

Splitting by file count does not split by cost, and this package's files differ
by about 4x. #2565's delivery note said the shards were "expected to fit, not to
be equal"; half of that was wrong and this corrects it.

## The fix

Four shards. Stride over the path-sorted list puts `plan_admission` and
`network/stages` in different jobs and cuts the worst known load from **335
mutants to 201** — about 200 minutes at the rate this run measured, against a
330-minute bound.

That is a bound with a measurement behind it. It is still a stride, so if a
shard breaches again the next step is assignment by measured cost rather than
more shards — `specs/VERIFICATION.md` now says exactly that.

## Both of #2565's mechanisms paid out immediately

Neither stayed hypothetical for even one night:

- **`timeout-minutes: 330`** turned what would have been
  `The runner has received a shutdown signal` at the six-hour cap into a bounded
  stop attributable to one named shard. Worth knowing: **GitHub records a
  timeout kill as `cancelled`, not `failure`** — easy to misread as infra noise.
- **The `always()` artifact upload** survived the timeout kill and carried the
  per-file `outcomes.json` that made the imbalance measurable. Without it the
  evidence would have died with the runner and the only move left would have
  been guessing at a shard count.

The same upload diagnosed the `mvm-vmm` failure (→ #2578) earlier in that run,
while job logs were still withheld because the run had not completed.

## Evidence

- `cargo test -p xtask --bin xtask shard` — 10 passed.
- `check-mutation-witnesses` accepts the four-way matrix — it is the gate that
  rejects an incomplete or overlapping split, so its acceptance is the check
  that the new matrix is total.
- `actionlint`, `check-declared-backing`, `check-honesty`, `check-no-overclaim`,
  `check-doc-claims` clean.

## What this does not prove

That `4of4` fits. Only the next nightly measures that.