### PR TITLE
fix(sdk-ts): bound the machine subprocess, and name what actually failed

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -54,3 +54,10 @@ jobs:
 
       - name: Run BDD conformance suite
         run: just bdd
+
+      # The Python and TypeScript SDKs each carry a unit suite that no cargo
+      # target reaches, so until now nothing in CI ran either. They belong on
+      # this lane: it is the one already scoped to `crates/mvm-sdk/`, and it
+      # already installs uv, Node and the TypeScript dependencies.
+      - name: Run the language SDK unit suites
+        run: just sdk-test

--- a/Justfile
+++ b/Justfile
@@ -163,6 +163,20 @@ sdk-install-typescript:
 sdk-build-typescript:
     npm --prefix crates/mvm-sdk/sdks/typescript run build
 
+# Run the language SDKs' own unit suites. Neither is a cargo target, so
+# `cargo nextest run --workspace` does not touch them and a Rust-only gate
+# leaves the hand-written half of each SDK — the subprocess wrappers, the
+# argv builders, the refusal paths — unproven.
+sdk-test: sdk-test-python sdk-test-typescript
+
+# `--extra schema` installs pydantic; without it the eight
+# `derive_schema` tests fail on an ImportError rather than being skipped.
+sdk-test-python:
+    uv run --directory crates/mvm-sdk/sdks/python --group dev --extra schema pytest -q
+
+sdk-test-typescript: sdk-install-typescript
+    npm --prefix crates/mvm-sdk/sdks/typescript run test
+
 # ── Testing (nextest) ────────────────────────────────────────────────────
 # Run all tests, keeping the full output at target/nextest/last-run.log.
 #

--- a/crates/mvm-sdk/sdks/python/mvm/_env/vars.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_env/vars.py
@@ -13,13 +13,13 @@ MVM_SDK_MODE_ENV = "MVM_SDK_MODE"
 MVM_SDK_OUT_PATH_ENV = "MVM_SDK_OUT_PATH"
 
 #: Overrides the per-call timeout, in seconds, applied to a `mvmctl
-#: machine` subprocess. Python-only: the TypeScript machine wrapper
-#: does not yet bound its subprocess at all.
+#: machine` subprocess. Both language wrappers read it and give up at
+#: the deadline rather than waiting forever.
 MVM_MACHINE_TIMEOUT_ENV = "MVM_MACHINE_TIMEOUT_SEC"
 
 #: Overrides the cap, in bytes, on captured output from a `mvmctl
-#: machine` subprocess. Python-only, for the same reason as the
-#: timeout above.
+#: machine` subprocess. Both language wrappers read it and report an
+#: overflow as an overflow.
 MVM_MACHINE_MAX_OUTPUT_ENV = "MVM_MACHINE_MAX_OUTPUT_BYTES"
 
 __all__ = [

--- a/crates/mvm-sdk/sdks/typescript/src/_env/read.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/_env/read.ts
@@ -1,0 +1,34 @@
+/**
+ * Numeric environment-variable readers.
+ *
+ * The *names* live in the generated `vars.ts`; this is how a value is read
+ * off one. The behaviour deliberately mirrors the Python SDK's `env_float` /
+ * `env_int`: absent, empty, or unparseable all fall back to the default,
+ * silently. Two SDKs that read the same variable and disagree about what a
+ * malformed value means is the kind of divergence the shared registry exists
+ * to prevent, so this matches Python rather than improving on it.
+ */
+
+function raw(name: string): string | undefined {
+  if (typeof process === "undefined") return undefined;
+  const value = process.env[name];
+  return value === undefined || value === "" ? undefined : value;
+}
+
+/** Read `name` as a float, falling back to `fallback`. */
+export function envFloat(name: string, fallback: number): number {
+  const value = raw(name);
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/** Read `name` as an integer, falling back to `fallback`. */
+export function envInt(name: string, fallback: number): number {
+  const value = raw(name);
+  if (value === undefined) return fallback;
+  // `Number` accepts "1.5" where Python's `int()` raises; truncating keeps a
+  // fractional byte count from silently becoming a non-integer `maxBuffer`.
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : fallback;
+}

--- a/crates/mvm-sdk/sdks/typescript/src/_env/vars.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/_env/vars.ts
@@ -15,3 +15,17 @@ export const MVM_SDK_MODE_ENV = "MVM_SDK_MODE";
  * path on exit, so a caller need not parse stdout.
  */
 export const MVM_SDK_OUT_PATH_ENV = "MVM_SDK_OUT_PATH";
+
+/**
+ * Overrides the per-call timeout, in seconds, applied to a `mvmctl
+ * machine` subprocess. Both language wrappers read it and give up at
+ * the deadline rather than waiting forever.
+ */
+export const MVM_MACHINE_TIMEOUT_ENV = "MVM_MACHINE_TIMEOUT_SEC";
+
+/**
+ * Overrides the cap, in bytes, on captured output from a `mvmctl
+ * machine` subprocess. Both language wrappers read it and report an
+ * overflow as an overflow.
+ */
+export const MVM_MACHINE_MAX_OUTPUT_ENV = "MVM_MACHINE_MAX_OUTPUT_BYTES";

--- a/crates/mvm-sdk/sdks/typescript/src/_machine.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/_machine.ts
@@ -7,12 +7,40 @@
  */
 
 import { cliResolutionHint, resolveCliBin } from "./_cli.js";
+import { envFloat, envInt } from "./_env/read.js";
+
+// Owned by the Rust registry (crates/mvm-sdk/src/env.rs), generated into
+// `_env/vars.ts`. Re-exported from this module so importers reach them where
+// the Python SDK puts them too.
+export { MVM_MACHINE_MAX_OUTPUT_ENV, MVM_MACHINE_TIMEOUT_ENV } from "./_env/vars.js";
+import { MVM_MACHINE_MAX_OUTPUT_ENV, MVM_MACHINE_TIMEOUT_ENV } from "./_env/vars.js";
 
 // This package is ESM ("type": "module"), so `require` does not exist at
 // runtime. These node builtins are imported statically; a lazy `require` here
 // throws `ReferenceError: require is not defined` for every consumer of the
 // built artifact.
 import * as child from "node:child_process";
+
+/** Wall-clock budget for one `mvmctl machine` call, in seconds. */
+const DEFAULT_MACHINE_TIMEOUT_SEC = 60;
+
+/** Cap on captured output, per stream, in bytes. */
+const DEFAULT_MACHINE_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+
+function machineTimeoutMs(): number {
+  const seconds = envFloat(MVM_MACHINE_TIMEOUT_ENV, DEFAULT_MACHINE_TIMEOUT_SEC);
+  const ms = Math.round(seconds * 1000);
+  // `spawnSync` treats 0 (and anything non-positive) as "no timeout", which
+  // inverts the meaning of a zero budget from "give up at once" — what the
+  // Python SDK does with the same value — into the unbounded wait this bound
+  // exists to remove. Floor it instead.
+  return Number.isFinite(ms) && ms > 0 ? ms : 1;
+}
+
+function machineMaxOutputBytes(): number {
+  const bytes = envInt(MVM_MACHINE_MAX_OUTPUT_ENV, DEFAULT_MACHINE_MAX_OUTPUT_BYTES);
+  return bytes > 0 ? bytes : DEFAULT_MACHINE_MAX_OUTPUT_BYTES;
+}
 
 export interface MachineResult {
   exitCode: number;
@@ -145,22 +173,52 @@ function runMachine(argv: string[]): MachineResult {
     throw new MachineError(String(err instanceof Error ? err.message : err));
   }
   const full = [bin, "machine", ...argv];
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const timeoutMs = machineTimeoutMs();
+  const maxBuffer = machineMaxOutputBytes();
   let result;
   try {
-    result = child.spawnSync(bin, ["machine", ...argv], { encoding: "utf-8" });
+    // The substrate may hang or return gigabytes. Bounding both here is what
+    // keeps a misbehaving machine from taking the caller down with it; the
+    // Python SDK bounds the same two things with the same two variables.
+    // Unlike Python's `run_capped`, `spawnSync` signals only the child, not
+    // its process group, so a grandchild that outlives the kill can still hold
+    // the pipes — the wait is bounded either way, the reap is best-effort.
+    result = child.spawnSync(bin, ["machine", ...argv], {
+      encoding: "utf-8",
+      timeout: timeoutMs,
+      maxBuffer,
+    });
   } catch (err) {
     throw new MachineError(`\`${bin}\` not found on disk; ${cliResolutionHint()}: ${String(err)}`, {
       argv: full,
     });
   }
   if (result.error) {
+    // `spawnSync` reports "could not start it", "it ran too long" and "it said
+    // too much" through the same field. Reading all three as a spawn failure
+    // sends the reader to look for a missing binary when the binary ran fine.
+    const code = (result.error as NodeJS.ErrnoException).code;
+    if (code === "ETIMEDOUT") {
+      throw new MachineError(`\`${bin}\` did not exit within ${timeoutMs / 1000}s`, { argv: full });
+    }
+    if (code === "ENOBUFS") {
+      // Node does not say which stream overflowed, so — unlike Python, which
+      // caps each one itself and names it — this names the cap, not the side.
+      throw new MachineError(`\`${bin}\` exceeded ${maxBuffer} bytes on stdout or stderr`, {
+        argv: full,
+      });
+    }
     throw new MachineError(`failed to spawn \`${bin}\`: ${result.error.message}`, {
       argv: full,
     });
   }
   if (result.status !== 0) {
-    throw new MachineError(`\`mvmctl machine\` failed with exit code ${result.status}`, {
+    // A signalled child has no exit code, and "exit code null" names nothing.
+    const cause =
+      result.status === null && result.signal
+        ? `was killed by ${result.signal}`
+        : `failed with exit code ${result.status}`;
+    throw new MachineError(`\`mvmctl machine\` ${cause}`, {
       argv: full,
       exitCode: result.status,
       stderr: result.stderr ?? "",

--- a/crates/mvm-sdk/sdks/typescript/src/index.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/index.ts
@@ -93,7 +93,12 @@ export type {
 
 // Machine-oriented host SDK wrappers. These shell to `mvmctl machine ...` so
 // admission/audit/policy stay in the CLI path.
-export { Machine, MachineError } from "./_machine.js";
+export {
+  MVM_MACHINE_MAX_OUTPUT_ENV,
+  MVM_MACHINE_TIMEOUT_ENV,
+  Machine,
+  MachineError,
+} from "./_machine.js";
 export type {
   MachineCheckArtifactOptions,
   MachineCreateOptions,

--- a/crates/mvm-sdk/sdks/typescript/tests/machine.test.ts
+++ b/crates/mvm-sdk/sdks/typescript/tests/machine.test.ts
@@ -327,3 +327,61 @@ describe("Machine persistent lifecycle", () => {
     );
   });
 });
+
+// A `mvmctl` that misbehaves in the two ways the wrapper has to survive:
+// it can hang, and it can talk more than the caller can hold.
+function writeMisbehavingMvmctl(opts: { sleepSeconds?: number; stdoutKib?: number }): string {
+  const script = path.join(tmpDir, "slow-mvmctl");
+  fs.writeFileSync(
+    script,
+    `#!/usr/bin/env bash
+set -u
+${opts.stdoutKib ? `dd if=/dev/zero bs=1024 count=${opts.stdoutKib} 2>/dev/null | tr '\\0' 'A'` : ""}
+${opts.sleepSeconds ? `sleep ${opts.sleepSeconds}` : ""}
+exit 0
+`,
+    { mode: 0o755 },
+  );
+  return script;
+}
+
+describe("Machine subprocess bounds", () => {
+  afterEach(() => {
+    delete process.env[mvm.MVM_MACHINE_TIMEOUT_ENV];
+    delete process.env[mvm.MVM_MACHINE_MAX_OUTPUT_ENV];
+  });
+
+  it("stops waiting at the configured timeout and says so", () => {
+    process.env.MVM_CLI_BIN = writeMisbehavingMvmctl({ sleepSeconds: 3 });
+    process.env[mvm.MVM_MACHINE_TIMEOUT_ENV] = "0.3";
+
+    // Naming the cause is the whole point: an unbounded wait that eventually
+    // returns, or a timeout reported as a spawn failure, both send the reader
+    // to the wrong place.
+    expect(() => mvm.Machine.ls()).toThrow(/did not exit within 0\.3s/);
+  });
+
+  it("reports an output overflow as an overflow, not a spawn failure", () => {
+    process.env.MVM_CLI_BIN = writeMisbehavingMvmctl({ stdoutKib: 2048 });
+    process.env[mvm.MVM_MACHINE_MAX_OUTPUT_ENV] = "1024";
+
+    let caught: unknown;
+    try {
+      mvm.Machine.ls();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(mvm.MachineError);
+    const message = (caught as Error).message;
+    expect(message).toMatch(/exceeded 1024 bytes/);
+    // The bug this pins: `spawnSync` reports the overflow through
+    // `result.error`, and treating any `result.error` as "could not start the
+    // process" blames the machine for something the machine did fine.
+    expect(message).not.toMatch(/failed to spawn/);
+  });
+
+  it("honours the defaults when the env vars are absent", () => {
+    process.env.MVM_CLI_BIN = writeFixtureMvmctl(0, "ok\n");
+    expect(mvm.Machine.run({ image: "alpine", command: ["true"] }).stdout).toBe("ok\n");
+  });
+});

--- a/crates/mvm-sdk/src/env.rs
+++ b/crates/mvm-sdk/src/env.rs
@@ -103,14 +103,14 @@ sdk_env_vars! {
     MVM_SDK_OUT_PATH_ENV = "MVM_SDK_OUT_PATH", [Rust, Python, TypeScript];
 
     /// Overrides the per-call timeout, in seconds, applied to a
-    /// `mvmctl machine` subprocess. Python-only: the TypeScript machine
-    /// wrapper does not yet bound its subprocess at all.
-    MVM_MACHINE_TIMEOUT_ENV = "MVM_MACHINE_TIMEOUT_SEC", [Rust, Python];
+    /// `mvmctl machine` subprocess. Both language wrappers read it and
+    /// give up at the deadline rather than waiting forever.
+    MVM_MACHINE_TIMEOUT_ENV = "MVM_MACHINE_TIMEOUT_SEC", [Rust, Python, TypeScript];
 
     /// Overrides the cap, in bytes, on captured output from a `mvmctl
-    /// machine` subprocess. Python-only, for the same reason as the
-    /// timeout above.
-    MVM_MACHINE_MAX_OUTPUT_ENV = "MVM_MACHINE_MAX_OUTPUT_BYTES", [Rust, Python];
+    /// machine` subprocess. Both language wrappers read it and report an
+    /// overflow as an overflow.
+    MVM_MACHINE_MAX_OUTPUT_ENV = "MVM_MACHINE_MAX_OUTPUT_BYTES", [Rust, Python, TypeScript];
 }
 
 /// The registry rows that `surface` exports, in declaration order.
@@ -167,15 +167,17 @@ mod tests {
     }
 
     #[test]
-    fn machine_vars_are_not_claimed_for_typescript() {
-        // Pins the honesty property: the TypeScript machine wrapper does
-        // not read these, so it must not export them. If TypeScript
-        // later honours them, this test is the place that says so.
+    fn machine_vars_are_claimed_for_typescript() {
+        // The honesty property, now pointing the other way: the TypeScript
+        // machine wrapper bounds its subprocess with these two, so it must
+        // export them. A row is listed for a surface only when that surface
+        // reads it — so this fails if the behaviour is ever removed and the
+        // claim is left behind.
         for ident in ["MVM_MACHINE_TIMEOUT_ENV", "MVM_MACHINE_MAX_OUTPUT_ENV"] {
             let v = REGISTRY.iter().find(|v| v.ident == ident).unwrap();
             assert!(
-                !v.exports_to(Surface::TypeScript),
-                "{ident} claims a TypeScript export that does not exist"
+                v.exports_to(Surface::TypeScript),
+                "{ident} is read by the TypeScript machine wrapper but not exported to it"
             );
         }
     }
@@ -188,7 +190,9 @@ mod tests {
             [
                 "MVM_CLI_BIN_ENV",
                 "MVM_SDK_MODE_ENV",
-                "MVM_SDK_OUT_PATH_ENV"
+                "MVM_SDK_OUT_PATH_ENV",
+                "MVM_MACHINE_TIMEOUT_ENV",
+                "MVM_MACHINE_MAX_OUTPUT_ENV"
             ]
         );
         assert_eq!(exported_to(Surface::Python).count(), 5);

--- a/features/suites/s27_sdk/fixtures/surface_divergence.json
+++ b/features/suites/s27_sdk/fixtures/surface_divergence.json
@@ -7,11 +7,11 @@
     "",
     "`typescript_only_absent_from_python` is empty and should stay that way:",
     "every name TypeScript exports is now either shared or Rust-owned.",
-    "The two MVM_MACHINE_* names below are a *behaviour* gap, not a naming",
-    "one — the TypeScript machine wrapper does not bound its subprocess at",
-    "all, so it has nothing to read them with. They are deliberately not",
-    "emitted into TypeScript (see crates/mvm-sdk/src/env.rs), because a",
-    "constant nothing reads would clear this list while changing nothing."
+    "The two MVM_MACHINE_* names used to sit below as a *behaviour* gap: the",
+    "TypeScript machine wrapper bounded nothing, so it had nothing to read",
+    "them with, and emitting the constants would have cleared this list while",
+    "changing nothing. They left it the only way they could — the wrapper now",
+    "bounds its subprocess and reads both, so the registry exports them."
   ],
   "python_only_type_erased_in_typescript": [
     "ExecResult",
@@ -29,8 +29,6 @@
   ],
   "python_only_absent_from_typescript": [
     "EmittingContextError",
-    "MVM_MACHINE_MAX_OUTPUT_ENV",
-    "MVM_MACHINE_TIMEOUT_ENV",
     "MsgpackUnavailable",
     "MvmTransportError",
     "NoVmIntrospectionError",

--- a/schema/sdk-env-v0.json
+++ b/schema/sdk-env-v0.json
@@ -39,21 +39,23 @@
       ]
     },
     {
-      "doc": "Overrides the per-call timeout, in seconds, applied to a `mvmctl machine` subprocess. Python-only: the TypeScript machine wrapper does not yet bound its subprocess at all.",
+      "doc": "Overrides the per-call timeout, in seconds, applied to a `mvmctl machine` subprocess. Both language wrappers read it and give up at the deadline rather than waiting forever.",
       "ident": "MVM_MACHINE_TIMEOUT_ENV",
       "name": "MVM_MACHINE_TIMEOUT_SEC",
       "surfaces": [
         "rust",
-        "python"
+        "python",
+        "typescript"
       ]
     },
     {
-      "doc": "Overrides the cap, in bytes, on captured output from a `mvmctl machine` subprocess. Python-only, for the same reason as the timeout above.",
+      "doc": "Overrides the cap, in bytes, on captured output from a `mvmctl machine` subprocess. Both language wrappers read it and report an overflow as an overflow.",
       "ident": "MVM_MACHINE_MAX_OUTPUT_ENV",
       "name": "MVM_MACHINE_MAX_OUTPUT_BYTES",
       "surfaces": [
         "rust",
-        "python"
+        "python",
+        "typescript"
       ]
     }
   ],

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-15
+Last updated: 2026-08-16
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -18,16 +18,25 @@ for detailed scope and acceptance criteria.
       extraction is the wrong direction; the manifest is authored
       declaratively and records *constraints*, with `syn` re-scoped to a
       coverage gate plus a golden-IR behavioural gate. Surfaced a live defect
-      (#2559): Rust's `host_port` accepts port `0` where Python rejects it. WS-2 built
+      (#2559): Rust's `host_port` accepts port `0` where Python rejects it —
+      fixed 2026-08-16 by moving the constraint to `mvm_contract::ir::validate`
+      (`dns_resolver` had the wider version of it) behind a shared golden
+      verdict corpus both languages are checked against, which is the first
+      slice of that behavioural gate. WS-2 built
       the pipeline end-to-end on Tier E — a `macro_rules!` registry in
       `mvm-sdk/src/env.rs`, `emit_sdk_env`, and a hand-written xtask emitter
       (necessary: `json-schema-to-typescript` emits only `export type`, which
       `tsc` erases, so a generated constant would be invisible to the s27
       runtime surface check). `MVM_CLI_BIN` was quadruplicated and invisible to
       every gate because all four copies agreed. TypeScript-only divergence is
-      now zero; the two `MVM_MACHINE_*` names are deliberately *not* emitted
-      into TypeScript, since nothing there reads them, and remain recorded as a
-      behaviour gap. Also fixed a ~50% pre-existing flake in the s27
+      now zero; the two `MVM_MACHINE_*` names were deliberately *not* emitted
+      into TypeScript, since nothing there read them, and were recorded as a
+      behaviour gap until #2558 supplied the behaviour — the wrapper now bounds
+      its subprocess with both, so the registry exports them and the divergence
+      file is down to the type-erased set plus the unported names. That work
+      also found that neither SDK's unit suite ran in CI at all (212 pytest,
+      138 vitest, no cargo target and no workflow step); `just sdk-test` on the
+      BDD lane closes it. Also fixed a ~50% pre-existing flake in the s27
       TypeScript live fixture (unawaited `wait()` racing `spawnSync`): base
       9/20, now 30/30. WS-3–WS-5, WS-7, WS-8 open; WS-6 (Tier C) untouched.
 

--- a/specs/plans/337-sdk-surface-generated-from-rust.md
+++ b/specs/plans/337-sdk-surface-generated-from-rust.md
@@ -377,6 +377,24 @@ typed `TransportTimeout` / `TransportOutputOverflow`. Filed as #2558; fixing
 it is a behaviour change to a shipped SDK, not env-name codegen, so it is not
 bundled here.
 
+**Closed 2026-08-16 (#2558).** `_machine.ts` now passes both bounds and
+classifies `result.error` by code — `ETIMEDOUT` as a timeout, `ENOBUFS` as an
+overflow, everything else as the spawn failure it actually is. With the
+behaviour in place the codegen followed mechanically, exactly as this tier
+predicted: both rows gained `TypeScript`, `gen-stubs` emitted the constants, the
+divergence file lost its last two behaviour entries, and
+`machine_vars_are_not_claimed_for_typescript` inverted into
+`machine_vars_are_claimed_for_typescript` — so the honesty property survives and
+now fails if the behaviour is removed and the claim left behind.
+
+That work also surfaced something this plan had not accounted for: **neither
+SDK's unit suite ran in CI at all.** 212 pytest tests and 138 vitest tests are
+not cargo targets, so `cargo nextest run --workspace` never reached them and no
+workflow invoked either runner. Any regression witness written in those suites —
+including every one WS-3 will need for the generated constructors — was
+ungated. `just sdk-test` plus a step on the BDD lane fixes that; WS-3.4's
+two-language fixtures now have somewhere to run.
+
 Note for WS-3: this tier demonstrates the whole manifest→two-languages pipeline
 using `macro_rules!` alone — no proc-macro, no `syn`, no new dependency —
 which is independent evidence for the WS-1 decision to author the manifest

--- a/specs/sprint/delivery/2558-typescript-machine-subprocess-bounds.md
+++ b/specs/sprint/delivery/2558-typescript-machine-subprocess-bounds.md
@@ -1,0 +1,91 @@
+# The TypeScript machine wrapper bounds its subprocess
+
+Delivered 2026-08-16. Closes #2558.
+
+## What was wrong
+
+`_machine.ts` called `child.spawnSync(bin, ["machine", ...argv], { encoding:
+"utf-8" })` with no `timeout` and no `maxBuffer`. Two consequences, one of them
+worse than it looks:
+
+- **Unbounded wait.** Node applies no default timeout. A `mvmctl machine` call
+  that hangs hangs the caller, with no recovery.
+- **A wrong diagnosis, not just a missing feature.** `spawnSync` defaults to a
+  1 MiB `maxBuffer` and reports the overflow through `result.error` with code
+  `ENOBUFS`. The wrapper turned *any* `result.error` into
+  ``failed to spawn `${bin}` ``, so a machine that ran perfectly and simply
+  talked a lot was reported as one that could not be started. That sends the
+  reader to check `MVM_CLI_BIN` and `PATH` for a problem that is neither.
+
+The Python SDK bounded both, through `run_capped`, with typed
+`TransportTimeout` / `TransportOutputOverflow`.
+
+## Why this was known and still open
+
+It was not undetected drift. The env-name registry work deliberately did *not*
+emit `MVM_MACHINE_TIMEOUT_ENV` / `MVM_MACHINE_MAX_OUTPUT_ENV` into TypeScript,
+because nothing there read them: emitting the constants would have cleared the
+last two entries from `surface_divergence.json` while changing no behaviour, and
+the gate would then have certified a parity that did not exist. Each registry
+row names the surfaces that actually *read* it, an s27 step checks that claim in
+both directions, and a unit test pinned this pair as not-TypeScript.
+
+So the mechanism worked. What was missing was the behaviour.
+
+## What changed
+
+**`src/_env/read.ts`** — `envFloat` / `envInt`, mirroring `_subprocess.py`'s
+readers including the part worth stating out loud: absent, empty and
+unparseable all fall back to the default, silently. Matching Python rather than
+improving on it is the point; two SDKs that disagree about what a malformed
+value means is the divergence class this whole registry exists to close.
+
+**`src/_machine.ts`** — passes `timeout` and `maxBuffer` to `spawnSync`, and
+classifies `result.error` instead of flattening it:
+
+- `ETIMEDOUT` → ``did not exit within ${n}s``
+- `ENOBUFS` → ``exceeded ${n} bytes on stdout or stderr``
+- anything else → the existing spawn-failure message, which is now true when it
+  is used
+
+A signalled child (`status === null`, `signal` set) is also named now rather
+than reported as "exit code null".
+
+Two honest differences from Python, both commented at the seam:
+
+- A zero timeout means "no timeout" to `spawnSync` and "give up at once" to
+  Python. Left unhandled, a `MVM_MACHINE_TIMEOUT_SEC=0` would silently restore
+  the unbounded wait this change removes, so the millisecond value is floored
+  at 1.
+- Node does not say which stream overflowed. Python caps each independently and
+  names it; this names the cap, not the side.
+- `spawnSync` signals only the child, not its process group. A grandchild that
+  outlives the kill can still hold the pipes. The wait is bounded either way;
+  the reap is best-effort.
+
+**`crates/mvm-sdk/src/env.rs`** — both rows now list `TypeScript`, and
+`machine_vars_are_not_claimed_for_typescript` is inverted into
+`machine_vars_are_claimed_for_typescript`, so the honesty property still holds
+and now fails if the behaviour is ever removed and the claim left behind.
+`cargo xtask gen-stubs` regenerated `_env/vars.ts` and `schema/sdk-env-v0.json`;
+`surface_divergence.json` drops the two names, and its comment records why they
+were there and how they left.
+
+## The gap this uncovered
+
+Neither SDK's unit suite ran anywhere in CI. `crates/mvm-sdk/sdks/python/tests`
+(212 tests) and `sdks/typescript/tests` (138) are not cargo targets, so
+`cargo nextest run --workspace` never saw them, and no workflow invoked `pytest`
+or `vitest`. A vitest regression for this bug would have been a decoration.
+
+Added `just sdk-test` and a step on the BDD lane, which is already scoped to
+`crates/mvm-sdk/` and already installs uv, Node and the TypeScript dependencies.
+`--extra schema` is passed to pytest so the eight `derive_schema` tests install
+pydantic and run, rather than failing on an ImportError.
+
+## Not done here
+
+The TypeScript wrapper still has no typed error hierarchy — timeout and overflow
+are `MachineError` with distinct messages, which is exactly what Python's
+`_machine.py` surfaces to its own callers after catching the typed transport
+exceptions. A shared taxonomy is Tier D of the generated-surface plan.


### PR DESCRIPTION
## What was wrong

`crates/mvm-sdk/sdks/typescript/src/_machine.ts` called

```ts
child.spawnSync(bin, ["machine", ...argv], { encoding: "utf-8" })
```

with no `timeout` and no `maxBuffer`.

- **Unbounded wait.** Node applies no default timeout. A `mvmctl machine` call
  that hangs hangs the caller, with no recovery.
- **A wrong diagnosis, not just a missing feature.** `spawnSync` defaults to a
  1 MiB `maxBuffer` and reports the overflow through `result.error` with code
  `ENOBUFS`. The wrapper turned *any* `result.error` into
  ``failed to spawn `${bin}` ``, so a machine that ran perfectly and simply
  talked a lot was reported as one that could not be started — sending the
  reader to check `MVM_CLI_BIN` and `PATH` for a problem that is neither.

## This was a known gap, not undetected drift

Worth separating from #2559, which it superficially resembles. The env-name
registry work deliberately did *not* emit `MVM_MACHINE_TIMEOUT_ENV` /
`MVM_MACHINE_MAX_OUTPUT_ENV` into TypeScript, because nothing there read them:
the constants would have cleared the last two entries from
`surface_divergence.json` while changing no behaviour, and the gate would then
have certified a parity that did not exist. A unit test pinned the pair as
not-TypeScript, and the divergence file's comment said why.

The mechanism worked. What was missing was the behaviour — so this PR supplies
it and lets the codegen follow.

## What changed

**`src/_env/read.ts`** (new) — `envFloat` / `envInt` mirroring
`_subprocess.py`'s readers, including the part worth stating out loud: absent,
empty and unparseable all fall back to the default, silently. Matching Python
rather than improving on it is the point; two SDKs disagreeing about what a
malformed value means is the divergence class the registry exists to close.

**`src/_machine.ts`** — passes `timeout` and `maxBuffer`, and classifies
`result.error` instead of flattening it:

| code | message |
| --- | --- |
| `ETIMEDOUT` | `` `<bin>` did not exit within <n>s `` |
| `ENOBUFS` | `` `<bin>` exceeded <n> bytes on stdout or stderr `` |
| anything else | the existing spawn-failure message, now true when used |

A signalled child (`status === null`, `signal` set) is named too, instead of
"exit code null".

Three deliberate differences from Python, each commented at the seam:

- A zero timeout means "no timeout" to `spawnSync` and "give up at once" to
  Python. Unhandled, `MVM_MACHINE_TIMEOUT_SEC=0` would silently restore the
  unbounded wait this PR removes, so the millisecond value is floored at 1.
- Node does not say which stream overflowed. Python caps each independently and
  names it; this names the cap, not the side.
- `spawnSync` signals only the child, not its process group. The wait is
  bounded either way; the reap is best-effort.

**`crates/mvm-sdk/src/env.rs`** — both rows list `TypeScript`, and
`machine_vars_are_not_claimed_for_typescript` is **inverted** into
`machine_vars_are_claimed_for_typescript` rather than deleted, so the honesty
property survives and now fails if the behaviour is removed and the claim left
behind. `cargo xtask gen-stubs` regenerated `_env/vars.ts` and
`schema/sdk-env-v0.json`; `surface_divergence.json` drops the two names and its
comment records how they left.

## The gap this uncovered

**Neither SDK's unit suite ran anywhere in CI.** `sdks/python/tests` (212 tests)
and `sdks/typescript/tests` (138) are not cargo targets, so
`cargo nextest run --workspace` never saw them, and no workflow invoked `pytest`
or `vitest`. A vitest regression for this bug would have been a decoration.

Added `just sdk-test` and a step on the BDD lane — already scoped to
`crates/mvm-sdk/`, already installing uv, Node and the TypeScript dependencies.
`--extra schema` is passed to pytest so the eight `derive_schema` tests install
pydantic and run rather than failing on an ImportError.

## Red proof

The overflow test is written to fail on the *specific* wrong cause rather than
on "an error was returned", which the broken code satisfies. Before the fix,
with 2 MiB of output:

```
 ❯ tests/machine.test.ts  (22 tests | 1 failed)
   × Machine subprocess bounds > reports an output overflow as an overflow, not a spawn failure
     → expected 'failed to spawn `/var/folders/y5/_5yh…' to match /exceeded 1024 bytes/

 FAIL  tests/machine.test.ts > Machine subprocess bounds > reports an output overflow as an overflow, not a spawn failure
AssertionError: expected 'failed to spawn `/var/folders/y5/_5yh…' to match /exceeded 1024 bytes/

- Expected:
/exceeded 1024 bytes/

+ Received:
"failed to spawn `/var/folders/.../slow-mvmctl`: spawnSync /var/folders/.../slow-mvmctl ENOBUFS"
```

That received string is the bug verbatim.

And the timeout, against a `mvmctl` that sleeps 3s with a 0.3s budget:

```
   × Machine subprocess bounds > stops waiting at the configured timeout and says so 3220ms
     → expected [Function] to throw an error
```

After:

```
 ✓ tests/machine.test.ts  (22 tests) 1536ms
   ✓ Machine subprocess bounds > stops waiting at the configured timeout and says so 303ms

 Test Files  1 passed (1)
      Tests  22 passed (22)
```

## Gates

- `cargo +nightly fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 11867 passed, 26 skipped
- `cargo test --workspace --doc` — clean
- `just check-gated` — clean
- `cargo xtask check-stubs` — no drift
- `cargo test -p mvm-conformance --test conformance --features bdd` — 193/194 (1 pre-existing skip); includes the surface-divergence and env-registry-reaches-its-surfaces scenarios
- `just sdk-test` — vitest 138 passed, pytest 212 passed / 7 skipped
- `actionlint .github/workflows/bdd.yml` — clean
- xtask lint gates including `check-workflow-paths` — clean

Closes #2558
