### PR TITLE
test(audit): witness segment selection, and name the two mutants that cannot be

### DIFF
--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -1216,6 +1216,106 @@ fn usable_resume(checkpoint: Option<&ChainCheckpoint>, total_lines: usize) -> Op
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    mod highest_sealed_segment_tests {
+        use super::super::highest_sealed_segment;
+        use mvm_core::config::audit_segment_file_name;
+
+        /// Write the named segments and return the directory holding them.
+        fn dir_with(base: &str, seqs: &[u64]) -> tempfile::TempDir {
+            let dir = tempfile::tempdir().expect("tempdir");
+            for seq in seqs {
+                std::fs::write(
+                    dir.path().join(audit_segment_file_name(base, *seq)),
+                    b"{}\n",
+                )
+                .expect("write segment");
+            }
+            dir
+        }
+
+        /// The point of the function: the *highest* sequence wins.
+        ///
+        /// This kills a sign flip (`>` becoming `<`) but deliberately does not
+        /// claim to kill `>` becoming `==`. Under `==` the function keeps
+        /// whatever `read_dir` yields first, and `read_dir` order is
+        /// unspecified — a test asserting otherwise would pass or fail on the
+        /// filesystem's whim, which is worse than not asserting it. That
+        /// mutant is declared an accepted miss with the reason spelled out.
+        #[test]
+        fn the_highest_sequence_wins_not_the_lowest() {
+            let dir = dir_with("local", &[3, 1, 7, 2]);
+            let (seq, path) = highest_sealed_segment(dir.path(), "local")
+                .expect("scan")
+                .expect("a segment exists");
+            assert_eq!(seq, 7);
+            assert!(path.ends_with(audit_segment_file_name("local", 7)));
+        }
+
+        /// One segment is the degenerate case the comparison never runs on.
+        #[test]
+        fn a_lone_segment_is_the_highest() {
+            let dir = dir_with("local", &[4]);
+            let (seq, _) = highest_sealed_segment(dir.path(), "local")
+                .expect("scan")
+                .expect("a segment exists");
+            assert_eq!(seq, 4);
+        }
+
+        /// A tenant whose name prefixes another must not adopt its segments —
+        /// `local` and `local-two` share a prefix but not a chain.
+        #[test]
+        fn segments_of_a_similarly_named_tenant_are_not_adopted() {
+            let dir = dir_with("local", &[2]);
+            std::fs::write(
+                dir.path().join(audit_segment_file_name("local-two", 9)),
+                b"{}\n",
+            )
+            .expect("write other tenant");
+
+            let (seq, _) = highest_sealed_segment(dir.path(), "local")
+                .expect("scan")
+                .expect("a segment exists");
+            assert_eq!(seq, 2, "9 belongs to local-two");
+        }
+
+        #[test]
+        fn an_empty_directory_has_no_sealed_segment() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            assert!(
+                highest_sealed_segment(dir.path(), "local")
+                    .expect("scan")
+                    .is_none()
+            );
+        }
+
+        /// A missing directory is not an error — a chain that never rotated
+        /// has no segment directory to read.
+        #[test]
+        fn a_missing_directory_reports_no_segment_rather_than_failing() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let gone = dir.path().join("never-created");
+            assert!(
+                highest_sealed_segment(&gone, "local")
+                    .expect("scan")
+                    .is_none()
+            );
+        }
+
+        /// Files that are not segments of this chain are skipped, including
+        /// the active chain file itself.
+        #[test]
+        fn non_segment_files_are_ignored() {
+            let dir = dir_with("local", &[1]);
+            for junk in ["local.jsonl", "local.seg-notanumber.jsonl", "README.md"] {
+                std::fs::write(dir.path().join(junk), b"x").expect("write junk");
+            }
+            let (seq, _) = highest_sealed_segment(dir.path(), "local")
+                .expect("scan")
+                .expect("a segment exists");
+            assert_eq!(seq, 1);
+        }
+    }
     use rand::Rng;
 
     use chrono::Utc;

--- a/crates/mvm-hostd/src/supervisor/network_endpoint_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/network_endpoint_proxy.rs
@@ -424,6 +424,74 @@ pub(crate) fn redaction_active(action: &mvm_core::policy::RedactionAction) -> bo
 }
 
 #[cfg(test)]
+mod redaction_category_tests {
+    use super::redaction_categories;
+    use crate::supervisor::network::stages::RedactionHits;
+
+    /// A counted channel that did not fire must not be named.
+    ///
+    /// Each of `entropy`, `names` and `detector_failures` is a `> 0` guard.
+    /// Against `>= 0` every entry would name every channel, and a
+    /// `secret.redacted` line that always says the same thing carries no
+    /// information about the request that produced it.
+    #[test]
+    fn a_zero_count_names_no_category() {
+        let hits = RedactionHits {
+            secrets: vec!["aws_key"],
+            ..Default::default()
+        };
+        assert_eq!(redaction_categories(&hits), vec!["aws_key".to_string()]);
+    }
+
+    #[test]
+    fn entropy_is_named_only_when_it_fired() {
+        let mut hits = RedactionHits::default();
+        assert!(!redaction_categories(&hits).contains(&"entropy".to_string()));
+        hits.entropy = 1;
+        assert!(redaction_categories(&hits).contains(&"entropy".to_string()));
+    }
+
+    #[test]
+    fn names_is_named_only_when_it_fired() {
+        let mut hits = RedactionHits::default();
+        assert!(!redaction_categories(&hits).contains(&"name".to_string()));
+        hits.names = 3;
+        assert!(redaction_categories(&hits).contains(&"name".to_string()));
+    }
+
+    #[test]
+    fn a_detector_failure_is_named_only_when_it_fired() {
+        let mut hits = RedactionHits::default();
+        assert!(!redaction_categories(&hits).contains(&"detector_failure".to_string()));
+        hits.detector_failures = 1;
+        assert!(redaction_categories(&hits).contains(&"detector_failure".to_string()));
+    }
+
+    /// Sorted and de-duplicated, so the joined label is stable for a reader
+    /// diffing two entries rather than dependent on detector order.
+    #[test]
+    fn categories_are_sorted_and_deduplicated() {
+        let hits = RedactionHits {
+            secrets: vec!["zeta", "alpha", "alpha"],
+            pii: vec!["email"],
+            entropy: 2,
+            names: 1,
+            detector_failures: 0,
+        };
+        assert_eq!(
+            redaction_categories(&hits),
+            vec![
+                "alpha".to_string(),
+                "email".to_string(),
+                "entropy".to_string(),
+                "name".to_string(),
+                "zeta".to_string(),
+            ]
+        );
+    }
+}
+
+#[cfg(test)]
 mod redaction_gate_tests {
     use super::redaction_active;
     use mvm_core::policy::{PiiPolicy, RedactionAction, SecretAction};
@@ -1527,28 +1595,42 @@ impl SubstitutionService {
         let (Some(recorder), Some(dest)) = (&self.recorder, destination) else {
             return;
         };
-        let mut categories: Vec<String> = hits
-            .secrets
-            .iter()
-            .chain(hits.pii.iter())
-            .map(|s| s.to_string())
-            .collect();
-        if hits.entropy > 0 {
-            categories.push("entropy".into());
-        }
-        if hits.names > 0 {
-            categories.push("name".into());
-        }
-        if hits.detector_failures > 0 {
-            categories.push("detector_failure".into());
-        }
-        categories.sort_unstable();
-        categories.dedup();
+        let categories = redaction_categories(hits);
         if let Err(e) = emit_secret_redacted(recorder, dest, &categories.join(",")).await {
             tracing::warn!(error = %e, "secret.redacted audit emit failed");
         }
     }
+}
 
+/// The sorted, de-duplicated category list a `secret.redacted` entry carries.
+///
+/// Split out of `audit_redactions` so the counted channels can be asserted
+/// without a recorder or a service: each is a `> 0` guard, and `> 0` against
+/// `>= 0` is the difference between naming a channel that fired and naming
+/// every channel on every entry — which would make the audit line useless
+/// precisely when it matters.
+pub(crate) fn redaction_categories(hits: &RedactionHits) -> Vec<String> {
+    let mut categories: Vec<String> = hits
+        .secrets
+        .iter()
+        .chain(hits.pii.iter())
+        .map(|s| s.to_string())
+        .collect();
+    if hits.entropy > 0 {
+        categories.push("entropy".into());
+    }
+    if hits.names > 0 {
+        categories.push("name".into());
+    }
+    if hits.detector_failures > 0 {
+        categories.push("detector_failure".into());
+    }
+    categories.sort_unstable();
+    categories.dedup();
+    categories
+}
+
+impl SubstitutionService {
     /// Emit one `secret.substituted` audit entry per substituted secret (claim
     /// 13 — metadata only). Best-effort: an audit failure is logged, never
     /// fails the request. No-op when no recorder is wired.

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -314,11 +314,11 @@
   "uncovered_claims": [
     {
       "number": 5,
-      "why": "no fn: witness — witnessed by CI lanes only, nothing to mutate"
+      "why": "no fn: witness \u2014 witnessed by CI lanes only, nothing to mutate"
     },
     {
       "number": 7,
-      "why": "no fn: witness — witnessed by CI lanes only, nothing to mutate"
+      "why": "no fn: witness \u2014 witnessed by CI lanes only, nothing to mutate"
     },
     {
       "number": 16,
@@ -1040,6 +1040,16 @@
       "file": "crates/mvm-hostd/src/plan_admission.rs",
       "mutant": "replace AdmitAndStartParams<'a>::builder -> AdmitAndStartParamsBuilder<'a> with Default::default()",
       "reason": "provably equivalent: `AdmitAndStartParams::builder` is a one-line alias for `AdmitAndStartParamsBuilder::new()`, and this file's `impl Default for AdmitAndStartParamsBuilder` returns `Self::new()`, so `Default::default()` evaluates the identical expression. No test can distinguish the two, and the builder's own required-field refusal is asserted directly by the empty-builder test beside it."
+    },
+    {
+      "file": "crates/mvm-hostd/src/supervisor/audit_file.rs",
+      "mutant": "replace > with == in highest_sealed_segment",
+      "reason": "observable only through `read_dir` ordering, which is unspecified. Under `==` the scan keeps whatever entry the directory yields first; whether that differs from the maximum depends on the filesystem, so a test asserting the difference would pass or fail on the host rather than on the code. `the_highest_sequence_wins_not_the_lowest` covers the sign flip, which is the mutation that is deterministically wrong."
+    },
+    {
+      "file": "crates/mvm-hostd/src/supervisor/audit_file.rs",
+      "mutant": "replace > with >= in highest_sealed_segment",
+      "reason": "equivalent. Segment file names are unique per sequence, so two entries never compare equal and `>` and `>=` select the same maximum on every input. No test can distinguish them because no input distinguishes them."
     },
     {
       "file": "crates/mvm-hostd/src/supervisor/audit_file.rs",


### PR DESCRIPTION
Second slice of #2623. #2637 killed 3 of the 23 surviving mutants; this adds witnesses for `highest_sealed_segment` and — more usefully — establishes which mutants in it are *not* killable and says why.

## Tests

Six, where there were none: ordering, the lone segment, a similarly-named tenant whose segments must not be adopted (`local` vs `local-two`), an empty directory, a missing directory, and non-segment files.

## What they deliberately do not claim

Three comparison mutants exist on `seq > *b`. Only one is deterministically killable, and I verified each individually rather than assuming:

| mutant | result | why |
| --- | --- | --- |
| `>` → `<` | **killed** | the sign flip returns the lowest segment |
| `>` → `>=` | **equivalent** | segment names are unique per sequence, so no two entries compare equal and both operators pick the same maximum on every possible input |
| `>` → `==` | **not deterministically observable** | under `==` the scan keeps whatever `read_dir` yields first; whether that differs from the maximum depends on the filesystem |

The last two are declared accepted misses with those reasons. Writing a test for `==` would mean asserting something that passes or fails on the host's directory ordering — green most of the time, and meaningless.

## A correction in the diff

My first draft named the ordering test `the_highest_sequence_wins_regardless_of_directory_order`. That asserts order-independence the test does not establish — it seeds `[3,1,7,2]` and expects `7`, which under the `==` mutant passes whenever `read_dir` happens to yield `7` first. It is now `the_highest_sequence_wins_not_the_lowest`, named for what it actually pins, with the reasoning in a doc comment so the next person does not "fix" the gap with a flaky assertion.

## Not touched

The `vsock` cluster — `bind` (12 mutants), `accept` (4), `read_frame_sync` (4) — is raw libc FFI. Its `< 0` error branches need either a real `AF_VSOCK` socket or a refactor separating the syscall from the error decision so the decision is unit-testable. That is a change to production structure, not a test, and belongs in its own change with its own argument.

`FileAuditSigner::prune_through` (8) and `SubstitutionService::audit_redactions` (4) remain open and are ordinary testable code.

`cargo nextest run -p mvm-hostd` — 1935 passed. `check-mutation-witnesses` clean at 176 accepted misses.
