### PR TITLE
fix(net): dial the egress port the builder actually allocated

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-egress-client.rs
+++ b/crates/mvm-agentd/src/bin/mvm-egress-client.rs
@@ -12,8 +12,35 @@
 
 use std::process::ExitCode;
 
-#[cfg(target_os = "linux")]
-use mvm_agentd::vsock::EGRESS_PORT as EGRESS_VSOCK_PORT;
+/// Compiled-in host vsock port, used when no init named one.
+const DEFAULT_HOST_VSOCK_PORT: u32 = mvm_agentd::vsock::EGRESS_PORT;
+
+/// Names the host vsock port the endpoint is listening on for this boot.
+///
+/// The builder tiers allocate that port per build — two builds on one host must
+/// not collide on a fixed number — and hand it down on the kernel cmdline,
+/// which each guest init reads and re-exports here. A guest that ignores it
+/// dials the compiled-in default, finds nothing, and reports a guest with no
+/// network; both guest inits already set this variable and, until now, nothing
+/// read it.
+const HOST_VSOCK_PORT_ENV: &str = "MVM_EGRESS_VSOCK_PORT";
+
+/// Resolve the host port to dial, falling back to the compiled-in default.
+///
+/// Pure over the raw value so the fallback and the refusal are testable without
+/// mutating process env. An unparsable or zero port is a refusal rather than a
+/// silent fallback: it means an init tried to tell us something and we could
+/// not read it, and dialing the default there would reproduce exactly the
+/// misdirected-connect this exists to prevent.
+fn host_vsock_port_from_env(raw: Option<&str>) -> Result<u32, String> {
+    let Some(raw) = raw else {
+        return Ok(DEFAULT_HOST_VSOCK_PORT);
+    };
+    match raw.trim().parse::<u32>() {
+        Ok(port) if port > 0 => Ok(port),
+        _ => Err(raw.to_string()),
+    }
+}
 
 fn main() -> ExitCode {
     tracing_subscriber::fmt()
@@ -25,6 +52,14 @@ fn main() -> ExitCode {
 
     let listen = std::env::var("MVM_EGRESS_LISTEN")
         .unwrap_or_else(|_| mvm_core::guest_netd::DEFAULT_EGRESS_PROXY_LISTEN.into());
+    let host_port =
+        match host_vsock_port_from_env(std::env::var(HOST_VSOCK_PORT_ENV).ok().as_deref()) {
+            Ok(port) => port,
+            Err(raw) => {
+                eprintln!("mvm-egress-client: bad {HOST_VSOCK_PORT_ENV} '{raw}'");
+                return ExitCode::from(2);
+            }
+        };
     let addr: std::net::SocketAddr = match listen.parse() {
         Ok(a) => a,
         Err(e) => {
@@ -32,11 +67,11 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
-    run(addr)
+    run(addr, host_port)
 }
 
 #[cfg(target_os = "linux")]
-fn run(addr: std::net::SocketAddr) -> ExitCode {
+fn run(addr: std::net::SocketAddr, host_port: u32) -> ExitCode {
     use mvm_agentd::flowmux::{FlowMuxError, FlowMuxReconnectClient};
     use mvm_agentd::flowmux_keys;
     use mvm_agentd::guest_vsock_session::connect_host_vsock;
@@ -84,19 +119,33 @@ fn run(addr: std::net::SocketAddr) -> ExitCode {
         }
     };
 
-    let client = match rt.block_on(FlowMuxReconnectClient::connect(
-        || async {
-            connect_host_vsock(EGRESS_VSOCK_PORT)
-                .await
-                .map_err(FlowMuxError::Transport)
-        },
-        guest_signing_key,
-        host_anchor,
-    )) {
-        Ok(client) => client,
-        Err(e) => {
-            eprintln!("mvm-egress-client: FlowMux connect failed: {e}");
-            return ExitCode::from(1);
+    // The host endpoint is a separate process the host is still starting while
+    // this guest boots, so the first dial routinely arrives before it listens
+    // and is reset. That is a race, not a refusal, and waiting it out is the
+    // difference between a guest with egress and a guest that powers down.
+    // A refusal — bad handshake, not admitted — still fails immediately.
+    let deadline = std::time::Instant::now() + mvm_agentd::flowmux::CONNECT_RETRY_BUDGET;
+    let mut attempt = 0u32;
+    let client = loop {
+        let outcome = rt.block_on(FlowMuxReconnectClient::connect(
+            move || async move {
+                connect_host_vsock(host_port)
+                    .await
+                    .map_err(FlowMuxError::Transport)
+            },
+            guest_signing_key.clone(),
+            host_anchor,
+        ));
+        match outcome {
+            Ok(client) => break client,
+            Err(e) if e.connect_is_retryable() && std::time::Instant::now() < deadline => {
+                attempt = attempt.saturating_add(1);
+                std::thread::sleep(mvm_agentd::flowmux::connect_retry_delay(attempt));
+            }
+            Err(e) => {
+                eprintln!("mvm-egress-client: FlowMux connect failed: {e}");
+                return ExitCode::from(1);
+            }
         }
     };
 
@@ -110,7 +159,46 @@ fn run(addr: std::net::SocketAddr) -> ExitCode {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn run(_addr: std::net::SocketAddr) -> ExitCode {
+fn run(_addr: std::net::SocketAddr, _host_port: u32) -> ExitCode {
     eprintln!("mvm-egress-client: AF_VSOCK egress is only available on Linux guests");
     ExitCode::from(1)
+}
+
+#[cfg(test)]
+mod host_port_tests {
+    use super::*;
+
+    /// A guest with no init-supplied port keeps the compiled-in default, which
+    /// is what the fixed-port tiers rely on.
+    #[test]
+    fn an_absent_env_falls_back_to_the_compiled_in_port() {
+        assert_eq!(host_vsock_port_from_env(None), Ok(DEFAULT_HOST_VSOCK_PORT));
+    }
+
+    /// The regression this exists for: the builder tiers allocate the port per
+    /// build and hand it down, and the client used to ignore it and dial the
+    /// default — reaching nothing, every time.
+    #[test]
+    fn an_init_supplied_port_is_honoured() {
+        assert_eq!(host_vsock_port_from_env(Some("683445")), Ok(683445));
+        assert_eq!(host_vsock_port_from_env(Some(" 45253 ")), Ok(45253));
+        assert_ne!(
+            host_vsock_port_from_env(Some("683445")),
+            Ok(DEFAULT_HOST_VSOCK_PORT),
+            "an explicit port must not silently resolve to the default"
+        );
+    }
+
+    /// An unreadable value means an init tried to say something we could not
+    /// parse. Falling back would reproduce the misdirected dial this fixes, so
+    /// it refuses instead.
+    #[test]
+    fn an_unparsable_or_zero_port_refuses_rather_than_falling_back() {
+        for bad in ["", "0", "-1", "http", "5253x"] {
+            assert!(
+                host_vsock_port_from_env(Some(bad)).is_err(),
+                "{bad:?} must refuse rather than fall back"
+            );
+        }
+    }
 }

--- a/crates/mvm-agentd/src/flowmux.rs
+++ b/crates/mvm-agentd/src/flowmux.rs
@@ -56,7 +56,45 @@ pub enum FlowMuxError {
     ChannelClosed,
 }
 
+/// Ceiling for the initial-connect backoff.
+pub const CONNECT_RETRY_MAX_MS: u64 = 250;
+
+/// How long the egress client may spend retrying its initial connect.
+///
+/// The guest init waits exactly this long for the proxy to bind, so the client
+/// must not retry past it.
+pub const CONNECT_RETRY_BUDGET: std::time::Duration =
+    mvm_core::guest_netd::EGRESS_PROXY_READY_TIMEOUT;
+
+/// Backoff before re-attempting the initial connect, doubling per attempt.
+///
+/// Starts at 2 ms deliberately. The gap being waited out is a process start,
+/// usually a few milliseconds; a coarser first sleep would spend more time
+/// waiting than the race it is recovering from.
+#[must_use]
+pub fn connect_retry_delay(attempt: u32) -> std::time::Duration {
+    let scaled = 1u64.saturating_mul(1u64 << attempt.min(16));
+    std::time::Duration::from_millis(scaled.min(CONNECT_RETRY_MAX_MS))
+}
+
 impl FlowMuxError {
+    /// Whether a *first* connect that failed this way is worth retrying.
+    ///
+    /// A guest routinely reaches its dial before the host endpoint is
+    /// listening — the guest boots in tens of milliseconds and the endpoint is
+    /// a separate process the host is still starting — so the dial is reset
+    /// and the connection is refused by nothing more than timing. That is a
+    /// race, and races are waited out.
+    ///
+    /// Everything else is a decision: a failed handshake, a refusal, or a
+    /// protocol violation means the host considered this guest and said no.
+    /// Retrying a decision only delays an accurate error and can look like a
+    /// guest hammering an endpoint that already rejected it.
+    #[must_use]
+    pub fn connect_is_retryable(&self) -> bool {
+        matches!(self, Self::Transport(_))
+    }
+
     fn refused(reason: impl Into<String>) -> Self {
         Self::Refused(reason.into())
     }
@@ -2139,5 +2177,64 @@ mod tests {
         .await;
 
         assert!(client.is_err());
+    }
+}
+
+#[cfg(test)]
+mod connect_retry_tests {
+    use super::*;
+
+    /// The failure this exists for: the host endpoint is not listening yet and
+    /// the guest's dial is reset.
+    #[test]
+    fn a_transport_error_is_retryable() {
+        let reset = io::Error::new(io::ErrorKind::ConnectionReset, "reset by peer");
+        assert!(FlowMuxError::Transport(reset).connect_is_retryable());
+
+        let refused = io::Error::new(io::ErrorKind::ConnectionRefused, "nothing listening");
+        assert!(FlowMuxError::Transport(refused).connect_is_retryable());
+    }
+
+    /// A decision must not be retried: the host looked at this guest and said
+    /// no, and retrying only delays an accurate diagnosis.
+    #[test]
+    fn a_rejection_is_never_retryable() {
+        for err in [
+            FlowMuxError::Handshake("bad signature".into()),
+            FlowMuxError::Refused("not admitted".into()),
+            FlowMuxError::Frame("bad length prefix".into()),
+            FlowMuxError::SessionClosed("go away".into()),
+            FlowMuxError::ChannelClosed,
+        ] {
+            assert!(
+                !err.connect_is_retryable(),
+                "{err} must not be retried on connect"
+            );
+        }
+    }
+
+    /// The retry budget must stay inside the window the guest init is willing
+    /// to wait, or the client is killed mid-retry and diagnosed as having
+    /// exited rather than as having lost a race.
+    #[test]
+    fn the_retry_budget_fits_inside_the_readiness_timeout() {
+        assert!(
+            CONNECT_RETRY_BUDGET <= mvm_core::guest_netd::EGRESS_PROXY_READY_TIMEOUT,
+            "retry budget {CONNECT_RETRY_BUDGET:?} exceeds the supervisor's wait"
+        );
+    }
+
+    #[test]
+    fn the_connect_backoff_starts_small_and_saturates() {
+        let ms = |a| connect_retry_delay(a).as_millis() as u64;
+        assert_eq!(ms(1), 2, "a lost race must not cost more than the race did");
+        assert_eq!(ms(2), 4);
+        assert_eq!(ms(3), 8);
+        assert!(ms(1) < ms(2) && ms(2) < ms(3), "must be monotonic");
+        assert_eq!(
+            ms(u32::MAX),
+            CONNECT_RETRY_MAX_MS,
+            "must saturate, not overflow"
+        );
     }
 }

--- a/crates/mvm-build/src/egress_readiness.rs
+++ b/crates/mvm-build/src/egress_readiness.rs
@@ -14,7 +14,11 @@ use std::time::Duration;
 pub const EGRESS_PROXY_LISTEN_ADDR: &str = mvm_core::guest_netd::DEFAULT_EGRESS_PROXY_LISTEN;
 
 /// How long a guest init waits for that listener before giving up.
-pub const EGRESS_PROXY_READY_TIMEOUT: Duration = Duration::from_secs(5);
+///
+/// Re-exported from `mvm-core` rather than defined here: the egress client
+/// bounds its own connect retries by the same number, and two copies would let
+/// the client outlive the window its supervisor waits.
+pub const EGRESS_PROXY_READY_TIMEOUT: Duration = mvm_core::guest_netd::EGRESS_PROXY_READY_TIMEOUT;
 
 /// How the readiness wait ended. Separated from the waiting so the decision —
 /// the part that has to be right — is a pure function over this enum rather

--- a/crates/mvm-core/src/guest_netd.rs
+++ b/crates/mvm-core/src/guest_netd.rs
@@ -15,6 +15,17 @@ pub const NO_PROXY_LOOPBACK: &str = "localhost,127.0.0.1,::1";
 /// the in-guest proxy daemon binds it. Callers that must name a scheme dial
 /// [`DEFAULT_EGRESS_PROXY_URL`] instead.
 pub const DEFAULT_EGRESS_PROXY_LISTEN: &str = "127.0.0.1:1080";
+
+/// How long a guest init waits for [`DEFAULT_EGRESS_PROXY_LISTEN`] to be bound
+/// before declaring the guest networkless.
+///
+/// Lives here because two crates need the same number and must not drift: the
+/// guest init that *waits* for the proxy, and the egress client that retries
+/// its connect to the host endpoint before it can bind. A client permitted to
+/// retry for longer than its supervisor will wait would be killed mid-retry
+/// and diagnosed as having exited, which is how a lost startup race reads as a
+/// broken client.
+pub const EGRESS_PROXY_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 /// SOCKS5h URL form of [`DEFAULT_EGRESS_PROXY_LISTEN`], used where a workload's
 /// `ALL_PROXY` / `HTTP_PROXY` must carry a scheme.
 pub const DEFAULT_EGRESS_PROXY_URL: &str = "socks5h://127.0.0.1:1080";


### PR DESCRIPTION
## The bug

The QEMU builder allocates its host egress vsock port **per build** — two builds on one host must not collide on a fixed number — and hands it to the guest on the kernel cmdline as `mvm.vsock_egress_port=`. Both guest inits parse that token and export it as `MVM_EGRESS_VSOCK_PORT`.

**Nothing read it.** `mvm-egress-client` dialled the compiled-in `EGRESS_PORT`.

Both inits set the variable. A test covers the cmdline parse. The one consumer that had to read it was never written.

## What that looked like

From a real failing build — the endpoint's own log and the guest console, same run:

```
endpoint:  "substitution endpoint bound (vsock)","port":683445
guest:     AF_VSOCK dial to host cid=2 port=5253 failed: Connection reset by peer
guest:     FATAL: mvm-egress-client exited before binding the local egress proxy
           at 127.0.0.1:1080; this guest has no NIC and reaches the network only
           through that proxy
```

The diagnosis is true and names the wrong layer: the proxy never bound because the client never connected, because it asked for a port nobody was listening on. **Every kernel and guest-image build on that tier failed this way, deterministically.** Two earlier failures of the same command looked like hangs.

## The fix

`mvm-egress-client` reads `MVM_EGRESS_VSOCK_PORT`, falling back to the compiled-in default when no init named one — the fixed-port tiers rely on that fallback.

An unparsable or zero value **refuses** rather than falling back. Falling back would dial the default and reproduce exactly the misdirected connect this fixes, with the same misleading error.

**Also makes the initial connect retry.** The host endpoint is a separate process still starting while the guest boots, so a first dial can arrive before it listens and be reset — a race, not a refusal. Transport errors retry under the readiness timeout; a failed handshake or a refusal stays immediately fatal, because those are decisions the host already made about this guest.

`EGRESS_PROXY_READY_TIMEOUT` moves to `mvm_core::guest_netd` so the init that waits and the client that retries read one number. A client allowed to retry past its supervisor's wait gets killed mid-retry and diagnosed as having exited — which is how a lost race reads as a broken client.

## Measured

On the Linux/KVM box, same command that had failed every time:

| | before | after |
|---|---|---|
| `exited before binding` failures | every run | **0** |
| guest lifetime | 42 s | **129 s** |
| FlowMux handshake | never | **complete** |
| stream | never | **`Opened stream_id 1`** |

The guest now authenticates to the host endpoint and opens a stream.

## What this does not fix

The build now fails one layer later, on the host's outbound leg:

```
proxy handshake error (97) cannot complete SOCKS5 connection to github.com
```

That is a separate defect. I checked for a seccomp kill on the landlock/seccomp-confined endpoint and found none logged, so the "exited with signal" in its log is teardown after the guest died, not the cause. Not chased here.

## Tests

Seven new, all pure, no guest required:

- absent env falls back to the compiled-in port
- an init-supplied port is honoured, and explicitly does **not** resolve to the default
- unparsable/zero/negative refuses rather than falling back
- transport errors are retryable; handshake, refusal, frame, session-closed and channel-closed are not
- the retry budget fits inside the readiness timeout
- the backoff starts at 2 ms, is monotonic, and saturates at the ceiling without overflowing at `u32::MAX`

## Verification

`cargo nextest run --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --all -- --check` clean. Cross-checked for Linux with `cargo zigbuild --target x86_64-unknown-linux-gnu`, since the client's `run` is `cfg(target_os = "linux")` and a macOS-only check would not compile it at all.