### PR TITLE
perf(agent): stop charging every exec a 50ms poll tick to notice a child that already exited

### DIFF
--- a/crates/mvm-agentd/src/exec_stream.rs
+++ b/crates/mvm-agentd/src/exec_stream.rs
@@ -17,7 +17,6 @@ use std::time::{Duration, Instant};
 /// (was `MAX_EXEC_OUTPUT` in the agent bin).
 pub const MAX_EXEC_OUTPUT: usize = 1024 * 1024;
 const DRAIN_BUF: usize = 4096;
-const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 fn spawn_drain<R: Read + Send + 'static>(
     mut reader: R,
@@ -143,10 +142,18 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
     let mut sent_out = 0usize;
     let mut sent_err = 0usize;
     let deadline = timeout_secs.map(|s| Instant::now() + Duration::from_secs(s));
+    // Consecutive polls that found neither output nor an exit. Reset on any
+    // progress so a chatty command keeps draining at the fast end of the
+    // backoff instead of decaying to the ceiling and staying there.
+    let mut idle_polls = 0u32;
 
     loop {
+        let before = (sent_out, sent_err);
         let capped = drain_into(&out_buf, &mut sent_out, true, &mut emit)
             | drain_into(&err_buf, &mut sent_err, false, &mut emit);
+        if (sent_out, sent_err) != before {
+            idle_polls = 0;
+        }
         if capped {
             kill_pgroup(&child);
             let _ = crate::child_wait::wait(&mut child);
@@ -188,7 +195,21 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
                     code: status.code().unwrap_or(-1),
                 };
             }
-            Ok(None) => std::thread::sleep(POLL_INTERVAL),
+            Ok(None) => {
+                // Backoff, not a flat tick. `/bin/true` has not been reaped by
+                // the time the first `try_wait` runs, so a fixed interval here
+                // was a floor under *every* exec: the second check found the
+                // child already gone, having waited the whole gap to look. It
+                // put 50ms on a command that takes microseconds.
+                //
+                // The same shared backoff the readiness and pid-exit waits
+                // use, so a quick command is noticed in ~1ms while a long one
+                // still settles to a ceiling rather than spinning. The ceiling
+                // is also what bounds output-streaming latency, since this
+                // loop drains stdout/stderr on each pass.
+                std::thread::sleep(mvm_core::poll_backoff::poll_delay(idle_polls));
+                idle_polls = idle_polls.saturating_add(1);
+            }
             Err(e) => {
                 emit(ExecEvent::Stderr {
                     chunk: format!("wait failed: {e}").into_bytes(),

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -667,7 +667,12 @@ for detailed scope and acceptance criteria.
     Measured on release, HVF/macOS, against an unchanged control span in the
     same runs: `stop_console_cleanup` 57.0 -> 7.0-7.7 ms while
     `stop_pid_disappearance` held at 33.4-35.5 ms against a 33.7 ms baseline.
-    Foreground teardown 91.4 -> 41-45 ms, total 287.2 -> ~233 ms.
+    Foreground teardown 91.4 -> 41-45 ms. A fifth cadence site was then found
+    inside the guest agent — `exec_stream` slept a flat 50 ms before rechecking
+    a child that had already exited, a hard floor under every exec — taking
+    `command` 52.5 -> 4.6-5.4 ms. Total 287.2 -> p50 191.2 ms over 9 samples
+    (not the 20 a publishable lane needs; the host became too loaded to finish
+    the set, so there is no p95/p99 yet).
     Admission's three pre-boot chain barriers now
     share one flush, closing #2293's open acceptance item without changing
     `sync_policy_for`'s fail-closed default, and the chain cursor reads a

--- a/specs/plans/299-cold-launch-performance.md
+++ b/specs/plans/299-cold-launch-performance.md
@@ -505,6 +505,60 @@ a launch appends ~6 entries, so admission cost up to 24 MiB of reads per launch
 a sawtooth in `admit` that no sample would explain. It now reads a bounded tail
 window and widens only if a record spans it.
 
+### The `command` span was a 50 ms floor in the guest agent
+
+`command` — authenticated agent to finished guest command — was 52.5 ms for
+`/bin/true`, and constant to a tenth of a millisecond across runs (52.5, 52.7,
+52.9). A constant is the shape of a floor.
+
+`exec_stream`'s wait loop slept a flat 50 ms whenever `try_wait` returned
+`None`. A command that exits in microseconds always loses that first race — the
+child cannot have been reaped by the time the loop reaches it — so the second
+check found it already gone, having waited the whole interval to look. Nothing
+could finish this span in under 50 ms.
+
+This is the fifth site of the cadence bug, and the first one inside the guest
+rather than on the host, which is why the four Phase 5 fixes and the two seal
+fixes never came near it. It now shares `mvm_core::poll_backoff` with the other
+four, with the idle counter reset on any output so a chatty command keeps
+draining at the fast end rather than decaying to the ceiling — this loop drains
+stdout/stderr on each pass, so the ceiling bounds streaming latency as well as
+exit latency.
+
+Measured, release, HVF/macOS: **52.5 -> 4.6-5.4 ms**.
+
+### Where prepared cold stands after this branch
+
+Release, HVF/macOS, `machine run --image alpine -- true`, warm artifact cache,
+first (cold) sample discarded — **9 samples, not the 20 a publishable lane
+requires**, because the host became too loaded to sample further:
+
+| span | before this branch | after |
+|---|---:|---:|
+| `admit` | 47.4 | 36-40 |
+| `vsock_wait` | 58.2 | 61-70 |
+| `command` | 52.0 | **4.6-5.4** |
+| `teardown` | 91.4 | **39-48** |
+| **total** | **287.2** | **p50 191.2, max 196.2** |
+
+`dispatch_window` is 79-85 ms against its 200 ms p50 budget, unchanged in
+substance by this branch — every cut here is outside the window the contract
+measures, which is the point: the contract was already met and the user-visible
+number was not.
+
+Three caveats, stated because the table above is the kind of thing that gets
+quoted without them. Nine samples is not the lane's 20, so there is no p95/p99
+here and these are not publishable numbers. `vsock_wait` drifted *up* slightly
+and is now the largest remaining span — it is Phase 5's event-driven readiness
+task and untouched by this branch. And `teardown` is still ~40 ms of which
+~33 ms is the guest-RAM reclaim measured above, so it scales with workload size
+and this 512 MiB figure is the best case.
+
+Remaining, in size order: `vsock_wait` 61-70 ms (Phase 5), `teardown` ~40 ms
+(guest-RAM reclaim, Phase 6), `admit` 36-40 ms (of which ~22 ms is three
+`F_FULLFSYNC`s — the chain batch, the receipt, and `plan.json`; the receipt is
+the open durability question above).
+
 ### `stop_pid_disappearance` is guest-RAM teardown, ~48 ms/GB — open
 
 The remaining teardown span. Two candidates were on the table: the 5 ms


### PR DESCRIPTION
Stacked on #2643. Base is that branch so this diff is exactly its own two commits; it will be rebased onto `main` and retargeted once #2643 squash-merges.

## The finding

`command` — the span from an authenticated guest agent to a finished guest command — was **52.5 ms** for `/bin/true`, and constant to a tenth of a millisecond across runs: 52.5, 52.7, 52.9. That constancy is the tell. A number that steady is a floor, not work.

`crates/mvm-agentd/src/exec_stream.rs:191` slept a flat 50 ms whenever `try_wait` returned `None`. A command that exits in microseconds always loses that first race — the child cannot have been reaped by the time the loop reaches it — so the second check found it already gone, having waited the entire interval to look. **Every exec paid one full tick, and nothing could finish this span in under 50 ms.**

This is the fifth site of the cadence bug this work has now found, and the first one *inside the guest* rather than on the host — which is why Plan 299's four fixes and the two seal fixes in #2643 never came near it.

## The change

It now shares `mvm_core::poll_backoff` with the other four sites, rather than being a fifth copy of a constant. The idle counter resets on any output, so a chatty command keeps draining at the fast end of the backoff instead of decaying to the ceiling and staying there — this loop drains stdout/stderr on each pass, so the ceiling bounds streaming latency as well as exit latency.

Measured, release, HVF/macOS: **`command` 52.5 → 4.6–5.4 ms.**

## Where prepared cold lands

Release, HVF/macOS, `machine run --image alpine -- true`, warm artifact cache, first (cold) sample discarded:

| span | before this work | after |
|---|---:|---:|
| `admit` | 47.4 | 36–40 |
| `vsock_wait` | 58.2 | 61–70 |
| `command` | 52.0 | **4.6–5.4** |
| `teardown` | 91.4 | **39–48** |
| **total** | **287.2** | **p50 191.2, max 196.2** |

**Read the caveats with the table.** This is **9 samples, not the 20** a publishable lane requires, so there is no p95/p99 and these are not publishable numbers — the host became too loaded to finish the set. `vsock_wait` drifted slightly *up* and is now the largest remaining span; it is Phase 5's event-driven-readiness task and is deliberately untouched, since Plan 299 records that tightening the poll cap widens the p99 tail. And the `teardown` figure is a 512 MiB best case, because ~33 ms of it is guest-RAM reclaim that scales at ~48 ms/GB.

`dispatch_window` is 79–85 ms against its 200 ms p50 budget and is not materially changed here — every cut is *outside* the window the contract measures, which is the point: the contract was already being met while the user-visible number was 287 ms.

## On test coverage

No unit test pins the latency. The honest guard would be a wall-clock budget, and this repo has been bitten by those failing for reasons unrelated to what they claim to measure. The 21 existing `exec_stream` tests cover the behaviour that must not change — ordering, tail bytes, timeout, output cap, exit codes — and all pass; the number itself is evidenced by the before/after recorded in Plan 299.

## Verification

- `cargo nextest run -p mvm-agentd` exec_stream + child_wait: 21 passed
- Full-workspace clippy via the pre-commit hook: clean
- `cargo +nightly fmt --all -- --check`: clean
- xtask `check-honesty`, `check-no-overclaim`, `check-doc-claims`, `check-plan-names`, `check-sprint-append`: all OK