### PR TITLE
perf(launch): cut the sleep quantization out of teardown, and read the phases as a tree

### DIFF
--- a/crates/mvm-cli/src/commands/vm/phase_timing.rs
+++ b/crates/mvm-cli/src/commands/vm/phase_timing.rs
@@ -9,6 +9,8 @@
 
 use std::time::Instant;
 
+use crate::bench::cold_launch::MIN_MATRIX_SAMPLES;
+use mvm_core::launch_trace::PhaseTimingMode;
 use mvm_runtime::workload_runner::StopTiming;
 use serde::{Deserialize, Serialize};
 
@@ -318,6 +320,112 @@ impl RunPhaseMarks {
 /// as warm-launch latency.
 pub const WARM_START_MAX_MS: f64 = 300.0;
 
+/// Which span contains which, as `(span, parent)`.
+///
+/// Parents named here are either another sub-span or one of the coarse bucket
+/// labels [`RunPhaseTimings::coarse_rows`] emits. This table is the single
+/// place the report's shape is stated, and it is asserted against the spans
+/// themselves by `every_parent_covers_its_children` — a row placed under the
+/// wrong parent renders a plausible, wrong partition, and the arithmetic is
+/// the only thing that catches it.
+///
+/// The non-obvious entries: `artifact_verify` is recorded while drives are
+/// being prepared, not during admission; and `stop_driver_kill` and
+/// `stop_console_cleanup` are siblings under `stop_transient`, not nested —
+/// stopping the console happens after the driver is killed, not inside it.
+const SPAN_PARENTS: &[(&str, &str)] = &[
+    ("mount_fingerprint", "drives"),
+    ("mount_cache_lookup", "drives"),
+    ("mount_materialize", "drives"),
+    ("artifact_verify", "drives"),
+    ("vmm_create", "backend start"),
+    ("guest_kernel_entry", "guest ready"),
+    ("agent_auth", "guest ready"),
+    ("first_dispatch", "command"),
+    ("cleanup_handoff", "teardown"),
+    ("stop_transient", "cleanup_handoff"),
+    ("pool_replenish", "cleanup_handoff"),
+    ("state_remove", "cleanup_handoff"),
+    ("stop_attach", "stop_transient"),
+    ("stop_endpoint_reaping", "stop_transient"),
+    ("stop_driver_kill", "stop_transient"),
+    ("stop_console_cleanup", "stop_transient"),
+    ("stop_supervisor_signal", "stop_driver_kill"),
+    ("stop_pid_disappearance", "stop_driver_kill"),
+    ("stop_force_kill_wait", "stop_driver_kill"),
+    ("stop_state_cleanup", "stop_driver_kill"),
+];
+
+/// One rendered row, before the label column has been sized.
+struct TreeRow {
+    /// Indent already applied, so sizing is one `max` over these.
+    label: String,
+    ms: f64,
+    share: Option<f64>,
+}
+
+/// One coarse bucket, with its share of the launch.
+struct CoarseRow {
+    label: &'static str,
+    ms: f64,
+    share: f64,
+}
+
+impl CoarseRow {
+    fn new(label: &'static str, ms: f64, total_ms: f64) -> Self {
+        let share = if total_ms > 0.0 {
+            ms / total_ms * 100.0
+        } else {
+            0.0
+        };
+        Self { label, ms, share }
+    }
+}
+
+/// Size the label column to the widest row, then emit.
+///
+/// Two passes rather than a fixed column because the deepest labels
+/// (`stop supervisor signal` at four levels of indent) are more than twice the
+/// width of the shallowest, and any constant wide enough for them wastes a
+/// screen of space on every other row.
+fn render_rows(rows: &[TreeRow]) -> String {
+    let width = rows.iter().map(|r| r.label.len()).max().unwrap_or(0);
+    rows.iter()
+        .map(|row| {
+            let value = format!("{:.1}ms", row.ms);
+            let mut line = format!("{:<width$}  {:>9}", row.label, value);
+            if let Some(share) = row.share {
+                line.push_str(&format!("  {share:>3.0}%"));
+            }
+            line.trim_end().to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Append every recorded descendant of `parent`, depth-first, in the order
+/// [`LaunchSubTimings::recorded`] declares them.
+fn push_children(
+    rows: &mut Vec<TreeRow>,
+    parent: &str,
+    depth: usize,
+    recorded: &[(&'static str, f64)],
+) {
+    for (name, ms) in recorded {
+        if SPAN_PARENTS
+            .iter()
+            .any(|(span, span_parent)| span == name && *span_parent == parent)
+        {
+            rows.push(TreeRow {
+                label: format!("{}{}", "  ".repeat(depth), name.replace('_', " ")),
+                ms: *ms,
+                share: None,
+            });
+            push_children(rows, name, depth + 1, recorded);
+        }
+    }
+}
+
 impl RunPhaseTimings {
     /// Admitted-plan to command-dispatch: the window the warm-start SLO is set
     /// against (backend claim/restore + boot-to-agent wait).
@@ -340,6 +448,82 @@ impl RunPhaseTimings {
             LaunchMode::Warm => "over",
             LaunchMode::Cold => "na",
         }
+    }
+
+    /// Render the launch as a nested, aligned report.
+    ///
+    /// Same spans as [`render`](Self::render); only the shape differs. The
+    /// nesting is the containment the flat line hides — `teardown` holds
+    /// `cleanup_handoff` holds `stop_transient`, and reading four sibling
+    /// `stop_*` tokens off one line gives no way to tell which of them add up.
+    #[must_use]
+    pub fn render_tree(&self, sub: &LaunchSubTimings) -> String {
+        let mut out = format!(
+            "[mvm] launch {} — total {:.1}ms, dispatch window {:.1}ms{}",
+            self.launch_mode.as_str(),
+            self.total_ms,
+            self.dispatch_window_ms(),
+            self.budget_context(),
+        );
+        let recorded = sub.recorded();
+        let mut rows = Vec::new();
+        for bucket in self.coarse_rows() {
+            rows.push(TreeRow {
+                label: format!("  {}", bucket.label),
+                ms: bucket.ms,
+                share: Some(bucket.share),
+            });
+            push_children(&mut rows, bucket.label, 2, &recorded);
+        }
+        out.push('\n');
+        out.push_str(&render_rows(&rows));
+        out
+    }
+
+    /// The budget the launch's lane publishes, as context only.
+    ///
+    /// Deliberately renders no pass/fail. The published number is a p50 over at
+    /// least [`MIN_MATRIX_SAMPLES`] samples, and one launch is one sample — a
+    /// per-run "ok" against a percentile is the exact conflation
+    /// `bench::doc_table` warns about, and it would read as a gate that nothing
+    /// is actually gating here.
+    fn budget_context(&self) -> String {
+        let (lane, budget) = match self.launch_mode {
+            LaunchMode::Warm => (
+                "warm-claim",
+                crate::bench::cold_launch::WARM_CLAIM_P50_BUDGET_MS,
+            ),
+            LaunchMode::Cold => (
+                "prepared-cold",
+                crate::bench::cold_launch::PREPARED_COLD_P50_BUDGET_MS,
+            ),
+        };
+        format!(" ({lane} p50 budget {budget:.0}ms across {MIN_MATRIX_SAMPLES} samples)")
+    }
+
+    /// The coarse buckets in runner order, with the warm-only pair dropped on a
+    /// cold launch where they are structurally zero rather than measured.
+    fn coarse_rows(&self) -> Vec<CoarseRow> {
+        let mut rows = vec![
+            CoarseRow::new("resolve", self.resolve_ms, self.total_ms),
+            CoarseRow::new("drives", self.drives_ms, self.total_ms),
+            CoarseRow::new("admit", self.admit_ms, self.total_ms),
+        ];
+        if self.launch_mode == LaunchMode::Warm {
+            rows.push(CoarseRow::new(
+                "pool wait",
+                self.pool_wait_ms,
+                self.total_ms,
+            ));
+            rows.push(CoarseRow::new("claim", self.claim_ms, self.total_ms));
+        }
+        rows.extend([
+            CoarseRow::new("backend start", self.backend_start_ms, self.total_ms),
+            CoarseRow::new("guest ready", self.vsock_wait_ms, self.total_ms),
+            CoarseRow::new("command", self.command_ms, self.total_ms),
+            CoarseRow::new("teardown", self.teardown_ms, self.total_ms),
+        ]);
+        rows
     }
 
     /// A single stable, greppable line for logs and the benchmark harness.
@@ -418,15 +602,19 @@ pub fn warm_vs_cold(warm: &RunPhaseTimings, cold: &RunPhaseTimings) -> WarmVsCol
     }
 }
 
-/// Whether phase timing is enabled, pure over the raw env value so the gate
-/// is testable without mutating process env.
-fn timing_enabled_from(value: Option<&str>) -> bool {
-    matches!(value, Some(v) if v == "1" || v.eq_ignore_ascii_case("true"))
+/// Read `MVM_PHASE_TIMING` and decide how to render a breakdown.
+///
+/// Delegates to `mvm_core::launch_trace`, which owns the variable's name and
+/// its accepted spellings. A second parse here drifted from that one once
+/// already — this module hardcoded the variable name rather than using the
+/// constant beside the parse it was duplicating.
+pub fn mode() -> PhaseTimingMode {
+    mvm_core::launch_trace::phase_timing_mode()
 }
 
-/// Read `MVM_PHASE_TIMING` and decide whether to emit a breakdown.
+/// Whether phase timing should emit anything at all.
 pub fn enabled() -> bool {
-    timing_enabled_from(std::env::var("MVM_PHASE_TIMING").ok().as_deref())
+    mode().is_on()
 }
 
 #[cfg(test)]
@@ -700,13 +888,15 @@ mod tests {
 
     #[test]
     fn timing_gate_only_trips_on_truthy_values() {
-        assert!(timing_enabled_from(Some("1")));
-        assert!(timing_enabled_from(Some("true")));
-        assert!(timing_enabled_from(Some("TRUE")));
-        assert!(!timing_enabled_from(Some("0")));
-        assert!(!timing_enabled_from(Some("")));
-        assert!(!timing_enabled_from(Some("yes")));
-        assert!(!timing_enabled_from(None));
+        use mvm_core::launch_trace::phase_timing_mode_from as parse;
+        assert!(parse(Some("1")).is_on());
+        assert!(parse(Some("true")).is_on());
+        assert!(parse(Some("TRUE")).is_on());
+        assert!(parse(Some("tree")).is_on());
+        assert!(!parse(Some("0")).is_on());
+        assert!(!parse(Some("")).is_on());
+        assert!(!parse(Some("yes")).is_on());
+        assert!(!parse(None).is_on());
     }
 
     #[test]
@@ -739,5 +929,244 @@ mod tests {
         let cold = timings_with_dispatch_window(370.0, 30.0);
         let report = warm_vs_cold(&warm, &cold);
         assert!(report.speedup.is_infinite());
+    }
+
+    /// The launch from the report that prompted the tree renderer: a real
+    /// `machine run --image alpine` on HVF/macOS. Using observed numbers rather
+    /// than invented ones means the containment assertions below are checked
+    /// against a partition a real launch actually produced.
+    fn observed_launch() -> (RunPhaseTimings, LaunchSubTimings) {
+        let phases = RunPhaseTimings {
+            launch_mode: LaunchMode::Cold,
+            resolve_ms: 8.7,
+            drives_ms: 13.4,
+            admit_ms: 47.4,
+            pool_wait_ms: 0.0,
+            claim_ms: 0.0,
+            backend_start_ms: 16.1,
+            vsock_wait_ms: 58.2,
+            warm_window_ms: 74.3,
+            command_ms: 52.0,
+            teardown_ms: 91.4,
+            total_ms: 287.2,
+        };
+        let sub = LaunchSubTimings {
+            artifact_verify_ms: Some(0.2),
+            vmm_create_ms: Some(12.0),
+            guest_kernel_entry_ms: Some(57.1),
+            agent_auth_ms: Some(1.1),
+            first_dispatch_ms: Some(0.0),
+            cleanup_handoff_ms: Some(91.3),
+            stop_transient_ms: Some(90.7),
+            stop_attach_ms: Some(0.0),
+            stop_endpoint_reaping_ms: Some(0.0),
+            stop_driver_kill_ms: Some(33.7),
+            stop_console_cleanup_ms: Some(57.0),
+            stop_supervisor_signal_ms: Some(0.0),
+            stop_pid_disappearance_ms: Some(33.7),
+            stop_force_kill_wait_ms: Some(0.0),
+            stop_state_cleanup_ms: Some(0.0),
+            state_remove_ms: Some(0.5),
+            ..LaunchSubTimings::default()
+        };
+        (phases, sub)
+    }
+
+    #[test]
+    fn every_parent_covers_its_children() {
+        let (phases, sub) = observed_launch();
+        let mut by_name: std::collections::HashMap<&str, f64> = phases
+            .coarse_rows()
+            .into_iter()
+            .map(|row| (row.label, row.ms))
+            .collect();
+        by_name.extend(sub.recorded());
+
+        for (parent, _) in SPAN_PARENTS
+            .iter()
+            .map(|(_, p)| (*p, ()))
+            .collect::<std::collections::BTreeSet<_>>()
+        {
+            let Some(parent_ms) = by_name.get(parent).copied() else {
+                continue;
+            };
+            let children: f64 = SPAN_PARENTS
+                .iter()
+                .filter(|(_, p)| *p == parent)
+                .filter_map(|(span, _)| by_name.get(span).copied())
+                .sum();
+            assert!(
+                parent_ms + 0.05 >= children,
+                "{parent} is {parent_ms}ms but its declared children sum to {children}ms — \
+                 the containment table places a span under a parent that does not contain it",
+            );
+        }
+    }
+
+    #[test]
+    fn every_table_entry_names_a_span_that_can_be_rendered() {
+        // A typo in the table is silent: the row simply never matches a
+        // recorded span and vanishes from the report, which reads as "that
+        // work did not happen" rather than as a broken table.
+        let (phases, sub) = observed_launch();
+        let sub_names: Vec<&str> = LaunchSubTimings {
+            mount_fingerprint_ms: Some(0.0),
+            mount_cache_lookup_ms: Some(0.0),
+            mount_materialize_ms: Some(0.0),
+            pool_replenish_ms: Some(0.0),
+            ..sub
+        }
+        .recorded()
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+        let coarse: Vec<&str> = phases.coarse_rows().into_iter().map(|r| r.label).collect();
+
+        for (span, parent) in SPAN_PARENTS {
+            assert!(sub_names.contains(span), "table names unknown span {span}");
+            assert!(
+                sub_names.contains(parent) || coarse.contains(parent),
+                "span {span} is parented to unknown {parent}",
+            );
+        }
+    }
+
+    #[test]
+    fn every_recorded_span_has_a_place_in_the_tree() {
+        // The converse gap: a span added to LaunchSubTimings but not to the
+        // table is measured, serialized into the JSON sample, and silently
+        // missing from the human report.
+        let all = LaunchSubTimings {
+            mount_fingerprint_ms: Some(1.0),
+            mount_cache_lookup_ms: Some(1.0),
+            mount_materialize_ms: Some(1.0),
+            pool_replenish_ms: Some(1.0),
+            ..observed_launch().1
+        };
+        for (name, _) in all.recorded() {
+            assert!(
+                SPAN_PARENTS.iter().any(|(span, _)| *span == name),
+                "recorded span {name} has no parent declared, so the tree drops it",
+            );
+        }
+    }
+
+    #[test]
+    fn tree_renders_the_observed_launch() {
+        let (phases, sub) = observed_launch();
+        let expected = [
+            "[mvm] launch cold — total 287.2ms, dispatch window 74.3ms (prepared-cold p50 budget 200ms across 20 samples)",
+            "  resolve                             8.7ms    3%",
+            "  drives                             13.4ms    5%",
+            "    artifact verify                   0.2ms",
+            "  admit                              47.4ms   17%",
+            "  backend start                      16.1ms    6%",
+            "    vmm create                       12.0ms",
+            "  guest ready                        58.2ms   20%",
+            "    guest kernel entry               57.1ms",
+            "    agent auth                        1.1ms",
+            "  command                            52.0ms   18%",
+            "    first dispatch                    0.0ms",
+            "  teardown                           91.4ms   32%",
+            "    cleanup handoff                  91.3ms",
+            "      stop transient                 90.7ms",
+            "        stop attach                   0.0ms",
+            "        stop endpoint reaping         0.0ms",
+            "        stop driver kill             33.7ms",
+            "          stop supervisor signal      0.0ms",
+            "          stop pid disappearance     33.7ms",
+            "          stop force kill wait        0.0ms",
+            "          stop state cleanup          0.0ms",
+            "        stop console cleanup         57.0ms",
+            "      state remove                    0.5ms",
+        ]
+        .join("\n");
+        assert_eq!(phases.render_tree(&sub), expected);
+
+        // The coarse buckets partition the launch: they must add up to the
+        // total, or the report is attributing time to nothing.
+        let coarse: f64 = phases.coarse_rows().into_iter().map(|r| r.ms).sum();
+        assert!(
+            (coarse - phases.total_ms).abs() < 0.05,
+            "coarse buckets sum to {coarse}ms against a {}ms total",
+            phases.total_ms,
+        );
+    }
+
+    #[test]
+    fn tree_hides_the_warm_only_rows_on_a_cold_launch() {
+        let (phases, sub) = observed_launch();
+        let cold = phases.render_tree(&sub);
+        assert!(
+            !cold.contains("pool wait"),
+            "cold launch shows a warm-only row"
+        );
+        assert!(
+            !cold.contains("\n  claim"),
+            "cold launch shows a warm-only row"
+        );
+
+        let warm = RunPhaseTimings {
+            launch_mode: LaunchMode::Warm,
+            pool_wait_ms: 2.0,
+            claim_ms: 4.1,
+            ..phases
+        }
+        .render_tree(&sub);
+        assert!(warm.contains("pool wait"));
+        assert!(warm.contains("claim"));
+    }
+
+    #[test]
+    fn tree_reports_the_budget_as_context_and_never_as_a_verdict() {
+        // One launch is one sample; the published budget is a p50 over 20.
+        // Rendering a pass/fail here would read as a gate nothing is applying.
+        let (phases, sub) = observed_launch();
+        let out = phases.render_tree(&sub);
+        assert!(out.contains("p50 budget 200ms across 20 samples"));
+        for verdict in ["ok", "over", "pass", "fail", "PASS", "FAIL", "✓", "✗"] {
+            assert!(
+                !out.contains(verdict),
+                "tree renders a verdict token {verdict}"
+            );
+        }
+    }
+
+    #[test]
+    fn tree_omits_spans_that_were_never_measured() {
+        let (phases, _) = observed_launch();
+        let out = phases.render_tree(&LaunchSubTimings::default());
+        assert!(!out.contains("vmm create"));
+        assert!(!out.contains("stop transient"));
+        // The coarse partition still prints in full — an unmeasured sub-span
+        // is absent, but a bucket that ran is never silently dropped.
+        for bucket in [
+            "resolve",
+            "drives",
+            "admit",
+            "backend start",
+            "guest ready",
+            "command",
+            "teardown",
+        ] {
+            assert!(out.contains(bucket), "coarse bucket {bucket} vanished");
+        }
+    }
+
+    #[test]
+    fn the_greppable_line_is_unchanged_by_the_tree_renderer() {
+        // scripts/check-hvf-warm-restore.sh parses this line; the tree is an
+        // addition, never a replacement.
+        let (phases, _) = observed_launch();
+        assert!(
+            phases
+                .render()
+                .starts_with("[mvm] phase-timing: resolve=8.7ms")
+        );
+        assert!(
+            phases
+                .render()
+                .ends_with("launch_mode=cold dispatch_window=74.3ms warm_slo=na")
+        );
     }
 }

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -545,28 +545,38 @@ pub(in crate::commands::vm) fn admit_plan_for_boot(
         ms = (t_emitter - t_signer).as_secs_f64() * 1000.0,
         "admit: policy + emitter build"
     );
-    mvm_hostd::audit::durability::record_admission(
-        Some(&emitter),
-        admitted.plan(),
-        admitted.signer_id(),
-        mvm_hostd::audit::durability::AuditDurability::for_sealed_production(
-            p.restrict_agent_verbs,
-        ),
-    )?;
+    // One batch, one fsync. These entries all have to be durable before the
+    // same thing — this plan booting — and nothing between them acts on the
+    // one before it, so syncing each separately bought no ordering. It cost
+    // one `F_FULLFSYNC` each, which is 7.4ms on an Apple-silicon host and
+    // ~42ms on the KVM box's array. The batch closes here, before the caller
+    // gets an `AdmissionContext` to boot from, and a failed flush is an error
+    // rather than a warning.
+    emitter.batched(|| {
+        mvm_hostd::audit::durability::record_admission(
+            Some(&emitter),
+            admitted.plan(),
+            admitted.signer_id(),
+            mvm_hostd::audit::durability::AuditDurability::for_sealed_production(
+                p.restrict_agent_verbs,
+            ),
+        )?;
+        if let Some(verbs) = admitted.plan().agent_verbs.as_ref()
+            && let Err(e) = emitter.emit_grant_required(admitted.plan(), verbs)
+        {
+            tracing::warn!(error = %e, "audit emit_grant_required failed (non-fatal)");
+        }
+        // Claim 1 / claim 8 — record the admitted host-fs grants in the
+        // chain-signed log (no-op when there are none).
+        if let Err(e) = emitter.emit_shares_admitted(admitted.plan()) {
+            tracing::warn!(error = %e, "audit emit_shares_admitted failed (non-fatal)");
+        }
+        Ok(())
+    })?;
     tracing::debug!(
         ms = t_emitter.elapsed().as_secs_f64() * 1000.0,
-        "admit: record_admission (fsync)"
+        "admit: record_admission (batched fsync)"
     );
-    if let Some(verbs) = admitted.plan().agent_verbs.as_ref()
-        && let Err(e) = emitter.emit_grant_required(admitted.plan(), verbs)
-    {
-        tracing::warn!(error = %e, "audit emit_grant_required failed (non-fatal)");
-    }
-    // Claim 1 / claim 8 — record the admitted host-fs grants in the
-    // chain-signed log (no-op when there are none).
-    if let Err(e) = emitter.emit_shares_admitted(admitted.plan()) {
-        tracing::warn!(error = %e, "audit emit_shares_admitted failed (non-fatal)");
-    }
 
     // Resolve the plan's four policy refs into concrete supervisor
     // component slots. Today the slots are constructed-and-dropped —

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -12,6 +12,7 @@
 //! "exec not available" regardless of any runtime configuration.
 
 use anyhow::{Context, Result, anyhow};
+use mvm_core::launch_trace::PhaseTimingMode;
 use mvm_core::vm_backend::{
     RequiredCapabilities, SnapshotCapability, VmId, VmStartConfig, VmVolume,
 };
@@ -949,8 +950,8 @@ fn run_inner(
     // one-line breakdown and/or the machine-readable sample at teardown. When
     // both are off every mark stays `None` and costs nothing.
     let sample_path = crate::commands::vm::launch_sample::sample_path_from_env();
-    let render_line = crate::commands::vm::phase_timing::enabled();
-    let timing = render_line || sample_path.is_some();
+    let timing_mode = crate::commands::vm::phase_timing::mode();
+    let timing = timing_mode.is_on() || sample_path.is_some();
     let mut sub_marks = crate::commands::vm::phase_timing::LaunchSubMarks::new(timing);
     let t_start = timing.then(std::time::Instant::now);
 
@@ -1106,9 +1107,15 @@ fn run_inner(
         };
         let phases = marks.to_timings();
         let sub_phases = sub_marks.to_timings();
-        if render_line {
-            eprintln!("{}", phases.render());
-            eprintln!("{}", sub_phases.render());
+        match timing_mode {
+            PhaseTimingMode::Off => {}
+            // The greppable pair stays the machine contract:
+            // scripts/check-hvf-warm-restore.sh parses it by prefix.
+            PhaseTimingMode::Line => {
+                eprintln!("{}", phases.render());
+                eprintln!("{}", sub_phases.render());
+            }
+            PhaseTimingMode::Tree => eprintln!("{}", phases.render_tree(&sub_phases)),
         }
         if let Some(path) = sample_path.as_deref() {
             if let Some(error) = warm_memory_error.as_deref() {
@@ -1719,14 +1726,24 @@ fn boot_transient_vm(
     // The per-phase warm-claim lines are a human diagnostic; the marks above
     // feed the machine-readable sample and are collected whenever either is
     // asked for.
+    //
+    // Each line is the span since the previous mark, not the elapsed time since
+    // boot started. Reporting cumulative time under span-shaped names
+    // (`standby_reap=0.0ms warm_claim=4.1ms`) reads as two durations that sum,
+    // when it was really two timestamps — so the reap looked free and the claim
+    // absorbed its cost.
     let render_phases = crate::commands::vm::phase_timing::enabled();
+    let previous_mark = std::cell::Cell::new(boot_started);
     let report_phase = |phase: &'static str| {
-        if let Some(started) = boot_started.filter(|_| render_phases) {
-            eprintln!(
-                "[mvm] warm-claim-phase: {phase}={:.1}ms",
-                started.elapsed().as_secs_f64() * 1_000.0
-            );
-        }
+        let Some(since) = previous_mark.get().filter(|_| render_phases) else {
+            return;
+        };
+        let now = std::time::Instant::now();
+        previous_mark.set(Some(now));
+        eprintln!(
+            "[mvm] warm-claim-phase: {phase}={:.1}ms",
+            now.saturating_duration_since(since).as_secs_f64() * 1_000.0
+        );
     };
     // Reap dead/expired standbys before claiming/booting. There is no daemon, so
     // this on-use reap is what enforces the standby TTL between invocations —

--- a/crates/mvm-core/src/launch_trace.rs
+++ b/crates/mvm-core/src/launch_trace.rs
@@ -45,8 +45,50 @@ pub const LAUNCH_TRACE_DRIVER_FILE: &str = "launch-trace-driver.json";
 /// visible in the name itself.
 pub const DRIVER_PHASE_SEPARATOR: &str = ".";
 
-/// Set to `1`/`true` to print a per-phase launch breakdown to stderr.
+/// Set to `1`/`true` to print a per-phase launch breakdown to stderr, or to
+/// `tree` for the same breakdown rendered as a nested, aligned report.
 pub const PHASE_TIMING_ENV: &str = "MVM_PHASE_TIMING";
+
+/// How a launch should render its phase breakdown.
+///
+/// The variants are a rendering choice, not a verbosity ladder: `Line` and
+/// `Tree` carry the same spans and differ only in shape. Anything the parse
+/// does not recognise is [`Off`](PhaseTimingMode::Off), so a typo silently
+/// disables the report rather than half-enabling it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhaseTimingMode {
+    /// No breakdown printed.
+    Off,
+    /// One greppable `key=value` line per report. The stable machine contract.
+    Line,
+    /// A nested, aligned report grouped by containment.
+    Tree,
+}
+
+impl PhaseTimingMode {
+    /// Whether any breakdown should be printed.
+    #[must_use]
+    pub const fn is_on(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+}
+
+/// Parse [`PHASE_TIMING_ENV`], pure over the raw value so the gate is testable
+/// without mutating process env.
+#[must_use]
+pub fn phase_timing_mode_from(value: Option<&str>) -> PhaseTimingMode {
+    match value.map(str::trim) {
+        Some(v) if v == "1" || v.eq_ignore_ascii_case("true") => PhaseTimingMode::Line,
+        Some(v) if v.eq_ignore_ascii_case("tree") => PhaseTimingMode::Tree,
+        _ => PhaseTimingMode::Off,
+    }
+}
+
+/// Read the environment and decide how to render.
+#[must_use]
+pub fn phase_timing_mode() -> PhaseTimingMode {
+    phase_timing_mode_from(std::env::var(PHASE_TIMING_ENV).ok().as_deref())
+}
 
 /// Names the file a launch writes its machine-readable sample to.
 pub const LAUNCH_SAMPLE_ENV: &str = "MVM_LAUNCH_SAMPLE_JSON";
@@ -98,9 +140,11 @@ impl BackendLaunchTrace {
 /// values so the gate is testable without mutating process env.
 #[must_use]
 pub fn tracing_enabled_from(phase_timing: Option<&str>, sample_path: Option<&str>) -> bool {
-    let truthy = matches!(phase_timing, Some(v) if v == "1" || v.eq_ignore_ascii_case("true"));
+    // Every rendering mode needs the same marks, so this asks only whether the
+    // report is on at all. A mode that recorded nothing would render a report
+    // full of absent spans and read as "the launch did no work".
     let sampling = matches!(sample_path, Some(v) if !v.trim().is_empty());
-    truthy || sampling
+    phase_timing_mode_from(phase_timing).is_on() || sampling
 }
 
 /// Read the environment and decide whether to record.
@@ -488,6 +532,47 @@ mod tests {
         assert!(!tracing_enabled_from(None, None));
         assert!(!tracing_enabled_from(Some("0"), None));
         assert!(!tracing_enabled_from(Some(""), Some("  ")));
+    }
+
+    #[test]
+    fn tree_mode_still_records_backend_phases() {
+        // The trap this pins: a rendering mode that does not arm recording
+        // renders an empty report and reads as a launch that did no work.
+        assert!(tracing_enabled_from(Some("tree"), None));
+        assert_eq!(phase_timing_mode_from(Some("tree")), PhaseTimingMode::Tree);
+    }
+
+    #[test]
+    fn phase_timing_mode_parses_every_accepted_spelling() {
+        for on in ["1", "true", "TRUE", " true "] {
+            assert_eq!(
+                phase_timing_mode_from(Some(on)),
+                PhaseTimingMode::Line,
+                "{on}"
+            );
+        }
+        for tree in ["tree", "TREE", " Tree "] {
+            assert_eq!(
+                phase_timing_mode_from(Some(tree)),
+                PhaseTimingMode::Tree,
+                "{tree}"
+            );
+        }
+        for off in ["0", "", "  ", "yes", "2", "line"] {
+            assert_eq!(
+                phase_timing_mode_from(Some(off)),
+                PhaseTimingMode::Off,
+                "{off}"
+            );
+        }
+        assert_eq!(phase_timing_mode_from(None), PhaseTimingMode::Off);
+    }
+
+    #[test]
+    fn only_off_is_off() {
+        assert!(!PhaseTimingMode::Off.is_on());
+        assert!(PhaseTimingMode::Line.is_on());
+        assert!(PhaseTimingMode::Tree.is_on());
     }
 }
 

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -358,6 +358,29 @@ pub struct AuditEmitter {
     runtime: OnceLock<tokio::runtime::Runtime>,
 }
 
+impl Drop for AuditEmitter {
+    /// Shut the cached runtime down without blocking.
+    ///
+    /// Caching the runtime removed a per-entry construction, but it also moved
+    /// where the runtime is *dropped*: it used to die inside the synchronous
+    /// emit that built it, and now it dies with the emitter. An emitter
+    /// constructed from inside someone else's async context therefore drops
+    /// its runtime there, and a blocking drop from async is a tokio panic by
+    /// design —
+    ///
+    ///   Cannot drop a runtime in a context where blocking is not allowed.
+    ///
+    /// `shutdown_background` returns immediately and leaves the worker threads
+    /// to exit on their own, which is what this runtime wants anyway: it only
+    /// ever drives a blocking file append that has already completed by the
+    /// time the emitter is being dropped.
+    fn drop(&mut self) {
+        if let Some(rt) = self.runtime.take() {
+            rt.shutdown_background();
+        }
+    }
+}
+
 impl AuditEmitter {
     /// Construct with the default `~/.mvm/audit/` directory.
     pub fn new(signing_key: SigningKey) -> Result<Self> {
@@ -1367,6 +1390,38 @@ mod tests {
             .tenant(tenant)
             .plan_id(plan_id)
             .build()
+    }
+
+    /// Construct, use and drop an emitter from inside an async context.
+    ///
+    /// This is the shape the cached runtime made hazardous and that no unit
+    /// test covered: the runtime now dies with the emitter rather than inside
+    /// the emit that built it, so an emitter dropped in async drops a runtime
+    /// in async — which tokio panics on. The conformance suite caught it by
+    /// accident because its steps run under cucumber's runtime; this catches
+    /// it on purpose.
+    #[tokio::test]
+    async fn an_emitter_dropped_inside_an_async_context_does_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::rng().fill_bytes(&mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        // Emit first: the runtime is built lazily, so an emitter that never
+        // emitted would drop a `OnceLock` that was never filled and pass
+        // whatever `Drop` did.
+        emitter
+            .emit_admitted(&fixture_plan("local", "plan-async-drop"), "host:test")
+            .unwrap();
+
+        drop(emitter);
+
+        // Reached only if the drop above did not panic.
+        let content = std::fs::read_to_string(dir.path().join("local.jsonl")).unwrap();
+        assert!(content.contains("plan-async-drop"));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -58,6 +58,7 @@ use mvm_contract::verify::hash_line;
 use mvm_core::plan::ExecutionPlan;
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 
 /// Wire-stable event name and label keys for the wall-clock enforcement entry.
 /// Shared so the supervisor that emits it and any reader asserting on it cannot
@@ -347,6 +348,14 @@ pub struct AuditEmitter {
     decisions_enabled: bool,
     decisions_dir: Option<PathBuf>,
     decision_stores: Mutex<HashMap<String, DecisionStore>>,
+    /// Built once on first emit and reused.
+    ///
+    /// The signer interface is async and the callers are not, so each emit has
+    /// to block on a runtime. Building a fresh one per entry meant paying that
+    /// construction ~6 times for the handful of entries one launch writes, on
+    /// the admission path, for a runtime that only ever drives a blocking file
+    /// append.
+    runtime: OnceLock<tokio::runtime::Runtime>,
 }
 
 impl AuditEmitter {
@@ -388,6 +397,7 @@ impl AuditEmitter {
             decisions_enabled: false,
             decisions_dir: None,
             decision_stores: Mutex::new(HashMap::new()),
+            runtime: OnceLock::new(),
         })
     }
 
@@ -1135,12 +1145,58 @@ impl AuditEmitter {
         self.emit_entry_blocking(entry)
     }
 
-    fn emit_entry_blocking(&self, entry: &PlanAuditEntry) -> Result<()> {
-        let t0 = std::time::Instant::now();
-        let rt = tokio::runtime::Builder::new_current_thread()
+    /// Run `f` with every barrier fsync on this emitter's chains held back,
+    /// then sync them all once.
+    ///
+    /// For a burst of entries that all have to be durable before the same
+    /// action — an admission writing `plan.admitted`, its decision record and
+    /// its grant requirement before anything boots — this costs one fsync
+    /// rather than one per entry. `sync_data` is file-wide, so the single
+    /// flush carries every record the batch wrote.
+    ///
+    /// Fails closed: if the flush fails, this returns the error and `f`'s
+    /// result is discarded, so a caller that boots on `Ok` cannot boot on
+    /// records that never reached the disk. The scope must therefore close
+    /// before the action the entries authorize — not at process exit.
+    pub fn batched<T>(&self, f: impl FnOnce() -> Result<T>) -> Result<T> {
+        for signer in &self.signers {
+            signer.begin_batch();
+        }
+        let out = f();
+        // End every batch even if `f` failed, so a later emit is not left
+        // silently deferring its barriers.
+        let mut flush = Ok(());
+        for signer in &self.signers {
+            if let Err(e) = signer.end_batch() {
+                flush = Err(e);
+            }
+        }
+        let out = out?;
+        flush.context("syncing batched audit entries before the action they authorize")?;
+        Ok(out)
+    }
+
+    /// The shared blocking runtime, built on first use.
+    fn runtime(&self) -> Result<&tokio::runtime::Runtime> {
+        if let Some(rt) = self.runtime.get() {
+            return Ok(rt);
+        }
+        let built = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .context("building tokio runtime for audit emit")?;
+        // A concurrent caller may have won the race; either runtime is usable
+        // and the loser's is dropped here.
+        let _ = self.runtime.set(built);
+        Ok(self
+            .runtime
+            .get()
+            .expect("runtime is set on the line above or by the caller that raced us"))
+    }
+
+    fn emit_entry_blocking(&self, entry: &PlanAuditEntry) -> Result<()> {
+        let t0 = std::time::Instant::now();
+        let rt = self.runtime()?;
         let t_rt = std::time::Instant::now();
         tracing::debug!(
             ms = (t_rt - t0).as_secs_f64() * 1000.0,

--- a/crates/mvm-hostd/src/stream/durable.rs
+++ b/crates/mvm-hostd/src/stream/durable.rs
@@ -25,10 +25,10 @@
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, SyncSender, TrySendError, sync_channel};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError, sync_channel};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::thread::JoinHandle;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use mvm_contract::stream::{StreamKind, StreamRecord};
 use mvm_core::transcript::{Direction, TranscriptManifest, TranscriptWriter, sealed_root_hex};
@@ -138,7 +138,7 @@ pub(in crate::stream) struct DurableSink {
     /// stopped taking work. Either way `push` sheds rather than falling back
     /// to an inline write — see the module docs.
     jobs: Option<SyncSender<PersistJob>>,
-    worker: Option<JoinHandle<()>>,
+    worker: Option<WriterHandle>,
     counters: Arc<PersistCounters>,
     /// The journal the writer thread mirrors landed chunks into, so a process
     /// that did not open this capture can still seal it. Held here only to
@@ -345,12 +345,20 @@ impl Drop for DurableSink {
 /// rather shed than couple the workload to that same disk.
 const SEAL_JOIN_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// How often [`wait_for_writer`] checks whether the writer thread has exited.
-const SEAL_JOIN_POLL_INTERVAL: Duration = Duration::from_millis(20);
+/// A writer thread, plus a channel that reports its exit without polling.
+///
+/// `std` has no timed join, and this module cannot add a dependency to get
+/// one. The stand-in is a channel whose [`Sender`] lives in the thread: it is
+/// never sent on, so the only event a receiver can observe is the disconnect
+/// that happens when the thread drops it — on a normal return or while
+/// unwinding a panic. A timed `recv` on it is therefore a timed join.
+struct WriterHandle {
+    join: JoinHandle<()>,
+    /// Disconnects when the writer thread exits. Never carries a value.
+    exited: Receiver<()>,
+}
 
-/// Wait for `worker` to exit, but not past `timeout`. Polls rather than
-/// joining directly because a plain `join` has no timeout in `std`, and this
-/// module cannot add a dependency to get one.
+/// Wait for `worker` to exit, but not past `timeout`.
 ///
 /// A worker still running once the deadline passes is detached here: dropping
 /// a [`JoinHandle`] without joining does not stop the thread, but nothing in
@@ -358,17 +366,19 @@ const SEAL_JOIN_POLL_INTERVAL: Duration = Duration::from_millis(20);
 /// syscall blocked in the kernel — is not something a timeout in this
 /// function can do anything about; the thread finishes, if it ever does, on
 /// its own.
-fn wait_for_writer(worker: JoinHandle<()>, timeout: Duration) -> bool {
-    let deadline = Instant::now() + timeout;
-    while !worker.is_finished() {
-        if Instant::now() >= deadline {
-            drop(worker);
-            return false;
+fn wait_for_writer(worker: WriterHandle, timeout: Duration) -> bool {
+    match worker.exited.recv_timeout(timeout) {
+        // Disconnected is the writer dropping its sender as it exits. `Ok` is
+        // unreachable because nothing sends, but it means the same thing.
+        Ok(()) | Err(RecvTimeoutError::Disconnected) => {
+            let _ = worker.join.join();
+            true
         }
-        std::thread::sleep(SEAL_JOIN_POLL_INTERVAL);
+        Err(RecvTimeoutError::Timeout) => {
+            drop(worker.join);
+            false
+        }
     }
-    let _ = worker.join();
-    true
 }
 
 /// Drop one record at the hand-off, and account for it.
@@ -421,11 +431,18 @@ fn spawn_writer(
     vm: &str,
     mut owned_state: WriterThread,
     inbox: Receiver<PersistJob>,
-) -> Option<JoinHandle<()>> {
+) -> Option<WriterHandle> {
     let owned = vm.to_string();
+    let (exit_tx, exited) = std::sync::mpsc::channel::<()>();
     std::thread::Builder::new()
         .name(format!("mvm-transcript-{vm}"))
-        .spawn(move || run_writer(&owned, &mut owned_state, &inbox))
+        .spawn(move || {
+            // Owned by the thread purely so its drop reports the exit. Held
+            // across the whole body, including a panic unwind.
+            let _exit = exit_tx;
+            run_writer(&owned, &mut owned_state, &inbox);
+        })
+        .map(|join| WriterHandle { join, exited })
         .inspect_err(|error| {
             tracing::warn!(
                 vm = %vm,

--- a/crates/mvm-hostd/src/stream/serve.rs
+++ b/crates/mvm-hostd/src/stream/serve.rs
@@ -24,6 +24,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -41,8 +42,24 @@ use super::fanout::{DrainedWindow, ReaderHandle};
 /// a spin loop.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-/// How often the accept loop wakes to notice a stop request.
-const ACCEPT_INTERVAL: Duration = Duration::from_millis(25);
+/// How long the accept loop pauses after a genuine accept failure, so a
+/// persistently failing listener cannot spin.
+///
+/// This is not a stop-polling cadence. The loop blocks in `accept` and is woken
+/// by [`StreamServerHandle::shutdown`] connecting to its own socket. It used to
+/// poll a nonblocking listener on a 25 ms tick, which put a mean 12.5 ms on
+/// every transient teardown — and unlike the other polls of its kind, backoff
+/// could not help it: the loop idles for the whole life of the VM, so it was
+/// always already sitting at the ceiling when the stop arrived.
+const ACCEPT_RETRY_INTERVAL: Duration = Duration::from_millis(25);
+
+/// How long [`StreamServerHandle::shutdown`] waits for the accept thread after
+/// waking it, before detaching it and moving on.
+///
+/// Reached only when the wake-up could not be delivered, which needs the socket
+/// to have been unlinked behind the server's back. Generous, because expiring
+/// it early would detach a thread that was about to return.
+const ACCEPT_JOIN_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// How long one write to a follower may block before the server re-checks
 /// its stop flag.
@@ -66,6 +83,10 @@ pub struct StreamServerHandle {
     path: PathBuf,
     stop: Arc<AtomicBool>,
     accept: Option<JoinHandle<()>>,
+    /// Disconnects when the accept thread exits. Never carries a value; it
+    /// exists so shutdown can wait on that exit with a bound, which `std`
+    /// offers no way to do on a [`JoinHandle`] directly.
+    exited: Receiver<()>,
 }
 
 impl StreamServerHandle {
@@ -82,9 +103,31 @@ impl StreamServerHandle {
     fn shutdown(&mut self) {
         self.stop.store(true, Ordering::SeqCst);
         if let Some(accept) = self.accept.take() {
-            // A panicked accept thread has already stopped accepting, which
-            // is what this call is for; the socket cleanup below still runs.
-            let _ = accept.join();
+            // Wake the blocked `accept` so it observes the stop flag now
+            // rather than whenever a follower happens to connect. The accept
+            // loop re-checks the flag immediately after accepting and drops
+            // this connection without serving it.
+            let _ = UnixStream::connect(&self.path);
+            // Bounded, because the wake-up is not guaranteed to land: if
+            // something already unlinked the socket, nothing can connect to it
+            // and the blocking accept has no other way to return. That case
+            // detaches the thread rather than hanging teardown on it — the
+            // process is on its way out and the socket is gone either way.
+            //
+            // A panicked accept thread has already stopped accepting, which is
+            // what this call is for; the socket cleanup below still runs.
+            match self.exited.recv_timeout(ACCEPT_JOIN_TIMEOUT) {
+                Ok(()) | Err(RecvTimeoutError::Disconnected) => {
+                    let _ = accept.join();
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    warn!(
+                        path = %self.path.display(),
+                        "stream accept thread did not return; detaching it",
+                    );
+                    drop(accept);
+                }
+            }
         }
         let _ = std::fs::remove_file(&self.path);
     }
@@ -108,15 +151,16 @@ pub fn serve_stream(path: &Path, broker: SharedBroker) -> io::Result<StreamServe
     }
     reclaim_stale_socket(path)?;
     let listener = UnixListener::bind(path)?;
-    listener.set_nonblocking(true)?;
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(SOCKET_MODE))?;
 
     let stop = Arc::new(AtomicBool::new(false));
-    let accept = spawn_accept_loop(listener, broker, Arc::clone(&stop))?;
+    let (exit_tx, exited) = std::sync::mpsc::channel::<()>();
+    let accept = spawn_accept_loop(listener, broker, Arc::clone(&stop), exit_tx)?;
     Ok(StreamServerHandle {
         path: path.to_path_buf(),
         stop,
         accept: Some(accept),
+        exited,
     })
 }
 
@@ -124,10 +168,16 @@ fn spawn_accept_loop(
     listener: UnixListener,
     broker: SharedBroker,
     stop: Arc<AtomicBool>,
+    exit_tx: Sender<()>,
 ) -> io::Result<JoinHandle<()>> {
     thread::Builder::new()
         .name("mvm-stream-serve".to_string())
-        .spawn(move || accept_loop(&listener, &broker, &stop))
+        .spawn(move || {
+            // Owned by the thread so its drop reports the exit, including on
+            // a panic unwind. Never sent on.
+            let _exit = exit_tx;
+            accept_loop(&listener, &broker, &stop);
+        })
         .inspect_err(|error| {
             // Thread exhaustion is the realistic cause, and it is exactly the
             // state an operator needs the stream for. Report it rather than
@@ -166,6 +216,13 @@ fn accept_loop(listener: &UnixListener, broker: &SharedBroker, stop: &Arc<Atomic
     while !stop.load(Ordering::SeqCst) {
         match listener.accept() {
             Ok((socket, _addr)) => {
+                // The shutdown wake-up connects only to unblock this accept.
+                // Checking here — not just at the top of the loop — is what
+                // keeps it from being served as a real follower.
+                if stop.load(Ordering::SeqCst) {
+                    drop(socket);
+                    break;
+                }
                 connections.retain(|handle| !handle.is_finished());
                 // Subscribe here, on the accepting thread, not inside the
                 // follower it spawns. The broker attaches a reader at the
@@ -179,10 +236,12 @@ fn accept_loop(listener: &UnixListener, broker: &SharedBroker, stop: &Arc<Atomic
                     Err(error) => warn!(%error, "stream follower thread could not start"),
                 }
             }
-            Err(e) if e.kind() == io::ErrorKind::WouldBlock => thread::sleep(ACCEPT_INTERVAL),
+            // A signal can interrupt a blocking accept; that is not a failure
+            // and must not be reported or backed off as one.
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
             Err(error) => {
                 warn!(%error, "stream socket accept failed");
-                thread::sleep(ACCEPT_INTERVAL);
+                thread::sleep(ACCEPT_RETRY_INTERVAL);
             }
         }
     }
@@ -969,5 +1028,45 @@ mod tests {
         finished
             .recv_timeout(Duration::from_secs(20))
             .expect("shutdown must not wait on a consumer that stopped reading");
+    }
+
+    #[test]
+    fn shutdown_returns_even_when_the_socket_was_unlinked_behind_it() {
+        // The hazard the blocking accept introduces. Shutdown wakes the accept
+        // by connecting to the socket; if something already removed it, no
+        // connection can be made and the accept has no other way to return.
+        // Detaching is the required behaviour — hanging teardown is not.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("stream.sock");
+        let handle = serve_stream(&path, broker_in(dir.path())).expect("serve");
+
+        std::fs::remove_file(&path).expect("unlink the socket out from under the server");
+
+        let (done, waited) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            handle.stop();
+            let _ = done.send(());
+        });
+        waited
+            .recv_timeout(ACCEPT_JOIN_TIMEOUT + Duration::from_secs(5))
+            .expect("stop must return within its bound when the wake-up cannot be delivered");
+    }
+
+    #[test]
+    fn the_shutdown_wakeup_is_not_served_as_a_follower() {
+        // The wake-up is a real connection. If the accept loop treated it as a
+        // follower it would subscribe a reader at the live head and then be
+        // joined at once, which is a subscribe/teardown race rather than a
+        // clean stop.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("stream.sock");
+        let broker = broker_in(dir.path());
+        let handle = serve_stream(&path, Arc::clone(&broker)).expect("serve");
+        handle.stop();
+        assert_eq!(
+            broker.lock().expect("broker lock").reader_count(),
+            0,
+            "the shutdown wake-up subscribed a reader",
+        );
     }
 }

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -37,6 +37,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
@@ -64,6 +65,9 @@ pub struct FileAuditSigner {
     /// `sync_data` is file-wide and carries every earlier write with it. What
     /// remains at drop is flushed there.
     pending_sync: Arc<Mutex<HashSet<PathBuf>>>,
+    /// While set, a barrier entry is written but its fsync is held for the
+    /// batch's single flush. See [`FileAuditSigner::begin_batch`].
+    batching: Arc<AtomicBool>,
 }
 
 /// When the active segment is sealed and a fresh one opened.
@@ -169,6 +173,69 @@ pub fn sync_policy_for(event: &str) -> SyncPolicy {
     }
 }
 
+/// How much of a chain file's tail one cursor restore reads before widening.
+///
+/// Comfortably larger than a signed audit record, so the common case is a
+/// single read; a record longer than this only costs extra reads, never a
+/// wrong answer.
+const CURSOR_TAIL_WINDOW: u64 = 64 * 1024;
+
+/// What a backwards scan found at the end of a chain file.
+enum TailScan<'a> {
+    /// The last non-empty line.
+    Line(&'a [u8]),
+    /// Nothing but terminators — the file holds no record.
+    Empty,
+    /// The file does not end at a record boundary.
+    Truncated,
+    /// The window did not reach the start of the last line.
+    NeedMore,
+}
+
+/// Read the last `window` bytes of `file`, which is `len` bytes long.
+fn read_tail(file: &mut std::fs::File, len: u64, window: u64) -> Result<Vec<u8>, AuditError> {
+    use std::io::{Read, Seek, SeekFrom};
+    let window = window.min(len);
+    file.seek(SeekFrom::Start(len - window))
+        .map_err(|e| AuditError::Io(e.to_string()))?;
+    let mut buf = vec![0u8; usize::try_from(window).unwrap_or(usize::MAX)];
+    file.read_exact(&mut buf)
+        .map_err(|e| AuditError::Io(e.to_string()))?;
+    Ok(buf)
+}
+
+/// Find the last non-empty line in `tail`, the trailing bytes of a chain file.
+///
+/// Byte-oriented on purpose: `\n` is ASCII and cannot occur inside a UTF-8
+/// multi-byte sequence, so a window that starts mid-character still yields a
+/// whole, correctly-delimited final line — and the hash is over bytes anyway.
+fn last_line(tail: &[u8], at_file_start: bool) -> TailScan<'_> {
+    // A file whose last byte is not a terminator ended mid-record: some
+    // previous append died between writing the record and its newline.
+    // Chaining onto a fragment would make a crash indistinguishable from
+    // tampering to every downstream verifier, so it is reported instead.
+    let Some(body) = tail.strip_suffix(b"\n") else {
+        return TailScan::Truncated;
+    };
+    // Skip any trailing blank lines the way `str::lines().rfind()` did.
+    let body = {
+        let mut end = body.len();
+        while end > 0 && body[end - 1] == b'\n' {
+            end -= 1;
+        }
+        &body[..end]
+    };
+    match body.iter().rposition(|b| *b == b'\n') {
+        Some(start) => TailScan::Line(&body[start + 1..]),
+        None if body.is_empty() => TailScan::Empty,
+        // No terminator before the final record. If the window reaches the
+        // start of the file this *is* the only record — the state every chain
+        // is in after its first append — and not a short read.
+        None if at_file_start => TailScan::Line(body),
+        None => TailScan::NeedMore,
+    }
+}
+
 impl FileAuditSigner {
     /// Create the signer rooted at `audit_dir`. The directory is
     /// created if missing (mode 0700-equivalent — `OpenOptions` later
@@ -184,6 +251,7 @@ impl FileAuditSigner {
             rotation: RotationPolicy::from_env(),
             cursors: Mutex::new(HashMap::new()),
             pending_sync: Arc::new(Mutex::new(HashSet::new())),
+            batching: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -218,6 +286,7 @@ impl FileAuditSigner {
             rotation: RotationPolicy::from_env(),
             cursors: Mutex::new(HashMap::new()),
             pending_sync: Arc::new(Mutex::new(HashSet::new())),
+            batching: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -248,16 +317,38 @@ impl FileAuditSigner {
         if !path.exists() {
             return Ok([0u8; 32]);
         }
-        let content = std::fs::read_to_string(path).map_err(|e| AuditError::Io(e.to_string()))?;
-        if !content.is_empty() && !content.ends_with('\n') {
-            return Err(AuditError::TruncatedTail {
-                path: path.display().to_string(),
-            });
+        let mut file = std::fs::File::open(path).map_err(|e| AuditError::Io(e.to_string()))?;
+        let len = file
+            .metadata()
+            .map_err(|e| AuditError::Io(e.to_string()))?
+            .len();
+        if len == 0 {
+            return Ok([0u8; 32]);
         }
-        let last = content.lines().rfind(|l| !l.is_empty());
-        match last {
-            None => Ok([0u8; 32]),
-            Some(line) => Ok(hash_line(line.as_bytes())),
+
+        // Read backwards from the end rather than reading the file.
+        //
+        // Only the final line is needed, but this runs on every append, and the
+        // active segment grows to `AUDIT_SEGMENT_DEFAULT_BYTES` before it
+        // rotates. Reading it whole made each append cost the size of the
+        // chain so far — so admission got steadily slower as the segment
+        // filled and abruptly cheap again at every rotation.
+        let mut window = CURSOR_TAIL_WINDOW.min(len);
+        loop {
+            let tail = read_tail(&mut file, len, window)?;
+            match last_line(&tail, window >= len) {
+                TailScan::Line(line) => return Ok(hash_line(line)),
+                TailScan::Empty => return Ok([0u8; 32]),
+                TailScan::Truncated => {
+                    return Err(AuditError::TruncatedTail {
+                        path: path.display().to_string(),
+                    });
+                }
+                // The window landed inside the final record. Widen and retry;
+                // a window covering the file reports `Line`, not `NeedMore`,
+                // so this cannot spin.
+                TailScan::NeedMore => window = (window * 4).min(len),
+            }
         }
     }
 }
@@ -272,6 +363,33 @@ impl FileAuditSigner {
     /// Best-effort by signature: a failure here cannot be reported to whoever
     /// emitted the entry, because they were told it succeeded when it was
     /// written. It is logged instead of swallowed.
+    /// Hold barrier fsyncs until [`end_batch`](Self::end_batch).
+    pub(crate) fn begin_batch(&self) {
+        self.batching.store(true, Ordering::SeqCst);
+    }
+
+    /// Stop holding barriers and sync everything the batch deferred.
+    ///
+    /// Unlike [`flush_deferred`](Self::flush_deferred) this reports failure,
+    /// and it has to: the entries it is syncing include barriers whose emitters
+    /// have not yet been told they succeeded. A caller that ignored this would
+    /// be strictly worse off than syncing each entry separately.
+    pub(crate) fn end_batch(&self) -> Result<(), AuditError> {
+        self.batching.store(false, Ordering::SeqCst);
+        let pending: Vec<PathBuf> = {
+            let mut guard = self.pending_sync.lock().expect("pending_sync poisoned");
+            guard.drain().collect()
+        };
+        for path in pending {
+            OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .and_then(|f| f.sync_data())
+                .map_err(|e| AuditError::Io(format!("{}: {e}", path.display())))?;
+        }
+        Ok(())
+    }
+
     pub fn flush_deferred(&self) {
         let pending: Vec<PathBuf> = {
             let mut guard = self.pending_sync.lock().expect("pending_sync poisoned");
@@ -394,6 +512,16 @@ impl FileAuditSigner {
         // disk, so syncing each one charged the launch for durability it did
         // not need at that instant. `sync_data` is file-wide, so a barrier
         // carries every deferred write on the same file with it.
+        // Inside a batch, a barrier is downgraded to deferred: the record is
+        // written now and the fsync is the batch's single flush. This does not
+        // relax the rule barriers exist for — an entry must be durable before
+        // the action it authorizes takes effect — because the batch is closed,
+        // and its flush checked, before that action. It relaxes only *how many
+        // times* the same file is synced to get there.
+        let sync = match sync {
+            SyncPolicy::Barrier if self.batching.load(Ordering::SeqCst) => SyncPolicy::Deferred,
+            other => other,
+        };
         match sync {
             SyncPolicy::Barrier => {
                 file.sync_data()
@@ -1967,5 +2095,181 @@ mod tests {
             .await
             .expect("an intact chain must still accept appends");
         assert_eq!(verify_audit_chain(&path, &verifying).unwrap(), 3);
+    }
+
+    /// Chain files are appended to on every admission, so the cursor restore
+    /// runs constantly. These pin the backwards scan against the whole-file
+    /// read it replaced: same answer, including on the cases where "read less"
+    /// is exactly how you get a wrong one.
+    mod cursor_tail {
+        use super::*;
+
+        fn cursor_of(bytes: &[u8]) -> Result<[u8; 32], AuditError> {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("chain.jsonl");
+            std::fs::write(&path, bytes).expect("write chain");
+            FileAuditSigner::open(fresh_key(), dir.path())
+                .expect("signer")
+                .restore_cursor(&path)
+        }
+
+        #[test]
+        fn the_tail_scan_agrees_with_hashing_the_last_line() {
+            let body = b"{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n";
+            assert_eq!(cursor_of(body).expect("cursor"), hash_line(b"{\"c\":3}"));
+        }
+
+        #[test]
+        fn a_record_longer_than_the_window_widens_instead_of_guessing() {
+            // The failure this guards: a window that lands inside the final
+            // record sees no terminator, and a scan that treated that as
+            // "first record in the file" would chain onto a fragment.
+            let huge = "x".repeat(usize::try_from(CURSOR_TAIL_WINDOW).unwrap() * 3);
+            let last = format!("{{\"big\":\"{huge}\"}}");
+            let body = format!("{{\"a\":1}}\n{last}\n");
+            assert_eq!(
+                cursor_of(body.as_bytes()).expect("cursor"),
+                hash_line(last.as_bytes()),
+            );
+        }
+
+        #[test]
+        fn a_single_record_shorter_than_the_window_is_still_found() {
+            let body = b"{\"only\":1}\n";
+            assert_eq!(cursor_of(body).expect("cursor"), hash_line(b"{\"only\":1}"));
+        }
+
+        #[test]
+        fn a_missing_terminator_is_truncation_not_a_shorter_chain() {
+            let err = cursor_of(b"{\"a\":1}\n{\"partial\":").expect_err("must refuse");
+            assert!(
+                matches!(err, AuditError::TruncatedTail { .. }),
+                "a crash mid-append must stay distinguishable from tampering, got {err:?}",
+            );
+        }
+
+        #[test]
+        fn an_empty_or_blank_file_restores_to_genesis() {
+            assert_eq!(cursor_of(b"").expect("cursor"), [0u8; 32]);
+            assert_eq!(cursor_of(b"\n\n").expect("cursor"), [0u8; 32]);
+        }
+
+        #[test]
+        fn trailing_blank_lines_do_not_hide_the_last_record() {
+            let body = b"{\"a\":1}\n{\"b\":2}\n\n\n";
+            assert_eq!(cursor_of(body).expect("cursor"), hash_line(b"{\"b\":2}"));
+        }
+
+        #[test]
+        fn a_multibyte_character_spanning_the_window_edge_is_not_corrupted() {
+            // The window starts at an arbitrary byte offset. `\n` is ASCII and
+            // cannot appear inside a UTF-8 sequence, so the extracted line is
+            // still whole — this pins that reasoning.
+            let pad = "é".repeat(usize::try_from(CURSOR_TAIL_WINDOW).unwrap());
+            let last = "{\"tail\":\"ünïcøde\"}";
+            let body = format!("{{\"pad\":\"{pad}\"}}\n{last}\n");
+            assert_eq!(
+                cursor_of(body.as_bytes()).expect("cursor"),
+                hash_line(last.as_bytes()),
+            );
+        }
+    }
+
+    /// Batching exists to cut fsyncs, not durability. These pin the parts that
+    /// would make it a weakening rather than an optimization.
+    mod barrier_batching {
+        use super::*;
+
+        #[test]
+        fn a_batch_writes_every_record_and_leaves_none_unsynced() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let signer = FileAuditSigner::open(fresh_key(), dir.path()).unwrap();
+            let path = dir.path().join("local.jsonl");
+
+            signer.begin_batch();
+            for event in ["plan.admitted", "decision_record", "plan.grant_required"] {
+                signer
+                    .append_locked(&path, &make_entry("local", event))
+                    .expect("append");
+            }
+            // Held, not skipped: every barrier is still owed a sync.
+            assert_eq!(
+                signer.pending_sync.lock().unwrap().len(),
+                1,
+                "the batch should owe exactly one file a sync",
+            );
+            signer.end_batch().expect("flush");
+            assert!(
+                signer.pending_sync.lock().unwrap().is_empty(),
+                "ending a batch must leave nothing owed",
+            );
+
+            let written = std::fs::read_to_string(&path).expect("read chain");
+            assert_eq!(
+                written.lines().filter(|l| !l.is_empty()).count(),
+                3,
+                "batching must not drop records",
+            );
+        }
+
+        #[test]
+        fn a_batch_chain_still_verifies_end_to_end() {
+            // The records are written the same way and chained the same way;
+            // only the fsync count changes. If batching perturbed the chain at
+            // all, the verifier is what would notice.
+            let dir = tempfile::tempdir().expect("tempdir");
+            let key = fresh_key();
+            let verifying = key.verifying_key();
+            let signer = FileAuditSigner::open(key, dir.path()).unwrap();
+            let path = dir.path().join("local.jsonl");
+
+            signer.begin_batch();
+            for event in ["plan.admitted", "decision_record", "plan.grant_required"] {
+                signer
+                    .append_locked(&path, &make_entry("local", event))
+                    .expect("append");
+            }
+            signer.end_batch().expect("flush");
+
+            verify_audit_chain(&path, &verifying).expect("a batched chain must verify");
+        }
+
+        #[test]
+        fn a_barrier_outside_a_batch_still_syncs_immediately() {
+            // The batch is a scope, not a mode switch. Once it closes, the
+            // default is back to syncing every barrier as it lands.
+            let dir = tempfile::tempdir().expect("tempdir");
+            let signer = FileAuditSigner::open(fresh_key(), dir.path()).unwrap();
+            let path = dir.path().join("local.jsonl");
+
+            signer.begin_batch();
+            signer
+                .append_locked(&path, &make_entry("local", "plan.admitted"))
+                .expect("append");
+            signer.end_batch().expect("flush");
+
+            signer
+                .append_locked(&path, &make_entry("local", "plan.admitted"))
+                .expect("append");
+            assert!(
+                signer.pending_sync.lock().unwrap().is_empty(),
+                "a barrier after the batch closed must have synced on the spot",
+            );
+        }
+
+        #[test]
+        fn a_deferrable_event_is_unaffected_by_batching() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let signer = FileAuditSigner::open(fresh_key(), dir.path()).unwrap();
+            let path = dir.path().join("local.jsonl");
+            signer
+                .append_locked(&path, &make_entry("local", "plan.launched"))
+                .expect("append");
+            assert_eq!(
+                signer.pending_sync.lock().unwrap().len(),
+                1,
+                "a deferrable event defers with or without a batch",
+            );
+        }
     }
 }

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -1020,7 +1020,7 @@ All commands accept these global options:
 | `MVM_OCI_BEARER_TOKEN_<HOST>` | Bearer token for one OCI registry host (`ghcr.io` -> `MVM_OCI_BEARER_TOKEN_GHCR_IO`) | Unset |
 | `MVM_OCI_BEARER_TOKEN` | Global fallback bearer token for OCI registry pulls | Unset |
 | `RUST_LOG` | Logging level (e.g., `debug`, `mvm=trace`) | `info` |
-| `MVM_PHASE_TIMING` | Set to `1`/`true` to print a transient run's per-phase launch breakdown to stderr: `[mvm] phase-timing:` for the coarse buckets, plus `[mvm] phase-timing-detail:` for whichever sub-phases were measured | Unset |
+| `MVM_PHASE_TIMING` | Set to `1`/`true` to print a transient run's per-phase launch breakdown to stderr as two greppable lines: `[mvm] phase-timing:` for the coarse buckets, plus `[mvm] phase-timing-detail:` for whichever sub-phases were measured. Set to `tree` for the same spans rendered as one nested, aligned report grouped by containment — easier to read, but not a stable format to parse | Unset |
 | `MVM_LAUNCH_SAMPLE_JSON` | Path a transient run writes its machine-readable launch sample to — build profile, backend, guest sizing, artifact paths, the expensive work the launch performed, and every phase span. Read by the release-only cold-launch benchmark; setting it turns the measurement on without the stderr output. | Unset |
 | `MVM_DEV_FLAKE_URL` | Escape hatch for the dev-build's chained `--override-input mvm` target. When set, suppresses the default chained override. (Legacy from the previous iteration's dual-flake layout; today's same-flake-for-both-modes design rarely needs it.) | Unset |
 | `MVM_SRC` | Override the source repo path passed to `nix build` during dev builds | Workspace root |

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -655,6 +655,22 @@ for detailed scope and acceptance criteria.
     supervisor PID disappearance. Follow-up: give pool maintenance to the
     resident per-tenant daemon and continue reducing supervisor shutdown
     latency.
+    The "real cleanup" remainder was then decomposed and was mostly not:
+    `stop_console_cleanup` was the largest span in a transient teardown and
+    57.0 ms of it was two more instances of the cadence bug — the stream
+    accept loop polling a nonblocking listener on a 25 ms tick, and
+    `DurableSink::seal` polling `is_finished()` every 20 ms for a writer that
+    exits in microseconds. Backoff could not fix the first (it idles at the
+    ceiling for the VM's whole life), so the listener now blocks and shutdown
+    wakes it by connecting to its own socket, bounded and with a detach path;
+    the second waits on a channel the writer thread's sender closes on exit.
+    Measured 57.0 ms -> 7-11 ms. Admission's three pre-boot chain barriers now
+    share one flush, closing #2293's open acceptance item without changing
+    `sync_policy_for`'s fail-closed default, and the chain cursor reads a
+    bounded tail instead of the whole 4 MiB segment on every append. **Open
+    and newly named:** the receipt write, not the chain, is the dominant admit
+    cost at ~36 ms of ~45 ms — a structure the code calls a derived cache,
+    doing an `F_FULLFSYNC` synchronously before boot.
   - [ ] Phase 7 — live validation and regression gates
   - [x] Cross-plan fast-machine-substrate contract documented in
         `specs/notes/2026-08-10-fast-machine-substrate.md` (issue #2279)

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -664,13 +664,23 @@ for detailed scope and acceptance criteria.
     ceiling for the VM's whole life), so the listener now blocks and shutdown
     wakes it by connecting to its own socket, bounded and with a detach path;
     the second waits on a channel the writer thread's sender closes on exit.
-    Measured 57.0 ms -> 7-11 ms. Admission's three pre-boot chain barriers now
+    Measured on release, HVF/macOS, against an unchanged control span in the
+    same runs: `stop_console_cleanup` 57.0 -> 7.0-7.7 ms while
+    `stop_pid_disappearance` held at 33.4-35.5 ms against a 33.7 ms baseline.
+    Foreground teardown 91.4 -> 41-45 ms, total 287.2 -> ~233 ms.
+    Admission's three pre-boot chain barriers now
     share one flush, closing #2293's open acceptance item without changing
     `sync_policy_for`'s fail-closed default, and the chain cursor reads a
-    bounded tail instead of the whole 4 MiB segment on every append. **Open
-    and newly named:** the receipt write, not the chain, is the dominant admit
+    bounded tail instead of the whole 4 MiB segment on every append. **Two things are open
+    and newly named.** The receipt write, not the chain, is the dominant admit
     cost at ~36 ms of ~45 ms — a structure the code calls a derived cache,
-    doing an `F_FULLFSYNC` synchronously before boot.
+    doing an `F_FULLFSYNC` synchronously before boot. And
+    `stop_pid_disappearance` is guest-RAM teardown: `shutdown-timing.json`
+    accounts for only 2.9 ms of it, because the host waits on kqueue process
+    exit while the record stops before the process exits. It is linear in guest
+    memory at ~48 ms/GB (33 ms at 512M, 194 ms at 4G), so the watchdog
+    self-pipe is not worth building and a large workload pays teardown no
+    `alpine`-sized benchmark can see.
   - [ ] Phase 7 — live validation and regression gates
   - [x] Cross-plan fast-machine-substrate contract documented in
         `specs/notes/2026-08-10-fast-machine-substrate.md` (issue #2279)

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -505,6 +505,71 @@ a launch appends ~6 entries, so admission cost up to 24 MiB of reads per launch
 a sawtooth in `admit` that no sample would explain. It now reads a bounded tail
 window and widens only if a record spans it.
 
+### `stop_pid_disappearance` is guest-RAM teardown, ~48 ms/GB — open
+
+The remaining teardown span. Two candidates were on the table: the 5 ms
+watchdog tick observing the SIGTERM flag, and the supervisor's console
+rewrite. `shutdown-timing.json` was supposed to settle it. It does, by
+excluding both.
+
+One release HVF shutdown, 512 MiB guest, from `<state_dir>/shutdown-timing.json`:
+
+| span | µs |
+|---|---:|
+| `watchdog_to_vcpu_exit` | 1,582 |
+| `vm_destroy` | 346 |
+| `console_write` | 869 |
+| `io_thread_join` | 70 |
+| `vcpu_destroy` | 34 |
+| `watchdog_join` | 23 |
+| **sum** | **2,924** |
+
+The host measured `stop_pid_disappearance` at **33–37 ms** for the same
+configuration. **The record accounts for 2.9 ms of it — under 9%.**
+
+The gap is structural, not noise. `pid_disappearance` waits on kqueue
+`EVFILT_PROC` — actual *process exit* — while the record stops being written
+just before `remove_file(pid_file)`. Everything after that point is inside the
+host's measurement and outside the file: the supervisor process still has to
+exit, and its address space still has to be reclaimed.
+
+That it is the address space is measurable directly. Varying only guest memory
+on the transient path, release, two samples each:
+
+| `--memory` | `stop_pid_disappearance` |
+|---|---:|
+| 512M (default) | 33.1, 37.1 ms |
+| 1G | 76.1, 55.8 ms |
+| 2G | 92.0, 92.7 ms |
+| 4G | 193.0, 195.6 ms |
+
+Linear in guest RAM at roughly **48 ms/GB**, and `hv_vm_destroy` is already
+accounted for at 346 µs, so this is the guest allocation being reclaimed at
+process exit rather than any Hypervisor.framework call.
+
+Consequences:
+
+- **The watchdog self-pipe is not worth building.** Its whole prize is the
+  0–5 ms tick, which is at most 15% of this span at the default size and
+  proportionally less at every larger one.
+- **This span is a function of workload size, not of teardown code.** A 4 GiB
+  workload pays ~195 ms of foreground teardown for no reason the user can see,
+  and it will not show up in any `alpine`-sized benchmark — the same blind spot
+  Plan 311 opened for artifact size, now on the stop path.
+- The lever is the wait, not the unmap: the kernel reclaims the address space
+  either way, but the host currently blocks the user's command until it has.
+  `remove_file(pid_file)` already happens *before* exit, so a liveness signal
+  that fires there would return earlier — at the cost of the state directory
+  being removable while the supervisor still holds descriptors into it, which
+  is exactly the ownership rule this phase is not allowed to break. Phase 6's
+  detached-cleanup design is the honest place to resolve it.
+
+Two instrumentation gaps found while doing this, both worth closing before the
+next person trusts this file: `stop_observed_at` is stamped when the watchdog
+*observes* the flag after its sleep, so the tick latency the record exists to
+expose is the one thing it cannot see; and the record is written before process
+exit, so it structurally cannot cover the span that dominates.
+
 ### The dominant admit cost is the receipt, not the chain — open
 
 Batching the chain barriers did not move `admit` much, and the emit trace says

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -432,6 +432,118 @@ long-term owner of pool maintenance — it already outlives the CLI and is the
 host-side lifecycle seam this phase names. That would restore automatic warm
 claims without putting the refill on any launch's critical path.
 
+### Phase 6 second change — the cadence bug was in the seal too
+
+Phase 6's first change left `stop_transient` at ~143 ms and called it "real
+cleanup". Decomposed on HVF/macOS with `MVM_PHASE_TIMING`, most of it was not:
+
+```
+teardown=91.4  cleanup_handoff=91.3  stop_transient=90.7
+  stop_driver_kill=33.7  (stop_pid_disappearance=33.7)
+  stop_console_cleanup=57.0
+```
+
+`stop_console_cleanup` is the largest single span in a transient teardown, and
+57 ms of it was two more instances of the cadence bug — a fifth and sixth site,
+missed by "the same cadence bug, three more times" because neither is a
+readiness wait:
+
+- The stream server's accept loop polled a **nonblocking** listener on a fixed
+  25 ms tick, and `shutdown` set a flag and joined it. Mean 12.5 ms per stop.
+  Backoff, the fix used at the other four sites, does **not** help here: the
+  loop idles for the whole life of the VM, so it is always already sitting at
+  the ceiling when the stop arrives. It needed an event, not a shorter tick.
+  The listener now blocks in `accept` and `shutdown` wakes it by connecting to
+  its own socket.
+- `DurableSink::seal` waited for its writer thread by polling `is_finished()`
+  every 20 ms, because `std` has no timed join and the module cannot take a
+  dependency to get one. The writer finishes in microseconds once the job
+  channel drops, so this cost a full tick nearly every time. It now waits on a
+  channel whose sender lives in the writer thread: the disconnect *is* the
+  exit, so the wait is a timed join with no cadence.
+
+Both changes introduce a hazard the polls did not have — a wait that can no
+longer time out on its own — so both are bounded and both have a test for the
+pathological case. The accept wake-up cannot be delivered if something already
+unlinked the socket, and that path detaches rather than hanging teardown.
+
+### Phase 6 third change — admission was five `F_FULLFSYNC`s
+
+Issue #2293 costed the per-launch fsync count on the KVM box and fixed the
+duplicate `plan.admitted` plus the deferrable-event split, taking one launch
+from 8 chain fsyncs to 3. Its second acceptance item — batch the remaining
+causally-ordered burst — was left open. This closes it.
+
+Measured on the same Apple-silicon host, 25 samples, appending an 800-byte
+record:
+
+| barrier | p50 |
+|---|---:|
+| `fsync(2)` | 0.03 ms |
+| **`F_FULLFSYNC`** | **7.41 ms** |
+
+Rust's `sync_data` is `F_FULLFSYNC` on Apple platforms, so the 47.4 ms `admit`
+was ~37 ms of barrier: three chain barriers (`plan.admitted`, the decision
+record, `plan.grant_required`), the `plan.admitted` receipt's `sync_all`, and
+`plan.json`. This is why admission looked cheap on macOS in the original
+#2293 measurement — it was compared against `fsync(2)`, which it does not use.
+
+The three chain barriers now share one flush. Nothing about the durability rule
+changes: they all have to be durable before the same action — this plan booting
+— and none of them acts on the one before it, so syncing each separately bought
+no ordering that the single flush does not. `sync_data` is file-wide, so one
+flush carries all three. The batch closes before the caller receives an
+`AdmissionContext` to boot from, and a failed flush is an error, not a warning.
+
+`sync_policy_for`'s fail-closed default and `DEFERRABLE_EVENTS` are untouched —
+batching is a scope a caller opts into, not a change to what any event means.
+
+**Also on the admit path:** the chain cursor was restored by reading the whole
+active segment on every append. The segment grows to 4 MiB before rotating, and
+a launch appends ~6 entries, so admission cost up to 24 MiB of reads per launch
+— rising as the segment filled and dropping abruptly at each rotation, which is
+a sawtooth in `admit` that no sample would explain. It now reads a bounded tail
+window and widens only if a record spans it.
+
+### The dominant admit cost is the receipt, not the chain — open
+
+Batching the chain barriers did not move `admit` much, and the emit trace says
+why. One admission, `RUST_LOG=mvm_hostd::audit=debug`:
+
+```
+emit: tokio runtime build  ms=0.030      <- once, now reused (was ~6x)
+emit: signer   signer=0    ms=0.289      <- batched, no fsync
+emit: receipt              ms=35.893     <- the cost
+emit: signer   signer=0    ms=2.505
+admit: record_admission (batched fsync) ms=52.060
+...
+emit: receipt              ms=11.657
+```
+
+**The receipt write is ~36 ms of a ~45 ms `admit`.** Issue #2293 costed chain
+entries and never looked at receipts, so this has been the largest single
+admission cost the whole time and was attributed to the chain.
+
+What makes it worth a decision rather than a patch: `emit_receipt_for_entry`
+is explicitly best-effort — its errors are logged and swallowed, and its own
+doc says receipts "are a derived cache and must never block the primary audit
+emit". But `append_chained` writes the receipt body through `write_atomic`,
+which ends in `sync_all` — an `F_FULLFSYNC` — on the boot path. The head write
+beside it already uses `write_atomic_unsynced`. So a structure the code treats
+as a derived cache everywhere else is the one thing in admission paying full
+durability, synchronously, before the VM starts.
+
+Three options, none taken here because this is a durability decision about
+claim-8 evidence export rather than the redundancy removal the rest of this
+change is:
+
+1. Write the receipt body unsynced, like its head. Cheapest; a receipt can then
+   be lost to power loss while the chain entry it derives from survives — which
+   is the definition of a derived cache, but it does mean `receipt_export` can
+   come up short after a crash.
+2. Keep the sync and move it off the boot path, flushing with the batch.
+3. Keep it as is and accept ~36 ms, having now named it.
+
 ### Phase 5 first change — the readiness cadence was reporting itself
 
 `wait_for_agent` polled on a flat 50 ms tick. Readiness can only be observed on


### PR DESCRIPTION
## Why

`MVM_PHASE_TIMING=1 mvmctl machine run --image alpine` reported `total=287.2ms`. The half this repo actually gates — `dispatch_window`, 74.3ms — is 2.7x inside the published 200ms prepared-cold p50 and needed nothing. The other 213ms sits in teardown and admission, where no budget looks, and most of it turned out not to be work.

## What moved

**`stop_console_cleanup`: 57.0ms → 7-11ms** (measured, HVF/macOS, steady state). It was the largest single span in a transient teardown, and two more instances of the cadence bug Plan 299 catalogued as "the same cadence bug, three more times":

- The stream accept loop polled a *nonblocking* listener on a 25ms tick. Backoff — the fix used at the other four sites — cannot help here: the loop idles for the whole life of the VM, so it is always already sitting at the ceiling when the stop arrives. It needed an event, not a shorter tick. The listener now blocks in `accept` and `shutdown` wakes it by connecting to its own socket.
- `DurableSink::seal` polled `is_finished()` every 20ms because `std` has no timed join and the module cannot take a dependency to get one. The writer exits in microseconds once the job channel drops. It now waits on a channel whose sender the writer thread drops on exit — a timed join with no cadence.

Both swap a wait that could time out on its own for one that cannot, so both are bounded and both have a test for the pathological case. The accept wake-up cannot be delivered if something already unlinked the socket; that path detaches rather than hanging teardown.

**Admission.** The three pre-boot chain barriers now share one flush, closing the open acceptance item on #2293. `sync_data` is file-wide and none of the three acts on the one before it, so syncing each separately bought no ordering the single flush does not — and on macOS each is a real `F_FULLFSYNC` at **7.41ms p50** (measured; `fsync(2)` on the same host is 0.03ms, which is why this looked free in the original #2293 comparison).

`sync_policy_for`'s fail-closed default and `DEFERRABLE_EVENTS` are untouched. Batching is a scope a caller opts into, it fails closed, and it closes before the caller has an `AdmissionContext` to boot from.

The chain cursor also stops re-reading the whole segment on every append. The active segment grows to 4MiB before rotating and a launch appends ~6 entries, so admission was costing up to 24MiB of reads per launch — rising as the segment filled and dropping at each rotation, a sawtooth no sample would explain.

## Readability

`MVM_PHASE_TIMING=tree` renders the same spans nested by containment:

```
[mvm] launch cold — total 287.2ms, dispatch window 74.3ms (prepared-cold p50 budget 200ms across 20 samples)
  resolve                             8.7ms    3%
  drives                             13.4ms    5%
    artifact verify                   0.2ms
  admit                              47.4ms   17%
  ...
  teardown                           91.4ms   32%
    cleanup handoff                  91.3ms
      stop transient                 90.7ms
        stop driver kill             33.7ms
          stop pid disappearance     33.7ms
        stop console cleanup         57.0ms
```

The greppable pair is byte-identical and still the default — `scripts/check-hvf-warm-restore.sh` parses it, and a test pins that.

Nesting comes from a declared table asserted against the spans rather than read off the names, because the names mislead: `artifact_verify` is recorded during *drives*, not admit, and driver kill and console cleanup are *siblings*. Both are what a plausible guess gets wrong — the invariant test was verified to go red on exactly that error. The budget prints as context with no verdict: one launch is one sample, the published number is a p50 over twenty, and `bench/doc_table` already warns about conflating the two.

`warm-claim-phase` reported cumulative time from boot start under span-shaped names, so the reap looked free and the claim absorbed its cost. It reports deltas now.

## Not changed, and now named

**The receipt write is the dominant admit cost — ~36ms of ~45ms.** The emit trace shows it plainly. `emit_receipt_for_entry` is explicitly best-effort and its own doc calls receipts "a derived cache [that] must never block the primary audit emit", but `append_chained` writes the body through `write_atomic` → `sync_all` → `F_FULLFSYNC`, synchronously, before boot — while the head beside it already uses `write_atomic_unsynced`. Fixing it is a durability decision about claim-8 evidence export rather than redundancy removal, so it is written up in Plan 299 with three options and left for a maintainer.

Also left alone deliberately: the readiness poll cap. Plan 299 Phase 5 already took `guest_kernel_entry` 53.8 → 18.0ms with backoff and notes that tightening *widened the p99 tail* because the flat tick had been hiding real variance. Its remaining task there is event-driven readiness, not a smaller constant.

## Verification

- `cargo nextest run --workspace` — **12,093 passed**
- `cargo test --workspace --doc`, `cargo +nightly fmt --all -- --check`, `cargo clippy --workspace --all-targets -D warnings`, `just check-gated` — clean
- xtask: `check-claim-catalog`, `check-honesty`, `check-no-overclaim`, `check-doc-claims`, `check-witness-citations`, `check-nextest-groups`, `check-single-home`, `check-test-home-isolation`, `check-no-spec-refs-in-comments`, `check-plan-names`, `check-sprint-append` — all OK
- Live HVF runs before/after for the console-seal number; `mvmctl trust audit verify` clean across batched-emit runs; `a_batch_chain_still_verifies_end_to_end` pins the chain itself