### PR TITLE
fix(sec): count the security jobs that never finished, and let the fuzz lane finish

### DIFF
--- a/.github/workflows/security-lane-watch.yml
+++ b/.github/workflows/security-lane-watch.yml
@@ -57,16 +57,36 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_EVENT: ${{ github.event.workflow_run.event }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           TITLE: "Security lane is red"
         run: |
           set -euo pipefail
 
+          # A run cancelled as a whole collected no verdict: every job reads
+          # `cancelled` whether it was about to pass or about to fail. The
+          # empty failing set below would then be reported as "green again"
+          # and close the tracking issue on evidence nobody gathered.
+          if [ "$RUN_CONCLUSION" = "cancelled" ]; then
+            echo "Security run $RUN_ID was cancelled; no per-job verdict to report."
+            exit 0
+          fi
+
           # Per-job conclusions, not the run's aggregate: a
           # continue-on-error job leaves the run green while reporting its
           # own failure here.
+          #
+          # `cancelled` is in the set deliberately. Actions reports a job
+          # killed by its own `timeout-minutes` as cancelled, not timed_out
+          # — the `timed_out` conclusion is in the schema and does not
+          # arrive in practice. Selecting on failure alone therefore read a
+          # mutation shard that never finished, and a fuzz lane killed at
+          # the six-hour platform cap, as jobs with nothing to say. Both had
+          # been happening nightly; both back numbered claims. The run-level
+          # guard above is what keeps an operator's cancellation out.
           gh api --paginate "repos/$REPO/actions/runs/$RUN_ID/jobs" \
-            --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out")
+            --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out"
+                                   or .conclusion == "cancelled")
                   | "- \(.name) — [log](\(.html_url))"' > failing.md
 
           EXISTING=$(gh issue list --repo "$REPO" --state open \
@@ -90,7 +110,7 @@ jobs:
             # shellcheck disable=SC2016
             printf 'The `Security` workflow (%s) failed on `%s`.\n\n' "$RUN_EVENT" "$HEAD_SHA"
             printf 'Run: %s\n\n' "$RUN_URL"
-            printf 'Failing jobs:\n\n'
+            printf 'Failing or unfinished jobs:\n\n'
             cat failing.md
             printf '\nThese lanes do not run on pull requests, so a failure here is\n'
             printf 'invisible until someone reads run history. Several of them are the\n'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -255,11 +255,29 @@ jobs:
   # ADR-001 §W4.2 + Plan 85 §R1 — cargo-fuzz harnesses for
   # GuestRequest, the authenticated-frame envelope, the libkrun
   # SupervisorConfig parser, and the OCI layer-unpack ingress.
-  # Run for 5 minutes per tag-push / dispatch; the nightly cron
-  # extends to 30 minutes.
+  # Per-target durations are the `FUZZ_SECS_*` budget below, deliberately
+  # not quoted here: they move as targets are added, and a duration named
+  # in two places goes stale in one of them.
   fuzz:
     name: Fuzz — parsers (vsock + OCI)
     runs-on: ubuntu-latest
+    # Under the six-hour platform cap, so a lane that outgrows its budget
+    # is stopped as this job rather than killed as the runner mid-target.
+    timeout-minutes: 300
+    env:
+      # Per-target fuzzing seconds. Literals at job scope rather than inside
+      # the script below because `xtask check-workflow-paths` reads them: it
+      # multiplies them by the number of targets in this job and refuses a
+      # budget that cannot finish inside `timeout-minutes`.
+      #
+      # 1800 was chosen when this lane had four targets. It has seventeen,
+      # and seventeen half-hours do not fit in six. Every nightly run was
+      # stopped partway down the list — most recently after eleven targets —
+      # so the last six, `fuzz_datapath_ingress` among them, had never
+      # executed on a cron run at all. The job's conclusion was `cancelled`,
+      # which the lane watcher did not count, so nothing said so.
+      FUZZ_SECS_SCHEDULE: 720
+      FUZZ_SECS_DISPATCH: 300
     steps:
       - uses: actions/checkout@v6
 
@@ -284,9 +302,9 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           if [ "$EVENT_NAME" = "schedule" ]; then
-            echo "secs=1800" >> "$GITHUB_OUTPUT"
+            echo "secs=$FUZZ_SECS_SCHEDULE" >> "$GITHUB_OUTPUT"
           else
-            echo "secs=300" >> "$GITHUB_OUTPUT"
+            echo "secs=$FUZZ_SECS_DISPATCH" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Fuzz GuestRequest (fuzz_guest_request)
@@ -544,7 +562,10 @@ jobs:
     # This has already earned itself: mvm-hostd/2of2 hit it on 2026-08-16 and
     # was reported as a bounded, attributable stop with its partial output
     # kept, which is what said the split was uneven and by how much. Note
-    # that GitHub records a timeout kill as `cancelled`, not `failure`.
+    # that GitHub records a timeout kill as `cancelled`, not `failure` —
+    # `security-lane-watch.yml` counts `cancelled` for that reason, and
+    # before it did, a shard that never finished was the one kind of red
+    # this whole lane could not report.
     timeout-minutes: 330
     # BLOCKING, and sharded per package.
     #

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1073,13 +1073,18 @@ updates only its own entry below.
       halfway. Fixed independently and first in #1958, which corrected the
       fourteen `working-directory` values in place; this branch's matrix
       rebuild was dropped in favour of it.
-      **Residual:** the targets remain sequential steps in one job at the
-      nightly `secs=1800` budget, and the job sets no `timeout-minutes`, so
-      14 x 1800s is 7 hours of fuzzing against GitHub's 6-hour default
-      ceiling — before per-target sanitizer builds. The lane should be
-      expected to time out rather than pass, and a matrix (one cell per
-      target, `fail-fast: false`) is the shape that both fits the ceiling
-      and stops one stale entry skipping every target after it.
+      **Residual, since closed:** the targets remain sequential steps in
+      one job, but the nightly budget was `secs=1800` with no
+      `timeout-minutes`, so 14 x 1800s was 7 hours of fuzzing against
+      GitHub's 6-hour ceiling — before per-target sanitizer builds. That is
+      exactly what happened: by 2026-08-16 the lane had grown to seventeen
+      targets and every cron run was killed partway down the list. The
+      budget is now 720s per target under `timeout-minutes: 300`, and
+      `xtask check-workflow-paths` multiplies the two so target eighteen
+      fails a PR rather than silently pushing the lane back over the
+      ceiling. A matrix (one cell per target, `fail-fast: false`) remains
+      the shape that would also stop one stale entry skipping every target
+      after it.
 
       **MVM-SEC-07's two witnesses failed for unrelated reasons.**
       `cargo-audit`: `quick-xml 0.37.5` carried RUSTSEC-2026-0194/0195 (both

--- a/specs/VERIFICATION.md
+++ b/specs/VERIFICATION.md
@@ -157,8 +157,16 @@ totals, or a bare entry alongside sharded ones all fail, because each
 leaves files nothing mutates while every remaining shard stays green.
 
 The job also carries `timeout-minutes: 330`, under the cap, so a shard
-that outgrows its budget fails as itself rather than as infrastructure,
+that outgrows its budget is stopped as this job rather than as the runner,
 and uploads its partial cargo-mutants output either way.
+
+**A shard stopped that way does not report as failed.** Actions gives a
+job killed by `timeout-minutes` the conclusion `cancelled`, not
+`timed_out`, so `security-lane-watch.yml` counts `cancelled` as failing and
+skips only when the run as a whole was cancelled. Before it did, a shard
+that never finished contributed no failing job — and on a night where it
+was the only casualty, the empty failing set read as green and closed the
+tracking issue.
 
 **The split is by file count, and file count is not cost.** The first run
 of the two-shard split, on 2026-08-16, measured the gap: `1of2` finished

--- a/specs/sprint/delivery/2585-unfinished-security-jobs.md
+++ b/specs/sprint/delivery/2585-unfinished-security-jobs.md
@@ -1,0 +1,109 @@
+# 2585 — a lane that never finishes is not a green lane
+
+## What the issue said, and whether it reproduced
+
+The tracking issue named one failing job on run 31927524890: `Claim
+witnesses — mutation-tested (mvm-vmm)`, four survivors in
+`EgressProxySpawnConfig::from_host_env`. All four were real witness gaps —
+the function had no direct coverage at all — and all four were already
+closed: #2578 landed six behavioural tests four minutes after the watcher
+opened the issue. Verified against `origin/main`:
+
+```
+cargo mutants -p mvm-vmm --file crates/mvm-vmm/src/host/network_endpoint_spawn.rs --re from_host_env
+Found 4 mutants to test
+ok       Unmutated baseline in 26s build + 7s test
+4 mutants tested in 74s: 4 caught
+```
+
+The fifth survivor in that log, `SubstitutionSpawnParams::builder ->
+Default::default()`, is the provably-equivalent one #2540 baselined; still
+correctly tolerated, and it shares an identity with nothing live.
+
+So the named failure needed no fix. The lane was red anyway, for two
+reasons the issue could not name — because the watcher could not see them.
+
+## A job killed by its own timeout reports `cancelled`
+
+`security-lane-watch.yml` selected jobs whose conclusion was `failure` or
+`timed_out`. Actions does not use `timed_out` for a job killed by
+`timeout-minutes`; it reports `cancelled`. Two jobs in that run were in
+exactly that state and appear nowhere in the issue:
+
+| job | ran for | budget |
+|---|---|---|
+| `Claim witnesses — mutation-tested (mvm-hostd/2of2)` | 5h30m26s | `timeout-minutes: 330` |
+| `Fuzz — parsers (vsock + OCI)` | 6h00m16s | none, so the platform cap |
+
+Missing them from a report is the small half. On a night where an
+unfinished shard is the only casualty, the failing set is *empty* — and the
+watcher reads an empty set as green and closes the tracking issue. A run
+cancelled as a whole had the same hole from the other side.
+
+`security.yml` had already written down the intent this defeated: a shard
+under the cap "fails as itself". It does not; it is stopped as itself, and
+reports as cancelled. Both the comment and the watcher now say so.
+
+The shard imbalance that caused the mutation-side timeout was fixed
+independently and first in #2584, which cut `mvm-hostd` four ways off the
+same measurement. That PR noticed the `cancelled` conclusion and recorded
+it; nothing acted on it, which is what this closes.
+
+## The fuzz lane had never finished a cron run
+
+`secs=1800` was chosen when the lane had four targets. It has seventeen.
+Step timings from the run:
+
+```
+34.8 min  success   Fuzz GuestRequest
+  ...               (nine more, all 30-32 min)
+18.6 min  cancelled Fuzz gateway packet parse + rebuild (host-side)
+ 0.0 min  skipped   Fuzz userspace datapath ingress (fuzz_datapath_ingress)
+ 0.0 min  skipped   Fuzz runtime recording (SDK trace)
+ 0.0 min  skipped   Fuzz ext4 build_image (rootfs writer)
+ 0.0 min  skipped   Fuzz FUSE dispatch (virtio-fs request parser)
+ 0.0 min  skipped   Fuzz virtqueue geometry (virtio-vsock ring walk)
+```
+
+`fuzz_datapath_ingress` is named in ADR-001 as a claim-5 witness. It had
+never executed on a nightly. The job reported `cancelled`, so nothing said
+so. `specs/SPRINT.md` predicted this in July — "the lane should be expected
+to time out rather than pass" — and the residual was never closed; it is
+closed here and that note amended in place.
+
+Budget is now 720s per target under `timeout-minutes: 300`: 17 × (720 +
+120s build allowance) = 238 min, 62 minutes of headroom. The build
+allowance is measured — the run's per-step times put a sanitizer build
+between a few seconds and five minutes.
+
+## Keeping the budget honest
+
+A duration set in one place and a target list grown in another is how 4 ×
+30 min became 17 × 30 min without either edit looking wrong. `xtask
+check-workflow-paths` already enumerated the fuzz targets, so it now
+multiplies them by the declared per-target seconds and refuses a product
+that cannot fit. Target eighteen fails a PR rather than silently pushing
+the lane back over its ceiling.
+
+Proof it bites — reverting `FUZZ_SECS_SCHEDULE` to 1800:
+
+```
+Error: check-workflow-paths: 1 fuzz lane(s) cannot finish inside their timeout:
+  security.yml: fuzz job budgets 17 target(s) × (1800s fuzzing + 120s build) = 544 min, past its own timeout-minutes: 300
+```
+
+and the unit witness with it:
+
+```
+thread 'check_workflow_paths::tests::the_fuzz_lane_fits_inside_its_own_timeout' panicked
+17 targets × 1800s + build does not fit in 300 min
+```
+
+Restored: 627 passed, 0 failed in `xtask`.
+
+## What is not fixed
+
+The shape #2578 named is still open: the surface pin protects against a
+*file* leaving mutation coverage, not against new uncovered code arriving
+inside a file already on the surface. That is how `from_host_env` shipped
+unwitnessed, and nothing here changes it.

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -10,9 +10,16 @@
 //!   - `cargo fuzz run [--fuzz-dir <d>] <target>` must resolve to a
 //!     `<working-directory>/<d>/fuzz_targets/<target>.rs`.
 //!
-//! This is a file-existence check, so it is cheap enough for the PR lint
-//! lane — which matters, because the workflows it guards mostly run on
-//! tags and cron, where a break is invisible for days.
+//! It also checks one number, for the same reason: the fuzz lane's
+//! per-target duration multiplied by its target count must fit inside the
+//! job's own timeout. A target is added in one place and the duration is
+//! set in another, so the product grew past six hours without either edit
+//! looking wrong — and the lane was killed partway down the list every
+//! night, with the targets below the cut never running.
+//!
+//! This is a file-existence check plus arithmetic, so it is cheap enough
+//! for the PR lint lane — which matters, because the workflows it guards
+//! mostly run on tags and cron, where a break is invisible for days.
 
 use anyhow::{Context, Result, bail};
 use std::path::Path;
@@ -25,10 +32,43 @@ struct FuzzInvocation {
     target: String,
 }
 
+/// Wall clock one fuzz target costs on top of its own fuzzing time: a
+/// sanitizer build of that crate's fuzz harness.
+///
+/// An allowance, not an average. Measured across a nightly run, the builds
+/// cost between a few seconds and five minutes each, so budgeting the mean
+/// would put the lane over its timeout on the day several slow ones land
+/// together.
+const FUZZ_BUILD_ALLOWANCE_SECS: u64 = 120;
+
+/// What the fuzz job says about how long it may take.
+#[derive(Debug, PartialEq, Eq)]
+struct FuzzBudget {
+    /// Seconds of fuzzing per target on the nightly cron — the longest of
+    /// the lane's two settings, so the one that has to fit.
+    per_target_secs: u64,
+    /// The job's own `timeout-minutes`.
+    timeout_minutes: u64,
+    /// How many targets the job runs.
+    targets: usize,
+}
+
+impl FuzzBudget {
+    /// Wall clock the declared budget implies, in seconds.
+    fn projected_secs(&self) -> u64 {
+        self.targets as u64 * (self.per_target_secs + FUZZ_BUILD_ALLOWANCE_SECS)
+    }
+
+    fn fits(&self) -> bool {
+        self.projected_secs() <= self.timeout_minutes * 60
+    }
+}
+
 pub fn run(workspace: &Path) -> Result<()> {
     let workflows = workflow_files(workspace)?;
     let members = workspace_package_names(workspace)?;
     let mut problems = Vec::new();
+    let mut budgets = Vec::new();
     let mut checked_dirs = 0usize;
     let mut checked_targets = 0usize;
     let mut checked_packages = 0usize;
@@ -79,6 +119,10 @@ pub fn run(workspace: &Path) -> Result<()> {
                 ));
             }
         }
+
+        if let Some(budget) = fuzz_budget(&src) {
+            budgets.push((name.clone(), budget));
+        }
     }
 
     if !problems.is_empty() {
@@ -89,6 +133,32 @@ pub fn run(workspace: &Path) -> Result<()> {
              that moves or renames the directory.",
             problems.len(),
             problems.join("\n  ")
+        );
+    }
+
+    let overrun: Vec<&(String, FuzzBudget)> = budgets.iter().filter(|(_, b)| !b.fits()).collect();
+    if !overrun.is_empty() {
+        let detail: Vec<String> = overrun
+            .iter()
+            .map(|(name, b)| {
+                format!(
+                    "{name}: fuzz job budgets {} target(s) × ({}s fuzzing + {FUZZ_BUILD_ALLOWANCE_SECS}s build) \
+                     = {} min, past its own timeout-minutes: {}",
+                    b.targets,
+                    b.per_target_secs,
+                    b.projected_secs() / 60,
+                    b.timeout_minutes
+                )
+            })
+            .collect();
+        bail!(
+            "check-workflow-paths: {} fuzz lane(s) cannot finish inside their timeout:\n  {}\n\n\
+             The job is killed partway down the target list, and every target below \
+             the cut never runs — including ones that witness a numbered claim. \
+             Lower the per-target seconds, or raise the timeout if it still fits \
+             under the six-hour platform cap.",
+            overrun.len(),
+            detail.join("\n  ")
         );
     }
 
@@ -240,6 +310,57 @@ fn workflow_files(root: &Path) -> Result<Vec<std::path::PathBuf>> {
     Ok(out)
 }
 
+/// The body of one top-level job, by name.
+///
+/// Text-scanned rather than parsed as YAML for the same reason the rest of
+/// this gate is: it has to stay a dependency-free file read that the PR
+/// lint lane can afford. Jobs sit at two-space indent, so the block ends
+/// at the next line with exactly that shape.
+fn job_body<'a>(src: &'a str, job: &str) -> Option<&'a str> {
+    let header = format!("\n  {job}:\n");
+    let start = src.find(&header)? + header.len();
+    let rest = &src[start..];
+    let end = rest
+        .lines()
+        .scan(0usize, |offset, line| {
+            let at = *offset;
+            *offset += line.len() + 1;
+            Some((at, line))
+        })
+        .find(|(_, line)| {
+            line.starts_with("  ")
+                && !line.starts_with("   ")
+                && !line.trim_start().starts_with('#')
+                && line.trim_end().ends_with(':')
+        })
+        .map_or(rest.len(), |(at, _)| at);
+    Some(&rest[..end])
+}
+
+/// A `key: <integer>` at any indent inside a block.
+fn scalar_u64(block: &str, key: &str) -> Option<u64> {
+    block.lines().find_map(|line| {
+        line.trim()
+            .strip_prefix(key)?
+            .strip_prefix(':')?
+            .split('#')
+            .next()?
+            .trim()
+            .parse()
+            .ok()
+    })
+}
+
+/// The fuzz job's declared budget, if the workflow has one.
+fn fuzz_budget(src: &str) -> Option<FuzzBudget> {
+    let block = job_body(src, "fuzz")?;
+    Some(FuzzBudget {
+        per_target_secs: scalar_u64(block, "FUZZ_SECS_SCHEDULE")?,
+        timeout_minutes: scalar_u64(block, "timeout-minutes")?,
+        targets: fuzz_invocations(block).len(),
+    })
+}
+
 /// Every `working-directory:` value in a workflow, unquoted.
 fn working_directories(src: &str) -> Vec<String> {
     src.lines()
@@ -356,21 +477,10 @@ mod tests {
         .unwrap_or_else(|error| panic!("{name} must be readable: {error}"))
     }
 
+    /// One job's body, panicking rather than returning `None` — the tests
+    /// name jobs that exist, and a rename should say so by name.
     fn job_block<'a>(workflow: &'a str, job: &str) -> &'a str {
-        let marker = format!("  {job}:\n");
-        let start = workflow
-            .find(&marker)
-            .unwrap_or_else(|| panic!("workflow is missing the {job} job"));
-        let rest_start = start + marker.len();
-        let rest = &workflow[rest_start..];
-        let end = rest
-            .match_indices("\n  ")
-            .find_map(|(offset, _)| {
-                let line = rest[offset + 1..].lines().next()?;
-                (!line.starts_with("    ") && line.ends_with(':')).then_some(rest_start + offset)
-            })
-            .unwrap_or(workflow.len());
-        &workflow[start..end]
+        job_body(workflow, job).unwrap_or_else(|| panic!("workflow is missing the {job} job"))
     }
 
     #[test]
@@ -840,6 +950,84 @@ mod tests {
         // GitHub's `${{ }}` or shell `${}` spelling.
         assert!(cargo_package_flags("        run: cargo test -p ${{ matrix.crate }}").is_empty());
         assert!(cargo_package_flags("          cargo publish -p ${CRATE}").is_empty());
+    }
+
+    /// A job's body stops where the next job starts, or the fuzz budget
+    /// would be read out of whatever job happened to follow.
+    #[test]
+    fn a_job_body_stops_at_the_next_job() {
+        let src = "jobs:\n  first:\n    timeout-minutes: 10\n  # a comment: not a job\n    env:\n      X: 1\n  second:\n    timeout-minutes: 99\n";
+        let first = job_body(src, "first").expect("first job");
+        assert!(first.contains("timeout-minutes: 10"));
+        assert!(
+            !first.contains("99"),
+            "the next job's settings leaked into this one: {first:?}"
+        );
+        // A comment at job indent is prose, not a boundary.
+        assert!(first.contains("X: 1"));
+        assert_eq!(job_body(src, "third"), None);
+    }
+
+    #[test]
+    fn a_scalar_is_read_without_its_trailing_comment() {
+        assert_eq!(
+            scalar_u64("    timeout-minutes: 300\n", "timeout-minutes"),
+            Some(300)
+        );
+        assert_eq!(
+            scalar_u64(
+                "      FUZZ_SECS_SCHEDULE: 720 # why\n",
+                "FUZZ_SECS_SCHEDULE"
+            ),
+            Some(720)
+        );
+        assert_eq!(
+            scalar_u64("    timeout-minutes: soon\n", "timeout-minutes"),
+            None
+        );
+        assert_eq!(scalar_u64("    other: 1\n", "timeout-minutes"), None);
+    }
+
+    /// The live assertion. Seventeen targets at half an hour each is nine
+    /// hours in a six-hour job, which is what the nightly lane was actually
+    /// running: killed partway down the list, every target below the cut
+    /// silently never fuzzed.
+    #[test]
+    fn the_fuzz_lane_fits_inside_its_own_timeout() {
+        let budget =
+            fuzz_budget(&workflow("security.yml")).expect("security.yml declares a fuzz budget");
+        assert!(
+            budget.targets >= 15,
+            "the target count did not resolve: {budget:?}"
+        );
+        assert!(
+            budget.fits(),
+            "{} targets × {}s + build does not fit in {} min",
+            budget.targets,
+            budget.per_target_secs,
+            budget.timeout_minutes
+        );
+    }
+
+    /// And it has to be able to say no, or it is decoration.
+    #[test]
+    fn a_lane_that_cannot_finish_is_rejected() {
+        let over = FuzzBudget {
+            per_target_secs: 1800,
+            timeout_minutes: 300,
+            targets: 17,
+        };
+        assert!(!over.fits());
+        // Halving the per-target time is the fix that brings it back.
+        assert!(
+            FuzzBudget {
+                per_target_secs: 720,
+                ..over
+            }
+            .fits()
+        );
+        // So is dropping targets.
+        assert!(FuzzBudget { targets: 4, ..over }.fits());
     }
 
     /// Every `cargo -p` across the real workflow tree resolves today. This is


### PR DESCRIPTION
Closes #2585.

## What the issue named, and whether it reproduces

The tracking issue listed one failing job on run 31927524890: `Claim
witnesses — mutation-tested (mvm-vmm)`, four survivors in
`EgressProxySpawnConfig::from_host_env`. All four were **real witness
gaps**, not equivalences — the function had no direct coverage at all. All
four were also **already fixed**: #2578 landed six behavioural tests four
minutes after the watcher opened the issue.

Verified against `origin/main`:

```
$ cargo mutants -p mvm-vmm --file crates/mvm-vmm/src/host/network_endpoint_spawn.rs --re from_host_env
Found 4 mutants to test
ok       Unmutated baseline in 26s build + 7s test
 INFO Auto-set test timeout to 60s
4 mutants tested in 74s: 4 caught
```

The fifth survivor in that log — `replace SubstitutionSpawnParams::builder
-> SubstitutionSpawnParamsBuilder with Default::default()` — is the
provably-equivalent one #2540 baselined. Still correctly tolerated, and its
identity is shared with nothing live.

So the named failure needed no fix. **The lane was red anyway, for two
reasons the issue could not name** — because the watcher could not see
them. One of the two, the `mvm-hostd` shard imbalance, was fixed
independently and first in #2584 while this was in flight; that PR is
already on main and this no longer touches the shard matrix.

## 1. A job killed by its own timeout reports `cancelled`

`security-lane-watch.yml` selected `failure` or `timed_out`. Actions does
not use `timed_out` for a job killed by `timeout-minutes`; it reports
`cancelled`. Two jobs in that same run were in exactly that state and
appear nowhere in the issue:

| job | ran for | budget |
|---|---|---|
| `Claim witnesses — mutation-tested (mvm-hostd/2of2)` | 5h30m26s | `timeout-minutes: 330` |
| `Fuzz — parsers (vsock + OCI)` | 6h00m16s | none, so the platform cap |

Missing them from a report is the small half. On a night where an
unfinished shard is the only casualty, the failing set is **empty** — and
the watcher reads an empty set as green and **closes** the tracking issue.
A run cancelled as a whole had the same hole from the other side.

Both are handled: `cancelled` counts as failing, and a run whose own
conclusion is `cancelled` returns without a verdict instead of closing
anything.

#2584 spotted the `cancelled` conclusion and wrote it down in the workflow
comment; nothing acted on it. This acts on it.

## 2. The fuzz lane has never finished a cron run

`secs=1800` was chosen when the lane had four targets. It has seventeen.
Step timings from the run:

```
34.8 min  success   Fuzz GuestRequest
  ...               (nine more, all 30-32 min)
18.6 min  cancelled Fuzz gateway packet parse + rebuild (host-side)
 0.0 min  skipped   Fuzz userspace datapath ingress (fuzz_datapath_ingress)
 0.0 min  skipped   Fuzz runtime recording (SDK trace)
 0.0 min  skipped   Fuzz ext4 build_image (rootfs writer)
 0.0 min  skipped   Fuzz FUSE dispatch (virtio-fs request parser)
 0.0 min  skipped   Fuzz virtqueue geometry (virtio-vsock ring walk)
```

`fuzz_datapath_ingress` is named in ADR-001 as a claim-5 witness. It has
never executed on a nightly. The job's conclusion was `cancelled`, so
nothing said so. `specs/SPRINT.md` predicted exactly this in July ("the
lane should be expected to time out rather than pass") and the residual was
never closed; it is closed here and that note amended in place.

Budget is now 720s per target under `timeout-minutes: 300` — 17 × (720 +
120s build allowance) = 238 min, 62 min of headroom. The allowance is
measured, not guessed: the run's step times put a sanitizer build between a
few seconds and five minutes.

## Keeping the budget honest

A duration set in one place and a target list grown in another is how 4 ×
30 min became 17 × 30 min without either edit looking wrong.
`check-workflow-paths` already enumerated the fuzz targets, so it now
multiplies them by the declared per-target seconds and refuses a product
that cannot fit. Target eighteen fails a PR rather than silently pushing
the lane back over its ceiling.

**Red proof.** Reverting `FUZZ_SECS_SCHEDULE` to its previous `1800`:

```
Error: check-workflow-paths: 1 fuzz lane(s) cannot finish inside their timeout:
  security.yml: fuzz job budgets 17 target(s) × (1800s fuzzing + 120s build) = 544 min, past its own timeout-minutes: 300

The job is killed partway down the target list, and every target below the cut never runs — including ones that witness a numbered claim. Lower the per-target seconds, or raise the timeout if it still fits under the six-hour platform cap.
```

and the unit witness with it:

```
thread 'check_workflow_paths::tests::the_fuzz_lane_fits_inside_its_own_timeout' panicked at xtask/src/check_workflow_paths.rs:1003:9:
17 targets × 1800s + build does not fit in 300 min

Summary [0.023s] 1 test run: 0 passed, 1 failed, 627 skipped
```

Restored to 720:

```
check-workflow-paths: clean (26 working-directory, 17 fuzz target(s), 131 cargo -p package(s) across 23 workflow file(s))
Summary [3.689s] 628 tests run: 628 passed, 0 skipped
```

The two duplicated `job_block` scanners — one in the gate, one in its tests
— are now one function; the test helper is a panicking wrapper over it.

## Verification

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run -p xtask` — 628 passed, 0 failed; `-p mvm-vmm` 1165 passed pre-rebase
- `actionlint .github/workflows/*.yml` — clean
- `check-workflow-paths`, `check-mutation-witnesses`, `check-sprint-append`, `check-honesty`, `check-no-overclaim`, `check-doc-claims`, `check-witness-citations`, `check-claim-catalog`, `check-no-spec-refs-in-comments`, `check-plan-names`, `check-declared-backing`, `check-adr-coverage` — all clean

## Not fixed

The shape #2578 named is still open: the surface pin protects against a
*file* leaving mutation coverage, not against new uncovered code arriving
inside a file already on the surface. That is how `from_host_env` shipped
unwitnessed, and nothing here changes it.
