### PR TITLE
fix(machine): remove a machine's runtime state with it, not just its spec

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1163,6 +1163,12 @@ pub(in crate::commands) struct MachineRestoreArgs {
 struct MachineRemoveSummary {
     name: String,
     removed: bool,
+    /// Whether the runtime state under `vms/<name>/` went with the spec.
+    ///
+    /// Reported rather than assumed: a directory a live process still owns is
+    /// kept, and a caller parsing this needs to be able to tell that apart from
+    /// a complete removal.
+    runtime_state_removed: bool,
 }
 
 #[derive(Debug)]
@@ -1429,6 +1435,32 @@ fn validate_machine_name(name: &str) -> Result<()> {
     naming::validate_id(name, "machine name")
 }
 
+/// Remove a machine's runtime state directory, reporting whether it went.
+///
+/// `machines/<name>/` is the declarative spec and `vms/<name>/` is the state a
+/// boot leaves behind — console log, sockets, pid file. They are separate
+/// namespaces, and `machine rm` used to delete only the first, so a removed
+/// machine kept the second forever and `machine ls`, which reads `vms/`, went
+/// on reporting it.
+///
+/// Returns `false` when a live process still owns the directory rather than
+/// deleting it. `--force` stops the machine first but only warns if that stop
+/// failed, so "we asked it to stop" is not "nothing is using this any more";
+/// removing a live supervisor's pid file and sockets would strand it and hide
+/// it from every later `machine ls` at the same time. Uses the same liveness
+/// probe `env cleanup` and the reconciler make this decision with.
+fn remove_machine_runtime_state(name: &str) -> Result<bool> {
+    let dir = config::vm_state_dir(name);
+    if !dir.exists() {
+        return Ok(true);
+    }
+    if mvm_vmm::host::process_liveness::state_dir_has_live_process(&dir) {
+        return Ok(false);
+    }
+    fs::remove_dir_all(&dir).with_context(|| format!("removing {}", dir.display()))?;
+    Ok(true)
+}
+
 fn remove_machine_spec(name: &str, yes: bool) -> Result<MachineRemoveSummary> {
     validate_machine_name(name)?;
     if !yes {
@@ -1439,9 +1471,11 @@ fn remove_machine_spec(name: &str, yes: bool) -> Result<MachineRemoveSummary> {
         bail!("machine {:?} does not exist", name);
     }
     fs::remove_dir_all(&dir).with_context(|| format!("removing {}", dir.display()))?;
+    let runtime_state_removed = remove_machine_runtime_state(name)?;
     Ok(MachineRemoveSummary {
         name: name.to_string(),
         removed: true,
+        runtime_state_removed,
     })
 }
 

--- a/crates/mvm-cli/src/commands/machine/spec_ops.rs
+++ b/crates/mvm-cli/src/commands/machine/spec_ops.rs
@@ -162,6 +162,16 @@ pub(super) fn remove_machine(args: MachineRemoveArgs) -> Result<()> {
         mvm_core::audit_emit!(ConfigChange, vm: &summary.name, "action=machine.rm");
         if !json {
             println!("removed machine {}", summary.name);
+            if !summary.runtime_state_removed {
+                // Saying only "removed" here is what made this hard to notice:
+                // the spec is gone, so the machine cannot be listed or started,
+                // while a live process still holds its runtime directory.
+                crate::ui::warn(&format!(
+                    "kept {} — a live process still owns it; \
+                     stop that process and re-run `mvmctl reconcile` to reclaim it",
+                    config::vm_state_dir(&summary.name).display(),
+                ));
+            }
         }
         summaries.push(summary);
     }

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -2166,6 +2166,68 @@ fn rm_args(names: &[&str], all: bool, yes: bool) -> MachineRemoveArgs {
     }
 }
 
+/// Seed the runtime state directory a booted machine leaves under `vms/`,
+/// which is a different namespace from the `machines/` spec.
+fn seed_runtime_state(name: &str) -> std::path::PathBuf {
+    let dir = config::vm_state_dir(name);
+    std::fs::create_dir_all(&dir).expect("state dir");
+    std::fs::write(dir.join("console.log"), b"boot log").expect("console log");
+    dir
+}
+
+#[test]
+fn removing_a_machine_removes_its_runtime_state_not_only_its_spec() {
+    // `machine rm` deletes `machines/<name>/`. It used to stop there, so a
+    // removed machine kept its console log, sockets and pid file under
+    // `vms/<name>/` forever — and `machine ls`, which reads that directory,
+    // kept listing it.
+    let _state = IsolatedMachineState::new();
+    seed_machine_spec("web");
+    let runtime = seed_runtime_state("web");
+    assert!(runtime.exists());
+
+    remove_machine(rm_args(&["web"], false, true)).expect("remove");
+
+    assert!(
+        !config::machine_state_dir("web").exists(),
+        "the spec must still be removed",
+    );
+    assert!(
+        !runtime.exists(),
+        "the runtime state directory outlived the machine it belonged to",
+    );
+}
+
+#[test]
+fn removing_a_machine_with_no_runtime_state_is_not_an_error() {
+    // A machine created but never booted has a spec and no `vms/` entry.
+    let _state = IsolatedMachineState::new();
+    seed_machine_spec("web");
+    assert!(!config::vm_state_dir("web").exists());
+    remove_machine(rm_args(&["web"], false, true)).expect("remove");
+    assert!(!config::machine_state_dir("web").exists());
+}
+
+#[test]
+fn runtime_state_owned_by_a_live_process_is_left_alone() {
+    // The case that makes this more than a cleanup: `--force` asks the machine
+    // to stop but only warns if the stop failed, so "we asked" is not "nothing
+    // is using this". Deleting a live supervisor's pid file and sockets would
+    // strand it, so a directory the liveness probe still claims is kept.
+    let _state = IsolatedMachineState::new();
+    let dir = config::vm_state_dir("web");
+    std::fs::create_dir_all(&dir).expect("state dir");
+    // Our own pid: the probe's definition of a live owner.
+    std::fs::write(dir.join("libkrun.pid"), std::process::id().to_string()).expect("pid file");
+    assert!(
+        mvm_vmm::host::process_liveness::state_dir_has_live_process(&dir),
+        "the probe must see this as live, or the test proves nothing",
+    );
+
+    assert!(!remove_machine_runtime_state("web").expect("probe"));
+    assert!(dir.exists(), "state owned by a live process must survive");
+}
+
 #[test]
 fn rm_running_refusal_wording() {
     assert!(rm_running_refusal(&[]).is_none());


### PR DESCRIPTION
## The bug

`mvmctl machine rm <name>` printed `removed machine <name>` and exited 0 while leaving `~/.mvm/vms/<name>/` on disk — console log, sockets, pid file. Hit twice while cleaning up after benchmarking.

`machines/<name>/` is the declarative spec; `vms/<name>/` is what a boot leaves behind. Separate namespaces, and `remove_machine_spec` only ever deleted the first — the second was **never referenced on the rm path at all**.

Two things kept it quiet:

- The pre-flight existence check also looks at the *spec* dir, so a second `rm` reports `does not exist` rather than noticing the leftovers.
- The leftovers only get swept if someone happens to run `mvmctl reconcile`, where they classify as `OrphanStateNoRecord`.

The visible symptom is worse than the disk usage: **`machine ls` reads `vms/`**, so a removed machine kept being listed. That is how two stale directories on my host ended up being mistaken for live VMs.

## The fix

`remove_machine_spec` now also removes the runtime state, and reports whether it went.

It is **guarded, not unconditional.** `--force` stops the machine first, but `stop_running_machine` only `tracing::warn!`s when the stop fails — so "we asked it to stop" is not "nothing is using this any more". A directory the liveness probe still claims is kept, and `machine rm` says so rather than reporting a clean removal:

```
removed machine web
warning: kept /Users/…/.mvm/vms/web — a live process still owns it;
         stop that process and re-run `mvmctl reconcile` to reclaim it
```

That case is not hypothetical. This was found on a host with a supervisor wedged in the kernel's exit path that `SIGKILL` could not clear; deleting its pid file and sockets would have stranded it *and* hidden it from every later `machine ls` at the same time.

Reuses `mvm_vmm::host::process_liveness::state_dir_has_live_process` — the probe `env cleanup` and the reconciler already make this exact decision with — rather than introducing a fourth opinion about what "running" means.

The JSON summary gains `runtime_state_removed` so a consumer can distinguish a complete removal from a kept one. `removed` keeps its meaning (the spec is gone).

## Verification

Red-then-green, confirmed by reverting only the fix and re-running:

```
FAIL removing_a_machine_removes_its_runtime_state_not_only_its_spec
     the runtime state directory outlived the machine it belonged to
```

Three new tests: the leak itself; a never-booted machine with no `vms/` entry is not an error; and state owned by a live process is left alone — that last one asserts the probe sees the seeded pid as live first, so it cannot pass by the directory simply being absent.

- `cargo nextest run -p mvm-cli -E 'test(/machine/)'` — 215 passed
- `cargo clippy` (full workspace, via pre-commit) and `cargo +nightly fmt --all -- --check` — clean
- `just check-gated` — clean
- xtask `check-honesty`, `check-single-home`, `check-test-home-isolation`, `check-cli-runtime-surface`, `check-machine-doc-guards`, `check-nextest-groups`, `check-no-spec-refs-in-comments` — all OK