### PR TITLE
fix(release): give the boot image jobs their toolchain, and refuse a partial publish

### DIFF
--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -66,8 +66,10 @@ jobs:
         include:
           - arch: aarch64
             runner: ubuntu-24.04-arm
+            musl_target: aarch64-unknown-linux-musl
           - arch: x86_64
             runner: ubuntu-latest
+            musl_target: x86_64-unknown-linux-musl
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -81,13 +83,34 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
+      - uses: ./.github/actions/install-zigbuild
+
+      # The builder-vm rootfs embeds the cross-compiled, statically
+      # musl-linked host-vm binaries, which the flake reads out of
+      # MVM_HOST_BIN_DIR at eval time under `--impure`. mvmctl normally
+      # extracts its embedded copy before invoking nix; nothing does that
+      # here, so the build has to produce them. Without this the eval dies
+      # with "MVM_HOST_BIN_DIR is not set" and the job publishes nothing —
+      # which is how the first boot-image release shipped with no builder-vm
+      # assets at all. Same recipe the reproducibility lanes in security.yml
+      # use, and the same one crates/mvm-cli/build.rs runs.
+      - name: Cross-compile host-vm binaries (MVM_HOST_BIN_DIR contract)
+        env:
+          MUSL_TARGET: ${{ matrix.musl_target }}
+        run: |
+          set -euo pipefail
+          cargo zigbuild --release --locked --target "$MUSL_TARGET" \
+            -p mvm-build --bin mvm-host-vm-init --bin mvm-egress-proxy \
+            --bin mvm-builderd
+          echo "MVM_HOST_BIN_DIR=$PWD/target/${MUSL_TARGET}/release" >> "$GITHUB_ENV"
+
       - name: Build builder VM image
         env:
           ARCH: ${{ matrix.arch }}
         run: |
           SYSTEM="${ARCH}-linux"
           nix build "./nix/images/builder-vm#packages.${SYSTEM}.default" \
-            --no-link --print-out-paths > /tmp/store-path.txt
+            --impure --no-link --print-out-paths > /tmp/store-path.txt
           STORE_PATH=$(head -1 /tmp/store-path.txt)
           echo "STORE_PATH=${STORE_PATH}" >> "$GITHUB_ENV"
           mkdir -p staging
@@ -455,6 +478,14 @@ jobs:
           sudo chmod 666 /dev/kvm
           ls -la /dev/kvm
 
+      # Building the root package runs crates/mvm-cli/build.rs, which
+      # cross-compiles the embedded host binaries and needs the pinned zig.
+      # Without it the boot gate below dies at compile time, before it starts
+      # a VM — which is how the first boot-image release shipped with no
+      # x86_64 default-microvm assets while every static check passed.
+      - uses: ./.github/actions/install-zigbuild
+        if: matrix.arch == 'x86_64'
+
       - name: Boot the staged image before it becomes a release asset
         if: matrix.arch == 'x86_64'
         # Boots the artifact in `staging/`, never a published one — the whole
@@ -603,7 +634,11 @@ jobs:
     # `!cancelled()` rather than plain success: the four image jobs are
     # independent artifacts and one arch's Nix build failing must not strand
     # the others, exactly as it does not strand the binary release next door.
-    # A boot-image tag publishes whatever built.
+    # It reaches this job so the completeness check below can name every
+    # missing asset in one report instead of one job conclusion at a time —
+    # it does NOT mean a partial set publishes. It used to: the first
+    # boot-image release went out carrying one arch and no builder VM, and
+    # the CLI release next door then treated its existence as sufficient.
     if: ${{ !cancelled() && (github.event_name == 'push' || github.event.inputs.dry_run == 'false') }}
     environment: release-signing
     runs-on: ubuntu-latest
@@ -656,6 +691,39 @@ jobs:
               "${blob}"
             echo "Signed: ${blob}"
           done
+
+      # release.yml attaches the newest boot-image release's assets to the CLI
+      # release and hard-fails when no such release exists — but it checks only
+      # that one EXISTS, not that it is complete. So a partial release here
+      # publishes a CLI release that is green and unusable: no x86_64 image
+      # means every x86_64 fresh install 404s on first boot, and no builder-vm
+      # assets means download_builder_vm_image 404s for everyone. Refuse here,
+      # where the missing pieces are still named, rather than downstream where
+      # they are silence.
+      - name: Assert every arch produced its full asset set
+        run: |
+          set -euo pipefail
+          missing=()
+          for arch in aarch64 x86_64; do
+            for f in \
+              "default-microvm-vmlinux-${arch}" \
+              "default-microvm-rootfs-${arch}.ext4" \
+              "default-microvm-meta-${arch}.json" \
+              "default-microvm-${arch}-checksums-sha256.txt" \
+              "builder-vm-vmlinux-${arch}" \
+              "builder-vm-rootfs-${arch}.ext4" \
+              "builder-vm-${arch}-checksums-sha256.txt" \
+              "runtime-overlay-${arch}.tar.gz" \
+              "sdk-sidecar-${arch}.tar.gz"; do
+              [ -s "artifacts/${f}" ] || missing+=("${f}")
+            done
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::boot image release is incomplete — refusing to publish. Missing: ${missing[*]}" >&2
+            echo "Re-run the failed image job(s); the successful ones are already uploaded as run artifacts." >&2
+            exit 1
+          fi
+          echo "All required boot image assets present for both arches."
 
       - name: Create boot image release
         env:


### PR DESCRIPTION
`boot-image/v0.1.0` published carrying one arch and no builder VM, and reported
success. The CLI release cut against it was cancelled before it could publish.

## What failed

**`builder-vm-image`, both arches.** The build never set `MVM_HOST_BIN_DIR` and
never passed `--impure`. The rootfs embeds the cross-compiled, statically
musl-linked host-vm binaries, which the flake reads out of that variable at eval
time; `mvmctl` extracts its embedded copy before invoking nix, and nothing did
that here. Evaluation died with `MVM_HOST_BIN_DIR is not set`, so no `builder-vm-*`
asset was produced at all.

**`default-microvm (x86_64)`.** The boot gate never installed the pinned zig.
Building the root package runs `crates/mvm-cli/build.rs`, so `cargo test` failed
to compile before it started a VM:

```
zig 0.13.0 is required to cross-compile the embedded host binaries but was not found.
```

The image itself was fine — it built and passed `assert-init-shebang.sh` and
`assert-kernel-format.sh`. The gate meant to prove it boots is what fell over, and
it took the job's assets with it.

**Neither failure stopped the publish.** `publish-boot-image` runs under
`!cancelled()` with `nullglob` so one arch cannot strand another — reasonable on
its own. But `release.yml` then attaches "the newest boot-image release" to the CLI
release and hard-fails only when *none* exists, never when one is incomplete. A CLI
release cut against that set is green and unusable: no x86_64 image means every
x86_64 fresh install 404s on first boot, and no builder-vm assets means
`download_builder_vm_image` 404s for everyone.

## What changed

- `builder-vm-image`: `install-zigbuild` + a `MVM_HOST_BIN_DIR` cross-compile step,
  and `--impure` on the nix build. Same recipe the reproducibility lanes in
  `security.yml` already use, and the same invocation `build.rs` runs. Matrix gains
  `musl_target`.
- `default-microvm`: `install-zigbuild` before the x86_64 boot gate.
- `publish-boot-image`: assert the full per-arch set before creating the release.
  The job still *reaches* this point on a partial build, deliberately — that is
  what lets it name every missing asset in one report instead of one job conclusion
  at a time — but it no longer publishes one.

## Verification

Replayed `boot-image/v0.1.0`'s actual published asset list through the new check:

```
REFUSED (10 missing): builder-vm-vmlinux-aarch64 builder-vm-rootfs-aarch64.ext4
builder-vm-aarch64-checksums-sha256.txt default-microvm-vmlinux-x86_64
default-microvm-rootfs-x86_64.ext4 default-microvm-meta-x86_64.json
default-microvm-x86_64-checksums-sha256.txt builder-vm-vmlinux-x86_64
builder-vm-rootfs-x86_64.ext4 builder-vm-x86_64-checksums-sha256.txt
```

and a complete set passes. Both directions, against real data rather than a
hypothetical. `actionlint` clean.

## After this merges

`boot-image/v0.1.0` needs re-cutting. Recommend deleting that release and tag and
re-cutting the same version rather than bumping to `v0.1.1`, since
`DEFAULT_BOOT_IMAGE_TAG` and `BOOT_IMAGE_IDENTITY_TEMPLATES` both name `v0.1.0`
and nothing consumes the published assets yet. Then re-run the `v0.18.0` release —
its tag is already pushed, and the attach step resolves the newest boot-image
release at run time.

Related: #2539, #2542, #2635.
