### PR TITLE
ci(bdd): stop the conformance lane evicting the cache every lane restores

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -42,15 +42,23 @@ jobs:
         with:
           tool: just
 
-      - name: Cache cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-bdd-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-bdd-
+      # Restore-only, through the shared action, for the reason its own
+      # comment gives: the repo cache is capped at 10 GB with LRU eviction, so
+      # a lane that writes a whole `target` directory from every pull-request
+      # and merge-queue ref evicts the entry every other lane restores.
+      #
+      # This job used to do exactly that with a raw `actions/cache` over
+      # `target` — four surviving entries at ~1.5 GB each, 6.2 GB of a 9.7 GB
+      # total. Writing nothing here costs this lane the workspace half of its
+      # cache and gives every other lane back the dependency half of theirs.
+      #
+      # It shares the default `workspace` key rather than taking one of its
+      # own: the warm job already builds on nightly, which is this lane's
+      # toolchain, so the dependency graph and every unchanged workspace crate
+      # come back warm. `--features bdd` adds a handful of crates on top. A
+      # `bdd`-keyed entry would need its own writer, and that means a second
+      # full build on every merge to save the smaller half of one lane.
+      - uses: ./.github/actions/rust-cache
 
       - name: Run BDD conformance suite
         run: just bdd


### PR DESCRIPTION
Addresses the cause of #2567. Not a full close — see acceptance below.

## Measurement

Live repository cache, sampled in full (5,524 entries):

```
total:      9.71 GB   against a 10 GB cap
cargo-bdd:  6.23 GB   across 4 entries      <- 64% of the budget
v1-rust:    0.34 GB   across 1 entry
```

That one surviving `v1-rust-workspace-Linux-x64-0d77c767-b2c4251f` was created and last accessed at the same instant — written by the warm job, never read by anything.

## Cause

`.github/actions/rust-cache` already documents the rule and the reason:

> the repo cache is capped at 10 GB with LRU eviction, and a Rust target directory this size means a busy day of PR writes would evict the very entry everything else depends on.

`bdd.yml` bypassed that action and hand-rolled `actions/cache` over `~/.cargo/registry`, `~/.cargo/git` and the whole `target` directory, with writing left on. `actions/cache` scopes an entry to the ref that wrote it, so every pull request and every merge-queue commit left its own ~1.5 GB copy behind — the exact pattern the shared action exists to prevent.

## Change

The lane restores through the shared action and writes nothing.

It uses the default `workspace` key rather than one of its own. The warm job already builds on **nightly**, which is this lane's toolchain, so the dependency graph and unchanged workspace crates come back warm and `--features bdd` adds a handful of crates on top. A `bdd`-keyed entry would need its own writer — a second full build on every merge to main, to save the smaller half of one lane.

## What this does and does not settle

This frees ~6 GB of a 10 GB cap. Whether that alone makes the compiling jobs report a hit is the acceptance criterion in #2567 and it is **measured after merge, not asserted here** — I cannot observe eviction pressure from a pull request.

I am also not claiming the four bdd entries are the only pressure: 5,524 entries share the remaining budget, the Nix binary cache among them. What is certain is that 64% of the cap sat in four entries written by a lane that the repository's own design says should not be writing at all.

Worth noting against my own earlier reading of this issue: I previously looked at this cache, measured 6.47 GB, and concluded there was no eviction problem. That was true when measured and is not true now. The number to watch is the ratio to the cap, not the absolute size.

## Follow-up

If PR jobs still miss after this lands, the next suspects are entry-count pressure from the Nix cache and the `node-cache` / other per-ref writers, in that order.