### PR TITLE
fix(release): pick the boot image by version, and refuse an incomplete one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,8 +293,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Highest version, not most recently created. `gh release list`
+          # orders by creation date, so `.[0]` picks whichever release was cut
+          # last — and the two disagree the moment one is re-cut out of order.
+          # That is not hypothetical: v0.1.1 published, then v0.1.0 was re-cut
+          # after a fix landed, leaving the newer release at the lower version.
+          # Sorting by parsed semver makes which image a CLI release ships a
+          # property of the version, not of the order someone happened to push.
+          # The strict N.N.N match also drops anything that is not a plain
+          # release tag rather than trying to order it.
           BOOT_TAG="$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
-            --json tagName --jq '[.[] | select(.tagName | startswith("boot-image/v"))] | .[0].tagName // empty')"
+            --json tagName --jq -r '
+              [ .[].tagName
+                | select(test("^boot-image/v[0-9]+\\.[0-9]+\\.[0-9]+$"))
+                | {tag: ., v: (ltrimstr("boot-image/v") | split(".") | map(tonumber))} ]
+              | sort_by(.v) | last | .tag // empty')"
           if [ -z "${BOOT_TAG}" ]; then
             echo "::error::no boot-image/v* release exists, so this release would ship with no boot image assets and every fresh install would 404 on first boot. Publish a boot-image/v* tag first, then re-run this release." >&2
             exit 1
@@ -302,6 +315,32 @@ jobs:
           echo "Attaching boot image assets from ${BOOT_TAG}"
           mkdir -p artifacts
           gh release download "${BOOT_TAG}" --repo "${GITHUB_REPOSITORY}" --dir artifacts --clobber
+
+          # Existence is not usability. The producing side refuses to publish an
+          # incomplete set, but it cannot retract one published before that gate
+          # existed, and this step would attach it without comment. A CLI release
+          # missing these is green and unusable: no x86_64 image means every
+          # x86_64 fresh install 404s on first boot, and no builder-vm assets
+          # means download_builder_vm_image 404s for everyone. The consumer-path
+          # check further down covers only runtime-overlay and sdk-sidecar, and
+          # skips whatever is absent, so nothing else in this job would notice.
+          missing=()
+          for arch in aarch64 x86_64; do
+            for f in \
+              "default-microvm-vmlinux-${arch}" \
+              "default-microvm-rootfs-${arch}.ext4" \
+              "default-microvm-meta-${arch}.json" \
+              "default-microvm-${arch}-checksums-sha256.txt" \
+              "builder-vm-vmlinux-${arch}" \
+              "builder-vm-rootfs-${arch}.ext4" \
+              "builder-vm-${arch}-checksums-sha256.txt"; do
+              [ -s "artifacts/${f}" ] || missing+=("${f}")
+            done
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::${BOOT_TAG} is incomplete — refusing to ship a CLI release whose boot image would 404 on first boot. Missing: ${missing[*]}" >&2
+            exit 1
+          fi
           # Drop the bundles this job re-mints. The signing step below writes
           # its bundle with create-new semantics, so leaving the boot image
           # train's copy in place would fail that step outright rather than be


### PR DESCRIPTION
Closes #2655.

Two gaps in `release.yml`'s "Attach the boot image release assets" step. Between
them they came one workflow run short of publishing a `v0.18.0` whose every fresh
x86_64 install would 404 on first boot.

## 1. Resolution was by creation date, not version

```bash
--json tagName --jq '[.[] | select(.tagName | startswith("boot-image/v"))] | .[0].tagName // empty'
```

`gh release list` orders newest-first, so `.[0]` is *most recently created*, not
*highest version*. The two agree only while tags are pushed in order. They stopped
agreeing here: `boot-image/v0.1.1` published at 23:25, then `boot-image/v0.1.0` was
re-cut at 00:42 after #2645 landed — leaving the newer release at the lower version.

Now sorted by parsed semver, with a strict `vN.N.N` match so a tag that is not a
plain release tag is dropped rather than ordered by guesswork. Parsing to numbers
rather than comparing strings is what keeps `v0.10.0` above `v0.9.0`.

## 2. Existence was the only thing checked

The step hard-failed on "no boot-image release at all" and nothing else. #2645 made
the producing side refuse to publish an incomplete set, but it cannot retract one
published before that gate existed — and this step would attach it without comment.
The consumer-path check further down covers only `runtime-overlay` and
`sdk-sidecar`, and skips whatever is absent, so nothing else in the job notices.

`boot-image/v0.1.1` was exactly such a release, cut 21 minutes before #2645 merged,
and had to be deleted by hand. Now both arches of the `default-microvm` and
`builder-vm` sets are asserted after download, and the publish refuses with the
missing names.

## Verification

Ran the exact selector from the file — same escaping, via `jq -f` — against the
real case and the edges that make this kind of selector quietly wrong:

```
out-of-order:  boot-image/v0.1.1     # version wins over date, either input order
10 vs 9:       boot-image/v0.10.0    # numeric, not lexicographic
rc ignored:    boot-image/v0.1.0     # -rc1 dropped, not ordered
dot literal:   boot-image/v0.1.0     # boot-imageXv0X1X0 does not match
none:          []                    # existing hard-fail still fires
```

The completeness check is the same shape #2645 validated against the asset list
that actually shipped. `actionlint` clean.
