### PR TITLE
ci: run the generator's own guards on the PRs that change the generator

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -816,7 +816,11 @@ jobs:
         with:
           filters: |
             spawn:
-              - 'crates/mvm-host-vm-init/**'
+              # Same absorbed-path bug the builder VM lane above already
+              # fixed: mvm-host-vm-init is a [[bin]] of mvm-build, so the
+              # standalone crate directory this named cannot exist and the
+              # filter never matched.
+              - 'crates/mvm-build/src/bin/mvm-host-vm-init/**'
 
       - name: Install Rust toolchain
         if: steps.filter.outputs.spawn == 'true' || github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,19 @@ jobs:
           # Anything that can change a compiled target, generated artifact, or
           # the commands used by a Rust lane keeps the full compiler/test
           # matrix. Prose, site assets, and process-only specs do not.
-          if grep -zE '^(crates/|src/|tests/|xtask/|scripts/|features/|schema/|model/|assets/|\.cargo/|\.config/|\.github/actions/|\.github/workflows/|nix/packaging/release/[^/]*\.sh$|Cargo\.(toml|lock)$|rust-toolchain\.toml$|build\.rs$|install\.sh$|[Jj]ustfile$)' "$CHANGED_FILE" >/dev/null; then
+          #
+          # `nix/` is here whole, replacing a narrow
+          # `nix/packaging/release/*.sh` entry, because the guest image
+          # generator has Rust guards that only run under this flag and
+          # tests/nix_flake_structure.rs reads across lib/, images/,
+          # packages/ and profiles/. `mk_guest_init_shebang_lands_at_byte_zero`
+          # renders `initText` out of nix/lib/mk-guest.nix and asserts the
+          # shebang lands on byte 0 — no Nix needed, well under a second. It
+          # was written for the defect that shipped a rootfs the kernel could
+          # not exec, and a PR touching only mk-guest.nix used to resolve
+          # code=false, so the one test that would have caught that change
+          # never ran on it.
+          if grep -zE '^(crates/|src/|tests/|xtask/|scripts/|features/|schema/|model/|assets/|\.cargo/|\.config/|\.github/actions/|\.github/workflows/|nix/|Cargo\.(toml|lock)$|rust-toolchain\.toml$|build\.rs$|install\.sh$|[Jj]ustfile$)' "$CHANGED_FILE" >/dev/null; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"
@@ -103,7 +115,11 @@ jobs:
             echo "architecture=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if grep -zE '^(nix/images/kernel/|nix/images/builder-vm/flake\.(nix|lock)$|xtask/src/check_kernel_config_budget\.rs$|\.github/workflows/(ci|kernel-build)\.yml$)' "$CHANGED_FILE" >/dev/null; then
+          # default-tenant and nix/lib/ join the kernel paths because the
+          # image flake imports both — nix/images/kernel/{base,workload}.nix
+          # for the vmlinux and lib.mkGuest for the rootfs — so a change to
+          # either alters what this lane builds.
+          if grep -zE '^(nix/images/kernel/|nix/images/default-tenant/|nix/lib/|nix/images/builder-vm/flake\.(nix|lock)$|xtask/src/check_kernel_config_budget\.rs$|\.github/workflows/(ci|kernel-build)\.yml$)' "$CHANGED_FILE" >/dev/null; then
             echo "kernel=true" >> "$GITHUB_OUTPUT"
           else
             echo "kernel=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The mechanical half of #2635. The expensive half — booting a tree-built image
before merge — is left in that issue, since it needs a call on whether a per-PR
`nix build` of the image is worth the runner time.

## The problem

`mk_guest_init_shebang_lands_at_byte_zero` (`tests/nix_flake_structure.rs:735`)
renders `initText` out of `nix/lib/mk-guest.nix` and asserts the first line is
`#!/bin/sh`. Pure Rust, no Nix, under a second. It exists for exactly one defect:
the published rootfs whose `/init` the kernel could not exec.

It runs in `test-workspace`, gated `if: needs.scope.outputs.code == 'true'`, and
`scope.code` matched `nix/` only via `nix/packaging/release/[^/]*\.sh$`. So a PR
touching only `nix/lib/mk-guest.nix` resolved:

| output | before | after |
|---|---|---|
| `code` | **false** | true |
| `kernel` | **false** | true |
| `nix` | true — but `nix-flake-check` is skipped on `pull_request` by design | unchanged |

`b4a6fadd7`, the fix for that outage, describes a diff of one line moving from
three spaces to four in that file and nothing else. A PR of that shape got no Nix
build, no boot, and did not run the one test written to catch it.

## What changed

- `scope.code`: `nix/packaging/release/[^/]*\.sh$` → `nix/`. Not a widening for its
  own sake — `tests/nix_flake_structure.rs` reads across `lib/`, `images/`,
  `packages/` and `profiles/`, so each of those already has a Rust guard behind
  this flag. The narrow entry is subsumed.
- `scope.kernel`: add `nix/images/default-tenant/` and `nix/lib/`. The image flake
  imports the kernel derivations *and* `lib.mkGuest`, so a change to either alters
  what that lane builds.
- `ci-full.yml`: the workload-spawn lane filtered on `crates/mvm-host-vm-init/**`,
  a directory that cannot exist — the binary is a `[[bin]]` of `mvm-build`. The
  same bug was already found and fixed in the builder VM lane a few hundred lines
  up, with a comment explaining it; this is the copy that was missed.

## Verification

Mutation, because a scope fix that doesn't actually make a guard fire is worth
nothing:

- reintroduced the one-column indentation drift in `mk-guest.nix` →
  `mk_guest_init_shebang_lands_at_byte_zero` **FAILED** in 0.00s
- restored → `cargo test --test nix_flake_structure` **45 passed, 0 failed**

Classification checked by extracting both regexes out of the workflow and running
them against sample paths:

```
nix/lib/mk-guest.nix                  code=T kernel=T
nix/images/default-tenant/flake.nix   code=T kernel=T
nix/images/kernel/base.nix            code=T kernel=T
public/src/content/docs/index.md      code=F kernel=F
specs/SPRINT.md                       code=F kernel=F
README.md                             code=F kernel=F
crates/mvm-core/src/config.rs         code=T kernel=F
```

Docs and specs still cost nothing, which is the property the scope job exists to
preserve.

`actionlint` on both files, `xtask check-workflow-paths` (26 working-directory, 17
fuzz targets, 134 cargo -p packages across 24 workflows) and
`xtask check-no-spec-refs-in-comments` all clean.

## Cost

Nix-only PRs now pay the full compiler/test matrix. That is the intended trade:
the flag's own comment says it covers "anything that can change a compiled target,
generated artifact", and a guest image is both.
