### PR TITLE
fix(net): make FlowMux name the stale half instead of failing silently

### DIFF
--- a/crates/mvm-agentd/src/addon_dns.rs
+++ b/crates/mvm-agentd/src/addon_dns.rs
@@ -439,6 +439,7 @@ mod tests {
     use crate::flowmux::{FlowMuxClient, FlowMuxReconnectClient};
     use hickory_proto::op::{OpCode, Query};
     use hickory_proto::rr::Name;
+    use mvm_contract::protocol::network_flow::hello::Handshake;
     use std::io;
     use tempfile::tempdir;
 
@@ -908,7 +909,7 @@ mod tests {
 
     #[tokio::test]
     async fn non_authoritative_query_uses_flowmux_resolver_and_rewrites_id() {
-        let resolver = build_mock_flowmux_resolver().await;
+        let (resolver, _owner) = build_mock_flowmux_resolver().await;
         let zone = Zone::new(vec![]);
         let config = DnsServerConfig {
             bind_addrs: vec!["127.0.0.1:5353".parse().unwrap()],
@@ -929,7 +930,13 @@ mod tests {
         assert!(message.answers.is_empty());
     }
 
-    async fn build_mock_flowmux_resolver() -> FlowMuxReconnectClient {
+    /// The sender comes back with the client: in production `reconnect_loop`
+    /// owns it for as long as the session lives, and a caller that drops it
+    /// makes every wait fail with "reconnect owner gone".
+    async fn build_mock_flowmux_resolver() -> (
+        FlowMuxReconnectClient,
+        tokio::sync::watch::Sender<Option<std::sync::Arc<FlowMuxClient>>>,
+    ) {
         use ed25519_dalek::{SigningKey, VerifyingKey};
         use mvm_contract::protocol::network_flow::{Opcode, encode_into};
         use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
@@ -999,7 +1006,7 @@ mod tests {
                 &mut host_session,
                 Opcode::HelloAck,
                 0,
-                &[],
+                &Handshake::local("test-host").encode(),
             )
             .await;
 
@@ -1031,9 +1038,7 @@ mod tests {
             .await
             .unwrap();
         let (tx, rx) = tokio::sync::watch::channel(Some(std::sync::Arc::new(client)));
-        // Hold the sender so the watch channel stays open for the test.
-        let _tx = tx;
-        FlowMuxReconnectClient::from_receiver(rx)
+        (FlowMuxReconnectClient::from_receiver(rx), tx)
     }
 
     fn test_config(upstream_addrs: Vec<SocketAddr>) -> DnsServerConfig {

--- a/crates/mvm-agentd/src/flowmux.rs
+++ b/crates/mvm-agentd/src/flowmux.rs
@@ -17,6 +17,7 @@ use std::task::{Context, Poll};
 use std::time::Duration;
 
 use ed25519_dalek::{SigningKey, VerifyingKey};
+use mvm_contract::protocol::network_flow::hello::{Handshake, agree};
 use mvm_contract::protocol::network_flow::{
     Direction, FrameError, Opcode, SessionValidator, decode, encode_into,
 };
@@ -24,6 +25,10 @@ use mvm_core::net::session::Session;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot, watch};
 use tracing::{info, warn};
+
+/// How this side names itself in a handshake refusal. Only ever read by a
+/// human reading the error.
+const GUEST_BUILD: &str = concat!("mvm-agentd ", env!("CARGO_PKG_VERSION"));
 
 /// Initial stream ID for guest-initiated flows. Guest IDs are odd.
 const FIRST_GUEST_STREAM_ID: u32 = 1;
@@ -144,14 +149,20 @@ enum ClientRequest {
 }
 
 /// Snapshot of session health observed by client handles.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionState {
+    /// The FlowMux handshake has not completed. No flow may be opened yet —
+    /// publishing `Ready` before the two peers have agreed is what let a
+    /// mismatched host look healthy until the first flow failed.
+    Connecting,
     /// Handshake complete and flows may be opened.
     Ready,
     /// Reconnecting after a transport failure.
     Reconnecting,
-    /// Reconnect attempts exhausted; the client is dead.
-    Dead,
+    /// The session will not come back. Carries why: for a handshake refusal
+    /// the reason names both builds, and it is the only thing that tells an
+    /// operator which of the two halves to rebuild.
+    Dead(Arc<str>),
 }
 
 /// An open request that is waiting for the host to confirm or refuse.
@@ -216,7 +227,7 @@ impl FlowMuxClient {
         let (session, _session_id, stream) = handshake?;
 
         let (client_tx, client_rx) = mpsc::unbounded_channel();
-        let (state_tx, state_rx) = watch::channel(SessionState::Ready);
+        let (state_tx, state_rx) = watch::channel(SessionState::Connecting);
 
         let next_stream_id = Arc::new(AtomicU32::new(FIRST_GUEST_STREAM_ID));
         let pump = SessionPump {
@@ -249,11 +260,13 @@ impl FlowMuxClient {
     async fn await_ready(&self) -> Result<(), FlowMuxError> {
         let mut state = self.state.clone();
         loop {
-            let snapshot = *state.borrow();
+            let snapshot = state.borrow().clone();
             match snapshot {
                 SessionState::Ready => return Ok(()),
-                SessionState::Dead => return Err(FlowMuxError::SessionClosed("dead".into())),
-                SessionState::Reconnecting => {
+                SessionState::Dead(reason) => {
+                    return Err(FlowMuxError::SessionClosed(reason.to_string()));
+                }
+                SessionState::Connecting | SessionState::Reconnecting => {
                     if state.changed().await.is_err() {
                         return Err(FlowMuxError::SessionClosed("state watch closed".into()));
                     }
@@ -340,6 +353,17 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     async fn run(mut self) -> Result<(), FlowMuxError> {
+        let outcome = self.run_until_closed().await;
+        self.fail_all("session closed");
+        let reason: Arc<str> = match &outcome {
+            Ok(()) => Arc::from("session closed"),
+            Err(e) => Arc::from(e.to_string().as_str()),
+        };
+        let _ = self.state_tx.send(SessionState::Dead(reason));
+        outcome
+    }
+
+    async fn run_until_closed(&mut self) -> Result<(), FlowMuxError> {
         self.send_hello().await?;
         self.read_hello_ack().await?;
         let _ = self.state_tx.send(SessionState::Ready);
@@ -369,8 +393,6 @@ where
                 }
             }
         }
-        self.fail_all("session closed");
-        let _ = self.state_tx.send(SessionState::Dead);
         Ok(())
     }
 
@@ -391,28 +413,44 @@ where
     }
 
     async fn send_hello(&mut self) -> Result<(), FlowMuxError> {
+        let payload = Handshake::local(GUEST_BUILD).encode();
         self.validator
-            .admit(&frame_facts(Direction::GuestToHost, Opcode::Hello, 0, 0))
+            .admit(&frame_facts(
+                Direction::GuestToHost,
+                Opcode::Hello,
+                0,
+                payload.len() as u32,
+            ))
             .map_err(|e| FlowMuxError::Frame(e.to_string()))?;
-        self.write_frame(Opcode::Hello, 0, &[]).await
+        self.write_frame(Opcode::Hello, 0, &payload).await
     }
 
     async fn read_hello_ack(&mut self) -> Result<(), FlowMuxError> {
-        let (opcode, stream_id, _payload_len, payload) = self
-            .read_frame()
-            .await?
-            .ok_or_else(|| FlowMuxError::SessionClosed("peer closed before HelloAck".into()))?;
-        if opcode != Opcode::HelloAck || stream_id != 0 || !payload.is_empty() {
+        let (opcode, stream_id, payload_len, payload) =
+            self.read_frame().await?.ok_or_else(|| {
+                // The host closing here is the shape of a host that is not
+                // speaking FlowMux at all, so say so rather than reporting a
+                // bare disconnect the operator has to guess at.
+                FlowMuxError::SessionClosed(format!(
+                    "host closed the connection before answering the FlowMux handshake; \
+                     this guest is {GUEST_BUILD} — the host endpoint is either stale or \
+                     serving a different egress protocol"
+                ))
+            })?;
+        if opcode != Opcode::HelloAck || stream_id != 0 {
             return Err(FlowMuxError::Frame(format!(
                 "expected HelloAck, got {opcode:?} on stream {stream_id}"
             )));
         }
+        let host = Handshake::decode(&payload).map_err(|e| FlowMuxError::Frame(e.to_string()))?;
+        agree(&Handshake::local(GUEST_BUILD), &host)
+            .map_err(|e| FlowMuxError::Frame(e.to_string()))?;
         self.validator
             .admit(&frame_facts(
                 Direction::HostToGuest,
                 Opcode::HelloAck,
                 stream_id,
-                0,
+                payload_len,
             ))
             .map_err(|e| FlowMuxError::Frame(e.to_string()))?;
         Ok(())
@@ -1225,18 +1263,50 @@ impl FlowMuxReconnectClient {
     }
 
     /// Wait until there is a ready session and return a clone of it.
+    ///
+    /// Two watches move independently here: `current` names which client the
+    /// reconnect loop owns, and the client's own state says whether that one
+    /// has finished its handshake. Waiting on only the first parks forever on
+    /// a client that is still connecting, since nothing replaces it.
     async fn active_client(&self) -> Result<Arc<FlowMuxClient>, FlowMuxError> {
         let mut current = self.current.clone();
         loop {
             let snapshot = current.borrow().clone();
-            if let Some(client) = snapshot {
-                let ready = {
-                    let state = client.state();
-                    *state.borrow() == SessionState::Ready
-                };
-                if ready {
-                    return Ok(client);
+            let Some(client) = snapshot else {
+                if current.changed().await.is_err() {
+                    return Err(FlowMuxError::SessionClosed("reconnect owner gone".into()));
                 }
+                continue;
+            };
+
+            let mut state = client.state();
+            let settled = loop {
+                match state.borrow().clone() {
+                    SessionState::Ready => break Some(client),
+                    // Dead is the reconnect loop's cue; wait for the client it
+                    // puts in place rather than re-reading this one.
+                    SessionState::Dead(_) => break None,
+                    SessionState::Connecting | SessionState::Reconnecting => {}
+                }
+                tokio::select! {
+                    changed = state.changed() => {
+                        if changed.is_err() {
+                            break None;
+                        }
+                    }
+                    changed = current.changed() => {
+                        if changed.is_err() {
+                            return Err(FlowMuxError::SessionClosed("reconnect owner gone".into()));
+                        }
+                        break None;
+                    }
+                }
+            };
+            if let Some(client) = settled {
+                return Ok(client);
+            }
+            if current.has_changed().unwrap_or(false) {
+                continue;
             }
             if current.changed().await.is_err() {
                 return Err(FlowMuxError::SessionClosed("reconnect owner gone".into()));
@@ -1296,7 +1366,7 @@ async fn reconnect_loop<S, F, Fut>(
     loop {
         // Wait for the current session to die.
         loop {
-            if *state_rx.borrow() == SessionState::Dead {
+            if matches!(*state_rx.borrow(), SessionState::Dead(_)) {
                 break;
             }
             if state_rx.changed().await.is_err() {
@@ -1349,6 +1419,7 @@ async fn reconnect_loop<S, F, Fut>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_contract::protocol::network_flow::hello::BEHAVIOR_REVISION;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
@@ -1448,14 +1519,14 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(opcode, Opcode::Hello);
-            assert!(payload.is_empty());
+            Handshake::decode(&payload).expect("Hello carries the guest's handshake");
 
             send_frame(
                 &mut host_stream,
                 &mut host_session,
                 Opcode::HelloAck,
                 0,
-                &[],
+                &Handshake::local("test-host").encode(),
             )
             .await;
 
@@ -1557,7 +1628,7 @@ mod tests {
                 &mut host_session,
                 Opcode::HelloAck,
                 0,
-                &[],
+                &Handshake::local("test-host").encode(),
             )
             .await;
 
@@ -1587,6 +1658,132 @@ mod tests {
         host.await.unwrap();
     }
 
+    /// A fresh client has not handshaken yet. Publishing `Ready` at
+    /// construction let a caller open a flow into a session that had agreed
+    /// nothing, so a mismatched host looked healthy until the flow failed.
+    #[tokio::test]
+    async fn a_fresh_client_is_connecting_until_the_host_answers() {
+        let (guest_stream, host_stream) = tokio::io::duplex(4096);
+        let (guest_key, _guest_anchor) = generate_keypair();
+        let (host_key, host_anchor) = generate_keypair();
+
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+        let host = tokio::spawn(async move {
+            let (mut host_stream, mut host_session) = host_handshake(host_stream, host_key).await;
+            let (opcode, _sid, _len, _payload) = recv_frame(&mut host_stream, &mut host_session)
+                .await
+                .unwrap();
+            assert_eq!(opcode, Opcode::Hello);
+            started_tx.send(()).unwrap();
+            // Hold the HelloAck back so the client is observed mid-handshake.
+            release_rx.await.unwrap();
+            send_frame(
+                &mut host_stream,
+                &mut host_session,
+                Opcode::HelloAck,
+                0,
+                &Handshake::local("test-host").encode(),
+            )
+            .await;
+            // Stay up: dropping the stream here would end the pump and the
+            // client would go Dead before the test could observe Ready.
+            finish_rx.await.unwrap();
+        });
+
+        let client = FlowMuxClient::connect(guest_stream, guest_key, host_anchor)
+            .await
+            .expect("transport session");
+        started_rx.await.unwrap();
+        assert_eq!(*client.state().borrow(), SessionState::Connecting);
+
+        release_tx.send(()).unwrap();
+        let mut state = client.state();
+        while *state.borrow() != SessionState::Ready {
+            state.changed().await.expect("state watch stays open");
+        }
+
+        finish_tx.send(()).unwrap();
+        host.await.unwrap();
+    }
+
+    /// A host built against a different revision must be named, not silently
+    /// tolerated: the guest is the side whose logs an operator reads first.
+    #[tokio::test]
+    async fn a_host_from_another_revision_is_refused_by_name() {
+        let (guest_stream, host_stream) = tokio::io::duplex(4096);
+        let (guest_key, _guest_anchor) = generate_keypair();
+        let (host_key, host_anchor) = generate_keypair();
+
+        let host = tokio::spawn(async move {
+            let (mut host_stream, mut host_session) = host_handshake(host_stream, host_key).await;
+            let (opcode, _sid, _len, _payload) = recv_frame(&mut host_stream, &mut host_session)
+                .await
+                .unwrap();
+            assert_eq!(opcode, Opcode::Hello);
+            let stale = Handshake {
+                behavior_revision: BEHAVIOR_REVISION.wrapping_add(1),
+                build: "mvm-hostd from-a-stale-tree".to_string(),
+            };
+            send_frame(
+                &mut host_stream,
+                &mut host_session,
+                Opcode::HelloAck,
+                0,
+                &stale.encode(),
+            )
+            .await;
+        });
+
+        // `connect` returns once the transport session is up; the FlowMux
+        // handshake runs in the pump, so the refusal surfaces on the first
+        // flow — which is the call an operator sees fail.
+        let client = FlowMuxClient::connect(guest_stream, guest_key, host_anchor)
+            .await
+            .expect("transport session");
+        let err = client
+            .open_tcp("example.com:80")
+            .await
+            .expect_err("a mismatched host must not serve a flow");
+        let msg = err.to_string();
+        assert!(msg.contains("mvm-hostd from-a-stale-tree"), "{msg}");
+        assert!(msg.contains(GUEST_BUILD), "{msg}");
+
+        host.await.unwrap();
+    }
+
+    /// A host that hangs up without answering is the shape of a host serving
+    /// some other protocol. Say that, rather than reporting a bare close.
+    #[tokio::test]
+    async fn a_host_that_never_answers_the_handshake_says_so() {
+        let (guest_stream, host_stream) = tokio::io::duplex(4096);
+        let (guest_key, _guest_anchor) = generate_keypair();
+        let (host_key, host_anchor) = generate_keypair();
+
+        let host = tokio::spawn(async move {
+            let (mut host_stream, mut host_session) = host_handshake(host_stream, host_key).await;
+            let (opcode, _sid, _len, _payload) = recv_frame(&mut host_stream, &mut host_session)
+                .await
+                .unwrap();
+            assert_eq!(opcode, Opcode::Hello);
+            drop(host_stream);
+        });
+
+        let client = FlowMuxClient::connect(guest_stream, guest_key, host_anchor)
+            .await
+            .expect("transport session");
+        let err = client
+            .open_tcp("example.com:80")
+            .await
+            .expect_err("a silent host must not serve a flow");
+        let msg = err.to_string();
+        assert!(msg.contains("FlowMux handshake"), "{msg}");
+        assert!(msg.contains(GUEST_BUILD), "{msg}");
+
+        host.await.unwrap();
+    }
+
     #[tokio::test]
     async fn guest_client_resolves_dns_name() {
         let (guest_stream, host_stream) = tokio::io::duplex(4096);
@@ -1605,7 +1802,7 @@ mod tests {
                 &mut host_session,
                 Opcode::HelloAck,
                 0,
-                &[],
+                &Handshake::local("test-host").encode(),
             )
             .await;
 
@@ -1658,7 +1855,7 @@ mod tests {
                 &mut host_session,
                 Opcode::HelloAck,
                 0,
-                &[],
+                &Handshake::local("test-host").encode(),
             )
             .await;
 

--- a/crates/mvm-agentd/src/flowmux_egress.rs
+++ b/crates/mvm-agentd/src/flowmux_egress.rs
@@ -404,6 +404,7 @@ pub mod dns_stub {
     mod tests {
         use super::*;
         use ed25519_dalek::{SigningKey, VerifyingKey};
+        use mvm_contract::protocol::network_flow::hello::Handshake;
         use mvm_contract::protocol::network_flow::{Opcode, encode_into};
         use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
@@ -478,7 +479,7 @@ pub mod dns_stub {
                     &mut host_session,
                     Opcode::HelloAck,
                     0,
-                    &[],
+                    &Handshake::local("test-host").encode(),
                 )
                 .await;
 

--- a/crates/mvm-contract/src/protocol/network_flow/hello.rs
+++ b/crates/mvm-contract/src/protocol/network_flow/hello.rs
@@ -1,0 +1,268 @@
+//! What the two peers tell each other in `Hello`/`HelloAck`.
+//!
+//! [`frame::PROTOCOL_VERSION`](super::frame) covers the byte layout: change
+//! the header and a mismatched peer's frames stop decoding. It does not
+//! cover the layer above it — which opcodes a peer emits, which it expects
+//! an answer to, what it does when one never arrives. Two builds can agree
+//! on every byte of the framing and still disagree about all of that, and
+//! the failure looks like a hang or a bare `ECONNREFUSED`, with nothing
+//! naming the two halves that disagree.
+//!
+//! So each peer states its [`BEHAVIOR_REVISION`] and a label for its own
+//! build, and [`agree`] refuses a session whose halves were built against
+//! different revisions — naming both, because the whole difficulty of this
+//! failure is finding out which side is stale.
+
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+/// The revision of what the peers expect of each other, beyond the framing.
+///
+/// Bump this in the same change that alters the expectation: a new opcode
+/// either side must answer, a changed meaning for an existing one, a
+/// different fail-closed rule. Leave it alone for changes a peer cannot
+/// observe. It is a declaration, not a derivation — nothing computes it,
+/// which is exactly why the bump belongs in the diff that earns it.
+pub const BEHAVIOR_REVISION: u32 = 1;
+
+/// The longest build label a peer may send. Long enough for a crate name
+/// and a version, short enough that it can never be the interesting part
+/// of a frame.
+pub const MAX_BUILD_LEN: usize = 128;
+
+/// A peer's self-description, carried on `Hello` and `HelloAck`.
+///
+/// The `build` label is diagnostic only — [`agree`] never decides anything
+/// from it. It exists so the refusal can say *which* two builds disagreed
+/// rather than that two builds did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Handshake {
+    /// The peer's [`BEHAVIOR_REVISION`] at compile time.
+    pub behavior_revision: u32,
+    /// A human-readable name for the peer's build. Untrusted, bounded,
+    /// and used only in messages.
+    pub build: String,
+}
+
+impl Handshake {
+    /// Describe this build. `build` is truncated to [`MAX_BUILD_LEN`] on a
+    /// character boundary rather than refused: a label too long to send is
+    /// a worse reason to fail a session than no label at all.
+    #[must_use]
+    pub fn local(build: &str) -> Self {
+        let mut build = build.to_string();
+        if build.len() > MAX_BUILD_LEN {
+            let mut end = MAX_BUILD_LEN;
+            while end > 0 && !build.is_char_boundary(end) {
+                end -= 1;
+            }
+            build.truncate(end);
+        }
+        Self {
+            behavior_revision: BEHAVIOR_REVISION,
+            build,
+        }
+    }
+
+    /// Serialize for a `Hello`/`HelloAck` payload: `u32` revision, `u16`
+    /// label length, then the label's UTF-8 bytes.
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let bytes = self.build.as_bytes();
+        let mut out = Vec::with_capacity(6 + bytes.len());
+        out.extend_from_slice(&self.behavior_revision.to_be_bytes());
+        // `local` bounds this to MAX_BUILD_LEN, which fits a u16.
+        out.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+        out.extend_from_slice(bytes);
+        out
+    }
+
+    /// Parse a peer's payload. Every field is peer-controlled, so the length
+    /// is checked against the buffer before it is trusted and against
+    /// [`MAX_BUILD_LEN`] before the label is kept.
+    pub fn decode(payload: &[u8]) -> Result<Self, HandshakeError> {
+        if payload.len() < 6 {
+            return Err(HandshakeError::Malformed {
+                why: format!(
+                    "handshake payload is {} bytes, need at least 6",
+                    payload.len()
+                ),
+            });
+        }
+        let behavior_revision =
+            u32::from_be_bytes([payload[0], payload[1], payload[2], payload[3]]);
+        let build_len = usize::from(u16::from_be_bytes([payload[4], payload[5]]));
+        if build_len > MAX_BUILD_LEN {
+            return Err(HandshakeError::Malformed {
+                why: format!("build label is {build_len} bytes, over the {MAX_BUILD_LEN} limit"),
+            });
+        }
+        let rest = &payload[6..];
+        if rest.len() != build_len {
+            return Err(HandshakeError::Malformed {
+                why: format!(
+                    "build label announced {build_len} bytes, {} follow the header",
+                    rest.len()
+                ),
+            });
+        }
+        let build = core::str::from_utf8(rest)
+            .map_err(|e| HandshakeError::Malformed {
+                why: format!("build label is not UTF-8: {e}"),
+            })?
+            .to_string();
+        Ok(Self {
+            behavior_revision,
+            build,
+        })
+    }
+}
+
+/// Why a handshake was refused.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum HandshakeError {
+    /// The payload was not a handshake. Fatal: the peer is either a
+    /// different protocol or a different framing of this one.
+    #[error("malformed FlowMux handshake: {why}")]
+    Malformed {
+        /// What was wrong with the bytes.
+        why: String,
+    },
+    /// The two halves were built against different behavior revisions.
+    #[error(
+        "FlowMux behavior revision mismatch: this side is revision {local_revision} \
+         (built from {local_build}), the peer is revision {peer_revision} \
+         (built from {peer_build}) — the two halves are from different builds, \
+         so rebuild and restage whichever is stale"
+    )]
+    RevisionMismatch {
+        /// This side's compiled-in [`BEHAVIOR_REVISION`].
+        local_revision: u32,
+        /// This side's build label.
+        local_build: String,
+        /// The revision the peer announced.
+        peer_revision: u32,
+        /// The build label the peer announced.
+        peer_build: String,
+    },
+}
+
+/// Decide whether two peers can talk.
+///
+/// Refuses on any revision difference rather than trying to serve the
+/// older one: every legitimate deployment builds both halves from the same
+/// tree — the host binary embeds the guest's — so a difference is a stale
+/// artifact, never a supported configuration.
+pub fn agree(local: &Handshake, peer: &Handshake) -> Result<(), HandshakeError> {
+    if local.behavior_revision == peer.behavior_revision {
+        return Ok(());
+    }
+    Err(HandshakeError::RevisionMismatch {
+        local_revision: local.behavior_revision,
+        local_build: local.build.clone(),
+        peer_revision: peer.behavior_revision,
+        peer_build: peer.build.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_handshake_round_trips_through_its_payload() {
+        let h = Handshake::local("mvm-egress-client 0.1.0");
+        assert_eq!(Handshake::decode(&h.encode()).expect("decode"), h);
+    }
+
+    #[test]
+    fn an_empty_build_label_round_trips() {
+        let h = Handshake::local("");
+        assert_eq!(Handshake::decode(&h.encode()).expect("decode"), h);
+    }
+
+    #[test]
+    fn an_over_long_label_is_truncated_rather_than_refused() {
+        let h = Handshake::local(&"x".repeat(MAX_BUILD_LEN * 3));
+        assert_eq!(h.build.len(), MAX_BUILD_LEN);
+        assert_eq!(Handshake::decode(&h.encode()).expect("decode"), h);
+    }
+
+    #[test]
+    fn truncation_lands_on_a_character_boundary() {
+        // A label of 3-byte characters cannot be cut at MAX_BUILD_LEN itself.
+        let h = Handshake::local(&"€".repeat(MAX_BUILD_LEN));
+        assert!(h.build.len() <= MAX_BUILD_LEN);
+        assert_eq!(Handshake::decode(&h.encode()).expect("decode"), h);
+    }
+
+    #[test]
+    fn matching_revisions_agree() {
+        let a = Handshake::local("host");
+        let b = Handshake::local("guest");
+        agree(&a, &b).expect("same revision must agree");
+    }
+
+    #[test]
+    fn a_revision_mismatch_names_both_builds() {
+        let local = Handshake {
+            behavior_revision: 7,
+            build: "mvm-network-endpoint 0.1.0".into(),
+        };
+        let peer = Handshake {
+            behavior_revision: 4,
+            build: "mvm-egress-client 0.1.0".into(),
+        };
+        let e = agree(&local, &peer).expect_err("differing revisions must refuse");
+        let msg = e.to_string();
+        assert!(msg.contains("mvm-network-endpoint 0.1.0"), "{msg}");
+        assert!(msg.contains("mvm-egress-client 0.1.0"), "{msg}");
+        assert!(msg.contains('7') && msg.contains('4'), "{msg}");
+    }
+
+    #[test]
+    fn a_short_payload_is_malformed_not_a_panic() {
+        for len in 0..6 {
+            let e = Handshake::decode(&vec![0u8; len]).expect_err("short payload");
+            assert!(matches!(e, HandshakeError::Malformed { .. }));
+        }
+    }
+
+    #[test]
+    fn an_empty_payload_is_refused() {
+        // The shape a peer that predates this handshake sends.
+        assert!(Handshake::decode(b"").is_err());
+    }
+
+    #[test]
+    fn a_lying_length_is_refused_without_reading_past_the_buffer() {
+        let mut bytes = Handshake::local("guest").encode();
+        bytes[4] = 0xff;
+        bytes[5] = 0xff;
+        let e = Handshake::decode(&bytes).expect_err("over-long announced label");
+        assert!(matches!(e, HandshakeError::Malformed { .. }));
+    }
+
+    #[test]
+    fn a_short_announced_length_is_refused() {
+        let mut bytes = Handshake::local("guest").encode();
+        bytes[5] = 1;
+        assert!(Handshake::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn a_non_utf8_label_is_refused() {
+        let mut bytes = 1u32.to_be_bytes().to_vec();
+        bytes.extend_from_slice(&2u16.to_be_bytes());
+        bytes.extend_from_slice(&[0xff, 0xfe]);
+        assert!(Handshake::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn a_handshake_payload_fits_a_frame() {
+        let biggest = Handshake::local(&"x".repeat(MAX_BUILD_LEN)).encode();
+        assert!(biggest.len() <= super::super::limits::MAX_PAYLOAD_LEN);
+    }
+}

--- a/crates/mvm-contract/src/protocol/network_flow/mod.rs
+++ b/crates/mvm-contract/src/protocol/network_flow/mod.rs
@@ -25,6 +25,7 @@
 //! belong to the endpoint that carries it.
 
 pub mod frame;
+pub mod hello;
 pub mod limits;
 pub mod opcode;
 pub mod state;

--- a/crates/mvm-hostd/src/supervisor/flowmux.rs
+++ b/crates/mvm-hostd/src/supervisor/flowmux.rs
@@ -22,6 +22,7 @@ use std::time::{Duration, Instant};
 
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use mvm_contract::protocol::dns::{MAX_DNS_MESSAGE, decode_query, encode_response};
+use mvm_contract::protocol::network_flow::hello::{Handshake, agree};
 use mvm_contract::protocol::network_flow::{
     Direction, FrameError, HEADER_LEN, LENGTH_PREFIX_LEN, Opcode, SessionValidator,
     UDP_ADDR_PREFIX_LEN, decode,
@@ -38,6 +39,10 @@ use self::udp_relay::{
 use crate::supervisor::audit_recorder::{EventCategory, Recorder};
 use crate::supervisor::dns_resolver::resolve_hostname_ips;
 use mvm_core::rate_limit::TokenBucket;
+
+/// How this side names itself in a handshake refusal. Only ever read by a
+/// human reading the error.
+const HOST_BUILD: &str = concat!("mvm-hostd ", env!("CARGO_PKG_VERSION"));
 
 /// Per-address connect budget when trying an admitted set: small so an
 /// unreachable address (e.g. an AAAA with no host IPv6 egress) fails over to
@@ -288,8 +293,8 @@ impl FlowMuxSession {
     pub fn serve(&mut self) -> Result<(), FlowMuxError> {
         // Wait for the guest's Hello, then acknowledge. The authenticated
         // session is already established; this is the FlowMux session opening.
-        match self.read_frame()? {
-            Some((Opcode::Hello, 0, 0)) => {}
+        let guest_payload_len = match self.read_frame()? {
+            Some((Opcode::Hello, 0, payload_len)) => payload_len,
             Some((opcode, _, _)) => {
                 return Err(FlowMuxError::FrameRefused(format!(
                     "expected Hello as first FlowMux frame, got {opcode:?}"
@@ -300,6 +305,20 @@ impl FlowMuxSession {
                     "peer closed before Hello".to_string(),
                 ));
             }
+        };
+
+        // Refuse a guest built against a different revision before serving it
+        // anything. A GoAway first, so the guest reports the same mismatch
+        // rather than a bare disconnect it cannot explain.
+        let local = Handshake::local(HOST_BUILD);
+        let payload_start = LENGTH_PREFIX_LEN + HEADER_LEN;
+        let guest = Handshake::decode(
+            &self.read_buf[payload_start..payload_start + guest_payload_len as usize],
+        )
+        .map_err(|e| FlowMuxError::FrameRefused(e.to_string()))?;
+        if let Err(e) = agree(&local, &guest) {
+            self.send_goaway(&e.to_string())?;
+            return Err(FlowMuxError::FrameRefused(e.to_string()));
         }
 
         lock_validator(&self.validator)
@@ -918,7 +937,7 @@ impl FlowMuxSession {
     }
 
     fn send_hello_ack(&self) -> Result<(), FlowMuxError> {
-        self.write_frame(Opcode::HelloAck, 0, b"")
+        self.write_frame(Opcode::HelloAck, 0, &Handshake::local(HOST_BUILD).encode())
     }
 
     fn send_goaway(&self, reason: &str) -> Result<(), FlowMuxError> {
@@ -1317,6 +1336,7 @@ fn parse_host_port(target: &str) -> Result<(&str, u16), String> {
 #[cfg(test)]
 mod tests {
     use super::udp_relay::encode_udp_addr;
+    use mvm_contract::protocol::network_flow::hello::BEHAVIOR_REVISION;
     use std::os::unix::net::UnixStream;
     use std::thread;
 
@@ -1387,6 +1407,132 @@ mod tests {
         )
     }
 
+    /// The guest's HelloAck must carry the host's handshake, or a guest built
+    /// against a different revision has nothing to compare against.
+    #[test]
+    fn the_hello_ack_carries_the_host_handshake() {
+        let (host_key, host_verify) = fresh_keys();
+        let (guest_key, guest_verify) = fresh_keys();
+        let (host_stream, mut guest_stream) = UnixStream::pair().unwrap();
+
+        let host_handle = thread::spawn(move || {
+            FlowMuxSession::accept(
+                host_stream,
+                "test-session",
+                host_key,
+                &guest_verify,
+                RegistryLimits::default(),
+                EgressGate::default_deny(),
+            )
+            .unwrap()
+            .serve()
+        });
+
+        let (mut guest_session, _id) =
+            Session::guest(&mut guest_stream, guest_key, &host_verify).unwrap();
+        write_frame(
+            &mut guest_stream,
+            &mut guest_session,
+            Opcode::Hello,
+            0,
+            &Handshake::local("test-guest").encode(),
+        );
+
+        let (opcode, _sid, payload) = read_flowmux_frame(&mut guest_stream, &mut guest_session);
+        assert_eq!(opcode, Opcode::HelloAck);
+        let host = Handshake::decode(&payload).expect("HelloAck carries a handshake");
+        assert_eq!(host.behavior_revision, BEHAVIOR_REVISION);
+        assert_eq!(host.build, HOST_BUILD);
+
+        drop(guest_stream);
+        let _ = host_handle.join().unwrap();
+    }
+
+    /// The failure this whole handshake exists for: two halves built against
+    /// different revisions. The host must refuse, and must say GoAway first so
+    /// the guest reports the same mismatch rather than a bare disconnect.
+    #[test]
+    fn a_guest_from_another_revision_is_refused_by_name() {
+        let (host_key, host_verify) = fresh_keys();
+        let (guest_key, guest_verify) = fresh_keys();
+        let (host_stream, mut guest_stream) = UnixStream::pair().unwrap();
+
+        let host_handle = thread::spawn(move || {
+            FlowMuxSession::accept(
+                host_stream,
+                "test-session",
+                host_key,
+                &guest_verify,
+                RegistryLimits::default(),
+                EgressGate::default_deny(),
+            )
+            .unwrap()
+            .serve()
+        });
+
+        let (mut guest_session, _id) =
+            Session::guest(&mut guest_stream, guest_key, &host_verify).unwrap();
+        let stale = Handshake {
+            behavior_revision: BEHAVIOR_REVISION.wrapping_add(1),
+            build: "mvm-agentd from-a-stale-tree".to_string(),
+        };
+        write_frame(
+            &mut guest_stream,
+            &mut guest_session,
+            Opcode::Hello,
+            0,
+            &stale.encode(),
+        );
+
+        let (opcode, _sid, payload) = read_flowmux_frame(&mut guest_stream, &mut guest_session);
+        assert_eq!(
+            opcode,
+            Opcode::GoAway,
+            "a mismatch must say why, not hang up"
+        );
+        let reason = String::from_utf8(payload).expect("GoAway reason is text");
+        assert!(reason.contains("mvm-agentd from-a-stale-tree"), "{reason}");
+        assert!(reason.contains(HOST_BUILD), "{reason}");
+
+        let err = host_handle
+            .join()
+            .unwrap()
+            .expect_err("the session must not be served");
+        assert!(err.to_string().contains("revision"), "{err}");
+    }
+
+    /// A peer that predates the handshake sends an empty Hello payload. That
+    /// is the stale-binary case, so it must be refused rather than defaulted.
+    #[test]
+    fn a_guest_with_no_handshake_at_all_is_refused() {
+        let (host_key, host_verify) = fresh_keys();
+        let (guest_key, guest_verify) = fresh_keys();
+        let (host_stream, mut guest_stream) = UnixStream::pair().unwrap();
+
+        let host_handle = thread::spawn(move || {
+            FlowMuxSession::accept(
+                host_stream,
+                "test-session",
+                host_key,
+                &guest_verify,
+                RegistryLimits::default(),
+                EgressGate::default_deny(),
+            )
+            .unwrap()
+            .serve()
+        });
+
+        let (mut guest_session, _id) =
+            Session::guest(&mut guest_stream, guest_key, &host_verify).unwrap();
+        write_frame(&mut guest_stream, &mut guest_session, Opcode::Hello, 0, b"");
+
+        let err = host_handle
+            .join()
+            .unwrap()
+            .expect_err("an empty Hello must not open a session");
+        assert!(err.to_string().contains("handshake"), "{err}");
+    }
+
     #[test]
     fn accept_succeeds_and_sends_hello_ack() {
         let (host_key, host_verify) = fresh_keys();
@@ -1412,7 +1558,13 @@ mod tests {
             Session::guest(&mut guest_stream, guest_key, &host_verify).unwrap();
 
         // The guest must send Hello to open the FlowMux session.
-        write_frame(&mut guest_stream, &mut guest_session, Opcode::Hello, 0, b"");
+        write_frame(
+            &mut guest_stream,
+            &mut guest_session,
+            Opcode::Hello,
+            0,
+            &Handshake::local("test-guest").encode(),
+        );
 
         // Read the HelloAck from the host.
         let (opcode, _stream_id, _payload) =
@@ -1462,7 +1614,13 @@ mod tests {
         let (mut guest_session, _session_id) =
             Session::guest(&mut guest_stream, guest_key, &host_verify).unwrap();
 
-        write_frame(&mut guest_stream, &mut guest_session, Opcode::Hello, 0, b"");
+        write_frame(
+            &mut guest_stream,
+            &mut guest_session,
+            Opcode::Hello,
+            0,
+            &Handshake::local("test-guest").encode(),
+        );
 
         let (opcode, _stream_id, _payload) =
             read_flowmux_frame(&mut guest_stream, &mut guest_session);
@@ -1549,7 +1707,13 @@ mod tests {
         let (mut guest_session, _session_id) =
             Session::guest(&mut guest_stream, guest_key, &host_verify).unwrap();
 
-        write_frame(&mut guest_stream, &mut guest_session, Opcode::Hello, 0, b"");
+        write_frame(
+            &mut guest_stream,
+            &mut guest_session,
+            Opcode::Hello,
+            0,
+            &Handshake::local("test-guest").encode(),
+        );
 
         let (opcode, _stream_id, _payload) =
             read_flowmux_frame(&mut guest_stream, &mut guest_session);
@@ -1611,7 +1775,13 @@ mod tests {
         let (mut guest_session, _session_id) =
             Session::guest(&mut guest_stream, guest_key, &host_verify).unwrap();
 
-        write_frame(&mut guest_stream, &mut guest_session, Opcode::Hello, 0, b"");
+        write_frame(
+            &mut guest_stream,
+            &mut guest_session,
+            Opcode::Hello,
+            0,
+            &Handshake::local("test-guest").encode(),
+        );
 
         let (opcode, _stream_id, _payload) =
             read_flowmux_frame(&mut guest_stream, &mut guest_session);
@@ -1755,7 +1925,13 @@ mod tests {
         let (mut guest_session, _session_id) =
             Session::guest(&mut guest_stream, guest_key, &host_verify).unwrap();
 
-        write_frame(&mut guest_stream, &mut guest_session, Opcode::Hello, 0, b"");
+        write_frame(
+            &mut guest_stream,
+            &mut guest_session,
+            Opcode::Hello,
+            0,
+            &Handshake::local("test-guest").encode(),
+        );
 
         let (opcode, _stream_id, _payload) =
             read_flowmux_frame(&mut guest_stream, &mut guest_session);

--- a/specs/plans/2026-08-15-flowmux-single-transport-cutover.md
+++ b/specs/plans/2026-08-15-flowmux-single-transport-cutover.md
@@ -10,7 +10,14 @@ work is demonstrably incomplete on `main`; this plan is where the remaining work
 
 ## Status
 
-**WS0–WS7 not started.** Guest egress is dead on `main`.
+**WS0–WS3 landed; WS4–WS7 open.** Guest egress works on `main`: Stage 0 fails
+fast with the true cause (WS0), the host serves sessions (WS1), identity is
+delivered per boot off the cmdline (WS2), and every spawn site threads it
+(WS3) — `mvmctl machine run --image python:3.12 -- python -c "print(2 + 2)"`
+prints `4`. What remains is the consolidation the plan is named for:
+substitution folded onto `OpenHttp` (WS4), ICMP dispatch (WS5), deleting
+`EgressMode`/`serve_wire`/`serve_raw` behind a one-protocol gate (WS6), and
+readiness failing closed (WS7).
 
 ## Why
 
@@ -79,17 +86,17 @@ is a later simplification, not a prerequisite.
 
 ## Workstreams
 
-### WS0 — Stage 0 fails fast with the true cause
+### WS0 — Stage 0 fails fast with the true cause — **complete**
 
-- [ ] `wait_for_vsock_egress_proxy_if_requested` (`crates/mvm-build/src/bin/stage0-init.rs:355-398`)
+- [x] `wait_for_vsock_egress_proxy_if_requested` (`crates/mvm-build/src/bin/stage0-init.rs:355-398`)
       returns a `Result` and aborts before `nix build` when the egress client exits or never
       binds, naming `mvm-egress-client` and its exit status; `dump_vsock_egress_diagnostics()`
       still runs
-- [ ] Decision extracted as a pure `egress_readiness_outcome(...) -> Result<(), String>`,
+- [x] Decision extracted as a pure `egress_readiness_outcome(...) -> Result<(), String>`,
       unit-tested without a VM, matching the `egress_child_exit_message` shape (`:341`)
-- [ ] Mirrored in `crates/mvm-build/src/bin/mvm-host-vm-init.rs`
-- [ ] The CLI surfaces the `stage0-init:` line instead of the downstream nix noise
-- [ ] `cmdline_overflow` (`crates/mvm-vmm/src/host/cmdline.rs:30-52`) enforced on both
+- [x] Mirrored in `crates/mvm-build/src/bin/mvm-host-vm-init.rs`
+- [x] The CLI surfaces the `stage0-init:` line instead of the downstream nix noise
+- [x] `cmdline_overflow` (`crates/mvm-vmm/src/host/cmdline.rs:30-52`) enforced on both
       builder paths — `libkrun_builder.rs:204` and `qemu_builder.rs:231` validate nothing today
 
 ### WS1 — Host accepts sessions properly — **complete**

--- a/specs/sprint/delivery/flowmux-build-skew-handshake.md
+++ b/specs/sprint/delivery/flowmux-build-skew-handshake.md
@@ -1,0 +1,47 @@
+# FlowMux tells you which half is stale
+
+`2821e2dd4` made the in-guest client FlowMux-only while every host spawn site
+still served Raw. Both halves were correct in isolation; together they were a
+dead network, and the symptom an operator saw was `ECONNREFUSED` with nothing
+naming either build. The frame header's `PROTOCOL_VERSION` did not catch it —
+the bytes never disagreed, the expectations did.
+
+So `Hello` and `HelloAck` now carry a
+`mvm_contract::protocol::network_flow::hello::Handshake`: a
+`BEHAVIOR_REVISION` both sides compile in, and a label for the build that sent
+it. `agree` refuses a session whose halves differ and names both, because
+every legitimate deployment builds both from the same tree — the host binary
+embeds the guest's — so a difference is a stale artifact, never a supported
+configuration. The host says `GoAway` with the reason before hanging up, so
+the guest reports the same mismatch rather than a bare disconnect.
+
+Two defects surfaced while wiring it, both in the same "nothing detects this"
+family:
+
+- The guest client published `SessionState::Ready` at construction, before the
+  handshake had been *sent*. A caller could open a flow into a session that
+  had agreed nothing. It now starts `Connecting`.
+- A pump error — a handshake refusal included — reached a `warn!` and stopped
+  there. Callers were already told `Ready` and never learned otherwise, so the
+  message naming both builds went nowhere. `SessionState::Dead` now carries the
+  reason and `await_ready` returns it.
+
+Fixing the first exposed a third: `active_client` waited on the reconnect
+owner's watch while reading readiness from the client's own. It only ever
+worked because a fresh client was born `Ready`; against a `Connecting` one it
+parked forever. It now waits on whichever moves.
+
+The mock in `addon_dns`'s tests had the mirror-image bug — `let _tx = tx;`
+under a comment claiming it held the sender open, dropping it at return. The
+real counterparty holds it for the session's life. Same lesson as the rest:
+a test double that does not fail the way the real thing fails is not
+testing the thing.
+
+Witnesses: `a_guest_from_another_revision_is_refused_by_name`,
+`a_guest_with_no_handshake_at_all_is_refused`,
+`the_hello_ack_carries_the_host_handshake` (host);
+`a_host_from_another_revision_is_refused_by_name`,
+`a_host_that_never_answers_the_handshake_says_so`,
+`a_fresh_client_is_connecting_until_the_host_answers` (guest); twelve unit
+tests on the payload codec and `agree`. The guest set is behind
+`--features addons`, which the `Lint feature coverage` lane builds.


### PR DESCRIPTION
Part of the FlowMux single-transport cutover. This is the second of the two product defects behind #2543 — the first (refusing a network endpoint older than the running `mvmctl`) is #2602.

## The failure this catches

`2821e2dd4` made the in-guest client FlowMux-only while every host spawn site still served Raw. Both halves were self-consistent; together they were a dead network, and what an operator saw was `ECONNREFUSED` naming neither build. The frame header's `PROTOCOL_VERSION` could not catch it — the bytes never disagreed, the expectations did.

## What changed

`Hello` and `HelloAck` now carry a `Handshake` (`mvm-contract/src/protocol/network_flow/hello.rs`): a `BEHAVIOR_REVISION` both sides compile in, plus a label for the build that sent it. `agree` refuses a session whose halves differ and names both.

Refusing on *any* difference is deliberate. Every legitimate deployment builds both halves from the same tree — the host binary embeds the guest's — so a difference is a stale artifact, never a supported configuration. The host sends `GoAway` with the reason before hanging up, so the guest reports the same mismatch rather than a disconnect it cannot explain.

`BEHAVIOR_REVISION` is a declaration, not a derivation: bump it in the same change that alters what either peer expects of the other. Nothing computes it, which is exactly why the bump belongs in the diff that earns it.

## Three defects this surfaced

All the same shape as the one above — a real failure that reached nobody who could act on it.

- The client published `SessionState::Ready` at construction, before the handshake was *sent*. A caller could open a flow into a session that had agreed nothing. It starts `Connecting`.
- A pump error, handshake refusal included, reached a `warn!` and stopped there. Callers had already been told `Ready`, so the message naming both builds went nowhere. `Dead` carries the reason and `await_ready` returns it.
- Fixing the first exposed that `active_client` waited on the reconnect owner's watch while reading readiness from the client's own. It worked only because a fresh client was born `Ready`; against a `Connecting` one it parked forever. It waits on whichever moves now.

The `addon_dns` mock had the mirror-image bug: `let _tx = tx;` under a comment claiming it held the watch sender open, dropping it at return. The real counterparty holds it for the session's life — a double that does not fail the way the real thing fails is not testing the thing.

## Witnesses

Host: `a_guest_from_another_revision_is_refused_by_name`, `a_guest_with_no_handshake_at_all_is_refused`, `the_hello_ack_carries_the_host_handshake`.
Guest: `a_host_from_another_revision_is_refused_by_name`, `a_host_that_never_answers_the_handshake_says_so`, `a_fresh_client_is_connecting_until_the_host_answers`.
Plus twelve unit tests on the payload codec and `agree`, including a lying length and a non-UTF-8 label.

Two of them confirmed red against a neutered `agree` rather than assumed to bite. The guest set is behind `--features addons`, which is why `--all-targets` never sees it; `Lint feature coverage` builds that lane.

## Also

Corrects the cutover plan's status line, which read `WS0–WS7 not started` while WS0–WS3 had landed and the reported command works.

## Gates

`cargo nextest run --workspace` 11969 passed · `cargo clippy --workspace --all-targets -D warnings` clean · `cargo zigbuild --target x86_64-unknown-linux-gnu` clean · ten xtask policy gates OK.