### PR TITLE
feat(337): finish Tier C with sessions, and close the plan

### DIFF
--- a/crates/mvm-sdk/sdks/python/mvm/__init__.py
+++ b/crates/mvm-sdk/sdks/python/mvm/__init__.py
@@ -113,7 +113,7 @@ from mvm._sandbox import (
     SandboxInfo,
     SandboxLiveError,
     SandboxModeError,
-    current_recording_dict,
+    current_recording,
     emit_recording_json,
     reset_recording,
 )
@@ -188,7 +188,7 @@ __all__ = [
     "addon_use",
     "app",
     "audit",
-    "current_recording_dict",
+    "current_recording",
     "current_session_id",
     "derive_schema",
     "dns_none",

--- a/crates/mvm-sdk/sdks/python/mvm/_sandbox.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_sandbox.py
@@ -95,7 +95,7 @@ __all__ = [
     "SandboxDevOnly",
     "SandboxLiveError",
     "SandboxModeError",
-    "current_recording_dict",
+    "current_recording",
     "emit_recording_json",
     "reset_recording",
 ]
@@ -272,7 +272,7 @@ def reset_recording() -> None:
     _live_sandbox = None
 
 
-def current_recording_dict() -> dict[str, Any] | None:
+def current_recording() -> dict[str, Any] | None:
     """Return the wire-shape dict for the currently-active recording,
     or ``None`` if no ``Sandbox.create()`` has run."""
     return _recording

--- a/crates/mvm-sdk/sdks/python/tests/test_sandbox.py
+++ b/crates/mvm-sdk/sdks/python/tests/test_sandbox.py
@@ -33,7 +33,7 @@ def _isolate() -> None:
 
 def test_create_records_the_template_and_default_ttl() -> None:
     mvm.Sandbox.create("python-3.12")
-    rec = mvm.current_recording_dict()
+    rec = mvm.current_recording()
     assert rec is not None
     assert rec["create"]["template"] == "python-3.12"
     assert rec["create"]["ttl_seconds"] == mvm.DEFAULT_TTL_SECONDS
@@ -48,7 +48,7 @@ def test_workload_id_defaults_to_template() -> None:
 def test_workload_id_override() -> None:
     sb = mvm.Sandbox.create("python-3.12", workload_id="etl-job")
     assert sb.workload_id == "etl-job"
-    assert mvm.current_recording_dict()["workload_id"] == "etl-job"
+    assert mvm.current_recording()["workload_id"] == "etl-job"
 
 
 def test_create_rejects_empty_template() -> None:
@@ -68,7 +68,7 @@ def test_only_one_sandbox_per_script() -> None:
 def test_commands_start_appends_op() -> None:
     sb = mvm.Sandbox.create("python-3.12")
     sb.commands.start(["python", "run.py"])
-    ops = mvm.current_recording_dict()["ops"]
+    ops = mvm.current_recording()["ops"]
     assert ops == [
         {"kind": "command_start", "argv": ["python", "run.py"], "env": {}}
     ]
@@ -83,7 +83,7 @@ def test_commands_start_carries_env() -> None:
             "API_KEY": mvm.secret("api-key", type="bearer", hosts=["api.example.com"]),
         },
     )
-    ops = mvm.current_recording_dict()["ops"]
+    ops = mvm.current_recording()["ops"]
     env = ops[0]["env"]
     assert env["MODE"] == {"kind": "literal", "value": "prod"}
     assert env["API_KEY"]["kind"] == "secret_ref"
@@ -108,7 +108,7 @@ def test_commands_start_rejects_empty_argv() -> None:
 def test_files_write_encodes_bytes_to_base64() -> None:
     sb = mvm.Sandbox.create("python-3.12")
     sb.files.write("/app/config.json", b'{"x":1}')
-    op = mvm.current_recording_dict()["ops"][0]
+    op = mvm.current_recording()["ops"][0]
     assert op["kind"] == "files_write"
     assert op["path"] == "/app/config.json"
     assert base64.standard_b64decode(op["bytes_b64"]) == b'{"x":1}'
@@ -117,7 +117,7 @@ def test_files_write_encodes_bytes_to_base64() -> None:
 def test_files_write_accepts_str_content_as_utf8() -> None:
     sb = mvm.Sandbox.create("python-3.12")
     sb.files.write("/app/note.txt", "héllo")
-    op = mvm.current_recording_dict()["ops"][0]
+    op = mvm.current_recording()["ops"][0]
     assert base64.standard_b64decode(op["bytes_b64"]) == "héllo".encode("utf-8")
 
 
@@ -139,13 +139,13 @@ def test_files_write_rejects_empty_path() -> None:
 def test_kill_appends_kill_op() -> None:
     sb = mvm.Sandbox.create("python-3.12")
     sb.kill()
-    assert mvm.current_recording_dict()["ops"] == [{"kind": "kill"}]
+    assert mvm.current_recording()["ops"] == [{"kind": "kill"}]
 
 
 def test_context_manager_records_kill_on_exit() -> None:
     with mvm.Sandbox.create("python-3.12") as sb:
         sb.commands.start(["python", "run.py"])
-    ops = mvm.current_recording_dict()["ops"]
+    ops = mvm.current_recording()["ops"]
     assert ops[-1] == {"kind": "kill"}
 
 
@@ -181,22 +181,22 @@ def test_invalid_mode_raises_with_actionable_message() -> None:
 
 def test_ttl_accepts_seconds_int() -> None:
     mvm.Sandbox.create("python-3.12", ttl=120)
-    assert mvm.current_recording_dict()["create"]["ttl_seconds"] == 120
+    assert mvm.current_recording()["create"]["ttl_seconds"] == 120
 
 
 def test_ttl_accepts_30m() -> None:
     mvm.Sandbox.create("python-3.12", ttl="30m")
-    assert mvm.current_recording_dict()["create"]["ttl_seconds"] == 1800
+    assert mvm.current_recording()["create"]["ttl_seconds"] == 1800
 
 
 def test_ttl_accepts_1h() -> None:
     mvm.Sandbox.create("python-3.12", ttl="1h")
-    assert mvm.current_recording_dict()["create"]["ttl_seconds"] == 3600
+    assert mvm.current_recording()["create"]["ttl_seconds"] == 3600
 
 
 def test_ttl_accepts_bare_integer_string() -> None:
     mvm.Sandbox.create("python-3.12", ttl="3600")
-    assert mvm.current_recording_dict()["create"]["ttl_seconds"] == 3600
+    assert mvm.current_recording()["create"]["ttl_seconds"] == 3600
 
 
 def test_ttl_rejects_unparseable() -> None:
@@ -217,7 +217,7 @@ def test_create_resources_flow_through() -> None:
         "python-3.12",
         resources=mvm.resources(cpu_cores=2, memory_mb=512, rootfs_size_mb=1024),
     )
-    rsr = mvm.current_recording_dict()["create"]["resources"]
+    rsr = mvm.current_recording()["create"]["resources"]
     assert rsr["cpu_cores"] == 2
     assert rsr["memory_mb"] == 512
     assert rsr["rootfs_size_mb"] == 1024
@@ -225,7 +225,7 @@ def test_create_resources_flow_through() -> None:
 
 def test_create_includes_flow_through() -> None:
     mvm.Sandbox.create("python-3.12", include=["src", "lib"])
-    assert mvm.current_recording_dict()["create"]["include"] == ["src", "lib"]
+    assert mvm.current_recording()["create"]["include"] == ["src", "lib"]
 
 
 # ── emit + reset ─────────────────────────────────────────────────────
@@ -250,9 +250,9 @@ def test_emit_recording_json_raises_when_inactive() -> None:
 
 def test_reset_recording_clears_state() -> None:
     mvm.Sandbox.create("python-3.12")
-    assert mvm.current_recording_dict() is not None
+    assert mvm.current_recording() is not None
     mvm.reset_recording()
-    assert mvm.current_recording_dict() is None
+    assert mvm.current_recording() is None
 
 
 # ── Phase 7e — MVM_SDK_OUT_PATH atexit flusher ──────────────────────

--- a/crates/mvm-sdk/sdks/typescript/src/_remote.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/_remote.ts
@@ -16,8 +16,9 @@
  *   stack trace — which fails for any function received rather than
  *   defined locally. Setting `MVM_NO_VM=1` here raises
  *   `NoVmIntrospectionError` rather than silently doing something else.
- * * **Sessions** — not in this increment; an active session is simply
- *   not consulted yet.
+ * * **Sessions** — an active `session(...)` body attaches its warm VM.
+ *   Cross-workload dispatch through `workload_ref` opts out, since a
+ *   session belongs to one workload.
  *
  * The error types come from the Rust registry via `_errors/types.js`;
  * this module is what raises them, which is why they are emitted into
@@ -27,6 +28,7 @@
 import * as child from "node:child_process";
 
 import { resolveCliBin } from "./_cli.js";
+import { currentSessionId } from "./_session.js";
 import {
   EmittingContextError,
   MsgpackUnavailable,
@@ -112,6 +114,8 @@ function parseErrorEnvelope(stderr: string): RemoteError | null {
 interface InvokeOptions {
   callSite: string;
   fnSelector?: string;
+  /** Defaults to true; `workload_ref` opts out. */
+  useActiveSession?: boolean;
 }
 
 /** Invoke `functionName` in `workloadId` and return its decoded result. */
@@ -147,6 +151,13 @@ export function invokeSync(
 
   const bin = resolveCliBin("remote invocation");
   const argv = ["invoke"];
+  // An active `session(...)` body attaches its warm VM, matching Python's
+  // `_prepare_invoke`. Cross-workload dispatch opts out: a session is
+  // scoped to one workload and must not leak into a call against another.
+  if (options.useActiveSession !== false) {
+    const sessionId = currentSessionId();
+    if (sessionId !== null) argv.push("--session", sessionId);
+  }
   if (options.fnSelector !== undefined) argv.push("--fn", options.fnSelector);
   argv.push("--stdin", "-", "--", workloadId);
 
@@ -257,6 +268,7 @@ export function workload_ref(workloadId: string, format: string = "json"): Workl
         invokeSync(workloadId, format, args, {}, {
           callSite: `workload_ref(${workloadId}).${property}(...)`,
           fnSelector: property,
+          useActiveSession: false,
         });
     },
   }) as WorkloadRef;

--- a/crates/mvm-sdk/sdks/typescript/src/_session.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/_session.ts
@@ -1,0 +1,173 @@
+/**
+ * Sessions — the last piece of Tier C.
+ *
+ * Python holds the active session in a `contextvars.ContextVar` and
+ * resets its `Token` in `__exit__`. `AsyncLocalStorage` does not work
+ * that way: it scopes a value to a *callback*, with no token to hand
+ * back later. The two available shapes are not equivalent, so the choice
+ * is recorded rather than papered over:
+ *
+ *   * `session(id, body)` — what this module implements. The session is
+ *     visible for exactly the dynamic extent of `body`, including across
+ *     `await`, and two concurrent sessions in different async tasks
+ *     cannot see each other's.
+ *   * `using s = session(id)` over a module-level variable — closer to
+ *     Python's call shape, but concurrent sessions clobber one another.
+ *
+ * The first was chosen because the failure mode of the second is one
+ * session's context leaking into another, which is a correctness bug
+ * rather than an ergonomic one.
+ *
+ * The abandonment net is also weaker than Python's, and deliberately so
+ * rather than by oversight. Python registers a `weakref.finalize` that
+ * best-effort stops a session the caller never closed. JavaScript's
+ * `FinalizationRegistry` may never run and is not run at exit, so a
+ * `try/finally` around the callback is the stronger guard available —
+ * which is another reason to scope by callback rather than by disposal.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import * as child from "node:child_process";
+
+import { resolveCliBin } from "./_cli.js";
+import { MvmTransportError } from "./_errors/types.js";
+
+const DEFAULT_SESSION_START_TIMEOUT_SEC = 60;
+const DEFAULT_SESSION_STOP_TIMEOUT_SEC = 30;
+const DEFAULT_MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+
+/** Holds the active session id for the dynamic extent of a `session()` body. */
+const active = new AsyncLocalStorage<string>();
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const parsed = Number(raw);
+  // Matches Python's `env_float` / `env_int`, which fall back silently
+  // on anything unparseable rather than raising.
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function checkId(label: string, value: string): void {
+  if (!value || value.startsWith("-")) {
+    throw new MvmTransportError(
+      `${label} must be a non-empty string that does not start with '-'`,
+    );
+  }
+}
+
+function runSessionVerb(argv: string[], timeoutSec: number, label: string): string {
+  const bin = resolveCliBin("session management");
+  const result = child.spawnSync(bin, argv, {
+    timeout: timeoutSec * 1000,
+    maxBuffer: envNumber("MVM_MAX_OUTPUT_BYTES", DEFAULT_MAX_OUTPUT_BYTES),
+  });
+
+  if (result.error !== undefined) {
+    const code = (result.error as NodeJS.ErrnoException).code;
+    if (code === "ETIMEDOUT") {
+      throw new MvmTransportError(`${label} timed out after ${timeoutSec}s`);
+    }
+    if (code === "ENOBUFS") {
+      throw new MvmTransportError(`${label} exceeded its output cap`);
+    }
+    throw new MvmTransportError(`failed to spawn mvmctl: ${result.error.message}`);
+  }
+
+  const stderr = (result.stderr ?? Buffer.alloc(0)).toString("utf-8").trim();
+  if (result.status !== 0) {
+    throw new MvmTransportError(
+      `${label} exited ${result.status}: ${stderr || "(no stderr)"}`,
+    );
+  }
+  return (result.stdout ?? Buffer.alloc(0)).toString("utf-8").trim();
+}
+
+function startSession(workloadId: string): string {
+  const timeout = envNumber("MVM_SESSION_START_TIMEOUT_SEC", DEFAULT_SESSION_START_TIMEOUT_SEC);
+  const id = runSessionVerb(
+    ["session", "start", "--", workloadId],
+    timeout,
+    `mvmctl session start ${workloadId}`,
+  );
+  if (!id) {
+    throw new MvmTransportError(
+      `mvmctl session start ${workloadId} returned an empty session id`,
+    );
+  }
+  return id;
+}
+
+function stopSession(sessionId: string): void {
+  const timeout = envNumber("MVM_SESSION_STOP_TIMEOUT_SEC", DEFAULT_SESSION_STOP_TIMEOUT_SEC);
+  runSessionVerb(["session", "stop", sessionId], timeout, `mvmctl session stop ${sessionId}`);
+}
+
+/** A warm session against one workload. */
+export class Session {
+  /** Substrate-assigned session id. */
+  readonly id: string;
+  /** Workload the session is bound to. */
+  readonly workload_id: string;
+
+  constructor(workloadId: string, id: string) {
+    this.workload_id = workloadId;
+    this.id = id;
+  }
+
+  toString(): string {
+    return this.id;
+  }
+}
+
+/** The session active in the current async context, or `null`. */
+export function currentSessionId(): string | null {
+  return active.getStore() ?? null;
+}
+
+/**
+ * Run `body` with a warm session against `workloadId`.
+ *
+ * The session is stopped when `body` returns or throws. If `body`
+ * returns a promise, the session is stopped once it settles — so an
+ * async body is awaited rather than torn down underneath.
+ */
+export function session<T>(workloadId: string, body: (session: Session) => T): T {
+  checkId("workload_id", workloadId);
+  const handle = new Session(workloadId, startSession(workloadId));
+
+  // Teardown must not mask a body failure: the substrate's session
+  // reaper collects the VM regardless, so a failed stop is swallowed the
+  // way Python's `_teardown` swallows it.
+  const teardown = () => {
+    try {
+      stopSession(handle.id);
+    } catch {
+      /* best effort, matching Python */
+    }
+  };
+
+  let result: T;
+  try {
+    result = active.run(handle.id, () => body(handle));
+  } catch (err) {
+    teardown();
+    throw err;
+  }
+
+  if (result instanceof Promise) {
+    return result.then(
+      (value) => {
+        teardown();
+        return value;
+      },
+      (err) => {
+        teardown();
+        throw err;
+      },
+    ) as T;
+  }
+
+  teardown();
+  return result;
+}

--- a/crates/mvm-sdk/sdks/typescript/src/index.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/index.ts
@@ -63,6 +63,9 @@ export * from "./_addon.js";
 // _remote.ts for what is deliberately absent and why.
 export { RemoteFunction, func, workload_ref } from "./_remote.js";
 export type { WorkloadRef } from "./_remote.js";
+// Sessions — callback-scoped; see the note in _session.ts for why the
+// shape differs from Python's context manager.
+export { Session, currentSessionId, session } from "./_session.js";
 export {
   EmittingContextError,
   MsgpackUnavailable,
@@ -83,6 +86,10 @@ export * from "./runtime/runtime.js";
 // are internals the SDK calls on its own behalf. They were exported here by
 // accident and are not part of the public surface in any other language.
 export {
+  // The record-mode introspection Python exposes as `current_recording`.
+  // It was internal here only because nothing had needed it from outside;
+  // the capability is the same, and the surfaces now agree.
+  currentRecording,
   DEFAULT_TTL_SECONDS,
   MVM_CLI_BIN_ENV,
   MVM_SDK_MODE_ENV,

--- a/crates/mvm-sdk/sdks/typescript/tests/session.test.ts
+++ b/crates/mvm-sdk/sdks/typescript/tests/session.test.ts
@@ -1,0 +1,111 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { Session, currentSessionId, session } from "../src/_session.js";
+
+/**
+ * A stand-in `mvmctl` that answers the two session verbs.
+ *
+ * `session start` prints a fresh id derived from the workload, so a test
+ * can tell two concurrent sessions apart; `session stop` records the
+ * teardown so a test can assert it happened.
+ */
+let tmp: string;
+let fakeCli: string;
+let stopLog: string;
+
+beforeAll(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mvm-session-test-"));
+  stopLog = path.join(tmp, "stops.log");
+  fakeCli = path.join(tmp, "mvmctl");
+  fs.writeFileSync(
+    fakeCli,
+    `#!/bin/bash
+if [ "$1" = "session" ] && [ "$2" = "start" ]; then
+  # argv: session start -- <workload_id>
+  echo "sid-$4"
+  exit 0
+fi
+if [ "$1" = "session" ] && [ "$2" = "stop" ]; then
+  echo "$3" >> "${stopLog}"
+  exit 0
+fi
+exit 64
+`,
+    { mode: 0o755 },
+  );
+  process.env.MVM_CLI_BIN = fakeCli;
+});
+
+afterAll(() => {
+  delete process.env.MVM_CLI_BIN;
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function stops(): string[] {
+  if (!fs.existsSync(stopLog)) return [];
+  return fs.readFileSync(stopLog, "utf-8").trim().split("\n").filter(Boolean);
+}
+
+describe("session", () => {
+  it("exposes the started id inside the body and nothing outside it", () => {
+    expect(currentSessionId()).toBeNull();
+    const seen = session("wl-a", (s) => {
+      expect(s).toBeInstanceOf(Session);
+      expect(s.workload_id).toBe("wl-a");
+      return currentSessionId();
+    });
+    expect(seen).toBe("sid-wl-a");
+    expect(currentSessionId()).toBeNull();
+  });
+
+  it("stops the session when the body returns", () => {
+    const before = stops().length;
+    session("wl-stop", () => undefined);
+    expect(stops().slice(before)).toContain("sid-wl-stop");
+  });
+
+  it("stops the session when the body throws, and re-raises", () => {
+    const before = stops().length;
+    expect(() => {
+      session("wl-throw", () => {
+        throw new Error("body failed");
+      });
+    }).toThrow("body failed");
+    // Teardown must not mask the body's failure, and must still happen.
+    expect(stops().slice(before)).toContain("sid-wl-throw");
+  });
+
+  it("keeps concurrent sessions from seeing each other", async () => {
+    // This is the property the callback shape was chosen for. A
+    // module-level variable with `using` would fail here: whichever body
+    // started last would win, and both would observe the same id.
+    const observe = async (workload: string, delayMs: number) =>
+      session(workload, async () => {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        return currentSessionId();
+      });
+
+    const [first, second] = await Promise.all([observe("wl-1", 20), observe("wl-2", 5)]);
+    expect(first).toBe("sid-wl-1");
+    expect(second).toBe("sid-wl-2");
+    expect(currentSessionId()).toBeNull();
+  });
+
+  it("waits for an async body before stopping", async () => {
+    const before = stops().length;
+    let finished = false;
+    await session("wl-async", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      // The session must still be live here; a teardown that did not
+      // await the promise would already have stopped it.
+      expect(currentSessionId()).toBe("sid-wl-async");
+      finished = true;
+    });
+    expect(finished).toBe(true);
+    expect(stops().slice(before)).toContain("sid-wl-async");
+  });
+});

--- a/features/suites/s27_sdk/fixtures/surface_divergence.json
+++ b/features/suites/s27_sdk/fixtures/surface_divergence.json
@@ -5,28 +5,17 @@
     "so a name can only appear or disappear here deliberately.",
     "Regenerate intentionally; do not paste over a failure.",
     "",
-    "`typescript_only_absent_from_python` is empty and should stay that way.",
+    "Both directional backlogs are now empty. What remains is the two",
+    "categories that describe differences rather than debt.",
     "",
-    "`python_only_permanent_by_design` is not a backlog. `derive_schema`",
-    "builds a JSON Schema from a Python function's type hints. TypeScript",
-    "erases types before the program runs, so at the moment a decorator would",
-    "inspect the function the annotations are already gone. No amount of work",
-    "closes this. TypeScript callers pass `args_schema` / `return_schema` to",
-    "`entrypoint_function` explicitly instead, which that function now",
-    "accepts.",
+    "`python_only_permanent_by_design` cannot close. `derive_schema` needs",
+    "runtime type information TypeScript erases before the program runs, and",
+    "`SecretInArgWarning` is a warning type JavaScript does not have. Both are",
+    "properties of the languages, not gaps in the SDK.",
     "",
-    "`python_only_type_erased_in_typescript` is the related but distinct case:",
-    "those names exist in TypeScript as `export type`, which tsc erases, so a",
-    "runtime surface check cannot see them.",
-    "",
-    "`python_only_absent_from_typescript` is the real backlog. What remains is",
-    "Tier C's remote-function machinery and the error types only Tier C",
-    "raises; they land together, because generating the errors first would",
-    "export classes nothing in TypeScript can throw.",
-    "",
-    "The two MVM_MACHINE_* names are a behaviour gap, not a naming one: the",
-    "TypeScript machine wrapper does not bound its subprocess, so it has",
-    "nothing to read them with."
+    "`python_only_type_erased_in_typescript` exists in TypeScript as",
+    "`export type`, which tsc erases, so a runtime surface check cannot see",
+    "it."
   ],
   "python_only_type_erased_in_typescript": [
     "ExecResult",
@@ -47,11 +36,6 @@
     "SecretInArgWarning",
     "derive_schema"
   ],
-  "python_only_absent_from_typescript": [
-    "Session",
-    "current_recording_dict",
-    "current_session_id",
-    "session"
-  ],
+  "python_only_absent_from_typescript": [],
   "typescript_only_absent_from_python": []
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,11 +1,32 @@
 # Refactor status
 
-Last updated: 2026-08-16
+Last updated: 2026-08-17
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
+
+- [x] **Plan 337 COMPLETE — the SDK surface is generated from Rust.** Sessions
+      finished Tier C. Python's `contextvars` + `Token` has no
+      `AsyncLocalStorage` equivalent, so the shape was a choice, not a
+      translation: `session(id, body)` was taken over `using s = session(id)`
+      because the latter lets concurrent sessions in different async tasks
+      clobber one another — a correctness bug rather than an ergonomic one. A
+      test runs two overlapping async bodies and checks each sees only its own
+      id. The abandonment net is weaker than Python's by necessity
+      (`FinalizationRegistry` may never run and is not run at exit), so the
+      callback shape carries a `try/finally`, which is the stronger guard and
+      another reason for the shape. `_remote.ts` now attaches `--session`;
+      `workload_ref` opts out, since a session belongs to one workload. Last
+      divergence name closed by renaming `current_recording_dict` to
+      `current_recording` — the `_dict` suffix encoded a Python-only return
+      type — and exporting the TypeScript counterpart. **Both directional
+      backlogs are empty: python-only 30 -> 0, typescript-only 2 -> 0.** What
+      remains in `surface_divergence.json` is difference, not debt: two names
+      that cannot close (`derive_schema`, `SecretInArgWarning`) and the
+      type-erased set. #2558 and #2559 were verified already fixed on main by
+      other sessions.
 
 - [x] **Plan 337 WS-6 increment 1 — Tier C transport and the error taxonomy,
       as a declared subset.** The eight Tier D error types and the code that

--- a/specs/plans/337-sdk-surface-generated-from-rust.md
+++ b/specs/plans/337-sdk-surface-generated-from-rust.md
@@ -3,8 +3,9 @@
 Backing: preview
 Validation: none
 
-**Status: IN PROGRESS** — WS-1 to WS-5, WS-6.1/6.2/6.4/6.6, WS-7 and WS-8
-(except 8.1) complete. Remaining: WS-6.3 + 6.5 (sessions), which gate WS-8.1.
+**Status: COMPLETE** — every workstream delivered. Both directional
+divergence backlogs are empty; what remains in the divergence file is
+difference, not debt.
 **Opened:** 2026-08-14
 **Follows:** Plan 336 WS-G4
 
@@ -572,10 +573,10 @@ permanently Python-only, and `SdkErrorType::exports_to` refuses to emit a
 - [x] 6.1 Size it properly against `_remote.py` and `_session.py` before
       writing code
 - [x] 6.2 `RemoteFunction` + `func` over generated protocol frames
-- [ ] 6.3 `Session` + `session` + `current_session_id` — next increment
+- [x] 6.3 `Session` + `session` + `current_session_id`
 - [x] 6.4 `WorkloadRef` + `workload_ref`
-- [ ] 6.5 BDD coverage against the recording CLI double, both languages, in the
-      s27 pattern Plan 336 established — lands with 6.3
+- [x] 6.5 BDD coverage against the recording CLI double, both languages, in the
+      s27 pattern Plan 336 established
 - [x] 6.6 Error taxonomy from WS-5 wired through
 
 #### Increment 1 — the transport, the errors, and the refusal
@@ -620,6 +621,41 @@ says so.
 Divergence after this increment: `python_only_absent_from_typescript` is down
 to four names — `Session`, `session`, `current_session_id`, and
 `current_recording_dict`.
+
+#### Increment 2 — sessions, and the choice made explicit
+
+`sdks/typescript/src/_session.ts` completes Tier C. The sizing pass found that
+Python's `contextvars` + `Token` pattern has no equivalent in
+`AsyncLocalStorage`, which scopes to a *callback* rather than handing back a
+token, and that the two available shapes are not interchangeable:
+
+* `session(id, body)` — chosen. The session is visible for exactly the dynamic
+  extent of `body`, including across `await`, and concurrent sessions in
+  different async tasks cannot see each other's.
+* `using s = session(id)` over a module-level variable — closer to Python's
+  call shape, but concurrent sessions clobber one another.
+
+The first was taken because the second's failure mode is one session's context
+leaking into another: a correctness bug, not an ergonomic one. A test asserts
+exactly that property, running two overlapping async bodies and checking each
+observes only its own id.
+
+The abandonment net is weaker than Python's by necessity — `FinalizationRegistry`
+may never run and is not run at exit — so the callback shape carries a
+`try/finally` instead, which is the stronger guard available and another reason
+the shape was chosen. Teardown swallows its own failure so it cannot mask a body
+exception, matching Python's `_teardown`.
+
+`_remote.ts` now consults the active session and attaches `--session`, matching
+Python's `_prepare_invoke`. Cross-workload dispatch through `workload_ref` opts
+out, because a session belongs to one workload and must not leak into a call
+against another.
+
+**`current_recording_dict` was renamed to `current_recording`.** The `_dict`
+suffix encoded a Python-specific return type; the TypeScript counterpart
+(`currentRecording`) returns a typed object and was internal only because
+nothing had needed it from outside. Both surfaces now expose the same
+capability under names that agree.
 
 #### 6.1 result — Tier C is two surfaces, and one of them cannot be ported
 
@@ -732,8 +768,7 @@ case of names that *do* exist in TypeScript but only as `export type`.
 
 ### WS-8 — close out
 
-- [ ] 8.1 `surface_divergence.json` reduced to Tier F plus the type-erased set
-      — **blocked on Tier C**, see below
+- [x] 8.1 `surface_divergence.json` reduced to Tier F plus the type-erased set
 - [x] 8.2 `xtask check-stubs` covers every generated artifact
 - [x] 8.3 Full gates: fmt, clippy, workspace nextest, doctests, Python, TypeScript
 - [x] 8.4 `specs/REFACTOR-STATUS.md` and a delivery note
@@ -746,15 +781,14 @@ byte-compared by `check-stubs`, which runs in `lint-policy` and again inside
 the BDD suite. Each new artifact was also shown to fail the gate on a
 hand-edit rather than assumed to.
 
-**8.1 cannot complete here, and saying otherwise would be false.** The target
-is a divergence file holding only Tier F plus the type-erased set. It currently
-also holds 16 names: Tier C's remote-function machinery and the eight error
-types only Tier C raises. Those close when WS-6 lands — the error taxonomy
-deliberately waits for it, because generating the types first would export
-classes nothing in TypeScript can throw. Everything WS-8.1 can close without
-Tier C is closed.
+**8.1 is now met.** Both directional backlogs are empty. What remains in
+`surface_divergence.json` describes differences rather than debt: two names that
+cannot close (`derive_schema` needs runtime types TypeScript erases;
+`SecretInArgWarning` is a warning type JavaScript does not have) and the
+type-erased set, which exists in TypeScript as `export type` and so cannot be
+seen by a runtime surface check.
 
-Progress across the plan: `python_only_absent_from_typescript` went 30 → 16,
+Progress across the plan: `python_only_absent_from_typescript` went **30 → 0**,
 and `typescript_only_absent_from_python` went 2 → 0 and has stayed there.
 
 ## Sequencing

--- a/specs/sprint/delivery/337-ws6-sessions-and-closeout.md
+++ b/specs/sprint/delivery/337-ws6-sessions-and-closeout.md
@@ -1,0 +1,91 @@
+# Plan 337 — WS-6.3/6.5 (sessions) and WS-8.1: the plan is complete
+
+**Delivered:** 2026-08-17
+**Plan:** `specs/plans/337-sdk-surface-generated-from-rust.md`
+**Follows:** `337-ws6-tier-c-increment-1.md`
+
+## First: the two open issues were already fixed
+
+#2559 (Rust `host_port` accepts port 0) and #2558 (TypeScript machine wrapper
+unbounded) were both closed by other sessions on 2026-08-16, while this work
+was in flight. Verified against main rather than trusting the closed state:
+`validate.rs:79` rejects port 0 for every language at one seam — the approach
+the issue recommended — and `_machine.ts` now bounds `spawnSync` with
+`timeout` + `maxBuffer` and classifies `ETIMEDOUT` / `ENOBUFS` separately, with
+tests. Nothing to redo.
+
+## Sessions — the choice, made explicit and tested
+
+`sdks/typescript/src/_session.ts` completes Tier C. The WS-6.1 sizing found
+that Python's `contextvars` + `Token` has no equivalent in `AsyncLocalStorage`,
+which scopes to a *callback* rather than handing back a token, and that the two
+available shapes are not interchangeable:
+
+- `session(id, body)` — **chosen**. Visible for exactly the dynamic extent of
+  `body`, including across `await`; concurrent sessions in different async
+  tasks cannot see each other's.
+- `using s = session(id)` over a module-level variable — closer to Python's
+  call shape, but concurrent sessions clobber one another.
+
+The first was taken because the second's failure mode is one session's context
+leaking into another — a correctness bug, not an ergonomic one. That is not
+asserted in prose only: a test runs two overlapping async bodies and checks each
+observes only its own id, which is precisely the case the rejected shape fails.
+
+The abandonment net is weaker than Python's by necessity — `FinalizationRegistry`
+may never run and is not run at exit — so the callback shape carries a
+`try/finally` instead. That is the stronger guard available, and another reason
+the shape was chosen rather than a consolation for it. Teardown swallows its own
+failure so it cannot mask a body exception, matching Python's `_teardown`, and
+is covered by a test that throws from the body and asserts both the re-raise and
+the stop.
+
+`_remote.ts` now consults the active session and attaches `--session`, matching
+Python's `_prepare_invoke`. Cross-workload dispatch through `workload_ref` opts
+out: a session belongs to one workload and must not leak into a call against
+another.
+
+## The last divergence name
+
+`current_recording_dict` was renamed to `current_recording`. The `_dict` suffix
+encoded a Python-specific return type; the TypeScript counterpart
+(`currentRecording`) returns a typed object and was internal only because
+nothing had needed it from outside. Both surfaces now expose the same capability
+under names that agree. A hard rename rather than an alias, per the project's
+convention of not carrying shims.
+
+## WS-8.1, and the plan closed
+
+Both directional backlogs are empty. What remains in `surface_divergence.json`
+describes differences rather than debt:
+
+- `python_only_permanent_by_design` — `derive_schema` needs runtime type
+  information TypeScript erases before the program runs; `SecretInArgWarning`
+  is a warning type JavaScript does not have.
+- `python_only_type_erased_in_typescript` — names that exist in TypeScript as
+  `export type`, which `tsc` erases, so a runtime surface check cannot see them.
+
+**Across Plan 337: `python_only_absent_from_typescript` went 30 → 0, and
+`typescript_only_absent_from_python` went 2 → 0 and stayed there.**
+
+## Verification
+
+- `cargo +nightly fmt --all -- --check` — clean
+- `check-stubs` — no drift
+- Python **223 passed, 7 skipped**
+- TypeScript **143 passed** (five new session tests), typecheck + build clean
+- BDD **206 scenarios, 205 passed, 1 skipped**
+
+Two BDD failures seen along the way were a stale target directory of my own
+making — `mvmctl` and `xtask` had been built from the wrong working directory,
+so the harness could not find them. Rebuilt in place; unrelated to the change.
+
+## What Plan 337 ended up being
+
+The plan opened by asking whether 29 names should be ported to TypeScript. The
+answer turned out to be no on both counts: the number was wrong, and porting was
+the wrong verb. What shipped is four Rust registries — env names, error
+taxonomy, constructors, and the surfaces each is allowed to appear on — from
+which both language SDKs are generated, plus a golden-IR document and a two-way
+divergence gate that make the remaining differences describable rather than
+accidental.


### PR DESCRIPTION
Finishes Plan 337. Follows #2568, #2598, #2608 and #2618.

## First: #2558 and #2559 were already fixed

Both were closed by other sessions on 2026-08-16 while this work was in flight. Verified against main rather than trusting the closed state: `validate.rs:79` rejects port 0 for every language at one seam — the approach #2559 recommended — and `_machine.ts` bounds `spawnSync` with `timeout` + `maxBuffer` and classifies `ETIMEDOUT` / `ENOBUFS` separately, with tests. Nothing to redo.

## Sessions — the shape was a choice, not a translation

Python holds the active session in a `contextvars.ContextVar` and resets its `Token` in `__exit__`. `AsyncLocalStorage` scopes to a *callback* instead, with no token to hand back, so the two available shapes are not interchangeable:

- **`session(id, body)` — taken.** Visible for exactly the dynamic extent of `body`, including across `await`; concurrent sessions in different async tasks cannot see each other's.
- `using s = session(id)` over a module-level variable — closer to Python's call shape, but concurrent sessions clobber one another.

The first was chosen because the second's failure mode is **one session's context leaking into another** — a correctness bug, not an ergonomic one. That's asserted rather than argued: a test runs two overlapping async bodies and checks each observes only its own id, which is precisely the case the rejected shape fails.

The abandonment net is weaker than Python's by necessity — `FinalizationRegistry` may never run and is not run at exit — so the callback shape carries a `try/finally`. That's the stronger guard available and another reason for the shape, not a consolation for it. Teardown swallows its own failure so it cannot mask a body exception, matching Python's `_teardown`, and is covered by a test that throws from the body and asserts both the re-raise and the stop.

`_remote.ts` now consults the active session and attaches `--session`, matching `_prepare_invoke`. **`workload_ref` opts out** — a session belongs to one workload and must not leak into a call against another.

## The last divergence name

`current_recording_dict` → `current_recording`, with the TypeScript counterpart exported. The `_dict` suffix encoded a Python-specific return type; the TypeScript version returns a typed object and was internal only because nothing had needed it from outside. A hard rename rather than an alias, per this project's convention.

## Plan 337 is complete

Both directional backlogs are empty. **`python_only_absent_from_typescript` went 30 → 0; `typescript_only_absent_from_python` went 2 → 0** and stayed there.

What remains in `surface_divergence.json` describes differences rather than debt:
- `python_only_permanent_by_design` — `derive_schema` needs runtime types TypeScript erases; `SecretInArgWarning` is a warning type JavaScript doesn't have.
- `python_only_type_erased_in_typescript` — exists in TypeScript as `export type`, which `tsc` erases.

## Verification

- `cargo +nightly fmt --all -- --check` — clean
- All 45 xtask gates from the CI Invariant job — 0 failing
- `check-stubs` — no drift
- Python **223 passed, 7 skipped**
- TypeScript **143 passed** (five new session tests); typecheck + build clean
- BDD **206 scenarios, 205 passed, 1 skipped**
- `cargo nextest run --workspace` — 12,067 passed. One `mvm-http` test failed only under `-j 6` and passes isolated in 0.014s; this change touches no file in that crate.

## What the plan turned out to be

It opened by asking whether 29 names should be ported to TypeScript. The answer was no on both counts — the number was wrong, and porting was the wrong verb. What shipped is four Rust registries (env names, error taxonomy, constructors, and the surfaces each may appear on) from which both SDKs are generated, plus a golden-IR document and a two-way divergence gate that make the remaining differences describable rather than accidental.
