### PR TITLE
fix(client): type MachineSpec.image, hoisting RootfsSource into mvm-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,9 @@ use mvm_client::{MvmClient, MachineSpec, LocalBackend};
 let client = LocalBackend::new();
 
 // Fluent builder — name + image are required; cpus/memory/env default + override.
-let spec = MachineSpec::builder("web", "alpine")
+// The image is parsed here, so a declaration that names nothing is refused at
+// construction rather than at boot.
+let spec = MachineSpec::builder("web", "alpine")?
     .cpus(2)
     .memory_mib(512)
     .env("PORT", "8080")

--- a/crates/mvm-client/src/inventory.rs
+++ b/crates/mvm-client/src/inventory.rs
@@ -627,7 +627,9 @@ mod tests {
     async fn mock_backend_inventory_lists_its_machines_as_transients() {
         let _home = IsolatedHome::new();
         let mock = MockBackend::default();
-        let spec = mvm_core::client::dto::MachineSpec::builder("adhoc", "img").build();
+        let spec = mvm_core::client::dto::MachineSpec::builder("adhoc", "img")
+            .expect("declared image parses")
+            .build();
         mock.run_machine(spec).await.unwrap();
 
         let records = inventory_with_specs(&mock, vec![]).await.unwrap();
@@ -645,7 +647,9 @@ mod tests {
     async fn mock_backend_inventory_joins_persisted_specs() {
         let _home = IsolatedHome::new();
         let mock = MockBackend::default();
-        let boot = mvm_core::client::dto::MachineSpec::builder("web", "img").build();
+        let boot = mvm_core::client::dto::MachineSpec::builder("web", "img")
+            .expect("declared image parses")
+            .build();
         mock.run_machine(boot).await.unwrap();
 
         let records = inventory_with_specs(&mock, vec![spec("web"), spec("db")])

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -26,6 +26,7 @@ use mvm_core::config::{machine_spec_path, machine_state_dir, machine_state_root,
 use mvm_core::domain::instance::InstanceReadiness;
 use mvm_core::plan::ExecutionPlan;
 use mvm_core::protocol::vm_backend::{VmId, VmStatus};
+use mvm_core::rootfs_source::RootfsSource;
 use mvm_hostd::audit::emitter::AuditEmitter;
 use mvm_hostd::plan_admission::{InMemoryNonceLedger, StartedMachine, SystemClock};
 use mvm_hostd::run::{LocalRunContext, LocalRunRequest, admit_and_boot_local};
@@ -176,7 +177,7 @@ impl std::ops::Deref for BackendHandle<'_> {
 /// lifecycle modes (and the trait's `run_machine`) reach.
 pub(crate) struct BootParams {
     pub(crate) name: String,
-    pub(crate) image: String,
+    pub(crate) image: RootfsSource,
     pub(crate) cpus: u32,
     pub(crate) memory_mib: u32,
     pub(crate) backend_override: Option<String>,
@@ -376,7 +377,7 @@ impl LocalBackend {
 /// `start_persistent` so that is checkable without booting a VM.
 fn start_request_from_spec(
     name: &str,
-    image: String,
+    image: RootfsSource,
     memory_mib: u32,
     spec: &mp::MachineSpec,
 ) -> Result<LaunchRequest> {
@@ -396,7 +397,9 @@ fn persisted_spec_from_request(request: &LaunchRequest, name: &str) -> mp::Machi
     mp::MachineSpec {
         schema_version: mp::MACHINE_SPEC_SCHEMA_VERSION,
         name: name.to_string(),
-        image: Some(request.image.clone()),
+        // The persisted record carries the written form — the same token the
+        // caller declared, so a spec read back reconstructs the same value.
+        image: Some(request.image.to_string()),
         manifest: None,
         deployment: None,
         resolved_digest: None,
@@ -705,7 +708,7 @@ impl LocalBackend {
 
 /// Refusals for persisted-spec shapes the in-process backend cannot honor
 /// (fail closed, never silently ignore a persisted field).
-fn ensure_spec_bootable_in_process(spec: &mp::MachineSpec) -> Result<String> {
+fn ensure_spec_bootable_in_process(spec: &mp::MachineSpec) -> Result<RootfsSource> {
     let unsupported = |what: &str| MvmError::InvalidSpec {
         reason: format!(
             "machine {:?} declares {what}, which the in-process local backend cannot \
@@ -733,8 +736,16 @@ fn ensure_spec_bootable_in_process(spec: &mp::MachineSpec) -> Result<String> {
     if !spec.init.is_empty() {
         return Err(unsupported("init commands"));
     }
-    spec.image.clone().ok_or_else(|| MvmError::InvalidSpec {
+    let image = spec.image.as_deref().ok_or_else(|| MvmError::InvalidSpec {
         reason: format!("machine {:?} has no image source", spec.name),
+    })?;
+    // The on-disk record stores the written form; a start reconstructs the
+    // declaration from it rather than passing the bytes on unread.
+    image.parse().map_err(|e| MvmError::InvalidSpec {
+        reason: format!(
+            "machine {:?} declares an unusable image source: {e}",
+            spec.name
+        ),
     })
 }
 

--- a/crates/mvm-client/src/launch/request.rs
+++ b/crates/mvm-client/src/launch/request.rs
@@ -14,6 +14,7 @@
 //! gate reads.
 
 use mvm_core::client::{MvmError, Result};
+use mvm_core::rootfs_source::RootfsSource;
 
 pub use crate::secret::MachineSecretRef;
 pub use crate::volume::AccessMode;
@@ -67,7 +68,7 @@ pub struct LaunchVolumeSpec {
 pub struct LaunchRequest {
     pub(crate) name: Option<String>,
     pub(crate) mode: LifecycleMode,
-    pub(crate) image: String,
+    pub(crate) image: RootfsSource,
     pub(crate) cpus: u32,
     pub(crate) memory_mib: u32,
     pub(crate) backend: Option<String>,
@@ -85,13 +86,15 @@ pub struct LaunchRequest {
 }
 
 impl LaunchRequest {
-    /// Start building a request for `mode` from OCI image source `image`
-    /// (a registry reference, an unpacked rootfs directory, or a
-    /// pre-materialized `rootfs.ext4` path).
-    pub fn builder(mode: LifecycleMode, image: impl Into<String>) -> LaunchRequestBuilder {
+    /// Start building a request for `mode` from the already-parsed rootfs
+    /// declaration `image` — a registry reference, an unpacked rootfs
+    /// directory, or a pre-materialized `rootfs.ext4` path. Taking the parsed
+    /// value rather than a string is what keeps a request that names nothing
+    /// unbuildable rather than merely refused.
+    pub fn builder(mode: LifecycleMode, image: RootfsSource) -> LaunchRequestBuilder {
         LaunchRequestBuilder {
             mode,
-            image: image.into(),
+            image,
             name: None,
             command: Vec::new(),
             env: Vec::new(),
@@ -124,7 +127,7 @@ impl LaunchRequest {
 #[derive(Debug, Clone)]
 pub struct LaunchRequestBuilder {
     mode: LifecycleMode,
-    image: String,
+    image: RootfsSource,
     name: Option<String>,
     command: Vec<String>,
     env: Vec<(String, String)>,
@@ -282,9 +285,6 @@ impl LaunchRequestBuilder {
     pub fn build(self) -> Result<LaunchRequest> {
         let invalid = |reason: String| MvmError::InvalidSpec { reason };
 
-        if self.image.trim().is_empty() {
-            return Err(invalid("image source must not be empty".into()));
-        }
         if let Some(name) = self.name.as_deref() {
             mvm_core::naming::validate_vm_name(name)
                 .map_err(|e| invalid(format!("invalid machine name {name:?}: {e}")))?;
@@ -364,13 +364,19 @@ impl LaunchRequestBuilder {
 mod tests {
     use super::*;
 
+    /// A parsed registry declaration — the shape a caller now has to arrive
+    /// with, since the request type no longer accepts an uninterpreted string.
+    fn oci(image_ref: &str) -> RootfsSource {
+        image_ref.parse().expect("test image parses")
+    }
+
     fn base(mode: LifecycleMode) -> LaunchRequestBuilder {
-        LaunchRequest::builder(mode, "alpine:3.20").name("web")
+        LaunchRequest::builder(mode, oci("alpine:3.20")).name("web")
     }
 
     #[test]
     fn minimal_transient_request_builds_with_defaults() {
-        let req = LaunchRequest::builder(LifecycleMode::Transient, "alpine:3.20")
+        let req = LaunchRequest::builder(LifecycleMode::Transient, oci("alpine:3.20"))
             .build()
             .expect("minimal transient request");
         assert_eq!(req.mode(), LifecycleMode::Transient);
@@ -383,7 +389,7 @@ mod tests {
 
     #[test]
     fn persistent_request_requires_a_name() {
-        let err = LaunchRequest::builder(LifecycleMode::Persistent, "alpine:3.20")
+        let err = LaunchRequest::builder(LifecycleMode::Persistent, oci("alpine:3.20"))
             .build()
             .unwrap_err();
         assert!(err.to_string().contains("requires a name"), "got: {err}");
@@ -393,13 +399,19 @@ mod tests {
     }
 
     #[test]
-    fn empty_image_and_invalid_name_are_refused() {
-        let err = LaunchRequest::builder(LifecycleMode::Transient, "  ")
-            .build()
-            .unwrap_err();
-        assert!(err.to_string().contains("image source"), "got: {err}");
+    fn an_empty_image_cannot_reach_a_request_at_all() {
+        // This used to be a `build()` refusal on a `String` field. It is now
+        // unrepresentable: the request names a parsed source, so the only way
+        // to express an empty one is to fail the parse first.
+        assert_eq!(
+            "  ".parse::<RootfsSource>().unwrap_err(),
+            mvm_core::rootfs_source::RootfsSourceParseError::Empty
+        );
+    }
 
-        let err = LaunchRequest::builder(LifecycleMode::Transient, "img")
+    #[test]
+    fn an_invalid_name_is_refused() {
+        let err = LaunchRequest::builder(LifecycleMode::Transient, oci("img"))
             .name("Bad Name!")
             .build()
             .unwrap_err();

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -99,12 +99,17 @@ fn seeded_secret_ref(service: &SecretService) -> MachineSecretRef {
     }
 }
 
+/// A parsed declaration from the string form these tests spell inline.
+fn declared(image: &str) -> mvm_core::rootfs_source::RootfsSource {
+    image.parse().expect("test image parses")
+}
+
 fn transient_request(image: &str) -> LaunchRequestBuilder {
-    LaunchRequest::builder(LifecycleMode::Transient, image)
+    LaunchRequest::builder(LifecycleMode::Transient, declared(image))
 }
 
 fn persistent_request(image: &str, name: &str) -> LaunchRequestBuilder {
-    LaunchRequest::builder(LifecycleMode::Persistent, image).name(name)
+    LaunchRequest::builder(LifecycleMode::Persistent, declared(image)).name(name)
 }
 
 async fn listed_names(client: &LocalBackend) -> Vec<String> {
@@ -932,6 +937,7 @@ async fn create_machine_persists_the_callers_grants() {
     let rootfs = home.rootfs();
 
     let spec = mvm_core::client::dto::MachineSpec::builder("p-granted", rootfs)
+        .expect("declared image parses")
         .cpus(2)
         .memory_mib(256)
         .cpu_millicores(1500)
@@ -986,7 +992,7 @@ fn a_restart_re_admits_under_the_persisted_grants_not_deny_all() {
     };
 
     let request =
-        super::start_request_from_spec("p-restart", "alpine:latest".to_string(), 256, &spec)
+        super::start_request_from_spec("p-restart", declared("alpine:latest"), 256, &spec)
             .expect("the start request builds");
     let carried = request
         .grants
@@ -1015,7 +1021,7 @@ fn a_restart_re_admits_under_the_persisted_grants_not_deny_all() {
     // baseline is unchanged.
     spec.grants = None;
     let ungranted =
-        super::start_request_from_spec("p-restart", "alpine:latest".to_string(), 256, &spec)
+        super::start_request_from_spec("p-restart", declared("alpine:latest"), 256, &spec)
             .expect("the start request builds");
     assert_eq!(ungranted.grants, None);
 }

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -21,12 +21,12 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use flate2::read::GzDecoder;
 use mvm_core::protocol::vm_backend::{BackendKind, VmId, VmInfo, VmStatus};
+use mvm_core::rootfs_source::RootfsSource;
 use mvm_fs::oci::{
     ImageReference, LayerDescriptor, LayerFetchOptions, OciLayerFetcher, OciManifestFetcher,
     UnpackOptions, UnpackReport, current_linux_platform, unpack_layer_with_prior_paths,
 };
 use mvm_runtime::AnyBackend;
-use mvm_runtime::artifacts::spec::RootfsSource;
 
 use mvm_core::client::BackendCapabilityReport;
 use mvm_core::client::dto::{
@@ -399,21 +399,12 @@ enum RootfsPlan {
     Pull(ImageReference),
 }
 
-/// Turn a caller-declared `spec.image` into the work it implies.
+/// Turn a caller-declared rootfs source into the work it implies.
 ///
-/// The declaration is parsed before anything is looked up, so a mistyped path
-/// stops here instead of falling through to the registry arm: the arms
-/// differ in how the bytes they produce are verified, and which one runs must
-/// not depend on the caller's working directory.
-fn plan_rootfs(image: &str) -> Result<RootfsPlan> {
-    let source: RootfsSource = image.parse().map_err(|e| MvmError::InvalidSpec {
-        reason: format!("{e}"),
-    })?;
-    plan_rootfs_source(source)
-}
-
-/// The declaration-to-work half of [`plan_rootfs`], split out so each arm is
-/// reachable in a test without going through the string grammar.
+/// The declaration arrives parsed, so a mistyped path stops here instead of
+/// falling through to the registry arm: the arms differ in how the bytes they
+/// produce are verified, and which one runs must not depend on the caller's
+/// working directory.
 fn plan_rootfs_source(source: RootfsSource) -> Result<RootfsPlan> {
     match source {
         // The filesystem is consulted only to tell a blob from a tree, and
@@ -461,8 +452,8 @@ fn path_collision_hint(image_ref: &str) -> String {
 /// Resolve `spec.image` to a host `rootfs.ext4` path, materializing in-process
 /// as needed (no subprocess, no CLI). Registry pulls are async; the dir +
 /// pre-materialized cases are synchronous.
-pub(crate) async fn resolve_local_rootfs(image: &str, name: &str) -> Result<PathBuf> {
-    match plan_rootfs(image)? {
+pub(crate) async fn resolve_local_rootfs(image: &RootfsSource, name: &str) -> Result<PathBuf> {
+    match plan_rootfs_source(image.clone())? {
         RootfsPlan::Materialized(path) => Ok(path),
         // An already-unpacked tree carries no unpack report, so there is
         // nothing the host filesystem deferred to merge back in.
@@ -1094,6 +1085,16 @@ mod tests {
         s.parse().expect("parses as an OCI reference")
     }
 
+    /// Both steps a caller takes with a declaration string — parse it, then
+    /// plan the work — so these tests keep exercising the grammar rather than
+    /// hand-building the parsed value.
+    fn plan_rootfs(image: &str) -> Result<RootfsPlan> {
+        let source: RootfsSource = image.parse().map_err(|e| MvmError::InvalidSpec {
+            reason: format!("{e}"),
+        })?;
+        plan_rootfs_source(source)
+    }
+
     #[test]
     fn plan_rootfs_routes_file_dir_and_registry() {
         let dir = tempfile::tempdir().unwrap();
@@ -1147,7 +1148,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let typo = dir.path().join("rootfs.ext5");
 
-        let err = crate::local::resolve_local_rootfs(&typo.to_string_lossy(), "m")
+        let declared: RootfsSource = typo.to_string_lossy().parse().expect("a path parses");
+        let err = crate::local::resolve_local_rootfs(&declared, "m")
             .await
             .expect_err("an absent declared path is an error");
 
@@ -1212,7 +1214,7 @@ mod tests {
         let be = LocalBackend::with_hypervisor("mock");
         let spec = MachineSpec {
             name: "local-boot-from-image-path".into(),
-            image: rootfs.to_string_lossy().into_owned(),
+            image: rootfs.to_string_lossy().parse().expect("a path parses"),
             cpus: 1,
             memory_mib: 128,
             env: vec![],
@@ -1243,7 +1245,7 @@ mod tests {
         let be = LocalBackend::with_hypervisor("mock");
         let spec = MachineSpec {
             name: "local-remove-target".into(),
-            image: rootfs.to_string_lossy().into_owned(),
+            image: rootfs.to_string_lossy().parse().expect("a path parses"),
             cpus: 1,
             memory_mib: 128,
             env: vec![],
@@ -1292,7 +1294,7 @@ mod tests {
         let be = LocalBackend::with_hypervisor("mock");
         let spec = MachineSpec {
             name: "local-stop-target".into(),
-            image: rootfs.to_string_lossy().into_owned(),
+            image: rootfs.to_string_lossy().parse().expect("a path parses"),
             cpus: 1,
             memory_mib: 128,
             env: vec![],

--- a/crates/mvm-client/tests/launch_lifecycle_live.rs
+++ b/crates/mvm-client/tests/launch_lifecycle_live.rs
@@ -12,9 +12,10 @@
 
 use mvm_client::{LaunchRequest, LifecycleMode, LocalBackend, MvmClient, RemoveOptions};
 use mvm_core::client::dto::{MachineId, MachineStatus};
+use mvm_core::rootfs_source::RootfsSource;
 
 /// Resolve the live-lane prerequisites, or explain the clean skip.
-fn live_env() -> Option<(String, String)> {
+fn live_env() -> Option<(String, RootfsSource)> {
     if !std::path::Path::new("/dev/kvm").exists() {
         eprintln!("skipping: /dev/kvm not present");
         return None;
@@ -25,7 +26,12 @@ fn live_env() -> Option<(String, String)> {
         eprintln!("skipping: MVM_E2E_KERNEL / MVM_E2E_ROOTFS do not name existing files");
         return None;
     }
-    Some((kernel, rootfs))
+    // Declared as a path outright: the env var may hold a relative one, which
+    // the string grammar would (correctly) read as a registry reference.
+    Some((
+        kernel,
+        RootfsSource::LocalPath(std::path::PathBuf::from(rootfs)),
+    ))
 }
 
 /// Make the lane self-contained: seed the supplied workload kernel into the

--- a/crates/mvm-client/tests/launch_lifecycle_live_hvf.rs
+++ b/crates/mvm-client/tests/launch_lifecycle_live_hvf.rs
@@ -14,16 +14,22 @@
 
 use mvm_client::{LaunchRequest, LifecycleMode, LocalBackend, MvmClient, RemoveOptions};
 use mvm_core::client::dto::{MachineId, MachineStatus};
+use mvm_core::rootfs_source::RootfsSource;
 
 /// Resolve the live-lane prerequisites, or explain the clean skip.
-fn live_env() -> Option<(String, String)> {
+fn live_env() -> Option<(String, RootfsSource)> {
     let kernel = std::env::var("MVM_E2E_KERNEL").ok()?;
     let rootfs = std::env::var("MVM_E2E_ROOTFS").ok()?;
     if !std::path::Path::new(&kernel).exists() || !std::path::Path::new(&rootfs).exists() {
         eprintln!("skipping: MVM_E2E_KERNEL / MVM_E2E_ROOTFS do not name existing files");
         return None;
     }
-    Some((kernel, rootfs))
+    // Declared as a path outright: the env var may hold a relative one, which
+    // the string grammar would (correctly) read as a registry reference.
+    Some((
+        kernel,
+        RootfsSource::LocalPath(std::path::PathBuf::from(rootfs)),
+    ))
 }
 
 /// Optional dwell between launch and stop (`MVM_E2E_LINGER_SECS`), so an

--- a/crates/mvm-core/src/client/dto.rs
+++ b/crates/mvm-core/src/client/dto.rs
@@ -5,6 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::rootfs_source::{RootfsSource, RootfsSourceParseError};
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct MachineId(pub String);
 
@@ -43,26 +45,31 @@ impl MachineStatus {
 /// ```
 /// use mvm_core::client::dto::MachineSpec;
 ///
-/// let spec = MachineSpec::builder("web", "nginx")
+/// let spec = MachineSpec::builder("web", "nginx")?
 ///     .cpus(2)
 ///     .memory_mib(512)
 ///     .env("PORT", "8080")
 ///     .build();
 /// assert_eq!(spec.name, "web");
+/// assert_eq!(spec.image.to_string(), "nginx");
+/// # Ok::<(), mvm_core::rootfs_source::RootfsSourceParseError>(())
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct MachineSpec {
     pub name: String,
-    /// What to boot, as a declaration rather than something to be guessed at:
-    /// an absolute, `./`-relative or `~/`-relative path (or an explicit
-    /// `path:<p>`) is a local rootfs — a materialized `rootfs.ext4` or an
-    /// unpacked tree — and anything else (or an explicit `oci:<ref>`) is an
-    /// OCI reference. A declared path that is absent is refused by name; it is
-    /// never retried as a registry pull, because the two take different
-    /// verification routes and which one runs must not depend on the caller's
-    /// working directory.
-    pub image: String,
+    /// What to boot — the parsed declaration, not a string still waiting to be
+    /// interpreted: an absolute, `./`-relative or `~/`-relative path (or an
+    /// explicit `path:<p>`) is a local rootfs, a `flake:<ref>#<attr>` is a
+    /// flake output, and anything else (or an explicit `oci:<ref>`) is an OCI
+    /// reference. Serialized as that same string, so a spec on a wire carries
+    /// the token a user typed.
+    ///
+    /// Typed here because the alternative was a boundary that accepted every
+    /// string and found out at boot. A declared path that is absent is still a
+    /// boot-time refusal — no filesystem is consulted at this layer — but a
+    /// string that names nothing at all no longer reaches one.
+    pub image: RootfsSource,
     pub cpus: u32,
     pub memory_mib: u32,
     pub env: Vec<(String, String)>,
@@ -83,15 +90,25 @@ impl MachineSpec {
     /// Start building a spec. `name` and `image` are the two required fields;
     /// everything else defaults (1 vCPU, 512 MiB, no env, no grants) and is
     /// overridable on the returned [`MachineSpecBuilder`].
-    pub fn builder(name: impl Into<String>, image: impl Into<String>) -> MachineSpecBuilder {
-        MachineSpecBuilder {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RootfsSourceParseError`] when `image` names no rootfs source —
+    /// an empty declaration, or a scheme with nothing after it. The refusal
+    /// lands here rather than at boot because that is where the caller can
+    /// still see which value they passed.
+    pub fn builder(
+        name: impl Into<String>,
+        image: impl AsRef<str>,
+    ) -> Result<MachineSpecBuilder, RootfsSourceParseError> {
+        Ok(MachineSpecBuilder {
             name: name.into(),
-            image: image.into(),
+            image: image.as_ref().parse()?,
             cpus: 1,
             memory_mib: 512,
             env: Vec::new(),
             grants: mvm_contract::grants::Grants::default(),
-        }
+        })
     }
 }
 
@@ -105,7 +122,7 @@ impl MachineSpec {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MachineSpecBuilder {
     name: String,
-    image: String,
+    image: RootfsSource,
     cpus: u32,
     memory_mib: u32,
     env: Vec<(String, String)>,
@@ -445,7 +462,7 @@ mod tests {
     fn machine_spec_serde_round_trips() {
         let spec = MachineSpec {
             name: "web".into(),
-            image: "docker.io/lib/nginx:1".into(),
+            image: "docker.io/lib/nginx:1".parse().unwrap(),
             cpus: 2,
             memory_mib: 512,
             env: vec![("PORT".into(), "8080".into())],
@@ -473,6 +490,7 @@ mod tests {
         // The library surface's reason to exist: before this, a caller could
         // not ask for outbound access at all without shelling out to the CLI.
         let spec = MachineSpec::builder("web", "nginx")
+            .expect("declared image parses")
             .cpu_millicores(1500)
             .allow_egress("api.example.com", 443)
             .allow_egress("db.internal", 5432)
@@ -495,6 +513,7 @@ mod tests {
         // vCPU count and host CPU share are different questions; setting one
         // must not move the other.
         let spec = MachineSpec::builder("web", "nginx")
+            .expect("declared image parses")
             .cpus(4)
             .cpu_millicores(500)
             .build();
@@ -507,12 +526,14 @@ mod tests {
 
     #[test]
     fn builder_applies_defaults_and_overrides() {
-        let spec = MachineSpec::builder("web", "nginx").build();
+        let spec = MachineSpec::builder("web", "nginx")
+            .expect("declared image parses")
+            .build();
         assert_eq!(
             spec,
             MachineSpec {
                 name: "web".into(),
-                image: "nginx".into(),
+                image: "nginx".parse().unwrap(),
                 cpus: 1,
                 memory_mib: 512,
                 env: vec![],
@@ -521,6 +542,7 @@ mod tests {
         );
 
         let spec = MachineSpec::builder("web", "nginx")
+            .expect("declared image parses")
             .cpus(4)
             .memory_mib(1024)
             .env("A", "1")
@@ -542,19 +564,101 @@ mod tests {
     #[test]
     fn builder_equals_struct_literal() {
         let built = MachineSpec::builder("web", "docker.io/lib/nginx:1")
+            .expect("declared image parses")
             .cpus(2)
             .memory_mib(512)
             .env("PORT", "8080")
             .build();
         let literal = MachineSpec {
             name: "web".into(),
-            image: "docker.io/lib/nginx:1".into(),
+            image: "docker.io/lib/nginx:1".parse().unwrap(),
             cpus: 2,
             memory_mib: 512,
             env: vec![("PORT".into(), "8080".into())],
             grants: None,
         };
         assert_eq!(built, literal);
+    }
+
+    #[test]
+    fn a_declaration_that_names_nothing_is_refused_at_construction() {
+        // The property typing this field exists to add. A `String` here took
+        // every one of these and handed the caller a spec that could not boot,
+        // deferring the refusal to whichever backend eventually parsed it —
+        // which for the mock backend was never.
+        assert_eq!(
+            MachineSpec::builder("web", "").unwrap_err(),
+            RootfsSourceParseError::Empty
+        );
+        assert_eq!(
+            MachineSpec::builder("web", "  \n ").unwrap_err(),
+            RootfsSourceParseError::Empty
+        );
+        assert_eq!(
+            MachineSpec::builder("web", "path:").unwrap_err(),
+            RootfsSourceParseError::EmptyPayload { scheme: "path:" }
+        );
+        assert_eq!(
+            MachineSpec::builder("web", "oci:").unwrap_err(),
+            RootfsSourceParseError::EmptyPayload { scheme: "oci:" }
+        );
+    }
+
+    #[test]
+    fn a_declaration_that_names_nothing_is_refused_at_deserialization() {
+        // Same refusal on the way in from a wire, where the caller is not a
+        // Rust one and the builder cannot speak for them. `deny_unknown_fields`
+        // already fails closed on a field nobody declared; this fails closed on
+        // a declared field that says nothing.
+        for image in ["", "   ", "path:", "oci:", "flake:"] {
+            let json = format!(
+                r#"{{"name":"web","image":{},"cpus":1,"memory_mib":512,"env":[]}}"#,
+                serde_json::to_string(image).unwrap()
+            );
+            let err = serde_json::from_str::<MachineSpec>(&json)
+                .expect_err("a declaration naming nothing must not deserialize");
+            assert!(
+                err.to_string().contains("rootfs source")
+                    || err.to_string().contains("prefix with no value"),
+                "{image:?} was refused for the wrong reason: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_declaration_is_stored_as_the_value_it_names_not_the_bytes_that_carried_it() {
+        // A pasted or command-substituted image arrives with whitespace around
+        // it. With a `String` field the spec kept those bytes, so the value a
+        // listing showed and the value that booted were different strings.
+        let spec = MachineSpec::builder("web", "  alpine:3.20\n")
+            .expect("declared image parses")
+            .build();
+        assert_eq!(
+            spec.image,
+            RootfsSource::Oci {
+                image_ref: "alpine:3.20".to_string()
+            }
+        );
+        // And it leaves as the same token a user would have typed, which is
+        // what the SDKs forward as `--image`.
+        assert_eq!(spec.image.to_string(), "alpine:3.20");
+    }
+
+    #[test]
+    fn a_local_path_declaration_survives_the_wire_as_a_path() {
+        // Typing the field must not quietly reclassify a path as a reference on
+        // the way through serde — the two take different verification routes.
+        let spec = MachineSpec::builder("web", "/var/lib/mvm/rootfs.ext4")
+            .expect("declared image parses")
+            .build();
+        let json = serde_json::to_string(&spec).unwrap();
+        assert!(
+            json.contains(r#""image":"/var/lib/mvm/rootfs.ext4""#),
+            "path lost its plain form: {json}"
+        );
+        let back: MachineSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.image, spec.image);
+        assert!(matches!(back.image, RootfsSource::LocalPath(_)));
     }
 
     #[test]

--- a/crates/mvm-core/src/client/gateway.rs
+++ b/crates/mvm-core/src/client/gateway.rs
@@ -684,9 +684,13 @@ impl MvmClient for GatewayBackend {
             });
         }
         let url = self.endpoint("/api/v1/sandboxes")?;
+        // The remote sandbox API names an image with a string. Written form,
+        // not a tagged enum: the token the caller declared is the token the
+        // remote sees, so the two ends describe one image the same way.
+        let image = spec.image.to_string();
         let body = CreateSandboxBody {
             name: &spec.name,
-            image: &spec.image,
+            image: &image,
             memory_mib: spec.memory_mib,
             vcpus: spec.cpus,
         };
@@ -1020,7 +1024,7 @@ mod tests {
         let be = GatewayBackend::new(cfg("https://fleet.example.com")).unwrap();
         let spec = MachineSpec {
             name: "w".into(),
-            image: "i".into(),
+            image: "i".parse().unwrap(),
             cpus: 1,
             memory_mib: 64,
             env: vec![("A".into(), "B".into())],

--- a/crates/mvm-core/src/client/mock.rs
+++ b/crates/mvm-core/src/client/mock.rs
@@ -202,7 +202,7 @@ mod tests {
 
         let spec = MachineSpec {
             name: "web".into(),
-            image: "img".into(),
+            image: "img".parse().unwrap(),
             cpus: 1,
             memory_mib: 128,
             env: vec![],
@@ -225,7 +225,7 @@ mod tests {
         let mock = MockBackend::default();
         let spec = MachineSpec {
             name: "db".into(),
-            image: "img".into(),
+            image: "img".parse().unwrap(),
             cpus: 1,
             memory_mib: 128,
             env: vec![],
@@ -278,7 +278,7 @@ mod tests {
         let started = mock
             .run_machine(MachineSpec {
                 name: "web".into(),
-                image: "i".into(),
+                image: "i".parse().unwrap(),
                 cpus: 1,
                 memory_mib: 64,
                 env: vec![],
@@ -332,7 +332,7 @@ mod tests {
         let started = mock
             .run_machine(MachineSpec {
                 name: "web".into(),
-                image: "i".into(),
+                image: "i".parse().unwrap(),
                 cpus: 1,
                 memory_mib: 64,
                 env: vec![],
@@ -358,7 +358,7 @@ mod tests {
         let started = mock
             .run_machine(MachineSpec {
                 name: "web".into(),
-                image: "i".into(),
+                image: "i".parse().unwrap(),
                 cpus: 1,
                 memory_mib: 64,
                 env: vec![],

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -132,6 +132,9 @@ pub mod provenance;
 pub mod rate_limit;
 pub mod receipt;
 pub mod residency;
+/// What a caller declared a machine should boot from — the one type both the
+/// declaration boundary and the build side name.
+pub mod rootfs_source;
 /// Hardened snapshot frame v0: cap-bounded, fail-closed parsing of the
 /// snapshot container mvm controls (eager-CoW / raw-hypervisor path).
 pub mod snapshot_frame;

--- a/crates/mvm-core/src/rootfs_source.rs
+++ b/crates/mvm-core/src/rootfs_source.rs
@@ -1,0 +1,359 @@
+//! What a caller declared a machine should boot from.
+//!
+//! One type answers the question for both layers that ask it: the declaration
+//! a caller hands in ([`crate::client::dto::MachineSpec::image`]) and the build
+//! input a builder consumes (`mvm_runtime::artifacts::spec::RootfsSpec`). It
+//! lives here rather than in the runtime because the declaration boundary sits
+//! below the runtime, and here rather than in `mvm-contract` because
+//! [`RootfsSource::LocalPath`] carries a [`PathBuf`], which `core` + `alloc`
+//! has no equivalent of — and a host filesystem path means nothing on the
+//! `wasm32` target that crate exists to serve.
+//!
+//! The string grammar is total and lossless: every value has a written form
+//! that parses back to itself, and every well-formed string names exactly one
+//! value. That is what lets a declaration travel as the plain string a user
+//! typed (`--image alpine:3.20`) while still being a parsed value in memory.
+
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Scheme prefixes that let a caller state which kind of source a string is,
+/// overriding the shape heuristic below.
+const PATH_SCHEME: &str = "path:";
+const OCI_SCHEME: &str = "oci:";
+const FLAKE_SCHEME: &str = "flake:";
+/// Separates a flake reference from its output attribute, matching nix's own
+/// `<flake-ref>#<attr>` spelling.
+const FLAKE_ATTR_SEPARATOR: char = '#';
+
+/// Where the rootfs comes from.
+///
+/// Serialized as its string form, not as a tagged enum: the same value reaches
+/// a guest as `--image <string>` argv, and two spellings of one declaration are
+/// two things that can disagree.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(into = "String", try_from = "String")]
+pub enum RootfsSource {
+    /// Build from a Nix flake output at the given path/URL.
+    Flake { flake_ref: String, attr: String },
+    /// Use a pre-built rootfs image at the given local path.
+    LocalPath(PathBuf),
+    /// Import from an OCI image reference (pulled by the builder VM).
+    Oci { image_ref: String },
+}
+
+/// Why a caller-supplied string is not a rootfs source at all.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RootfsSourceParseError {
+    #[error("empty rootfs source")]
+    Empty,
+    #[error("`{scheme}` prefix with no value")]
+    EmptyPayload { scheme: &'static str },
+    #[error("flake source `{flake_ref}` names no output attribute (write `flake:<ref>#<attr>`)")]
+    MissingFlakeAttr { flake_ref: String },
+}
+
+impl RootfsSource {
+    /// True for strings whose *shape* declares a filesystem location: an
+    /// absolute path, an explicitly-relative one, or a home-relative one. An
+    /// OCI reference can take none of these forms, so the two spaces do not
+    /// overlap and the answer needs no filesystem lookup.
+    fn is_path_shaped(s: &str) -> bool {
+        s.starts_with('/')
+            || s.starts_with("./")
+            || s.starts_with("../")
+            || s == "."
+            || s == ".."
+            || s.starts_with("~/")
+    }
+}
+
+impl FromStr for RootfsSource {
+    type Err = RootfsSourceParseError;
+
+    /// Classify a caller-declared rootfs string **without consulting the
+    /// filesystem**. What a string means is what the caller declared, not a
+    /// function of what happens to exist in their working directory — probing
+    /// makes a typo fall through to a different arm, and the arms differ in
+    /// how the resulting bytes are verified.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Command substitution and file reads routinely carry a trailing
+        // newline; the surrounding whitespace is never part of the intent.
+        let s = s.trim();
+        if s.is_empty() {
+            return Err(RootfsSourceParseError::Empty);
+        }
+        if let Some(rest) = s.strip_prefix(PATH_SCHEME) {
+            return non_empty(rest, PATH_SCHEME).map(|v| Self::LocalPath(PathBuf::from(v)));
+        }
+        if let Some(rest) = s.strip_prefix(OCI_SCHEME) {
+            return non_empty(rest, OCI_SCHEME).map(|v| Self::Oci {
+                image_ref: v.to_string(),
+            });
+        }
+        if let Some(rest) = s.strip_prefix(FLAKE_SCHEME) {
+            let rest = non_empty(rest, FLAKE_SCHEME)?;
+            // Split on the *last* separator so a flake ref that carries its own
+            // `#` still yields the attribute the caller wrote last.
+            let (flake_ref, attr) = rest.rsplit_once(FLAKE_ATTR_SEPARATOR).ok_or_else(|| {
+                RootfsSourceParseError::MissingFlakeAttr {
+                    flake_ref: rest.to_string(),
+                }
+            })?;
+            if flake_ref.is_empty() || attr.is_empty() {
+                return Err(RootfsSourceParseError::MissingFlakeAttr {
+                    flake_ref: rest.to_string(),
+                });
+            }
+            return Ok(Self::Flake {
+                flake_ref: flake_ref.to_string(),
+                attr: attr.to_string(),
+            });
+        }
+        if Self::is_path_shaped(s) {
+            Ok(Self::LocalPath(PathBuf::from(s)))
+        } else {
+            Ok(Self::Oci {
+                image_ref: s.to_string(),
+            })
+        }
+    }
+}
+
+impl fmt::Display for RootfsSource {
+    /// The shortest spelling that parses back to `self`. A declaration whose
+    /// shape already speaks for itself is written verbatim, so a value that
+    /// arrived as `alpine:3.20` leaves as `alpine:3.20` — the exact token the
+    /// SDKs pass through as `--image`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LocalPath(path) => {
+                write_bare_or_qualified(f, PATH_SCHEME, &path.to_string_lossy(), self)
+            }
+            Self::Oci { image_ref } => write_bare_or_qualified(f, OCI_SCHEME, image_ref, self),
+            // A flake is never shape-inferable, so it always names its scheme.
+            Self::Flake { flake_ref, attr } => {
+                write!(f, "{FLAKE_SCHEME}{flake_ref}{FLAKE_ATTR_SEPARATOR}{attr}")
+            }
+        }
+    }
+}
+
+/// Write `payload` on its own when it parses back to `value`, and
+/// scheme-qualified otherwise. Deciding by re-parsing rather than by a second
+/// copy of the shape rules keeps the written form correct by construction:
+/// there is no heuristic here that can drift out of step with `FromStr`.
+fn write_bare_or_qualified(
+    f: &mut fmt::Formatter<'_>,
+    scheme: &str,
+    payload: &str,
+    value: &RootfsSource,
+) -> fmt::Result {
+    if payload.parse::<RootfsSource>().as_ref() == Ok(value) {
+        f.write_str(payload)
+    } else {
+        write!(f, "{scheme}{payload}")
+    }
+}
+
+impl TryFrom<String> for RootfsSource {
+    type Error = RootfsSourceParseError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
+impl From<RootfsSource> for String {
+    fn from(value: RootfsSource) -> Self {
+        value.to_string()
+    }
+}
+
+fn non_empty<'a>(value: &'a str, scheme: &'static str) -> Result<&'a str, RootfsSourceParseError> {
+    if value.is_empty() {
+        Err(RootfsSourceParseError::EmptyPayload { scheme })
+    } else {
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod rootfs_source_parse_tests {
+    use super::*;
+
+    fn parse(s: &str) -> Result<RootfsSource, RootfsSourceParseError> {
+        s.parse()
+    }
+
+    fn local(p: &str) -> RootfsSource {
+        RootfsSource::LocalPath(PathBuf::from(p))
+    }
+
+    fn oci(r: &str) -> RootfsSource {
+        RootfsSource::Oci {
+            image_ref: r.to_string(),
+        }
+    }
+
+    fn flake(flake_ref: &str, attr: &str) -> RootfsSource {
+        RootfsSource::Flake {
+            flake_ref: flake_ref.to_string(),
+            attr: attr.to_string(),
+        }
+    }
+
+    #[test]
+    fn path_shapes_parse_as_local_paths() {
+        assert_eq!(
+            parse("/var/lib/rootfs.ext4").unwrap(),
+            local("/var/lib/rootfs.ext4")
+        );
+        assert_eq!(parse("./rootfs.ext4").unwrap(), local("./rootfs.ext4"));
+        assert_eq!(
+            parse("../out/rootfs.ext4").unwrap(),
+            local("../out/rootfs.ext4")
+        );
+        assert_eq!(
+            parse("~/images/rootfs.ext4").unwrap(),
+            local("~/images/rootfs.ext4")
+        );
+        assert_eq!(parse(".").unwrap(), local("."));
+    }
+
+    #[test]
+    fn registry_shapes_parse_as_oci_references() {
+        assert_eq!(parse("alpine:3.20").unwrap(), oci("alpine:3.20"));
+        assert_eq!(
+            parse("docker.io/library/alpine:3.20").unwrap(),
+            oci("docker.io/library/alpine:3.20")
+        );
+        // A bare name that could name a file in someone's cwd is still a
+        // reference — nothing here looks at the filesystem.
+        assert_eq!(parse("rootfs.ext4").unwrap(), oci("rootfs.ext4"));
+    }
+
+    #[test]
+    fn schemes_override_the_shape_heuristic() {
+        assert_eq!(parse("path:rootfs.ext4").unwrap(), local("rootfs.ext4"));
+        assert_eq!(
+            parse("oci:/weird/repo:tag").unwrap(),
+            oci("/weird/repo:tag")
+        );
+    }
+
+    #[test]
+    fn flake_sources_carry_a_reference_and_an_attribute() {
+        assert_eq!(parse("flake:.#default").unwrap(), flake(".", "default"));
+        assert_eq!(
+            parse("flake:github:o/r?ref=main#packages.aarch64-linux.rootfs").unwrap(),
+            flake("github:o/r?ref=main", "packages.aarch64-linux.rootfs")
+        );
+    }
+
+    #[test]
+    fn a_flake_without_an_attribute_is_an_error() {
+        assert_eq!(
+            parse("flake:.").unwrap_err(),
+            RootfsSourceParseError::MissingFlakeAttr {
+                flake_ref: ".".to_string()
+            }
+        );
+        assert_eq!(
+            parse("flake:.#").unwrap_err(),
+            RootfsSourceParseError::MissingFlakeAttr {
+                flake_ref: ".#".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn empty_and_valueless_schemes_are_errors() {
+        assert_eq!(parse("").unwrap_err(), RootfsSourceParseError::Empty);
+        assert_eq!(parse("   \n").unwrap_err(), RootfsSourceParseError::Empty);
+        assert_eq!(
+            parse("path:").unwrap_err(),
+            RootfsSourceParseError::EmptyPayload {
+                scheme: PATH_SCHEME
+            }
+        );
+        assert_eq!(
+            parse("oci:").unwrap_err(),
+            RootfsSourceParseError::EmptyPayload { scheme: OCI_SCHEME }
+        );
+        assert_eq!(
+            parse("flake:").unwrap_err(),
+            RootfsSourceParseError::EmptyPayload {
+                scheme: FLAKE_SCHEME
+            }
+        );
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_not_part_of_the_declaration() {
+        assert_eq!(
+            parse("  /var/rootfs.ext4\n").unwrap(),
+            local("/var/rootfs.ext4")
+        );
+    }
+
+    #[test]
+    fn the_written_form_is_the_token_the_caller_typed() {
+        // A declaration that needs no help keeps its exact bytes: this is the
+        // same string the SDKs hand to `--image`, and a canonicalization that
+        // rewrote it would put the declaration and the argv out of step.
+        assert_eq!(oci("alpine:3.20").to_string(), "alpine:3.20");
+        assert_eq!(
+            local("/var/lib/rootfs.ext4").to_string(),
+            "/var/lib/rootfs.ext4"
+        );
+        assert_eq!(local("./rootfs.ext4").to_string(), "./rootfs.ext4");
+        // Only a value the shape heuristic would misread names its scheme.
+        assert_eq!(local("rootfs.ext4").to_string(), "path:rootfs.ext4");
+        assert_eq!(oci("/weird/repo:tag").to_string(), "oci:/weird/repo:tag");
+        assert_eq!(flake(".", "default").to_string(), "flake:.#default");
+    }
+
+    #[test]
+    fn every_value_round_trips_through_its_written_form() {
+        // Totality is what lets the serialized form be the plain string: no
+        // variant is unwritable, so serialization can never fail.
+        for value in [
+            local("/var/lib/rootfs.ext4"),
+            local("./rootfs.ext4"),
+            local("rootfs.ext4"),
+            local("~/img/rootfs.ext4"),
+            oci("alpine:3.20"),
+            oci("ghcr.io/o/r@sha256:abc"),
+            oci("path:not-a-path"),
+            oci("/weird/repo:tag"),
+            flake(".", "default"),
+            flake("github:o/r?ref=main", "packages.rootfs"),
+        ] {
+            let written = value.to_string();
+            assert_eq!(
+                parse(&written).unwrap(),
+                value,
+                "{written:?} did not parse back to what wrote it"
+            );
+        }
+    }
+
+    #[test]
+    fn serde_uses_the_string_form_and_rejects_a_meaningless_one() {
+        let value = oci("alpine:3.20");
+        assert_eq!(serde_json::to_string(&value).unwrap(), "\"alpine:3.20\"");
+        assert_eq!(
+            serde_json::from_str::<RootfsSource>("\"alpine:3.20\"").unwrap(),
+            value
+        );
+        let err = serde_json::from_str::<RootfsSource>("\"\"").unwrap_err();
+        assert!(
+            err.to_string().contains("empty rootfs source"),
+            "got: {err}"
+        );
+    }
+}

--- a/crates/mvm-runtime/src/artifacts/spec.rs
+++ b/crates/mvm-runtime/src/artifacts/spec.rs
@@ -8,6 +8,9 @@ use std::path::PathBuf;
 
 use mvm_core::arch::GuestArch;
 use mvm_core::kernel_format::KernelFormat;
+// The rootfs declaration is named by callers that sit below this crate, so the
+// type lives in `mvm-core`; the build spec keeps naming it here.
+pub use mvm_core::rootfs_source::{RootfsSource, RootfsSourceParseError};
 use serde::{Deserialize, Serialize};
 
 use crate::compat::{MicrovmBackend, RootfsFormat};
@@ -22,18 +25,6 @@ pub enum KernelSource {
     LocalPath(PathBuf),
     /// Use the builder VM's bundled kernel (libkrun embedded kernel).
     Bundled,
-}
-
-/// Where the rootfs comes from.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum RootfsSource {
-    /// Build from a Nix flake output at the given path/URL.
-    Flake { flake_ref: String, attr: String },
-    /// Use a pre-built rootfs image at the given local path.
-    LocalPath(PathBuf),
-    /// Import from an OCI image reference (pulled by the builder VM).
-    Oci { image_ref: String },
 }
 
 /// What kernel to produce (or consume).
@@ -71,159 +62,4 @@ pub struct MicrovmBuildSpec {
     pub build_id: String,
     /// Optional tenant scope for the resulting manifest.
     pub tenant_id: Option<String>,
-}
-
-/// Scheme prefixes that let a caller state which kind of source a string is,
-/// overriding the shape heuristic below.
-const PATH_SCHEME: &str = "path:";
-const OCI_SCHEME: &str = "oci:";
-
-/// Why a caller-supplied string is not a rootfs source at all.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum RootfsSourceParseError {
-    #[error("empty rootfs source")]
-    Empty,
-    #[error("`{scheme}` prefix with no value")]
-    EmptyPayload { scheme: &'static str },
-}
-
-impl RootfsSource {
-    /// True for strings whose *shape* declares a filesystem location: an
-    /// absolute path, an explicitly-relative one, or a home-relative one. An
-    /// OCI reference can take none of these forms, so the two spaces do not
-    /// overlap and the answer needs no filesystem lookup.
-    fn is_path_shaped(s: &str) -> bool {
-        s.starts_with('/')
-            || s.starts_with("./")
-            || s.starts_with("../")
-            || s == "."
-            || s == ".."
-            || s.starts_with("~/")
-    }
-}
-
-impl std::str::FromStr for RootfsSource {
-    type Err = RootfsSourceParseError;
-
-    /// Classify a caller-declared rootfs string **without consulting the
-    /// filesystem**. What a string means is what the caller declared, not a
-    /// function of what happens to exist in their working directory — probing
-    /// makes a typo fall through to a different arm, and the arms differ in
-    /// how the resulting bytes are verified.
-    ///
-    /// `Flake` is not reachable from a string: a flake source carries an
-    /// attribute alongside the reference and is constructed by the build side.
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // Command substitution and file reads routinely carry a trailing
-        // newline; the surrounding whitespace is never part of the intent.
-        let s = s.trim();
-        if s.is_empty() {
-            return Err(RootfsSourceParseError::Empty);
-        }
-        if let Some(rest) = s.strip_prefix(PATH_SCHEME) {
-            return non_empty(rest, PATH_SCHEME).map(|v| Self::LocalPath(PathBuf::from(v)));
-        }
-        if let Some(rest) = s.strip_prefix(OCI_SCHEME) {
-            return non_empty(rest, OCI_SCHEME).map(|v| Self::Oci {
-                image_ref: v.to_string(),
-            });
-        }
-        if Self::is_path_shaped(s) {
-            Ok(Self::LocalPath(PathBuf::from(s)))
-        } else {
-            Ok(Self::Oci {
-                image_ref: s.to_string(),
-            })
-        }
-    }
-}
-
-fn non_empty<'a>(value: &'a str, scheme: &'static str) -> Result<&'a str, RootfsSourceParseError> {
-    if value.is_empty() {
-        Err(RootfsSourceParseError::EmptyPayload { scheme })
-    } else {
-        Ok(value)
-    }
-}
-
-#[cfg(test)]
-mod rootfs_source_parse_tests {
-    use super::*;
-
-    fn parse(s: &str) -> Result<RootfsSource, RootfsSourceParseError> {
-        s.parse()
-    }
-
-    fn local(p: &str) -> RootfsSource {
-        RootfsSource::LocalPath(PathBuf::from(p))
-    }
-
-    fn oci(r: &str) -> RootfsSource {
-        RootfsSource::Oci {
-            image_ref: r.to_string(),
-        }
-    }
-
-    #[test]
-    fn path_shapes_parse_as_local_paths() {
-        assert_eq!(
-            parse("/var/lib/rootfs.ext4").unwrap(),
-            local("/var/lib/rootfs.ext4")
-        );
-        assert_eq!(parse("./rootfs.ext4").unwrap(), local("./rootfs.ext4"));
-        assert_eq!(
-            parse("../out/rootfs.ext4").unwrap(),
-            local("../out/rootfs.ext4")
-        );
-        assert_eq!(
-            parse("~/images/rootfs.ext4").unwrap(),
-            local("~/images/rootfs.ext4")
-        );
-        assert_eq!(parse(".").unwrap(), local("."));
-    }
-
-    #[test]
-    fn registry_shapes_parse_as_oci_references() {
-        assert_eq!(parse("alpine:3.20").unwrap(), oci("alpine:3.20"));
-        assert_eq!(
-            parse("docker.io/library/alpine:3.20").unwrap(),
-            oci("docker.io/library/alpine:3.20")
-        );
-        // A bare name that could name a file in someone's cwd is still a
-        // reference — nothing here looks at the filesystem.
-        assert_eq!(parse("rootfs.ext4").unwrap(), oci("rootfs.ext4"));
-    }
-
-    #[test]
-    fn schemes_override_the_shape_heuristic() {
-        assert_eq!(parse("path:rootfs.ext4").unwrap(), local("rootfs.ext4"));
-        assert_eq!(
-            parse("oci:/weird/repo:tag").unwrap(),
-            oci("/weird/repo:tag")
-        );
-    }
-
-    #[test]
-    fn empty_and_valueless_schemes_are_errors() {
-        assert_eq!(parse("").unwrap_err(), RootfsSourceParseError::Empty);
-        assert_eq!(parse("   \n").unwrap_err(), RootfsSourceParseError::Empty);
-        assert_eq!(
-            parse("path:").unwrap_err(),
-            RootfsSourceParseError::EmptyPayload {
-                scheme: PATH_SCHEME
-            }
-        );
-        assert_eq!(
-            parse("oci:").unwrap_err(),
-            RootfsSourceParseError::EmptyPayload { scheme: OCI_SCHEME }
-        );
-    }
-
-    #[test]
-    fn surrounding_whitespace_is_not_part_of_the_declaration() {
-        assert_eq!(
-            parse("  /var/rootfs.ext4\n").unwrap(),
-            local("/var/rootfs.ext4")
-        );
-    }
 }

--- a/crates/mvm-sdk/src/facade.rs
+++ b/crates/mvm-sdk/src/facade.rs
@@ -204,15 +204,12 @@ fn run_args(spec: &MachineSpec) -> Result<GrantArgv> {
             reason: "name must not be empty".into(),
         });
     }
-    if spec.image.is_empty() {
-        return Err(MvmError::InvalidSpec {
-            reason: "image must not be empty".into(),
-        });
-    }
     let mut args = vec![
         "run".to_string(),
         "--image".to_string(),
-        spec.image.clone(),
+        // The written form of the declaration — the same token a user would
+        // have typed, so the argv the CLI sees matches what the caller wrote.
+        spec.image.to_string(),
         "--name".to_string(),
         spec.name.clone(),
         "--cpus".to_string(),
@@ -241,13 +238,8 @@ fn create_args(spec: &MachineSpec) -> Result<GrantArgv> {
             reason: "name must not be empty".into(),
         });
     }
-    if spec.image.is_empty() {
-        return Err(MvmError::InvalidSpec {
-            reason: "image must not be empty".into(),
-        });
-    }
     let mut args = MachineCreate::builder(&spec.name)
-        .image(&spec.image)
+        .image(spec.image.to_string())
         .cpus(spec.cpus as u16)
         .memory(format!("{}M", spec.memory_mib))
         .machine_args()
@@ -614,7 +606,7 @@ mod tests {
     fn run_args_builds_persistent_up_json_invocation() {
         let spec = MachineSpec {
             name: "web".into(),
-            image: "alpine:latest".into(),
+            image: "alpine:latest".parse().unwrap(),
             cpus: 2,
             memory_mib: 512,
             env: vec![("MODE".into(), "test".into())],
@@ -645,7 +637,7 @@ mod tests {
         // client's create argv is drift-locked against the CLI + every SDK.
         let spec = MachineSpec {
             name: "web".into(),
-            image: "alpine:3.20".into(),
+            image: "alpine:3.20".parse().unwrap(),
             cpus: 2,
             memory_mib: 512,
             env: vec![],
@@ -675,10 +667,12 @@ mod tests {
     }
 
     #[test]
-    fn create_args_reject_empty_name_and_image() {
+    fn create_args_rejects_an_empty_name() {
+        // The companion empty-image guard is gone: the spec's image is a parsed
+        // declaration, so an empty one never gets this far to be checked.
         let bad = MachineSpec {
             name: String::new(),
-            image: "img".into(),
+            image: "img".parse().unwrap(),
             cpus: 1,
             memory_mib: 64,
             env: vec![],
@@ -688,10 +682,10 @@ mod tests {
     }
 
     #[test]
-    fn run_args_rejects_empty_name_and_image() {
+    fn run_args_rejects_an_empty_name() {
         let base = MachineSpec {
             name: "web".into(),
-            image: "alpine".into(),
+            image: "alpine".parse().unwrap(),
             cpus: 1,
             memory_mib: 64,
             env: vec![],
@@ -704,13 +698,13 @@ mod tests {
             }),
             Err(MvmError::InvalidSpec { .. })
         ));
-        assert!(matches!(
-            run_args(&MachineSpec {
-                image: String::new(),
-                ..base
-            }),
-            Err(MvmError::InvalidSpec { .. })
-        ));
+        // An empty image has no `MachineSpec` to be checked in: it is refused
+        // where the declaration is parsed, not where the argv is assembled.
+        assert!(
+            "".parse::<mvm_core::rootfs_source::RootfsSource>().is_err(),
+            "an empty declaration must not parse"
+        );
+        drop(base);
     }
 
     // ── Grants on the argv ────────────────────────────────────────────
@@ -721,6 +715,7 @@ mod tests {
     #[test]
     fn a_cpu_and_egress_grant_reach_the_run_argv() {
         let spec = MachineSpec::builder("web", "alpine:latest")
+            .expect("declared image parses")
             .cpus(2)
             .memory_mib(512)
             .cpu_millicores(1500)
@@ -761,6 +756,7 @@ mod tests {
     #[test]
     fn a_cpu_and_egress_grant_reach_the_create_argv() {
         let spec = MachineSpec::builder("web", "alpine:3.20")
+            .expect("declared image parses")
             .cpus(2)
             .memory_mib(512)
             .cpu_millicores(1500)
@@ -790,6 +786,7 @@ mod tests {
         // The pre-grant baseline: no flags appear for a spec with no grants,
         // so the conformance-pinned argv is unchanged.
         let spec = MachineSpec::builder("web", "alpine:3.20")
+            .expect("declared image parses")
             .cpus(2)
             .memory_mib(512)
             .build();
@@ -812,6 +809,7 @@ mod tests {
         // CLI's own spellings: `--cpu-limit` is millicores, `--timeout` is
         // seconds, and `--allow-host HOST:PORT` is the egress grant.
         let spec = MachineSpec::builder("web", "alpine:latest")
+            .expect("declared image parses")
             .cpu_millicores(1500)
             .wall_clock_secs(std::num::NonZeroU32::new(600).unwrap())
             .allow_egress("api.example.com", 443)
@@ -847,6 +845,7 @@ mod tests {
         // is no conversion, so flattening one into the other would be a
         // different grant. The file carries it unchanged.
         let spec = MachineSpec::builder("web", "alpine:latest")
+            .expect("declared image parses")
             .cpu_fuel(100_000)
             .allow_egress("api.example.com", 443)
             .build();
@@ -882,6 +881,7 @@ mod tests {
         // wall-clock ceiling admits; an explicit `Unbounded` is refused by that
         // same ceiling. Dropping it would turn a refusal into a boot.
         let spec = MachineSpec::builder("web", "alpine:latest")
+            .expect("declared image parses")
             .grants(mvm_contract::grants::Grants {
                 wall_clock: Some(mvm_contract::grants::WallClockGrant::Unbounded),
                 ..Default::default()
@@ -897,6 +897,7 @@ mod tests {
         // Both deny every destination, so nothing opens either way — but only
         // one of them is what the caller declared, and the plan records which.
         let spec = MachineSpec::builder("web", "alpine:latest")
+            .expect("declared image parses")
             .grants(mvm_contract::grants::Grants {
                 egress: Some(mvm_contract::grants::EgressGrant { allow: vec![] }),
                 ..Default::default()
@@ -914,6 +915,7 @@ mod tests {
         // `--allow-host` splits on the last colon, so this would come back as a
         // different host and port than it went in as.
         let spec = MachineSpec::builder("web", "alpine:latest")
+            .expect("declared image parses")
             .allow_egress("::1", 443)
             .build();
         let invocation = run_args(&spec).unwrap();
@@ -957,7 +959,7 @@ mod tests {
         let state = be
             .run_machine(MachineSpec {
                 name: "web".into(),
-                image: "alpine:latest".into(),
+                image: "alpine:latest".parse().unwrap(),
                 cpus: 1,
                 memory_mib: 128,
                 env: vec![],

--- a/public/src/content/docs/getting-started/rust-quickstart.md
+++ b/public/src/content/docs/getting-started/rust-quickstart.md
@@ -45,7 +45,7 @@ use mvm_client_local::LocalBackend;
 // inside an async context:
 let client = LocalBackend::new();
 
-let spec = MachineSpec::builder("web", "nginx")
+let spec = MachineSpec::builder("web", "nginx")?
     .cpus(2)
     .memory_mib(512)
     .env("PORT", "8080")

--- a/public/src/content/docs/sdk/rust.md
+++ b/public/src/content/docs/sdk/rust.md
@@ -47,7 +47,13 @@ REST. Both speak the same `MachineSpec` intent type.
 
 Build a `MachineSpec` fluently with `MachineSpec::builder(name, image)` — the two
 required fields are supplied up front, so `build()` is infallible; `cpus`
-(default 1), `memory_mib` (default 512), and `env` (accumulates) are optional:
+(default 1), `memory_mib` (default 512), and `env` (accumulates) are optional.
+
+`builder` itself returns a `Result`: `image` is parsed into a `RootfsSource` (an
+absolute / `./` / `~/` path or `path:<p>` is a local rootfs, `flake:<ref>#<attr>`
+is a flake output, anything else or `oci:<ref>` is a registry reference), so a
+declaration that names nothing is refused here rather than at boot. The spec
+carries the parsed value and serializes it back as that same string.
 
 ```rust
 use mvm_client::{MvmClient, MachineSpec};
@@ -56,7 +62,7 @@ use mvm_client_local::LocalBackend;
 // inside an async context:
 let client = LocalBackend::new();
 
-let spec = MachineSpec::builder("web", "nginx")
+let spec = MachineSpec::builder("web", "nginx")?
     .cpus(2)
     .memory_mib(512)
     .env("PORT", "8080")

--- a/specs/sprint/delivery/2553-typed-machine-spec-image.md
+++ b/specs/sprint/delivery/2553-typed-machine-spec-image.md
@@ -1,0 +1,63 @@
+# 2553 — the machine declaration names a rootfs source, not a string
+
+2544 put the parse at the client boundary; `MachineSpec.image` itself stayed a
+`String`, so the declaration was only authoritative from that boundary inward.
+A caller could hand the DTO a string that meant nothing — `""`, `"path:"`, a
+value pasted with a trailing newline — and construction succeeded. The mock
+backend, which never parses anything, would run such a machine to completion.
+
+`RootfsSource` now lives in `mvm-core` (`crates/mvm-core/src/rootfs_source.rs`)
+and `MachineSpec.image` names it. `mvm-runtime`'s `artifacts::spec` re-exports
+it so the build spec keeps its call sites unchanged.
+
+## Where the type went, and why not `mvm-contract`
+
+`mvm-contract` was the other candidate — the issue noted the enum is
+"no_std-shaped already", and `ImageReference` already lives there. It does not
+fit: `RootfsSource::LocalPath` carries a `PathBuf`, which `core` + `alloc` has
+no equivalent of, and the crate must keep building for
+`wasm32-unknown-unknown`. Demoting the arm to `String` to fit would restore the
+stringly-typed representation this change exists to remove, and a host
+filesystem path has no meaning on the browser target that crate serves.
+`mvm-core` is std, sits below both `mvm-client` and `mvm-runtime`, and already
+hosts the DTO — so `dto.rs` names the type with no dependency inversion.
+
+## Persisted specs
+
+Nothing persisted deserializes as this type. The on-disk record at
+`~/.mvm/machines/<name>/machine.json` is a *different* `MachineSpec`
+(`mvm_runtime::machine::persist`, `image: Option<String>`), untouched here;
+`save_machine_spec`/`overwrite_machine_spec` are its only writers. The DTO
+reaches no file, no test fixture, and no JSON corpus, and even the gateway wire
+copies `&spec.image` into a separate `CreateSandboxBody` rather than sending
+the DTO. So the migration question has no live state behind it.
+
+The serialized form stays the flat string anyway, and not for compatibility:
+the same value reaches a guest as `--image <string>` argv — what both language
+SDKs emit and what the drift-locked `tests/machine-fixtures/create-image.argv`
+pins — so a tagged enum would make the DTO's field and the argv two spellings
+of one declaration. `Display` writes the shortest form that re-parses to the
+value, decided by re-parsing rather than by a second copy of the shape rules,
+so `alpine:3.20` and `/var/lib/rootfs.ext4` keep their exact bytes.
+
+## `Flake` in a boot declaration
+
+Kept in the one type rather than split into a narrower boot-side enum. The
+string grammar gained `flake:<ref>#<attr>` (nix's own spelling), which makes
+`FromStr`/`Display` total — no variant is unwritable, so serialization can
+never fail — and leaves the refusal where it belongs: the in-process backend
+cannot build a flake, which is a backend capability limit, not a malformed
+declaration. A second enum would have duplicated the grammar and pre-empted a
+backend that later can.
+
+## Follow-on
+
+`LaunchRequest.image` is typed too, which deleted its `image source must not be
+empty` runtime check (unrepresentable now) and the redundant re-parse in
+`resolve_local_rootfs`. `mvm-sdk`'s two `spec.image.is_empty()` guards went the
+same way.
+
+Not done: `RootfsSource::Oci` still carries a `String`, not the
+`ImageReference` the plan resolves it to downstream. That would change the
+build spec's serialized form and touch the nix builder, and is a separate
+change.


### PR DESCRIPTION
## What

`MachineSpec.image` (`crates/mvm-core/src/client/dto.rs`) was a `String`. #2552 put the parse at the client boundary, so the declaration was authoritative *from that boundary inward* — but a caller could still construct a spec whose image named nothing (`""`, `"path:"`, a value pasted with a trailing newline) and find out at boot. Through `MockBackend`, which parses nothing, they never found out at all.

The field now names `RootfsSource`, and the type moved down to `mvm-core`.

## Where the type went, and why not `mvm-contract`

`mvm-contract` was the other candidate the issue named — the enum is "no_std-shaped already", and `ImageReference` already lives there. It does not fit:

- `RootfsSource::LocalPath` carries a `std::path::PathBuf`, which `core` + `alloc` has no equivalent of, and `mvm-contract` must keep building for `wasm32-unknown-unknown`. Demoting the arm to `String` to make it fit would restore exactly the stringly-typed representation this change removes, and force a `String → PathBuf` conversion at every filesystem consumer.
- A host filesystem path has no meaning on the browser target that crate exists to serve.

`mvm-core` is std, sits below both `mvm-client` and `mvm-runtime`, and already hosts the DTO — so `dto.rs` names the type with no dependency inversion. `mvm-runtime::artifacts::spec` re-exports it, so `RootfsSpec.source` and the nix builder are untouched.

## Persisted specs — explicit answer: nothing breaks, and nothing could

Nothing persisted deserializes as this type.

- The on-disk record at `~/.mvm/machines/<name>/machine.json` is a **different** `MachineSpec` — `mvm_runtime::machine::persist`, `image: Option<String>`. `save_machine_spec` / `overwrite_machine_spec` are its only writers, and this PR does not change it.
- Every `serde_json::to_*` that touches the DTO is an in-memory test assertion. It reaches no file, no fixture, and no JSON corpus.
- Even on the gateway wire the DTO is not the body: `gateway.rs` copies `&spec.image` into a separate `CreateSandboxBody`.
- mvmd (path-dep on this workspace) does not compile the type at all — `mvm-core/client` is feature-gated and nothing in mvmd's closure enables it.

**The flat string stays anyway, and not for compatibility.** The same value reaches a guest as `--image <string>` argv — what both language SDKs emit and what the drift-locked `tests/machine-fixtures/create-image.argv` pins — so a tagged enum would leave the DTO field and the argv as two spellings of one declaration. `Display` writes the shortest form that re-parses to the value, and decides that **by re-parsing** rather than by a second copy of the shape rules, so it cannot drift from `FromStr`. `alpine:3.20` and `/var/lib/rootfs.ext4` keep their exact bytes.

The pre-existing `a_persisted_machine_spec_without_grants_still_loads` doubles as the compatibility witness: `{"image":"nginx"}` still loads and still round-trips byte-identically.

## `Flake` in a boot declaration

The issue asked whether `Flake` belongs here or whether the boot path should name a narrower enum. Kept in the one type: the grammar gained `flake:<ref>#<attr>` (nix's own spelling), which makes `FromStr`/`Display` **total** — no variant is unwritable, so serialization can never fail — and leaves the refusal with the backend, where it is a capability limit (the in-process backend cannot build a flake) rather than a malformed declaration. A second enum would have duplicated the grammar and pre-empted a backend that later can.

## Red proofs

Two neuters, each restoring one alternative under the shipped signatures.

**A — the pre-typing behaviour** (`from_str` accepts every byte string verbatim, which is what `image: String` did):

```
     Summary [   0.024s] 3 tests run: 0 passed, 3 failed, 1872 skipped
        FAIL (1/3) mvm-core client::dto::tests::a_declaration_is_stored_as_the_value_it_names_not_the_bytes_that_carried_it
        FAIL (2/3) mvm-core client::dto::tests::a_declaration_that_names_nothing_is_refused_at_deserialization
        FAIL (3/3) mvm-core client::dto::tests::a_declaration_that_names_nothing_is_refused_at_construction
```

Construction accepted a declaration naming nothing — asserting on the *typed* outcome, not that "an error occurred":

```
thread 'client::dto::tests::a_declaration_that_names_nothing_is_refused_at_construction' panicked at crates/mvm-core/src/client/dto.rs:590:45:
called `Result::unwrap_err()` on an `Ok` value: MachineSpecBuilder { name: "web", image: Oci { image_ref: "" }, cpus: 1, memory_mib: 512, env: [], grants: Grants { cpu: None, wall_clock: None, egress: None } }
```

...and so did the wire, which is where the caller is not a Rust one:

```
thread 'client::dto::tests::a_declaration_that_names_nothing_is_refused_at_deserialization' panicked at crates/mvm-core/src/client/dto.rs:619:18:
a declaration naming nothing must not deserialize: MachineSpec { name: "web", image: Oci { image_ref: "" }, cpus: 1, memory_mib: 512, env: [], grants: None }
```

A pasted value kept its bytes rather than becoming the value it named:

```
thread 'client::dto::tests::a_declaration_is_stored_as_the_value_it_names_not_the_bytes_that_carried_it' panicked at crates/mvm-core/src/client/dto.rs:636:9:
assertion `left == right` failed
  left: Oci { image_ref: "  alpine:3.20\n" }
 right: Oci { image_ref: "alpine:3.20" }
```

**B — the tagged-enum serde form**, the alternative the issue asked to be weighed (`#[serde(rename_all = "snake_case")]` in place of `into`/`try_from`):

```
     Summary [   0.027s] 3 tests run: 0 passed, 3 failed, 1872 skipped
        FAIL (1/3) mvm-core client::dto::tests::a_persisted_machine_spec_without_grants_still_loads
        FAIL (2/3) mvm-core client::dto::tests::a_local_path_declaration_survives_the_wire_as_a_path
        FAIL (3/3) mvm-core rootfs_source::rootfs_source_parse_tests::serde_uses_the_string_form_and_rejects_a_meaningless_one
```

```
thread 'client::dto::tests::a_persisted_machine_spec_without_grants_still_loads' panicked at crates/mvm-core/src/client/dto.rs:481:62:
legacy spec still loads: Error("unknown variant `nginx`, expected one of `flake`, `local_path`, `oci`", line: 1, column: 29)
```

```
thread 'client::dto::tests::a_local_path_declaration_survives_the_wire_as_a_path' panicked at crates/mvm-core/src/client/dto.rs:655:9:
path lost its plain form: {"name":"web","image":{"local_path":"/var/lib/mvm/rootfs.ext4"},"cpus":1,"memory_mib":512,"env":[]}
```

```
thread 'rootfs_source::rootfs_source_parse_tests::serde_uses_the_string_form_and_rejects_a_meaningless_one' panicked at crates/mvm-core/src/rootfs_source.rs:354:9:
assertion `left == right` failed
  left: "{\"oci\":{\"image_ref\":\"alpine:3.20\"}}"
 right: "\"alpine:3.20\""
```

## Follow-on inside the same seam

`LaunchRequest.image` is typed too, which deletes its `image source must not be empty` runtime check (unrepresentable now) and the redundant re-parse in `resolve_local_rootfs`. `mvm-sdk`'s two `spec.image.is_empty()` guards go the same way. `ensure_spec_bootable_in_process` reconstructs the declaration from the persisted string rather than passing the bytes on unread.

Two existing tests changed shape rather than meaning: `empty_image_and_invalid_name_are_refused` split (the empty-image half is now a parse assertion, since the request cannot express one), and `run_args_rejects_empty_name_and_image` / `create_args_reject_empty_name_and_image` lost their image halves for the same reason.

## Not done

`RootfsSource::Oci` still carries a `String` rather than the `ImageReference` the plan resolves it to downstream. That would change the build spec's serialized form and touch the nix builder — a separate change.

## Verification

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 11877 passed, 0 failed
- `cargo test --workspace --doc` — clean
- `just check-gated` (`cargo-zigbuild check --target x86_64-unknown-linux-gnu --workspace --all-targets` + `cargo check -p mvm-conformance --all-targets --features bdd`) — clean
- `cargo check --workspace --all-targets --all-features` — clean (this is what catches the `client-facade` and `test-support` gated files)
- `cargo build -p mvm-contract --target wasm32-unknown-unknown --lib` — clean (unchanged by this PR, verified anyway)
- Every `xtask check-*` the Lint job runs — clean, except `check-adr-coverage`, which fails identically on `origin/main` and is already being fixed by #2583.

Closes #2553
