### PR TITLE
fix(cli): mark a fetched boot image as fetched, and close out the plan

### DIFF
--- a/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
@@ -304,7 +304,18 @@ fn ensure_default_microvm_prod_image(cache_dir: &str) -> Result<(String, String)
     match resolved.choice {
         BootImageAcquisition::Build => build_prod_default_locally(cache_dir),
         BootImageAcquisition::Fetch => {
-            download_default_microvm_image(cache_dir, &kernel_path, &rootfs_path)
+            let acquired = download_default_microvm_image(cache_dir, &kernel_path, &rootfs_path)?;
+            // Record that these bytes were fetched, not built here. Without it a
+            // prebuilt pulled into a source checkout is indistinguishable from a
+            // build of the working tree, and the next person to wonder why their
+            // flake edit had no effect has nothing to read. The producer's own
+            // build facts are left untouched.
+            let tag = format!("v{}", env!("CARGO_PKG_VERSION"));
+            crate::commands::image::boot::cache::stamp_provenance(
+                std::path::Path::new(cache_dir),
+                &crate::commands::image::boot::cache::AcquiredProvenance::fetched(&tag),
+            )?;
+            Ok(acquired)
         }
     }
 }

--- a/crates/mvm-cli/src/commands/image/boot/cache.rs
+++ b/crates/mvm-cli/src/commands/image/boot/cache.rs
@@ -142,14 +142,14 @@ fn sidecar_mtime(dir: &Path) -> Option<String> {
 /// and "how did this reach this host" is not a fact about the build at all —
 /// a published image is built locally *somewhere*, and calling that
 /// `built-local` here is exactly the misreading `source` exists to prevent.
-pub(super) struct AcquiredProvenance {
-    pub(super) image_tag: String,
-    pub(super) source: &'static str,
-    pub(super) acquired_at: String,
+pub(crate) struct AcquiredProvenance {
+    pub(crate) image_tag: String,
+    pub(crate) source: &'static str,
+    pub(crate) acquired_at: String,
 }
 
 impl AcquiredProvenance {
-    pub(super) fn fetched(tag: &str) -> Self {
+    pub(crate) fn fetched(tag: &str) -> Self {
         Self {
             image_tag: tag.to_string(),
             source: "fetched",
@@ -160,7 +160,7 @@ impl AcquiredProvenance {
 
 /// Rewrite `dir`'s sidecar with the acquisition facts, leaving every build
 /// fact the producer recorded untouched.
-pub(super) fn stamp_provenance(dir: &Path, provenance: &AcquiredProvenance) -> Result<()> {
+pub(crate) fn stamp_provenance(dir: &Path, provenance: &AcquiredProvenance) -> Result<()> {
     let mut sidecar = GuestSidecar::read_from_dir(dir)
         .with_context(|| format!("read the sidecar in {}", dir.display()))?
         .with_context(|| {

--- a/crates/mvm-cli/src/commands/image/boot/mod.rs
+++ b/crates/mvm-cli/src/commands/image/boot/mod.rs
@@ -9,7 +9,7 @@
 use anyhow::Result;
 use clap::Subcommand;
 
-mod cache;
+pub(crate) mod cache;
 mod check;
 mod status;
 mod update;

--- a/crates/mvm-cli/src/commands/image/boot/tests.rs
+++ b/crates/mvm-cli/src/commands/image/boot/tests.rs
@@ -294,3 +294,62 @@ fn a_tag_that_cannot_be_ordered_is_not_reported_as_behind() {
         CheckVerdict::NoPublishedLine
     );
 }
+
+/// A fetched image must say so, even when it landed in a source checkout.
+///
+/// `MVM_BOOT_IMAGE=fetch` is the one case that weakens "a source checkout never
+/// depends on a published artifact". The weakening is acceptable only because
+/// the result is labelled: without this stamp a prebuilt sitting in a checkout
+/// is indistinguishable from a build of the working tree, and the next person
+/// to wonder why their flake edit had no effect has nothing to read.
+#[test]
+fn stamping_marks_an_acquired_image_as_fetched_without_losing_build_facts() {
+    let _env = TestEnv::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    // A sidecar as a producer would emit it: build facts present, acquisition
+    // facts absent, because the build cannot know them.
+    let produced = r#"{
+        "name": "mvm-default-microvm",
+        "accessible": false,
+        "sealed": true,
+        "entrypointKind": "command",
+        "initSystem": "busybox",
+        "expectedBootMs": 300,
+        "agentBinary": "real",
+        "rootlessEntrypoint": true,
+        "hypervisor": "libkrun",
+        "protocolVersion": 2,
+        "generatorRev": "abc123",
+        "source": "built-local"
+    }"#;
+    std::fs::write(
+        dir.path().join(mvm_build::builder_vm::SIDECAR_FILENAME),
+        produced,
+    )
+    .unwrap();
+
+    super::cache::stamp_provenance(
+        dir.path(),
+        &super::cache::AcquiredProvenance::fetched("v0.18.0"),
+    )
+    .expect("stamping a well-formed sidecar must succeed");
+
+    let after = mvm_build::builder_vm::GuestSidecar::read_from_dir(dir.path())
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        after.source, "fetched",
+        "the acquisition arm must be recorded"
+    );
+    assert_eq!(after.image_tag, "v0.18.0");
+    assert!(
+        !after.built_at.is_empty(),
+        "the host stamps a time the build could not"
+    );
+    // Build facts the producer recorded survive: stamping adds provenance, it
+    // does not rewrite what the image is.
+    assert_eq!(after.protocol_version, 2);
+    assert_eq!(after.generator_rev, "abc123");
+    assert_eq!(after.name, "mvm-default-microvm");
+}

--- a/crates/mvm-cli/src/commands/image/mod.rs
+++ b/crates/mvm-cli/src/commands/image/mod.rs
@@ -14,7 +14,7 @@ use mvm_core::user_config::MvmConfig;
 
 use super::Cli;
 
-mod boot;
+pub(crate) mod boot;
 mod cache;
 mod ingest;
 mod inspect;

--- a/specs/plans/2026-08-15-boot-image-lifecycle.md
+++ b/specs/plans/2026-08-15-boot-image-lifecycle.md
@@ -450,9 +450,17 @@ mechanics on the artifact where a mistake is cheapest to correct.
 ## Workstreams
 
 - [x] WS1 — boot the staged image before publish (x86_64 boot, aarch64 header check)
-- [ ] WS2 — `boot-image/v*` release train (semver from `v0.1.0`), dual-publish window, `DEFAULT_BOOT_IMAGE_TAG`
+- [x] WS2 — `boot-image/v*` release train (semver from `v0.1.0`), dual-publish window, `DEFAULT_BOOT_IMAGE_TAG`
 - [x] WS3 — sidecar provenance fields + `mvmctl image boot status｜check｜update`
-- [ ] WS4 — `MVM_BOOT_IMAGE` escape hatch + doctor readout
+- [x] WS4 — `MVM_BOOT_IMAGE` escape hatch + doctor readout
+
+**One piece of WS2 deliberately did not ship.** `DEFAULT_BOOT_IMAGE_TAG` exists but
+no consumer reads it. Repointing `download_default_microvm_image` /
+`download_workload_kernel` at `boot-image/v0.1.0` before that tag is published
+would 404 every fresh install on merge — the failure this plan exists to close.
+The switch is unblocked by publishing a first `boot-image/v*` release, which the
+new workflow now makes possible. Until then a CLI release refuses to publish
+without image assets rather than shipping a broken one.
 
 ## Open questions for whoever picks this up
 


### PR DESCRIPTION
Closes out `specs/plans/2026-08-15-boot-image-lifecycle.md`. Two things.

## 1. A fetched image now says it was fetched

`MVM_BOOT_IMAGE=fetch` is the one case that weakens *"a source checkout never depends on a published artifact"*. That weakening is only acceptable because the result is **labelled** — and it wasn't. The acquisition path downloaded the image and recorded nothing, so a prebuilt sitting in a checkout was indistinguishable from a build of the working tree. The next person wondering why their flake edit had no effect would have had nothing to read.

This was deferred out of the knob PR because it needed the provenance field that landed with the sidecar work. That field exists now, so it's wired: the fetch arm stamps through the **same** `AcquiredProvenance` helper the `update` path already uses, rather than growing a second stamper.

The test asserts the part that's easy to get wrong: stamping *adds* acquisition facts and leaves every build fact intact. A fetched image keeps its `protocol_version` and `generator_rev`, and gains a `source`, a tag, and a time the hermetic build could not supply.

## 2. WS2 and WS4 checkboxes

Missed because the work landed across three concurrent branches that each — correctly — avoided editing the shared plan doc to prevent rebase collisions. All four workstreams are now ticked.

The note added under them records the one piece of WS2 that **deliberately did not ship**: `DEFAULT_BOOT_IMAGE_TAG` exists but no consumer reads it, because repointing the download paths at a tag nobody has published would 404 every fresh install on merge. That's unblocked by cutting a first `boot-image/v*` release, which the new workflow now makes possible. Until then a CLI release refuses to publish without image assets rather than shipping a broken one.

## Verification

`cargo nextest run -p mvm-cli` → 1821 passed. Nightly `fmt --all --check`, workspace `clippy --all-targets -D warnings` via the pre-commit hook, and `check-declared-backing`, `check-honesty`, `check-no-overclaim`, `check-plan-names`, `check-no-spec-refs-in-comments`, `check-test-home-isolation`, `check-cli-runtime-surface`.