### PR TITLE
fix(nix): manifest the kernel the loader takes, not the first one ls returns

### DIFF
--- a/nix/images/kernel/flake.nix
+++ b/nix/images/kernel/flake.nix
@@ -68,11 +68,52 @@
           # artifact_hash). Field names mirror the KernelArtifactId type
           # the host resolves a kernel pin against. The checksums file
           # follows the existing hash-verified download format.
+          # The file the consumer's loader actually takes. `metricsFor` above
+          # deliberately keeps the `ls` probe — it measures the compressed
+          # image the tiny-kernel claim is anchored to, and the ELF is ~20 MB
+          # against the bzImage's ~8 MB, so repointing it would silently
+          # restate that claim.
+          #
+          # This manifest is different: `update.rs::download_kernel` verifies a
+          # fetched `vmlinux-<arch>-<variant>` against it and hands the result
+          # to a backend as a `vmlinux`. On x86_64 `ls` sorts `bzImage` ahead of
+          # `vmlinux`, so the manifest recorded a bzImage's digest under the
+          # name `vmlinux` — and since the kernel package now carries both, it
+          # picked the wrong one of two present files. The download then
+          # verifies green and boots nothing, which is #2594 again: a hash
+          # proves provenance and says nothing about format.
+          manifestKernelFile = if pkgs.stdenv.hostPlatform.isAarch64 then "Image" else "vmlinux";
           manifestFor =
             kpkg: cfg:
             pkgs.runCommand "mvm-kernel-manifest-${arch}" { } ''
               mkdir -p $out
-              img=$(ls ${kpkg}/Image ${kpkg}/bzImage ${kpkg}/vmlinux 2>/dev/null | head -1)
+              img=${kpkg}/${manifestKernelFile}
+              if [ ! -f "$img" ]; then
+                echo "ERROR: kernel ${kpkg} produced no ${manifestKernelFile}." >&2
+                exit 1
+              fi
+
+              # Assert the format the name promises, so a manifest cannot
+              # publish a digest for bytes the loader will refuse.
+              magic0=$(${pkgs.coreutils}/bin/od -An -tx1 -N4 "$img" | tr -d ' \n')
+              magic56=$(${pkgs.coreutils}/bin/od -An -c -j56 -N4 "$img" | tr -d ' \n')
+              ${
+                if pkgs.stdenv.hostPlatform.isAarch64 then ''
+                if [ "$magic56" != "ARMd" ]; then
+                  echo "ERROR: $img is not an arm64 Image (magic@56='$magic56', want 'ARMd')." >&2
+                  exit 1
+                fi
+                '' else ''
+                if [ "$magic0" != "7f454c46" ]; then
+                  echo "ERROR: $img is not an ELF kernel (magic@0=0x$magic0, want 0x7f454c46)." >&2
+                  echo "The manifest names this artifact 'vmlinux', and Firecracker's x86_64" >&2
+                  echo "loader takes an uncompressed ELF only. Publishing a bzImage digest" >&2
+                  echo "under that name verifies green and boots nothing." >&2
+                  exit 1
+                fi
+                ''
+              }
+
               ch=$(sha256sum ${cfg} | cut -d' ' -f1)
               ah=$(sha256sum "$img" | cut -d' ' -f1)
               printf '{"kernel_version":"%s","config_hash":"%s","artifact_hash":"%s"}\n' \

--- a/nix/images/kernel/flake.nix
+++ b/nix/images/kernel/flake.nix
@@ -80,8 +80,9 @@
           # `vmlinux`, so the manifest recorded a bzImage's digest under the
           # name `vmlinux` — and since the kernel package now carries both, it
           # picked the wrong one of two present files. The download then
-          # verifies green and boots nothing, which is #2594 again: a hash
-          # proves provenance and says nothing about format.
+          # verifies green and boots nothing. A hash proves provenance and says
+          # nothing about format — the same way an unloadable image once
+          # shipped under a name the loader is documented against.
           manifestKernelFile = if pkgs.stdenv.hostPlatform.isAarch64 then "Image" else "vmlinux";
           manifestFor =
             kpkg: cfg:


### PR DESCRIPTION
Closes #2624.

## Cause

`manifestFor` picked its artifact with:

```sh
img=$(ls ${kpkg}/Image ${kpkg}/bzImage ${kpkg}/vmlinux 2>/dev/null | head -1)
```

`ls` sorts, so on x86_64 that returns **`bzImage`** — and since #2594 the kernel package carries a real ELF `vmlinux` too, so it chose the wrong one of two present files. It then wrote that digest under the name `vmlinux`:

```sh
printf '%s  vmlinux\n' "$ah" > $out/kernel-${arch}-checksums-sha256.txt
```

`update.rs::download_kernel` verifies a fetched `vmlinux-<arch>-<variant>` against exactly that manifest and hands the result to a backend as a vmlinux. The hash matches; the format is wrong; Firecracker's x86_64 loader refuses it before init runs.

That is #2594 one layer up. A digest proves provenance and says nothing about what the bytes are — which is the lesson that issue already paid for once.

## Fix

Select by what the consumer's loader takes — `Image` on aarch64, ELF `vmlinux` on x86_64 — and assert the magic before hashing. Same shape #2600 used in `default-tenant/flake.nix`.

## `metricsFor` deliberately keeps the old probe

It measures the compressed image the tiny-kernel size claim is anchored to. The ELF is ~20 MB against the bzImage's ~8 MB, so repointing it would restate that claim by a factor of two while looking like a consistency cleanup.

The two probes now differ, and the difference is load-bearing. #2624 called this out and it is worth carrying into the code, which is why the comment says so at both sites.

## Verification

`nix flake check --no-build` passes, and the manifest derivation evaluates for both `x86_64-linux` and `aarch64-linux` — the arch-conditional branch and its interpolation are valid on the arch that actually has two candidate files.

I did not build the kernel itself; that needs a Linux builder and the assertion it adds is a build-time failure by construction.

## Note on urgency

#2624 flagged that it could not confirm the release publishes `vmlinux-<arch>-workload` at all — it 404s on `v0.17.0`. I did not confirm it either. If unpublished, this is latent rather than live, but it is latent in the direction where the next publish ships something unbootable and green.
