### PR TITLE
refactor(build): one resolver for mvm-network-endpoint, not two

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -471,91 +471,14 @@ impl Drop for BuilderVsockEgressEndpoint {
     }
 }
 
+/// Locate the endpoint binary through the canonical resolver.
+///
+/// Delegates rather than re-deriving the search order: this path used to have
+/// its own copy that skipped `$MVM_AUX_BIN_DIR`, so a stale binary beside the
+/// dev exe shadowed the freshly built one and edits appeared to do nothing.
 fn resolve_network_endpoint_path() -> Result<PathBuf, BuilderVmError> {
-    if let Some(path) = std::env::var_os("MVM_SUBSTITUTION_ENDPOINT_PATH").map(PathBuf::from) {
-        if path.is_file() {
-            return Ok(path);
-        }
-        return Err(BuilderVmError::ExtractionFailed(format!(
-            "MVM_SUBSTITUTION_ENDPOINT_PATH points at {} which is not a file",
-            path.display()
-        )));
-    }
-
-    if let Ok(current_exe) = std::env::current_exe()
-        && let Some(dir) = current_exe.parent()
-    {
-        let candidate = dir.join("mvm-network-endpoint");
-        if candidate.is_file() {
-            return Ok(candidate);
-        }
-    }
-
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let Some(workspace_root) = manifest_dir.parent().and_then(|p| p.parent()) else {
-        return Err(BuilderVmError::ExtractionFailed(
-            "resolve workspace root for mvm-network-endpoint".to_string(),
-        ));
-    };
-
-    let mut target_roots = vec![workspace_root.join("target")];
-    if let Some(target_dir) = std::env::var_os("CARGO_TARGET_DIR")
-        && !target_dir.is_empty()
-    {
-        let candidate = PathBuf::from(target_dir);
-        let normalized = if candidate.is_absolute() {
-            candidate
-        } else {
-            workspace_root.join(candidate)
-        };
-        if !target_roots.iter().any(|root| root == &normalized) {
-            target_roots.push(normalized);
-        }
-    }
-
-    for root in &target_roots {
-        for variant in ["release", "debug"] {
-            let candidate = root.join(variant).join("mvm-network-endpoint");
-            if candidate.is_file() {
-                return Ok(candidate);
-            }
-        }
-    }
-
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut build = Command::new(cargo);
-    build.current_dir(workspace_root).args([
-        "build",
-        "-p",
-        "mvm-hostd",
-        "--bin",
-        "mvm-network-endpoint",
-    ]);
-    if !build
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
-    {
-        return Err(BuilderVmError::ExtractionFailed(
-            "build mvm-network-endpoint".to_string(),
-        ));
-    }
-
-    for root in &target_roots {
-        let built = root.join("debug").join("mvm-network-endpoint");
-        if built.is_file() {
-            return Ok(built);
-        }
-    }
-    Err(BuilderVmError::ExtractionFailed(format!(
-        "mvm-network-endpoint not found after build (searched: {})",
-        target_roots
-            .iter()
-            .map(|root| root.join("debug").join("mvm-network-endpoint"))
-            .map(|path| path.display().to_string())
-            .collect::<Vec<_>>()
-            .join(", ")
-    )))
+    mvm_vmm::host::network_endpoint_spawn::resolve_network_endpoint_path()
+        .map_err(|e| BuilderVmError::ExtractionFailed(format!("{e:#}")))
 }
 
 fn reap_builder_vsock_egress_endpoint(state_dir: &Path) {

--- a/crates/mvm-vmm/src/host/network_endpoint_spawn.rs
+++ b/crates/mvm-vmm/src/host/network_endpoint_spawn.rs
@@ -254,8 +254,14 @@ fn stderr_tail(path: &Path, max_bytes: usize) -> Option<String> {
 }
 
 /// Locate the `mvm-network-endpoint` binary. Compiled by mvmctl's build
-/// script; see [`mvm_vmm::host::aux_bin`] for the search order.
-fn resolve_network_endpoint_path() -> Result<PathBuf> {
+/// script; see [`crate::host::aux_bin`] for the search order.
+///
+/// The one definition of this binary's name and override variable. The builder
+/// path carried its own copy that omitted `$MVM_AUX_BIN_DIR` — the build
+/// script's output dir, and the first candidate the canonical resolver checks —
+/// so it silently preferred whatever stale copy sat next to a dev `cargo run`
+/// exe. That is the exact shadowing `aux_bin`'s ordering exists to prevent.
+pub fn resolve_network_endpoint_path() -> Result<PathBuf> {
     crate::host::aux_bin::resolve(&crate::host::aux_bin::AuxBin {
         bin: "mvm-network-endpoint",
         env_var: "MVM_SUBSTITUTION_ENDPOINT_PATH",

--- a/specs/plans/2026-08-15-aux-helper-binary-freshness.md
+++ b/specs/plans/2026-08-15-aux-helper-binary-freshness.md
@@ -12,6 +12,13 @@ Deferred out of the builder-egress handshake fix. Neither item caused that
 failure — the handshake timeout did — but both were found while diagnosing it,
 and both make a future occurrence harder to diagnose than it needs to be.
 
+**Since written:** section 2's watch-list gaps were closed by
+`fix(net): let the host validator see its own sends, and the embed watch see the
+guest`. Section 1 is closed by the change carrying this edit. Both cost real
+debugging time in between: a guest-egress fix appeared to do nothing three times
+running, because the embedded binary was never rebuilt and the builder preferred
+a stale copy.
+
 ## 1. Two resolvers for `mvm-network-endpoint`, with opposite precedence
 
 `mvm_vmm::host::aux_bin::resolve` (`crates/mvm-vmm/src/host/aux_bin.rs`) is the
@@ -26,12 +33,13 @@ picks exactly the copy the canonical resolver exists to avoid. `mvm-build`
 already depends on `mvm-vmm` (`crates/mvm-build/Cargo.toml`), so it can call
 `aux_bin::resolve` directly.
 
-- [ ] Delete `resolve_network_endpoint_path` and call `aux_bin::resolve`.
-- [ ] Note that this also drops the run-time `cargo build -p mvm-hostd`
+- [x] Delete `resolve_network_endpoint_path` and call `aux_bin::resolve`.
+- [x] Note that this also drops the run-time `cargo build -p mvm-hostd`
       fallback, which is the intended behaviour: `aux_bin::resolve`
       deliberately never builds and errors with a `just build-supervisors` hint.
-- [ ] Test: the builder path prefers `$MVM_AUX_BIN_DIR` over a decoy copy
-      beside the exe.
+- [x] Test: not duplicated. The builder now delegates, and the ordering it was
+      missing is already pinned by `candidate_order_is_aux_then_exe_then_targets`
+      in `aux_bin`. A second copy of that assertion would drift, not protect.
 
 ## 2. The build script's watch list has two holes
 
@@ -49,9 +57,9 @@ Observed consequence: two `mvm-network-endpoint` binaries coexisting under one
 shared target dir, built from different commits — one linking `rand 0.10` and
 `crates/mvm-http/src/proxy.rs`, the other `rand 0.8` with no `proxy.rs`.
 
-- [ ] Switch the `mvm-hostd/src` and `mvm-core/src` entries to
+- [x] Switch the `mvm-hostd/src` and `mvm-core/src` entries to
       `emit_rerun_for_tree`.
-- [ ] Add `crates/mvm-vmm/src`.
+- [x] Add `crates/mvm-vmm/src`.
 - [ ] Extend the existing freshness guard rather than adding a second one:
       `supervisor_needs_rebuild` / `LIBKRUN_SUPERVISOR_INPUT_ROOTS` in
       `crates/mvm-build/src/libkrun_builder.rs` today covers only


### PR DESCRIPTION
`mvm_vmm::host::aux_bin::resolve` is the canonical search for a per-VM helper,
and its ordering is deliberate: `$<ENV_VAR>` → `$MVM_AUX_BIN_DIR` → beside
`current_exe` → workspace `target/`. The build script's dir comes first so a
freshly built helper is not shadowed by a stale copy sitting next to a dev
`cargo run` exe, which cargo never refreshes for a `[[bin]]` it did not build.

The builder path had its own 86-line copy that omitted `$MVM_AUX_BIN_DIR`
entirely, so it preferred exactly the stale copy the ordering exists to avoid.

That is not theoretical. Diagnosing the guest-egress failures this week, a fix
to `mvm-egress-client` appeared to do nothing three runs in a row: the embedded
binary was not being rebuilt (since fixed) *and* the builder was resolving a
stale endpoint. Each round cost a full Stage 0 boot to discover.

The duplicate is deleted and the builder delegates.
`resolve_network_endpoint_path` is now `pub` in `network_endpoint_spawn`, so the
binary's name and its override variable have one definition rather than two that
can drift.

This also drops the builder's run-time `cargo build -p mvm-hostd` fallback,
which is the intended behaviour: `aux_bin::resolve` deliberately never builds,
and errors with the `just build-supervisors` recovery hint instead. The workload
path has always behaved that way.

No new test. The property the builder was missing — aux dir before exe dir — is
already pinned by `candidate_order_is_aux_then_exe_then_targets`; a second copy
of that assertion in `mvm-build` would drift rather than protect.

Closes sections 1 and 2 of
`specs/plans/2026-08-15-aux-helper-binary-freshness.md`; section 2's watch-list
gaps were closed separately, and the plan is updated to say so.

## Verification

- `cargo nextest run -p mvm-build -p mvm-vmm` — 1332 passed
- `cargo clippy -p mvm-build -p mvm-vmm --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all -- --check` — clean
- `xtask check-declared-backing`, `check-deferrals` — clean