### PR TITLE
fix(jailer): let the confined endpoint write the audit entry it is granted

### DIFF
--- a/crates/mvm-hostd/src/jailer/mod.rs
+++ b/crates/mvm-hostd/src/jailer/mod.rs
@@ -437,6 +437,11 @@ mod tests {
         assert!(spec.allowed_syscalls.contains(&"setsockopt"));
         // Cert-store dir read for rustls-native-certs.
         assert!(spec.allowed_syscalls.contains(&"getdents64"));
+        // Appending to the per-tenant audit log takes a file lock. Without
+        // this the endpoint is killed by SIGSYS on the first flow it allows —
+        // after the upstream connect succeeded, so the failure surfaces as a
+        // guest whose proxy handshake never completes.
+        assert!(spec.allowed_syscalls.contains(&"flock"));
         // Still no privilege-escalation syscalls.
         assert!(!spec.allowed_syscalls.contains(&"execve"));
         assert!(!spec.allowed_syscalls.contains(&"ptrace"));

--- a/crates/mvm-hostd/src/jailer/seccomp.rs
+++ b/crates/mvm-hostd/src/jailer/seccomp.rs
@@ -40,6 +40,18 @@ pub(crate) const CONFINED_ROLE_SYSCALLS: &[(&str, libc::c_long)] = &[
     ("read", libc::SYS_read),
     ("write", libc::SYS_write),
     ("fsync", libc::SYS_fsync),
+    // The audit recorder locks the per-tenant log before appending, so the
+    // first chain-signed event this endpoint emits calls `flock`. That event is
+    // `host.flow.allowed`, written on the first egress the gate permits — so a
+    // missing `flock` SIGSYS-kills the endpoint at the moment it starts
+    // working, after the connect it was about to report succeeded. The
+    // confinement already grants Landlock write on the audit dir; this is the
+    // syscall that makes the grant usable.
+    ("flock", libc::SYS_flock),
+    // ...and `fdatasync` to make the append durable. The audit chain writes
+    // each entry then syncs it, so both syscalls are on the same first-event
+    // path; allowing only the lock moves the kill one syscall later.
+    ("fdatasync", libc::SYS_fdatasync),
     ("openat", libc::SYS_openat),
     ("close", libc::SYS_close),
     // glibc's resolver seeks while reading /etc/hosts (getaddrinfo); a missing
@@ -147,6 +159,18 @@ pub(crate) const CONFINED_ROLE_SYSCALLS: &[(&str, libc::c_long)] = &[
     ("read", libc::SYS_read),
     ("write", libc::SYS_write),
     ("fsync", libc::SYS_fsync),
+    // The audit recorder locks the per-tenant log before appending, so the
+    // first chain-signed event this endpoint emits calls `flock`. That event is
+    // `host.flow.allowed`, written on the first egress the gate permits — so a
+    // missing `flock` SIGSYS-kills the endpoint at the moment it starts
+    // working, after the connect it was about to report succeeded. The
+    // confinement already grants Landlock write on the audit dir; this is the
+    // syscall that makes the grant usable.
+    ("flock", libc::SYS_flock),
+    // ...and `fdatasync` to make the append durable. The audit chain writes
+    // each entry then syncs it, so both syscalls are on the same first-event
+    // path; allowing only the lock moves the kill one syscall later.
+    ("fdatasync", libc::SYS_fdatasync),
     ("openat", libc::SYS_openat),
     ("close", libc::SYS_close),
     // glibc's resolver seeks while reading /etc/hosts (getaddrinfo); a missing


### PR DESCRIPTION
## The bug

The substitution endpoint self-confines with Landlock + seccomp before serving. The confinement **already grants Landlock write on the audit directory** — but it could not use that grant: the audit recorder locks the per-tenant log and syncs each append, and neither `flock` nor `fdatasync` was in `CONFINED_ROLE_SYSCALLS`.

The first entry it writes is `host.flow.allowed`, emitted on the **first flow the egress gate permits**. So the endpoint was killed by SIGSYS at the moment it started working — one call after the upstream connect it was about to report. All six threads died, core dumped.

## Why it was hard to see

Every visible signal said the network was fine, because it was:

```
guest:     proxy handshake error (97) cannot complete SOCKS5 connection to github.com
host:      builder egress endpoint pid=NNNNN exited with status exit status: 1
endpoint:  ... "FlowMux sending Opened","stream_id":1     <- last line
```

`send_opened` is emitted **only after** `connect_first_admitted` succeeds, so the TCP connect to github.com had already worked. The guest blamed the proxy, the host blamed the endpoint, and the endpoint's own log ended mid-success.

Nothing appeared in `dmesg` either — `SeccompAction::Trap` does not log.

## Finding the complete set

`strace` located the first violation (`flock`). Fixing only that did **not** help, because the trace terminates at the kill: each pass only ever reveals the *next* missing syscall.

So for one diagnostic run I switched the filter's action from `Trap` to `Log`. `Log` lets the process run to completion while the kernel records every violation, which enumerates the whole set in a single pass. That run named exactly one remaining violation:

```
audit: type=1326 ... comm="mvm-subst-endpo" syscall=75    (fdatasync, x86_64)
```

**`Trap` is unchanged in this PR.** The refusal posture it documents — kill rather than hand a compromised sidecar an observable errno — is deliberate, and the flip was a throwaway on a test box.

## Verified under the real policy

Log mode proves *which* syscalls are needed, not that Trap mode passes, so this was re-run on the Linux/KVM builder with `Trap` restored and both syscalls allowed:

- endpoint completes a full session: `Opened` → serving → `Reset by peer` → `peer closed session`
- exits by **SIGTERM (teardown)**, not signal 31
- **zero** seccomp audit records attributable to that run's pid
- `nix build` now fetches and unpacks the Linux 6.12.103 source — the exact download that previously failed

It then fails on guest build space (`No space left on device`), which is a separate defect and not addressed here.

## Test

The existing `network_endpoint_allowlist_covers_tls_and_runtime` gains an assertion for `flock`, with a comment naming the failure mode so the next person reading it knows why an audit-path syscall is in a network endpoint's allowlist.

## Note for reviewers

This is the third syscall of this class missed in this file — the `lseek` entry directly above carries the same kind of note (*"a missing `lseek` SIGSYS-kills the endpoint mid-egress"*). The shared pattern is a syscall used only on a rare path — a first audit write, a resolver seek — which stays invisible until real traffic reaches it. Worth considering whether a periodic `Log`-mode run against a realistic workload belongs in CI, rather than discovering these one production incident at a time.

## Verification

`cargo nextest run --workspace` — 12,069 passed. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo +nightly fmt --all -- --check` clean. Cross-checked for Linux with `cargo zigbuild --target x86_64-unknown-linux-gnu`, since both allowlists are `cfg(target_arch)`-gated and a macOS build compiles neither.