### PR TITLE
feat(cli): `mvmctl run npm test` picks the image

### DIFF
--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -355,6 +355,16 @@ fn workload_needs_raw_ip_stack(workload_ir: Option<&std::path::Path>) -> Result<
 }
 
 pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig) -> Result<()> {
+    // Settle the boot source before `resolve_mode` decides whether one is
+    // missing — the same resolver `mvmctl run` uses, so the two verbs infer
+    // identically or not at all.
+    let cwd = std::env::current_dir().context("resolving the working directory")?;
+    crate::commands::vm::exec::resolve_run_source(
+        &mut args.run,
+        &cwd,
+        crate::commands::vm::exec::Inference::ExplicitOnly,
+    )?
+    .announce();
     let resolved_flake_slot = if let Some(flake_ref) = args.run.flake.take() {
         let slot_hash = build::build_flake_to_slot(&flake_ref, args.run.flake_profile.as_deref())?;
         args.run.manifest = Some(slot_hash.clone());

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -110,6 +110,8 @@ const SOURCES_EXCEPT_MANIFEST: [&str; 4] = ["image", "flake", "runtime_pack", "d
 const SOURCES_EXCEPT_FLAKE: [&str; 4] = ["image", "manifest", "runtime_pack", "deployment"];
 const SOURCES_EXCEPT_RUNTIME_PACK: [&str; 4] = ["image", "manifest", "flake", "deployment"];
 const SOURCES_EXCEPT_DEPLOYMENT: [&str; 4] = ["image", "manifest", "flake", "runtime_pack"];
+const SOURCES_EXCEPT_RUNTIME: [&str; 5] =
+    ["image", "manifest", "flake", "runtime_pack", "deployment"];
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct RunArgs {
@@ -147,6 +149,12 @@ pub(in crate::commands) struct RunArgs {
     /// Boot a verified attested runtime pack.
     #[arg(long, conflicts_with_all = SOURCES_EXCEPT_RUNTIME_PACK)]
     pub runtime_pack: bool,
+    /// Boot a named runtime from the built-in catalog.
+    #[arg(long, value_name = "NAME", conflicts_with_all = SOURCES_EXCEPT_RUNTIME)]
+    pub runtime: Option<String>,
+    /// Do not infer a runtime from the command or working directory.
+    #[arg(long, conflicts_with = "runtime")]
+    pub no_detect: bool,
     /// Enable outbound networking (off by default).
     #[arg(long)]
     pub net: bool,
@@ -216,6 +224,150 @@ pub(in crate::commands) struct RunArgs {
     pub hypervisor: Option<String>,
 }
 
+/// Whether a verb infers a boot source it was not given.
+///
+/// `run` is the one-shot where "just run this" is the whole point, so it infers.
+/// `machine run` creates a named — possibly persistent — machine, and guessing
+/// its base image from whatever directory you happened to be standing in is a
+/// footgun there: `machine run` inside any Rust checkout would silently build a
+/// machine on `rust:1-alpine`. It keeps its own error, which names every way to
+/// supply a source. `--runtime` still works on both, because that is the user
+/// naming one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::commands) enum Inference {
+    /// Infer from `mvm.toml`, then argv[0], then a project file.
+    Enabled,
+    /// Only an explicit `--runtime` resolves.
+    ExplicitOnly,
+}
+
+/// Where a run's boot source came from once every rule has had its say.
+///
+/// Returned rather than logged from inside the resolver so the caller decides
+/// how to say it: a boot the user did not explicitly ask for must not be silent
+/// about why it happened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands) enum ResolvedSource {
+    /// The user named a source; nothing was inferred.
+    Explicit,
+    /// An `mvm.toml` in or above the working directory supplied it.
+    ProjectManifest(PathBuf),
+    /// The command or the working directory selected a catalog runtime.
+    Runtime(mvm_core::runtime_catalog::Detection),
+    /// Nothing matched; the bundled default image is used.
+    BundledDefault,
+}
+
+impl ResolvedSource {
+    /// Say what was inferred, on stderr.
+    ///
+    /// Not `ui::info`, which is opt-in chatter shown only under `--verbose`: a
+    /// boot whose image the user did not choose has to announce itself every
+    /// time, or the first they learn of it is a "command not found" from a
+    /// guest they never picked. stderr keeps `--json` stdout machine-readable.
+    pub(in crate::commands) fn announce(&self) {
+        if let Some(note) = self.note() {
+            eprintln!("[mvm] {note}");
+        }
+    }
+
+    /// The line to print before booting, or `None` when the user already knows
+    /// what they asked for.
+    pub(in crate::commands) fn note(&self) -> Option<String> {
+        match self {
+            ResolvedSource::Explicit | ResolvedSource::BundledDefault => None,
+            ResolvedSource::ProjectManifest(path) => Some(format!(
+                "using {} from the project directory",
+                path.display()
+            )),
+            ResolvedSource::Runtime(d) => Some(format!(
+                "detected {} from {} — booting {}",
+                d.runtime,
+                d.via.describe(),
+                d.image
+            )),
+        }
+    }
+}
+
+/// Settle which source a run boots from, filling `args` in place.
+///
+/// One resolver for both verbs. The order is the whole contract:
+///
+/// 1. An explicit `--image` / `--manifest` / `--flake` / `--deployment` /
+///    `--runtime-pack` wins and nothing is inferred.
+/// 2. `--runtime <name>` resolves against the built-in catalog. An unknown name
+///    refuses — it never falls through to a default.
+/// 3. `--no-detect`, or a verb that only takes explicit sources, stops here.
+/// 4. An `mvm.toml` in or above the working directory, found by the same
+///    walk-up `mvmctl build` already uses.
+/// 5. The command being run, then a project file in the working directory.
+/// 6. The bundled default image.
+///
+/// Inference only ever picks a *source*. It does not touch policy: a detected
+/// run admits through the same signed `ExecutionPlan` with the same default-deny
+/// egress as one that named its image, which is what
+/// `a_detected_run_is_still_deny_all_and_admitted` pins.
+pub(in crate::commands) fn resolve_run_source(
+    args: &mut RunArgs,
+    cwd: &std::path::Path,
+    inference: Inference,
+) -> Result<ResolvedSource> {
+    if args.image.is_some()
+        || args.manifest.is_some()
+        || args.flake.is_some()
+        || args.deployment.is_some()
+        || args.runtime_pack
+    {
+        return Ok(ResolvedSource::Explicit);
+    }
+
+    let catalog = mvm_core::runtime_catalog::RuntimeCatalog::builtin();
+
+    if let Some(name) = args.runtime.clone() {
+        let detection = catalog
+            .resolve_named(&name)
+            .map_err(|e| anyhow::anyhow!(e))?;
+        args.image = Some(detection.image.clone());
+        return Ok(ResolvedSource::Runtime(detection));
+    }
+
+    if args.no_detect || inference == Inference::ExplicitOnly {
+        return Ok(ResolvedSource::BundledDefault);
+    }
+
+    if let Some(manifest) = mvm_core::domain::manifest::discover_manifest_from_dir(cwd)
+        .context("looking for an mvm.toml in the working directory")?
+    {
+        args.manifest = Some(manifest.display().to_string());
+        return Ok(ResolvedSource::ProjectManifest(manifest));
+    }
+
+    let present = project_files_in(cwd);
+    if let Some(detection) = catalog.detect(args.argv.first().map(String::as_str), &present) {
+        args.image = Some(detection.image.clone());
+        return Ok(ResolvedSource::Runtime(detection));
+    }
+
+    Ok(ResolvedSource::BundledDefault)
+}
+
+/// The plain filenames directly in `cwd`.
+///
+/// Detection reads names only — never contents — so a directory the user merely
+/// stood in cannot influence anything but which image is chosen. An unreadable
+/// directory detects nothing rather than failing the run.
+fn project_files_in(cwd: &std::path::Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(cwd) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_file()))
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect()
+}
+
 /// The SDK transport surface, carried by `mvmctl run` alone.
 ///
 /// These are kept out of [`RunArgs`] deliberately. `RunArgs` is flattened into
@@ -283,6 +435,8 @@ impl Default for RunArgs {
             pty: false,
             vm_name: None,
             runtime_pack: false,
+            runtime: None,
+            no_detect: false,
             net: false,
             allow_host: Vec::new(),
             cpus: 2,
@@ -399,7 +553,7 @@ pub(in crate::commands) fn run_secure(cli: &Cli, args: RunArgs, cfg: &MvmConfig)
 /// `RunArgs` be flattened into `machine run` without dragging them along.
 pub(in crate::commands) fn run_transient(
     cli: &Cli,
-    args: TransientRunArgs,
+    mut args: TransientRunArgs,
     cfg: &MvmConfig,
 ) -> Result<()> {
     if let Some(mode) = resolve_run_mode(&args.sdk, &args.run)? {
@@ -410,6 +564,8 @@ pub(in crate::commands) fn run_transient(
     // field is shared: `machine run -d` legitimately boots with no command, and
     // naming `mode`/`dev` from the shared struct would reference args that do
     // not exist on the `machine` side. So the one verb that needs it checks it.
+    let cwd = std::env::current_dir().context("resolving the working directory")?;
+    resolve_run_source(&mut args.run, &cwd, Inference::Enabled)?.announce();
     if args.run.argv.is_empty() && args.run.launch_plan.is_none() {
         anyhow::bail!(
             "`mvmctl run` needs a command: `mvmctl run -- <cmd>`. Use `--launch-plan <path>` \
@@ -1707,6 +1863,207 @@ mod tests {
             timeout: Some(60),
             argv: vec!["/bin/true".to_string()],
             ..Default::default()
+        }
+    }
+
+    /// The resolver decides which *source* a run boots from. These pin the
+    /// order, because the order is the whole contract — and pin that inference
+    /// never reaches policy.
+    mod source_resolution {
+        use super::*;
+
+        fn touch(dir: &std::path::Path, name: &str) {
+            std::fs::write(dir.join(name), b"").expect("write fixture file");
+        }
+
+        /// A directory with no `.git` above it, so the manifest walk-up stops
+        /// there rather than finding this repo's own `mvm.toml`.
+        fn sealed_dir() -> tempfile::TempDir {
+            let dir = tempfile::tempdir().expect("tmpdir");
+            std::fs::create_dir(dir.path().join(".git")).expect("git boundary");
+            dir
+        }
+
+        #[test]
+        fn an_explicit_image_is_never_second_guessed() {
+            let dir = sealed_dir();
+            touch(dir.path(), "package.json");
+            let mut args = RunArgs {
+                image: Some("alpine:3.20".to_string()),
+                argv: vec!["npm".to_string()],
+                ..Default::default()
+            };
+            let resolved =
+                resolve_run_source(&mut args, dir.path(), Inference::Enabled).expect("resolves");
+            assert_eq!(resolved, ResolvedSource::Explicit);
+            assert_eq!(args.image.as_deref(), Some("alpine:3.20"));
+            assert!(
+                resolved.note().is_none(),
+                "nothing was inferred to announce"
+            );
+        }
+
+        #[test]
+        fn a_named_runtime_sets_its_image() {
+            let dir = sealed_dir();
+            let mut args = RunArgs {
+                runtime: Some("go".to_string()),
+                ..Default::default()
+            };
+            let resolved =
+                resolve_run_source(&mut args, dir.path(), Inference::Enabled).expect("resolves");
+            assert!(matches!(resolved, ResolvedSource::Runtime(_)));
+            assert_eq!(args.image.as_deref(), Some("golang:1-alpine"));
+        }
+
+        #[test]
+        fn an_unknown_named_runtime_refuses_rather_than_falling_through() {
+            let dir = sealed_dir();
+            let mut args = RunArgs {
+                runtime: Some("pyhton".to_string()),
+                ..Default::default()
+            };
+            let err = resolve_run_source(&mut args, dir.path(), Inference::Enabled)
+                .expect_err("must refuse");
+            assert!(err.to_string().contains("unknown runtime"), "{err}");
+            assert!(
+                args.image.is_none(),
+                "a refused run must not have chosen an image anyway"
+            );
+        }
+
+        #[test]
+        fn no_detect_leaves_the_bundled_default_even_in_a_project() {
+            let dir = sealed_dir();
+            touch(dir.path(), "Cargo.toml");
+            let mut args = RunArgs {
+                no_detect: true,
+                argv: vec!["cargo".to_string()],
+                ..Default::default()
+            };
+            let resolved =
+                resolve_run_source(&mut args, dir.path(), Inference::Enabled).expect("resolves");
+            assert_eq!(resolved, ResolvedSource::BundledDefault);
+            assert!(args.image.is_none());
+            assert!(args.manifest.is_none());
+        }
+
+        #[test]
+        fn a_project_manifest_beats_the_runtime_catalog() {
+            // The project said what it is; the command is only a hint.
+            let dir = sealed_dir();
+            std::fs::write(
+                dir.path().join("mvm.toml"),
+                b"schema_version = 1\nname = \"demo\"\nimage = \"alpine:3.20\"\n",
+            )
+            .expect("write manifest");
+            touch(dir.path(), "package.json");
+            let mut args = RunArgs {
+                argv: vec!["npm".to_string()],
+                ..Default::default()
+            };
+            let resolved =
+                resolve_run_source(&mut args, dir.path(), Inference::Enabled).expect("resolves");
+            assert!(matches!(resolved, ResolvedSource::ProjectManifest(_)));
+            assert!(args.manifest.is_some());
+            assert!(args.image.is_none(), "the manifest supplies the image");
+        }
+
+        #[test]
+        fn the_catalog_runs_when_there_is_no_manifest() {
+            let dir = sealed_dir();
+            touch(dir.path(), "Cargo.toml");
+            let mut args = RunArgs::default();
+            let resolved =
+                resolve_run_source(&mut args, dir.path(), Inference::Enabled).expect("resolves");
+            assert!(matches!(resolved, ResolvedSource::Runtime(_)));
+            assert_eq!(args.image.as_deref(), Some("rust:1-alpine"));
+        }
+
+        #[test]
+        fn nothing_recognised_falls_back_to_the_bundled_default() {
+            let dir = sealed_dir();
+            touch(dir.path(), "README.md");
+            let mut args = RunArgs {
+                argv: vec!["./mystery".to_string()],
+                ..Default::default()
+            };
+            let resolved =
+                resolve_run_source(&mut args, dir.path(), Inference::Enabled).expect("resolves");
+            assert_eq!(resolved, ResolvedSource::BundledDefault);
+            assert!(args.image.is_none());
+        }
+
+        /// Inference picks a source. It must not pick a posture: a detected run
+        /// carries the same profile and the same deny-all egress as one that
+        /// named its image, or "convenience" would be a policy bypass.
+        #[test]
+        fn a_detected_run_is_still_deny_all_and_standard_profile() {
+            let dir = sealed_dir();
+            touch(dir.path(), "package.json");
+            let mut args = RunArgs::default();
+            let before = (args.profile, args.net, args.allow_host.clone());
+
+            resolve_run_source(&mut args, dir.path(), Inference::Enabled).expect("resolves");
+
+            assert_eq!(args.image.as_deref(), Some("node:22-alpine"));
+            assert_eq!(
+                (args.profile, args.net, args.allow_host.clone()),
+                before,
+                "detection changed a policy field"
+            );
+            assert_eq!(args.profile, RunProfile::Standard);
+            assert!(!args.net, "detected runs stay deny-all");
+            assert!(args.allow_host.is_empty());
+        }
+
+        /// The verb that creates a named machine must not pick its base image
+        /// from whatever directory the user happened to be standing in. Before
+        /// this split, `machine run` inside any Rust checkout silently chose
+        /// `rust:1-alpine`.
+        #[test]
+        fn explicit_only_ignores_the_working_directory() {
+            let dir = sealed_dir();
+            touch(dir.path(), "Cargo.toml");
+            let mut args = RunArgs {
+                argv: vec!["cargo".to_string(), "test".to_string()],
+                ..Default::default()
+            };
+            let resolved = resolve_run_source(&mut args, dir.path(), Inference::ExplicitOnly)
+                .expect("resolves");
+            assert_eq!(resolved, ResolvedSource::BundledDefault);
+            assert!(
+                args.image.is_none() && args.manifest.is_none(),
+                "explicit-only inferred a source anyway"
+            );
+        }
+
+        /// …but naming one is the user speaking, so it resolves on both verbs.
+        #[test]
+        fn explicit_only_still_resolves_a_named_runtime() {
+            let dir = sealed_dir();
+            let mut args = RunArgs {
+                runtime: Some("python".to_string()),
+                ..Default::default()
+            };
+            let resolved = resolve_run_source(&mut args, dir.path(), Inference::ExplicitOnly)
+                .expect("resolves");
+            assert!(matches!(resolved, ResolvedSource::Runtime(_)));
+            assert_eq!(args.image.as_deref(), Some("python:3.12-alpine"));
+        }
+
+        #[test]
+        fn an_unreadable_directory_detects_nothing_instead_of_failing() {
+            let mut args = RunArgs {
+                argv: vec!["./mystery".to_string()],
+                ..Default::default()
+            };
+            let missing = std::path::Path::new("/nonexistent-mvm-detect-fixture");
+            // The manifest walk-up canonicalises, so a missing dir is an error
+            // there; what must not happen is a panic or a silent image choice.
+            let result = resolve_run_source(&mut args, missing, Inference::Enabled);
+            assert!(args.image.is_none());
+            assert!(result.is_err() || result.expect("ok") == ResolvedSource::BundledDefault);
         }
     }
 

--- a/crates/mvm-core/src/lib.rs
+++ b/crates/mvm-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod at_rest;
 pub mod build_env;
 pub mod catalog;
 pub mod checkpoint;
+pub mod runtime_catalog;
 // The `MvmClient` machine-driving facade (trait + DTOs + mock + remote gateway).
 // Off by default so the runtime-free closure never pulls `async-trait`; enabled
 // by `mvm-client` (which adds the in-process `LocalBackend`) and by `mvm-sdk`'s

--- a/crates/mvm-core/src/runtime_catalog.rs
+++ b/crates/mvm-core/src/runtime_catalog.rs
@@ -1,0 +1,405 @@
+//! Map a command or a project file to the OCI image that can run it.
+//!
+//! `mvmctl run npm test` should boot a Node image without the user naming one.
+//! The mapping is a curated, in-tree table — versioned with the code, reviewed
+//! like code, never fetched at runtime — for the same reason the service-binding
+//! catalog is: a security-relevant default that can change under you between two
+//! invocations is not a default, it is a remote input.
+//!
+//! Detection here is pure. The caller decides what the working directory
+//! contains and passes the filenames in, so every rule is unit-testable without
+//! a filesystem and the ordering between rules is visible in one place.
+//!
+//! The pinned refs are tags, not digests, and that is deliberate rather than an
+//! oversight: they are a convenience for dev-tier runs. `--prod` refuses a
+//! mutable reference before any network fetch, so a production run cannot
+//! inherit a detected tag — it has to name a digest.
+
+use serde::{Deserialize, Serialize};
+
+/// One runtime the catalog can recognise.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeEntry {
+    /// Selector name, e.g. "python". What `--runtime <name>` takes.
+    pub name: String,
+    /// Short description, shown when listing.
+    pub description: String,
+    /// The OCI reference a detected run boots.
+    pub image: String,
+    /// argv[0] values that select this runtime, e.g. `python`, `python3`, `pip`.
+    #[serde(default)]
+    pub commands: Vec<String>,
+    /// Project filenames that select this runtime, e.g. `pyproject.toml`.
+    #[serde(default)]
+    pub project_files: Vec<String>,
+    /// Searchable tags.
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+/// A collection of runtime entries.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeCatalog {
+    /// Schema version for forward compatibility.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+    /// The runtime entries.
+    pub entries: Vec<RuntimeEntry>,
+}
+
+fn default_schema_version() -> u32 {
+    1
+}
+
+/// Why a runtime was chosen. Carried so the CLI can say what it did — a boot
+/// the user did not ask for should never be silent about why it happened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DetectedVia {
+    /// The command being run, e.g. `npm` → node.
+    Command(String),
+    /// A file in the working directory, e.g. `Cargo.toml` → rust.
+    ProjectFile(String),
+}
+
+impl DetectedVia {
+    /// Human-readable cause, for the line the CLI prints before booting.
+    pub fn describe(&self) -> String {
+        match self {
+            DetectedVia::Command(cmd) => format!("the command `{cmd}`"),
+            DetectedVia::ProjectFile(file) => format!("`{file}` in the working directory"),
+        }
+    }
+}
+
+/// A resolved detection: which runtime, which image, and what caused it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Detection {
+    /// The entry's `name`.
+    pub runtime: String,
+    /// The entry's `image`.
+    pub image: String,
+    /// What selected it.
+    pub via: DetectedVia,
+}
+
+impl RuntimeCatalog {
+    /// The curated in-tree table. Small on purpose: a short list that is right
+    /// beats a long one that is stale, and every entry here is a default
+    /// somebody gets without asking for it.
+    pub fn builtin() -> Self {
+        let entry = |name: &str,
+                     description: &str,
+                     image: &str,
+                     commands: &[&str],
+                     project_files: &[&str],
+                     tags: &[&str]| RuntimeEntry {
+            name: name.to_string(),
+            description: description.to_string(),
+            image: image.to_string(),
+            commands: commands.iter().map(|s| s.to_string()).collect(),
+            project_files: project_files.iter().map(|s| s.to_string()).collect(),
+            tags: tags.iter().map(|s| s.to_string()).collect(),
+        };
+
+        Self {
+            schema_version: default_schema_version(),
+            entries: vec![
+                entry(
+                    "python",
+                    "CPython with pip",
+                    "python:3.12-alpine",
+                    &["python", "python3", "pip", "pip3", "pytest"],
+                    &["pyproject.toml", "requirements.txt", "Pipfile", "setup.py"],
+                    &["python", "script"],
+                ),
+                entry(
+                    "node",
+                    "Node.js with npm",
+                    "node:22-alpine",
+                    &["node", "npm", "npx", "yarn", "pnpm"],
+                    &["package.json"],
+                    &["node", "javascript", "typescript"],
+                ),
+                entry(
+                    "rust",
+                    "Rust toolchain with cargo",
+                    "rust:1-alpine",
+                    &["cargo", "rustc"],
+                    &["Cargo.toml"],
+                    &["rust", "compiled"],
+                ),
+                entry(
+                    "go",
+                    "Go toolchain",
+                    "golang:1-alpine",
+                    &["go", "gofmt"],
+                    &["go.mod"],
+                    &["go", "compiled"],
+                ),
+                entry(
+                    "ruby",
+                    "Ruby with bundler",
+                    "ruby:3-alpine",
+                    &["ruby", "bundle", "rake", "gem"],
+                    &["Gemfile", "Rakefile"],
+                    &["ruby", "script"],
+                ),
+                entry(
+                    "shell",
+                    "POSIX shell and core utilities",
+                    "alpine:3",
+                    &["sh", "bash", "ash"],
+                    &[],
+                    &["shell", "minimal"],
+                ),
+            ],
+        }
+    }
+
+    /// Find an entry by exact name.
+    pub fn find(&self, name: &str) -> Option<&RuntimeEntry> {
+        self.entries.iter().find(|e| e.name == name)
+    }
+
+    /// Search entries by name, description, or tag substring (case-insensitive).
+    pub fn search(&self, query: &str) -> Vec<&RuntimeEntry> {
+        let q = query.to_lowercase();
+        self.entries
+            .iter()
+            .filter(|e| {
+                e.name.to_lowercase().contains(&q)
+                    || e.description.to_lowercase().contains(&q)
+                    || e.tags.iter().any(|t| t.to_lowercase().contains(&q))
+            })
+            .collect()
+    }
+
+    /// Every selector name, in catalog order. For error messages and listings.
+    pub fn names(&self) -> Vec<&str> {
+        self.entries.iter().map(|e| e.name.as_str()).collect()
+    }
+
+    /// Resolve an explicitly named runtime.
+    ///
+    /// An unknown name is an error, never a fall-through to a default: a typo'd
+    /// `--runtime pyhton` must not silently boot the bundled image and leave the
+    /// user reading a "command not found" from inside a guest that was never the
+    /// one they asked for.
+    pub fn resolve_named(&self, name: &str) -> Result<Detection, UnknownRuntime> {
+        self.find(name)
+            .map(|e| Detection {
+                runtime: e.name.clone(),
+                image: e.image.clone(),
+                via: DetectedVia::Command(name.to_string()),
+            })
+            .ok_or_else(|| UnknownRuntime {
+                requested: name.to_string(),
+                known: self.names().iter().map(|s| s.to_string()).collect(),
+            })
+    }
+
+    /// Detect a runtime from the command being run and the files present.
+    ///
+    /// Command wins over project file: `mvmctl run python3 script.py` inside a
+    /// Node project means Python, because argv is what the user just typed and
+    /// the directory is only where they happen to be standing.
+    ///
+    /// `present_files` is the caller's view of the working directory. Passing it
+    /// in rather than reading the filesystem keeps every rule testable and keeps
+    /// the ordering decision here instead of spread across two layers.
+    pub fn detect(&self, argv0: Option<&str>, present_files: &[String]) -> Option<Detection> {
+        if let Some(argv0) = argv0
+            && let Some(entry) = self.for_command(argv0)
+        {
+            return Some(Detection {
+                runtime: entry.name.clone(),
+                image: entry.image.clone(),
+                via: DetectedVia::Command(command_basename(argv0).to_string()),
+            });
+        }
+
+        // Catalog order decides between two matching project files, so the
+        // answer does not depend on directory-listing order.
+        for entry in &self.entries {
+            for candidate in &entry.project_files {
+                if present_files.iter().any(|f| f == candidate) {
+                    return Some(Detection {
+                        runtime: entry.name.clone(),
+                        image: entry.image.clone(),
+                        via: DetectedVia::ProjectFile(candidate.clone()),
+                    });
+                }
+            }
+        }
+        None
+    }
+
+    /// The entry whose `commands` contains this argv[0], matched on its
+    /// basename so `/usr/bin/python3` resolves like `python3`.
+    pub fn for_command(&self, argv0: &str) -> Option<&RuntimeEntry> {
+        let base = command_basename(argv0);
+        self.entries
+            .iter()
+            .find(|e| e.commands.iter().any(|c| c == base))
+    }
+}
+
+/// Strip any directory prefix from argv[0].
+fn command_basename(argv0: &str) -> &str {
+    argv0.rsplit('/').next().unwrap_or(argv0)
+}
+
+/// A `--runtime <name>` that names nothing in the catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownRuntime {
+    /// What the user asked for.
+    pub requested: String,
+    /// What they could have asked for.
+    pub known: Vec<String>,
+}
+
+impl std::fmt::Display for UnknownRuntime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "unknown runtime `{}`; known runtimes: {}",
+            self.requested,
+            self.known.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for UnknownRuntime {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn files(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn a_command_selects_its_runtime() {
+        let c = RuntimeCatalog::builtin();
+        let d = c.detect(Some("npm"), &[]).expect("npm is a node command");
+        assert_eq!(d.runtime, "node");
+        assert_eq!(d.image, "node:22-alpine");
+        assert_eq!(d.via, DetectedVia::Command("npm".to_string()));
+    }
+
+    #[test]
+    fn a_project_file_selects_its_runtime_when_the_command_is_unknown() {
+        let c = RuntimeCatalog::builtin();
+        let d = c
+            .detect(Some("./build.sh"), &files(&["Cargo.toml"]))
+            .expect("Cargo.toml is rust");
+        assert_eq!(d.runtime, "rust");
+        assert_eq!(d.via, DetectedVia::ProjectFile("Cargo.toml".to_string()));
+    }
+
+    #[test]
+    fn the_command_wins_over_the_directory() {
+        // Running a Python script inside a Node project means Python. argv is
+        // what the user just typed; the directory is where they were standing.
+        let c = RuntimeCatalog::builtin();
+        let d = c
+            .detect(Some("python3"), &files(&["package.json"]))
+            .expect("argv0 wins");
+        assert_eq!(d.runtime, "python");
+    }
+
+    #[test]
+    fn an_absolute_command_path_matches_on_its_basename() {
+        let c = RuntimeCatalog::builtin();
+        let d = c.detect(Some("/usr/local/bin/cargo"), &[]).expect("cargo");
+        assert_eq!(d.runtime, "rust");
+        assert_eq!(d.via, DetectedVia::Command("cargo".to_string()));
+    }
+
+    #[test]
+    fn nothing_recognised_detects_nothing() {
+        let c = RuntimeCatalog::builtin();
+        assert!(
+            c.detect(Some("./mystery"), &files(&["README.md"]))
+                .is_none()
+        );
+        assert!(c.detect(None, &[]).is_none());
+    }
+
+    #[test]
+    fn two_matching_project_files_resolve_by_catalog_order_not_listing_order() {
+        let c = RuntimeCatalog::builtin();
+        let forward = c.detect(None, &files(&["package.json", "pyproject.toml"]));
+        let reversed = c.detect(None, &files(&["pyproject.toml", "package.json"]));
+        assert_eq!(forward, reversed, "detection must not depend on file order");
+        assert_eq!(forward.expect("a match").runtime, "python");
+    }
+
+    #[test]
+    fn an_unknown_named_runtime_refuses_rather_than_falling_through() {
+        let c = RuntimeCatalog::builtin();
+        let err = c.resolve_named("pyhton").expect_err("a typo must refuse");
+        assert_eq!(err.requested, "pyhton");
+        assert!(err.known.contains(&"python".to_string()));
+        assert!(err.to_string().contains("known runtimes"));
+    }
+
+    #[test]
+    fn a_known_named_runtime_resolves_to_its_image() {
+        let c = RuntimeCatalog::builtin();
+        let d = c.resolve_named("go").expect("go is known");
+        assert_eq!(d.image, "golang:1-alpine");
+    }
+
+    #[test]
+    fn every_entry_is_reachable_by_name_and_declares_an_image() {
+        let c = RuntimeCatalog::builtin();
+        assert!(!c.entries.is_empty());
+        for e in &c.entries {
+            assert!(c.find(&e.name).is_some(), "{} not findable", e.name);
+            assert!(!e.image.is_empty(), "{} has no image", e.name);
+            assert!(
+                !e.commands.is_empty() || !e.project_files.is_empty(),
+                "{} can never be detected",
+                e.name
+            );
+        }
+    }
+
+    #[test]
+    fn no_command_or_project_file_is_claimed_by_two_runtimes() {
+        // An ambiguous trigger would make detection depend on catalog order for
+        // a case the user has no way to see.
+        let c = RuntimeCatalog::builtin();
+        let mut seen_commands = std::collections::BTreeMap::new();
+        let mut seen_files = std::collections::BTreeMap::new();
+        for e in &c.entries {
+            for cmd in &e.commands {
+                if let Some(prev) = seen_commands.insert(cmd.clone(), e.name.clone()) {
+                    panic!("command `{cmd}` claimed by both {prev} and {}", e.name);
+                }
+            }
+            for file in &e.project_files {
+                if let Some(prev) = seen_files.insert(file.clone(), e.name.clone()) {
+                    panic!("file `{file}` claimed by both {prev} and {}", e.name);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn search_finds_by_tag_and_description() {
+        let c = RuntimeCatalog::builtin();
+        assert!(c.search("typescript").iter().any(|e| e.name == "node"));
+        assert!(c.search("cargo").iter().any(|e| e.name == "rust"));
+    }
+
+    #[test]
+    fn catalog_round_trips_through_json() {
+        let c = RuntimeCatalog::builtin();
+        let json = serde_json::to_string(&c).expect("serialize");
+        let back: RuntimeCatalog = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(c, back);
+    }
+}

--- a/features/suites/s0_cli/machine_run_contract.feature
+++ b/features/suites/s0_cli/machine_run_contract.feature
@@ -85,3 +85,22 @@ Feature: machine run request contract
     And the output contains "profile: restrictive"
     And the output contains "cpus=4"
     And the output contains "memory=1G (1024 MiB)"
+
+  # Inference decides which image boots. It must not decide anything else: a
+  # detected run carries the same profile and the same deny-all egress as one
+  # that named its image, or the convenience would be a policy bypass.
+  Scenario: a detected runtime does not relax the run's posture
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "run --dry-run --runtime node -- npm test"
+    Then the command exits with code 0
+    And the output contains "profile: standard"
+    And the output contains "network: deny-all"
+
+  # A typo must not silently boot the bundled default and leave the user
+  # reading a "command not found" from a guest they never asked for.
+  Scenario: an unknown runtime name is refused and lists the known ones
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "run --runtime pyhton -- true"
+    Then the command exits with code 1
+    And the error output contains "unknown runtime"
+    And the error output contains "python"

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -355,6 +355,9 @@ shell).
 |---------|-------------|
 | `mvmctl run -- <cmd>...` | Boot the bundled default microVM image, run `<cmd>`, exit |
 | `mvmctl run --manifest <name-or-path> -- <cmd>...` | Boot a registered manifest/template instead of the default |
+| `mvmctl run npm test` | Infer the runtime when no source flag is given (see **Runtime detection** below) |
+| `mvmctl run --runtime <name> -- <cmd>...` | Boot a named runtime from the built-in catalog; an unknown name is refused, never defaulted |
+| `mvmctl run --no-detect -- <cmd>...` | Skip inference and use the bundled default image |
 | `mvmctl run --image <ref> -- <cmd>...` | Pull or reuse a cached OCI image, emit signed audit-chain provenance for the resolved image, boot its prepared OCI rootfs (read-only virtiofs-root on capable dev-tier backends, otherwise block `rootfs.ext4`), run `<cmd>`, exit |
 | `mvmctl run --image <ref> --prod -- <cmd>...` | Production OCI-image policy: require `<ref>` to be digest-pinned and cosign-verified by the OCI policy before cache use or boot |
 | `mvmctl run --profile standard -- <cmd>` | Default profile on both `run` and `machine run`: explicit env is allowed; host shares must be read-only |
@@ -383,6 +386,53 @@ the default image, start a VM, execute the command, or write a receipt.
 `run --json` is intended for machine callers. It preserves the command's exit
 code, but the JSON does not include raw argv, env values, stdout, stderr, or host
 paths.
+
+### Runtime detection
+
+With no `--image` / `--manifest` / `--flake` / `--deployment` / `--runtime-pack`,
+`mvmctl run` settles the boot source in this order. The order is the contract:
+
+1. **An explicit source flag.** Nothing is inferred.
+2. **`--runtime <name>`** against the built-in catalog. An unknown name is
+   refused and lists the known ones — a typo never falls through to a default.
+3. **`--no-detect`** stops here, leaving the bundled default image.
+4. **An `mvm.toml` (or `Mvmfile.toml`)** in or above the working directory,
+   found by the same walk-up `mvmctl build` uses, stopping at a `.git` boundary.
+5. **The command, then a project file.** `npm` selects node; `Cargo.toml`
+   selects rust. The command wins over the directory — argv is what you just
+   typed, the directory is where you happened to be standing.
+6. **The bundled default image.**
+
+| Runtime | Image | Commands | Project files |
+|---------|-------|----------|---------------|
+| `python` | `python:3.12-alpine` | `python`, `python3`, `pip`, `pip3`, `pytest` | `pyproject.toml`, `requirements.txt`, `Pipfile`, `setup.py` |
+| `node` | `node:22-alpine` | `node`, `npm`, `npx`, `yarn`, `pnpm` | `package.json` |
+| `rust` | `rust:1-alpine` | `cargo`, `rustc` | `Cargo.toml` |
+| `go` | `golang:1-alpine` | `go`, `gofmt` | `go.mod` |
+| `ruby` | `ruby:3-alpine` | `ruby`, `bundle`, `rake`, `gem` | `Gemfile`, `Rakefile` |
+| `shell` | `alpine:3` | `sh`, `bash`, `ash` | — |
+
+An inferred source always announces itself on stderr before booting
+(`[mvm] detected node from the command `npm` — booting node:22-alpine`), so a
+run never boots an image you did not choose without saying so. `--json` stdout
+is unaffected.
+
+Detection picks a **source**, never a posture. An inferred run admits through
+the same signed `ExecutionPlan`, with the same `--profile standard` default and
+the same deny-all egress, as one that named its image.
+
+**`machine run` does not infer.** Steps 4 and 5 are skipped there: it creates a
+named, possibly persistent machine, and picking its base image from whatever
+directory you were standing in is a footgun — `machine run` inside any Rust
+checkout would quietly build a machine on `rust:1-alpine`. It keeps its error
+naming every way to supply a source. `--runtime <name>` works on both verbs,
+because that is you naming one.
+
+The catalog is curated, in-tree, and versioned with the code; it is never
+fetched at runtime. Its refs are **tags, not digests**, which is deliberate:
+they are a dev-tier convenience. `--prod` refuses a mutable reference before any
+network fetch, so a production run cannot inherit a detected tag — it has to
+name a digest.
 
 ## Machine (beginner UX)
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1147,8 +1147,11 @@ for detailed scope and acceptance criteria.
       Phase 1 then landed the shared argument core: the 26 shared execution
       flags are declared once in `RunArgs` and flattened into both verbs, with
       `run` adding the SDK transport and `machine run` the lifecycle flags. Both
-      verbs now default to `--profile standard`. Phases 2–4 and 6–8 remain;
-      runtime auto-detection is next.
+      verbs now default to `--profile standard`. Phase 2 then landed runtime
+      detection: `mvm_core::runtime_catalog` plus one shared resolver whose
+      order is explicit source > `--runtime` > `mvm.toml` walk-up > argv[0] >
+      project file > bundled default. Inference is `run`-only; `machine run`
+      keeps its explicit-source contract. Phases 3–4 and 6–8 remain.
 - [ ] Plan 329 — Browser-tier microVM demo (`specs/plans/329-browser-wasm-backend-demo.md`)
       — in progress on `feat/329-browser-wasm-backend`. Extends Plan 320 with a
       `wasm32-wasip1` guest that boots, provides a shell, and delegates `fetch`

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -218,20 +218,36 @@ argument surface.
 
 ### Phase 2 — Runtime auto-detection
 
-- [ ] Define a small, auditable runtime catalog mapping command names and
-      project files to OCI image refs (e.g. `python3` / `requirements.txt` →
-      `python:3.12-alpine`, `cargo` / `Cargo.toml` → `rust:1.85-alpine`).
-- [ ] Implement detection order: explicit `--image`, then argv[0], then
-      project files in the working directory, then the bundled default image.
-- [ ] Add `--no-detect` to force the default image, and `--image` to override.
-- [ ] Add `--template` to pick a built-in template by name.
-- [ ] Ensure auto-detected runs still produce a signed `ExecutionPlan` with
-      default-deny egress.
-- [ ] Add unit tests for each detection rule and BDD scenarios for at least
-      Python, Node, Rust, and Go.
+- [x] Define a small, auditable runtime catalog mapping command names and
+      project files to OCI image refs. `mvm_core::runtime_catalog`, modelled on
+      the existing `Catalog`/`CatalogEntry` — same `search`/`find` shape, same
+      `schema_version`. In-tree, never fetched at runtime.
+- [x] Implement detection order: explicit source, `--runtime`, `--no-detect`,
+      `mvm.toml` walk-up, argv[0], project files, bundled default. **Reuses
+      `mvm_core::domain::manifest::discover_manifest_from_dir`** rather than
+      adding a second project-config idiom (Corrections 3).
+- [x] Add `--no-detect` to force the default image; `--image` already overrode.
+      Also `--runtime <name>` as the explicit selector.
+- [ ] Add `--template` to pick a built-in template by name. *(Deferred to
+      Phase 4, which is where templates are built.)*
+- [x] Ensure auto-detected runs still produce a signed `ExecutionPlan` with
+      default-deny egress. Detection settles a *source* and touches no policy
+      field; witnessed by `a_detected_run_is_still_deny_all_and_standard_profile`
+      and a BDD scenario asserting `profile: standard` / `network: deny-all`.
+- [x] Add unit tests for each detection rule (12 in `mvm-core`, 12 in the CLI
+      resolver) and BDD scenarios. Ordering and refusal rules mutation-checked
+      red before being believed.
 
 **Acceptance:** `mvmctl run python3 -c "print('ok')"` boots the right image
 without a manifest; detection is deterministic and tested.
+
+**Scope correction made while building it:** inference is `mvmctl run` only.
+`machine run` creates a named, possibly persistent machine, and picking its base
+image from the working directory is a footgun there — before the split,
+`machine run` inside any Rust checkout silently chose `rust:1-alpine`. It keeps
+its error naming every way to supply a source. `--runtime` works on both, since
+that is the user naming one. The seam is one `Inference` enum passed to one
+resolver, so the two verbs cannot drift apart on anything else.
 
 ### Phase 3 — Security profile presets
 

--- a/specs/sprint/delivery/runtime-detection.md
+++ b/specs/sprint/delivery/runtime-detection.md
@@ -1,0 +1,56 @@
+# `mvmctl run npm test` picks the image
+
+**Plan:** `specs/plans/329-run-first-cli-and-upstream-adoption.md`, Phase 2.
+
+## What shipped
+
+`mvm_core::runtime_catalog` — a curated, in-tree table mapping commands and
+project files to OCI images, modelled on the existing `Catalog`/`CatalogEntry`
+(same `search`/`find` shape, same `schema_version`) rather than inventing a
+second catalog idiom. Six runtimes: python, node, rust, go, ruby, shell.
+
+One resolver, `resolve_run_source`, shared by both verbs. The order is the
+contract:
+
+1. an explicit `--image`/`--manifest`/`--flake`/`--deployment`/`--runtime-pack`
+2. `--runtime <name>` — an unknown name refuses and lists the known ones
+3. `--no-detect`, or a verb that only takes explicit sources
+4. an `mvm.toml` in or above the working directory
+5. the command, then a project file
+6. the bundled default
+
+## What it reuses rather than reinvents
+
+Step 4 is `mvm_core::domain::manifest::discover_manifest_from_dir` — the same
+Cargo-style walk-up, stopping at the same `.git` boundary, that `mvmctl build`
+already used. The project config file `mvm.toml` already existed and already
+carried an image; it was simply never consulted by a run. No second config idiom
+was added.
+
+## Two decisions worth recording
+
+**Detection picks a source, never a posture.** An inferred run admits through the
+same signed `ExecutionPlan`, with the same `--profile standard` and the same
+deny-all egress, as one that named its image. Pinned by
+`a_detected_run_is_still_deny_all_and_standard_profile`, mutation-checked by
+making the detection branch also set `net = true`.
+
+**Inference is `run`-only.** `machine run` creates a named, possibly persistent
+machine. Inferring its base image from the working directory meant that
+`machine run` inside any Rust checkout silently chose `rust:1-alpine` — caught by
+running it in this repo, where a BDD scenario asserting the no-source error went
+red for the wrong reason. The split is one `Inference` enum passed to the one
+resolver, so the verbs cannot drift on anything else.
+
+## Honesty about the pins
+
+The catalog's refs are tags, not digests. That is a dev-tier convenience, and it
+is safe because `--prod` refuses a mutable reference before any network fetch: a
+production run cannot inherit a detected tag, it has to name a digest.
+
+An inferred source announces itself on stderr every time
+(`[mvm] detected node from the command `npm` — booting node:22-alpine`), not
+through `ui::info`, which is opt-in chatter shown only under `--verbose`. A boot
+whose image the user did not choose has to say so, or the first they learn of it
+is a "command not found" from a guest they never picked. stderr keeps `--json`
+stdout machine-readable.


### PR DESCRIPTION
Phase 2 of `specs/plans/329-run-first-cli-and-upstream-adoption.md`.

**Stacked on #2648** — base is `feat/consolidate-run-args`, and this needs retargeting to `main` once that merges. Review the top commit only.

## The problem

`run` needed `--image` or a manifest before it would boot anything, so the shortest path to "run this once in a microVM" was two decisions long: what to run, and what to run it on.

```console
$ cd my-node-project && mvmctl run -- npm test
[mvm] detected node from the command `npm` — booting node:22-alpine
```

## The shape

`mvm_core::runtime_catalog` is a curated in-tree table mapping commands and project files to images — modelled on the existing `Catalog`/`CatalogEntry` (same `search`/`find` shape, same `schema_version`) rather than a second catalog idiom. Six runtimes: python, node, rust, go, ruby, shell.

One resolver, shared by both verbs. **The order is the contract:**

1. an explicit `--image` / `--manifest` / `--flake` / `--deployment` / `--runtime-pack`
2. `--runtime <name>` — unknown names refuse
3. `--no-detect`, or a verb that only takes explicit sources
4. an `mvm.toml` in or above the working directory
5. the command, then a project file
6. the bundled default

**Step 4 reuses what was already there.** `mvm_core::domain::manifest::discover_manifest_from_dir` is the same Cargo-style walk-up, stopping at the same `.git` boundary, that `mvmctl build` already used. `mvm.toml` already existed and already carried an image — nothing had ever consulted it on a run. No second config idiom was added.

## Two properties this had to keep

**Detection picks a source, never a posture.** An inferred run admits through the same signed `ExecutionPlan`, with the same `--profile standard` and the same deny-all egress, as one that named its image. Pinned by `a_detected_run_is_still_deny_all_and_standard_profile` plus a BDD scenario asserting `profile: standard` / `network: deny-all` — confirmed red by making the detection branch also set `net = true`.

**An unknown `--runtime` refuses**, listing the known ones, mirroring the egress-preset precedent. A typo'd `--runtime pyhton` must not boot the bundled default and leave the user reading a "command not found" from a guest they never asked for.

## A scope correction made while building it

**Inference is `run`-only.** `machine run` creates a named, possibly persistent machine, and inferring its base image from the working directory meant `machine run` inside *any Rust checkout* silently chose `rust:1-alpine`. That is how it was caught — a BDD scenario asserting the no-source error went red for the wrong reason, in this repo.

`machine run` keeps its error naming every way to supply a source. `--runtime` works on both, because that is the user naming one. The split is one `Inference` enum passed to the one resolver, so the verbs cannot drift on anything else. Plan 329 Phase 2 records the correction.

## Honesty about the pins

The catalog's refs are **tags, not digests**, deliberately: they are a dev-tier convenience, and `--prod` refuses a mutable reference before any network fetch, so a production run cannot inherit a detected tag — it has to name a digest.

An inferred source announces itself on stderr **every time**, not through `ui::info`, which only appears under `--verbose`. A boot whose image the user did not choose has to say so. stderr keeps `--json` stdout machine-readable.

## Verification

- `cargo nextest run --workspace` — **12108 passed, 0 failed**
- **BDD conformance: 208 passed, 0 failed** (TypeScript SDK built, so the s27 parity scenarios actually run)
- `cargo test --workspace --doc`, `just check-gated`, nightly fmt, `cargo clippy --workspace --all-targets -- -D warnings`
- Gates: `check-cli-help-matches-docs`, `check-core-runtime-free` (the new module keeps mvm-core tokio-free), `check-no-spec-refs-in-comments`, `check-claim-catalog`, `check-honesty`, `check-machine-doc-guards`, `check-no-overclaim`, `check-adr-coverage`
- 24 unit tests (12 in the catalog, 12 in the resolver). Four load-bearing rules mutation-checked red: command-beats-directory, manifest-beats-catalog, unknown-refuses, and detection-touches-no-policy.

Also verified by hand against the built binary in temp fixtures: node project, argv0-beats-directory, `--runtime go`, unknown-refuses, `--no-detect`, `mvm.toml` in cwd, `mvm.toml` walk-up from a subdir, and explicit `--image` overriding a manifest.