### PR TITLE
fix(release): make the boot gate assert what a bare image can actually prove

### DIFF
--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -498,17 +498,30 @@ jobs:
         # Boots the artifact in `staging/`, never a published one — the whole
         # point is to refuse the upload rather than diagnose it afterwards.
         #
-        # This is not a latency assertion. The budget is an order of magnitude
-        # above the observed median and RUNS/CONCURRENT are 1, because the
-        # question here is "does it reach userspace". Latency belongs to the
-        # `boot-latency` lane, which has its own threshold and its own argument.
+        # `start-return`, not `guest-agent`, and the difference is the honest
+        # limit of this gate. The guest agent ships in the runtime overlay, a
+        # separate verity-sealed disk mounted at /mvm/runtime; a bare
+        # kernel+rootfs boot has no overlay, so /init finds no agent and exits
+        # by design. Asserting agent-readiness here would fail every correct
+        # image. Attaching the overlay — it is built in this same run — is the
+        # way to strengthen this, and is tracked separately.
+        #
+        # So what this proves is that Firecracker accepts the artifact and the
+        # kernel loads and starts. That is the class that shipped as a bzImage
+        # named vmlinux, which fails InstanceStart outright. What it does NOT
+        # prove is that userspace works: the /init defect that shipped
+        # alongside it is caught by the static shebang assert above, not here.
+        #
+        # Not a latency assertion either. The budget is an order of magnitude
+        # above the observed median and RUNS/CONCURRENT are 1. Latency belongs
+        # to the `boot-latency` lane, which has its own threshold and argument.
         env:
           ARCH: ${{ matrix.arch }}
           MVM_RUNTIME_BOOT_BENCH: "1"
           MVM_RUNTIME_BOOT_BACKEND: firecracker
           MVM_RUNTIME_BOOT_KERNEL: staging/default-microvm-vmlinux-x86_64
           MVM_RUNTIME_BOOT_ROOTFS: staging/default-microvm-rootfs-x86_64.ext4
-          MVM_RUNTIME_BOOT_READY: guest-agent
+          MVM_RUNTIME_BOOT_READY: start-return
           MVM_RUNTIME_BOOT_RUNS: "1"
           MVM_RUNTIME_BOOT_CONCURRENT: "1"
           MVM_RUNTIME_BOOT_BUDGET_MS: "60000"

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -579,3 +579,34 @@ fn the_boot_gate_installs_the_toolchain_its_test_needs() {
          without it the gate fails before reaching a guest"
     );
 }
+
+/// The boot gate must not assert a readiness signal the artifact cannot give.
+///
+/// The guest agent ships in the runtime overlay — a separate verity-sealed disk
+/// mounted at /mvm/runtime — so a bare kernel+rootfs boot has no agent and
+/// /init exits by design. `guest-agent` readiness here fails every *correct*
+/// image, which is the worst kind of gate: it blocks releases and teaches
+/// everyone to distrust it.
+///
+/// This is a real regression, not a hypothetical: the gate shipped asserting
+/// `guest-agent`, inherited from a lane that is dispatch-only and pinned to a
+/// release whose kernel could not load, so that assertion had never once been
+/// proven to hold.
+#[test]
+fn the_boot_gate_does_not_demand_an_agent_the_bare_image_cannot_have() {
+    let workflow = boot_image_workflow();
+    let job = workflow
+        .split("  default-microvm:")
+        .nth(1)
+        .expect("the boot image workflow must define default-microvm");
+
+    assert!(
+        job.contains("MVM_RUNTIME_BOOT_READY: start-return"),
+        "the gate must assert start-return while no overlay is attached"
+    );
+    assert!(
+        !job.contains("MVM_RUNTIME_BOOT_READY: guest-agent"),
+        "asserting guest-agent without attaching the runtime overlay fails every \
+         correct image; attach the overlay before strengthening this"
+    );
+}


### PR DESCRIPTION
`boot-image/v0.1.1` refused the x86_64 image again. The refusal was mine, not the artifact's.

## What actually happened

The kernel loaded (the ELF fix works), reached userspace, exec'd `/init` — and then:

```
mvm-init: no guest agent resolved from /mvm/runtime and no baked fallback
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
```

The guest agent ships in the **runtime overlay** — a separate verity-sealed disk mounted at `/mvm/runtime` per ADR-018. A bare kernel+rootfs boot has no overlay, so `/init` finds no agent and exits **by design**. The gate was asserting `MVM_RUNTIME_BOOT_READY=guest-agent` against an image that structurally cannot satisfy it.

**It was failing every correct image.** That is the worst kind of gate: it blocks releases and teaches everyone to distrust it.

## How it got there

I copied the readiness signal from the `boot-latency` lane. That lane is `workflow_dispatch`-only and pinned to `v0.17.0` — whose kernel was a bzImage that could not load — **so the assertion had never once been proven to hold.** Copying a witness that has never gone green is the same trap as trusting one that has never gone red, and I walked into it.

## What the gate proves now

`start-return` — Firecracker accepts the artifact and the kernel loads and starts.

| Historical defect | Caught by |
|---|---|
| bzImage published as `vmlinux` (fails `InstanceStart`) | **this gate** |
| `/init` shebang at byte 1 (ENOEXEC) | the static shebang assert, one step earlier |
| anything past kernel handoff | **nothing yet** — needs the overlay |

Stated in the workflow comment rather than left for someone to infer, including the part it does *not* prove.

## Not strengthening it here

Attaching the overlay is the real fix and the overlay is already built in the same run. Filed separately. The last two attempts at this gate were each wrong in a way only a real release surfaced; a third guess without evidence is not an improvement.

## Verification

16 tests in `release_assets.rs`. The new guard asserts `start-return` is set and `guest-agent` is not — restoring `guest-agent` fails it, verified then reverted byte-identically. `actionlint` clean.