### PR TITLE
ci: run the guest egress data path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,6 +529,20 @@ jobs:
           cargo nextest run -p mvm-sdk --features schema
           cargo check -p mvm-sdk --features schema --bins
 
+      # `addons` is off by default so the sealed agent's request path stays
+      # synchronous and tokio-free (`check-guest-agent-runtime-free` enforces
+      # that, so this must stay a feature rather than move into default). But
+      # the feature also gates the entire guest egress data path — `flowmux`,
+      # `flowmux_egress`, `egress_client` — which every builder VM's networking
+      # runs through. Nothing in the default lane compiles it, and a run of
+      # defects shipped inside it as a result, each one only reachable by
+      # booting a real VM. `--bins` because the loopback proxy is a `[[bin]]`
+      # and a lib-only run would not build its entrypoint.
+      - name: addons feature tests (guest egress data path)
+        run: |
+          cargo nextest run -p mvm-agentd --features addons
+          cargo check -p mvm-agentd --features addons --bins
+
       - name: Assert auto-detect still picks libkrun off Linux/HVF
         run: |
           cargo test -p mvm-build --features builder-vm --lib \


### PR DESCRIPTION
`addons` is off by default, so `cargo nextest run --workspace` never compiles
`flowmux`, `flowmux_egress` or `egress_client` — the loopback SOCKS/HTTP proxy
and FlowMux client that every builder VM's networking runs through. CI has never
built that code, let alone tested it.

That is not a hypothetical gap. Ten defects shipped inside it and were found
only by booting a real builder VM and reading how far a download got: a SOCKS
version byte read twice, credit never returned, credit never decoded on either
side, exhaustion treated as an error instead of backpressure, a `select!` that
dropped partial frame reads, two Resets sent per stream. Every one of them is
the kind of thing a unit test catches in milliseconds; none of them could be
caught by a suite that does not compile the file.

This adds the feature to the existing `lint-features` lane, which is where the
other off-by-default features are already covered:

    789 tests run   (what CI runs today for mvm-agentd)
    846 tests run   (with --features addons)

57 tests that have never run in CI, in the code path carrying every builder
VM's traffic.

## Why not make it a default feature

Because the gate is load-bearing. `addons` is off so the sealed agent's
request-serving path stays synchronous and pulls no tokio, and
`check-guest-agent-runtime-free` enforces exactly that. Moving the egress path
into default features would trade one real invariant for test coverage that a
CI step buys outright.

## Why `--bins` as well

`mvm-egress-client` is a `[[bin]]`. `nextest run` builds test targets, so a
lib-only run would leave the guest's actual entrypoint uncompiled — which is
how a broken bin would still reach a VM. Same shape as the `schema` step
directly above it.

## Cost

One more feature resolution in a job that already runs several, so it rebuilds
`mvm-agentd`'s subtree once. The test step itself is ~6s. Worth naming rather
than hiding: this lane is on the pull-request critical path.

## Verification

- `cargo nextest run -p mvm-agentd --features addons` — 846 passed
- `cargo check -p mvm-agentd --features addons --bins` — clean
- `actionlint .github/workflows/ci.yml` — clean
- `xtask check-workflow-paths` — clean

The one `LEAK` nextest reports is pre-existing and unrelated: it appears
identically in the default 789-test run.