### PR TITLE
feat(release): boot the staged microVM image before publishing it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,6 +600,92 @@ jobs:
           bash nix/packaging/release/assert-init-shebang.sh \
             "staging/default-microvm-rootfs-${ARCH}.ext4" "staged ${ARCH}"
 
+      # Nothing in this job ever started the image. Every gate below the build
+      # is a checksum, a signature or a byte-level read, and none of those can
+      # answer the only question a user asks of a boot image: does it boot. A
+      # release shipped for five weeks whose guest panicked before userspace,
+      # with every checksum verifying clean the whole time.
+      #
+      # x86_64 only: the aarch64 leg runs on ubuntu-24.04-arm, which has no
+      # nested KVM and cannot boot a guest at all. That leg's coverage is the
+      # static /init read above, which catches the defect class that actually
+      # shipped and is a stated compromise rather than a claim of equivalence —
+      # an aarch64-only regression that is not a shebang defect still gets past.
+      - name: Install firecracker for the boot gate
+        if: matrix.arch == 'x86_64'
+        env:
+          # Tracks `crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT`. The
+          # launch path passes `--enable-pci`, which older Firecracker rejects
+          # before it creates its API socket.
+          FC_VERSION: v1.14.1
+        run: |
+          set -euo pipefail
+          curl -fL -o firecracker.tgz \
+            "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-x86_64.tgz"
+          tar -xzf firecracker.tgz
+          sudo install -m 0755 "release-${FC_VERSION}-x86_64/firecracker-${FC_VERSION}-x86_64" /usr/bin/firecracker
+          /usr/bin/firecracker --version
+
+      - name: Grant /dev/kvm access for the boot gate
+        if: matrix.arch == 'x86_64'
+        # ubuntu-latest's /dev/kvm is root:kvm 0660 and the runner user is not
+        # in the kvm group. The runner is ephemeral, so the looser mode is
+        # confined to this job.
+        run: |
+          set -euo pipefail
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm missing on this runner — the boot gate cannot run." >&2
+            exit 1
+          fi
+          sudo chmod 666 /dev/kvm
+          ls -la /dev/kvm
+
+      - name: Boot the staged image before it becomes a release asset
+        if: matrix.arch == 'x86_64'
+        # Boots the artifact in `staging/`, never a published one — the whole
+        # point is to refuse the upload rather than diagnose it afterwards.
+        #
+        # This is not a latency assertion. The budget is an order of magnitude
+        # above the observed median and RUNS/CONCURRENT are 1, because the
+        # question here is "does it reach userspace". Latency belongs to the
+        # `boot-latency` lane, which has its own threshold and its own argument.
+        env:
+          ARCH: ${{ matrix.arch }}
+          MVM_RUNTIME_BOOT_BENCH: "1"
+          MVM_RUNTIME_BOOT_BACKEND: firecracker
+          MVM_RUNTIME_BOOT_KERNEL: staging/default-microvm-vmlinux-x86_64
+          MVM_RUNTIME_BOOT_ROOTFS: staging/default-microvm-rootfs-x86_64.ext4
+          MVM_RUNTIME_BOOT_READY: guest-agent
+          MVM_RUNTIME_BOOT_RUNS: "1"
+          MVM_RUNTIME_BOOT_CONCURRENT: "1"
+          MVM_RUNTIME_BOOT_BUDGET_MS: "60000"
+        run: |
+          set -euo pipefail
+          # The runtime-overlay admission gate reads `mvm-meta.json` from the
+          # rootfs's own directory and refuses to boot without it. The build
+          # stages that sidecar under its arch-qualified asset name, so put a
+          # copy back under the name the gate looks for.
+          cp "staging/default-microvm-meta-${ARCH}.json" staging/mvm-meta.json
+          cargo test --test runtime_boot_bench \
+            prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
+
+      - name: Dump VMM diagnostics on failure
+        if: ${{ failure() && matrix.arch == 'x86_64' }}
+        # Firecracker's stderr goes to `firecracker.log` in the per-VM state dir
+        # and its console to `console.log`; neither reaches the job output.
+        # Without this a refused publish surfaces only as "API socket did not
+        # appear", which is a symptom and never the cause.
+        run: |
+          for d in "$HOME"/.mvm/vms/*/; do
+            echo "===== $d ====="
+            ls -la "$d" || true
+            for f in firecracker.log console.log; do
+              if [ -s "$d$f" ]; then
+                echo "--- $f ---"; tail -50 "$d$f"
+              fi
+            done
+          done
+
       - name: Generate default microVM SBOM
         env:
           ARCH: ${{ matrix.arch }}

--- a/specs/plans/2026-08-15-boot-image-lifecycle.md
+++ b/specs/plans/2026-08-15-boot-image-lifecycle.md
@@ -449,7 +449,7 @@ mechanics on the artifact where a mistake is cheapest to correct.
 
 ## Workstreams
 
-- [ ] WS1 — boot the staged image before publish (x86_64 boot, aarch64 header check)
+- [x] WS1 — boot the staged image before publish (x86_64 boot, aarch64 header check)
 - [ ] WS2 — `boot-image/v*` release train (semver from `v0.1.0`), dual-publish window, `DEFAULT_BOOT_IMAGE_TAG`
 - [ ] WS3 — sidecar provenance fields + `mvmctl image boot status｜check｜update`
 - [ ] WS4 — `MVM_BOOT_IMAGE` escape hatch + doctor readout

--- a/specs/sprint/delivery/ws1-boot-staged-image-before-publish.md
+++ b/specs/sprint/delivery/ws1-boot-staged-image-before-publish.md
@@ -1,0 +1,57 @@
+# WS1 — boot the staged image before publishing it
+
+Every gate in `release.yml`'s `default-microvm` job was a checksum, a signature,
+or a byte-level read. None of them can answer the only question anyone asks of a
+boot image: does it boot. v0.17.0 shipped an image whose guest panicked with
+ENOEXEC before userspace and stayed published for five weeks, with every
+checksum verifying clean the entire time — a faithful copy of a broken image is
+still faithful.
+
+The job now boots the artifact in `staging/` between the build and the upload,
+so a rootfs that cannot reach userspace never becomes a release asset.
+
+## Scope was smaller than the plan
+
+The plan proposed two halves: an x86_64 boot and an aarch64 static `/init`
+header check. The header check **already landed** in the release-verification
+work that followed the ENOEXEC incident — and landed better than proposed, as
+`assert-init-shebang.sh` running on *both* arches, on the staged image before
+upload and again on the published image after download, with a red-first fixture
+case in `verify-release-assets.test.sh`. Only the boot was missing. Duplicating
+the header check would have been a second copy of a gate that already had one.
+
+## What the boot gate is, and is not
+
+It boots the staged bytes on the x86_64 leg only. The aarch64 leg runs on
+`ubuntu-24.04-arm`, which has no nested KVM and cannot boot a guest at all; its
+coverage stays the static `/init` read. That is a stated compromise, not a claim
+of equivalence — an aarch64-only regression that is not a shebang defect still
+gets past.
+
+It is **not** a latency assertion. `MVM_RUNTIME_BOOT_BUDGET_MS` is 60s against an
+observed median near 2s, and `RUNS`/`CONCURRENT` are both 1. The question is
+"does it reach userspace". Latency belongs to the separate `boot-latency` lane,
+which has its own threshold and its own argument, and which one budget cannot
+serve: loose enough to survive shared-runner noise is too loose to catch drift.
+
+Prerequisites (Firecracker at the pinned `FC_VERSION_DEFAULT`, `/dev/kvm` made
+accessible, `mvm-meta.json` placed under the name the admission gate reads) are
+copied from the existing `boot-latency` lane rather than reinvented.
+
+## The ordering is the whole value
+
+These are steps in one job, so a failed boot aborts before the upload — but only
+while it stays above it. Reorder the two and the gate silently becomes a
+post-mortem on an artifact the world already has. So
+`the_staged_microvm_image_is_booted_before_it_is_uploaded` pins three things:
+the step exists, it precedes the upload, and it boots `staging/` rather than a
+published URL. Mutation-tested — deleting the step, moving it below the upload,
+and repointing it at a downloaded artifact each fail it.
+
+## Not done
+
+The `boot-latency` lane is still `workflow_dispatch`-only and pinned to
+`v0.17.0`. #2542 would put it back on every PR but cannot go green: it repins to
+`v0.18.0`, which does not exist, and v0.17.0's own image is the broken one. That
+lane is unblocked by cutting a release, not by editing CI, and is unrelated to
+this gate — which is the point of booting the *staged* image instead.

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -243,3 +243,56 @@ fn every_published_checksum_manifest_is_signed_and_its_bundle_attached() {
         "kernel-build.yml must upload {manifest}.bundle beside the manifest"
     );
 }
+
+/// The staged image must be booted, and booted *before* it is uploaded.
+///
+/// Every other gate in the `default-microvm` job is a checksum, a signature, or
+/// a byte-level read, and none of them can answer the only question asked of a
+/// boot image: does it boot. A release shipped for five weeks whose guest
+/// panicked before userspace while every checksum verified clean.
+///
+/// The ordering is the whole value. These are steps in one job, so a failed
+/// boot aborts before the upload — but only while it stays above it. Reorder
+/// the two and the gate silently becomes a post-mortem on an artifact the world
+/// already has.
+#[test]
+fn the_staged_microvm_image_is_booted_before_it_is_uploaded() {
+    let workflow = release_workflow();
+    let job = workflow
+        .split("  default-microvm:")
+        .nth(1)
+        .expect("release.yml must define the default-microvm job");
+    let job = job
+        .split("\n  # ")
+        .next()
+        .expect("the job block is non-empty");
+
+    let boot = job
+        .find("- name: Boot the staged image before it becomes a release asset")
+        .expect("the default-microvm job must boot the image it is about to publish");
+    let upload = job
+        .find("- name: Upload default microVM image artifacts")
+        .expect("the default-microvm job must upload its artifacts");
+    assert!(
+        boot < upload,
+        "the boot gate must run before the upload, or it cannot refuse the publish"
+    );
+
+    // It must boot the staged bytes. Booting a published asset would be the
+    // `boot-latency` lane's job and would prove nothing about this release.
+    // Scoped to the boot step alone — the span up to the upload also covers the
+    // SBOM and pack-manifest steps, which legitimately name release URLs.
+    let rest = &job[boot..upload];
+    let step_end = rest[1..]
+        .find("\n      - name:")
+        .map_or(rest.len(), |offset| offset + 1);
+    let step = &rest[..step_end];
+    assert!(
+        step.contains("MVM_RUNTIME_BOOT_ROOTFS: staging/"),
+        "the boot gate must boot the staged rootfs, not a published one"
+    );
+    assert!(
+        !step.contains("releases/download"),
+        "the boot gate must not fetch a published artifact"
+    );
+}


### PR DESCRIPTION
Implements **WS1** of `specs/plans/2026-08-15-boot-image-lifecycle.md`.

## The gap

Every gate in the `default-microvm` job is a checksum, a signature, or a byte-level read. None of them can answer the only question anyone asks of a boot image: **does it boot.**

v0.17.0 shipped an image whose guest panicked with ENOEXEC before userspace and stayed published for five weeks. Every checksum verified clean the entire time — a faithful copy of a broken image is still faithful.

The job now boots the artifact in `staging/` between the build and the upload, so a rootfs that cannot reach userspace never becomes a release asset.

## Scope was smaller than the plan said

The plan proposed two halves: an x86_64 boot and an aarch64 static `/init` header check. **The header check already landed** with the release-verification work that followed the ENOEXEC incident — and landed better than proposed: `assert-init-shebang.sh` runs on *both* arches, on the staged image before upload and again on the published image after download, with a red-first fixture case in `verify-release-assets.test.sh`.

So only the boot was missing. Duplicating the header check would have been a second copy of a gate that already has one.

## What this is, and is not

**x86_64 only.** The aarch64 leg runs on `ubuntu-24.04-arm`, which has no nested KVM and cannot boot a guest at all; its coverage stays the static `/init` read. A stated compromise, not a claim of equivalence — an aarch64-only regression that is not a shebang defect still gets past.

**Not a latency assertion.** Budget is 60s against an observed median near 2s, `RUNS`/`CONCURRENT` are 1. The question is whether userspace is reached. Latency stays with `boot-latency`, which has its own threshold — one budget cannot do both jobs, since loose enough to survive shared-runner noise is too loose to catch drift.

Prerequisites (Firecracker at the pinned `FC_VERSION_DEFAULT`, `/dev/kvm` access, `mvm-meta.json` under the name the admission gate reads) are copied from the existing `boot-latency` lane rather than reinvented.

## The ordering is the whole value

These are steps in one job, so a failed boot aborts before the upload — but **only while it stays above it**. Reorder the two and the gate silently becomes a post-mortem on an artifact the world already has.

`the_staged_microvm_image_is_booted_before_it_is_uploaded` pins three things, each mutation-tested:

| Mutation | Result |
|---|---|
| Delete the boot step | fails |
| Move it below the upload | fails |
| Repoint it at a downloaded artifact | fails |

Workflow restored byte-identically after each.

## Verification

`cargo nextest run -p mvmctl --test release_assets` → 9 passed. Nightly `fmt --all --check`, `actionlint`, `clippy -p mvmctl --all-targets -D warnings`, and `check-declared-backing`, `check-honesty`, `check-no-overclaim`, `check-plan-names`, `check-sprint-append`, `check-workflow-paths`, `check-no-spec-refs-in-comments`, `check-test-home-isolation`.

The boot step itself only executes on a real release run — booting is the point and there is no hermetic substitute. What is testable here is that it is wired in the right place, which is what the new test covers.

## Note on #2542

Unrelated and still blocked. It repins `boot-latency` to `v0.18.0`, which **does not exist** (404), and v0.17.0's own image is the broken one. That lane needs a release cut, not a CI edit — which is precisely why this gate boots the *staged* image instead.