### PR TITLE
refactor(cli): one argument core behind `run` and `machine run`

### DIFF
--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -135,7 +135,7 @@ impl Commands {
     /// reserve that channel before reconcile-on-entry or other startup chrome.
     pub(super) fn emits_machine_readable_stdout(&self) -> bool {
         match self {
-            Commands::Run(a) => a.json,
+            Commands::Run(a) => a.run.json,
             Commands::SdkNoVm(_) => true,
             Commands::Machine(a) => match &a.action {
                 // Folded advanced ops delegate to their own check.
@@ -143,7 +143,7 @@ impl Commands {
                 // `machine run --json` streams a structured MachineRunSummary;
                 // `machine run --up-json` emits the SDK boot envelope;
                 // reserve stdout so reconcile chrome can't interleave.
-                machine::MachineAction::Run(r) => r.json || r.up_json,
+                machine::MachineAction::Run(r) => r.run.json || r.up_json,
                 // `machine timeline --json` prints a structured lineage.
                 machine::MachineAction::Timeline(t) => t.json,
                 // A `--json` restore reuses the fork path's structured output.

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -22,7 +22,7 @@ impl TopLevelCommand for Commands {
             #[cfg(feature = "builder-vm")]
             Commands::BuilderShellJob(a) => builder_shell_job::run(cli, a, cfg),
             Commands::Explain(a) => vm::explain::run(a),
-            Commands::Run(a) => vm::exec::run_secure(cli, a, cfg),
+            Commands::Run(a) => vm::exec::run_transient(cli, a, cfg),
             Commands::SdkNoVm(a) => vm::sdk_no_vm::run(&a),
             Commands::Doctor(a) => env::doctor::run(cli, a, cfg),
             Commands::Dashboard(a) => dashboard::run(a),

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -429,15 +429,7 @@ impl MachineRunArgs {
 
     fn into_run_args(self) -> RunArgs {
         RunArgs {
-            // Placeholder; `run_dispatch` overwrites it with the mode
-            // `preflight_network` actually settled on for this launch, which is
-            // the value that reaches the signed plan.
-            network_mode: mvm_contract::plan::NetworkMode::default(),
             manifest: self.manifest,
-            // Default off; `run_dispatch` sets it for the warm-claim-eligible
-            // transient mode.
-            warm_pool_size: 0,
-            pty: false,
             vm_name: self.name,
             image: self.image,
             runtime_pack: self.runtime_pack,
@@ -455,16 +447,7 @@ impl MachineRunArgs {
             receipt: self.receipt,
             json: self.json,
             dry_run: self.dry_run,
-            launch_plan: None,
-            prod: false,
-            // SDK-transport surface (`--mode`/`--dev`/`--ack-divergence`) stays
-            // off — `machine run` is the beginner contract; that transport lives
-            // on the hidden `run` verb the SDKs shell to.
-            mode: None,
-            dev: false,
-            ack_divergence: Vec::new(),
             argv: self.argv,
-            stdin: Vec::new(),
             healthcheck: crate::exec::build_healthcheck(
                 self.healthcheck.as_deref(),
                 self.health_interval,
@@ -474,6 +457,12 @@ impl MachineRunArgs {
             ),
             hypervisor: self.hypervisor,
             host_service: self.host_service,
+            // Everything else is a clap default: `network_mode` and
+            // `warm_pool_size` are overwritten by `run_dispatch` once it knows
+            // the mode this launch settled on, and the SDK transport surface
+            // (`--mode`/`--dev`/`--prod`/`--launch-plan`/`--ack-divergence`)
+            // stays off — `machine run` is the beginner contract.
+            ..Default::default()
         }
     }
 

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -256,69 +256,11 @@ pub(in crate::commands) fn preflight_network(
 /// flags and translates into the same admitted execution path.
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct MachineRunArgs {
-    /// Boot an OCI image.
-    #[arg(long, value_name = "REF", conflicts_with_all = ["manifest", "flake", "runtime_pack", "deployment"])]
-    pub image: Option<String>,
-    /// Boot a pre-built manifest.
-    #[arg(long, value_name = "PATH", conflicts_with_all = ["image", "flake", "runtime_pack", "deployment"])]
-    pub manifest: Option<String>,
-    /// Build and boot a Nix flake.
-    #[arg(long, value_name = "PATH", conflicts_with_all = ["image", "manifest", "runtime_pack", "deployment"])]
-    pub flake: Option<String>,
-    /// Boot a verified runtime pack.
-    #[arg(long, conflicts_with_all = ["image", "manifest", "flake", "deployment"])]
-    pub runtime_pack: bool,
-    /// Boot a local attested deployment (deploy.json plus rootfs.ext4).
-    #[arg(long, value_name = "DIR", conflicts_with_all = ["image", "manifest", "flake", "runtime_pack"])]
-    pub deployment: Option<PathBuf>,
-    /// Select a flake package.
-    #[arg(long, value_name = "PROFILE", requires = "flake")]
-    pub flake_profile: Option<String>,
-    /// Enable outbound networking (off by default).
-    #[arg(long)]
-    pub net: bool,
-    /// Allow outbound access to HOST[:PORT] (repeatable).
-    #[arg(long = "allow-host", value_name = "HOST[:PORT]")]
-    pub allow_host: Vec<String>,
-    /// Set how many vCPUs the guest sees (not a host CPU share).
-    #[arg(long, default_value = "2")]
-    pub cpus: u32,
-    /// Cap host CPU time in millicores (1500 = 1.5 cores); not `--cpus`.
-    #[arg(long = "cpu-limit", value_name = "MILLICORES")]
-    pub cpu_limit: Option<u32>,
-    /// Read grants (CPU, wall clock, egress) from a JSON file.
-    #[arg(long = "grants-file", value_name = "PATH")]
-    pub grants_file: Option<PathBuf>,
-    /// Set memory (for example, 512M or 1G).
-    #[arg(long, default_value = "512M")]
-    pub memory: String,
-    /// Select a security profile.
-    #[arg(long, value_enum, default_value = "dev")]
-    pub profile: RunProfile,
-    /// Allow a production-safe guest-agent verb (repeatable).
-    #[arg(long = "agent-verb", value_name = "VERB")]
-    pub agent_verb: Vec<String>,
-    /// Bind a host service the workload may call (repeatable).
-    #[arg(long = "host-service", value_name = "SERVICE")]
-    pub host_service: Vec<String>,
-    /// Mount HOST_PATH at GUEST_PATH[:MODE].
-    #[arg(long = "mount", visible_alias = "volume")]
-    pub volume: Vec<String>,
-    /// Set a guest environment variable (KEY=VALUE; repeatable).
-    #[arg(short, long)]
-    pub env: Vec<String>,
-    /// Set the command timeout in seconds.
-    #[arg(long)]
-    pub timeout: Option<u64>,
-    /// Write a signed execution receipt.
-    #[arg(long, value_name = "PATH")]
-    pub receipt: Option<PathBuf>,
-    /// Print a redacted JSON summary.
-    #[arg(long)]
-    pub json: bool,
-    /// Show the run plan without booting.
-    #[arg(long)]
-    pub dry_run: bool,
+    /// Every flag `mvmctl run` also takes. Declared once, in `RunArgs`, and
+    /// flattened here — the two verbs had drifted apart field by field, most
+    /// visibly on `--profile`, whose default differed between them.
+    #[command(flatten)]
+    pub run: RunArgs,
     /// Set the machine name.
     #[arg(long, value_name = "NAME")]
     pub name: Option<String>,
@@ -368,9 +310,6 @@ pub(in crate::commands) struct MachineRunArgs {
     /// Recreate a named machine when its config changed.
     #[arg(long)]
     pub force: bool,
-    /// Select the VMM (firecracker, hvf, libkrun, or qemu).
-    #[arg(long, value_name = "HYPERVISOR")]
-    pub hypervisor: Option<String>,
     /// Skip plan-admission signing (hidden; for testing only).
     #[arg(long, hide = true)]
     pub no_supervisor: bool,
@@ -407,12 +346,38 @@ pub(in crate::commands) struct MachineRunArgs {
         conflicts_with_all = ["image", "manifest", "flake", "deployment", "fresh", "reset", "detach"]
     )]
     pub attach: bool,
-    /// Command and arguments to run in the guest.
-    // No `allow_hyphen_values`: it makes an unrecognized flag a silent argv
-    // element, so a typo boots a VM and fails inside the guest shell instead of
-    // being named here. Hyphenated guest argv still works after `--`.
-    #[arg(trailing_var_arg = true)]
-    pub argv: Vec<String>,
+}
+
+/// The same values clap fills in when a flag is absent, for the same reason
+/// [`RunArgs::default`] exists. `machine_run_parsed_defaults_match_the_default_impl`
+/// is the witness that the two stay in step.
+impl Default for MachineRunArgs {
+    fn default() -> Self {
+        Self {
+            run: RunArgs::default(),
+            name: None,
+            detach: false,
+            port: Vec::new(),
+            up_json: false,
+            ttl: None,
+            healthcheck: None,
+            health_interval: 30,
+            health_timeout: 5,
+            health_retries: 3,
+            health_start_period: 0,
+            tty: false,
+            interactive: false,
+            force: false,
+            no_supervisor: false,
+            kernel_pin: None,
+            entrypoint: false,
+            fresh: false,
+            reset: false,
+            from_workload_ir: None,
+            stdin: None,
+            attach: false,
+        }
+    }
 }
 
 impl MachineRunArgs {
@@ -429,25 +394,9 @@ impl MachineRunArgs {
 
     fn into_run_args(self) -> RunArgs {
         RunArgs {
-            manifest: self.manifest,
+            // `--name` is the machine's identity; the shared struct calls the
+            // same thing `vm_name` because a transient run has no other name.
             vm_name: self.name,
-            image: self.image,
-            runtime_pack: self.runtime_pack,
-            net: self.net,
-            allow_host: self.allow_host,
-            cpus: self.cpus,
-            cpu_limit: self.cpu_limit,
-            grants_file: self.grants_file,
-            memory: self.memory,
-            profile: self.profile,
-            agent_verb: self.agent_verb,
-            mounts: self.volume,
-            env: self.env,
-            timeout: self.timeout,
-            receipt: self.receipt,
-            json: self.json,
-            dry_run: self.dry_run,
-            argv: self.argv,
             healthcheck: crate::exec::build_healthcheck(
                 self.healthcheck.as_deref(),
                 self.health_interval,
@@ -455,14 +404,7 @@ impl MachineRunArgs {
                 self.health_retries,
                 self.health_start_period,
             ),
-            hypervisor: self.hypervisor,
-            host_service: self.host_service,
-            // Everything else is a clap default: `network_mode` and
-            // `warm_pool_size` are overwritten by `run_dispatch` once it knows
-            // the mode this launch settled on, and the SDK transport surface
-            // (`--mode`/`--dev`/`--prod`/`--launch-plan`/`--ack-divergence`)
-            // stays off — `machine run` is the beginner contract.
-            ..Default::default()
+            ..self.run
         }
     }
 
@@ -487,7 +429,7 @@ impl MachineRunArgs {
     /// Resolve the lifecycle mode purely from the flags. Fresh foreground runs
     /// need an image source and an argv; persistent runs just boot and return.
     fn resolve_mode(&self) -> Result<MachineRunMode> {
-        if !self.port.is_empty() && !self.argv.is_empty() {
+        if !self.port.is_empty() && !self.run.argv.is_empty() {
             bail!(
                 "`machine run --port` cannot also run an ad-hoc command; start the service from the image or manifest, or forward it afterward with `machine forward`"
             );
@@ -500,7 +442,7 @@ impl MachineRunArgs {
             // Fresh-boot modes always materialize a new VM and need an image.
             (true, false) => {
                 self.require_image_for_fresh_boot()?;
-                if self.argv.is_empty() {
+                if self.run.argv.is_empty() {
                     bail!("machine run -it needs a command after `--`, for example `-- /bin/sh`");
                 }
                 MachineRunMode::InteractiveTransient
@@ -509,7 +451,7 @@ impl MachineRunArgs {
                 self.require_image_for_fresh_boot()?;
                 // The wasm backend runs the module itself; there is no guest
                 // agent command to dispatch, so an empty argv is allowed.
-                if self.argv.is_empty() && self.hypervisor.as_deref() != Some("wasm") {
+                if self.run.argv.is_empty() && self.run.hypervisor.as_deref() != Some("wasm") {
                     bail!(
                         "machine run needs a command: pass `-- <cmd>`, \
                          or `-d`/`--detach` to boot a persistent machine, \
@@ -525,11 +467,11 @@ impl MachineRunArgs {
     /// Fresh-boot modes (transient, interactive-transient) have no spec to fall
     /// back on, so an image, manifest, flake, or runtime pack is mandatory.
     fn require_image_for_fresh_boot(&self) -> Result<()> {
-        if self.image.is_none()
-            && self.manifest.is_none()
-            && self.flake.is_none()
-            && self.deployment.is_none()
-            && !self.runtime_pack
+        if self.run.image.is_none()
+            && self.run.manifest.is_none()
+            && self.run.flake.is_none()
+            && self.run.deployment.is_none()
+            && !self.run.runtime_pack
         {
             bail!(
                 "machine run needs `--image <ref>`, `--manifest <path>`, `--flake <path>`, `--deployment <dir>`, or \
@@ -654,9 +596,9 @@ fn profile_allows_writable_volume(profile: &str) -> bool {
 /// boot path re-validates via `build_machine_volume_cfg`, so this is the
 /// early, user-facing gate, not the only one.
 fn machine_run_volume_specs(args: &MachineRunArgs) -> Result<Vec<String>> {
-    let profile = run_profile_name(args.profile);
-    let mut out = Vec::with_capacity(args.volume.len());
-    for raw in &args.volume {
+    let profile = run_profile_name(args.run.profile);
+    let mut out = Vec::with_capacity(args.run.mounts.len());
+    for raw in &args.run.mounts {
         let spec = super::shared::parse_volume_spec(raw)?;
         let vmv = super::shared::vm_volume_from_spec_validated(&spec)
             .with_context(|| format!("volume {raw:?}"))?;
@@ -701,19 +643,19 @@ fn machine_run_spec(
     resolved_manifest_slot: Option<&str>,
 ) -> Result<MachineSpec> {
     validate_machine_name(&name)?;
-    let (image, manifest, deployment) = if let Some(path) = &args.deployment {
+    let (image, manifest, deployment) = if let Some(path) = &args.run.deployment {
         let deployment = resolve_local_deployment(path)?;
         (None, None, Some(deployment.directory.display().to_string()))
     } else if let Some(slot) = resolved_manifest_slot {
         // Flake was pre-built; store the slot hash as the manifest source.
         (None, Some(slot.to_string()), None)
-    } else if let Some(m) = &args.manifest {
+    } else if let Some(m) = &args.run.manifest {
         // Manifest-backed: store the manifest ref.
         (None, Some(m.clone()), None)
-    } else if let Some(img) = &args.image {
+    } else if let Some(img) = &args.run.image {
         // Image-backed: store the OCI ref.
         (Some(img.clone()), None, None)
-    } else if args.runtime_pack {
+    } else if args.run.runtime_pack {
         // The verified runtime pack is its own source; recorded via
         // `runtime_pack: true` below, not `image`/`manifest`.
         (None, None, None)
@@ -728,19 +670,19 @@ fn machine_run_spec(
     };
     let config = mvm_core::user_config::load(None);
     let resolved = super::shared::resolve_run_grants(super::shared::GrantInputs {
-        cpu_limit_millicores: args.cpu_limit,
-        timeout_secs: args.timeout,
-        allow_host: &args.allow_host,
-        net: args.net,
-        grants_file: args.grants_file.as_deref(),
+        cpu_limit_millicores: args.run.cpu_limit,
+        timeout_secs: args.run.timeout,
+        allow_host: &args.run.allow_host,
+        net: args.run.net,
+        grants_file: args.run.grants_file.as_deref(),
         // A persistent `machine run` names its source on the command line and
         // reads no project manifest; `machine create` is the verb that sources
         // a `[grants]` table.
         manifest: None,
         config: &config,
     })?;
-    let _ = validate_machine_memory(&args.memory, None)?;
-    let profile = run_profile_name(args.profile).to_string();
+    let _ = validate_machine_memory(&args.run.memory, None)?;
+    let profile = run_profile_name(args.run.profile).to_string();
     Ok(MachineSpec {
         schema_version: MACHINE_SPEC_SCHEMA_VERSION,
         name,
@@ -748,17 +690,17 @@ fn machine_run_spec(
         manifest,
         deployment,
         resolved_digest: None,
-        runtime_pack: args.runtime_pack,
-        net: args.net,
-        allow_host: args.allow_host.clone(),
+        runtime_pack: args.run.runtime_pack,
+        net: args.run.net,
+        allow_host: args.run.allow_host.clone(),
         ports: args.port.clone(),
-        cpus: args.cpus,
-        memory: args.memory.clone(),
+        cpus: args.run.cpus,
+        memory: args.run.memory.clone(),
         mem_initial: None,
         profile,
         volumes: machine_run_volume_specs(args)?,
         init: Vec::new(),
-        agent_verb: args.agent_verb.clone(),
+        agent_verb: args.run.agent_verb.clone(),
         created_at: Some(mvm_core::time::utc_now()),
         last_started_at: None,
         health_check: crate::exec::build_healthcheck(
@@ -1690,52 +1632,17 @@ fn run_args_for_image_revert(
     };
     (
         MachineRunArgs {
-            image,
-            flake: None,
-            hypervisor: run.hypervisor,
-            json: run.json,
-            name: None,
             // Restoring an image node replays a recorded workload rather than
             // carrying a caller's stdin, so it requests no input grant.
             stdin: None,
-            manifest,
-            deployment: None,
-            runtime_pack: false,
-            flake_profile: None,
-            net: false,
-            allow_host: Vec::new(),
-            cpus: 2,
-            cpu_limit: None,
-            grants_file: None,
-            memory: "512M".to_string(),
-            profile: RunProfile::Dev,
-            agent_verb: Vec::new(),
-            volume: Vec::new(),
-            env: Vec::new(),
-            timeout: None,
-            receipt: None,
-            dry_run: false,
-            tty: false,
-            interactive: false,
-            force: false,
-            no_supervisor: false,
-            up_json: false,
-            ttl: None,
-            healthcheck: None,
-            health_interval: 30,
-            health_timeout: 5,
-            health_retries: 3,
-            health_start_period: 0,
-            entrypoint: false,
-            fresh: false,
-            reset: false,
-            from_workload_ir: None,
-            attach: false,
-            detach: false,
-            kernel_pin: None,
-            argv: Vec::new(),
-            host_service: Vec::new(),
-            port: Vec::new(),
+            run: RunArgs {
+                image,
+                manifest,
+                hypervisor: run.hypervisor,
+                json: run.json,
+                ..Default::default()
+            },
+            ..Default::default()
         },
         source,
     )

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -10,9 +10,9 @@ pub(super) fn resolve_persistent_spec(
     resolved_manifest_slot: Option<&str>,
 ) -> Result<(MachineSpec, SpecReconcile)> {
     let direct_boot = std::env::var("MVM_DIRECT_BOOT").as_deref() == Ok("1");
-    let has_source = args.image.is_some()
-        || args.manifest.is_some()
-        || args.deployment.is_some()
+    let has_source = args.run.image.is_some()
+        || args.run.manifest.is_some()
+        || args.run.deployment.is_some()
         || resolved_manifest_slot.is_some()
         || direct_boot;
     if !has_source {
@@ -49,13 +49,13 @@ fn run_persistent(
     let existing = load_machine_spec(&name).ok();
     let (spec, action) = resolve_persistent_spec(&args, &name, existing, resolved_flake_slot)?;
 
-    if args.dry_run {
+    if args.run.dry_run {
         let summary = machine_start_preflight_summary(
             &spec,
-            args.hypervisor.as_deref(),
-            args.receipt.as_deref(),
+            args.run.hypervisor.as_deref(),
+            args.run.receipt.as_deref(),
         )?;
-        if args.json {
+        if args.run.json {
             println!("{}", serde_json::to_string_pretty(&summary)?);
         } else {
             print_machine_start_preflight_human(&summary);
@@ -70,17 +70,17 @@ fn run_persistent(
         MachineStartArgs {
             name: name.clone(),
             create_flags: MachineStartCreateFlags::default(),
-            receipt: args.receipt.clone(),
-            json: args.json,
+            receipt: args.run.receipt.clone(),
+            json: args.run.json,
             dry_run: false,
             quiet: false,
-            hypervisor: args.hypervisor.clone(),
+            hypervisor: args.run.hypervisor.clone(),
             no_supervisor: args.no_supervisor,
             kernel_pin: args.kernel_pin.clone(),
-            has_ad_hoc_argv: !args.argv.is_empty(),
+            has_ad_hoc_argv: !args.run.argv.is_empty(),
         },
     )?;
-    if !booted && !args.json && !args.up_json {
+    if !booted && !args.run.json && !args.up_json {
         println!("machine {name} already running");
     }
 
@@ -122,7 +122,7 @@ fn run_persistent_post_start(
     args: &MachineRunArgs,
     name: &str,
 ) -> Result<()> {
-    if !args.argv.is_empty() {
+    if !args.run.argv.is_empty() {
         if !shared::wait_for_guest_agent(name, 30) {
             anyhow::bail!("guest agent for {name:?} not reachable to run the command");
         }
@@ -130,7 +130,7 @@ fn run_persistent_post_start(
             cli,
             console::Args {
                 name: name.to_string(),
-                command: Some(machine_exec_command(&args.argv)),
+                command: Some(machine_exec_command(&args.run.argv)),
                 force: false,
                 env: Vec::new(),
                 pty_argv: Vec::new(),
@@ -181,7 +181,7 @@ pub(super) fn post_start_action(args: &MachineRunArgs) -> PostStart {
         PostStart::Envelope
     } else if !args.port.is_empty() {
         PostStart::Forward
-    } else if args.json {
+    } else if args.run.json {
         PostStart::Quiet
     } else if args.detach {
         PostStart::PrintId
@@ -242,7 +242,7 @@ fn apply_machine_ttl(name: &str, dur_str: &str) -> Result<()> {
 }
 
 fn resolve_build_mode_for_envelope(args: &MachineRunArgs, name: &str) -> &'static str {
-    resolve_machine_build_mode(args.manifest.as_deref(), name)
+    resolve_machine_build_mode(args.run.manifest.as_deref(), name)
 }
 
 /// Resolve a machine's `build_mode` (`"dev"` / `"prod"`) for the boot-time
@@ -255,12 +255,12 @@ pub(super) fn resolve_machine_build_mode(manifest: Option<&str>, name: &str) -> 
 }
 
 fn run_entrypoint_action(args: MachineRunArgs, resolved_flake_slot: Option<String>) -> Result<()> {
-    if args.deployment.is_some() {
+    if args.run.deployment.is_some() {
         anyhow::bail!(
             "machine run --entrypoint does not accept --deployment; use a manifest or flake source"
         );
     }
-    if args.image.is_some() {
+    if args.run.image.is_some() {
         anyhow::bail!(
             "machine run --entrypoint dispatches a manifest/flake image's baked \
              /etc/mvm/entrypoint; an OCI --image runs its own command via the \
@@ -271,7 +271,7 @@ fn run_entrypoint_action(args: MachineRunArgs, resolved_flake_slot: Option<Strin
         resolve_machine_run_name(&args)?
     } else if let Some(slot) = resolved_flake_slot {
         slot
-    } else if let Some(manifest) = args.manifest.clone() {
+    } else if let Some(manifest) = args.run.manifest.clone() {
         manifest
     } else {
         anyhow::bail!(
@@ -279,19 +279,19 @@ fn run_entrypoint_action(args: MachineRunArgs, resolved_flake_slot: Option<Strin
              (or `--attach --name <NAME>` to dispatch into a running machine)"
         );
     };
-    let (memory_mib, _) = validate_machine_memory(&args.memory, None)?;
+    let (memory_mib, _) = validate_machine_memory(&args.run.memory, None)?;
     // Resolve `--net` / `--allow-host` into the egress policy exactly as the
     // transient argv path does, so a baked entrypoint enforces the same posture.
-    let network_policy = shared::resolve_run_network_policy(args.net, &args.allow_host)?;
+    let network_policy = shared::resolve_run_network_policy(args.run.net, &args.run.allow_host)?;
     let stdin = resolve_entrypoint_stdin(args.stdin.as_deref())?;
     invoke::run_entrypoint(invoke::EntrypointCall {
         source,
         stdin,
-        timeout: args.timeout.unwrap_or(30),
-        cpus: args.cpus,
+        timeout: args.run.timeout.unwrap_or(30),
+        cpus: args.run.cpus,
         memory_mib,
         from_workload_ir: args.from_workload_ir.clone(),
-        agent_verb_override: args.agent_verb.clone(),
+        agent_verb_override: args.run.agent_verb.clone(),
         reset: args.reset,
         keep_alive: args.persistent(),
         keep_alive_dev: false,
@@ -355,14 +355,15 @@ fn workload_needs_raw_ip_stack(workload_ir: Option<&std::path::Path>) -> Result<
 }
 
 pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig) -> Result<()> {
-    let resolved_flake_slot = if let Some(flake_ref) = args.flake.take() {
-        let slot_hash = build::build_flake_to_slot(&flake_ref, args.flake_profile.as_deref())?;
-        args.manifest = Some(slot_hash.clone());
+    let resolved_flake_slot = if let Some(flake_ref) = args.run.flake.take() {
+        let slot_hash = build::build_flake_to_slot(&flake_ref, args.run.flake_profile.as_deref())?;
+        args.run.manifest = Some(slot_hash.clone());
         Some(slot_hash)
     } else {
         None
     };
     let local_deployment = args
+        .run
         .deployment
         .as_deref()
         .map(super::resolve_local_deployment)
@@ -390,7 +391,7 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
     // The wasm backend is a claim-free, host-wasmtime runner: it has no
     // standby-pool machinery and should never be blocked by a warm-pool
     // default that it cannot satisfy.
-    let warm_pool_size = if args.hypervisor.as_deref() == Some("wasm") {
+    let warm_pool_size = if args.run.hypervisor.as_deref() == Some("wasm") {
         0
     } else {
         warm_pool_size
@@ -399,7 +400,7 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
     match mode {
         MachineRunMode::Transient => {
             if let Some(slot) = resolved_flake_slot {
-                args.manifest = Some(slot);
+                args.run.manifest = Some(slot);
             }
             let mut run_args = args.into_run_args();
             // The mode settled above, not a re-derivation: one value reaches
@@ -421,7 +422,7 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
             use std::io::IsTerminal as _;
             require_tty(std::io::stdin().is_terminal())?;
             if let Some(slot) = resolved_flake_slot {
-                args.manifest = Some(slot);
+                args.run.manifest = Some(slot);
             }
             let mut run_args = args.into_run_args();
             // The mode settled above, not a re-derivation: one value reaches
@@ -451,51 +452,17 @@ pub(in crate::commands) fn boot_persistent_by_name(
         cli,
         MachineRunArgs {
             name: Some(name),
-            flake,
             kernel_pin,
-            hypervisor,
             // Booting by name carries no caller stdin, so it requests no input
             // grant and the plan stays ungranted.
             stdin: None,
             detach: true,
-            image: None,
-            manifest: None,
-            deployment: None,
-            runtime_pack: false,
-            flake_profile: None,
-            net: false,
-            allow_host: Vec::new(),
-            cpus: 2,
-            cpu_limit: None,
-            grants_file: None,
-            memory: "512M".to_string(),
-            profile: RunProfile::Dev,
-            agent_verb: Vec::new(),
-            volume: Vec::new(),
-            env: Vec::new(),
-            timeout: None,
-            receipt: None,
-            json: false,
-            dry_run: false,
-            tty: false,
-            interactive: false,
-            force: false,
-            no_supervisor: false,
-            up_json: false,
-            ttl: None,
-            healthcheck: None,
-            health_interval: 30,
-            health_timeout: 5,
-            health_retries: 3,
-            health_start_period: 0,
-            entrypoint: false,
-            fresh: false,
-            reset: false,
-            from_workload_ir: None,
-            attach: false,
-            argv: Vec::new(),
-            host_service: Vec::new(),
-            port: Vec::new(),
+            run: RunArgs {
+                flake,
+                hypervisor,
+                ..Default::default()
+            },
+            ..Default::default()
         },
         cfg,
     )

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -315,8 +315,8 @@ fn assert_manifest_fixture_reaches_unknown_key_gate(mut sdk_args: Vec<String>) {
 #[test]
 fn run_parses_image_and_trailing_argv() {
     let args = parse_run(&["run", "--image", "alpine", "--", "echo", "hello"]).expect("parse");
-    assert_eq!(args.image.as_deref(), Some("alpine"));
-    assert_eq!(args.argv, vec!["echo", "hello"]);
+    assert_eq!(args.run.image.as_deref(), Some("alpine"));
+    assert_eq!(args.run.argv, vec!["echo", "hello"]);
 }
 
 #[test]
@@ -348,7 +348,7 @@ fn exec_rejects_an_unknown_flag_before_the_argv_separator() {
 fn run_keeps_hyphenated_argv_after_the_separator() {
     let args = parse_run(&["run", "--image", "alpine", "--", "uname", "-a", "--all"])
         .expect("hyphenated argv after `--` stays argv");
-    assert_eq!(args.argv, vec!["uname", "-a", "--all"]);
+    assert_eq!(args.run.argv, vec!["uname", "-a", "--all"]);
 }
 
 #[test]
@@ -364,7 +364,7 @@ fn run_parses_hypervisor_flag_and_forwards_to_run_args() {
         "hello",
     ])
     .expect("parse");
-    assert_eq!(args.hypervisor.as_deref(), Some("libkrun"));
+    assert_eq!(args.run.hypervisor.as_deref(), Some("libkrun"));
 
     let run = args.into_run_args();
     assert_eq!(run.hypervisor.as_deref(), Some("libkrun"));
@@ -373,7 +373,7 @@ fn run_parses_hypervisor_flag_and_forwards_to_run_args() {
 #[test]
 fn run_without_hypervisor_flag_forwards_none() {
     let args = parse_run(&["run", "--image", "alpine", "--", "echo", "hello"]).expect("parse");
-    assert!(args.hypervisor.is_none());
+    assert!(args.run.hypervisor.is_none());
 
     let run = args.into_run_args();
     assert!(run.hypervisor.is_none());
@@ -382,7 +382,7 @@ fn run_without_hypervisor_flag_forwards_none() {
 #[test]
 fn run_parses_runtime_pack_flag_and_forwards_to_run_args() {
     let args = parse_run(&["run", "--runtime-pack", "--", "true"]).expect("parse");
-    assert!(args.runtime_pack);
+    assert!(args.run.runtime_pack);
 
     let run = args.into_run_args();
     assert!(run.runtime_pack);
@@ -409,7 +409,7 @@ fn run_runtime_pack_conflicts_with_image_manifest_and_flake() {
 fn run_parses_deployment_source_and_conflicts_with_other_sources() {
     let args = parse_run(&["run", "--deployment", "/tmp/deployment", "--", "true"])
         .expect("deployment source parses");
-    assert_eq!(args.deployment, Some(PathBuf::from("/tmp/deployment")));
+    assert_eq!(args.run.deployment, Some(PathBuf::from("/tmp/deployment")));
 
     let err = parse_run(&[
         "run",
@@ -439,8 +439,8 @@ fn run_parses_and_forwards_net_flags() {
         "true",
     ])
     .expect("parse");
-    assert!(args.net);
-    assert_eq!(args.allow_host, vec!["a.com", "b.com:8443"]);
+    assert!(args.run.net);
+    assert_eq!(args.run.allow_host, vec!["a.com", "b.com:8443"]);
     // The flags ride through into the canonical run args unchanged.
     let run = args.into_run_args();
     assert!(run.net);
@@ -450,8 +450,8 @@ fn run_parses_and_forwards_net_flags() {
 #[test]
 fn run_net_flags_default_off() {
     let args = parse_run(&["run", "--image", "alpine", "--", "true"]).expect("parse");
-    assert!(!args.net);
-    assert!(args.allow_host.is_empty());
+    assert!(!args.run.net);
+    assert!(args.run.allow_host.is_empty());
 }
 
 #[test]
@@ -482,13 +482,17 @@ fn transient_run_without_argv_is_rejected_at_dispatch() {
 #[test]
 fn run_defaults_match_the_lower_level_runner() {
     let args = parse_run(&["run", "--image", "alpine", "--", "true"]).expect("parse");
-    assert_eq!(args.cpus, 2);
-    assert_eq!(args.memory, "512M");
-    assert_eq!(args.profile, RunProfile::Dev);
-    assert!(!args.json);
-    assert!(!args.dry_run);
-    assert!(args.volume.is_empty());
-    assert!(args.env.is_empty());
+    assert_eq!(args.run.cpus, 2);
+    assert_eq!(args.run.memory, "512M");
+    assert_eq!(
+        args.run.profile,
+        RunProfile::Standard,
+        "`machine run` and `mvmctl run` share one default"
+    );
+    assert!(!args.run.json);
+    assert!(!args.run.dry_run);
+    assert!(args.run.mounts.is_empty());
+    assert!(args.run.env.is_empty());
     assert!(args.name.is_none());
     assert!(!args.detach);
     assert!(!args.tty);
@@ -520,15 +524,15 @@ fn run_accepts_passthrough_flags() {
         "-a",
     ])
     .expect("parse");
-    assert_eq!(args.cpus, 4);
-    assert_eq!(args.memory, "1G");
-    assert_eq!(args.profile, RunProfile::Dev);
-    assert_eq!(args.volume, vec!["/host:/work:rw"]);
-    assert_eq!(args.env, vec!["FOO=bar"]);
-    assert_eq!(args.timeout, Some(30));
-    assert!(args.json);
-    assert!(args.dry_run);
-    assert_eq!(args.argv, vec!["uname", "-a"]);
+    assert_eq!(args.run.cpus, 4);
+    assert_eq!(args.run.memory, "1G");
+    assert_eq!(args.run.profile, RunProfile::Dev);
+    assert_eq!(args.run.mounts, vec!["/host:/work:rw"]);
+    assert_eq!(args.run.env, vec!["FOO=bar"]);
+    assert_eq!(args.run.timeout, Some(30));
+    assert!(args.run.json);
+    assert!(args.run.dry_run);
+    assert_eq!(args.run.argv, vec!["uname", "-a"]);
 }
 
 #[test]
@@ -543,14 +547,14 @@ fn volume_flag_carries_live_mount_and_d_is_detach() {
         "true",
     ])
     .expect("parse");
-    assert_eq!(args.volume, vec!["/host:/work:rw"]);
+    assert_eq!(args.run.mounts, vec!["/host:/work:rw"]);
     let forwarded = args.clone().into_run_args_for_test();
     assert_eq!(forwarded.mounts, vec!["/host:/work:rw"]);
     // `-d` now means --detach, so it must NOT consume the following value as
     // a dir share.
     let detached = parse_run(&["run", "--image", "alpine", "-d"]).expect("parse");
     assert!(detached.detach);
-    assert!(detached.volume.is_empty());
+    assert!(detached.run.mounts.is_empty());
 }
 
 #[test]
@@ -711,9 +715,9 @@ fn resolve_mode_wasm_allows_empty_argv() {
 #[test]
 fn resolve_mode_accepts_materialized_flake_slot_after_build() {
     let mut args = parse_run(&["run", "--flake", ".", "--", "cmd"]).expect("parse");
-    let flake = args.flake.take().expect("flake source present");
+    let flake = args.run.flake.take().expect("flake source present");
     assert_eq!(flake, ".");
-    args.manifest = Some("materialized-slot".to_string());
+    args.run.manifest = Some("materialized-slot".to_string());
 
     let mode = args.resolve_mode().expect("materialized flake is a source");
 
@@ -959,8 +963,10 @@ fn run_volume_is_threaded_into_managed_spec_with_absolute_host() {
 fn run_rw_volume_requires_dev_profile() {
     let dir = tempfile::tempdir().expect("tmpdir");
     let host = dir.path().to_string_lossy().into_owned();
-    // CLI runs default to `dev`, so a writable share works without repeating
-    // the profile flag.
+    // The default is `standard`, so a writable share is refused unless the user
+    // asks for `dev` explicitly. It refuses at spec time with the flag to pass,
+    // rather than quietly handing the guest a read-only mount it will fail to
+    // write to later.
     let default_args = parse_run(&[
         "run",
         "--image",
@@ -971,9 +977,12 @@ fn run_rw_volume_requires_dev_profile() {
         &format!("{host}:/work:rw"),
     ])
     .expect("parse");
-    let default_spec = machine_run_spec(&default_args, "web".to_string(), None)
-        .expect("default dev profile allows :rw");
-    assert!(default_spec.volumes[0].ends_with(":/work:rw"));
+    let default_err = machine_run_spec(&default_args, "web".to_string(), None)
+        .expect_err(":rw is not in the default profile");
+    assert!(
+        default_err.to_string().contains("profile dev"),
+        "the refusal must name the flag that grants it: {default_err}"
+    );
 
     // An explicitly stricter profile still refuses the writable share.
     let std_args = parse_run(&[
@@ -2265,8 +2274,8 @@ fn top_level_cli_routes_machine_run() {
     match cli.command {
         Commands::Machine(args) => match args.action {
             MachineAction::Run(run) => {
-                assert_eq!(run.image.as_deref(), Some("alpine"));
-                assert_eq!(run.argv, vec!["echo", "hi"]);
+                assert_eq!(run.run.image.as_deref(), Some("alpine"));
+                assert_eq!(run.run.argv, vec!["echo", "hi"]);
             }
             other => panic!("expected run action, got {other:?}"),
         },
@@ -2900,7 +2909,7 @@ fn an_allow_host_rule_does_not_influence_the_transport() {
         "api.example.com:443",
     ])
     .unwrap();
-    assert_eq!(args.allow_host, vec!["api.example.com:443"]);
+    assert_eq!(args.run.allow_host, vec!["api.example.com:443"]);
     assert_eq!(
         super::derive_network_mode(false),
         mvm_contract::plan::NetworkMode::HostVsockProxy
@@ -2925,18 +2934,21 @@ fn cpus_and_cpu_limit_are_independent_controls() {
         "500",
     ])
     .expect("both flags parse together");
-    assert_eq!(args.cpus, 4);
-    assert_eq!(args.cpu_limit, Some(500));
+    assert_eq!(args.run.cpus, 4);
+    assert_eq!(args.run.cpu_limit, Some(500));
 
     let only_cpus = parse_run(&["run", "--image", "alpine", "--cpus", "4"]).expect("parses");
-    assert_eq!(only_cpus.cpus, 4);
-    assert_eq!(only_cpus.cpu_limit, None, "--cpus must not imply a share");
+    assert_eq!(only_cpus.run.cpus, 4);
+    assert_eq!(
+        only_cpus.run.cpu_limit, None,
+        "--cpus must not imply a share"
+    );
 
     let only_limit =
         parse_run(&["run", "--image", "alpine", "--cpu-limit", "500"]).expect("parses");
-    assert_eq!(only_limit.cpu_limit, Some(500));
+    assert_eq!(only_limit.run.cpu_limit, Some(500));
     assert_eq!(
-        only_limit.cpus, 2,
+        only_limit.run.cpus, 2,
         "--cpu-limit must not move the vCPU count off its default"
     );
 }
@@ -2969,7 +2981,10 @@ fn the_cpu_flags_help_text_tells_them_apart() {
 fn a_grants_file_is_accepted_on_run_and_create() {
     let run = parse_run(&["run", "--image", "alpine", "--grants-file", "/tmp/g.json"])
         .expect("run accepts --grants-file");
-    assert_eq!(run.grants_file.as_deref(), Some(Path::new("/tmp/g.json")));
+    assert_eq!(
+        run.run.grants_file.as_deref(),
+        Some(Path::new("/tmp/g.json"))
+    );
 
     let create = match parse(&[
         "create",
@@ -3118,11 +3133,11 @@ fn the_argv_the_sdk_facade_emits_parses_back_into_the_grant_it_encoded() {
     let config = mvm_core::user_config::MvmConfig::default();
     let resolved =
         crate::commands::shared::resolve_run_grants(crate::commands::shared::GrantInputs {
-            cpu_limit_millicores: args.cpu_limit,
-            timeout_secs: args.timeout,
-            allow_host: &args.allow_host,
-            net: args.net,
-            grants_file: args.grants_file.as_deref(),
+            cpu_limit_millicores: args.run.cpu_limit,
+            timeout_secs: args.run.timeout,
+            allow_host: &args.run.allow_host,
+            net: args.run.net,
+            grants_file: args.run.grants_file.as_deref(),
             manifest: None,
             config: &config,
         })

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -156,7 +156,7 @@ pub(in crate::commands) enum Commands {
     /// The argument surface still differs from `machine run` in both
     /// directions; consolidating the two into one struct is the next step.
     #[command(display_order = 2)]
-    Run(vm::exec::RunArgs),
+    Run(vm::exec::TransientRunArgs),
     /// Internal SDK host-dispatch transport for `MVM_NO_VM=1`.
     #[command(name = "__sdk-no-vm", hide = true)]
     SdkNoVm(vm::sdk_no_vm::Args),

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1169,7 +1169,10 @@ fn test_up_manifest_flag() {
     match cli.command {
         Commands::Machine(mg) => match mg.action {
             machine::MachineAction::Run(machine::MachineRunArgs {
-                manifest, flake, ..
+                run: exec::RunArgs {
+                    manifest, flake, ..
+                },
+                ..
             }) => {
                 assert!(flake.is_none());
                 assert_eq!(manifest, Some("openclaw".to_string()));
@@ -1195,7 +1198,10 @@ fn test_up_manifest_short_flag() {
     .unwrap();
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { manifest, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { manifest, .. },
+                ..
+            }) => {
                 assert_eq!(manifest, Some("openclaw".to_string()));
             }
             _ => panic!("Expected machine run"),
@@ -1294,13 +1300,13 @@ fn machine_run_flake_resolves_to_persistent_lifecycle() {
         Commands::Machine(machine::Args {
             action: machine::MachineAction::Run(ref run_args),
         }) => {
-            assert_eq!(run_args.flake.as_deref(), Some("."));
+            assert_eq!(run_args.run.flake.as_deref(), Some("."));
             assert!(
-                run_args.image.is_none(),
+                run_args.run.image.is_none(),
                 "image must be absent when --flake set"
             );
             assert!(
-                run_args.manifest.is_none(),
+                run_args.run.manifest.is_none(),
                 "manifest must be absent when --flake set"
             );
             // -d selects Persistent lifecycle
@@ -1332,8 +1338,8 @@ fn machine_run_entrypoint_flag_parses() {
     // stdin at dispatch — there is no `--stdin` flag.
     let args = parse_machine_run(&["--manifest", "tmpl", "--entrypoint"]).unwrap();
     assert!(args.entrypoint);
-    assert_eq!(args.manifest.as_deref(), Some("tmpl"));
-    assert!(args.argv.is_empty());
+    assert_eq!(args.run.manifest.as_deref(), Some("tmpl"));
+    assert!(args.run.argv.is_empty());
 }
 
 #[test]
@@ -1402,7 +1408,7 @@ fn machine_run_entrypoint_agent_verbs_parse() {
     ])
     .unwrap();
     assert!(args.entrypoint);
-    assert_eq!(args.agent_verb, vec!["run-entrypoint", "ping"]);
+    assert_eq!(args.run.agent_verb, vec!["run-entrypoint", "ping"]);
 }
 
 #[test]
@@ -1498,7 +1504,10 @@ fn test_run_volume_dir_inject() {
     .unwrap();
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { volume, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { mounts: volume, .. },
+                ..
+            }) => {
                 assert_eq!(volume.len(), 2);
                 assert_eq!(volume[0], "/tmp/config:/mnt/config");
                 assert_eq!(volume[1], "/tmp/secrets:/mnt/secrets");
@@ -1525,7 +1534,10 @@ fn test_run_volume_persistent() {
     .unwrap();
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { volume, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { mounts: volume, .. },
+                ..
+            }) => {
                 assert_eq!(volume.len(), 1);
                 assert_eq!(volume[0], "/data:/mnt/data:4G");
             }
@@ -1610,7 +1622,10 @@ fn test_run_port_and_env_flags() {
     .unwrap();
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { env, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { env, .. },
+                ..
+            }) => {
                 assert_eq!(env, vec!["NODE_ENV=production", "DEBUG=true"]);
             }
             _ => panic!("Expected machine run"),
@@ -1633,7 +1648,10 @@ fn test_run_port_and_env_default_empty() {
     .unwrap();
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { env, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { env, .. },
+                ..
+            }) => {
                 assert!(env.is_empty());
             }
             _ => panic!("Expected machine run"),
@@ -1909,8 +1927,11 @@ fn test_run_command_is_recognized() {
     .unwrap();
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { profile, argv, .. }) => {
-                assert_eq!(profile, exec::RunProfile::Dev);
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { profile, argv, .. },
+                ..
+            }) => {
+                assert_eq!(profile, exec::RunProfile::Standard);
                 assert_eq!(argv, vec!["/bin/true".to_string()]);
             }
             _ => panic!("Expected machine run"),
@@ -3164,13 +3185,17 @@ fn run_transient_default_manifest_argv_only() {
     match cli.command {
         Commands::Machine(mg) => match mg.action {
             machine::MachineAction::Run(machine::MachineRunArgs {
-                manifest,
-                cpus,
-                memory,
-                volume,
-                env,
-                timeout,
-                argv,
+                run:
+                    exec::RunArgs {
+                        manifest,
+                        cpus,
+                        memory,
+                        mounts: volume,
+                        env,
+                        timeout,
+                        argv,
+                        ..
+                    },
                 ..
             }) => {
                 assert!(manifest.is_none());
@@ -3204,7 +3229,10 @@ fn run_transient_timeout_parses_to_some() {
     .expect("parse");
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { timeout, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { timeout, .. },
+                ..
+            }) => {
                 assert_eq!(timeout, Some(5), "--timeout 5 ⇒ Some(5)");
             }
             _ => panic!("Expected machine run"),
@@ -3230,20 +3258,24 @@ fn run_default_profile_argv_only() {
     match cli.command {
         Commands::Machine(mg) => match mg.action {
             machine::MachineAction::Run(machine::MachineRunArgs {
-                manifest,
-                image,
-                net,
-                allow_host,
-                cpus,
-                memory,
-                profile,
-                volume,
-                env,
-                timeout,
-                receipt,
-                json,
-                dry_run,
-                argv,
+                run:
+                    exec::RunArgs {
+                        manifest,
+                        image,
+                        net,
+                        allow_host,
+                        cpus,
+                        memory,
+                        profile,
+                        mounts: volume,
+                        env,
+                        timeout,
+                        receipt,
+                        json,
+                        dry_run,
+                        argv,
+                        ..
+                    },
                 ..
             }) => {
                 assert!(manifest.is_none());
@@ -3252,7 +3284,7 @@ fn run_default_profile_argv_only() {
                 assert!(allow_host.is_empty());
                 assert_eq!(cpus, 2);
                 assert_eq!(memory, "512M");
-                assert_eq!(profile, exec::RunProfile::Dev);
+                assert_eq!(profile, exec::RunProfile::Standard);
                 assert!(volume.is_empty());
                 assert!(env.is_empty());
                 assert_eq!(timeout, None);
@@ -3284,7 +3316,10 @@ fn run_timeout_parses_to_some() {
     .expect("parse");
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { timeout, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { timeout, .. },
+                ..
+            }) => {
                 assert_eq!(timeout, Some(5), "--timeout 5 ⇒ Some(5)");
             }
             _ => panic!("Expected machine run"),
@@ -3297,11 +3332,11 @@ fn run_timeout_parses_to_some() {
 fn machine_run_interactive_image_shell_dx_parses() {
     let args = parse_machine_run(&["--net", "-it", "--image", "alpine", "--", "/bin/sh"])
         .expect("parse Docker-style interactive shell run");
-    assert!(args.net);
+    assert!(args.run.net);
     assert!(args.tty);
     assert!(args.interactive);
-    assert_eq!(args.image.as_deref(), Some("alpine"));
-    assert_eq!(args.argv, vec!["/bin/sh".to_string()]);
+    assert_eq!(args.run.image.as_deref(), Some("alpine"));
+    assert_eq!(args.run.argv, vec!["/bin/sh".to_string()]);
 }
 
 #[test]
@@ -3320,7 +3355,10 @@ fn run_image_flag_parses() {
     .expect("parse");
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { image, argv, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { image, argv, .. },
+                ..
+            }) => {
                 assert_eq!(image.as_deref(), Some("docker.io/library/alpine:3.20"));
                 assert_eq!(
                     argv,
@@ -3353,12 +3391,10 @@ fn run_image_prod_flag_parses_as_image_policy() {
     ])
     .expect("parse");
     match cli.command {
-        Commands::Run(exec::RunArgs {
-            image, prod, mode, ..
-        }) => {
-            assert_eq!(image.as_deref(), Some(pinned));
-            assert!(prod);
-            assert!(mode.is_none());
+        Commands::Run(exec::TransientRunArgs { run, sdk }) => {
+            assert_eq!(run.image.as_deref(), Some(pinned));
+            assert!(run.prod);
+            assert!(sdk.mode.is_none());
         }
         _ => panic!("Expected Run command"),
     }
@@ -3397,7 +3433,10 @@ fn run_accepts_restrictive_profile() {
     .expect("parse");
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { profile, argv, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { profile, argv, .. },
+                ..
+            }) => {
                 assert_eq!(profile, exec::RunProfile::Restrictive);
                 assert_eq!(argv, vec!["/bin/true".to_string()]);
             }
@@ -3439,7 +3478,10 @@ fn run_receipt_flag_parses() {
     .expect("parse");
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { receipt, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { receipt, .. },
+                ..
+            }) => {
                 assert_eq!(
                     receipt.as_deref(),
                     Some(std::path::Path::new("/tmp/mvm-run-receipt.json"))
@@ -3466,7 +3508,10 @@ fn run_json_flag_parses() {
     .expect("parse");
     match cli.command {
         Commands::Machine(mg) => match mg.action {
-            machine::MachineAction::Run(machine::MachineRunArgs { json, argv, .. }) => {
+            machine::MachineAction::Run(machine::MachineRunArgs {
+                run: exec::RunArgs { json, argv, .. },
+                ..
+            }) => {
                 assert!(json);
                 assert_eq!(argv, vec!["/bin/true".to_string()]);
             }
@@ -3493,9 +3538,13 @@ fn run_dry_run_json_flags_parse() {
     match cli.command {
         Commands::Machine(mg) => match mg.action {
             machine::MachineAction::Run(machine::MachineRunArgs {
-                dry_run,
-                json,
-                argv,
+                run:
+                    exec::RunArgs {
+                        dry_run,
+                        json,
+                        argv,
+                        ..
+                    },
                 ..
             }) => {
                 assert!(dry_run);
@@ -3736,11 +3785,9 @@ fn run_transient_with_launch_plan_no_argv() {
     let cli =
         Cli::try_parse_from(["mvmctl", "run", "--launch-plan", "./plan.json"]).expect("parse");
     match cli.command {
-        Commands::Run(exec::RunArgs {
-            launch_plan, argv, ..
-        }) => {
-            assert_eq!(launch_plan.as_deref(), Some("./plan.json"));
-            assert!(argv.is_empty());
+        Commands::Run(exec::TransientRunArgs { run, .. }) => {
+            assert_eq!(run.launch_plan.as_deref(), Some("./plan.json"));
+            assert!(run.argv.is_empty());
         }
         _ => panic!("Expected Run command"),
     }
@@ -3782,10 +3829,14 @@ fn run_transient_with_manifest_and_resources() {
     match cli.command {
         Commands::Machine(mg) => match mg.action {
             machine::MachineAction::Run(machine::MachineRunArgs {
-                manifest,
-                cpus,
-                memory,
-                argv,
+                run:
+                    exec::RunArgs {
+                        manifest,
+                        cpus,
+                        memory,
+                        argv,
+                        ..
+                    },
                 ..
             }) => {
                 assert_eq!(manifest.as_deref(), Some("my-tpl"));
@@ -3825,7 +3876,14 @@ fn run_transient_with_mount_and_env() {
     match cli.command {
         Commands::Machine(mg) => match mg.action {
             machine::MachineAction::Run(machine::MachineRunArgs {
-                volume, env, argv, ..
+                run:
+                    exec::RunArgs {
+                        mounts: volume,
+                        env,
+                        argv,
+                        ..
+                    },
+                ..
             }) => {
                 assert_eq!(
                     volume,
@@ -3853,9 +3911,9 @@ fn direct_run_accepts_a_read_only_mount() {
     ])
     .expect("parse");
     match cli.command {
-        Commands::Run(exec::RunArgs { mounts, argv, .. }) => {
-            assert_eq!(mounts, vec!["/tmp:/work:ro"]);
-            assert_eq!(argv, vec!["ls", "/work"]);
+        Commands::Run(exec::TransientRunArgs { run, .. }) => {
+            assert_eq!(run.mounts, vec!["/tmp:/work:ro"]);
+            assert_eq!(run.argv, vec!["ls", "/work"]);
         }
         _ => panic!("Expected Run command"),
     }
@@ -3863,9 +3921,23 @@ fn direct_run_accepts_a_read_only_mount() {
 
 #[test]
 fn run_transient_requires_argv() {
-    // Without trailing argv, Clap should reject because `argv` is required.
-    let cli = Cli::try_parse_from(["mvmctl", "run"]);
-    assert!(cli.is_err());
+    // `argv` is shared with `machine run`, which legitimately boots with no
+    // command (`-d`), so the requirement moved off the clap attribute and onto
+    // `run_transient`. It parses; running it is what refuses.
+    let cli = Cli::try_parse_from(["mvmctl", "run"]).expect("parses");
+    let Commands::Run(args) = cli.command else {
+        panic!("expected Commands::Run");
+    };
+    let err = exec::run_transient(
+        &Cli::parse_from(["mvmctl", "doctor"]),
+        args,
+        &mvm_core::user_config::MvmConfig::default(),
+    )
+    .expect_err("a bare `run` must refuse");
+    assert!(
+        err.to_string().contains("needs a command"),
+        "unexpected error: {err}"
+    );
 }
 
 // --- Init CLI tests (pure project-scaffold; DIR is required) ---
@@ -4835,8 +4907,8 @@ fn machine_run_verbose_after_options_is_not_guest_argv() {
     let machine::MachineAction::Run(args) = machine_args.action else {
         panic!("expected machine run")
     };
-    assert_eq!(args.allow_host, vec!["google.com"]);
-    assert_eq!(args.argv, vec!["ps", "aux"]);
+    assert_eq!(args.run.allow_host, vec!["google.com"]);
+    assert_eq!(args.run.argv, vec!["ps", "aux"]);
 }
 
 #[test]
@@ -4867,7 +4939,7 @@ fn debug_alias_parses_before_and_after_machine_run() {
     let machine::MachineAction::Run(args) = machine_args.action else {
         panic!("expected machine run")
     };
-    assert_eq!(args.argv, vec!["true"]);
+    assert_eq!(args.run.argv, vec!["true"]);
 }
 
 #[test]
@@ -5030,7 +5102,7 @@ fn machine_run_up_json_and_ttl_parse() {
     let args = parse_machine_run(&["--up-json", "--manifest", "x", "--ttl", "60s"]).unwrap();
     assert!(args.up_json);
     assert_eq!(args.ttl.as_deref(), Some("60s"));
-    assert_eq!(args.manifest.as_deref(), Some("x"));
+    assert_eq!(args.run.manifest.as_deref(), Some("x"));
 }
 
 #[test]
@@ -5042,7 +5114,7 @@ fn machine_run_up_json_implies_persistent_mode() {
     let args = parse_machine_run(&["--up-json", "--manifest", "x"]).unwrap();
     assert!(args.up_json, "up_json field must be set");
     // The manifest source must survive parsing.
-    assert_eq!(args.manifest.as_deref(), Some("x"));
+    assert_eq!(args.run.manifest.as_deref(), Some("x"));
     // No detach flag needed — up_json alone implies persistence.
     assert!(!args.detach, "detach is not required when up_json is set");
 }

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -103,6 +103,14 @@ pub(in crate::commands) enum RunProfile {
     Permissive,
 }
 
+/// A run boots from exactly one source. Spelling the other four at each flag is
+/// what let `run` and `machine run` disagree about which sources exist at all.
+const SOURCES_EXCEPT_IMAGE: [&str; 4] = ["manifest", "flake", "runtime_pack", "deployment"];
+const SOURCES_EXCEPT_MANIFEST: [&str; 4] = ["image", "flake", "runtime_pack", "deployment"];
+const SOURCES_EXCEPT_FLAKE: [&str; 4] = ["image", "manifest", "runtime_pack", "deployment"];
+const SOURCES_EXCEPT_RUNTIME_PACK: [&str; 4] = ["image", "manifest", "flake", "deployment"];
+const SOURCES_EXCEPT_DEPLOYMENT: [&str; 4] = ["image", "manifest", "flake", "runtime_pack"];
+
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct RunArgs {
     /// The transport this launch derived, carried to admission so the signed
@@ -110,16 +118,21 @@ pub(in crate::commands) struct RunArgs {
     /// machine surface derives it from what the workload declares it needs.
     #[arg(skip)]
     pub network_mode: mvm_contract::plan::NetworkMode,
-    /// Boot a pre-built manifest (path to `mvm.toml`, its directory, or a
-    /// legacy slot name). If omitted, the bundled default microVM image is used.
-    #[arg(short = 'm', long, conflicts_with = "image")]
+    /// Boot a pre-built manifest (mvm.toml, a directory, or a slot).
+    #[arg(short = 'm', long, value_name = "PATH", conflicts_with_all = SOURCES_EXCEPT_MANIFEST)]
     pub manifest: Option<String>,
-    /// Pull or reuse a cached OCI image reference and boot its materialized rootfs.
-    ///
-    /// The image is resolved through the local OCI cache first. A cache miss
-    /// performs the existing verified OCI pull and rootfs materialization path.
-    #[arg(long, value_name = "REF")]
+    /// Boot an OCI image (resolved through the local cache first).
+    #[arg(long, value_name = "REF", conflicts_with_all = SOURCES_EXCEPT_IMAGE)]
     pub image: Option<String>,
+    /// Build and boot a Nix flake.
+    #[arg(long, value_name = "PATH", conflicts_with_all = SOURCES_EXCEPT_FLAKE)]
+    pub flake: Option<String>,
+    /// Select a flake package variant.
+    #[arg(long, value_name = "PROFILE", requires = "flake")]
+    pub flake_profile: Option<String>,
+    /// Boot a local attested deployment (deploy.json plus rootfs.ext4).
+    #[arg(long, value_name = "DIR", conflicts_with_all = SOURCES_EXCEPT_DEPLOYMENT)]
+    pub deployment: Option<PathBuf>,
     /// Internal (not a CLI flag): warm-pool size for this run, set by
     /// `machine run` dispatch from the resolved run mode. `> 0` ⇒ eligible to
     /// claim a pre-booted standby + replenish the pool.
@@ -131,20 +144,16 @@ pub(in crate::commands) struct RunArgs {
     /// Internal (not a CLI flag): optional foreground transient VM identity.
     #[arg(skip)]
     pub vm_name: Option<String>,
-    /// Internal (not a CLI flag): boot from a verified attested runtime pack
-    /// instead of `--manifest`/`--image`/the bundled default. Set by
-    /// `machine run --runtime-pack`.
-    #[arg(skip)]
+    /// Boot a verified attested runtime pack.
+    #[arg(long, conflicts_with_all = SOURCES_EXCEPT_RUNTIME_PACK)]
     pub runtime_pack: bool,
-    /// Enable dev-tier outbound networking (broad egress + DNS). Off by
-    /// default (deny-all). Narrow it with `--allow-host`.
+    /// Enable outbound networking (off by default).
     #[arg(long)]
     pub net: bool,
-    /// Allow egress only to these hosts: `HOST[:PORT]` (PORT defaults to
-    /// 443), repeatable. Implies networking and **wins over `--net`**.
+    /// Allow outbound access to HOST[:PORT] (repeatable).
     #[arg(long = "allow-host", value_name = "HOST[:PORT]")]
     pub allow_host: Vec<String>,
-    /// vCPU cores the guest sees (default: 2). Not a host CPU share.
+    /// Set how many vCPUs the guest sees (not a host CPU share).
     #[arg(long, default_value = "2")]
     pub cpus: u32,
     /// Cap host CPU time in millicores (1500 = 1.5 cores); not `--cpus`.
@@ -153,92 +162,44 @@ pub(in crate::commands) struct RunArgs {
     /// Read grants (CPU, wall clock, egress) from a JSON file.
     #[arg(long = "grants-file", value_name = "PATH")]
     pub grants_file: Option<PathBuf>,
-    /// Memory (supports human-readable: 512M, 1G, ...)
+    /// Set memory (for example, 512M or 1G).
     #[arg(long, default_value = "512M")]
     pub memory: String,
-    /// Security profile for the transient run.
+    /// Select a security profile.
     #[arg(long, value_enum, default_value = "standard")]
     pub profile: RunProfile,
-    /// Attach a live read-only host directory at a guest path.
-    /// Format: `HOST_PATH:/GUEST_PATH:ro`. Repeatable.
-    #[arg(long = "mount", value_name = "HOST:GUEST:ro")]
+    /// Attach a read-only host directory (HOST:/GUEST:ro, repeatable).
+    #[arg(long = "mount", visible_alias = "volume", value_name = "HOST:GUEST:ro")]
     pub mounts: Vec<String>,
-    /// Explicit environment variable to inject (KEY=VALUE). Repeatable.
-    /// Disabled by `--profile restrictive`.
+    /// Inject an environment variable (KEY=VALUE, repeatable).
     #[arg(short, long)]
     pub env: Vec<String>,
-    /// Per-command timeout in seconds. Unset ⇒ no per-command kill.
+    /// Set a per-command timeout in seconds.
     #[arg(long)]
     pub timeout: Option<u64>,
-    /// Write a signed execution receipt to this path. The receipt records
-    /// command/env/mount hashes, output hashes, and exit status; it never
-    /// stores raw argv, env values, stdout, or stderr.
+    /// Write a signed execution receipt to this path.
     #[arg(long, value_name = "PATH")]
     pub receipt: Option<PathBuf>,
-    /// Print a machine-readable, redacted execution summary as JSON.
-    ///
-    /// Guest stdout/stderr are not streamed in this mode; the JSON carries
-    /// only byte counts and hashes. Combine with `--receipt` when a signed
-    /// artifact is needed.
+    /// Print a redacted JSON execution summary (no guest output).
     #[arg(long)]
     pub json: bool,
-    /// Validate and explain the effective run plan without booting a VM.
-    ///
-    /// This preflight never resolves, builds, or starts the selected image. It
-    /// reports hashes and policy-relevant metadata only; raw argv, env values,
-    /// and host paths are omitted.
+    /// Validate the run plan without booting a VM.
     #[arg(long)]
     pub dry_run: bool,
-    /// Path to an mvmforge launch document. Mutually exclusive with trailing argv.
+    /// Path to a launch document (excludes trailing argv).
     #[arg(long, value_name = "PATH", conflicts_with = "argv")]
     pub launch_plan: Option<String>,
-    /// SDK transport mode for `mvmctl run`.
-    ///
-    /// - `--mode plan`: synthesize an ExecutionPlan per Sandbox call
-    ///   and route through `mvm_hostd::supervisor::admit_for_run`; no
-    ///   microVM ever boots.
-    /// - `--mode live`: spawn the user's script with `MVM_SDK_MODE=live`
-    ///   so the SDK shells each `Sandbox` operation to existing
-    ///   `mvmctl up` / `proc start` / `fs write` / `down` against a
-    ///   real microVM.
-    /// - `--mode record` redirects users to `mvmctl compile` (where
-    ///   record is the default mode).
-    ///
-    /// When unset, the verb behaves as a transient-sandbox runner
-    /// over the trailing argv.
-    #[arg(long = "mode", value_enum)]
-    pub mode: Option<RunMode>,
-    /// Friendly alias for `--mode live`.
-    #[arg(long = "dev", conflicts_with_all = ["prod", "mode"])]
-    pub dev: bool,
-    /// Friendly alias for `--mode record`. `mvmctl run --prod`
-    /// redirects users to `mvmctl compile`, where record is the
-    /// default.
-    #[arg(long = "prod", conflicts_with_all = ["dev", "mode"])]
+    /// Require production policy (digest-pinned, verified images).
+    #[arg(long = "prod")]
     pub prod: bool,
-    /// Argv to run inside the guest (use `--` to separate). Required unless
-    /// `--launch-plan` is supplied. Under `--mode plan`, the first
-    /// argv element is a `.py`/`.ts`/`.js` script path.
+    /// Command to run inside the guest (after `--`).
     // No `allow_hyphen_values` — see `Args::argv` above.
-    #[arg(
-        trailing_var_arg = true,
-        required_unless_present_any = ["launch_plan", "mode", "dev", "prod"]
-    )]
+    #[arg(trailing_var_arg = true)]
     pub argv: Vec<String>,
-    /// Acknowledge a divergence class on the plan-mode admission
-    /// path (repeatable). Unacknowledged divergence refuses
-    /// admission: what you previewed is not what would ship.
-    #[arg(long = "ack-divergence", value_name = "KIND")]
-    pub ack_divergence: Vec<String>,
-    /// Internal (not a CLI flag): raw `--agent-verb` values forwarded from
-    /// `machine run`. Empty ⇒ the computed sealed-prod default is used at
-    /// the admit site.
-    #[arg(skip)]
+    /// Allow a production-safe guest-agent verb (repeatable).
+    #[arg(long = "agent-verb", value_name = "VERB")]
     pub agent_verb: Vec<String>,
-    /// Bind a host service this workload may call over the broker channel
-    /// (repeatable). Baked into the signed `ExecutionPlan`; the broker refuses
-    /// any service absent from the set, and binding an SDK-served service
-    /// attaches the optional SDK sidecar read-only.
+    /// Bind a host service this workload may call (repeatable).
     #[arg(long = "host-service", value_name = "SERVICE")]
     pub host_service: Vec<String>,
     /// Internal (not a CLI flag): stdin bytes to forward into the guest `Exec`
@@ -250,11 +211,52 @@ pub(in crate::commands) struct RunArgs {
     /// forwarded from `machine run`'s `--healthcheck` + tuning flags.
     #[arg(skip)]
     pub healthcheck: Option<mvm_contract::ir::HealthCheck>,
-    /// Requested workload hypervisor from `machine run --hypervisor <x>`. Set
-    /// programmatically by `MachineRunArgs::into_run_args`; the transient backend
-    /// selection reads it (taking precedence over the `MVM_HYPERVISOR` env var).
-    #[arg(skip)]
+    /// Select the VMM (firecracker, hvf, libkrun, or qemu).
+    #[arg(long, value_name = "HYPERVISOR")]
     pub hypervisor: Option<String>,
+}
+
+/// The SDK transport surface, carried by `mvmctl run` alone.
+///
+/// These are kept out of [`RunArgs`] deliberately. `RunArgs` is flattened into
+/// both `run` and `machine run` so a shared flag is declared exactly once;
+/// `--mode`/`--dev`/`--ack-divergence` are not shared — `machine run` is the
+/// beginner contract and has no business growing an SDK transport — so putting
+/// them here is what lets the rest be flattened.
+#[derive(ClapArgs, Debug, Clone, Default)]
+pub(in crate::commands) struct SdkTransportArgs {
+    /// SDK transport mode for `mvmctl run`.
+    ///
+    /// - `--mode plan`: synthesize an ExecutionPlan per Sandbox call
+    ///   and route through `mvm_hostd::supervisor::admit_for_run`; no
+    ///   microVM ever boots.
+    /// - `--mode live`: spawn the user's script with `MVM_SDK_MODE=live`
+    ///   so the SDK shells each `Sandbox` operation to existing
+    ///   `mvmctl` verbs against a real microVM.
+    /// - `--mode record` redirects users to `mvmctl compile` (where
+    ///   record is the default mode).
+    ///
+    /// When unset, the verb behaves as a transient-sandbox runner
+    /// over the trailing argv.
+    #[arg(long = "mode", value_enum)]
+    pub mode: Option<RunMode>,
+    /// Friendly alias for `--mode live`.
+    #[arg(long = "dev", conflicts_with_all = ["prod", "mode"])]
+    pub dev: bool,
+    /// Acknowledge a divergence class on the plan-mode admission
+    /// path (repeatable). Unacknowledged divergence refuses
+    /// admission: what you previewed is not what would ship.
+    #[arg(long = "ack-divergence", value_name = "KIND")]
+    pub ack_divergence: Vec<String>,
+}
+
+/// `mvmctl run` — the shared execution surface plus the SDK transport.
+#[derive(ClapArgs, Debug, Clone, Default)]
+pub(in crate::commands) struct TransientRunArgs {
+    #[command(flatten)]
+    pub run: RunArgs,
+    #[command(flatten)]
+    pub sdk: SdkTransportArgs,
 }
 
 /// The same values clap fills in when a flag is absent.
@@ -274,6 +276,9 @@ impl Default for RunArgs {
             network_mode: mvm_contract::plan::NetworkMode::default(),
             manifest: None,
             image: None,
+            flake: None,
+            flake_profile: None,
+            deployment: None,
             warm_pool_size: 0,
             pty: false,
             vm_name: None,
@@ -292,11 +297,8 @@ impl Default for RunArgs {
             json: false,
             dry_run: false,
             launch_plan: None,
-            mode: None,
-            dev: false,
             prod: false,
             argv: Vec::new(),
-            ack_divergence: Vec::new(),
             agent_verb: Vec::new(),
             host_service: Vec::new(),
             stdin: Vec::new(),
@@ -389,6 +391,34 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
     run_secure_with_source(cli, args, cfg, None)
 }
 
+/// `mvmctl run`: peel off the SDK transport, then fall through to the ordinary
+/// transient run every other caller uses.
+///
+/// The peel happens here rather than inside `run_secure_with_source` so the
+/// shared execution path never sees the transport flags, which is what lets
+/// `RunArgs` be flattened into `machine run` without dragging them along.
+pub(in crate::commands) fn run_transient(
+    cli: &Cli,
+    args: TransientRunArgs,
+    cfg: &MvmConfig,
+) -> Result<()> {
+    if let Some(mode) = resolve_run_mode(&args.sdk, &args.run)? {
+        return super::run_plan::dispatch_sdk_mode(mode, &args.run, &args.sdk);
+    }
+    // `argv` used to be `required_unless_present_any` over `launch_plan` /
+    // `mode` / `dev` / `prod`. It cannot stay a clap attribute now that the
+    // field is shared: `machine run -d` legitimately boots with no command, and
+    // naming `mode`/`dev` from the shared struct would reference args that do
+    // not exist on the `machine` side. So the one verb that needs it checks it.
+    if args.run.argv.is_empty() && args.run.launch_plan.is_none() {
+        anyhow::bail!(
+            "`mvmctl run` needs a command: `mvmctl run -- <cmd>`. Use `--launch-plan <path>` \
+             for a launch document, or `mvmctl machine run -d` to boot a machine with no command."
+        );
+    }
+    run_secure(cli, args.run, cfg)
+}
+
 /// Run a transient workload through the normal admitted path, optionally
 /// overriding the user-facing image lookup with an already-verified source.
 /// The override is used only by content-addressed restore, where following a
@@ -404,9 +434,6 @@ pub(in crate::commands) fn run_secure_with_source(
     // in. `--dev` (alias for live) is refused in v1; `--prod` (alias
     // for record) redirects to `mvmctl compile`; `--mode plan` routes
     // through the plan-mode admission dry-run.
-    if let Some(mode) = resolve_run_mode(&args)? {
-        return super::run_plan::dispatch_sdk_mode(mode, &args);
-    }
     validate_run_profile(&args)?;
     if args.dry_run {
         let summary = RunPreflightSummary::from_args(&args)?;
@@ -658,15 +685,18 @@ pub(in crate::commands) fn run_secure_with_source(
 /// Env-var precedence matches `mvmctl compile`: `MVM_SDK_MODE`
 /// supersedes any flag-only override so a wrapper script can pin a
 /// mode without the user retyping `--mode`.
-pub(in crate::commands) fn resolve_run_mode(args: &RunArgs) -> Result<Option<RunMode>> {
+pub(in crate::commands) fn resolve_run_mode(
+    sdk: &SdkTransportArgs,
+    run: &RunArgs,
+) -> Result<Option<RunMode>> {
     if let Ok(env_mode) = std::env::var(mvm_sdk::env::MVM_SDK_MODE_ENV) {
         return Ok(Some(parse_env_run_mode(&env_mode)?));
     }
-    if args.dev {
+    if sdk.dev {
         return Ok(Some(RunMode::Live));
     }
-    if args.prod {
-        if args.image.is_some() {
+    if run.prod {
+        if run.image.is_some() {
             return Ok(None);
         }
         anyhow::bail!(
@@ -675,7 +705,7 @@ pub(in crate::commands) fn resolve_run_mode(args: &RunArgs) -> Result<Option<Run
              on `mvmctl run` is for the live sandbox runner, not for SDK record-mode)."
         );
     }
-    match args.mode {
+    match sdk.mode {
         None => Ok(None),
         Some(RunMode::Live) => Ok(Some(RunMode::Live)),
         Some(RunMode::Record) => anyhow::bail!(
@@ -1493,7 +1523,7 @@ mod host_service_flag_tests {
         let crate::commands::machine::MachineAction::Run(run) = group.action else {
             panic!("expected machine run");
         };
-        assert_eq!(run.host_service, ["host.audit.v1", "host.time.v1"]);
+        assert_eq!(run.run.host_service, ["host.audit.v1", "host.time.v1"]);
         let forwarded = run.into_run_args_for_test().into_exec_args();
         assert_eq!(forwarded.host_service, ["host.audit.v1", "host.time.v1"]);
     }
@@ -1691,52 +1721,128 @@ mod tests {
         let crate::commands::Commands::Run(parsed) = parsed.command else {
             panic!("expected Commands::Run");
         };
-        let expected = RunArgs {
-            argv: vec!["x".to_string()],
+        let expected = TransientRunArgs {
+            run: RunArgs {
+                argv: vec!["x".to_string()],
+                ..Default::default()
+            },
             ..Default::default()
         };
 
-        assert_eq!(parsed.cpus, expected.cpus, "--cpus default");
-        assert_eq!(parsed.memory, expected.memory, "--memory default");
-        assert_eq!(parsed.profile, expected.profile, "--profile default");
-        assert_eq!(parsed.net, expected.net, "--net default");
-        assert_eq!(parsed.json, expected.json, "--json default");
-        assert_eq!(parsed.dry_run, expected.dry_run, "--dry-run default");
-        assert_eq!(parsed.dev, expected.dev, "--dev default");
-        assert_eq!(parsed.prod, expected.prod, "--prod default");
-        assert_eq!(parsed.timeout, expected.timeout, "--timeout default");
-        assert_eq!(parsed.cpu_limit, expected.cpu_limit, "--cpu-limit default");
-        assert_eq!(parsed.mode, expected.mode, "--mode default");
+        assert_eq!(parsed.run.cpus, expected.run.cpus, "--cpus default");
+        assert_eq!(parsed.run.memory, expected.run.memory, "--memory default");
         assert_eq!(
-            parsed.allow_host, expected.allow_host,
+            parsed.run.profile, expected.run.profile,
+            "--profile default"
+        );
+        assert_eq!(parsed.run.net, expected.run.net, "--net default");
+        assert_eq!(parsed.run.json, expected.run.json, "--json default");
+        assert_eq!(
+            parsed.run.dry_run, expected.run.dry_run,
+            "--dry-run default"
+        );
+        assert_eq!(parsed.run.prod, expected.run.prod, "--prod default");
+        assert_eq!(
+            parsed.run.timeout, expected.run.timeout,
+            "--timeout default"
+        );
+        assert_eq!(
+            parsed.run.cpu_limit, expected.run.cpu_limit,
+            "--cpu-limit default"
+        );
+        assert_eq!(
+            parsed.run.allow_host, expected.run.allow_host,
             "--allow-host default"
         );
-        assert_eq!(parsed.mounts, expected.mounts, "--mount default");
-        assert_eq!(parsed.env, expected.env, "--env default");
-        assert_eq!(parsed.argv, expected.argv, "trailing argv");
+        assert_eq!(parsed.run.mounts, expected.run.mounts, "--mount default");
+        assert_eq!(parsed.run.env, expected.run.env, "--env default");
+        assert_eq!(parsed.run.argv, expected.run.argv, "trailing argv");
+        assert_eq!(parsed.sdk.mode, expected.sdk.mode, "--mode default");
+        assert_eq!(parsed.sdk.dev, expected.sdk.dev, "--dev default");
+        assert_eq!(
+            parsed.sdk.ack_divergence, expected.sdk.ack_divergence,
+            "--ack-divergence default"
+        );
+    }
+
+    /// The shared half of `machine run` is the same `RunArgs`, so its defaults
+    /// are the same values — including `--profile`, which the two verbs used to
+    /// disagree about.
+    #[test]
+    fn machine_run_parsed_defaults_match_the_default_impl() {
+        use clap::Parser;
+
+        let parsed = crate::commands::Cli::try_parse_from(["mvmctl", "machine", "run", "--", "x"])
+            .expect("bare `machine run -- x` parses");
+        let crate::commands::Commands::Machine(machine) = parsed.command else {
+            panic!("expected Commands::Machine");
+        };
+        let crate::commands::machine::MachineAction::Run(parsed) = machine.action else {
+            panic!("expected MachineAction::Run");
+        };
+        let expected = crate::commands::machine::MachineRunArgs::default();
+
+        assert_eq!(parsed.run.cpus, expected.run.cpus, "--cpus default");
+        assert_eq!(parsed.run.memory, expected.run.memory, "--memory default");
+        assert_eq!(
+            parsed.run.profile, expected.run.profile,
+            "--profile default must match `mvmctl run`"
+        );
+        assert_eq!(parsed.detach, expected.detach, "--detach default");
+        assert_eq!(parsed.tty, expected.tty, "--tty default");
+        assert_eq!(
+            parsed.entrypoint, expected.entrypoint,
+            "--entrypoint default"
+        );
+        assert_eq!(
+            parsed.health_interval, expected.health_interval,
+            "--health-interval default"
+        );
+        assert_eq!(
+            parsed.health_timeout, expected.health_timeout,
+            "--health-timeout default"
+        );
+        assert_eq!(
+            parsed.health_retries, expected.health_retries,
+            "--health-retries default"
+        );
+        assert_eq!(
+            parsed.health_start_period, expected.health_start_period,
+            "--health-start-period default"
+        );
+    }
+
+    /// `resolve_run_mode` now reads the transport off `SdkTransportArgs` and the
+    /// shared `RunArgs` separately, so each case names which half it exercises.
+    fn sdk(mode: Option<RunMode>, dev: bool) -> SdkTransportArgs {
+        SdkTransportArgs {
+            mode,
+            dev,
+            ack_divergence: Vec::new(),
+        }
     }
 
     #[test]
     fn resolve_run_mode_returns_none_when_no_mode_flag() {
         let args = run_args(RunProfile::Standard);
-        let mode = resolve_run_mode(&args).expect("no flag resolves to None");
+        let mode = resolve_run_mode(&sdk(None, false), &args).expect("no flag resolves to None");
         assert!(mode.is_none());
     }
 
     #[test]
     fn resolve_run_mode_returns_plan_when_mode_plan() {
-        let mut args = run_args(RunProfile::Standard);
-        args.mode = Some(RunMode::Plan);
-        let mode = resolve_run_mode(&args).expect("plan resolves").unwrap();
+        let args = run_args(RunProfile::Standard);
+        let mode = resolve_run_mode(&sdk(Some(RunMode::Plan), false), &args)
+            .expect("plan resolves")
+            .unwrap();
         assert_eq!(mode, RunMode::Plan);
     }
 
     #[test]
     fn resolve_run_mode_returns_live_for_dev_alias() {
-        let mut args = run_args(RunProfile::Standard);
-        args.dev = true;
-        let mode = resolve_run_mode(&args)
-            .expect("--dev resolves to Some(Live) post-H-live")
+        let args = run_args(RunProfile::Standard);
+        let mode = resolve_run_mode(&sdk(None, true), &args)
+            .expect("--dev resolves to Some(Live)")
             .expect("must be Some(Live)");
         assert_eq!(mode, RunMode::Live);
     }
@@ -1745,9 +1851,8 @@ mod tests {
     fn resolve_run_mode_bails_redirect_for_prod_alias() {
         let mut args = run_args(RunProfile::Standard);
         args.prod = true;
-        let err = resolve_run_mode(&args).expect_err("--prod must bail");
-        let msg = err.to_string();
-        assert!(msg.contains("mvmctl compile"));
+        let err = resolve_run_mode(&sdk(None, false), &args).expect_err("--prod must bail");
+        assert!(err.to_string().contains("mvmctl compile"));
     }
 
     #[test]
@@ -1758,27 +1863,25 @@ mod tests {
                 .to_string(),
         );
         args.prod = true;
-        let mode = resolve_run_mode(&args).expect("image prod is not SDK mode");
+        let mode = resolve_run_mode(&sdk(None, false), &args).expect("image prod is not SDK mode");
         assert!(mode.is_none());
     }
 
     #[test]
     fn resolve_run_mode_returns_live_for_mode_live() {
-        let mut args = run_args(RunProfile::Standard);
-        args.mode = Some(RunMode::Live);
-        let mode = resolve_run_mode(&args)
-            .expect("--mode live resolves to Some(Live) post-H-live")
+        let args = run_args(RunProfile::Standard);
+        let mode = resolve_run_mode(&sdk(Some(RunMode::Live), false), &args)
+            .expect("--mode live resolves to Some(Live)")
             .expect("must be Some(Live)");
         assert_eq!(mode, RunMode::Live);
     }
 
     #[test]
     fn resolve_run_mode_bails_redirect_for_mode_record() {
-        let mut args = run_args(RunProfile::Standard);
-        args.mode = Some(RunMode::Record);
-        let err = resolve_run_mode(&args).expect_err("--mode record must bail");
-        let msg = err.to_string();
-        assert!(msg.contains("mvmctl compile"));
+        let args = run_args(RunProfile::Standard);
+        let err = resolve_run_mode(&sdk(Some(RunMode::Record), false), &args)
+            .expect_err("--mode record must bail");
+        assert!(err.to_string().contains("mvmctl compile"));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -257,6 +257,55 @@ pub(in crate::commands) struct RunArgs {
     pub hypervisor: Option<String>,
 }
 
+/// The same values clap fills in when a flag is absent.
+///
+/// Two consumers want a `RunArgs` without spelling thirty fields: the
+/// `machine` dispatch sites that build one programmatically, and the tests.
+/// Writing them out by hand meant every new field edited every one of those
+/// sites, so they drifted toward whatever the author happened to type rather
+/// than toward what the CLI actually does.
+///
+/// The risk this introduces is that these values and the `#[arg(default_value)]`
+/// attributes above disagree. `parsed_defaults_match_the_default_impl` is the
+/// witness: it parses a bare `run -- x` and compares the result field by field.
+impl Default for RunArgs {
+    fn default() -> Self {
+        Self {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
+            manifest: None,
+            image: None,
+            warm_pool_size: 0,
+            pty: false,
+            vm_name: None,
+            runtime_pack: false,
+            net: false,
+            allow_host: Vec::new(),
+            cpus: 2,
+            cpu_limit: None,
+            grants_file: None,
+            memory: "512M".to_string(),
+            profile: RunProfile::Standard,
+            mounts: Vec::new(),
+            env: Vec::new(),
+            timeout: None,
+            receipt: None,
+            json: false,
+            dry_run: false,
+            launch_plan: None,
+            mode: None,
+            dev: false,
+            prod: false,
+            argv: Vec::new(),
+            ack_divergence: Vec::new(),
+            agent_verb: Vec::new(),
+            host_service: Vec::new(),
+            stdin: Vec::new(),
+            healthcheck: None,
+            hypervisor: None,
+        }
+    }
+}
+
 /// SDK transport modes for `mvmctl run`. Mirrors the `Mode` enum on
 /// `mvmctl compile` but specialises the rejection messages to point
 /// users at the right verb when they pick the wrong default.
@@ -1624,38 +1673,47 @@ mod tests {
 
     fn run_args(profile: RunProfile) -> RunArgs {
         RunArgs {
-            network_mode: mvm_contract::plan::NetworkMode::default(),
-            warm_pool_size: 0,
-            pty: false,
-            vm_name: None,
-            manifest: None,
-            image: None,
-            runtime_pack: false,
-            net: false,
-            allow_host: Vec::new(),
-            cpus: 2,
-            cpu_limit: None,
-            grants_file: None,
-            memory: "512M".to_string(),
             profile,
-            agent_verb: Vec::new(),
-            mounts: Vec::new(),
-            env: Vec::new(),
             timeout: Some(60),
-            receipt: None,
-            json: false,
-            dry_run: false,
-            launch_plan: None,
-            mode: None,
-            dev: false,
-            prod: false,
             argv: vec!["/bin/true".to_string()],
-            ack_divergence: Vec::new(),
-            stdin: Vec::new(),
-            healthcheck: None,
-            hypervisor: None,
-            host_service: Vec::new(),
+            ..Default::default()
         }
+    }
+
+    /// `Default` is hand-written, so it can drift from the `default_value`
+    /// attributes clap actually applies. Parse a bare invocation and compare.
+    #[test]
+    fn parsed_defaults_match_the_default_impl() {
+        use clap::Parser;
+
+        let parsed = crate::commands::Cli::try_parse_from(["mvmctl", "run", "--", "x"])
+            .expect("bare `run -- x` parses");
+        let crate::commands::Commands::Run(parsed) = parsed.command else {
+            panic!("expected Commands::Run");
+        };
+        let expected = RunArgs {
+            argv: vec!["x".to_string()],
+            ..Default::default()
+        };
+
+        assert_eq!(parsed.cpus, expected.cpus, "--cpus default");
+        assert_eq!(parsed.memory, expected.memory, "--memory default");
+        assert_eq!(parsed.profile, expected.profile, "--profile default");
+        assert_eq!(parsed.net, expected.net, "--net default");
+        assert_eq!(parsed.json, expected.json, "--json default");
+        assert_eq!(parsed.dry_run, expected.dry_run, "--dry-run default");
+        assert_eq!(parsed.dev, expected.dev, "--dev default");
+        assert_eq!(parsed.prod, expected.prod, "--prod default");
+        assert_eq!(parsed.timeout, expected.timeout, "--timeout default");
+        assert_eq!(parsed.cpu_limit, expected.cpu_limit, "--cpu-limit default");
+        assert_eq!(parsed.mode, expected.mode, "--mode default");
+        assert_eq!(
+            parsed.allow_host, expected.allow_host,
+            "--allow-host default"
+        );
+        assert_eq!(parsed.mounts, expected.mounts, "--mount default");
+        assert_eq!(parsed.env, expected.env, "--env default");
+        assert_eq!(parsed.argv, expected.argv, "trailing argv");
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -553,37 +553,10 @@ mod tests {
 
     fn base_run_args() -> RunArgs {
         RunArgs {
-            network_mode: mvm_contract::plan::NetworkMode::default(),
-            manifest: None,
-            warm_pool_size: 0,
-            pty: false,
-            vm_name: None,
-            image: None,
-            runtime_pack: false,
-            net: false,
-            allow_host: Vec::new(),
-            cpus: 2,
-            cpu_limit: None,
-            grants_file: None,
-            memory: "512M".to_string(),
             profile: RunProfile::Standard,
-            agent_verb: Vec::new(),
-            mounts: Vec::new(),
-            env: Vec::new(),
             timeout: Some(60),
-            receipt: None,
-            json: false,
-            launch_plan: None,
             mode: Some(RunMode::Plan),
-            dev: false,
-            prod: false,
-            dry_run: false,
-            argv: Vec::new(),
-            ack_divergence: Vec::new(),
-            stdin: Vec::new(),
-            healthcheck: None,
-            hypervisor: None,
-            host_service: Vec::new(),
+            ..Default::default()
         }
     }
 

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -74,9 +74,13 @@ use super::exec::{RunArgs, RunMode};
 /// Dispatch an SDK-mode `mvmctl run` invocation. Plan and Live both
 /// reach this entry now; `Record` is still refused at the
 /// `resolve_run_mode` layer.
-pub(in crate::commands) fn dispatch_sdk_mode(mode: RunMode, args: &RunArgs) -> Result<()> {
+pub(in crate::commands) fn dispatch_sdk_mode(
+    mode: RunMode,
+    args: &RunArgs,
+    sdk: &super::exec::SdkTransportArgs,
+) -> Result<()> {
     match mode {
-        RunMode::Plan => run_plan_mode(args),
+        RunMode::Plan => run_plan_mode(args, sdk),
         RunMode::Live => run_live_mode(args),
         RunMode::Record => unreachable!(
             "exec::resolve_run_mode refuses RunMode::Record before reaching dispatch; this is a \
@@ -161,7 +165,7 @@ fn run_live_mode(args: &RunArgs) -> Result<()> {
     Ok(())
 }
 
-fn run_plan_mode(args: &RunArgs) -> Result<()> {
+fn run_plan_mode(args: &RunArgs, sdk: &super::exec::SdkTransportArgs) -> Result<()> {
     let script = extract_script_arg(args)?;
     let lang = script_language_from_path(&script).ok_or_else(|| {
         anyhow::anyhow!(
@@ -185,7 +189,7 @@ fn run_plan_mode(args: &RunArgs) -> Result<()> {
 
     eprintln!("recording sha256: {digest_hex}");
     refuse_embedded_secrets(&secret_findings)?;
-    require_acknowledged(&findings, &args.ack_divergence)?;
+    require_acknowledged(&findings, &sdk.ack_divergence)?;
 
     if workload.apps.is_empty() {
         bail!(
@@ -419,7 +423,7 @@ fn placeholder_image_sha(workload_id: &str, app_name: &str) -> String {
 mod tests {
     use super::*;
     use crate::commands::build::trace_secret_scan::scan_recording_for_secrets;
-    use crate::commands::vm::exec::{RunMode, RunProfile};
+    use crate::commands::vm::exec::RunProfile;
     use base64::Engine;
     use mvm_hostd::supervisor::secrets_scanner::SecretsScanner;
     use mvm_sdk::runtime::{Divergence, RecordedOp, RuntimeRecording, SandboxCreate};
@@ -555,7 +559,6 @@ mod tests {
         RunArgs {
             profile: RunProfile::Standard,
             timeout: Some(60),
-            mode: Some(RunMode::Plan),
             ..Default::default()
         }
     }

--- a/features/suites/s0_cli/machine_run_contract.feature
+++ b/features/suites/s0_cli/machine_run_contract.feature
@@ -67,7 +67,7 @@ Feature: machine run request contract
     When I run mvmctl in the isolated mvm home with "machine run --image alpine --dry-run --name bdd-dry-run -- /bin/true"
     Then the command exits with code 0
     And the output contains "no VM will be booted"
-    And the output contains "profile: dev"
+    And the output contains "profile: standard"
     And the isolated mvm home does not contain directory "vms/bdd-dry-run"
 
   # Deny-all is the default posture, and a dry run is where an operator checks

--- a/features/suites/s5_lifecycle/restore_reapplies_confinement.feature
+++ b/features/suites/s5_lifecycle/restore_reapplies_confinement.feature
@@ -3,9 +3,9 @@ Feature: Restore reapplies confinement
   Confinement parameters are part of the launch contract and must remain
   effective across warm restore.
 
-  Scenario: a dry-run workload advertises its dev confinement profile
+  Scenario: a dry-run workload advertises its confinement profile
     When I run mvmctl with "machine run --image alpine --dry-run -- echo hi"
     Then the command exits with code 0
-    And the output contains "profile: dev"
+    And the output contains "profile: standard"
     And the output contains "network: deny-all"
     And the output contains "enforced: flow-drop"

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -357,7 +357,8 @@ shell).
 | `mvmctl run --manifest <name-or-path> -- <cmd>...` | Boot a registered manifest/template instead of the default |
 | `mvmctl run --image <ref> -- <cmd>...` | Pull or reuse a cached OCI image, emit signed audit-chain provenance for the resolved image, boot its prepared OCI rootfs (read-only virtiofs-root on capable dev-tier backends, otherwise block `rootfs.ext4`), run `<cmd>`, exit |
 | `mvmctl run --image <ref> --prod -- <cmd>...` | Production OCI-image policy: require `<ref>` to be digest-pinned and cosign-verified by the OCI policy before cache use or boot |
-| `mvmctl run --profile standard -- <cmd>` | Default profile: explicit env is allowed; host shares must be read-only |
+| `mvmctl run --profile standard -- <cmd>` | Default profile on both `run` and `machine run`: explicit env is allowed; host shares must be read-only |
+| `mvmctl run --profile dev -- <cmd>` | Dev tier: as standard, plus a writable (`:rw`) host share on a persistent machine and the dev guest profile for a sealed-image entrypoint run |
 | `mvmctl run --profile restrictive -- <cmd>` | No env injection and no host directory shares |
 | `mvmctl run --mount .:/work:ro -- <cmd>` | Attach a live read-only host-directory share |
 | `mvmctl run --profile permissive -- <cmd>` | Escape hatch; requires `MVM_ACK_PERMISSIVE_RUN=1` |

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1103,8 +1103,11 @@ for detailed scope and acceptance criteria.
       reference rows written, and `xtask check-cli-help-matches-docs` added to
       the Lint job so `mvmctl --help` and the published CLI reference cannot
       drift apart again. Phase 5 (snapshot/fork DX) was already complete.
-      Phases 1–4 and 6–8 remain: consolidating the two run-argument structs is
-      next and blocks the rest.
+      Phase 1 then landed the shared argument core: the 26 shared execution
+      flags are declared once in `RunArgs` and flattened into both verbs, with
+      `run` adding the SDK transport and `machine run` the lifecycle flags. Both
+      verbs now default to `--profile standard`. Phases 2–4 and 6–8 remain;
+      runtime auto-detection is next.
 - [ ] Plan 329 — Browser-tier microVM demo (`specs/plans/329-browser-wasm-backend-demo.md`)
       — in progress on `feat/329-browser-wasm-backend`. Extends Plan 320 with a
       `wasm32-wasip1` guest that boots, provides a shell, and delegates `fetch`

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -1,9 +1,8 @@
 # Plan 329 — Run-first CLI ergonomics and upstream-sandbox adoption
 
-**Status:** Active. Phase A (below) landed the ADR-027 amendment, the verb
-visibility triage, and `xtask check-cli-help-matches-docs`. `mvmctl run` and
-`mvmctl machine run` are both visible top-level commands; consolidating them
-onto one argument struct is Phase 1 and has not landed yet.
+**Status:** Active. Phase A landed the ADR-027 amendment, the verb visibility
+triage, and `xtask check-cli-help-matches-docs`. Phase 1 landed the shared
+argument core: `RunArgs` is declared once and flattened into both verbs.
 
 **Bound by:** [ADR-027](../adrs/027-cli-surface-consolidation.md) (amended
 2026-08-17),
@@ -193,17 +192,23 @@ complete; no unresolved capability gap.
 
 ### Phase 1 — Consolidate the `run` argument surface
 
-- [ ] Merge `vm::exec::Args`, `vm::exec::RunArgs`, and
-      `machine::MachineRunArgs` into a single `RunArgs` source of truth in
-      `mvm-cli`.
+- [x] Merge the shared surface into a single `RunArgs` source of truth in
+      `mvm-cli`, flattened into both verbs. **Deviation from the wording
+      above, deliberate:** a literal single struct would give `mvmctl run`
+      `--name`/`-d`/`--port`/`--ttl`/`--entrypoint` and make it a complete
+      synonym for `machine run`, contradicting "flagship one-shot" in the
+      decision record above and re-creating the second-name-for-one-operation
+      that ADR-027 forbids. The 26 shared execution flags are declared once in
+      `RunArgs`; `run` adds `SdkTransportArgs`, `machine run` adds the
+      lifecycle flags.
 - [ ] Ensure the consolidated args can drive both the direct execution path
       and the `mvm-client::MvmClient::run_machine` facade method.
-- [ ] Ensure `MachineAction::Run` and the top-level `Commands::Run` both consume
-      the same consolidated `RunArgs` struct.
+- [x] Ensure `MachineAction::Run` and the top-level `Commands::Run` both consume
+      the same consolidated `RunArgs` struct (flattened into each).
 - [x] Promote `Commands::Run` from `hide = true` to a documented, ordered
       top-level subcommand while keeping `machine run` visible. *(Phase A)*
 - [ ] Update clap completions generation to include the visible `run` surface.
-- [ ] Adjust tests and BDD fixtures that assumed `run` was hidden or that
+- [x] Adjust tests and BDD fixtures that assumed `run` was hidden or that
       `machine run` had a divergent argument surface.
 
 **Acceptance:** `cargo nextest run --workspace` and `cargo clippy --workspace
@@ -231,11 +236,14 @@ without a manifest; detection is deterministic and tested.
 ### Phase 3 — Security profile presets
 
 - [ ] Add `--profile {restrictive,standard,dev,permissive}` to `mvmctl run`.
-- [ ] Map each preset unambiguously to existing policy flags (env passthrough,
-      host mounts, network allowlist, seccomp posture).
+- [x] Reconcile the default: both verbs now default to `standard`. `machine
+      run` defaulted to `dev`, which on the persistent machine-spec path
+      admitted a writable (`:rw`) host share without the user asking. It now
+      refuses at spec time naming `--profile dev`, so the share fails closed
+      and loudly rather than being silently downgraded to read-only.
 - [ ] Surface the effective profile in execution receipts and `mvmctl doctor`.
-- [ ] Reject `--profile permissive` unless `MVM_ACK_PERMISSIVE_RUN=1` is set,
-      matching the current escape-hatch behavior.
+- [x] Reject `--profile permissive` unless `MVM_ACK_PERMISSIVE_RUN=1` is set
+      (already shipped before this plan — see Corrections 1).
 - [ ] Add tests for preset-to-policy mapping and receipt contents.
 
 **Acceptance:** Presets work, are documented, and do not create new privileged

--- a/specs/sprint/delivery/shared-run-argument-core.md
+++ b/specs/sprint/delivery/shared-run-argument-core.md
@@ -1,0 +1,57 @@
+# One argument core behind `run` and `machine run`
+
+**Plan:** `specs/plans/329-run-first-cli-and-upstream-adoption.md`, Phase 1.
+
+## What was wrong
+
+The two run verbs each declared their own argument struct and `machine run`
+converted into the other by hand. Twenty-one flags were spelled twice, and they
+had drifted:
+
+- `--profile` defaulted to `dev` on `machine run` and `standard` on `run`.
+- `--agent-verb` and `--hypervisor` were real flags on `machine run` and
+  `#[arg(skip)]` internals on `run`.
+- `--flake`, `--flake-profile`, `--deployment` and `--runtime-pack` existed only
+  on `machine run`; `--prod` — which selects production OCI policy, not just an
+  SDK mode — existed only on `run`, so the beginner verb could not ask for a
+  digest-pinned, verified image.
+
+## The shape
+
+`RunArgs` holds the 26 shared execution flags and is flattened into both verbs.
+`run` adds `SdkTransportArgs` (`--mode`, `--dev`, `--ack-divergence`);
+`machine run` adds the lifecycle flags (`--name`, `-d`, `--port`, `--ttl`,
+`--tty`, `--entrypoint`, the healthcheck family, …).
+
+This deviates from Plan 329's literal "one consolidated struct" wording, and the
+plan now records why: a single struct hands `run` the whole lifecycle surface
+and makes it a synonym for `machine run`, which contradicts the same plan's
+"flagship one-shot" and re-creates the second-name-for-one-operation ADR-027
+exists to forbid.
+
+## Behaviour changes
+
+- **`--profile` defaults to `standard` on `machine run`** (was `dev`). On the
+  persistent machine-spec path `dev` admitted a writable `:rw` host share; the
+  default now refuses at spec time with a message naming `--profile dev`. It
+  fails closed and loudly rather than silently handing the guest a read-only
+  mount it would fail to write to later. The transient path was already
+  read-only under both profiles.
+- **`machine run` gains** `--prod`, `--launch-plan`, `-m` as a `--manifest`
+  short, and `--mount`'s `--volume` alias is now on both verbs.
+- **`run` gains** `--flake`, `--flake-profile`, `--deployment`,
+  `--runtime-pack`, `--agent-verb`, `--hypervisor`.
+- **A bare `mvmctl run` now refuses at runtime, not at parse time.** `argv`'s
+  `required_unless_present_any` could not survive the flatten: `machine run -d`
+  legitimately boots with no command, and the attribute named `mode`/`dev`,
+  which do not exist on the `machine` side. `run_transient` checks it and says
+  what to type instead.
+
+## Witnesses
+
+`parsed_defaults_match_the_default_impl` and
+`machine_run_parsed_defaults_match_the_default_impl` parse a bare invocation of
+each verb and compare field by field against the hand-written `Default`, which
+is what stops the impl and the `#[arg(default_value)]` attributes drifting. The
+second also asserts the two verbs agree on `--profile`. Confirmed red by moving
+the impl's `cpus` to 4.


### PR DESCRIPTION
Phase 1 of `specs/plans/329-run-first-cli-and-upstream-adoption.md`, following #2631.

## The problem

The two run verbs each declared their own argument struct, and `machine run` converted into the other by hand. **Twenty-one flags were spelled twice, and they had drifted:**

| | `mvmctl run` | `mvmctl machine run` |
|---|---|---|
| `--profile` default | `standard` | `dev` |
| `--agent-verb`, `--hypervisor` | `#[arg(skip)]` internals | real flags |
| `--flake`, `--flake-profile`, `--deployment`, `--runtime-pack` | absent | present |
| `--prod` (production OCI policy) | present | **absent** |

That last row is the sharp one: `--prod` selects digest-pinned, cosign-verified image policy, not just an SDK mode — and the beginner-facing verb could not ask for it.

## The shape

`RunArgs` holds the 26 shared execution flags and is flattened into both verbs. `run` adds `SdkTransportArgs` (`--mode`, `--dev`, `--ack-divergence`); `machine run` adds the lifecycle flags (`--name`, `-d`, `--port`, `--ttl`, `--tty`, `--entrypoint`, the healthcheck family).

**This is not the single struct Plan 329 literally asked for, and the plan now records why.** One struct hands `run` the entire lifecycle surface — `mvmctl run --detach --name foo --port 8080` — making it a complete synonym for `machine run`. That contradicts the same plan's "flagship one-shot" and re-creates exactly the second-name-for-one-operation ADR-027 exists to forbid.

## Behaviour changes

Each is a consequence of there now being one answer where there were two:

- **`machine run` defaults to `--profile standard`** (was `dev`). On the persistent machine-spec path `dev` admitted a writable `:rw` host share without the user asking; the default now refuses at spec time with a message naming `--profile dev`. It fails closed and loudly rather than silently handing the guest a read-only mount it would fail to write to later. The transient path was already read-only under both profiles.
- **`machine run` gains** `--prod`, `--launch-plan`, `-m` as a `--manifest` short.
- **`run` gains** `--flake`, `--flake-profile`, `--deployment`, `--runtime-pack`, `--agent-verb`, `--hypervisor`.
- **A bare `mvmctl run` refuses at runtime, not at parse time.** `argv`'s `required_unless_present_any` could not survive the flatten — `machine run -d` legitimately boots with no command, and the attribute named `mode`/`dev`, which don't exist on the machine side. `run_transient` checks it and says what to type instead.

## Witnesses

`parsed_defaults_match_the_default_impl` and `machine_run_parsed_defaults_match_the_default_impl` parse a bare invocation of each verb and compare field by field against the hand-written `Default` — which is what stops the impl and the `#[arg(default_value)]` attributes drifting. The second also pins that the two verbs agree on `--profile`. Confirmed red by moving the impl's `cpus` to 4.

The first commit is separable: it adds `Default` and collapses four sites that each spelled all 31 fields, which is what made the second commit's diff readable.

## Verification

- `cargo nextest run --workspace` — **12085 passed, 0 failed**
- **BDD conformance: 206 passed, 0 failed** (run with the TypeScript SDK built, so the s27 SDK-parity scenarios actually execute)
- `cargo test --workspace --doc`, `just check-gated`, nightly `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- `check-cli-help-matches-docs`, `check-no-spec-refs-in-comments`, `check-machine-doc-guards`, `check-claim-catalog`, `check-honesty`

Two BDD scenarios asserting `profile: dev` were updated to `standard`, and the CLI reference gains a `--profile dev` row explaining what the non-default tier buys.