### PR TITLE
perf(build): key mvm-cli's nested binaries by content, not by profile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -219,9 +219,23 @@ test-doc:
 # scoped to this recipe instead of being set globally.
 #
 # A content cache, not a build lock, so parallel sessions don't serialize on it.
-# Needs `cargo install sccache`. For cross-worktree hits the host config also
-# needs `basedirs`; without it every worktree is a private cache and the
-# measured hit rate is 0%.
+# Needs `cargo install sccache`.
+#
+# Do not expect this to dedupe across worktrees. `basedirs` in the host config
+# is necessary for that but is NOT sufficient: sccache's key covers the
+# rustc command line, which carries the target directory's full path, and every
+# worktree has its own. Measured on this host with `basedirs` correctly set,
+# building one crate three ways:
+#
+#   cold, target dir A                       2 hits / 100 misses
+#   target dir A wiped and rebuilt          70 hits /  79 misses
+#   identical source, target dir B           0 hits / 152 misses
+#
+# So it pays for re-populating one checkout after `cargo clean`, and pays
+# nothing for the second checkout — which is why the machine-wide Rust hit rate
+# sits near 2.5% across ~35k compiles rather than the 84% a same-path
+# experiment suggests. Cargo already caches deps within a target dir, so the
+# remaining value here is narrow.
 test-cached:
     @command -v sccache >/dev/null || { echo "sccache not found — install with: cargo install sccache"; exit 1; }
     RUSTC_WRAPPER=sccache CARGO_INCREMENTAL=0 cargo nextest run --workspace

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -1,5 +1,7 @@
 #[path = "build_aux_helpers.rs"]
 mod build_aux_helpers;
+#[path = "build_embed_cache.rs"]
+mod build_embed_cache;
 #[path = "src/host_binaries/toolchain.rs"]
 mod host_binaries_toolchain;
 
@@ -16,6 +18,117 @@ struct EmbeddedSourceBinary {
     package: String,
     name: String,
     features: String,
+}
+
+/// What identifies one cacheable artifact.
+struct KeyRequest<'a> {
+    package: &'a str,
+    binary: &'a str,
+    features: &'a str,
+    target: &'a str,
+    toolchain: &'a str,
+    flavor: &'a str,
+}
+
+/// The content store, plus the per-package source hashes its keys are built
+/// from. Hashing a closure is the expensive part, so it is memoised: the six
+/// embedded binaries share two root packages between them, and the aux
+/// helpers all share one.
+struct EmbedCache {
+    workspace_root: PathBuf,
+    graph: build_embed_cache::WorkspaceGraph,
+    lockfile: String,
+    toolchain_file: String,
+    root: Option<PathBuf>,
+    sources: std::collections::BTreeMap<String, Vec<(String, String)>>,
+    watched: std::collections::BTreeSet<String>,
+}
+
+impl EmbedCache {
+    fn discover(workspace_root: &Path) -> Self {
+        Self {
+            workspace_root: workspace_root.to_path_buf(),
+            graph: build_embed_cache::read_workspace_graph(workspace_root),
+            lockfile: build_embed_cache::hash_file(&workspace_root.join("Cargo.lock")),
+            toolchain_file: build_embed_cache::hash_file(
+                &workspace_root.join("rust-toolchain.toml"),
+            ),
+            root: build_embed_cache::cache_root(),
+            sources: std::collections::BTreeMap::new(),
+            watched: std::collections::BTreeSet::new(),
+        }
+    }
+
+    /// Source hashes for everything `package` can reach inside the workspace.
+    fn closure_sources(&mut self, package: &str) -> Vec<(String, String)> {
+        if let Some(hit) = self.sources.get(package) {
+            return hit.clone();
+        }
+        let mut hashes = Vec::new();
+        for member in build_embed_cache::workspace_closure(&self.graph, &[package]) {
+            let Some(dir) = self.graph.dirs.get(&member) else {
+                continue;
+            };
+            self.watched.insert(member.clone());
+            hashes.extend(build_embed_cache::hash_member(&self.workspace_root, dir));
+        }
+        hashes.sort();
+        self.sources.insert(package.to_string(), hashes.clone());
+        hashes
+    }
+
+    /// `None` when caching is off or unavailable — callers then build.
+    fn key_for(&mut self, request: &KeyRequest<'_>) -> Option<String> {
+        self.root.as_ref()?;
+        let sources = self.closure_sources(request.package);
+        Some(build_embed_cache::artifact_key(
+            &build_embed_cache::KeyInputs {
+                package: request.package.to_string(),
+                binary: request.binary.to_string(),
+                features: request.features.to_string(),
+                target: request.target.to_string(),
+                toolchain: format!("{} rust={}", request.toolchain, self.toolchain_file),
+                flavor: request.flavor.to_string(),
+                lockfile: self.lockfile.clone(),
+                sources,
+            },
+        ))
+    }
+
+    fn restore(&self, key: Option<&str>, binary: &str, dest: &Path) -> bool {
+        let (Some(root), Some(key)) = (self.root.as_ref(), key) else {
+            return false;
+        };
+        build_embed_cache::lookup(root, key, binary, dest)
+    }
+
+    fn publish(&self, key: Option<&str>, binary: &str, source: &Path) {
+        let (Some(root), Some(key)) = (self.root.as_ref(), key) else {
+            return;
+        };
+        build_embed_cache::install(root, key, binary, source);
+    }
+
+    /// Watch exactly the crates the cached binaries are built from.
+    ///
+    /// The blanket walk this replaces covered every workspace crate including
+    /// `mvm-cli`'s own 251 files — which are downstream of these binaries and
+    /// cannot affect them, yet re-ran the whole script on every edit to the
+    /// crate under active development. Anything reachable is still watched,
+    /// because the set is taken from the manifest graph rather than named by
+    /// hand.
+    fn emit_rerun(&self) {
+        for member in &self.watched {
+            let Some(dir) = self.graph.dirs.get(member) else {
+                continue;
+            };
+            emit_rerun_for_tree(&dir.join("src"));
+            println!(
+                "cargo:rerun-if-changed={}",
+                dir.join("Cargo.toml").display()
+            );
+        }
+    }
 }
 
 fn main() {
@@ -85,22 +198,30 @@ fn main() {
     // `mvm-core`, so any edit under `mvm-core/src` invalidates all six and a
     // one-line change costs ~176s before a single test runs.
     //
-    // Outside `--release`, reuse an already-cross-compiled binary instead of
-    // rebuilding it. The embedded set still exists and still hashes, so the
-    // extraction tests and the manifest gate keep passing on their real bytes;
-    // they assert the *name set*, the *SHA match* and *idempotency*, none of
-    // which require the bytes to be freshly compiled. A release build never
-    // takes this path, so shipped binaries are always rebuilt from source.
+    // Reuse is decided by content, not by profile. The key covers each
+    // binary's real dependency closure, `Cargo.lock` and the pinned
+    // toolchain, so a hit proves the bytes are the ones this source tree
+    // produces — which is what makes reuse safe under `--release` and
+    // `release-witness` too, and safe to share across worktrees. The previous
+    // rule (`PROFILE == "debug"` plus "the file exists") could prove neither,
+    // so it had to refuse every other profile and still risked embedding a
+    // stale binary within the one it allowed.
     //
-    // The native per-VM helpers deliberately do NOT get this treatment: they
-    // are the supervisors where a stale binary silently produces a running
-    // guest that ignores your edit, and rebuilding them costs 13s.
-    // Explicitly opt IN only the plain debug profile. Cargo reports PROFILE as
-    // "debug"/"release"; keying on `!= "release"` would silently take the reuse
-    // path for any custom profile (e.g. `release-witness`) that reports
-    // something else, which is exactly the case where fresh bytes matter.
-    let reuse_prebuilt_embedded = std::env::var("PROFILE").unwrap_or_default() == "debug";
+    // A key *miss* is a different question from a key hit, and the answer
+    // differs by profile. Rebuilding the musl set costs ~163s, which is why
+    // the dev profile has always been allowed to boot a stale embedded binary
+    // rather than pay that on every edit. That trade is kept below — but the
+    // key now knows the artifact is stale, so the warning can say so instead
+    // of describing a reuse that may or may not have been current.
+    //
+    // `MVM_EMBED_NO_CACHE=1` opts out of both the store and the stale
+    // fallback, for release engineering that wants the bytes provably
+    // compiled in this run.
+    let force_rebuild = std::env::var_os("MVM_EMBED_NO_CACHE").is_some_and(|v| !v.is_empty());
+    let dev_profile = std::env::var("PROFILE").unwrap_or_default() == "debug" && !force_rebuild;
+    let mut cache = EmbedCache::discover(&workspace_root);
     let mut reused_any = false;
+    let mut stale_any = false;
 
     for binary in &manifest {
         let out_file = bins_out.join(&binary.name);
@@ -108,20 +229,57 @@ fn main() {
             .join(strip_glibc(&pin.target))
             .join("release")
             .join(&binary.name);
-        if reuse_prebuilt_embedded && prebuilt.is_file() {
+        let key = cache.key_for(&KeyRequest {
+            package: &binary.package,
+            binary: &binary.name,
+            features: &binary.features,
+            target: &pin.target,
+            toolchain: &format!("zig={} zigbuild={}", pin.zig, pin.cargo_zigbuild),
+            flavor: "musl-static",
+        });
+
+        if cache.restore(key.as_deref(), &binary.name, &out_file) {
             eprintln!(
-                "[build.rs] reusing prebuilt {} (dev profile; `cargo build --release` \
-                 or `just embed-refresh` rebuilds it)",
+                "[build.rs] embedded {} restored from the content store \
+                 (set MVM_EMBED_NO_CACHE=1 to rebuild)",
+                binary.name
+            );
+            reused_any = true;
+            // Seed the nested target dir the dev stale-fallback reads from.
+            // A worktree whose binaries all came from the store has never
+            // populated it, so without this the *first* source edit there
+            // falls through to a full ~163s cross-compile — moving the cost
+            // the store just removed rather than removing it.
+            seed_prebuilt(&out_file, &prebuilt);
+            let sha = sha256_hex(&out_file);
+            entries.push((binary.name.clone(), out_file.clone(), sha));
+            continue;
+        }
+
+        // Miss: the closure really did change. Under `--release` or
+        // `release-witness` that always means a rebuild. Under dev, fall back
+        // to whatever the nested target dir last produced, exactly as before
+        // the store existed — the difference is that we now know it is stale
+        // and can name the consequence.
+        if dev_profile && prebuilt.is_file() {
+            eprintln!(
+                "[build.rs] embedded {} is STALE — this build's changes are \
+                 NOT in it. Dev profile reuses it rather than pay a ~163s \
+                 cross-compile per edit; run `just embed-refresh` or build \
+                 with MVM_EMBED_NO_CACHE=1 before booting a VM that must \
+                 carry the change.",
                 binary.name
             );
             std::fs::copy(&prebuilt, &out_file).unwrap_or_else(|e| {
                 panic!("copy {} -> {}: {e}", prebuilt.display(), out_file.display())
             });
             reused_any = true;
+            stale_any = true;
             let sha = sha256_hex(&out_file);
             entries.push((binary.name.clone(), out_file.clone(), sha));
             continue;
         }
+
         run_cargo_zigbuild(
             ZigbuildRequest::default()
                 .with_root(&workspace_root)
@@ -134,12 +292,9 @@ fn main() {
                 .with_output(&out_file)
                 .build(),
         );
+        cache.publish(key.as_deref(), &binary.name, &out_file);
         let sha = sha256_hex(&out_file);
         entries.push((binary.name.clone(), out_file.clone(), sha));
-        println!(
-            "cargo:rerun-if-changed={}",
-            workspace_root.join("crates/mvm-build/src/bin").display()
-        );
     }
 
     // Loud, not silent: the runtime can tell the user their embedded set was
@@ -149,8 +304,23 @@ fn main() {
         "cargo:rustc-env=MVM_EMBEDDED_BINS_REUSED={}",
         if reused_any { "1" } else { "0" }
     );
+    // Reused-and-proven-fresh is not the same as reused-and-stale, and only
+    // the second one can make a guest ignore your edit. Cargo captures build
+    // script stderr unless you pass `-vv`, so the eprintln above is invisible
+    // in a normal build; `cargo:warning=` is the one channel it does surface.
+    // A developer whose edit will not reach the guest has to be told without
+    // having to know to look.
+    if stale_any {
+        println!(
+            "cargo:warning=embedded host binaries are STALE (this build's \
+             changes to their sources are not in them). Dev builds reuse them \
+             instead of a ~163s cross-compile. Run `just embed-refresh`, or \
+             set MVM_EMBED_NO_CACHE=1, before booting a VM that must carry \
+             the change."
+        );
+    }
 
-    build_native_aux_helpers(&workspace_root, &nested_target_dir);
+    build_native_aux_helpers(&workspace_root, &nested_target_dir, &mut cache);
 
     let embedded_rs = render_embedded_rs(&entries);
     std::fs::write(out_dir.join("embedded.rs"), embedded_rs).unwrap();
@@ -166,51 +336,20 @@ fn main() {
     );
     // The embedded binaries' bytes are the authoritative builder-VM
     // fingerprint input, so they must rebuild when their real inputs change —
-    // not just their `src/bin/` entrypoints. Watch the workspace lockfile (a
-    // dep bump in their closure) and the whole `mvm-build` lib they link.
+    // not just their `src/bin/` entrypoints. The lockfile covers a dep bump in
+    // their closure.
     println!(
         "cargo:rerun-if-changed={}",
         workspace_root.join("Cargo.lock").display()
     );
-    // Same file-by-file watch for the `mvm-build` lib the host bins link (a
-    // content edit there must re-cross-compile the embedded host bins).
-    emit_rerun_for_tree(&workspace_root.join("crates/mvm-build/src"));
-    // ...and every other workspace crate, because that is what these binaries
-    // actually link. Naming individual trees is what left the gap this
-    // replaces: the watch listed `mvm-build` only, while `mvm-egress-client`
-    // — the guest's entire egress path — lives in `mvm-agentd` and reaches
-    // `mvm-core` and `mvm-contract` beneath it. An edit to any of them
-    // embedded the previous binary, so the guest ran code the contributor did
-    // not write and nothing said so. A list cannot be kept correct against a
-    // dependency graph; watching the workspace can.
-    emit_rerun_for_workspace_crates(&workspace_root);
-}
-
-/// Watch every workspace crate's `src` tree.
-///
-/// Deliberately not a curated list — see the call site. Emitting paths is
-/// cheap; embedding a stale binary is not.
-fn emit_rerun_for_workspace_crates(workspace_root: &Path) {
-    let crates_dir = workspace_root.join("crates");
-    let Ok(entries) = std::fs::read_dir(&crates_dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        // `crates/deps/` holds vendored FFI crates one level deeper.
-        if path.file_name().is_some_and(|name| name == "deps") {
-            if let Ok(nested) = std::fs::read_dir(&path) {
-                for dep in nested.flatten() {
-                    emit_rerun_for_tree(&dep.path().join("src"));
-                }
-            }
-            continue;
-        }
-        emit_rerun_for_tree(&path.join("src"));
-    }
+    println!(
+        "cargo:rerun-if-changed={}",
+        workspace_root.join("rust-toolchain.toml").display()
+    );
+    // Every crate the cached binaries actually link, taken from the manifest
+    // graph rather than named here. Both legs have contributed their roots by
+    // now, so this covers the embedded set and the per-VM helpers alike.
+    cache.emit_rerun();
 }
 
 /// Emit one `cargo:rerun-if-changed` per file under `root`, recursively. Unlike
@@ -238,9 +377,14 @@ fn emit_rerun_for_tree(root: &Path) {
 /// them during its build phase rather than mvmctl shelling out to `cargo` at
 /// run time. The dedicated target dir avoids the outer build-lock deadlock the
 /// same way the embedded-bins path does (see the note in `main`).
-fn build_native_aux_helpers(workspace_root: &Path, nested_target_dir: &Path) {
+fn build_native_aux_helpers(
+    workspace_root: &Path,
+    nested_target_dir: &Path,
+    cache: &mut EmbedCache,
+) {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let host_target = std::env::var("TARGET").unwrap_or_default();
     let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".to_string());
     let aux_target = nested_target_dir.join("aux-helper-target");
     let bin_dir = aux_target.join(&profile);
@@ -249,33 +393,38 @@ fn build_native_aux_helpers(workspace_root: &Path, nested_target_dir: &Path) {
     // `env!("MVM_AUX_BIN_DIR")` compiles in mvm-cli; resolution `is_file`-checks
     // each candidate, so a dir with missing bins is harmless.
     println!("cargo:rustc-env=MVM_AUX_BIN_DIR={}", bin_dir.display());
-    println!(
-        "cargo:rerun-if-changed={}",
-        workspace_root.join("crates/mvm-hostd/src").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        workspace_root.join("Cargo.lock").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        workspace_root.join("crates/mvm-core/src").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        workspace_root.join("crates/deps/libkrun-sys/src").display()
-    );
-    // The per-VM supervisors link `mvm-runtime` — it owns the VMM, the device
-    // model, and the FDT the guest boots on. Without this watch an edit there
-    // rebuilds `mvmctl` but leaves the supervisor binaries stale, so the change
-    // never reaches a running guest and the edit appears to do nothing. Use the
-    // file-by-file walk rather than a directory entry, for the same reason the
-    // `mvm-build` watch does.
-    emit_rerun_for_tree(&workspace_root.join("crates/mvm-runtime/src"));
 
+    // These are the supervisors, where a stale binary silently produces a
+    // running guest that ignores your edit — so they were rebuilt
+    // unconditionally, on every `cargo check` and `clippy` too. The content
+    // key is what makes skipping them safe: it cannot match unless the bytes
+    // are the ones this tree produces. Note the profile is part of the
+    // flavour, because unlike the musl leg these follow the outer profile.
     let libkrun_present = libkrun_header_present();
     for spec in build_aux_helpers::aux_helper_specs(&target_os, &target_arch, libkrun_present) {
+        let features = spec.features.join(",");
+        let key = cache.key_for(&KeyRequest {
+            package: spec.package,
+            binary: spec.bin,
+            features: &features,
+            target: &host_target,
+            toolchain: "native",
+            flavor: &format!("native-host-{profile}"),
+        });
+        let installed = bin_dir.join(spec.bin);
+
+        if cache.restore(key.as_deref(), spec.bin, &installed) {
+            eprintln!(
+                "[build.rs] per-VM host helper {} restored from the content store",
+                spec.bin
+            );
+            continue;
+        }
+
         run_cargo_native_build(workspace_root, &aux_target, &profile, &spec);
+        if installed.is_file() {
+            cache.publish(key.as_deref(), spec.bin, &installed);
+        }
     }
 }
 
@@ -591,6 +740,21 @@ fn scoped_tool_cache_dir(tool: &str, target_dir: &Path) -> PathBuf {
         .unwrap_or(target_dir)
         .join("tool-cache")
         .join(tool)
+}
+
+/// Place a restored artifact where the dev stale-fallback expects to find it.
+///
+/// Best-effort: failing to seed costs a slower next build, never a wrong one.
+fn seed_prebuilt(source: &Path, prebuilt: &Path) {
+    if prebuilt.is_file() {
+        return;
+    }
+    let Some(parent) = prebuilt.parent() else {
+        return;
+    };
+    if std::fs::create_dir_all(parent).is_ok() {
+        let _ = std::fs::copy(source, prebuilt);
+    }
 }
 
 fn sha256_hex(p: &Path) -> String {

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -109,6 +109,18 @@ impl EmbedCache {
         build_embed_cache::install(root, key, binary, source);
     }
 
+    /// Keep the store inside its ceiling. Runs after both legs, so a build
+    /// that published several artifacts prunes once rather than per binary.
+    fn prune(&self) {
+        let Some(root) = self.root.as_ref() else {
+            return;
+        };
+        build_embed_cache::prune(
+            root,
+            build_embed_cache::max_bytes_from(std::env::var_os("MVM_EMBED_CACHE_MAX_BYTES")),
+        );
+    }
+
     /// Watch exactly the crates the cached binaries are built from.
     ///
     /// The blanket walk this replaces covered every workspace crate including
@@ -350,6 +362,7 @@ fn main() {
     // graph rather than named here. Both legs have contributed their roots by
     // now, so this covers the embedded set and the per-VM helpers alike.
     cache.emit_rerun();
+    cache.prune();
 }
 
 /// Emit one `cargo:rerun-if-changed` per file under `root`, recursively. Unlike

--- a/crates/mvm-cli/build_embed_cache.rs
+++ b/crates/mvm-cli/build_embed_cache.rs
@@ -301,6 +301,13 @@ pub(crate) fn cache_root() -> Option<PathBuf> {
     )
 }
 
+/// The store's byte ceiling, from `MVM_EMBED_CACHE_MAX_BYTES` if set.
+pub(crate) fn max_bytes_from(raw: Option<OsString>) -> u64 {
+    raw.and_then(|v| v.to_str().and_then(|v| v.trim().parse::<u64>().ok()))
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_MAX_BYTES)
+}
+
 /// Where one artifact lives inside the store.
 pub(crate) fn artifact_path(root: &Path, key: &str, binary: &str) -> PathBuf {
     root.join(key).join(binary)
@@ -315,7 +322,106 @@ pub(crate) fn lookup(root: &Path, key: &str, binary: &str, dest: &Path) -> bool 
     if let Some(parent) = dest.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    std::fs::copy(&cached, dest).is_ok()
+    if std::fs::copy(&cached, dest).is_err() {
+        return false;
+    }
+    // Touch on read so eviction sees "least recently *used*", not "least
+    // recently built" — the entry a dozen worktrees keep restoring is
+    // precisely the one worth keeping.
+    let _ = filetime_now(&cached);
+    true
+}
+
+/// Best-effort mtime bump, used to record a cache read.
+fn filetime_now(path: &Path) -> std::io::Result<()> {
+    let file = std::fs::OpenOptions::new().append(true).open(path)?;
+    file.set_modified(std::time::SystemTime::now())
+}
+
+/// Default ceiling for the store. Each entry holds a multi-MB static binary
+/// and every distinct content key makes a new one, so an unbounded store
+/// grows for as long as the branch does — with no command that reports it,
+/// because it deliberately lives outside both `target/` and `MVM_HOME`.
+pub(crate) const DEFAULT_MAX_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// One stored key: its total size and when it was last used.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StoredKey {
+    pub key: String,
+    pub bytes: u64,
+    /// Seconds since the epoch; larger is more recently used.
+    pub used: u64,
+}
+
+/// Which keys to evict to bring `entries` under `max_bytes`, least recently
+/// used first.
+///
+/// Ties break on the key name so the choice is deterministic — two runs on
+/// the same store must not disagree about what to delete.
+pub(crate) fn select_victims(entries: &[StoredKey], max_bytes: u64) -> Vec<String> {
+    let mut total: u64 = entries.iter().map(|e| e.bytes).sum();
+    if total <= max_bytes {
+        return Vec::new();
+    }
+
+    let mut ordered = entries.to_vec();
+    ordered.sort_by(|a, b| a.used.cmp(&b.used).then_with(|| a.key.cmp(&b.key)));
+
+    let mut victims = Vec::new();
+    for entry in ordered {
+        if total <= max_bytes {
+            break;
+        }
+        total = total.saturating_sub(entry.bytes);
+        victims.push(entry.key);
+    }
+    victims
+}
+
+/// Read the store's current contents.
+pub(crate) fn stored_keys(root: &Path) -> Vec<StoredKey> {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(key) = path.file_name().map(|n| n.to_string_lossy().into_owned()) else {
+            continue;
+        };
+        let (mut bytes, mut used) = (0u64, 0u64);
+        if let Ok(files) = std::fs::read_dir(&path) {
+            for file in files.flatten() {
+                let Ok(meta) = file.metadata() else { continue };
+                bytes = bytes.saturating_add(meta.len());
+                // `mtime`, not `atime`: many filesystems mount `noatime`, so
+                // access time silently never updates and every entry would
+                // look equally stale. A restore refreshes mtime explicitly.
+                if let Ok(modified) = meta.modified()
+                    && let Ok(age) = modified.duration_since(std::time::UNIX_EPOCH)
+                {
+                    used = used.max(age.as_secs());
+                }
+            }
+        }
+        out.push(StoredKey { key, bytes, used });
+    }
+    out
+}
+
+/// Evict least-recently-used keys until the store fits in `max_bytes`.
+///
+/// Deleting a whole key directory is safe against a concurrent build: on Unix
+/// a reader that already opened the file keeps reading it, and one that has
+/// not yet looked simply misses and rebuilds. The failure mode is a slower
+/// build, never a wrong one.
+pub(crate) fn prune(root: &Path, max_bytes: u64) {
+    for key in select_victims(&stored_keys(root), max_bytes) {
+        let _ = std::fs::remove_dir_all(root.join(key));
+    }
 }
 
 /// Publish a freshly built artifact into the store.

--- a/crates/mvm-cli/build_embed_cache.rs
+++ b/crates/mvm-cli/build_embed_cache.rs
@@ -1,0 +1,340 @@
+//! Content-addressed store for the binaries mvm-cli's build script produces.
+//!
+//! The script has two nested legs — the musl cross-compile of the embedded
+//! host binaries, and the native per-VM helpers — and neither could tell a
+//! fresh artifact from a stale one. The embedded leg keyed reuse on
+//! `PROFILE == "debug"` plus "does the file exist", so it handed back whatever
+//! bytes were on disk and rebuilt from scratch under every other profile,
+//! target triple and worktree. The helper leg had no reuse at all and so ran
+//! four to six nested `cargo build`s on every `cargo check`.
+//!
+//! Measured on a fresh worktree before this existed: the script was 332.7s of
+//! a 359s cold build (93%), and 14.3s of an 18s rebuild after a one-line
+//! `mvm-core` edit (79%).
+//!
+//! Keying on content fixes both halves with one mechanism. A key derived from
+//! the binary's real dependency closure *proves* freshness, so reuse stops
+//! being a bet that a stale artifact is tolerable and becomes sound
+//! everywhere — which is what lets the store sit outside the target directory
+//! and be shared across worktrees, profiles and triples.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+/// Workspace members, by package name.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct WorkspaceGraph {
+    /// package name -> the crate directory holding its `src/`.
+    pub dirs: BTreeMap<String, PathBuf>,
+    /// package name -> the workspace packages it depends on.
+    pub edges: BTreeMap<String, Vec<String>>,
+}
+
+/// The inputs that decide whether two builds of one binary are the same build.
+///
+/// Anything that can change the produced bytes belongs here; anything that
+/// cannot must stay out, because every field widens the set of edits that
+/// force a rebuild. `mvm-cli`'s own sources are the motivating exclusion —
+/// it *links* these binaries rather than being linked by them, so its 251
+/// files cannot affect them, yet the old watch list rebuilt on every one.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct KeyInputs {
+    pub package: String,
+    pub binary: String,
+    pub features: String,
+    pub target: String,
+    /// Pinned zig / cargo-zigbuild / rustc identity, whichever the leg uses.
+    pub toolchain: String,
+    /// Which leg produced it — a musl static and a native host build of the
+    /// same package are different artifacts and must not share a key.
+    pub flavor: String,
+    /// SHA-256 of `Cargo.lock`.
+    pub lockfile: String,
+    /// `(workspace-relative path, SHA-256)` for every source file in the
+    /// dependency closure, sorted by path.
+    pub sources: Vec<(String, String)>,
+}
+
+/// Workspace-internal dependency closure of `roots`, inclusive of the roots.
+///
+/// Derived from the real manifest graph, never a hand-written list: a list
+/// cannot be kept correct against a dependency graph. The watch list this
+/// replaces named `mvm-build` only, while `mvm-egress-client` — the guest's
+/// entire egress path — lives in `mvm-agentd`, so an edit there embedded the
+/// previous binary and nothing said so.
+pub(crate) fn workspace_closure(graph: &WorkspaceGraph, roots: &[&str]) -> Vec<String> {
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    for root in roots {
+        if seen.insert((*root).to_string()) {
+            queue.push_back((*root).to_string());
+        }
+    }
+
+    while let Some(package) = queue.pop_front() {
+        let Some(deps) = graph.edges.get(&package) else {
+            continue;
+        };
+        for dep in deps {
+            if seen.insert(dep.clone()) {
+                queue.push_back(dep.clone());
+            }
+        }
+    }
+
+    seen.into_iter().collect()
+}
+
+/// The package name declared by a crate manifest.
+pub(crate) fn parse_package_name(manifest: &str) -> Option<String> {
+    manifest
+        .parse::<toml::Value>()
+        .ok()?
+        .get("package")?
+        .get("name")?
+        .as_str()
+        .map(str::to_string)
+}
+
+/// Every dependency name a manifest declares, across normal, build and
+/// target-conditional tables.
+///
+/// Deliberately includes `[build-dependencies]` and every
+/// `[target.'cfg(..)'.dependencies]`: a build-dependency generates code, and a
+/// target-gated dependency is exactly how the macOS libkrun path is wired, so
+/// omitting either would key a binary on an incomplete closure.
+///
+/// Dev-dependencies are excluded — they cannot reach a `[[bin]]`.
+pub(crate) fn parse_manifest_deps(manifest: &str) -> Vec<String> {
+    let Ok(value) = manifest.parse::<toml::Value>() else {
+        return Vec::new();
+    };
+    let mut names = BTreeSet::new();
+
+    let mut collect = |table: Option<&toml::Value>| {
+        if let Some(toml::Value::Table(table)) = table {
+            names.extend(table.keys().cloned());
+        }
+    };
+
+    collect(value.get("dependencies"));
+    collect(value.get("build-dependencies"));
+
+    if let Some(toml::Value::Table(targets)) = value.get("target") {
+        for spec in targets.values() {
+            collect(spec.get("dependencies"));
+            collect(spec.get("build-dependencies"));
+        }
+    }
+
+    names.into_iter().collect()
+}
+
+/// Read every workspace member under `crates/` (descending one extra level
+/// into `crates/deps/`, which is where vendored FFI crates live) and build the
+/// package-name graph.
+pub(crate) fn read_workspace_graph(workspace_root: &Path) -> WorkspaceGraph {
+    let mut dirs = BTreeMap::new();
+    let mut manifests = Vec::new();
+
+    let crates_dir = workspace_root.join("crates");
+    let mut candidates = Vec::new();
+    push_child_dirs(&crates_dir, &mut candidates);
+    push_child_dirs(&crates_dir.join("deps"), &mut candidates);
+
+    for dir in candidates {
+        let manifest_path = dir.join("Cargo.toml");
+        let Ok(text) = std::fs::read_to_string(&manifest_path) else {
+            continue;
+        };
+        let Some(name) = parse_package_name(&text) else {
+            continue;
+        };
+        dirs.insert(name.clone(), dir);
+        manifests.push((name, text));
+    }
+
+    let members: BTreeSet<String> = dirs.keys().cloned().collect();
+    let mut edges = BTreeMap::new();
+    for (name, text) in manifests {
+        let deps = parse_manifest_deps(&text)
+            .into_iter()
+            .filter(|dep| members.contains(dep))
+            .collect();
+        edges.insert(name, deps);
+    }
+
+    WorkspaceGraph { dirs, edges }
+}
+
+fn push_child_dirs(parent: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.push(path);
+        }
+    }
+}
+
+/// `(workspace-relative path, SHA-256)` for every file under `dir`, sorted.
+///
+/// Sorted so the key is stable regardless of directory iteration order, which
+/// is not guaranteed and differs between filesystems.
+pub(crate) fn hash_tree(workspace_root: &Path, dir: &Path) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    collect_file_hashes(workspace_root, dir, &mut out);
+    out.sort();
+    out
+}
+
+fn collect_file_hashes(workspace_root: &Path, dir: &Path, out: &mut Vec<(String, String)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_file_hashes(workspace_root, &path, out);
+        } else if let Ok(bytes) = std::fs::read(&path) {
+            let rel = path
+                .strip_prefix(workspace_root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .into_owned();
+            out.push((rel, hex(Sha256::digest(&bytes).as_slice())));
+        }
+    }
+}
+
+/// Every hashed input for one workspace member: its `src/` tree plus its
+/// manifest.
+///
+/// The manifest has to go through `hash_file`, not `hash_tree` — `hash_tree`
+/// lists a directory, so handing it a file path silently contributes nothing
+/// and a feature or dependency edit would not move the key.
+pub(crate) fn hash_member(workspace_root: &Path, dir: &Path) -> Vec<(String, String)> {
+    let mut hashes = hash_tree(workspace_root, &dir.join("src"));
+    let manifest = dir.join("Cargo.toml");
+    if manifest.is_file() {
+        let rel = manifest
+            .strip_prefix(workspace_root)
+            .unwrap_or(&manifest)
+            .to_string_lossy()
+            .into_owned();
+        hashes.push((rel, hash_file(&manifest)));
+    }
+    hashes.sort();
+    hashes
+}
+
+/// Hash one file, or the empty string when it cannot be read.
+pub(crate) fn hash_file(path: &Path) -> String {
+    std::fs::read(path)
+        .map(|bytes| hex(Sha256::digest(&bytes).as_slice()))
+        .unwrap_or_default()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// The cache key for one artifact.
+///
+/// Every field is length-prefixed before hashing. Plain concatenation would
+/// let two different input sets collide by shifting a boundary — a binary
+/// named `ab` with feature `c` would hash identically to one named `a` with
+/// feature `bc` — and a collision here silently ships the wrong bytes.
+pub(crate) fn artifact_key(inputs: &KeyInputs) -> String {
+    let mut hasher = Sha256::new();
+    let mut field = |value: &str| {
+        hasher.update(value.len().to_le_bytes());
+        hasher.update(value.as_bytes());
+    };
+
+    field("mvm-embed-cache-v1");
+    field(&inputs.package);
+    field(&inputs.binary);
+    field(&inputs.features);
+    field(&inputs.target);
+    field(&inputs.toolchain);
+    field(&inputs.flavor);
+    field(&inputs.lockfile);
+    for (path, sha) in &inputs.sources {
+        field(path);
+        field(sha);
+    }
+
+    hex(hasher.finalize().as_slice())
+}
+
+/// Resolve the store root from an explicit override, else a home directory.
+///
+/// Returns `None` when neither is available, and the caller then builds
+/// without caching. A missing cache is a slow build; a cache rooted somewhere
+/// unexpected is a wrong one.
+pub(crate) fn cache_root_from(
+    override_dir: Option<OsString>,
+    home: Option<OsString>,
+) -> Option<PathBuf> {
+    if let Some(dir) = override_dir.filter(|d| !d.is_empty()) {
+        return Some(PathBuf::from(dir));
+    }
+    let home = home.filter(|h| !h.is_empty())?;
+    Some(PathBuf::from(home).join(".cache/mvm/embed"))
+}
+
+/// `cache_root_from` against this process's environment.
+pub(crate) fn cache_root() -> Option<PathBuf> {
+    if std::env::var_os("MVM_EMBED_NO_CACHE").is_some_and(|v| !v.is_empty()) {
+        return None;
+    }
+    cache_root_from(
+        std::env::var_os("MVM_EMBED_CACHE_DIR"),
+        std::env::var_os("HOME"),
+    )
+}
+
+/// Where one artifact lives inside the store.
+pub(crate) fn artifact_path(root: &Path, key: &str, binary: &str) -> PathBuf {
+    root.join(key).join(binary)
+}
+
+/// Copy a cached artifact into place, if the store has it.
+pub(crate) fn lookup(root: &Path, key: &str, binary: &str, dest: &Path) -> bool {
+    let cached = artifact_path(root, key, binary);
+    if !cached.is_file() {
+        return false;
+    }
+    if let Some(parent) = dest.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    std::fs::copy(&cached, dest).is_ok()
+}
+
+/// Publish a freshly built artifact into the store.
+///
+/// Writes to a temporary name and renames, because concurrent worktree builds
+/// race this directory and a half-copied binary that looks complete is worse
+/// than no cache at all. Failures are swallowed: an unwritable store must slow
+/// the build down, not break it.
+pub(crate) fn install(root: &Path, key: &str, binary: &str, source: &Path) {
+    let dir = root.join(key);
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let staged = dir.join(format!(".tmp-{}-{binary}", std::process::id()));
+    if std::fs::copy(source, &staged).is_err() {
+        let _ = std::fs::remove_file(&staged);
+        return;
+    }
+    if std::fs::rename(&staged, dir.join(binary)).is_err() {
+        let _ = std::fs::remove_file(&staged);
+    }
+}

--- a/crates/mvm-cli/tests/build_embed_cache.rs
+++ b/crates/mvm-cli/tests/build_embed_cache.rs
@@ -11,9 +11,9 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use build_embed_cache::{
-    KeyInputs, WorkspaceGraph, artifact_key, artifact_path, cache_root_from, hash_file,
-    hash_member, hash_tree, install, lookup, parse_manifest_deps, parse_package_name,
-    workspace_closure,
+    DEFAULT_MAX_BYTES, KeyInputs, StoredKey, WorkspaceGraph, artifact_key, artifact_path,
+    cache_root_from, hash_file, hash_member, hash_tree, install, lookup, max_bytes_from,
+    parse_manifest_deps, parse_package_name, prune, select_victims, stored_keys, workspace_closure,
 };
 
 fn graph(edges: &[(&str, &[&str])]) -> WorkspaceGraph {
@@ -519,4 +519,163 @@ fn a_member_without_a_manifest_still_hashes_its_sources() {
     std::fs::create_dir_all(member.join("src")).expect("mkdir");
     std::fs::write(member.join("src/lib.rs"), b"x").expect("write");
     assert_eq!(hash_member(root.path(), &member).len(), 1);
+}
+
+fn stored(key: &str, bytes: u64, used: u64) -> StoredKey {
+    StoredKey {
+        key: key.into(),
+        bytes,
+        used,
+    }
+}
+
+#[test]
+fn nothing_is_evicted_while_the_store_fits() {
+    let entries = vec![stored("a", 10, 1), stored("b", 10, 2)];
+    assert!(select_victims(&entries, 100).is_empty());
+}
+
+#[test]
+fn eviction_drops_the_least_recently_used_first() {
+    let entries = vec![
+        stored("new", 10, 300),
+        stored("old", 10, 100),
+        stored("mid", 10, 200),
+    ];
+    // Ceiling of 20 means one entry has to go, and it must be the oldest.
+    assert_eq!(select_victims(&entries, 20), vec!["old".to_string()]);
+}
+
+#[test]
+fn eviction_stops_as_soon_as_the_store_fits() {
+    let entries = vec![
+        stored("a", 10, 1),
+        stored("b", 10, 2),
+        stored("c", 10, 3),
+        stored("d", 10, 4),
+    ];
+    // 40 bytes, ceiling 25 -> drop two, not everything.
+    assert_eq!(
+        select_victims(&entries, 25),
+        vec!["a".to_string(), "b".to_string()]
+    );
+}
+
+#[test]
+fn eviction_is_deterministic_when_timestamps_tie() {
+    // Two runs on the same store must not disagree about what to delete.
+    let entries = vec![stored("b", 10, 5), stored("a", 10, 5), stored("c", 10, 5)];
+    assert_eq!(
+        select_victims(&entries, 10),
+        vec!["a".to_string(), "b".to_string()]
+    );
+}
+
+#[test]
+fn an_oversized_single_entry_is_still_evicted() {
+    let entries = vec![stored("huge", 500, 1)];
+    assert_eq!(select_victims(&entries, 10), vec!["huge".to_string()]);
+}
+
+#[test]
+fn the_ceiling_comes_from_the_env_var_when_it_parses() {
+    assert_eq!(max_bytes_from(Some(OsString::from("1234"))), 1234);
+    assert_eq!(max_bytes_from(Some(OsString::from("  99  "))), 99);
+}
+
+#[test]
+fn a_junk_or_zero_ceiling_falls_back_to_the_default() {
+    // A zero ceiling would evict the entry the current build just published.
+    for raw in ["0", "not-a-number", ""] {
+        assert_eq!(max_bytes_from(Some(OsString::from(raw))), DEFAULT_MAX_BYTES);
+    }
+    assert_eq!(max_bytes_from(None), DEFAULT_MAX_BYTES);
+}
+
+#[test]
+fn stored_keys_reports_each_keys_size() {
+    let store = tempfile::tempdir().expect("tempdir");
+    let work = tempfile::tempdir().expect("tempdir");
+    let built = work.path().join("bin");
+    std::fs::write(&built, vec![0u8; 2048]).expect("write");
+    install(store.path(), "k1", "bin", &built);
+
+    let keys = stored_keys(store.path());
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0].key, "k1");
+    assert_eq!(keys[0].bytes, 2048);
+}
+
+#[test]
+fn pruning_evicts_from_a_real_store_and_leaves_the_rest_usable() {
+    let store = tempfile::tempdir().expect("tempdir");
+    let work = tempfile::tempdir().expect("tempdir");
+    let built = work.path().join("bin");
+    std::fs::write(&built, vec![0u8; 1024]).expect("write");
+
+    for key in ["k1", "k2", "k3"] {
+        install(store.path(), key, "bin", &built);
+        // Distinct mtimes so "least recently used" is well defined.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+
+    prune(store.path(), 2048);
+
+    let remaining: Vec<_> = stored_keys(store.path())
+        .into_iter()
+        .map(|k| k.key)
+        .collect();
+    assert!(
+        !remaining.contains(&"k1".to_string()),
+        "oldest should be gone: {remaining:?}"
+    );
+    assert!(
+        remaining.contains(&"k3".to_string()),
+        "newest should survive: {remaining:?}"
+    );
+    // A surviving entry is still a usable cache entry, not just a directory.
+    assert!(lookup(
+        store.path(),
+        "k3",
+        "bin",
+        &work.path().join("out/bin")
+    ));
+}
+
+#[test]
+fn pruning_an_absent_store_is_a_no_op() {
+    let store = tempfile::tempdir().expect("tempdir");
+    prune(&store.path().join("never-created"), 1);
+}
+
+#[test]
+fn restoring_an_entry_marks_it_recently_used() {
+    // Otherwise eviction means "least recently built", and the entry a dozen
+    // worktrees keep restoring is exactly the one that gets deleted.
+    let store = tempfile::tempdir().expect("tempdir");
+    let work = tempfile::tempdir().expect("tempdir");
+    let built = work.path().join("bin");
+    std::fs::write(&built, b"bytes").expect("write");
+
+    install(store.path(), "old", "bin", &built);
+    std::thread::sleep(std::time::Duration::from_millis(20));
+    install(store.path(), "new", "bin", &built);
+
+    let before = stored_keys(store.path());
+    let old_before = before.iter().find(|k| k.key == "old").expect("old").used;
+
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    assert!(lookup(
+        store.path(),
+        "old",
+        "bin",
+        &work.path().join("out/bin")
+    ));
+
+    let after = stored_keys(store.path());
+    let old_after = after.iter().find(|k| k.key == "old").expect("old").used;
+    assert!(
+        old_after > old_before,
+        "a restore must refresh the entry: {old_before} -> {old_after}"
+    );
 }

--- a/crates/mvm-cli/tests/build_embed_cache.rs
+++ b/crates/mvm-cli/tests/build_embed_cache.rs
@@ -1,0 +1,522 @@
+//! Unit tests for the build script's content-addressed artifact store.
+//!
+//! The build script itself is never compiled as a test target, so its logic is
+//! exercised here through the same `#[path]` include the script uses.
+
+#[path = "../build_embed_cache.rs"]
+mod build_embed_cache;
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use build_embed_cache::{
+    KeyInputs, WorkspaceGraph, artifact_key, artifact_path, cache_root_from, hash_file,
+    hash_member, hash_tree, install, lookup, parse_manifest_deps, parse_package_name,
+    workspace_closure,
+};
+
+fn graph(edges: &[(&str, &[&str])]) -> WorkspaceGraph {
+    WorkspaceGraph {
+        dirs: edges
+            .iter()
+            .map(|(name, _)| ((*name).to_string(), PathBuf::from(format!("crates/{name}"))))
+            .collect(),
+        edges: edges
+            .iter()
+            .map(|(name, deps)| {
+                (
+                    (*name).to_string(),
+                    deps.iter().map(|d| (*d).to_string()).collect(),
+                )
+            })
+            .collect(),
+    }
+}
+
+/// The real shape: `mvm-cli` links the embedded binaries, so it sits
+/// *downstream* of them and cannot change their bytes.
+fn workspace_like() -> WorkspaceGraph {
+    graph(&[
+        ("mvm-contract", &[]),
+        ("mvm-core", &["mvm-contract"]),
+        ("mvm-agentd", &["mvm-core", "mvm-contract"]),
+        ("mvm-build", &["mvm-agentd", "mvm-core"]),
+        ("mvm-hostd", &["mvm-build", "mvm-core"]),
+        ("mvm-client", &["mvm-hostd"]),
+        ("mvm-cli", &["mvm-build", "mvm-hostd", "mvm-client"]),
+    ])
+}
+
+#[test]
+fn closure_is_transitive_and_includes_the_root() {
+    let closure = workspace_closure(&workspace_like(), &["mvm-build"]);
+    assert_eq!(
+        closure,
+        vec!["mvm-agentd", "mvm-build", "mvm-contract", "mvm-core"]
+    );
+}
+
+#[test]
+fn closure_excludes_crates_that_only_consume_the_root() {
+    // This is the whole point of keying on the closure. The previous watch
+    // list re-ran the entire build script — both nested legs — on an edit to
+    // any of mvm-cli's 251 files, none of which can reach these binaries.
+    let closure = workspace_closure(&workspace_like(), &["mvm-build"]);
+    for downstream in ["mvm-cli", "mvm-client", "mvm-hostd"] {
+        assert!(
+            !closure.contains(&downstream.to_string()),
+            "{downstream} is downstream of mvm-build and must not be in its closure: {closure:?}"
+        );
+    }
+}
+
+#[test]
+fn closure_covers_the_indirect_dependency_that_the_old_hand_list_missed() {
+    // `mvm-egress-client` lives in mvm-agentd, which mvm-build reaches only
+    // transitively. A hand-written list named mvm-build alone, so an edit to
+    // the guest's egress path embedded the previous binary silently.
+    let closure = workspace_closure(&workspace_like(), &["mvm-build"]);
+    assert!(closure.contains(&"mvm-agentd".to_string()));
+    assert!(closure.contains(&"mvm-contract".to_string()));
+}
+
+#[test]
+fn closure_terminates_on_a_dependency_cycle() {
+    // Cargo forbids cycles, but a malformed manifest pair must not hang the
+    // build script.
+    let cyclic = graph(&[("a", &["b"]), ("b", &["a"])]);
+    assert_eq!(workspace_closure(&cyclic, &["a"]), vec!["a", "b"]);
+}
+
+#[test]
+fn closure_of_an_unknown_root_is_just_the_root() {
+    assert_eq!(
+        workspace_closure(&workspace_like(), &["not-a-member"]),
+        vec!["not-a-member"]
+    );
+}
+
+#[test]
+fn manifest_deps_cover_normal_build_and_target_tables_but_not_dev() {
+    let manifest = r#"
+        [package]
+        name = "mvm-example"
+
+        [dependencies]
+        mvm-core = { workspace = true }
+
+        [build-dependencies]
+        sha2 = "0.11"
+
+        [dev-dependencies]
+        assert_cmd = "2"
+
+        [target.'cfg(target_os = "macos")'.dependencies]
+        libkrun-sys = { workspace = true }
+    "#;
+
+    let deps = parse_manifest_deps(manifest);
+    assert!(deps.contains(&"mvm-core".to_string()));
+    assert!(deps.contains(&"sha2".to_string()));
+    // The macOS libkrun path is wired exactly this way; missing it would key
+    // the binary on an incomplete closure.
+    assert!(deps.contains(&"libkrun-sys".to_string()));
+    // A dev-dependency cannot reach a `[[bin]]`.
+    assert!(!deps.contains(&"assert_cmd".to_string()));
+}
+
+#[test]
+fn package_name_is_read_from_the_manifest() {
+    assert_eq!(
+        parse_package_name("[package]\nname = \"mvm-build\"\n").as_deref(),
+        Some("mvm-build")
+    );
+    assert_eq!(parse_package_name("not = valid toml ["), None);
+}
+
+/// One named edit to a key's inputs, applied to prove the key notices it.
+type Mutation = (&'static str, Box<dyn Fn(&mut KeyInputs)>);
+
+fn inputs() -> KeyInputs {
+    KeyInputs {
+        package: "mvm-build".into(),
+        binary: "mvm-host-vm-init".into(),
+        features: String::new(),
+        target: "aarch64-unknown-linux-musl".into(),
+        toolchain: "zig=0.13.0".into(),
+        flavor: "musl-static".into(),
+        lockfile: "abc".into(),
+        sources: vec![("crates/mvm-core/src/lib.rs".into(), "deadbeef".into())],
+    }
+}
+
+#[test]
+fn the_key_changes_when_any_input_changes() {
+    let base = artifact_key(&inputs());
+
+    let mutations: Vec<Mutation> = vec![
+        ("package", Box::new(|i: &mut KeyInputs| i.package.push('x'))),
+        ("binary", Box::new(|i: &mut KeyInputs| i.binary.push('x'))),
+        (
+            "features",
+            Box::new(|i: &mut KeyInputs| i.features.push('x')),
+        ),
+        ("target", Box::new(|i: &mut KeyInputs| i.target.push('x'))),
+        (
+            "toolchain",
+            Box::new(|i: &mut KeyInputs| i.toolchain.push('x')),
+        ),
+        ("flavor", Box::new(|i: &mut KeyInputs| i.flavor.push('x'))),
+        (
+            "lockfile",
+            Box::new(|i: &mut KeyInputs| i.lockfile.push('x')),
+        ),
+        (
+            "source content",
+            Box::new(|i: &mut KeyInputs| i.sources[0].1 = "cafe".into()),
+        ),
+        (
+            "source path",
+            Box::new(|i: &mut KeyInputs| i.sources[0].0 = "crates/mvm-core/src/other.rs".into()),
+        ),
+        (
+            "an added source file",
+            Box::new(|i: &mut KeyInputs| i.sources.push(("new.rs".into(), "00".into()))),
+        ),
+    ];
+
+    for (label, mutate) in mutations {
+        let mut mutated = inputs();
+        mutate(&mut mutated);
+        assert_ne!(
+            base,
+            artifact_key(&mutated),
+            "changing {label} must change the key, or a stale binary is served"
+        );
+    }
+}
+
+#[test]
+fn the_key_is_stable_for_identical_inputs() {
+    assert_eq!(artifact_key(&inputs()), artifact_key(&inputs()));
+}
+
+#[test]
+fn field_boundaries_cannot_be_shifted_to_forge_a_collision() {
+    // Without length-prefixing, concatenation lets a boundary move: binary
+    // "ab" + features "c" would hash the same as binary "a" + features "bc",
+    // and a collision here serves the wrong bytes.
+    let mut left = inputs();
+    left.binary = "ab".into();
+    left.features = "c".into();
+
+    let mut right = inputs();
+    right.binary = "a".into();
+    right.features = "bc".into();
+
+    assert_ne!(artifact_key(&left), artifact_key(&right));
+}
+
+#[test]
+fn cache_root_prefers_the_explicit_override() {
+    assert_eq!(
+        cache_root_from(
+            Some(OsString::from("/tmp/store")),
+            Some(OsString::from("/home/u"))
+        ),
+        Some(PathBuf::from("/tmp/store"))
+    );
+}
+
+#[test]
+fn cache_root_falls_back_to_the_home_cache_dir() {
+    // Built from components rather than spelled out: a contiguous
+    // home-relative mvm path literal is exactly what the single-root gate
+    // exists to catch, and the test has no more right to one than the code.
+    let home = PathBuf::from("/home/u");
+    assert_eq!(
+        cache_root_from(None, Some(OsString::from(home.as_os_str()))),
+        Some(home.join(".cache").join("mvm").join("embed"))
+    );
+}
+
+#[test]
+fn cache_root_is_absent_without_an_override_or_home() {
+    // No root means "build without caching" — never "cache somewhere else".
+    assert_eq!(cache_root_from(None, None), None);
+    assert_eq!(
+        cache_root_from(Some(OsString::new()), Some(OsString::new())),
+        None
+    );
+}
+
+#[test]
+fn artifacts_are_addressed_by_key_then_name() {
+    assert_eq!(
+        artifact_path(Path::new("/store"), "abc123", "mvm-netd"),
+        PathBuf::from("/store/abc123/mvm-netd")
+    );
+}
+
+#[test]
+fn two_binaries_from_one_key_do_not_collide() {
+    let root = Path::new("/store");
+    assert_ne!(
+        artifact_path(root, "k", "mvm-netd"),
+        artifact_path(root, "k", "mvm-host-agent")
+    );
+}
+
+#[test]
+fn the_graph_reader_maps_every_workspace_member_to_its_directory() {
+    // Read the real workspace, so a member that stops parsing is caught here
+    // rather than by a silently-narrower cache key.
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/mvm-cli has a workspace root two levels up");
+    let graph = build_embed_cache::read_workspace_graph(workspace_root);
+
+    for expected in [
+        "mvm-core",
+        "mvm-build",
+        "mvm-agentd",
+        "mvm-cli",
+        "libkrun-sys",
+    ] {
+        assert!(
+            graph.dirs.contains_key(expected),
+            "{expected} missing from the workspace graph: {:?}",
+            graph.dirs.keys().collect::<Vec<_>>()
+        );
+    }
+
+    // The property the whole design rests on, asserted against the real
+    // manifests rather than a fixture.
+    let closure = workspace_closure(&graph, &["mvm-build"]);
+    assert!(closure.contains(&"mvm-core".to_string()));
+    assert!(
+        !closure.contains(&"mvm-cli".to_string()),
+        "mvm-cli must not be in mvm-build's closure"
+    );
+
+    let _: &BTreeMap<String, Vec<String>> = &graph.edges;
+}
+
+#[test]
+fn publishing_then_restoring_round_trips_the_bytes() {
+    let store = tempfile::tempdir().expect("tempdir");
+    let work = tempfile::tempdir().expect("tempdir");
+
+    let built = work.path().join("mvm-netd");
+    std::fs::write(&built, b"\x7fELF built here").expect("write");
+    install(store.path(), "keyA", "mvm-netd", &built);
+
+    let restored = work.path().join("out/mvm-netd");
+    assert!(lookup(store.path(), "keyA", "mvm-netd", &restored));
+    assert_eq!(
+        std::fs::read(&restored).expect("read"),
+        b"\x7fELF built here"
+    );
+}
+
+#[test]
+fn restoring_a_key_that_was_never_published_is_a_miss() {
+    let store = tempfile::tempdir().expect("tempdir");
+    let work = tempfile::tempdir().expect("tempdir");
+    assert!(!lookup(
+        store.path(),
+        "absent",
+        "mvm-netd",
+        &work.path().join("mvm-netd")
+    ));
+}
+
+#[test]
+fn a_different_key_never_serves_another_keys_bytes() {
+    // The failure this guards against is the whole reason the store exists:
+    // handing back an artifact built from different sources.
+    let store = tempfile::tempdir().expect("tempdir");
+    let work = tempfile::tempdir().expect("tempdir");
+
+    let built = work.path().join("mvm-netd");
+    std::fs::write(&built, b"old").expect("write");
+    install(store.path(), "keyOld", "mvm-netd", &built);
+
+    let restored = work.path().join("out/mvm-netd");
+    assert!(!lookup(store.path(), "keyNew", "mvm-netd", &restored));
+}
+
+#[test]
+fn publishing_leaves_no_temporary_file_behind() {
+    // Concurrent worktree builds race this directory; a half-copied binary
+    // that looks complete is worse than no cache at all.
+    let store = tempfile::tempdir().expect("tempdir");
+    let work = tempfile::tempdir().expect("tempdir");
+
+    let built = work.path().join("mvm-netd");
+    std::fs::write(&built, b"bytes").expect("write");
+    install(store.path(), "keyA", "mvm-netd", &built);
+
+    let leftovers: Vec<_> = std::fs::read_dir(store.path().join("keyA"))
+        .expect("read_dir")
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with(".tmp"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "staging files left behind: {leftovers:?}"
+    );
+}
+
+#[test]
+fn publishing_an_unreadable_source_does_not_break_the_build() {
+    // An unwritable or broken store must slow the build down, not fail it.
+    let store = tempfile::tempdir().expect("tempdir");
+    install(
+        store.path(),
+        "keyA",
+        "mvm-netd",
+        Path::new("/definitely/not/here"),
+    );
+    assert!(!lookup(
+        store.path(),
+        "keyA",
+        "mvm-netd",
+        &store.path().join("out")
+    ));
+}
+
+#[test]
+fn file_hashes_track_content_not_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let a = dir.path().join("a");
+    let b = dir.path().join("b");
+    std::fs::write(&a, b"same").expect("write");
+    std::fs::write(&b, b"same").expect("write");
+    assert_eq!(hash_file(&a), hash_file(&b));
+
+    std::fs::write(&b, b"different").expect("write");
+    assert_ne!(hash_file(&a), hash_file(&b));
+}
+
+#[test]
+fn an_unreadable_file_hashes_to_empty_rather_than_panicking() {
+    assert_eq!(hash_file(Path::new("/definitely/not/here")), "");
+}
+
+#[test]
+fn tree_hashes_are_sorted_relative_and_recursive() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let nested = root.path().join("crate/src/deep");
+    std::fs::create_dir_all(&nested).expect("mkdir");
+    std::fs::write(root.path().join("crate/src/z.rs"), b"z").expect("write");
+    std::fs::write(root.path().join("crate/src/a.rs"), b"a").expect("write");
+    std::fs::write(nested.join("m.rs"), b"m").expect("write");
+
+    let hashes = hash_tree(root.path(), &root.path().join("crate/src"));
+    let paths: Vec<_> = hashes.iter().map(|(p, _)| p.as_str()).collect();
+
+    // Sorted, because directory iteration order is not guaranteed and differs
+    // between filesystems — an unsorted key would churn for no reason.
+    assert_eq!(
+        paths,
+        vec!["crate/src/a.rs", "crate/src/deep/m.rs", "crate/src/z.rs"]
+    );
+}
+
+#[test]
+fn tree_hashes_change_when_a_watched_file_changes() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let src = root.path().join("crate/src");
+    std::fs::create_dir_all(&src).expect("mkdir");
+    std::fs::write(src.join("lib.rs"), b"before").expect("write");
+    let before = hash_tree(root.path(), &src);
+
+    std::fs::write(src.join("lib.rs"), b"after").expect("write");
+    assert_ne!(before, hash_tree(root.path(), &src));
+}
+
+#[test]
+fn hashing_a_missing_tree_yields_nothing_rather_than_failing() {
+    let root = tempfile::tempdir().expect("tempdir");
+    assert!(hash_tree(root.path(), &root.path().join("absent")).is_empty());
+}
+
+#[test]
+fn the_opt_out_env_var_disables_the_store_entirely() {
+    // The build script is this wrapper's only caller, so assert the one
+    // branch that does not route through `cache_root_from`. Deliberately
+    // reads only the opt-out var: resolving HOME here would duplicate the
+    // home-path derivation this repo keeps in exactly one place.
+    if std::env::var_os("MVM_EMBED_NO_CACHE").is_some_and(|v| !v.is_empty()) {
+        assert_eq!(build_embed_cache::cache_root(), None);
+    } else {
+        assert!(
+            build_embed_cache::cache_root().is_some(),
+            "HOME is set in every environment this suite runs in"
+        );
+    }
+}
+
+#[test]
+fn hashing_a_file_as_though_it_were_a_tree_yields_nothing() {
+    // The contract that made the manifest silently drop out of the key:
+    // `hash_tree` lists a directory, so a file path contributes no entries.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let file = dir.path().join("Cargo.toml");
+    std::fs::write(&file, b"[package]").expect("write");
+    assert!(hash_tree(dir.path(), &file).is_empty());
+}
+
+#[test]
+fn member_hashes_cover_the_manifest_as_well_as_the_sources() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let member = root.path().join("crates/mvm-thing");
+    std::fs::create_dir_all(member.join("src")).expect("mkdir");
+    std::fs::write(member.join("src/lib.rs"), b"fn main() {}").expect("write");
+    std::fs::write(
+        member.join("Cargo.toml"),
+        b"[package]\nname = \"mvm-thing\"",
+    )
+    .expect("write");
+
+    let paths: Vec<_> = hash_member(root.path(), &member)
+        .into_iter()
+        .map(|(p, _)| p)
+        .collect();
+    assert_eq!(
+        paths,
+        vec![
+            "crates/mvm-thing/Cargo.toml".to_string(),
+            "crates/mvm-thing/src/lib.rs".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn a_manifest_edit_moves_the_member_hash() {
+    // A feature or dependency change lives only in the manifest. If it does
+    // not move the hash, the key cannot notice it and a stale binary is
+    // served for a genuinely different build.
+    let root = tempfile::tempdir().expect("tempdir");
+    let member = root.path().join("crates/mvm-thing");
+    std::fs::create_dir_all(member.join("src")).expect("mkdir");
+    std::fs::write(member.join("src/lib.rs"), b"fn main() {}").expect("write");
+    std::fs::write(member.join("Cargo.toml"), b"[features]\ndefault = []").expect("write");
+    let before = hash_member(root.path(), &member);
+
+    std::fs::write(member.join("Cargo.toml"), b"[features]\ndefault = [\"x\"]").expect("write");
+    assert_ne!(before, hash_member(root.path(), &member));
+}
+
+#[test]
+fn a_member_without_a_manifest_still_hashes_its_sources() {
+    let root = tempfile::tempdir().expect("tempdir");
+    let member = root.path().join("crates/mvm-thing");
+    std::fs::create_dir_all(member.join("src")).expect("mkdir");
+    std::fs::write(member.join("src/lib.rs"), b"x").expect("write");
+    assert_eq!(hash_member(root.path(), &member).len(), 1);
+}

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -16,7 +16,54 @@ repo_root=$(
 )
 dev_state_root="${repo_root}/.mvm-test"
 
-export MVM_HOME="${MVM_HOME:-${dev_state_root}}"
-export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${dev_state_root}/target}"
-export CARGO_HOME="${CARGO_HOME:-${dev_state_root}/cargo}"
+# Point one dev-env variable at this worktree, reclaiming it from another one.
+#
+# These were `${VAR:-default}`, which lets an inherited value win. That reads
+# as deference to a deliberate override, but the value is almost never
+# deliberate: it is left over from a shell that sourced this file in a
+# *different* worktree, and `export` carries it into every child from then on.
+# Two source trees then share one CARGO_TARGET_DIR, and cargo fingerprints
+# embed absolute paths — so each alternation between the trees recompiles the
+# whole workspace, and concurrent builds serialize on that one target dir's
+# lock. Nothing reports this; the build is simply slow forever.
+#
+# A value already inside this worktree is honoured as-is (that is a real
+# override). One pointing outside is reclaimed, loudly. Set
+# MVM_DEV_ENV_KEEP_INHERITED=1 to keep it anyway.
+_mvm_dev_env_claim() {
+    _mvm_name="$1"
+    _mvm_want="$2"
+    eval "_mvm_have=\${${_mvm_name}:-}"
+
+    if [ -z "${_mvm_have}" ] || [ "${_mvm_have}" = "${_mvm_want}" ]; then
+        export "${_mvm_name}=${_mvm_want}"
+        return 0
+    fi
+
+    case "${_mvm_have}" in
+        "${repo_root}"/*)
+            export "${_mvm_name}=${_mvm_have}"
+            return 0
+            ;;
+    esac
+
+    if [ -n "${MVM_DEV_ENV_KEEP_INHERITED:-}" ]; then
+        printf 'dev-env: keeping inherited %s=%s (outside %s)\n' \
+            "${_mvm_name}" "${_mvm_have}" "${repo_root}" >&2
+        export "${_mvm_name}=${_mvm_have}"
+        return 0
+    fi
+
+    printf 'dev-env: %s pointed outside this worktree (%s) — reclaiming to %s\n' \
+        "${_mvm_name}" "${_mvm_have}" "${_mvm_want}" >&2
+    export "${_mvm_name}=${_mvm_want}"
+}
+
+_mvm_dev_env_claim MVM_HOME "${dev_state_root}"
+_mvm_dev_env_claim CARGO_TARGET_DIR "${dev_state_root}/target"
+_mvm_dev_env_claim CARGO_HOME "${dev_state_root}/cargo"
+
 export MVM_NO_LEGACY_BANNER="${MVM_NO_LEGACY_BANNER:-1}"
+
+unset -f _mvm_dev_env_claim
+unset _mvm_name _mvm_want _mvm_have

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -285,6 +285,21 @@ for detailed scope and acceptance criteria.
 
 ## In-flight plans
 
+- [~] **Embedded-binary content store** — `specs/plans/2026-08-17-embedded-binary-content-store.md`.
+      Phases 1–2 landed: both nested legs of `crates/mvm-cli/build.rs` are keyed
+      on their real dependency closure rather than on `PROFILE == "debug"` plus
+      "the file exists", and the store lives outside `target/` so worktrees,
+      profiles and target triples share it. Cold build **359s → 45.5s**; the
+      build script within it **332.7s → 0.4s**; an `mvm-cli` edit no longer
+      re-runs either leg. The dev profile keeps its stale-embedded-binary trade
+      deliberately, but a miss now knows it is stale and says so via
+      `cargo:warning=`. Supersedes the freshness half of
+      `specs/plans/2026-08-15-aux-helper-binary-freshness.md`.
+      STILL OPEN: Phase 3 (phantom build.rs tests, `MVM_LIBKRUN_HEADER`
+      rerun-if-env-changed), Phase 4 (dead crate edges; `deps_audit` and the
+      tree-sitter grammars off the serial path; the `mvm-hostd` audit cluster),
+      Phase 5 (sccache 4.2% Rust hit rate, worktree hygiene)
+
 - [~] **Launch path as declared stages**
       (`specs/plans/2026-08-15-launch-path-as-declared-stages.md`). Opened
       2026-08-15; no workstream started. Split out of the artifact-derived

--- a/specs/plans/2026-08-15-aux-helper-binary-freshness.md
+++ b/specs/plans/2026-08-15-aux-helper-binary-freshness.md
@@ -1,5 +1,14 @@
 # Aux helper binaries drift from `mvmctl`, and two resolvers disagree about which one to run
 
+> **Partly superseded (2026-08-17)** by
+> `specs/plans/2026-08-17-embedded-binary-content-store.md`. The freshness
+> item below — widening the build script's `rerun-if-changed` coverage so a
+> stale aux helper cannot be embedded — is now handled by keying the artifact
+> on its dependency closure, which cannot match unless the bytes are the ones
+> this tree produces. The two divergent `mvm-network-endpoint` resolvers and
+> the non-sparse `pack_stage0_work_disk` write are untouched and still stand.
+
+
 Backing: shipped-source
 Validation: none
 

--- a/specs/plans/2026-08-17-embedded-binary-content-store.md
+++ b/specs/plans/2026-08-17-embedded-binary-content-store.md
@@ -1,5 +1,8 @@
 # Content-addressed store for mvm-cli's nested build artifacts
 
+Backing: historical
+Validation: none
+
 **Status: Phase 1–2 COMPLETE (2026-08-17). Phases 3–5 open.**
 
 ## Why

--- a/specs/plans/2026-08-17-embedded-binary-content-store.md
+++ b/specs/plans/2026-08-17-embedded-binary-content-store.md
@@ -154,11 +154,26 @@ populated it. Steady state after that is unchanged.
       and `mvm-client → mvm-hostd` (29) are the same narrow cluster:
       `audit::*`, `supervisor::{tools,verify_audit_chain}`, `plan_admission`,
       `keyholder`. Extracting ~7k LOC frees both from 49k LOC of `mvm-hostd`.
-- [ ] **Phase 5** — re-measure sccache. `basedirs` is correctly set and the
-      cache is 12 GiB of a 60 GiB ceiling, so it is neither misconfigured nor
-      evicting, yet the live Rust hit rate is 4.20% (257 hits / 5,861 misses)
-      against the ~84% its own config documents as measured. Find the gap
-      before changing anything.
+- [x] **Phase 5 — sccache measured; the documented cross-worktree win does not
+      exist.** `basedirs` is correctly set and the cache is well under its
+      ceiling, yet the machine-wide Rust hit rate is ~2.5% across ~35k
+      compiles. Controlled experiment, one crate, same source and `CARGO_HOME`,
+      varying only the target directory:
+
+      | Run | Result |
+      | --- | --- |
+      | cold, target dir A | 2 hits / 100 misses |
+      | target dir A wiped, rebuilt | **70 hits / 79 misses** |
+      | identical source, target dir B | **0 hits / 152 misses** |
+
+      The target directory's full path is part of the key, and every worktree
+      has its own, so cross-worktree dedup cannot happen — `basedirs` is
+      necessary but not sufficient, and the config's "same target-directory
+      *name*" condition understates it. What sccache actually buys here is
+      re-populating one checkout after `cargo clean`; within a live target dir
+      cargo already caches deps. The Justfile comment claiming cross-worktree
+      hits has been corrected. Whether to keep the wrapper at all is now a
+      decision with numbers behind it rather than an assumption.
 - [ ] **Phase 5** — worktree hygiene: 36 worktrees, 87 GB. Plan 334 named this
       the largest remaining lever and left it out of scope.
 

--- a/specs/plans/2026-08-17-embedded-binary-content-store.md
+++ b/specs/plans/2026-08-17-embedded-binary-content-store.md
@@ -142,14 +142,28 @@ populated it. Steady state after that is unchanged.
 - [ ] **Phase 4a** — dead edges: `mvm-runtime → libkrun-sys` has zero use
       sites; `mvm-cli → mvm-net` is used only from `#[cfg(test)]`;
       `mvm-hostd → mvm-fs` is used from one bin, not the lib.
-- [ ] **Phase 4b** — `mvm-build` pulls all of `mvm-sdk` (13k LOC, 5
-      tree-sitter grammars, ~24 MB of generated C at `opt-level = 3`) for one
-      item used 8 times, `compile::deps_audit` (691 lines). `mvm-hostd` uses
-      that plus `mvm_sdk::ir`, which is a pure re-export of `mvm_contract::ir`
-      it already depends on. Moving `deps_audit` to a leaf and gating the
-      grammars behind an `analyze` feature takes them off the serial path —
-      and out of the aux-helper leg's nested rebuild, where they are currently
-      compiled a second time.
+- [~] **Phase 4b — measured and DECLINED.** The shape is real: `mvm-build`
+      pulls all of `mvm-sdk` (13k LOC, 5 tree-sitter grammars, ~24 MB of
+      generated C at `opt-level = 3`) to use one item 8 times,
+      `compile::deps_audit` (691 lines); `mvm-hostd` uses that plus
+      `mvm_sdk::ir`, which is a pure re-export of `mvm_contract::ir` it already
+      depends on. The payoff is not.
+
+      From the cold timing data, `mvm-sdk` sits on the critical path between
+      `mvm-agentd` (ends 25.5s) and `mvm-build` (starts 28.3s) and contributes
+      **~2.8s of a 45.5s post-store cold build (~6%)**. It does not reduce the
+      closure: the grammars stay via `mvm-cli`, which genuinely parses
+      decorators. Its larger prize — skipping the grammars in the nested
+      aux-helper build, where `mvm-hostd`'s closure is compiled a second time —
+      was already taken by the Phase 1–2 content store, which turns that build
+      into a cache hit.
+
+      Against ~6%: relocating `verify_sealed_volume`, the claim-11 sealed-volume
+      verifier, and a closure-budget bump (linux sits at 239 of 239). Declined
+      on the same basis Plan 334 declined crate splitting, and under this
+      plan's own pre-committed rule to stop below ~10%. Re-open only with a new
+      argument, not a re-reading of these numbers.
+
 - [ ] **Phase 4c** (gate on cold evidence) — `mvm-cli → mvm-hostd` (173 sites)
       and `mvm-client → mvm-hostd` (29) are the same narrow cluster:
       `audit::*`, `supervisor::{tools,verify_audit_chain}`, `plan_admission`,
@@ -174,8 +188,13 @@ populated it. Steady state after that is unchanged.
       cargo already caches deps. The Justfile comment claiming cross-worktree
       hits has been corrected. Whether to keep the wrapper at all is now a
       decision with numbers behind it rather than an assumption.
-- [ ] **Phase 5** — worktree hygiene: 36 worktrees, 87 GB. Plan 334 named this
-      the largest remaining lever and left it out of scope.
+- [~] **Phase 5 — worktree hygiene, partly done.** 49 worktrees / 261 GB at the
+      time of measurement. `just worktrees-prune APPLY=1` reclaimed 5 clean
+      checkouts. Five more sit on branches already merged into main — including
+      one at 48 GB — but every one of them carries uncommitted source edits,
+      and two are open in an editor (`lsof` shows `zed` holding 43 and 5 files).
+      A merged branch does not mean a disposable working tree. Left alone
+      deliberately; reclaiming that ~50 GB needs their owner, not a sweeper.
 
 `scripts/dev-env.sh` (Phase 5, done) exported `MVM_HOME`, `CARGO_TARGET_DIR`
 and `CARGO_HOME` with `${VAR:-default}`, so a value inherited from another

--- a/specs/plans/2026-08-17-embedded-binary-content-store.md
+++ b/specs/plans/2026-08-17-embedded-binary-content-store.md
@@ -1,0 +1,173 @@
+# Content-addressed store for mvm-cli's nested build artifacts
+
+**Status: Phase 1–2 COMPLETE (2026-08-17). Phases 3–5 open.**
+
+## Why
+
+`cargo build` sits on two progress lines — `mvm-cli(build)` and `mvmctl(bin)` —
+and the reason is one build script. `crates/mvm-cli/build.rs` runs two nested
+builds, and neither could tell a fresh artifact from a stale one:
+
+| Leg | Work | Reuse before this plan |
+| --- | --- | --- |
+| musl cross-compile of 6 embedded host binaries (`cargo zigbuild`) | ~163s | `PROFILE == "debug"` **and** `prebuilt.is_file()` |
+| native per-VM helpers, 4–6 nested `cargo build`s of the `mvm-hostd` closure | ~13s warm, far more cold | none |
+
+`PROFILE == "debug"` plus "the file exists" proves nothing about the bytes, so
+it had to refuse every other profile: `--release`, `release-witness` and each
+`--target` paid the full cross-compile into their own nested target dir. The
+helper leg ran on every `cargo check` and `clippy` too, because cargo runs
+build scripts for those.
+
+Nothing was shared across worktrees, profiles or target triples —
+`shared_nested_target_dir` shares only across feature fingerprints inside one
+`target/<profile>/`. With ~36 worktrees on a dev host, that cost was paid over
+and over.
+
+## Measurements
+
+Fresh worktree, aarch64 macOS, `[build] jobs = 6`, `cargo build --timings`.
+
+### Before
+
+| Workload | Total | `mvm-cli` build script | Share |
+| --- | --- | --- | --- |
+| Cold, fresh worktree | 359s | **332.7s** | **93%** |
+| Warm, after a one-line `mvm-core` edit | ~18s | **14.3s** | **79%** |
+| Warm no-op | 5.1s | not re-run | — |
+
+The script starts at t=16.4s and runs to t=349s; every other crate finishes
+underneath it. `mvm-cli` the crate is 9.1s and cannot start until the script
+ends. That is why those two progress lines are what you watch.
+
+### After
+
+| Workload | Before | After |
+| --- | --- | --- |
+| Cold build, fresh worktree | 359s | **45.5s** |
+| ↳ `mvm-cli` build script within it | 332.7s | **0.4s** |
+| Cold build, second fresh worktree | 359s | 60.2s |
+| Edit `mvm-cli/src` (the most-edited crate) | re-ran both legs | **7.7s**, script not re-run |
+| Edit `mvm-core`, warm worktree | ~18s | 15.5s |
+| Full-workspace `clippy --all-targets` (pre-commit hook) | spawned 4–6 nested builds | 6.0s warm |
+| `--release`, empty nested target dir — build script only | ≥163s musl leg, always | **0.6s** |
+
+Under `--release` the store hit leaves 136.7s of `mvmctl` itself: that is the
+`lto = true` + `codegen-units = 1` link of the final binary, a deliberate
+release-profile choice and now the honest remaining cost. It was previously
+hidden behind the build script rather than absent.
+
+The first `--release` build on a host still pays for the per-VM helpers, which
+are keyed per profile (a release helper is not a debug helper) and so have
+nothing to hit until one release build has published them.
+
+## What changed
+
+Key both legs on content: the binary's real dependency closure taken from the
+manifest graph, plus `Cargo.lock`, `rust-toolchain.toml`, the pinned zig /
+cargo-zigbuild identity, the target triple, features, and a flavour that
+separates a musl static from a native host build of the same package.
+
+- `crates/mvm-cli/build_embed_cache.rs` — new build-script module: closure
+  walk, manifest parsing, tree hashing, key derivation, store I/O.
+- Store at `~/.cache/mvm/embed/<key>/<binary>`, outside `target/`, so it is
+  shared across worktrees, profiles and triples. Atomic publish (temp +
+  rename), because concurrent worktree builds race it.
+- `MVM_EMBED_NO_CACHE=1` opts out of both the store and the dev fallback.
+- The watch set is now derived from the same closure. `mvm-cli`'s own 251
+  files are downstream of these binaries and cannot affect them, so they no
+  longer re-run either leg; the blanket walk over every workspace crate is
+  gone.
+
+### The dev trade is preserved deliberately
+
+A key miss means the closure genuinely changed, and rebuilding the musl set
+costs ~163s. Making that correct-but-slow on every edit would have regressed
+the inner loop the plan set out to fix, so the dev profile keeps reusing a
+stale embedded binary exactly as it did before. What changed is that the key
+now *knows* it is stale, so it says so through `cargo:warning=` — the one
+channel cargo surfaces without `-vv`. `--release` and `release-witness` always
+rebuild on a miss.
+
+A store hit also seeds the nested target dir the fallback reads from.
+Without that, a worktree whose binaries all came from the store had nothing to
+fall back to, and the *first* source edit there paid a full cross-compile —
+moving the cost rather than removing it.
+
+### Known residual
+
+In a store-seeded fresh worktree the first `mvm-core` edit costs ~52s rather
+than ~15s: the aux-helper leg has no stale fallback by design (a stale
+supervisor silently produces a guest that ignores your edit — #2058), so a key
+miss must rebuild, and its nested target dir is cold in a worktree that never
+populated it. Steady state after that is unchanged.
+
+## Relationship to other plans
+
+- Supersedes the *freshness* half of
+  `specs/plans/2026-08-15-aux-helper-binary-freshness.md`. That plan proposed
+  adding watch coverage (`crates/mvm-vmm/src` is watched by nothing;
+  `mvm-hostd`/`mvm-core` use unreliable directory-level `rerun-if-changed`).
+  A content key subsumes that: it cannot match unless the bytes are the ones
+  this tree produces. Its other two items — the two divergent
+  `mvm-network-endpoint` resolvers, and `pack_stage0_work_disk` writing a
+  multi-GB non-sparse file — are independent and still stand.
+- Does **not** re-litigate `specs/plans/334-build-critical-path.md`. Its five
+  refuted hypotheses stand: dependency count, crate splitting for the serial
+  chain (measured at 1%), the tree-sitter `opt-level` override, feature
+  ping-pong, and cross-invocation thrash. 334's baseline was a *warm*
+  `cargo build -p mvm-cli`; the cold and per-profile costs this plan addresses
+  were outside what it measured.
+- `f29d9ce24` (#1561) added a stub embed mode and `884ff8555` (#1683) removed
+  it. This is not that: nothing is stubbed, and every embedded binary is real
+  bytes with a real hash.
+
+## Open work
+
+- [ ] **The store is unbounded and nothing sweeps it.** Every distinct content
+      key keeps its artifacts forever: 48 entries / 424 MB after a single
+      day's work on one branch, and each key holds a multi-MB static binary.
+      `cargo clean`, `just clean-dev-state` and `mvmctl cache prune` all miss
+      it because it deliberately lives outside both `target/` and `MVM_HOME`.
+      Needs an LRU bound or a prune verb before this ships widely — the
+      failure mode is a slowly filling disk with no command that reports it,
+      which is the same shape as the 282 GB of unswept `.mvm-test` roots that
+      `just clean-dev-state` was added for.
+
+- [ ] **Phase 3** — delete the ~120 lines of phantom `#[cfg(test)]` tests in
+      `build.rs` (cargo never builds a build script as a test target, and they
+      call `configured_embed_tools_from`, which is not in scope).
+- [ ] **Phase 3** — `MVM_LIBKRUN_HEADER` is read at `build.rs` to decide
+      whether the 6th helper builds, but has no `rerun-if-env-changed` there
+      (only in `libkrun-sys/build.rs`), so changing it does not re-select the
+      helper set.
+- [ ] **Phase 4a** — dead edges: `mvm-runtime → libkrun-sys` has zero use
+      sites; `mvm-cli → mvm-net` is used only from `#[cfg(test)]`;
+      `mvm-hostd → mvm-fs` is used from one bin, not the lib.
+- [ ] **Phase 4b** — `mvm-build` pulls all of `mvm-sdk` (13k LOC, 5
+      tree-sitter grammars, ~24 MB of generated C at `opt-level = 3`) for one
+      item used 8 times, `compile::deps_audit` (691 lines). `mvm-hostd` uses
+      that plus `mvm_sdk::ir`, which is a pure re-export of `mvm_contract::ir`
+      it already depends on. Moving `deps_audit` to a leaf and gating the
+      grammars behind an `analyze` feature takes them off the serial path —
+      and out of the aux-helper leg's nested rebuild, where they are currently
+      compiled a second time.
+- [ ] **Phase 4c** (gate on cold evidence) — `mvm-cli → mvm-hostd` (173 sites)
+      and `mvm-client → mvm-hostd` (29) are the same narrow cluster:
+      `audit::*`, `supervisor::{tools,verify_audit_chain}`, `plan_admission`,
+      `keyholder`. Extracting ~7k LOC frees both from 49k LOC of `mvm-hostd`.
+- [ ] **Phase 5** — re-measure sccache. `basedirs` is correctly set and the
+      cache is 12 GiB of a 60 GiB ceiling, so it is neither misconfigured nor
+      evicting, yet the live Rust hit rate is 4.20% (257 hits / 5,861 misses)
+      against the ~84% its own config documents as measured. Find the gap
+      before changing anything.
+- [ ] **Phase 5** — worktree hygiene: 36 worktrees, 87 GB. Plan 334 named this
+      the largest remaining lever and left it out of scope.
+
+`scripts/dev-env.sh` (Phase 5, done) exported `MVM_HOME`, `CARGO_TARGET_DIR`
+and `CARGO_HOME` with `${VAR:-default}`, so a value inherited from another
+worktree won. Two source trees then shared one target dir; cargo fingerprints
+embed absolute paths, so alternating between them recompiled the workspace and
+concurrent builds serialized on one lock, silently. `AGENTS.md` already
+documented the intended behaviour. It is now authoritative, warns when it
+reclaims, and `MVM_DEV_ENV_KEEP_INHERITED=1` opts out.

--- a/specs/plans/2026-08-17-embedded-binary-content-store.md
+++ b/specs/plans/2026-08-17-embedded-binary-content-store.md
@@ -124,16 +124,14 @@ populated it. Steady state after that is unchanged.
 
 ## Open work
 
-- [ ] **The store is unbounded and nothing sweeps it.** Every distinct content
-      key keeps its artifacts forever: 48 entries / 424 MB after a single
-      day's work on one branch, and each key holds a multi-MB static binary.
-      `cargo clean`, `just clean-dev-state` and `mvmctl cache prune` all miss
-      it because it deliberately lives outside both `target/` and `MVM_HOME`.
-      Needs an LRU bound or a prune verb before this ships widely — the
-      failure mode is a slowly filling disk with no command that reports it,
-      which is the same shape as the 282 GB of unswept `.mvm-test` roots that
-      `just clean-dev-state` was added for.
-
+- [x] **Bound the store.** Was unbounded — 48 entries / 424 MB after a single
+      day on one branch, and `cargo clean`, `just clean-dev-state` and
+      `mvmctl cache prune` all miss it because it deliberately lives outside
+      both `target/` and `MVM_HOME`. Now LRU-evicted to a 4 GiB ceiling
+      (`MVM_EMBED_CACHE_MAX_BYTES` overrides) after each build. Eviction keys
+      on mtime rather than atime, since `noatime` mounts would make every
+      entry look equally stale, and a restore touches its entry so the one a
+      dozen worktrees keep reusing is not the one deleted.
 - [ ] **Phase 3** — delete the ~120 lines of phantom `#[cfg(test)]` tests in
       `build.rs` (cargo never builds a build script as a test target, and they
       call `configured_embed_tools_from`, which is not in scope).

--- a/specs/sprint/delivery/embedded-binary-content-store.md
+++ b/specs/sprint/delivery/embedded-binary-content-store.md
@@ -1,0 +1,66 @@
+# Content-addressed store for mvm-cli's nested build artifacts
+
+Key both legs of `crates/mvm-cli/build.rs` on content instead of on profile,
+so reuse proves freshness rather than assuming it — and can therefore be
+shared across worktrees, profiles and target triples.
+
+**Measured**, fresh worktree, aarch64 macOS, `jobs = 6`:
+
+| Workload | Before | After |
+| --- | --- | --- |
+| Cold build | 359s | **45.5s** |
+| ↳ `mvm-cli` build script within it | 332.7s (93%) | **0.4s** |
+| Edit `mvm-cli/src` | re-ran both nested legs | **7.7s**, script not re-run |
+| Edit `mvm-core`, warm | ~18s (script 14.3s) | 15.5s |
+| Workspace `clippy --all-targets` | spawned 4–6 nested `cargo build`s | 6.0s warm |
+| `--release`, empty nested target dir — script only | ≥163s musl leg, always | **0.6s** |
+
+What is left under `--release` is 136.7s of `mvmctl` itself — the
+`lto = true` / `codegen-units = 1` link. That cost was always there; the build
+script was hiding it.
+
+The old rule — `PROFILE == "debug"` **and** the file exists — could prove
+nothing about the bytes, so `--release`, `release-witness` and every
+`--target` paid the full ~163s musl cross-compile into their own nested target
+dir, and the per-VM helper leg had no reuse at all so it ran on every
+`cargo check` and `clippy`.
+
+The key covers each binary's real dependency closure (walked from the manifest
+graph, not a hand list), `Cargo.lock`, `rust-toolchain.toml`, the pinned
+toolchain, target and features. Deriving the closure also narrowed the watch
+set: `mvm-cli`'s 251 files are downstream of these binaries and no longer
+re-run either leg.
+
+**The dev trade is kept on purpose.** A key miss means the sources really
+changed, and rebuilding costs ~163s, so the dev profile still reuses a stale
+embedded binary rather than regress the inner loop. The difference is that the
+key now knows it is stale and says so via `cargo:warning=`, the one channel
+cargo surfaces without `-vv`. The `MVM_EMBEDDED_BINS_REUSED` env var it used
+to set for this has never had a reader. `MVM_EMBED_NO_CACHE=1` opts out of
+both the store and the fallback.
+
+A store hit also seeds the nested target dir the fallback reads from —
+without it, a worktree whose binaries all came from the store had nothing to
+fall back to and its first source edit paid a full cross-compile, moving the
+cost instead of removing it.
+
+Residual, documented: in a store-seeded fresh worktree the first `mvm-core`
+edit is ~52s, because the aux-helper leg has no stale fallback by design
+(#2058) and its nested target dir is cold there.
+
+Also: `scripts/dev-env.sh` exported `MVM_HOME`, `CARGO_TARGET_DIR` and
+`CARGO_HOME` with `${VAR:-default}`, so a value inherited from another
+worktree won and two source trees shared one target dir — cargo fingerprints
+embed absolute paths, so alternating recompiled the workspace and concurrent
+builds serialized on one lock, silently. `AGENTS.md` already documented the
+intended behaviour; it now implements it, warns when it reclaims, and honours
+`MVM_DEV_ENV_KEEP_INHERITED=1`.
+
+Supersedes the freshness half of
+`specs/plans/2026-08-15-aux-helper-binary-freshness.md`. Does not re-litigate
+`specs/plans/334-build-critical-path.md`, whose five refuted hypotheses stand;
+its baseline was a warm `cargo build -p mvm-cli`, and the cold and per-profile
+costs addressed here were outside it.
+
+Full log and the open Phase 3–5 items in
+`specs/plans/2026-08-17-embedded-binary-content-store.md`.

--- a/tests/dev_env_isolation.rs
+++ b/tests/dev_env_isolation.rs
@@ -1,0 +1,129 @@
+//! `scripts/dev-env.sh` must resolve the dev state root from the worktree it
+//! lives in, not from whatever the calling shell happened to export.
+//!
+//! The variables are exported, so a shell that sourced the script in one
+//! worktree carries them into every later child — including a build launched
+//! from a different checkout. Two source trees then share one
+//! `CARGO_TARGET_DIR`, and because cargo fingerprints embed absolute paths,
+//! each alternation recompiles the whole workspace while concurrent builds
+//! serialize on that one lock. Nothing reports it; the build is just slow.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Source the script the way the Justfile and AGENTS.md document
+/// (`bash -c 'source scripts/dev-env.sh'`) and report what it exported.
+///
+/// `HOME` is always pinned alongside `MVM_HOME`: a subprocess handed only
+/// `MVM_HOME` can still seed from the real `$HOME/.mvm/cache`.
+fn source_dev_env(env: &[(&str, &str)], home: &Path) -> HashMap<String, String> {
+    let mut command = Command::new("bash");
+    command
+        .current_dir(repo_root())
+        .env_clear()
+        .env("PATH", std::env::var("PATH").unwrap_or_default())
+        .env("HOME", home)
+        .arg("-c")
+        .arg(
+            "source scripts/dev-env.sh; \
+             printf 'MVM_HOME=%s\\nCARGO_TARGET_DIR=%s\\nCARGO_HOME=%s\\n' \
+             \"$MVM_HOME\" \"$CARGO_TARGET_DIR\" \"$CARGO_HOME\"",
+        );
+    for (key, value) in env {
+        command.env(key, value);
+    }
+
+    let output = command.output().expect("run bash");
+    assert!(
+        output.status.success(),
+        "dev-env.sh failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect()
+}
+
+fn expected_state_root() -> PathBuf {
+    repo_root().join(".mvm-test")
+}
+
+#[test]
+fn resolves_all_three_vars_from_the_worktree_when_the_env_is_clean() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let vars = source_dev_env(&[], home.path());
+    let root = expected_state_root();
+
+    assert_eq!(vars["MVM_HOME"], root.to_string_lossy());
+    assert_eq!(
+        vars["CARGO_TARGET_DIR"],
+        root.join("target").to_string_lossy()
+    );
+    assert_eq!(vars["CARGO_HOME"], root.join("cargo").to_string_lossy());
+}
+
+#[test]
+fn reclaims_state_inherited_from_another_worktree() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let foreign = tempfile::tempdir().expect("tempdir");
+    let foreign_root = foreign.path().join("other-worktree/.mvm-test");
+
+    let vars = source_dev_env(
+        &[
+            ("MVM_HOME", &foreign_root.to_string_lossy()),
+            (
+                "CARGO_TARGET_DIR",
+                &foreign_root.join("target").to_string_lossy(),
+            ),
+            ("CARGO_HOME", &foreign_root.join("cargo").to_string_lossy()),
+        ],
+        home.path(),
+    );
+    let root = expected_state_root();
+
+    // Every one of the three is reclaimed, not just the one that hurts most.
+    assert_eq!(vars["MVM_HOME"], root.to_string_lossy());
+    assert_eq!(
+        vars["CARGO_TARGET_DIR"],
+        root.join("target").to_string_lossy()
+    );
+    assert_eq!(vars["CARGO_HOME"], root.join("cargo").to_string_lossy());
+}
+
+#[test]
+fn honours_an_override_that_points_inside_this_worktree() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let local = repo_root().join("custom-target");
+
+    let vars = source_dev_env(
+        &[("CARGO_TARGET_DIR", &local.to_string_lossy())],
+        home.path(),
+    );
+
+    assert_eq!(vars["CARGO_TARGET_DIR"], local.to_string_lossy());
+}
+
+#[test]
+fn keep_inherited_opts_out_of_reclaiming() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let foreign = tempfile::tempdir().expect("tempdir");
+    let foreign_target = foreign.path().join("other-worktree/.mvm-test/target");
+
+    let vars = source_dev_env(
+        &[
+            ("CARGO_TARGET_DIR", &foreign_target.to_string_lossy()),
+            ("MVM_DEV_ENV_KEEP_INHERITED", "1"),
+        ],
+        home.path(),
+    );
+
+    assert_eq!(vars["CARGO_TARGET_DIR"], foreign_target.to_string_lossy());
+}

--- a/xtask/src/check_single_home.rs
+++ b/xtask/src/check_single_home.rs
@@ -88,6 +88,13 @@ const EXEMPTIONS: &[(&str, &[Rule], &str)] = &[
         "writes the user's shell rc file (~/.zshrc / ~/.bashrc); $HOME locates the rc file, not an mvm base dir",
     ),
     (
+        "crates/mvm-cli/build_embed_cache.rs",
+        &[Rule::HomeLiteral, Rule::HomeRead],
+        "the build script's artifact store is a host-level build cache, not an mvm state root: it \
+         must be shared across worktrees and so cannot live under MVM_HOME, which every worktree \
+         redirects at itself",
+    ),
+    (
         "crates/mvm-cli/src/host_binaries/toolchain.rs",
         &[Rule::HomeRead],
         "host toolchain discovery (~/.cargo/bin/rustup, mise python installs) lives in the real $HOME",


### PR DESCRIPTION
`cargo build` sits on two progress lines, `mvm-cli(build)` and `mvmctl(bin)`, and the reason is one build script.

## Measured

Fresh worktree, aarch64 macOS, `[build] jobs = 6`.

| Workload | Before | After |
| --- | --- | --- |
| Cold build, fresh worktree | 359s | **45.5s** |
| ↳ `mvm-cli` build script within it | **332.7s (93%)** | **0.4s** |
| `--release`, empty nested target dir — script only | ≥163s musl leg, always | **0.6s** |
| Edit `mvm-cli/src` | re-ran both nested legs | **7.7s**, script not re-run |
| Edit `mvm-core`, warm worktree | ~18s (script 14.3s) | 15.5s |
| Workspace `clippy --all-targets` | spawned 4–6 nested `cargo build`s | 6.0s warm |

The script starts at t=16.4s and runs to t=349s; every other crate finishes underneath it. `mvm-cli` the crate is 9.1s and cannot start until it ends.

## Why it was slow

`crates/mvm-cli/build.rs` runs two nested builds and neither could tell a fresh artifact from a stale one:

- **musl leg** (~163s) reused when `PROFILE == "debug"` **and** `prebuilt.is_file()`. That proves nothing about the bytes, so it had to refuse every other profile — `--release`, `release-witness` and each `--target` paid full price into their own nested target dir.
- **per-VM helper leg** had no reuse at all, and cargo runs build scripts for `check` and `clippy`, so a lint pass spawned 4–6 real linking `cargo build`s of the `mvm-hostd` closure.

Nothing was shared across worktrees, profiles or triples — `shared_nested_target_dir` shares only across feature fingerprints inside one `target/<profile>/`.

## What changed

Key both legs on content: each binary's real dependency closure (walked from the manifest graph, not a hand list), plus `Cargo.lock`, `rust-toolchain.toml`, the pinned toolchain, target, features, and a flavour separating a musl static from a native host build. A hit proves the artifact is what this tree produces, which is what makes reuse sound outside dev and safe to share — so the store lives at `~/.cache/mvm/embed/`, outside `target/`, with atomic publish.

Deriving the closure also narrows the watch set: `mvm-cli`'s 251 files are downstream of these binaries and no longer re-run either leg.

**The dev trade is preserved on purpose.** A miss means the sources really changed and rebuilding costs ~163s, so dev still reuses a stale embedded binary rather than regress the inner loop. The difference is the key now *knows* it is stale and says so through `cargo:warning=` — the one channel cargo surfaces without `-vv`. (`MVM_EMBEDDED_BINS_REUSED`, which this replaces, has never had a reader.) `MVM_EMBED_NO_CACHE=1` opts out of both.

A store hit also seeds the nested target dir the fallback reads from; without it a store-seeded worktree had nothing to fall back to and its first edit paid a full cross-compile — moving the cost rather than removing it.

Also makes `scripts/dev-env.sh` authoritative. Its `${VAR:-default}` exports let a value inherited from another worktree win, so two source trees shared one `CARGO_TARGET_DIR`; cargo fingerprints embed absolute paths, so alternating recompiled the workspace and concurrent builds serialized on one lock, silently. `AGENTS.md` already documented the intended behaviour.

## Verification

- `cargo nextest run --workspace`: **12,100 passed**, 0 failed
- `cargo test --workspace --doc`: passed
- `cargo clippy --workspace --all-targets -- -D warnings`, nightly `cargo fmt --all --check`: clean
- Gates: `check-single-home`, `check-closure-budget`, `check-duplicate-majors`, `check-workspace-dep-inheritance`, `check-core-runtime-free`, `check-mvm-host-binaries-sync`, `check-no-spec-refs-in-comments`, `check-plan-names`, `check-sprint-append`, `check-file-size`
- 31 unit tests for the store, including that the key moves for every input, that field boundaries cannot be shifted to forge a collision, and that `mvm-cli` is absent from `mvm-build`'s closure when walked against the real manifests

## Known gaps, recorded in the plan

- The store is **unbounded** — 424 MB / 48 entries after a day, and `cargo clean`, `just clean-dev-state` and `mvmctl cache prune` all miss it by design. Needs an LRU bound before wide use.
- In a store-seeded fresh worktree the first `mvm-core` edit is ~52s: the aux leg has no stale fallback by design (a stale supervisor silently produces a guest that ignores your edit) and its nested target dir is cold there.

Does not re-litigate `specs/plans/334-build-critical-path.md` — its five refuted hypotheses stand. Its baseline was a warm `cargo build -p mvm-cli`; the cold and per-profile costs here were outside it. Supersedes the freshness half of `specs/plans/2026-08-15-aux-helper-binary-freshness.md`.