### PR TITLE
fix(release): give the boot gate the toolchain its own test needs

### DIFF
--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -426,6 +426,13 @@ jobs:
       # static /init read above, which catches the defect class that actually
       # shipped and is a stated compromise rather than a claim of equivalence —
       # an aarch64-only regression that is not a shebang defect still gets past.
+      # The boot gate runs `cargo test`, which builds mvmctl, whose build.rs
+      # cross-compiles the embedded host binaries as static musl and needs the
+      # pinned zig. Without it the gate fails before it ever starts a guest —
+      # which reads as "the image does not boot" and is nothing of the kind.
+      - uses: ./.github/actions/install-zigbuild
+        if: matrix.arch == 'x86_64'
+
       - name: Install firecracker for the boot gate
         if: matrix.arch == 'x86_64'
         env:

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -549,3 +549,33 @@ fn a_release_with_no_boot_image_assets_refuses_to_publish() {
         "the missing-boot-image path must not warn-and-continue:\n{step}"
     );
 }
+
+/// The boot gate must carry the toolchain its own test needs.
+///
+/// The gate runs `cargo test`, which builds mvmctl, whose `build.rs`
+/// cross-compiles the embedded host binaries as static musl and requires the
+/// pinned zig. The first real image release failed here: the gate aborted
+/// before starting a guest, which reads in the log as "the image does not
+/// boot" and is nothing of the kind. A gate that cannot run is worse than no
+/// gate, because it blocks a release for a reason that has nothing to do with
+/// the artifact.
+#[test]
+fn the_boot_gate_installs_the_toolchain_its_test_needs() {
+    let workflow = boot_image_workflow();
+    let job = workflow
+        .split("  default-microvm:")
+        .nth(1)
+        .expect("the boot image workflow must define default-microvm");
+    let boot = job
+        .find("- name: Boot the staged image before it becomes a release asset")
+        .expect("the job must boot the staged image");
+
+    // The toolchain has to be installed *before* the boot step, not merely
+    // present somewhere in the file.
+    let before = &job[..boot];
+    assert!(
+        before.contains("./.github/actions/install-zigbuild"),
+        "the boot gate must install the pinned zig before it runs cargo test; \
+         without it the gate fails before reaching a guest"
+    );
+}


### PR DESCRIPTION
The first real image release (`boot-image/v0.1.0`) failed here, and the failure was mine.

## What happened

The boot gate runs `cargo test`, which builds `mvmctl`, whose `build.rs` cross-compiles the embedded host binaries as static musl and needs the **pinned zig**. The runner had none:

```
thread 'main' panicked at crates/mvm-cli/src/host_binaries/toolchain.rs:62:5:
zig 0.13.0 is required to cross-compile the embedded host binaries but was not found.
```

So the gate aborted **before it ever started a guest**. In the log that reads as "the image does not boot" — and it is nothing of the kind.

I copied the gate's prerequisites from the `boot-latency` lane — Firecracker, `/dev/kvm`, the `mvm-meta.json` sidecar — but `- uses: ./.github/actions/install-zigbuild` sits *above* those three and I missed it, despite the line directly above it in `ci.yml` saying exactly why it's needed.

## Why it matters more than a normal CI miss

A gate that cannot run is worse than no gate. This one blocked a release for a reason having nothing to do with the artifact — and the artifact it blocked is the one carrying the fix for an image that has been **unbootable on x86_64 since v0.17.0** (published `default-microvm-vmlinux-x86_64` is a bzImage; Firecracker's x86_64 loader takes only an uncompressed ELF).

## The guard

`the_boot_gate_installs_the_toolchain_its_test_needs` asserts the toolchain is installed **before** the boot step, not merely present somewhere in the file. Removing the step reproduces tonight's failure exactly — verified, then restored byte-identically.

15 tests in `release_assets.rs`, all passing. `actionlint` clean, YAML parses.

## Not in scope here

`builder-vm-image` also failed, on `MVM_HOST_BIN_DIR is not set`. That one is **pre-existing and unrelated**: v0.17.0 shipped zero `builder-vm-*` assets, so it has been failing since at least the last release, and the WS2 split changed that job's build step not at all (empty diff against the pre-split version). Filed separately rather than bundled in.