### PR TITLE
test(sec): witness the redaction gate and the fail-closed cap

### DIFF
--- a/crates/mvm-hostd/src/supervisor/network_endpoint_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/network_endpoint_proxy.rs
@@ -445,6 +445,68 @@ mod redaction_gate_tests {
         };
         assert!(!redaction_active(&action));
     }
+
+    /// The all-off action the single-channel cases start from.
+    fn all_channels_off() -> RedactionAction {
+        RedactionAction {
+            pii: PiiPolicy {
+                mode: Some("disabled".into()),
+                categories: Vec::new(),
+            },
+            secrets: SecretAction::Audit,
+            ..Default::default()
+        }
+    }
+
+    // `redaction_active` is a four-way OR, and the two cases above are
+    // all-on and all-off — which an AND satisfies identically. So neither
+    // test could tell the gate from its own inversion, and a mutation to
+    // `&&` survived: a request protected by exactly one channel would have
+    // been reported as carrying no protection at all, and the fail-closed
+    // scan gate above skipped.
+    //
+    // Any single channel has to arm it, because that is the fail-safe
+    // direction — the gate asks "is anything being redacted", not "is
+    // everything".
+
+    #[test]
+    fn secrets_alone_arms_the_gate() {
+        let mut action = all_channels_off();
+        action.secrets = SecretAction::Redact;
+        assert!(redaction_active(&action));
+    }
+
+    #[test]
+    fn pii_alone_arms_the_gate() {
+        let mut action = all_channels_off();
+        action.pii.mode = Some("curated".into());
+        assert!(redaction_active(&action));
+    }
+
+    #[test]
+    fn entropy_alone_arms_the_gate() {
+        let mut action = all_channels_off();
+        action.entropy = mvm_core::policy::EntropyMode::Audit {
+            min_bits_per_char: 3.5,
+            min_run_len: 20,
+        };
+        assert!(redaction_active(&action));
+    }
+
+    #[test]
+    fn names_alone_arms_the_gate() {
+        let mut action = all_channels_off();
+        action.names = mvm_core::policy::NameMode::Audit;
+        assert!(redaction_active(&action));
+    }
+
+    #[test]
+    fn an_absent_pii_mode_arms_the_gate() {
+        // `None` is not `Some("disabled")`, so it counts as protection.
+        let mut action = all_channels_off();
+        action.pii.mode = None;
+        assert!(redaction_active(&action));
+    }
 }
 
 /// The fail-closed scan-gate the cleartext cores run before substitute/forward:
@@ -470,6 +532,75 @@ pub(crate) fn fail_closed_reason(
         Some("fail_closed_oversize")
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod fail_closed_gate_tests {
+    use super::fail_closed_reason;
+    use mvm_core::policy::{DEFAULT_BODY_CAP_BYTES, PiiPolicy, RedactionAction, SecretAction};
+
+    /// Redaction on, so the gate is reached at all.
+    fn armed() -> RedactionAction {
+        RedactionAction::default()
+    }
+
+    /// Redaction fully off — the gate returns early whatever the body is.
+    fn disarmed() -> RedactionAction {
+        RedactionAction {
+            pii: PiiPolicy {
+                mode: Some("disabled".into()),
+                categories: Vec::new(),
+            },
+            secrets: SecretAction::Audit,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn an_unredacted_destination_is_never_refused() {
+        let huge = DEFAULT_BODY_CAP_BYTES as usize + 1;
+        assert_eq!(fail_closed_reason(&[], huge, &disarmed()), None);
+    }
+
+    // The cap is a `>` comparison, so exactly-at-cap and one-over are the
+    // only inputs that tell it from `>=`. Without both, a body of precisely
+    // `DEFAULT_BODY_CAP_BYTES` could start being refused — or, in the other
+    // direction, one byte over could start being forwarded unscanned —
+    // without a single test noticing.
+
+    #[test]
+    fn a_body_exactly_at_the_cap_is_scannable() {
+        let at_cap = DEFAULT_BODY_CAP_BYTES as usize;
+        assert_eq!(fail_closed_reason(&[], at_cap, &armed()), None);
+    }
+
+    #[test]
+    fn a_body_one_byte_over_the_cap_is_refused() {
+        let over = DEFAULT_BODY_CAP_BYTES as usize + 1;
+        assert_eq!(
+            fail_closed_reason(&[], over, &armed()),
+            Some("fail_closed_oversize")
+        );
+    }
+
+    #[test]
+    fn a_compressed_body_is_refused_whatever_its_size() {
+        let headers = vec![("Content-Encoding".to_string(), "gzip".to_string())];
+        assert_eq!(
+            fail_closed_reason(&headers, 1, &armed()),
+            Some("fail_closed_compressed")
+        );
+    }
+
+    #[test]
+    fn compression_outranks_size_because_it_is_the_harder_bypass() {
+        let headers = vec![("content-encoding".to_string(), "br".to_string())];
+        let over = DEFAULT_BODY_CAP_BYTES as usize + 1;
+        assert_eq!(
+            fail_closed_reason(&headers, over, &armed()),
+            Some("fail_closed_compressed")
+        );
     }
 }
 


### PR DESCRIPTION
Partial fix for #2623. The scheduled Security lane is red with 23 surviving mutants in `network_endpoint_proxy.rs`; this kills the ones on the two functions that decide whether a body is scanned before it leaves the host, and is explicit about leaving the other twenty.

## `redaction_active` — the gate could not be told from its own inversion

It is a four-way OR. Both existing tests were all-channels-on and all-channels-off, which an AND satisfies identically:

| input | `\|\|` | `&&` |
| --- | --- | --- |
| all off | false | false |
| all on | true | true |
| **exactly one on** | **true** | **false** |

Only the third row discriminates, and nothing exercised it. So a request protected by exactly one channel would have been reported as carrying no protection at all, and the fail-closed scan gate above it skipped.

Five single-channel cases fix that. The OR is the fail-safe direction — the gate asks *is anything being redacted*, not *is everything*.

## `fail_closed_reason` — no tests at all

The body cap is a `>`, so exactly-at-cap and one-over are the only inputs that distinguish it from `>=`. Without both, the cap can move a byte in either direction unnoticed, and one of those directions forwards an unscanned body to a destination that asked for redaction.

Five cases: the disarmed early return, both sides of the boundary, compression, and compression outranking size.

## Verified in both directions

Not assumed to bite:

- each of the three `||` mutants, applied **one at a time** as cargo-mutants does — I first mutated all three together, which is a different and weaker test — **survives** the original two tests and is **killed** by the new ones
- the `>` → `>=` mutant is killed by `a_body_exactly_at_the_cap_is_scannable`

`cargo nextest run -p mvm-hostd` — 1915 passed. fmt and clippy clean.

## What is left

Twenty of the 23 remain: the `vsock::` framing and accept paths, the `SignRequest` builder, `audit_redactions`, and `handle_terminator_connection`. Each needs its own witness.

They should not be closed with `--write-baseline`, which is what the gate's own error message suggests. Re-pinning records the claim as unwitnessed rather than witnessing it — the same trap as the claim-13 surface in #2609, where the suggested re-pin would have silently dropped coverage.
