### PR TITLE
perf(fc): stop narrating every boot across an emulated serial port

### DIFF
--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -77,10 +77,47 @@ impl Default for FcDriver {
 /// UART), and carry NO `mvm.ip=` / `mvm.gw=` tokens — the converged path has no
 /// guest NIC. The root/init selection follows the boot shape; the shared cmdline
 /// assembler layers verity/grants/egress/uvols tokens on top of this.
+/// Set to `1`/`true` to restore full kernel console output on a Firecracker
+/// guest, at the cost documented on [`fc_console_verbosity`].
+pub const GUEST_CONSOLE_VERBOSE_ENV: &str = "MVM_GUEST_CONSOLE_VERBOSE";
+
+/// The console-verbosity token for a Firecracker boot, `" quiet"` by default.
+///
+/// Firecracker's `ttyS0` is an emulated 16550A: the guest takes a VM exit per
+/// byte written to it. Measured on a Linux/KVM host with speculative-execution
+/// mitigations active, a workload boot emits ~19 KB of kernel log that way and
+/// pays 148-176 ms for it — a third of the launch, spent narrating a boot
+/// nobody is reading. The other backends do not share the cost: libkrun and the
+/// mock boot `console=hvc0`, a virtio-console whose output rides a ring.
+///
+/// `quiet` raises the console loglevel so `KERN_INFO` chatter stops crossing
+/// the port. Warnings and errors still print, and the guest agent's own
+/// messages are userspace writes rather than printk, so they are unaffected —
+/// `console.log` keeps the lines an operator actually reads.
+///
+/// The escape hatch matters: kernel boot output is how a hung guest gets
+/// diagnosed. [`GUEST_CONSOLE_VERBOSE_ENV`] restores it in full.
+fn fc_console_verbosity() -> &'static str {
+    verbosity_token_for(std::env::var(GUEST_CONSOLE_VERBOSE_ENV).ok().as_deref())
+}
+
+/// The verbosity decision, pure over the raw env value so it is testable
+/// without mutating process state.
+fn verbosity_token_for(requested: Option<&str>) -> &'static str {
+    match requested {
+        Some(v) if v == "1" || v.eq_ignore_ascii_case("true") => "",
+        _ => " quiet",
+    }
+}
+
 fn fc_base_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
     // Serial console + reboot/panic behavior + stable interface naming. The NIC
     // fields the raw Firecracker TAP path appends here are deliberately absent.
-    let console = "console=ttyS0 reboot=k panic=1 net.ifnames=0";
+    let console = format!(
+        "console=ttyS0{} reboot=k panic=1 net.ifnames=0",
+        fc_console_verbosity()
+    );
+    let console = console.as_str();
     if virtiofs_root {
         format!("{console} rootfstype=virtiofs root=mvmroot ro init=/init")
     } else if has_disk {
@@ -1357,7 +1394,7 @@ mod tests {
 
         // Verity / initramfs base: serial console only, no root/init token.
         let verity = d.workload_base_bootargs(false, false);
-        assert_eq!(verity, "console=ttyS0 reboot=k panic=1 net.ifnames=0");
+        assert_eq!(verity, "console=ttyS0 quiet reboot=k panic=1 net.ifnames=0");
         assert!(!verity.contains("root="), "got: {verity}");
 
         // The virtiofs-root variant still uses ttyS0, not another VMM's console.
@@ -1503,7 +1540,7 @@ mod tests {
             "{boot}"
         );
         assert!(
-            boot.contains(r#""boot_args": "console=ttyS0 reboot=k panic=1 net.ifnames=0""#),
+            boot.contains(r#""boot_args": "console=ttyS0 quiet reboot=k panic=1 net.ifnames=0""#),
             "{boot}"
         );
     }
@@ -2120,5 +2157,51 @@ mod tests {
         // (rejected before any connect attempt).
         assert!(vm.vsock_connect(GUEST_AGENT_PORT + 1).is_err());
         assert!(vm.vsock_connect(9999).is_err());
+    }
+}
+
+#[cfg(test)]
+mod console_verbosity_tests {
+    use super::*;
+
+    /// Firecracker's ttyS0 costs a VM exit per byte, so the default boot must
+    /// not narrate itself across it.
+    #[test]
+    fn the_default_firecracker_cmdline_is_quiet() {
+        for (virtiofs_root, has_disk) in [(false, false), (false, true), (true, false)] {
+            let args = fc_base_bootargs(virtiofs_root, has_disk);
+            assert!(
+                args.contains("console=ttyS0 quiet"),
+                "boot shape ({virtiofs_root}, {has_disk}) lost the quiet token: {args}"
+            );
+        }
+    }
+
+    /// `quiet` raises the console loglevel; it must not disturb the rest of the
+    /// cmdline, whose tokens other code and the guest init both parse.
+    #[test]
+    fn quiet_is_additive_and_leaves_the_boot_shape_tokens_alone() {
+        assert_eq!(
+            fc_base_bootargs(false, true),
+            "console=ttyS0 quiet reboot=k panic=1 net.ifnames=0 rootwait init=/init"
+        );
+        assert_eq!(
+            fc_base_bootargs(true, false),
+            "console=ttyS0 quiet reboot=k panic=1 net.ifnames=0 \
+             rootfstype=virtiofs root=mvmroot ro init=/init"
+        );
+    }
+
+    /// A hung guest is diagnosed from kernel boot output, so the suppression
+    /// has to be reversible without a rebuild.
+    #[test]
+    fn the_verbose_escape_hatch_restores_full_kernel_output() {
+        // Pure over the env read so the test does not mutate process state.
+        assert_eq!(verbosity_token_for(None), " quiet");
+        assert_eq!(verbosity_token_for(Some("0")), " quiet");
+        assert_eq!(verbosity_token_for(Some("no")), " quiet");
+        assert_eq!(verbosity_token_for(Some("1")), "");
+        assert_eq!(verbosity_token_for(Some("true")), "");
+        assert_eq!(verbosity_token_for(Some("TRUE")), "");
     }
 }


### PR DESCRIPTION
## The cost

Firecracker's `ttyS0` is an emulated 16550A — the guest takes **a VM exit per byte** written to it. A workload boot emitted ~19 KB of kernel log that way. On a host with speculative-execution mitigations active, each of those exits is expensive, and the two multiply.

## Measured

12 launches per arm on Linux/KVM, same binary, same rootfs, same guest kernel, **mitigations on both sides** — so this is the real-world figure:

| | before | after |
|---|---:|---:|
| dispatch p50 | 504.0 ms | **297.7 ms** |
| dispatch p95 | 916.8 ms | **328.2 ms** |
| `driver_boot` | 435.6 ms | **222.4 ms** |
| console volume | 19,095 B / 247 lines | **2,752 B / 24 lines** |

**206 ms off p50**, and the tail closed further than the median did.

For scale: a separate controlled test on the same box — toggling only the host's `mitigations=` parameter, with the host kernel pinned across the reboot so version could not confound it — moved dispatch 504.0 ms → 308.1 ms. Nearly all of that penalty was being paid *per console byte*, which is why removing the bytes recovers it while the mitigations stay on.

## What `quiet` does and does not do

It raises the console loglevel; it does not remove the console. Warnings and errors still print, and the guest agent's own messages are userspace writes rather than printk, so `console.log` keeps the lines an operator actually reads — 24 of them instead of 247.

`MVM_GUEST_CONSOLE_VERBOSE=1` restores full kernel output, because a hung guest is diagnosed from exactly that. The verbosity decision is a pure function over the env value, in the same shape as `tracing_enabled_from`, so it is tested without mutating process state.

## Why not virtio-console, like libkrun

**Firecracker has no virtio-console device.** I checked before proposing it as a follow-up:

| cmdline under FC 1.14.1 | output |
|---|---:|
| `console=hvc0` | 6,664 B — *identical to no console at all* |
| `console=ttyS0` | 20,520 B |

`hvc0` produces nothing because the device does not exist; FC's model is block/net/vsock/balloon/rng plus the 8250. libkrun and the mock boot `console=hvc0` and never pay per-byte exits. **The asymmetry between the backends is a capability Firecracker lacks, not a choice mvm made** — and there is no structural fix short of patching Firecracker upstream, so `quiet` is the fix rather than a stopgap.

## Tests

Two existing tests pinned the old cmdline and are updated. Four added:

- default cmdline is quiet across all three boot shapes (virtiofs-root, disk, initramfs)
- `quiet` is additive and leaves the boot-shape tokens other code parses alone
- the verbose escape hatch, over the raw env values including `0`/`no`/`TRUE`

## Verification

`cargo nextest run --workspace` — **11,994 passed, 0 failed**. `cargo +nightly fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.