### PR TITLE
perf(kernel): drop debug instrumentation a sealed guest has no reader for

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -380,6 +380,26 @@ let
     "DEBUG_INFO_DWARF5"
     "DEBUG_INFO_DWARF4"
     "DEBUG_INFO_BTF"
+
+    # Kernel debug instrumentation a sealed workload guest has no reader for:
+    # nothing collects a stack-depth report out of it, and a W+X finding there
+    # would be a fact about the image we built rather than about anything the
+    # guest did.
+    #
+    # This buys size, NOT boot time, and the distinction is recorded here
+    # because the console log makes it look otherwise. Their messages sit on
+    # the two largest inter-timestamp gaps of an x86_64 guest boot — `x86/mm:
+    # Checked W+X mappings` twice for ~71 ms, `used greatest stack depth` for
+    # ~43 ms — which reads as a third of guest boot waiting to be reclaimed.
+    # It is not. Measured on the Linux/Firecracker host, 12 launches per arm:
+    # dispatch window 495.5 ms with them on and 504.0 ms with them off,
+    # `driver_boot` 435.7 ms against 436.8 ms. No change beyond noise.
+    #
+    # The gap before a console line is not the cost of the work that line
+    # names; on a serial console it is dominated by emitting the output before
+    # it. Do not size a kernel change from those gaps — measure the launch.
+    "DEBUG_WX"
+    "DEBUG_STACK_USAGE"
   ]
   ++ pkgs.lib.optionals (kernelArch == "x86_64") [
     # x86 defconfig carries physical-PC, laptop, and foreign-hypervisor


### PR DESCRIPTION
## What

Disables `DEBUG_WX` and `DEBUG_STACK_USAGE` in the shared guest kernel config.

They're development aids. A workload guest boots a sealed rootfs to an agent: nothing collects a stack-depth report out of it, and a W+X finding there would be a fact about the image we built rather than about anything the guest did.

## The measured effect is size, not boot time — and that's the point of the comment

I went after these expecting a launch-latency win, and **there isn't one.** Their messages sit on the two largest inter-timestamp gaps of an x86_64 guest boot:

```
36.6ms  x86/mm: Checked W+X mappings: passed
34.8ms  x86/mm: Checked W+X mappings: passed
21.7ms  init (44) used greatest stack depth
21.4ms  init (45) used greatest stack depth
```

~114 ms against a ~341 ms guest boot. It reads as a third of guest boot waiting to be reclaimed. It isn't.

Measured on the Linux/Firecracker host, 12 launches per arm, same binary, same rootfs, only the kernel config differing:

| | debug on | debug off |
|---|---:|---:|
| dispatch window p50 | 495.5 ms | **504.0 ms** |
| `driver_boot` p50 | 435.7 ms | **436.8 ms** |
| `vmlinux` | 4,318,208 B | 4,310,016 B |
| built-in symbols | 917 | 914 |

**No boot-time change beyond noise.** Confirmed the config actually took, rather than assuming: `CONFIG_DEBUG_WX=y` and `CONFIG_DEBUG_STACK_USAGE=y` are both absent from the emitted config (`olddefconfig` did not revert them), and the booted guest emits zero `Checked W+X` and zero `greatest stack depth` lines.

**The reason is recorded in `base.nix` next to the disables:** the gap before a console line is not the cost of the work that line names — on a serial console it is dominated by emitting the output before it. Sizing a kernel change from those gaps is invalid. That note is most of the value of this PR.

## So why land it

For the 8 KiB and three built-in symbols, on the same grounds as the existing shrink work — and so the next person who spots `DEBUG_WX` on a boot log doesn't re-derive the negative result. It is **not** a launch-latency fix and the commit message says so.

If you'd rather not carry a change this small, closing it is reasonable; the comment is the part worth keeping and could move to the issue instead.

## Verification

`check-no-spec-refs-in-comments`, `check-honesty`, `check-no-overclaim` pass. `check-kernel-config-budget` needs a resolved `.config` and runs in the kernel lane. Config-only change; no Rust touched.