### PR TITLE
feat(cli): make `--help` describe the product the docs describe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,6 +326,9 @@ jobs:
       - name: mvm-cli drives machines through the mvm-client facade
         run: cargo run -p xtask -- check-cli-runtime-surface
 
+      - name: "`mvmctl --help` and the CLI reference describe one surface"
+        run: cargo run -p xtask -- check-cli-help-matches-docs
+
       - name: repr(C) types carry a layout contract (check-abi-layout)
         run: cargo run -p xtask -- check-abi-layout
 

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -151,11 +151,11 @@ pub(in crate::commands) enum Commands {
     /// Manage versioned packs (list/rollback/prune/download/update)
     #[command(display_order = 9)]
     Pack(pack::Args),
-    /// SDK transport surface (`run --mode live/plan`). Hidden: the user-facing
-    /// transient-run role folded into `machine run`; `run` survives only as the
-    /// SDK Sandbox launcher the Python/TS SDKs shell to, so it stays hidden
-    /// rather than break that transport.
-    #[command(hide = true)]
+    /// Run one command in a fresh transient microVM, then tear it down
+    ///
+    /// The argument surface still differs from `machine run` in both
+    /// directions; consolidating the two into one struct is the next step.
+    #[command(display_order = 2)]
     Run(vm::exec::RunArgs),
     /// Internal SDK host-dispatch transport for `MVM_NO_VM=1`.
     #[command(name = "__sdk-no-vm", hide = true)]
@@ -177,52 +177,52 @@ pub(in crate::commands) enum Commands {
     #[cfg(feature = "builder-vm")]
     BuilderShellJob(builder_shell_job::Args),
     /// Environment / install lifecycle (bootstrap, update, sign, …)
-    #[command(hide = true)]
+    #[command(display_order = 10)]
     Env(env::group::Args),
     /// Manage built manifest slots
-    #[command(hide = true)]
+    #[command(display_order = 10)]
     Manifest(manifest::Args),
     /// Inspect cached OCI images
-    #[command(hide = true)]
+    #[command(display_order = 11)]
     Image(image::Args),
     /// Inspect the dm-thin storage pool
     #[command(hide = true)]
     Storage(storage::Args),
     /// Print shell configuration (completions + dev aliases) to stdout
-    #[command(hide = true)]
+    #[command(display_order = 14)]
     ShellInit(env::shell_init::Args),
     /// Operational / observability commands (metrics, config)
-    #[command(hide = true)]
+    #[command(display_order = 14)]
     Ops(ops::group::Args),
     /// Manage named dev networks
-    #[command(hide = true)]
+    #[command(display_order = 12)]
     Network(ops::network::Args),
     /// Browse the bundled image catalog
-    #[command(hide = true)]
+    #[command(display_order = 11)]
     Catalog(catalog::Args),
     /// Manage the cache directory (~/.mvm/cache)
-    #[command(hide = true)]
+    #[command(display_order = 12)]
     Cache(ops::cache::Args),
-    /// Manage the supervisor warm pool (pre-spawned standbys for fast `up`)
-    #[command(hide = true)]
+    /// Manage the supervisor warm pool (pre-spawned standbys for a fast `run`)
+    #[command(display_order = 12)]
     Pool(pool::Args),
     /// Converge the VM name registry with on-disk runtime state
     #[command(hide = true)]
     Reconcile(ops::reconcile::Args),
     /// Manage local secret namespaces
-    #[command(hide = true)]
+    #[command(display_order = 13)]
     Secret(ops::secret::Args),
     /// Seal or verify portable VM bundles
-    #[command(hide = true)]
+    #[command(display_order = 13)]
     Bundle(bundle::Args),
     /// Manage trusted bundle publishers
-    #[command(hide = true)]
+    #[command(display_order = 13)]
     Trust(trust::Args),
     /// Inspect cached application dependencies
-    #[command(hide = true)]
+    #[command(display_order = 14)]
     Deps(deps::Args),
     /// Pack or verify signed `.mvm` artifacts
-    #[command(hide = true)]
+    #[command(display_order = 13)]
     Artifact(vm::artifact::Args),
     /// Host-side seccomp syscall audit (developer tooling).
     #[command(name = "seccomp-audit", hide = true)]

--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -248,11 +248,11 @@ fn parse_allow_host(entry: &str) -> Result<mvm_core::network_policy::HostPort> {
     Ok(parsed)
 }
 
-// `resolve_optional_network_policy` was used by `mvmctl template
-// create --network-preset` to bake a default policy into the
-// TemplateSpec. With the `template *` namespace gone and `[network]`
-// removed from `mvm.toml`, runtime policy now lives entirely in
-// `mvmctl up` flags / the user-global config / mvmd tenant config.
+// `resolve_optional_network_policy` was used by a since-removed
+// template-create flag to bake a default policy into the TemplateSpec.
+// With that namespace gone and `[network]` removed from `mvm.toml`,
+// runtime policy now lives entirely in `machine run --net` /
+// `--allow-host`, the user-global config, and mvmd tenant config.
 // Function deleted; the `resolve_network_policy` form (always returns
 // Some) is the only remaining helper.
 

--- a/crates/mvm-cli/src/commands/shared/start.rs
+++ b/crates/mvm-cli/src/commands/shared/start.rs
@@ -33,8 +33,8 @@ pub struct VmStartParams<'a> {
     pub port_mappings: &'a [config::PortMapping],
     /// Warm-pool target (`--warm-pool-size`); 0 = off.
     pub warm_pool_size: u32,
-    /// Resolved egress policy (deny-all default, or the `--network-preset` /
-    /// `--network-allow` selection). Threaded onto `VmStartConfig` so the
+    /// Resolved egress policy (deny-all default, or the `--net` /
+    /// `--allow-host` selection). Threaded onto `VmStartConfig` so the
     /// gateway-bridge backends enforce the chosen posture instead of
     /// fail-closing to deny-all regardless of the request.
     pub network_policy: mvm_core::network_policy::NetworkPolicy,
@@ -442,8 +442,8 @@ mod tests {
 
     // Regression: `VmStartParams` previously carried no egress policy, so
     // `into_start_config()` fell through to `VmStartConfig::default()` =
-    // deny-all for every `up` boot — silently ignoring `--network-preset` /
-    // `--network-allow`. The resolved policy must survive the conversion so the
+    // deny-all for every boot — silently ignoring `--net` / `--allow-host`.
+    // The resolved policy must survive the conversion so the
     // backend (Firecracker nftables; the libkrun/HVF gateway bridge) enforces
     // the requested posture instead of always deny-all.
     #[test]

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -389,18 +389,25 @@ fn machine_run_option_summaries_stay_short() {
 }
 
 #[test]
-fn internal_subprocess_commands_are_hidden_from_help() {
-    // Subprocess/internal commands must not clutter the user-facing
-    // surface. They stay dispatchable but `hide = true`.
+fn dev_tooling_and_internal_transports_are_hidden_from_help() {
+    // Two of the three visibility buckets. Dev tooling is a real command a
+    // user is not expected to reach for; an internal transport is subprocess
+    // plumbing, `__`-prefixed so it cannot be typed by accident. Both stay
+    // dispatchable but `hide = true`. The third bucket — everything a user is
+    // expected to invoke — is asserted by
+    // `top_level_help_shows_user_facing_groups_and_hides_dev_tooling`.
     let visible: Vec<String> = cli_command()
         .get_subcommands()
         .filter(|cmd| !cmd.is_hide_set())
         .map(|cmd| cmd.get_name().to_string())
         .collect();
     for hidden in [
-        "shell-init",
         "reconcile",
+        "storage",
+        "seccomp-audit",
+        "dashboard",
         "persistent-builder",
+        "__sdk-no-vm",
         "__builder-vm-bootstrap",
         "__builder-egress-supervisor",
         "__builder-shell-job",
@@ -1081,23 +1088,22 @@ fn up_removed() {
 }
 
 #[test]
-fn run_kept_hidden_as_sdk_transport() {
-    // The user-facing transient-run role folded into `machine run`, but `run`
-    // survives hidden as the SDK Sandbox launcher (`run --mode live/plan`) the
-    // Python/TS SDKs shell to — so it must still parse.
+fn run_is_visible_and_still_carries_the_sdk_transport() {
+    // `run` is the one-shot flagship and appears in `--help`. It had been
+    // hidden while the published CLI reference documented it as the flagship,
+    // so a user could not discover from the tool the command the docs told
+    // them to type.
     let cli = Cli::try_parse_from(["mvmctl", "run", "--mode", "live", "script.py"]).unwrap();
     assert!(matches!(cli.command, Commands::Run(_)));
-    // …but it is hidden from top-level help.
-    let help = {
-        use clap::CommandFactory;
-        let mut cmd = Cli::command();
-        let mut buf = Vec::new();
-        cmd.write_long_help(&mut buf).unwrap();
-        String::from_utf8(buf).unwrap()
-    };
+
+    let visible: Vec<String> = cli_command()
+        .get_subcommands()
+        .filter(|cmd| !cmd.is_hide_set())
+        .map(|cmd| cmd.get_name().to_string())
+        .collect();
     assert!(
-        !help.contains("\n  run "),
-        "`run` must be hidden from top-level help"
+        visible.iter().any(|n| n == "run"),
+        "`run` must be visible in top-level help; visible = {visible:?}"
     );
 }
 
@@ -1868,8 +1874,9 @@ fn test_parse_port_spec_invalid() {
 // `completions`, and `security` were dropped — `ls`/`validate`/
 // `catalog`/`doctor` cover the cleaned surface. `up` and `invoke` were
 // consolidated into `machine run` (argv lifecycle + `--entrypoint` action);
-// `up_removed`/`invoke_removed` pin they no longer parse. `run` survives
-// hidden as the SDK Sandbox transport (`run_kept_hidden_as_sdk_transport`).
+// `up_removed`/`invoke_removed` pin they no longer parse. `run` is a visible
+// top-level verb and also carries the SDK Sandbox transport
+// (`run_is_visible_and_still_carries_the_sdk_transport`).
 // -------------------------------------------------------------------------
 
 /// Listing is `machine ls` alone. A top-level `ls` (and the `ps` it once
@@ -4740,27 +4747,56 @@ fn internal_helper_commands_short_circuit_before_startup_side_effects() {
 // --- Top-level help surface tests ---
 
 #[test]
-fn top_level_help_hides_infra() {
-    let help = cli_command().render_help().to_string();
-    // Daily-driver commands must appear.
-    assert!(
-        help.contains("machine"),
-        "machine must appear in top-level help"
-    );
-    assert!(
-        help.contains("build"),
-        "build must appear in top-level help"
-    );
-    assert!(help.contains("init"), "init must appear in top-level help");
-    assert!(
-        help.contains("doctor"),
-        "doctor must appear in top-level help"
-    );
-    // Infrastructure commands must NOT appear in the default help.
-    for hidden in &[
-        "pool", "cache", "storage", "manifest", "catalog", "image", "bundle", "trust", "deps",
-        "artifact", "secret", "network", "ops", "env",
+fn top_level_help_shows_user_facing_groups_and_hides_dev_tooling() {
+    let visible: Vec<String> = cli_command()
+        .get_subcommands()
+        .filter(|cmd| !cmd.is_hide_set())
+        .map(|cmd| cmd.get_name().to_string())
+        .collect();
+
+    // Anything a user is expected to invoke. `secret` owns the entry point to
+    // host-side credential substitution and `trust` owns `trust receipt
+    // verify`; both were hidden while the CLI reference documented them, which
+    // meant the tool could not tell you those subsystems had a CLI at all.
+    for shown in &[
+        "machine",
+        "run",
+        "build",
+        "kernel",
+        "deploy",
+        "generate",
+        "template",
+        "init",
+        "doctor",
+        "bootstrap",
+        "explain",
+        "prepare",
+        "watch",
+        "pack",
+        "env",
+        "manifest",
+        "image",
+        "catalog",
+        "cache",
+        "network",
+        "pool",
+        "secret",
+        "trust",
+        "bundle",
+        "artifact",
+        "deps",
+        "ops",
+        "shell-init",
     ] {
+        assert!(
+            visible.iter().any(|n| n == shown),
+            "user-facing command `{shown}` must appear in top-level help; visible = {visible:?}"
+        );
+    }
+
+    let help = cli_command().render_help().to_string();
+    // Dev tooling stays out of the way. It still works when typed.
+    for hidden in &["storage", "reconcile", "seccomp-audit", "dashboard"] {
         // Commands are listed one per line; a hidden command's name should
         // not appear as a standalone word at the start of a help line.
         let visible_as_subcommand = help.lines().any(|line| {
@@ -4770,7 +4806,7 @@ fn top_level_help_hides_infra() {
         });
         assert!(
             !visible_as_subcommand,
-            "infra command `{hidden}` must be hidden from top-level help but was found"
+            "dev-tooling command `{hidden}` must be hidden from top-level help but was found"
         );
     }
 }

--- a/crates/mvm-cli/src/doctor/security_checks.rs
+++ b/crates/mvm-cli/src/doctor/security_checks.rs
@@ -671,8 +671,9 @@ pub(super) fn security_network_policy_default_check() -> Check {
         info: if is_deny_all {
             "deny_all (claim 10 holds — egress refused unless explicitly admitted)".to_string()
         } else {
-            "unrestricted — claim 10 does NOT hold; ADR-002 §10 regression. \
-             Workloads boot with open egress unless --network-preset is set explicitly."
+            "unrestricted — claim 10 does NOT hold; ADR-001 claim-10 regression. \
+             Workloads boot with open egress instead of refusing it unless \
+             `machine run --net` / `--allow-host` admits a destination."
                 .to_string()
         },
     }

--- a/features/suites/s8_readme_contract/readme_contract.feature
+++ b/features/suites/s8_readme_contract/readme_contract.feature
@@ -22,13 +22,14 @@ Feature: README CLI contract
     And the help output lists the "doctor" verb
     And the help output lists the "bootstrap" verb
 
-  Scenario: the SDK-transport `run` verb resolves even though it is hidden
-    # `run --mode live/plan` is documented in the SDK section but hidden from the
-    # top-level verb list, so it is checked by resolving its own help.
+  Scenario: the SDK transport survives `run` becoming a listed verb
+    # `run` is no longer hidden and its summary now describes the transient-run
+    # verb a user sees. What this scenario protects is the transport underneath:
+    # the Python and TS SDKs shell to `run --mode live/plan`, so the flag and
+    # its meaning must survive any rewording of the verb itself.
     When I run mvmctl with "run --help"
     Then the command exits with code 0
     And the help output contains "--mode"
-    And the help output contains "run --mode live/plan"
     And the help output contains "SDK transport mode"
 
   Scenario: `trust audit verify` is a real command

--- a/features/suites/s8_readme_contract/readme_contract.feature
+++ b/features/suites/s8_readme_contract/readme_contract.feature
@@ -21,6 +21,19 @@ Feature: README CLI contract
     And the help output lists the "kernel" verb
     And the help output lists the "doctor" verb
     And the help output lists the "bootstrap" verb
+    And the help output lists the "run" verb
+
+  Scenario: the subsystems the reference documents are discoverable from --help
+    # Each of these was documented in the CLI reference while `hide = true`, so
+    # the tool could not tell you the subsystem had a CLI at all. `secret` is the
+    # entry point to host-side credential substitution and `trust` owns
+    # `trust receipt verify`.
+    When I run mvmctl with "--help"
+    Then the command exits with code 0
+    And the help output lists the "secret" verb
+    And the help output lists the "trust" verb
+    And the help output lists the "image" verb
+    And the help output lists the "cache" verb
 
   Scenario: the SDK transport survives `run` becoming a listed verb
     # `run` is no longer hidden and its summary now describes the transient-run

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -106,6 +106,7 @@ guest-RPC surface, fleet-shaped workflows).
 
 | Command | Description |
 |---------|-------------|
+| `mvmctl kernel build` | Build the custom microVM kernels (builder and workload) |
 | `mvmctl build image <path>` | Build from Mvmfile.toml in the given directory |
 | `mvmctl build image --flake <ref>` | Build from a Nix flake (local or remote) |
 | `mvmctl build image --flake <ref> --profile <variant>` | Build a specific flake package variant |
@@ -959,6 +960,44 @@ flow and the distinction between build time and runtime boot time.
 | `mvmctl cache prune --deep` | Reclaim regenerable caches too — Stage 0 blobs, the prebuilt default microVM image, pulled OCI layers (each costs a re-fetch/rebuild next time). Implies `--orphan-dirs` |
 | `mvmctl cache repair` | Clear a degraded builder VM store so the next build cold-rebuilds it. Refuses while a Stage 0 bootstrap is in flight; auto-stops a running builder VM first |
 | `mvmctl cache repair --force` | Clear the store even while a Stage 0 bootstrap lock is held (use only if the lock is stale, e.g. after a crash) |
+
+## Workload Authoring and Inspection
+
+These verbs operate on a workload before and after it runs, rather than on a
+running microVM.
+
+| Command | Description |
+|---------|-------------|
+| `mvmctl init` | Scaffold a new project (`mvm.toml` alongside your `flake.nix`) |
+| `mvmctl generate sdk <script>` | Generate a runnable project from an SDK-decorated `.py`/`.ts` source: parses the decorator, emits `flake.nix` + `launch.json`, bundles the source tree into `--out <dir>` |
+| `mvmctl template list` | List available templates (bundled plus cached remote) |
+| `mvmctl template search <query>` | Search the remote registry for matching templates |
+| `mvmctl template show <name>` | Show details for one bundled or remote template |
+| `mvmctl deploy <ir.json>` | Build, seal, and record a workload into a local deployment directory (`image.tar.gz`, `rootfs.ext4`, `deploy.json`); optionally ship it to mvmd |
+| `mvmctl deploy --from-ir <path>` | Read the Workload IR from a file instead of a positional path or stdin |
+| `mvmctl prepare` | Report whether a verified runtime pack is ready for instant launch |
+| `mvmctl explain <run>` | Explain a run after the fact from the chain-signed audit log |
+| `mvmctl watch <ir.json>` | Rebuild a workload when its local inputs change |
+
+## Packs, Bundles, and Dependencies
+
+| Command | Description |
+|---------|-------------|
+| `mvmctl pack list` | List every recorded pack version, marking each key's active one |
+| `mvmctl pack rollback` | Point a pack class's active version at an already-cached one |
+| `mvmctl pack prune` | Reclaim non-active pack versions beyond the newest N per key |
+| `mvmctl pack download` | Fetch a pack version into the cache without changing the active one |
+| `mvmctl pack update` | Fetch the latest pack version and activate it |
+| `mvmctl bundle export` | Seal a built template into a signed `.mvmpkg`, signed by the host signer at `~/.mvm/keys/host-signer.ed25519` — the same key that signs `ExecutionPlan` envelopes |
+| `mvmctl bundle fetch` | Verify a `.mvmpkg` against the local trust store, reporting the parsed manifest |
+| `mvmctl bundle install` | Verify and atomically install a `.mvmpkg` into `~/.mvm/bundles/<sha>/` |
+| `mvmctl bundle gc` | Prune installed bundles — a specific `<SHA>` or `--all` |
+| `mvmctl artifact pack` / `verify` / `inspect` / `extract` | Pack or verify signed `.mvm` artifacts |
+| `mvmctl deps inspect` | Show a sealed application-dep volume's SBOM, CVE, and hash-chained metadata without spawning a VM |
+| `mvmctl deps audit` | Re-verify a sealed dep volume against its recorded chain |
+| `mvmctl deps capture` / `install` | Capture or install application dependencies into a sealed volume |
+| `mvmctl pool warm [COUNT]` | Pre-spawn standby microVMs so the next run claims a warm one |
+| `mvmctl pool status [--json]` | Report standby pool occupancy |
 
 ## Security
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-16
+Last updated: 2026-08-17
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -1074,6 +1074,16 @@ for detailed scope and acceptance criteria.
         to sign real audit entries.
   - [ ] Does **not** retire `web/audit-verify/` (no Merkle inclusion) — B5 and
         `mvmctl audit pubkey` remain plan 301's
+- [ ] Run-first CLI ergonomics
+      (`specs/plans/329-run-first-cli-and-upstream-adoption.md` — note three
+      plans share the number 329; refer to this one by path) — Phase A landed:
+      ADR-027 amended so `run` is a first-class visible verb, the fifteen
+      user-facing verb groups promoted out of `hide = true`, twelve missing
+      reference rows written, and `xtask check-cli-help-matches-docs` added to
+      the Lint job so `mvmctl --help` and the published CLI reference cannot
+      drift apart again. Phase 5 (snapshot/fork DX) was already complete.
+      Phases 1–4 and 6–8 remain: consolidating the two run-argument structs is
+      next and blocks the rest.
 - [ ] Plan 329 — Browser-tier microVM demo (`specs/plans/329-browser-wasm-backend-demo.md`)
       — in progress on `feat/329-browser-wasm-backend`. Extends Plan 320 with a
       `wasm32-wasip1` guest that boots, provides a shell, and delegates `fetch`

--- a/specs/adrs/027-cli-surface-consolidation.md
+++ b/specs/adrs/027-cli-surface-consolidation.md
@@ -1,8 +1,11 @@
-# ADR-027: `machine` is the sole CLI surface for workload microVMs
+# ADR-027: `machine` is the workload-microVM noun, and `run` is its one-shot
 
 ## Status
 
-Accepted
+Accepted. Amended 2026-08-17: `run` is a first-class visible top-level
+verb, and the hidden/visible split is restated as three buckets with a
+gate. See "`run` is a first-class transient verb" and "Three visibility
+buckets, and the cost of hiding".
 
 ## Context
 
@@ -26,14 +29,13 @@ Every workload lifecycle and operate-on-running-VM verb hangs off
 operation (pause, resume, snapshot, cp, fs, proc, session, volume,
 sandbox, and the rest) flattened directly into the same subcommand list.
 There is no separate `vm` noun; its verbs are `machine`'s verbs. There is
-no `up`, `down`, `run` (as a top-level verb), `console`, or `invoke`
-command — those names do not exist at the top level.
+no `up`, `down`, `console`, or `invoke` command — those names do not
+exist at the top level.
 
-Two other top-level surfaces exist deliberately alongside `machine`,
-because they are different objects: `dev` (host build substrate, not a
-workload) and the SDK-only `run` transport, kept but hidden from
-`--help`, retained solely because the Python/TS SDKs shell to it as their
-launch mechanism — not a user-facing command.
+`run` is the exception, and it is a deliberate one: see
+"`run` is a first-class transient verb" below. `dev` (host build
+substrate, not a workload) is the other top-level surface that exists
+alongside `machine` because it is a different object.
 
 ### One listing, over every store
 
@@ -92,17 +94,56 @@ command, not separate verbs:
   function-call path) instead of running an argv command, and can target
   an already-running named machine instead of booting a fresh one.
 
-### Hidden internals, visible daily drivers
+### `run` is a first-class transient verb (amendment)
 
-`machine`, `build`, `kernel`, `init`, `doctor`, plus a handful of
-reporting verbs (`explain`, `prepare`, `pack`, `bootstrap`) are the
-visible top-level surface. Every other historical top-level command —
-`env`, `manifest`, `image`, `storage`, `ops`, `network`, `catalog`,
-`cache`, `pool`, `reconcile`, `secret`, `bundle`, `trust`, `deps`,
-`artifact`, and internal subprocess transports (`shell-init`,
-`persistent-builder`, the QEMU vsock bridge) — is
-marked hidden. They still work; they simply do not compete for attention
-in `--help`.
+`mvmctl run <command>` is a visible top-level verb: the lowest-friction
+path to "run this once in a fresh microVM." `mvmctl machine run` remains
+visible as its noun-grouped sibling. They are not two implementations and
+not an alias pair — the intent is one argument struct consumed by both,
+so there is no second name for a second behaviour.
+
+This does not reopen the wall of verbs. `run` earns its place by being
+the single most common thing anyone asks the tool to do, and by having
+been documented as the flagship in the CLI reference for long enough that
+hiding it was the drift, not the discipline. Every other lifecycle verb
+stays under `machine`.
+
+### Three visibility buckets, and the cost of hiding
+
+The original rule — daily drivers visible, everything else hidden — was
+applied until `--help` no longer described the product. `secret`,
+`trust`, `image`, `catalog`, `cache`, `network`, `bundle`, `deps`,
+`artifact`, `pool`, `env` and `manifest` were all hidden while the
+published CLI reference documented them; a user could not discover
+`mvmctl secret set` (the entry point to the whole substitution subsystem)
+or `mvmctl trust receipt verify` (the verification half of the receipt
+feature) from the tool itself. A verb a user cannot discover is a verb
+they do not have.
+
+Verbs sort into three buckets:
+
+- **Visible.** Anything a user is expected to invoke: `machine`, `run`,
+  `build`, `kernel`, `deploy`, `generate`, `template`, `init`, `doctor`,
+  `bootstrap`, the reporting verbs (`explain`, `prepare`, `watch`,
+  `pack`), and the object groups `env`, `manifest`, `image`, `catalog`,
+  `cache`, `network`, `pool`, `secret`, `trust`, `bundle`, `artifact`,
+  `deps`, `ops`, `shell-init`. Grouped by `display_order` so `--help`
+  reads in tiers rather than alphabetically.
+- **Dev tooling.** Real commands that a user is not expected to reach
+  for, and whose absence from `--help` costs them nothing:
+  `seccomp-audit`, `storage`, `reconcile`, `dashboard`,
+  `persistent-builder`.
+- **Internal transports.** Subprocess plumbing, named with a `__` prefix
+  so it cannot be typed by accident: `__sdk-no-vm`,
+  `__builder-vm-bootstrap`, `__builder-egress-supervisor`,
+  `__builder-shell-job`, `__qemu-vsock-bridge`.
+
+`xtask check-cli-help-matches-docs` holds the visible bucket and
+`public/src/content/docs/reference/cli-commands.md` to each other in both
+directions: a documented verb must be visible, and a visible verb must be
+documented. Hiding a verb to avoid writing its reference row therefore
+also deletes it from `--help` — the escape has a price, which is what
+stops this drift from returning silently.
 
 ### Hard removal, no aliases
 

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -1,9 +1,12 @@
 # Plan 329 — Run-first CLI ergonomics and upstream-sandbox adoption
 
-**Status:** Active — ratified. `mvmctl run` and `mvmctl machine run` are both
-first-class commands sharing one consolidated implementation.
+**Status:** Active. Phase A (below) landed the ADR-027 amendment, the verb
+visibility triage, and `xtask check-cli-help-matches-docs`. `mvmctl run` and
+`mvmctl machine run` are both visible top-level commands; consolidating them
+onto one argument struct is Phase 1 and has not landed yet.
 
-**Bound by:** [ADR-027](../adrs/027-cli-surface-consolidation.md) (to be amended),
+**Bound by:** [ADR-027](../adrs/027-cli-surface-consolidation.md) (amended
+2026-08-17),
 [ADR-023](../adrs/023-secrets-subsystem-egress-substitution.md),
 [ADR-025](../adrs/025-warm-snapshot-prior-art-adoption-boundary.md),
 [Plan 255](255-vsock-first-snapshot-egress-adoption.md),
@@ -104,15 +107,85 @@ flagship while keeping mvm's stronger assurance posture intact:
 
 ## Phases
 
+## Corrections to this plan (2026-08-17)
+
+Grounding the plan against the tree found four places where it was scoped
+against something other than what is there.
+
+1. **Phase 3 was largely already shipped when this plan was written.**
+   `RunProfile` already carries all four presets — `restrictive` / `standard` /
+   `dev` / `permissive` — at `crates/mvm-cli/src/commands/vm/exec.rs`, and
+   `permissive` already gates on `MVM_ACK_PERMISSIVE_RUN=1`. What is actually
+   missing is narrower: the two entry points disagree on the default
+   (`machine run` defaults to `dev`, `run` to `standard`), and the effective
+   profile is not surfaced in `mvmctl doctor`. Phase 3 is re-scoped to those.
+
+2. **The two run surfaces diverged in both directions**, so Phase 1 is a merge,
+   not a rename. `machine run` alone has `--net`, `--allow-host`,
+   `--healthcheck` and its four companions, `--ttl`, `--stdin`, `--attach`,
+   `--fresh`, `--reset`, `--from-workload-ir`, `--cpu-limit`, `--grants-file`.
+   The formerly-hidden `run` alone has `--mode live|plan|record`, `--dev`,
+   `--prod`, `--launch-plan`, `--ack-divergence`. This is the Phase 0
+   capability-gap audit, and it is now done.
+
+3. **Phase 2 must not invent a project config file.** One exists:
+   `mvm.toml` / `Mvmfile.toml`, with a Cargo-style walk-up from the working
+   directory that stops at a `.git` boundary
+   (`mvm_core::domain::manifest::discover_manifest_from_dir`), and a
+   `ManifestMachineWorkflow` table already carrying image, net, allow_hosts,
+   cpus, and mem. It is simply not consulted by `machine run`, which errors
+   when given no source flag. Wire the existing discovery in rather than
+   adding a second config idiom.
+
+4. **Phase 6 is blocked by a standing decision this plan did not acknowledge.**
+   [ADR-002](../adrs/002-local-mcp-server.md) is **Withdrawn** — the server,
+   its `mcp` Cargo feature, the `mvmctl ops mcp stdio` verb and the CI lane
+   were deleted — and `xtask check-workflow-paths` enforces
+   `removed_mcp_server_stays_out_of_ci`. Reviving MCP means superseding an ADR
+   and deciding that gate's fate before any code is written.
+
+## Phase A — CLI truth: ADR amendment, verb visibility, docs gate
+
+Added 2026-08-17. Not in the original phase list, and a precondition for all of
+it: the published CLI reference and `mvmctl --help` described different
+products. The reference documented `mvmctl run` as the one-shot flagship and
+`mvmctl secret` / `mvmctl trust` as the entry points to the substitution and
+receipt subsystems; all three were `hide = true`. Eleven documented verbs were
+invisible, and seven visible verbs had no reference row.
+
+- [x] Amend ADR-027: `run` is a first-class transient verb; restate the
+      hidden/visible split as three buckets (visible / dev tooling / internal
+      `__` transports) with the cost of hiding made explicit.
+- [x] Promote the user-facing verb groups out of `hide = true` — `run`, `env`,
+      `manifest`, `image`, `catalog`, `cache`, `network`, `pool`, `secret`,
+      `trust`, `bundle`, `artifact`, `deps`, `ops`, `shell-init` — grouped by
+      `display_order`.
+- [x] Keep `seccomp-audit`, `storage`, `reconcile`, `dashboard`,
+      `persistent-builder` hidden as dev tooling, and the `__`-prefixed
+      subprocess transports hidden as internal.
+- [x] Add reference rows for the visible verbs that had none: `kernel`,
+      `deploy`, `generate`, `template`, `prepare`, `explain`, `watch`, `pack`,
+      `pool`, `bundle`, `artifact`, `deps`.
+- [x] Add `xtask check-cli-help-matches-docs` — every documented verb is
+      visible, every visible verb is documented — and register it in the Lint
+      job. Mutation-checked red in both directions before being believed.
+- [x] Fix the stale `--network-preset` references on live paths; the flag does
+      not exist. The `mvmctl doctor` claim-10 failure string named it, and
+      also cited ADR-002 for a claim that lives in ADR-001.
+
+**Acceptance:** `mvmctl --help` and `cli-commands.md` agree, and a gate keeps
+them agreeing.
+
 ### Phase 0 — Ratify the CLI decision
 
-- [ ] Draft an amendment to ADR-027 recording Option C.
+- [x] Draft an amendment to ADR-027 recording Option C. *(Phase A)*
 - [ ] Review the amendment in the simplification worktree; confirm no claim
       conflict.
 - [ ] Audit every in-repo reference to `mvmctl machine run` (tests, docs,
       SDKs, examples, BDD fixtures, scripts).
-- [ ] Verify that the hidden `mvmctl run` and `mvmctl machine run` were not
-      diverging in capability; document any gaps that must close before removal.
+- [x] Verify that the hidden `mvmctl run` and `mvmctl machine run` were not
+      diverging in capability; document any gaps that must close before
+      removal. *(They had diverged in both directions — see Corrections 2.)*
 - [ ] Update SDK subprocess calls to use the new canonical `mvmctl run` path.
 
 **Acceptance:** ADR-027 amendment accepted; inventory of `machine run` uses
@@ -127,8 +200,8 @@ complete; no unresolved capability gap.
       and the `mvm-client::MvmClient::run_machine` facade method.
 - [ ] Ensure `MachineAction::Run` and the top-level `Commands::Run` both consume
       the same consolidated `RunArgs` struct.
-- [ ] Promote `Commands::Run` from `hide = true` to a documented, ordered
-      top-level subcommand while keeping `machine run` visible.
+- [x] Promote `Commands::Run` from `hide = true` to a documented, ordered
+      top-level subcommand while keeping `machine run` visible. *(Phase A)*
 - [ ] Update clap completions generation to include the visible `run` surface.
 - [ ] Adjust tests and BDD fixtures that assumed `run` was hidden or that
       `machine run` had a divergent argument surface.

--- a/specs/sprint/delivery/cli-help-matches-docs.md
+++ b/specs/sprint/delivery/cli-help-matches-docs.md
@@ -1,0 +1,48 @@
+# `mvmctl --help` and the CLI reference now describe one product
+
+**Plan:** `specs/plans/329-run-first-cli-and-upstream-adoption.md`, Phase A
+(added in this change). **ADR:** ADR-027, amended.
+
+## What was wrong
+
+The published CLI reference documented `mvmctl run` as the one-shot flagship —
+"like `docker run --rm` but with a Firecracker microVM as the sandbox" — and
+put it in the three-command happy path for the primary audience. In the code it
+carried `hide = true`, demoted in its own doc comment to an SDK transport.
+
+It was not only `run`. Eleven documented verbs were invisible in `--help`,
+including `secret` (the entry point to the whole host-side substitution
+subsystem) and `trust` (which owns `trust receipt verify`, the verification
+half of the signed-receipt feature). Seven visible verbs had no reference row.
+A user could not discover from the tool that either subsystem had a CLI.
+
+## What changed
+
+- ADR-027 amended: `run` is a first-class visible top-level verb alongside
+  `machine run`, and the hidden/visible split is restated as three buckets —
+  visible, dev tooling, and `__`-prefixed internal transports.
+- Fifteen user-facing verb groups promoted out of `hide = true` and grouped by
+  `display_order`. Five stay hidden as dev tooling; the subprocess transports
+  stay hidden as internal.
+- Twelve reference rows written for visible verbs that had none.
+- The `mvmctl doctor` claim-10 failure string told the user to set a flag that
+  does not exist (`--network-preset`) and cited ADR-002 for a claim that lives
+  in ADR-001. Both fixed, along with two comments on live paths naming the same
+  dead flag.
+
+## The gate
+
+`xtask check-cli-help-matches-docs`, in the Lint job. Two rules, both
+directions: a documented verb must be visible, and a visible verb must be
+documented. Only command evidence counts as documentation — a table row or a
+fenced invocation — because the reference legitimately discusses retired verbs
+in prose and in one place explicitly negates one ("not by a public
+`mvmctl policy` command").
+
+Hiding a verb to avoid writing its row also deletes it from `--help`. That is
+the price that keeps the escape honest, and it is why the gate needs no
+allowlist.
+
+Mutation-checked before being believed: re-hiding `secret` and deleting the
+`pool` rows each produced exactly one finding, and restoring them returned the
+gate to clean.

--- a/xtask/src/check_cli_help_matches_docs.rs
+++ b/xtask/src/check_cli_help_matches_docs.rs
@@ -1,0 +1,331 @@
+//! `xtask check-cli-help-matches-docs`
+//!
+//! The published CLI reference and `mvmctl --help` must describe the same
+//! surface. They had drifted badly in both directions: the reference documented
+//! `mvmctl run` as the one-shot flagship and `mvmctl secret` / `mvmctl trust` as
+//! the entry points to the substitution and receipt subsystems, while all three
+//! carried `hide = true` and could not be found from `--help` at all; and seven
+//! visible verbs appeared in no reference row.
+//!
+//! A user who cannot discover a verb does not have it. This gate holds the two
+//! descriptions together:
+//!
+//! 1. every top-level verb with a reference row is a real, non-hidden variant;
+//! 2. every non-hidden variant has a reference row.
+//!
+//! Hidden verbs are exempt from rule 2 by construction — hiding one is the
+//! declaration that it is internal or dev-only. Hiding a verb to dodge writing
+//! its row therefore also deletes it from `--help`, which is the cost that
+//! keeps the escape honest.
+//!
+//! Only *command evidence* counts as documentation: a table row opening
+//! `` | `mvmctl <verb> `` or a fenced-block line starting `mvmctl <verb>`.
+//! Prose is ignored on purpose — the reference discusses retired verbs
+//! (`mvmctl security`, `mvmctl flake check`) and explicitly negates others
+//! ("not by a public `mvmctl policy` command"), and none of that is a claim
+//! that the verb exists.
+
+use anyhow::{Context, Result, bail};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+const CLI_REFERENCE: &str = "public/src/content/docs/reference/cli-commands.md";
+const COMMANDS_SOURCE: &str = "crates/mvm-cli/src/commands/mod.rs";
+
+/// A top-level clap subcommand as declared in the `Commands` enum.
+#[derive(Debug, PartialEq, Eq)]
+struct Verb {
+    name: String,
+    hidden: bool,
+    line: usize,
+}
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let source = read_required(workspace, COMMANDS_SOURCE)?;
+    let reference = read_required(workspace, CLI_REFERENCE)?;
+
+    let verbs = parse_commands_enum(&source)?;
+    if verbs.is_empty() {
+        bail!(
+            "{COMMANDS_SOURCE}: parsed no top-level verbs — the enum shape changed and this gate is now blind"
+        );
+    }
+    let documented = parse_documented_verbs(&reference);
+
+    let by_name: BTreeMap<&str, &Verb> = verbs.iter().map(|v| (v.name.as_str(), v)).collect();
+    let mut findings: Vec<String> = Vec::new();
+
+    for name in &documented {
+        match by_name.get(name.as_str()) {
+            None => findings.push(format!(
+                "{CLI_REFERENCE} documents `mvmctl {name}`, which is not a top-level command"
+            )),
+            Some(verb) if verb.hidden => findings.push(format!(
+                "{CLI_REFERENCE} documents `mvmctl {name}`, but {COMMANDS_SOURCE}:{} hides it from `--help`",
+                verb.line
+            )),
+            Some(_) => {}
+        }
+    }
+
+    for verb in &verbs {
+        if !verb.hidden && !documented.contains(&verb.name) {
+            findings.push(format!(
+                "{COMMANDS_SOURCE}:{} exposes `mvmctl {}` in `--help`, but {CLI_REFERENCE} has no row for it",
+                verb.line, verb.name
+            ));
+        }
+    }
+
+    if findings.is_empty() {
+        eprintln!(
+            "check-cli-help-matches-docs: clean ({} verbs, {} visible)",
+            verbs.len(),
+            verbs.iter().filter(|v| !v.hidden).count()
+        );
+        return Ok(());
+    }
+
+    eprintln!(
+        "check-cli-help-matches-docs: {} finding(s) — `mvmctl --help` and the CLI reference disagree",
+        findings.len()
+    );
+    for finding in &findings {
+        eprintln!("  {finding}");
+    }
+    std::process::exit(1);
+}
+
+fn read_required(workspace: &Path, rel: &str) -> Result<String> {
+    let path = workspace.join(rel);
+    if !path.is_file() {
+        bail!("required file missing: {}", path.display());
+    }
+    std::fs::read_to_string(&path).with_context(|| format!("reading {}", path.display()))
+}
+
+/// Pull `(name, hidden)` for each variant of the `Commands` enum.
+///
+/// Deliberately a source scan rather than a link against `mvm-cli`: xtask does
+/// not depend on the CLI crate, and building it to read its own help text would
+/// put a full workspace build in front of a lint that must stay cheap.
+fn parse_commands_enum(source: &str) -> Result<Vec<Verb>> {
+    let lines: Vec<&str> = source.lines().collect();
+    let start = lines
+        .iter()
+        .position(|l| l.contains("enum Commands {"))
+        .context("could not find `enum Commands {` — the gate cannot parse the CLI surface")?;
+
+    let mut verbs = Vec::new();
+    let mut pending_name: Option<String> = None;
+    let mut pending_hidden = false;
+    let mut depth = 0usize;
+
+    for (offset, line) in lines[start..].iter().enumerate() {
+        let trimmed = line.trim();
+        depth += line.matches('{').count();
+        depth = depth.saturating_sub(line.matches('}').count());
+        if depth == 0 && offset > 0 {
+            break;
+        }
+
+        if trimmed.starts_with("#[command(") || trimmed.starts_with("#[clap(") {
+            if trimmed.contains("hide = true") || trimmed.contains("hide=true") {
+                pending_hidden = true;
+            }
+            if let Some(name) = attribute_name(trimmed) {
+                pending_name = Some(name);
+            }
+            continue;
+        }
+        if trimmed.starts_with("///") || trimmed.starts_with("//") || trimmed.starts_with("#[cfg") {
+            continue;
+        }
+
+        if let Some(ident) = variant_ident(trimmed) {
+            let name = pending_name.take().unwrap_or_else(|| kebab_case(&ident));
+            verbs.push(Verb {
+                name,
+                hidden: pending_hidden,
+                line: start + offset + 1,
+            });
+            pending_hidden = false;
+        }
+    }
+
+    Ok(verbs)
+}
+
+/// `#[command(name = "seccomp-audit", hide = true)]` → `seccomp-audit`.
+fn attribute_name(attr: &str) -> Option<String> {
+    let rest = attr.split_once("name = \"")?.1;
+    let name = rest.split_once('"')?.0;
+    Some(name.to_string())
+}
+
+/// `Machine(machine::Args),` → `Machine`. Only tuple variants are commands.
+fn variant_ident(line: &str) -> Option<String> {
+    let ident = line.split_once('(')?.0.trim();
+    if ident.is_empty() || !ident.chars().next()?.is_ascii_uppercase() {
+        return None;
+    }
+    if !ident.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    Some(ident.to_string())
+}
+
+/// Clap's default renaming for a variant with no explicit `name`.
+fn kebab_case(ident: &str) -> String {
+    let mut out = String::with_capacity(ident.len() + 2);
+    for (idx, ch) in ident.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if idx > 0 {
+                out.push('-');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// Top-level verbs the reference documents as commands, ignoring prose.
+fn parse_documented_verbs(reference: &str) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    let mut in_fence = false;
+
+    for line in reference.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+
+        let invocation = if in_fence {
+            trimmed.strip_prefix("mvmctl ")
+        } else {
+            trimmed.strip_prefix("| `mvmctl ")
+        };
+
+        if let Some(rest) = invocation
+            && let Some(verb) = first_verb(rest)
+        {
+            found.insert(verb);
+        }
+    }
+
+    found
+}
+
+/// Global flags that take a value. A boolean global (`--verbose`) must not
+/// swallow the verb that follows it, so the two kinds cannot share a
+/// does-the-next-token-look-like-a-value heuristic.
+const VALUED_GLOBAL_FLAGS: &[&str] = &[
+    "--log-format",
+    "--fc-version",
+    "--builder",
+    "--kernel-source",
+];
+
+/// First bare token of an invocation tail, skipping global flags and their
+/// values so `mvmctl --builder qemu machine run` still resolves to `machine`.
+fn first_verb(rest: &str) -> Option<String> {
+    let mut tokens = rest.split_whitespace().peekable();
+    while let Some(token) = tokens.next() {
+        if token.starts_with('-') {
+            if VALUED_GLOBAL_FLAGS.contains(&token)
+                && tokens.peek().is_some_and(|n| !n.starts_with('-'))
+            {
+                tokens.next();
+            }
+            continue;
+        }
+        let verb: String = token
+            .chars()
+            .take_while(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '-')
+            .collect();
+        if verb.is_empty() {
+            return None;
+        }
+        return Some(verb);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+enum Commands {
+    /// Beginner microVM workflows
+    #[command(display_order = 1)]
+    Machine(machine::Args),
+    /// SDK transport surface
+    #[command(hide = true)]
+    Run(vm::exec::RunArgs),
+    /// Host-side seccomp syscall audit.
+    #[command(name = "seccomp-audit", hide = true)]
+    SeccompAudit(seccomp_audit::Args),
+    /// Print shell configuration
+    ShellInit(env::shell_init::Args),
+}
+"#;
+
+    #[test]
+    fn parses_names_hidden_flags_and_clap_renaming() {
+        let verbs = parse_commands_enum(SAMPLE).expect("parses");
+        let names: Vec<(&str, bool)> = verbs.iter().map(|v| (v.name.as_str(), v.hidden)).collect();
+        assert_eq!(
+            names,
+            vec![
+                ("machine", false),
+                ("run", true),
+                ("seccomp-audit", true),
+                ("shell-init", false),
+            ]
+        );
+    }
+
+    #[test]
+    fn documentation_evidence_is_rows_and_fences_never_prose() {
+        let doc = "\
+| `mvmctl machine run --image x` | boot |
+Retired: the `mvmctl security` verb folded into doctor.
+tenant policy is not exposed by a public `mvmctl policy` command.
+```bash
+mvmctl trust receipt verify ./r.json
+mvmctl --builder qemu machine ls
+```
+";
+        let found = parse_documented_verbs(doc);
+        assert!(found.contains("machine"), "table row counts");
+        assert!(found.contains("trust"), "fenced invocation counts");
+        assert!(!found.contains("security"), "prose must not count");
+        assert!(!found.contains("policy"), "negated prose must not count");
+    }
+
+    #[test]
+    fn global_flags_do_not_shadow_the_verb() {
+        assert_eq!(
+            first_verb("--builder qemu machine ls").as_deref(),
+            Some("machine")
+        );
+        assert_eq!(first_verb("--verbose doctor").as_deref(), Some("doctor"));
+        assert_eq!(
+            first_verb("--log-format=json doctor").as_deref(),
+            Some("doctor")
+        );
+        assert_eq!(first_verb("machine run").as_deref(), Some("machine"));
+    }
+
+    #[test]
+    fn backtick_and_punctuation_terminate_the_verb() {
+        assert_eq!(
+            first_verb("doctor` | diagnostics |").as_deref(),
+            Some("doctor")
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -17,6 +17,7 @@ mod check_build_egress_callers;
 mod check_builder_shell_job_sites;
 mod check_claim_catalog;
 mod check_claim_witness_freshness;
+mod check_cli_help_matches_docs;
 mod check_cli_runtime_surface;
 mod check_closure_budget;
 mod check_conformance;
@@ -132,6 +133,10 @@ fn main() -> Result<()> {
         Some("check-doc-claims") => {
             let workspace = workspace_root();
             check_doc_claims::run(&workspace)
+        }
+        Some("check-cli-help-matches-docs") => {
+            let workspace = workspace_root();
+            check_cli_help_matches_docs::run(&workspace)
         }
         Some("check-machine-doc-guards") => {
             let workspace = workspace_root();
@@ -402,7 +407,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-vsock-only-egress, check-one-guest-protocol, check-no-gateway-names, check-uniform-vsock-egress, check-l3-expansion-freeze, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-vsock-only-egress, check-one-guest-protocol, check-no-gateway-names, check-uniform-vsock-egress, check-l3-expansion-freeze, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -422,6 +427,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-doc-claims                        Plan 74 W0 lint: reject gated marketing phrases in public docs"
+            );
+            eprintln!(
+                "  check-cli-help-matches-docs             Hold `mvmctl --help` and the CLI reference to the same verb set"
             );
             eprintln!(
                 "  check-machine-doc-guards                Plan 200 lint: require machine use-case/limitations docs and reject beginner overclaims"


### PR DESCRIPTION
## The problem

The published CLI reference documents `mvmctl run` as the one-shot flagship — *"like `docker run --rm` but with a Firecracker microVM as the sandbox"* — and `getting-started/happy-paths.md` puts it in the three-command path for the primary audience. In the code it carried `hide = true`, demoted in its own doc comment to an SDK transport.

It was not only `run`. **Eleven documented verbs were invisible in `--help`**, including:

- `secret` — the entry point to the whole host-side credential-substitution subsystem
- `trust` — which owns `trust receipt verify`, the verification half of the signed-receipt feature

and **seven visible verbs had no reference row at all**. A user typing `mvmctl --help` could not learn from the tool that either subsystem had a CLI. A verb you cannot discover is a verb you do not have.

## What changed

**ADR-027 amended.** `run` is a first-class visible top-level verb alongside `machine run`. The hidden/visible split is restated as three buckets:

| Bucket | Contents |
|---|---|
| Visible | anything a user is expected to invoke, grouped by `display_order` |
| Dev tooling | `seccomp-audit`, `storage`, `reconcile`, `dashboard`, `persistent-builder` |
| Internal transports | the `__`-prefixed subprocess plumbing |

Fifteen user-facing groups promoted out of `hide = true`; twelve missing reference rows written.

**A gate, so this cannot drift back.** `xtask check-cli-help-matches-docs` (Lint job) enforces both directions: a documented verb must be visible, a visible verb must be documented. Only *command evidence* counts as documentation — a table row or a fenced invocation — because the reference legitimately discusses retired verbs in prose and in one place explicitly negates one ("not by a public `mvmctl policy` command").

Hiding a verb to dodge writing its row also deletes it from `--help`. That price is what keeps the escape honest, and it is why the gate needs no allowlist.

**Also fixed:** the `mvmctl doctor` claim-10 failure string told the user to set `--network-preset`, a flag that does not exist, and cited ADR-002 for a claim that lives in ADR-001. Two comments on live paths named the same dead flag.

## The resulting surface

```
  machine     Beginner microVM workflows (run an OCI image and more)
  run         Run one command in a fresh transient microVM, then tear it down
  build       Build-time commands (image, compile, validate, kernel)
  ...
  secret      Manage local secret namespaces
  trust       Manage trusted bundle publishers
  deps        Inspect cached application dependencies
```

## Verification

- `cargo nextest run --workspace` — 12072 tests, green (one unrelated `mvm-http` parallelism flake, passes isolated)
- `cargo test --workspace --doc`, `just check-gated`, nightly `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- Doc/spec gates: `check-cli-help-matches-docs`, `check-machine-doc-guards`, `check-doc-claims`, `check-adr-coverage`, `check-claim-catalog`, `check-honesty`, `check-no-overclaim`, `check-plan-names`, `check-sprint-append`, `check-no-spec-refs-in-comments`, `check-workflow-paths`
- **Mutation-checked:** re-hiding `secret` and deleting the `pool` rows each produced exactly one finding; restoring them returned the gate to clean.

Three existing tests encoded the old policy and were rewritten to encode the new bucket rule rather than deleted — they are the in-crate counterpart to the gate.

## Scope

This is Phase A of the run-first CLI plan (`specs/plans/329-run-first-cli-and-upstream-adoption.md`, which also gains a corrections section: Phase 3's presets were already shipped, the two run surfaces diverged in *both* directions, Phase 2 must reuse the existing `mvm.toml` discovery rather than invent a config file, and Phase 6 is blocked behind a withdrawn ADR).

Consolidating `RunArgs` and `MachineRunArgs` onto one struct is the next phase and is deliberately not in this PR.