### PR TITLE
fix(conformance): stop the SDK codegen step leaking a target dir per run

### DIFF
--- a/crates/mvm-conformance/tests/steps/sdk.rs
+++ b/crates/mvm-conformance/tests/steps/sdk.rs
@@ -141,18 +141,24 @@ fn run_sdk_codegen_drift_check(world: &mut CliWorld) {
     let xtask = target_dir.join("debug/xtask");
     let tool_home = tempfile::tempdir().expect("create isolated SDK codegen home");
     let tool_home_path = tool_home.path().to_path_buf();
-    let codegen_target =
-        std::env::temp_dir().join(format!("mvm-sdk-codegen-{}", std::process::id()));
-    let uv_cache = std::env::temp_dir().join(format!("mvm-sdk-uv-cache-{}", std::process::id()));
+    // All three are `TempDir` so the run cleans up after itself.
+    //
+    // The target dir and the uv cache used to be hand-built `temp_dir()` paths
+    // keyed by pid. Nothing removed them, and a pid is not stable across runs,
+    // so each run both rebuilt from scratch *and* left its ~5 GB behind — 117
+    // of them, 347 GB, before anyone noticed. A `TempDir` keeps the isolation
+    // and the rebuild cost identical and gives back the disk on drop.
+    let codegen_target = tempfile::tempdir().expect("create isolated SDK codegen target dir");
+    let uv_cache = tempfile::tempdir().expect("create isolated SDK codegen uv cache");
     world.sdk_output = Some(
         Command::new(xtask)
             .arg("check-stubs")
             .current_dir(repo_root())
             .env("CARGO_MANIFEST_DIR", repo_root().join("xtask"))
-            .env("CARGO_TARGET_DIR", codegen_target)
+            .env("CARGO_TARGET_DIR", codegen_target.path())
             .env("UV_TOOL_DIR", tool_home_path.join("uv/tools"))
             .env("UV_TOOL_BIN_DIR", tool_home_path.join("uv/bin"))
-            .env("UV_CACHE_DIR", uv_cache)
+            .env("UV_CACHE_DIR", uv_cache.path())
             .output()
             .expect("spawn SDK codegen drift check"),
     );


### PR DESCRIPTION
Found while reclaiming a terabyte of disk. `$TMPDIR` held **117 `mvm-sdk-codegen-*` directories at ~5.1 GB each — 346.6 GB** — plus 114 `mvm-sdk-uv-cache-*`. Oldest 2026-08-08, newest the day I looked, so it was still growing.

## Cause

`run_sdk_codegen_drift_check` (`crates/mvm-conformance/tests/steps/sdk.rs`) handed the child a `CARGO_TARGET_DIR` and `UV_CACHE_DIR` built by hand:

```rust
let tool_home = tempfile::tempdir().expect("create isolated SDK codegen home");   // cleaned on drop
let codegen_target = std::env::temp_dir().join(format!("mvm-sdk-codegen-{}", std::process::id()));
let uv_cache = std::env::temp_dir().join(format!("mvm-sdk-uv-cache-{}", std::process::id()));
```

The first is a `TempDir` and cleans up. The other two are plain paths nothing removes — and because a pid is not stable between runs, each run got a *fresh* one. Worst of both: a full rebuild every time **and** ~5 GB left behind every time.

## Fix

All three become `TempDir`. Isolation and rebuild cost are identical; the disk comes back on drop.

## Why no gate

The mechanical check — "a hand-built temp path must not become a build tool's output directory" — cannot be expressed at file granularity without an allow-list. `libkrun_builder.rs` mentions both `temp_dir()` and `CARGO_TARGET_DIR` but roots its target dirs in the workspace, so it would be a false positive, and an allow-list of one entry for a false positive is the kind of gate that rots into noise.

I checked rather than guessed: every other `.env("CARGO_TARGET_DIR", ...)` in the tree resolves to a workspace root or `~/.mvm/cache`. This was the only per-pid one.

## Related, not fixed here

`$TMPDIR` also held 71 leaked `mvm-subst-*` fixture dirs from the substitution tests, and `readme_contract.rs:33` builds a pid-keyed path the same way. Those are kilobytes rather than gigabytes — a tidiness problem, not a disk one. Worth a follow-up, not worth widening this change.
