### PR TITLE
fix(build): stop the Stage 0 source copy walking into its own output

### DIFF
--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -418,6 +418,7 @@ pub(crate) fn copy_tree_filtered(
 #[cfg(test)]
 mod copy_barrier_tests {
     use super::{WORK_TREE_EXCLUDE_DIRS, copy_tree_filtered};
+    use mvm_core::util::test_env::TestEnv;
 
     /// The reported failure: a staging destination inside the tree being
     /// copied. Name-matched filtering walked into it and kept going until the
@@ -465,18 +466,15 @@ mod copy_barrier_tests {
         std::fs::create_dir_all(home.join("cache/builder-vm")).expect("mkdir");
         std::fs::write(home.join("cache/builder-vm/huge.img"), b"x").expect("write");
 
-        // SAFETY: single-threaded test process; restored before returning.
-        let previous = std::env::var_os("MVM_HOME");
-        unsafe { std::env::set_var("MVM_HOME", &home) };
+        // `isolate_mvm_home` moves HOME with MVM_HOME and restores both on
+        // drop. Setting MVM_HOME alone leaves the test able to read the
+        // developer's real home, which `xtask check-test-home-isolation`
+        // refuses — it caught this exact pair.
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(&home);
 
         let dst = root.path().join("out");
-        let result = copy_tree_filtered(&src, &dst, WORK_TREE_EXCLUDE_DIRS);
-
-        match previous {
-            Some(v) => unsafe { std::env::set_var("MVM_HOME", v) },
-            None => unsafe { std::env::remove_var("MVM_HOME") },
-        }
-        result.expect("copy");
+        copy_tree_filtered(&src, &dst, WORK_TREE_EXCLUDE_DIRS).expect("copy");
 
         assert!(
             dst.join("crates/lib.rs").is_file(),
@@ -497,18 +495,11 @@ mod copy_barrier_tests {
         std::fs::create_dir_all(src.join(".mvm-verify")).expect("mkdir");
         std::fs::write(src.join(".mvm-verify/notes.md"), b"not a home").expect("write");
 
-        let previous = std::env::var_os("MVM_HOME");
-        // SAFETY: single-threaded test process; restored before returning.
-        unsafe { std::env::set_var("MVM_HOME", root.path().join("elsewhere")) };
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(root.path().join("elsewhere"));
 
         let dst = root.path().join("out");
-        let result = copy_tree_filtered(&src, &dst, WORK_TREE_EXCLUDE_DIRS);
-
-        match previous {
-            Some(v) => unsafe { std::env::set_var("MVM_HOME", v) },
-            None => unsafe { std::env::remove_var("MVM_HOME") },
-        }
-        result.expect("copy");
+        copy_tree_filtered(&src, &dst, WORK_TREE_EXCLUDE_DIRS).expect("copy");
 
         assert!(
             dst.join(".mvm-verify/notes.md").is_file(),

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -339,12 +339,46 @@ fn run_stage0_qemu(
 /// `/work` tree without the heavy `target/`/`.git` dirs before packing it.
 /// `pub(crate)` so the libkrun Stage 0 path can stage its own filtered
 /// `/work` copy with the same walk instead of a second implementation.
+/// Directories this copy must never descend into, resolved to real paths
+/// rather than matched by name.
+///
+/// `exclude` is a list of *names*, which is fine for `target/` and `.git` —
+/// they are named by convention. It is not fine for two cases that are
+/// defined by where they are, not what they are called:
+///
+/// - **The destination.** When `dst` lives under `src`, a name-matched filter
+///   walks the copy into its own output and keeps going until the path
+///   exceeds `PATH_MAX`. That is always a bug, whatever the directory is
+///   called.
+/// - **`MVM_HOME`.** The default name is on the exclude list, but the
+///   variable can point anywhere. Pointed inside the checkout under any other
+///   name — `.mvm-verify`, say — it was copied, and since Stage 0 stages into
+///   `MVM_HOME/cache/builder-vm/vms/...` that is the first case again.
+fn resolved_copy_barriers(src: &Path, dst: &Path) -> Vec<PathBuf> {
+    let mut barriers = Vec::new();
+    let real = |p: &Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+    let src_real = real(src);
+
+    let dst_real = real(dst);
+    if dst_real.starts_with(&src_real) {
+        barriers.push(dst_real);
+    }
+
+    let home = PathBuf::from(mvm_core::config::mvm_home());
+    let home_real = real(&home);
+    if home_real.starts_with(&src_real) {
+        barriers.push(home_real);
+    }
+    barriers
+}
+
 pub(crate) fn copy_tree_filtered(
     src: &Path,
     dst: &Path,
     exclude: &[&str],
 ) -> Result<(), BuilderVmError> {
     std::fs::create_dir_all(dst).map_err(|e| io_err("creating staging dir", dst, e))?;
+    let barriers = resolved_copy_barriers(src, dst);
     let mut stack = vec![(src.to_path_buf(), dst.to_path_buf())];
     while let Some((from, to)) = stack.pop() {
         for entry in std::fs::read_dir(&from).map_err(|e| io_err("reading", &from, e))? {
@@ -358,6 +392,12 @@ pub(crate) fn copy_tree_filtered(
             if ft.is_dir() {
                 if exclude.contains(&name.to_string_lossy().as_ref()) {
                     continue;
+                }
+                if !barriers.is_empty() {
+                    let real = std::fs::canonicalize(&src_p).unwrap_or_else(|_| src_p.clone());
+                    if barriers.iter().any(|b| real.starts_with(b)) {
+                        continue;
+                    }
                 }
                 std::fs::create_dir_all(&dst_p).map_err(|e| io_err("mkdir", &dst_p, e))?;
                 stack.push((src_p, dst_p));
@@ -373,6 +413,108 @@ pub(crate) fn copy_tree_filtered(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod copy_barrier_tests {
+    use super::{WORK_TREE_EXCLUDE_DIRS, copy_tree_filtered};
+
+    /// The reported failure: a staging destination inside the tree being
+    /// copied. Name-matched filtering walked into it and kept going until the
+    /// path outgrew `PATH_MAX` (ENAMETOOLONG), roughly ten levels deep.
+    #[test]
+    fn a_destination_inside_the_source_is_not_copied_into_itself() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let src = root.path().join("checkout");
+        std::fs::create_dir_all(src.join("crates")).expect("mkdir");
+        std::fs::write(src.join("crates/lib.rs"), b"fn main() {}").expect("write");
+
+        // The destination lives under the source, named nothing special.
+        let dst = src.join("stage0-work/work-src");
+        copy_tree_filtered(&src, &dst, WORK_TREE_EXCLUDE_DIRS).expect("copy");
+
+        assert!(
+            dst.join("crates/lib.rs").is_file(),
+            "real content is copied"
+        );
+        // The defect was unbounded recursion, not the empty parent directory
+        // the walk leaves behind on its way past the destination. What must
+        // not exist is a *copy of the destination inside the destination* —
+        // the first turn of the loop that ran until ENAMETOOLONG.
+        assert!(
+            !dst.join("stage0-work/work-src").exists(),
+            "the copy must not descend into its own destination"
+        );
+        assert!(
+            !dst.join("stage0-work/work-src/crates").exists(),
+            "and must not carry content around that loop"
+        );
+    }
+
+    /// `MVM_HOME` under a name the exclude list does not know. Stage 0 stages
+    /// into `MVM_HOME/cache/...`, so copying it is the recursion above by
+    /// another route — and the name list cannot see it coming.
+    #[test]
+    fn an_mvm_home_inside_the_source_is_skipped_whatever_it_is_called() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let src = root.path().join("checkout");
+        std::fs::create_dir_all(src.join("crates")).expect("mkdir");
+        std::fs::write(src.join("crates/lib.rs"), b"fn main() {}").expect("write");
+
+        let home = src.join(".mvm-verify");
+        std::fs::create_dir_all(home.join("cache/builder-vm")).expect("mkdir");
+        std::fs::write(home.join("cache/builder-vm/huge.img"), b"x").expect("write");
+
+        // SAFETY: single-threaded test process; restored before returning.
+        let previous = std::env::var_os("MVM_HOME");
+        unsafe { std::env::set_var("MVM_HOME", &home) };
+
+        let dst = root.path().join("out");
+        let result = copy_tree_filtered(&src, &dst, WORK_TREE_EXCLUDE_DIRS);
+
+        match previous {
+            Some(v) => unsafe { std::env::set_var("MVM_HOME", v) },
+            None => unsafe { std::env::remove_var("MVM_HOME") },
+        }
+        result.expect("copy");
+
+        assert!(
+            dst.join("crates/lib.rs").is_file(),
+            "real content is copied"
+        );
+        assert!(
+            !dst.join(".mvm-verify").exists(),
+            "the resolved MVM_HOME must be skipped even under an unknown name"
+        );
+    }
+
+    /// The barrier is about location, not name: an `.mvm-verify` that is *not*
+    /// the active `MVM_HOME` is ordinary content and must still be copied.
+    #[test]
+    fn a_directory_that_merely_shares_the_name_is_still_copied() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let src = root.path().join("checkout");
+        std::fs::create_dir_all(src.join(".mvm-verify")).expect("mkdir");
+        std::fs::write(src.join(".mvm-verify/notes.md"), b"not a home").expect("write");
+
+        let previous = std::env::var_os("MVM_HOME");
+        // SAFETY: single-threaded test process; restored before returning.
+        unsafe { std::env::set_var("MVM_HOME", root.path().join("elsewhere")) };
+
+        let dst = root.path().join("out");
+        let result = copy_tree_filtered(&src, &dst, WORK_TREE_EXCLUDE_DIRS);
+
+        match previous {
+            Some(v) => unsafe { std::env::set_var("MVM_HOME", v) },
+            None => unsafe { std::env::remove_var("MVM_HOME") },
+        }
+        result.expect("copy");
+
+        assert!(
+            dst.join(".mvm-verify/notes.md").is_file(),
+            "a same-named directory that is not the active home is content"
+        );
+    }
 }
 
 fn stage_qemu_vsock_guest_modules(host_bins_dir: &Path) -> Result<(), BuilderVmError> {


### PR DESCRIPTION
Closes #2613.

## Cause

`copy_tree_filtered` excluded directories by **name**. That is right for `target/` and `.git`, which are named by convention. Two things it has to skip are defined by *where they are* instead:

- **The destination.** When `dst` lives under `src`, a name-matched filter walks the copy into its own output and keeps going until the path exceeds `PATH_MAX`. That is a bug whatever the directory is called.
- **`MVM_HOME`.** Its default name is on the list, but the variable points wherever it is told. Inside the checkout under any other name — `.mvm-verify` in the report — it was copied, and since Stage 0 stages into `MVM_HOME/cache/builder-vm/vms/…`, that is the first case by another route.

Both are now resolved to real paths and skipped as paths.

## Not over-excluded

The barrier is location, not name. An `.mvm-verify` that is *not* the active `MVM_HOME` is ordinary content and is still copied — there is a test for that, because a fix that over-excludes would be silent.

## Verified in both directions

Without the barrier, the destination case fails with the reported error and the same repeating segment:

```
mkdir .../checkout/stage0-work/work-src/stage0-work/work-src/.../crates:
File name too long (os error 63)
```

The `MVM_HOME` case fails too; the control still passes. With the barrier all three pass, and `cargo nextest run -p mvm-build` is 793 green. fmt and clippy clean.

## One note on the assertion

The walk still creates the empty parent directory on its way past the destination. That is finite and harmless, and the defect was the unbounded loop — so the test asserts that no copy of the destination appears *inside* the destination, not that the parent is absent.

My first draft asserted the stronger thing and failed against a correct fix. Worth stating because the weaker assertion is the one that matches the bug.
