### PR TITLE
fix(release): ship every per-VM binary mvmctl spawns, from one registry

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -152,6 +152,9 @@ jobs:
       - name: host-binaries manifest parity (Plan 115 / ADR-065)
         run: cargo run -p xtask -- check-mvm-host-binaries-sync
 
+      - name: release ships every spawnable per-VM binary
+        run: cargo run -p xtask -- check-per-vm-host-binaries-sync
+
       # security.yml runs on tags + cron, so a step pointing at a renamed
       # crate is invisible on a PR and dead until someone reads a nightly.
       # This resolves those paths here, where the rename happens.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,12 @@ jobs:
       - name: host-binaries manifest parity
         run: cargo run -p xtask -- check-mvm-host-binaries-sync
 
+      # release.yml runs on tags, so a per-VM binary added to the registry but
+      # not to the release job is invisible until a user's downloaded mvmctl
+      # fails to spawn it. Resolve it here, on the PR that adds it.
+      - name: release ships every spawnable per-VM binary
+        run: cargo run -p xtask -- check-per-vm-host-binaries-sync
+
       - name: mvm-core default build is runtime-free
         run: cargo run -p xtask -- check-core-runtime-free
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,22 +121,20 @@ jobs:
       # guest). They are SEPARATE bin targets in `mvm-hostd` — the root
       # `cargo build` above only produces `mvmctl` — so they are built here and
       # ship next to `mvmctl` in the tarball, where the backend's
-      # adjacent-to-exe resolver finds them on a downloaded install.
-      #   - mvm-network-endpoint: the per-VM egress gate. Every VM spawns
-      #     one, on both the FC (Linux) and HVF (macOS) paths, so it ships on
-      #     every target.
-      #   - mvm-hvf-supervisor (macOS only): the raw-HVF VMM supervisor.
-      #   - mvm-libkrun-supervisor (macOS only, and INTENTIONALLY so — not a
-      #     follow-up): it has `required-features = ["libkrun-sys"]`, and the
-      #     released Linux mvmctl deliberately does NOT link libkrun — the
-      #     `libkrun-sys` feature is a macOS-only target dep (see the rationale
-      #     at the top-level Cargo.toml, `[target.'cfg(target_os="macos")']`:
-      #     "Linux CI/runtimes use Firecracker … no libkrun-dev package exists").
-      #     So on Linux the supervisor can't be built here (no libkrun to link)
-      #     and isn't needed at runtime: workloads use Firecracker and the
-      #     builder VM uses libkrun-if-genuinely-available-else-QEMU (ADR-093),
-      #     with libkrun's FFI stubbed out in a no-feature build so it never
-      #     spawns this supervisor.
+      # adjacent-to-exe resolver finds them on a downloaded install. On a
+      # downloaded install that resolver has no `target/` dir to fall back to,
+      # so a binary missing here is a spawn failure at run time.
+      #
+      # This list is the `PerVmScope::Always` half of `PER_VM_HOST_BINARIES` in
+      # crates/mvm-cli/src/host_binaries/manifest.rs, and
+      # `xtask check-per-vm-host-binaries-sync` fails the build if the two
+      # drift. Add a binary there, not here.
+      #
+      # macOS additionally gets the two supervisors. mvm-libkrun-supervisor is
+      # macOS-only INTENTIONALLY — it has `required-features = ["libkrun-sys"]`
+      # and the released Linux mvmctl deliberately does not link libkrun (see
+      # the rationale in the top-level Cargo.toml): Linux workloads use
+      # Firecracker, so the supervisor is neither buildable nor needed there.
       - name: Build per-VM host binaries
         env:
           TARGET: ${{ matrix.target }}
@@ -146,12 +144,18 @@ jobs:
         run: |
           if [[ "${TARGET}" == *apple-darwin ]]; then
             cargo build --release --target "${TARGET}" -p mvm-hostd \
-              --bin mvm-hvf-supervisor \
+              --bin mvm-hvf-supervisor
+            cargo build --release --target "${TARGET}" -p mvm-hostd \
               --bin mvm-libkrun-supervisor --features libkrun-sys
           fi
           # Ships on every target — see the note above.
           cargo build --release --target "${TARGET}" -p mvm-hostd \
-            --bin mvm-network-endpoint
+            --bin mvm-host-agent \
+            --bin mvm-signer-helper \
+            --bin mvm-network-endpoint \
+            --bin mvm-netd \
+            --bin mvm-broker \
+            --bin mvm-audit-signer
 
       - name: Smoke test binary (native targets only)
         if: matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-apple-darwin'
@@ -204,12 +208,24 @@ jobs:
           cp "target/${TARGET}/release/${BIN_NAME}" "staging/${ARCHIVE_NAME}/"
           # Per-VM host processes (built in the prior step), shipped next to
           # mvmctl so the backend's adjacent-to-exe resolver finds them on a
-          # downloaded install. copy-if-exists: the set differs by OS (macOS also
-          # gets the hvf/libkrun supervisors), but the substitution endpoint
-          # ships on every target.
-          for hostbin in mvm-hvf-supervisor mvm-libkrun-supervisor mvm-network-endpoint; do
+          # downloaded install. Kept in step with PER_VM_HOST_BINARIES by
+          # `xtask check-per-vm-host-binaries-sync`.
+          #
+          # Fail closed rather than copy-if-exists: a binary that failed to
+          # build would otherwise be silently dropped from the tarball and
+          # surface much later as a spawn failure on a user's machine.
+          REQUIRED_HOSTBINS="mvm-host-agent mvm-signer-helper mvm-network-endpoint mvm-netd mvm-broker mvm-audit-signer"
+          if [[ "${TARGET}" == *apple-darwin ]]; then
+            REQUIRED_HOSTBINS="${REQUIRED_HOSTBINS} mvm-hvf-supervisor mvm-libkrun-supervisor"
+          fi
+          for hostbin in ${REQUIRED_HOSTBINS}; do
             src="target/${TARGET}/release/${hostbin}"
-            [ -f "$src" ] && cp "$src" "staging/${ARCHIVE_NAME}/" && echo "bundled ${hostbin}"
+            if [ ! -f "$src" ]; then
+              echo "::error::${hostbin} was not built for ${TARGET}; mvmctl spawns it at run time and the adjacent-to-exe resolver has no fallback on a downloaded install" >&2
+              exit 1
+            fi
+            cp "$src" "staging/${ARCHIVE_NAME}/"
+            echo "bundled ${hostbin}"
           done
           cp -r assets "staging/${ARCHIVE_NAME}/" 2>/dev/null || true
           cp README.md "staging/${ARCHIVE_NAME}/" 2>/dev/null || true

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -414,29 +414,39 @@ fn build_native_aux_helpers(
     // are the ones this tree produces. Note the profile is part of the
     // flavour, because unlike the musl leg these follow the outer profile.
     let libkrun_present = libkrun_header_present();
-    for spec in build_aux_helpers::aux_helper_specs(&target_os, &target_arch, libkrun_present) {
+    let aux_manifest_src = std::fs::read_to_string(
+        workspace_root.join("crates/mvm-cli/src/host_binaries/manifest.rs"),
+    )
+    .expect("read host-binaries manifest");
+    for spec in build_aux_helpers::aux_helper_specs_from(
+        &aux_manifest_src,
+        &target_os,
+        &target_arch,
+        libkrun_present,
+    ) {
         let features = spec.features.join(",");
+        let (spec_package, spec_bin) = (spec.package.as_str(), spec.bin.as_str());
         let key = cache.key_for(&KeyRequest {
-            package: spec.package,
-            binary: spec.bin,
+            package: spec_package,
+            binary: spec_bin,
             features: &features,
             target: &host_target,
             toolchain: "native",
             flavor: &format!("native-host-{profile}"),
         });
-        let installed = bin_dir.join(spec.bin);
+        let installed = bin_dir.join(spec_bin);
 
-        if cache.restore(key.as_deref(), spec.bin, &installed) {
+        if cache.restore(key.as_deref(), spec_bin, &installed) {
             eprintln!(
                 "[build.rs] per-VM host helper {} restored from the content store",
-                spec.bin
+                spec_bin
             );
             continue;
         }
 
         run_cargo_native_build(workspace_root, &aux_target, &profile, &spec);
         if installed.is_file() {
-            cache.publish(key.as_deref(), spec.bin, &installed);
+            cache.publish(key.as_deref(), spec_bin, &installed);
         }
     }
 }
@@ -456,7 +466,7 @@ fn run_cargo_native_build(
     );
     let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
     let mut cmd = Command::new(cargo);
-    cmd.args(["build", "-p", spec.package, "--bin", spec.bin]);
+    cmd.args(["build", "-p", &spec.package, "--bin", &spec.bin]);
     if profile == "release" {
         cmd.arg("--release");
     }

--- a/crates/mvm-cli/build_aux_helpers.rs
+++ b/crates/mvm-cli/build_aux_helpers.rs
@@ -9,59 +9,101 @@ use std::path::{Path, PathBuf};
 /// only the run target, never sibling `[[bin]]`s in other crates).
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct AuxHelperSpec {
-    pub package: &'static str,
-    pub bin: &'static str,
-    pub features: &'static [&'static str],
+    pub package: String,
+    pub bin: String,
+    pub features: Vec<String>,
 }
 
-/// The helpers to build for `(target_os, target_arch)`, given whether libkrun
-/// is installed. The libkrun supervisor is included only where libkrun is
-/// present because it links `-lkrun`; the HVF supervisor only on macOS/aarch64.
-pub(crate) fn aux_helper_specs(
+/// One `PER_VM_HOST_BINARIES` entry, parsed out of the manifest source.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct PerVmEntry {
+    pub package: String,
+    pub name: String,
+    pub features: String,
+    pub scope: String,
+}
+
+/// Parse `PER_VM_HOST_BINARIES` out of the text of
+/// `crates/mvm-cli/src/host_binaries/manifest.rs`.
+///
+/// Text-parsed rather than imported because a build script cannot depend on
+/// the crate it is building; this mirrors how `build.rs` already reads
+/// `HOST_BINARIES` and `SEED_BINARIES` from the same file, and keeps this
+/// module I/O-free so the selection rules stay unit-testable.
+pub(crate) fn parse_per_vm_binaries(src: &str) -> Vec<PerVmEntry> {
+    let Some(i) = src.find("PER_VM_HOST_BINARIES") else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    let (mut package, mut name, mut features) = (None, None, None);
+    for line in src[i..].lines() {
+        if let Some(v) = extract_quoted_after(line, "package:") {
+            package = Some(v);
+        }
+        if let Some(v) = extract_quoted_after(line, "name:") {
+            name = Some(v);
+        }
+        if let Some(v) = extract_quoted_after(line, "features:") {
+            features = Some(v);
+        }
+        if let Some(scope) = line.trim().strip_prefix("scope: PerVmScope::") {
+            let scope = scope.trim_end_matches(',').trim().to_string();
+            if let (Some(package), Some(name), Some(features)) =
+                (package.take(), name.take(), features.take())
+            {
+                out.push(PerVmEntry {
+                    package,
+                    name,
+                    features,
+                    scope,
+                });
+            }
+        }
+        // The const ends at the closing `];` in column 0.
+        if line.starts_with("];") && !out.is_empty() {
+            break;
+        }
+    }
+    out
+}
+
+/// Whether a registry entry applies to this host, given its scope.
+pub(crate) fn scope_applies(
+    scope: &str,
+    target_os: &str,
+    target_arch: &str,
+    libkrun_present: bool,
+) -> bool {
+    match scope {
+        "Always" => true,
+        "MacOsAarch64" => target_os == "macos" && target_arch == "aarch64",
+        "RequiresLibkrun" => libkrun_present,
+        _ => false,
+    }
+}
+
+/// The helpers to build for `(target_os, target_arch)`, selected from the
+/// canonical `PER_VM_HOST_BINARIES` registry. `manifest_src` is the text of
+/// `crates/mvm-cli/src/host_binaries/manifest.rs`.
+pub(crate) fn aux_helper_specs_from(
+    manifest_src: &str,
     target_os: &str,
     target_arch: &str,
     libkrun_present: bool,
 ) -> Vec<AuxHelperSpec> {
-    let mut specs = vec![
-        AuxHelperSpec {
-            package: "mvm-hostd",
-            bin: "mvm-host-agent",
-            features: &[],
-        },
-        AuxHelperSpec {
-            package: "mvm-hostd",
-            bin: "mvm-signer-helper",
-            features: &[],
-        },
-        AuxHelperSpec {
-            package: "mvm-hostd",
-            bin: "mvm-network-endpoint",
-            features: &[],
-        },
-        // The per-VM L3 gateway. Built everywhere mvmctl is: whether a host
-        // can serve the tunnel is decided at admission, not by whether the
-        // binary happens to exist.
-        AuxHelperSpec {
-            package: "mvm-hostd",
-            bin: "mvm-netd",
-            features: &[],
-        },
-    ];
-    if target_os == "macos" && target_arch == "aarch64" {
-        specs.push(AuxHelperSpec {
-            package: "mvm-hostd",
-            bin: "mvm-hvf-supervisor",
-            features: &[],
-        });
-    }
-    if libkrun_present {
-        specs.push(AuxHelperSpec {
-            package: "mvm-hostd",
-            bin: "mvm-libkrun-supervisor",
-            features: &["libkrun-sys"],
-        });
-    }
-    specs
+    parse_per_vm_binaries(manifest_src)
+        .into_iter()
+        .filter(|e| scope_applies(&e.scope, target_os, target_arch, libkrun_present))
+        .map(|e| AuxHelperSpec {
+            package: e.package,
+            bin: e.name,
+            features: if e.features.is_empty() {
+                Vec::new()
+            } else {
+                e.features.split(',').map(str::to_string).collect()
+            },
+        })
+        .collect()
 }
 
 /// Extract the quoted string after `key` on one line, e.g.
@@ -102,23 +144,39 @@ mod tests {
     }
 
     #[test]
-    fn hostd_helpers_include_network_endpoint() {
-        let specs = aux_helper_specs("macos", "aarch64", false);
-        assert!(specs.iter().any(|spec| spec.bin == "mvm-network-endpoint"));
+    fn parser_reads_package_name_features_and_scope() {
+        let src = r#"
+pub const PER_VM_HOST_BINARIES: &[PerVmBinary] = &[
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-netd",
+        features: "",
+        scope: PerVmScope::Always,
+    },
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-libkrun-supervisor",
+        features: "libkrun-sys",
+        scope: PerVmScope::RequiresLibkrun,
+    },
+];
+"#;
+        let got = parse_per_vm_binaries(src);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].name, "mvm-netd");
+        assert_eq!(got[0].scope, "Always");
+        assert_eq!(got[1].features, "libkrun-sys");
+        assert_eq!(got[1].scope, "RequiresLibkrun");
     }
 
     #[test]
-    fn host_service_helpers_are_built_beside_mvmctl() {
-        let specs = aux_helper_specs("macos", "aarch64", false);
-        for required in ["mvm-host-agent", "mvm-signer-helper"] {
-            assert!(specs.iter().any(|spec| spec.bin == required));
-        }
+    fn parser_yields_nothing_when_the_const_is_absent() {
+        assert!(parse_per_vm_binaries("fn main() {}").is_empty());
     }
 
     #[test]
-    fn helper_specs_are_never_globally_skipped() {
-        assert!(!aux_helper_specs("linux", "x86_64", false).is_empty());
-        assert!(!aux_helper_specs("macos", "aarch64", true).is_empty());
+    fn an_unknown_scope_selects_nothing() {
+        assert!(!scope_applies("SomethingNew", "linux", "x86_64", true));
     }
 
     #[test]

--- a/crates/mvm-cli/src/host_binaries/manifest.rs
+++ b/crates/mvm-cli/src/host_binaries/manifest.rs
@@ -70,3 +70,107 @@ pub const BOOTSTRAP_SUPPORT_BINARIES: &[SourceBuiltBinary] = &[SourceBuiltBinary
     name: "mvm-egress-client",
     features: "addons",
 }];
+
+/// Where a per-VM host binary can be built, expressed as data so the
+/// build script, the release workflow, and the sync gate all read one
+/// list instead of three hand-kept copies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PerVmScope {
+    /// Every target `mvmctl` ships for.
+    Always,
+    /// macOS on Apple Silicon — the raw-HVF VMM supervisor.
+    MacOsAarch64,
+    /// Only where libkrun headers exist to link against. Deliberately not
+    /// a Linux target: the released Linux `mvmctl` does not link libkrun,
+    /// so the supervisor is neither buildable nor needed there.
+    RequiresLibkrun,
+}
+
+/// A per-VM host process `mvmctl` spawns at runtime, one process per guest.
+///
+/// These are separate `[[bin]]` targets in other packages, so the root
+/// `cargo build` that produces `mvmctl` does not produce them. They are
+/// found at runtime by `resolve_subprocess_bin`, whose only viable lookup
+/// on a downloaded install is *adjacent to the executable* — the
+/// `target/{release,debug}` fallback exists solely for source checkouts.
+/// A binary listed here that the release tarball omits is therefore a
+/// spawn failure for anyone who installed from a release rather than
+/// building from source.
+#[derive(Debug, Clone, Copy)]
+pub struct PerVmBinary {
+    /// Workspace package that owns the `[[bin]]` target.
+    pub package: &'static str,
+    /// Binary name on disk, and the name `resolve_subprocess_bin` asks for.
+    pub name: &'static str,
+    /// Comma-separated Cargo features the binary target requires.
+    pub features: &'static str,
+    pub scope: PerVmScope,
+}
+
+/// The canonical per-VM host binary set. `mvm-cli/build.rs` builds these
+/// beside `mvmctl` for a source checkout, `.github/workflows/release.yml`
+/// builds and packages them for a downloaded install, and
+/// `xtask check-per-vm-host-binaries-sync` fails the build when those two
+/// consumers drift from this list.
+pub const PER_VM_HOST_BINARIES: &[PerVmBinary] = &[
+    // The per-tenant host-services daemon. `host_agent_daemon_enabled()`
+    // defaults to ON, so this is the default services path for every
+    // admitted workload on every backend.
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-host-agent",
+        features: "",
+        scope: PerVmScope::Always,
+    },
+    // Resolved by mvm-host-agent adjacent to *itself*, so it travels
+    // wherever mvm-host-agent does.
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-signer-helper",
+        features: "",
+        scope: PerVmScope::Always,
+    },
+    // The per-VM egress gate. Every VM spawns one, on both the Firecracker
+    // and HVF paths.
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-network-endpoint",
+        features: "",
+        scope: PerVmScope::Always,
+    },
+    // The per-VM L3 gateway. Whether a host may serve the tunnel is decided
+    // at admission, not by whether the binary happens to exist.
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-netd",
+        features: "",
+        scope: PerVmScope::Always,
+    },
+    // The per-VM broker fork and its audit signer. Reached when
+    // `MVM_HOST_AGENT_DAEMON=0` selects the pre-daemon path, which is a
+    // documented escape hatch rather than dead code — so both ship.
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-broker",
+        features: "",
+        scope: PerVmScope::Always,
+    },
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-audit-signer",
+        features: "",
+        scope: PerVmScope::Always,
+    },
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-hvf-supervisor",
+        features: "",
+        scope: PerVmScope::MacOsAarch64,
+    },
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-libkrun-supervisor",
+        features: "libkrun-sys",
+        scope: PerVmScope::RequiresLibkrun,
+    },
+];

--- a/crates/mvm-cli/tests/build_aux_helpers.rs
+++ b/crates/mvm-cli/tests/build_aux_helpers.rs
@@ -3,10 +3,17 @@ mod build_aux_helpers;
 
 use std::path::Path;
 
-use build_aux_helpers::{AuxHelperSpec, aux_helper_specs, shared_nested_target_dir};
+use build_aux_helpers::{AuxHelperSpec, aux_helper_specs_from, shared_nested_target_dir};
+
+/// The canonical registry itself, so a manifest edit is what these tests see.
+const MANIFEST: &str = include_str!("../src/host_binaries/manifest.rs");
+
+fn specs(os: &str, arch: &str, libkrun: bool) -> Vec<AuxHelperSpec> {
+    aux_helper_specs_from(MANIFEST, os, arch, libkrun)
+}
 
 fn bins(specs: &[AuxHelperSpec]) -> Vec<&str> {
-    specs.iter().map(|s| s.bin).collect()
+    specs.iter().map(|s| s.bin.as_str()).collect()
 }
 
 /// Every host/arch combination mvmctl builds for.
@@ -18,6 +25,17 @@ const HOSTS: &[(&str, &str)] = &[
 ];
 
 #[test]
+fn the_registry_is_not_silently_empty() {
+    // The parser is text-based, so a refactor of manifest.rs that renamed the
+    // const or reshaped the literal would otherwise turn every assertion below
+    // into a vacuous pass over an empty list.
+    assert!(
+        build_aux_helpers::parse_per_vm_binaries(MANIFEST).len() >= 6,
+        "PER_VM_HOST_BINARIES failed to parse out of manifest.rs"
+    );
+}
+
+#[test]
 fn the_host_independent_helpers_build_on_every_host() {
     // Neither of these is gated on host capability, and the reason is the
     // same for both: whether a launch uses the egress endpoint or the L3
@@ -26,8 +44,8 @@ fn the_host_independent_helpers_build_on_every_host() {
     // host-dependent decision.
     for (os, arch) in HOSTS {
         for libkrun in [false, true] {
-            let specs = aux_helper_specs(os, arch, libkrun);
-            let bins = bins(&specs);
+            let s = specs(os, arch, libkrun);
+            let bins = bins(&s);
             for required in ["mvm-network-endpoint", "mvm-netd"] {
                 assert!(
                     bins.contains(&required),
@@ -38,32 +56,52 @@ fn the_host_independent_helpers_build_on_every_host() {
     }
 }
 
+/// The regression this registry exists for. `resolve_subprocess_bin` finds
+/// these only adjacent to the executable on a downloaded install, and
+/// `host_agent_daemon_enabled()` defaults to on — so the agent pair is what a
+/// plain `up` reaches, and the broker pair is what `MVM_HOST_AGENT_DAEMON=0`
+/// reaches. A host that ships none of them fails at spawn, not at build.
+#[test]
+fn every_spawnable_service_binary_builds_on_every_host() {
+    for (os, arch) in HOSTS {
+        let s = specs(os, arch, false);
+        let bins = bins(&s);
+        for required in [
+            "mvm-host-agent",
+            "mvm-signer-helper",
+            "mvm-broker",
+            "mvm-audit-signer",
+        ] {
+            assert!(
+                bins.contains(&required),
+                "{required} must build on {os}/{arch}, got {bins:?}"
+            );
+        }
+    }
+}
+
 #[test]
 fn hvf_supervisor_only_on_macos_aarch64() {
-    let mac = aux_helper_specs("macos", "aarch64", false);
-    assert!(bins(&mac).contains(&"mvm-hvf-supervisor"));
-    let linux = aux_helper_specs("linux", "aarch64", false);
-    assert!(!bins(&linux).contains(&"mvm-hvf-supervisor"));
-    let intel_mac = aux_helper_specs("macos", "x86_64", false);
-    assert!(!bins(&intel_mac).contains(&"mvm-hvf-supervisor"));
+    assert!(bins(&specs("macos", "aarch64", false)).contains(&"mvm-hvf-supervisor"));
+    assert!(!bins(&specs("linux", "aarch64", false)).contains(&"mvm-hvf-supervisor"));
+    assert!(!bins(&specs("macos", "x86_64", false)).contains(&"mvm-hvf-supervisor"));
 }
 
 #[test]
 fn libkrun_supervisor_only_when_libkrun_present() {
-    let present = aux_helper_specs("macos", "aarch64", true);
+    let present = specs("macos", "aarch64", true);
     let spec = present
         .iter()
         .find(|s| s.bin == "mvm-libkrun-supervisor")
         .expect("libkrun supervisor present");
-    assert_eq!(spec.features, &["libkrun-sys"]);
-    let absent = aux_helper_specs("macos", "aarch64", false);
-    assert!(!bins(&absent).contains(&"mvm-libkrun-supervisor"));
+    assert_eq!(spec.features, vec!["libkrun-sys".to_string()]);
+    assert!(!bins(&specs("macos", "aarch64", false)).contains(&"mvm-libkrun-supervisor"));
 }
 
 #[test]
 fn helper_specs_are_never_globally_skipped() {
-    assert!(!aux_helper_specs("linux", "x86_64", false).is_empty());
-    assert!(!aux_helper_specs("macos", "aarch64", true).is_empty());
+    assert!(!specs("linux", "x86_64", false).is_empty());
+    assert!(!specs("macos", "aarch64", true).is_empty());
 }
 
 #[test]

--- a/nix/packaging/release/verify-release-assets.test.sh
+++ b/nix/packaging/release/verify-release-assets.test.sh
@@ -279,7 +279,15 @@ fi
 # creates whatever bins_for names, so a required-but-unbuilt binary verifies
 # green here and fails only at release time. Compare against the workflow.
 RELEASE_YML="$HERE/../../../.github/workflows/release.yml"
-shipped="mvmctl $(sed -n 's/^[[:space:]]*for hostbin in \(.*\); do$/\1/p' "$RELEASE_YML" | head -1)"
+# `release.yml` builds its list into a shell variable and then loops over it,
+# so reading the `for` line yields the literal `${REQUIRED_HOSTBINS}` and every
+# required bin looks like drift. Union the assignments instead — including the
+# conditional one that appends the macOS supervisors — and drop the
+# self-reference the append carries.
+# shellcheck disable=SC2016  # the ${REQUIRED_HOSTBINS} below is a literal to
+# strip out of the workflow's text, not a variable for this shell to expand.
+shipped="mvmctl $(sed -n 's/^[[:space:]]*REQUIRED_HOSTBINS="\(.*\)"[[:space:]]*$/\1/p' "$RELEASE_YML" \
+  | sed 's/\${REQUIRED_HOSTBINS}//g' | tr ' ' '\n' | grep -v '^$' | sort -u | tr '\n' ' ')"
 required="$(sed -n '/^required_bins_for_target()/,/^}/p' "$SCRIPT" \
   | sed -n 's/.*echo "\([^"]*\)".*/\1/p' | tr ' ' '\n' | sort -u)"
 drift=""

--- a/xtask/src/check_per_vm_host_binaries_sync.rs
+++ b/xtask/src/check_per_vm_host_binaries_sync.rs
@@ -1,0 +1,223 @@
+//! `xtask check-per-vm-host-binaries-sync`
+//!
+//! CI lint — asserts the canonical `PER_VM_HOST_BINARIES` registry in
+//! `crates/mvm-cli/src/host_binaries/manifest.rs` and the two lists in
+//! `.github/workflows/release.yml` (the `cargo build --bin` step and the
+//! tarball's `REQUIRED_HOSTBINS`) name the same binaries.
+//!
+//! Why this needs a gate rather than review: `resolve_subprocess_bin` finds
+//! these binaries next to the executable, falling back to `target/{release,
+//! debug}` — a path that exists only in a source checkout. So a binary present
+//! for every contributor can be absent for every *user*, and the failure
+//! surfaces as a spawn error on their machine long after the release is cut.
+//! The release workflow runs on tags, so nothing on the PR that opens the gap
+//! would otherwise notice.
+
+use anyhow::{Context, Result, bail};
+use std::collections::BTreeSet;
+use std::path::Path;
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let registry = parse_registry(workspace)?;
+    if registry.is_empty() {
+        bail!(
+            "no PER_VM_HOST_BINARIES entries parsed out of \
+             crates/mvm-cli/src/host_binaries/manifest.rs — the registry moved \
+             or was reshaped, and this gate is now vacuous"
+        );
+    }
+
+    let release = workspace.join(".github/workflows/release.yml");
+    let src =
+        std::fs::read_to_string(&release).with_context(|| format!("read {}", release.display()))?;
+
+    let built: BTreeSet<String> = bin_flags(&src);
+    let packaged: BTreeSet<String> = required_hostbins(&src);
+
+    let mut problems = Vec::new();
+
+    for (name, _scope) in &registry {
+        if !built.contains(name) {
+            problems.push(format!(
+                "release.yml never builds `{name}` (no `--bin {name}`)"
+            ));
+        }
+        if !packaged.contains(name) {
+            problems.push(format!(
+                "release.yml never packages `{name}` (absent from REQUIRED_HOSTBINS)"
+            ));
+        }
+    }
+
+    let known: BTreeSet<&str> = registry.iter().map(|(n, _)| n.as_str()).collect();
+    for name in &packaged {
+        if !known.contains(name.as_str()) {
+            problems.push(format!(
+                "release.yml packages `{name}`, which is not in PER_VM_HOST_BINARIES"
+            ));
+        }
+    }
+
+    if !problems.is_empty() {
+        bail!(
+            "per-VM host binary lists have drifted:\n  {}\n\n\
+             Fix: PER_VM_HOST_BINARIES in crates/mvm-cli/src/host_binaries/manifest.rs \
+             is the source of truth. Update .github/workflows/release.yml's \
+             `--bin` list and REQUIRED_HOSTBINS to match it.",
+            problems.join("\n  ")
+        );
+    }
+
+    eprintln!(
+        "check-per-vm-host-binaries-sync: {} registry entries built and packaged by release.yml",
+        registry.len()
+    );
+    Ok(())
+}
+
+/// `(name, scope)` for every `PER_VM_HOST_BINARIES` entry.
+fn parse_registry(root: &Path) -> Result<Vec<(String, String)>> {
+    let path = root.join("crates/mvm-cli/src/host_binaries/manifest.rs");
+    let src = std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+    Ok(parse_registry_str(&src))
+}
+
+fn parse_registry_str(src: &str) -> Vec<(String, String)> {
+    let Some(i) = src.find("PER_VM_HOST_BINARIES") else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    let mut name: Option<String> = None;
+    for line in src[i..].lines() {
+        if let Some(v) = extract_quoted_after(line, "name:") {
+            name = Some(v);
+        }
+        if let Some(scope) = line.trim().strip_prefix("scope: PerVmScope::")
+            && let Some(n) = name.take()
+        {
+            out.push((n, scope.trim_end_matches(',').trim().to_string()));
+        }
+        if line.starts_with("];") && !out.is_empty() {
+            break;
+        }
+    }
+    out
+}
+
+/// Every `--bin <name>` argument anywhere in the workflow.
+fn bin_flags(src: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in src.lines() {
+        let mut rest = line;
+        while let Some(i) = rest.find("--bin ") {
+            rest = &rest[i + "--bin ".len()..];
+            let name = rest
+                .split_whitespace()
+                .next()
+                .unwrap_or_default()
+                .trim_end_matches('\\')
+                .trim();
+            if name.starts_with("mvm-") {
+                out.insert(name.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Every binary named in a `REQUIRED_HOSTBINS=` assignment (the base list and
+/// any target-conditional extension).
+fn required_hostbins(src: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for line in src.lines() {
+        let t = line.trim();
+        let Some(rest) = t.strip_prefix("REQUIRED_HOSTBINS=") else {
+            continue;
+        };
+        for tok in rest.trim_matches('"').split_whitespace() {
+            let tok = tok.trim_matches('"');
+            if tok.starts_with("mvm-") {
+                out.insert(tok.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn extract_quoted_after(line: &str, key: &str) -> Option<String> {
+    let i = line.find(key)? + key.len();
+    let rest = &line[i..];
+    let q1 = rest.find('"')? + 1;
+    let q2 = rest[q1..].find('"')?;
+    Some(rest[q1..q1 + q2].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn workspace_root() -> PathBuf {
+        let manifest = std::env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+        manifest
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or(manifest)
+    }
+
+    #[test]
+    fn registry_parses_names_and_scopes() {
+        let got = parse_registry_str(
+            r#"
+pub const PER_VM_HOST_BINARIES: &[PerVmBinary] = &[
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-netd",
+        features: "",
+        scope: PerVmScope::Always,
+    },
+    PerVmBinary {
+        package: "mvm-hostd",
+        name: "mvm-hvf-supervisor",
+        features: "",
+        scope: PerVmScope::MacOsAarch64,
+    },
+];
+"#,
+        );
+        assert_eq!(
+            got,
+            vec![
+                ("mvm-netd".to_string(), "Always".to_string()),
+                ("mvm-hvf-supervisor".to_string(), "MacOsAarch64".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn bin_flags_reads_continued_lines() {
+        let got =
+            bin_flags("cargo build -p mvm-hostd \\\n  --bin mvm-broker \\\n  --bin mvm-netd\n");
+        assert!(got.contains("mvm-broker"));
+        assert!(got.contains("mvm-netd"));
+    }
+
+    #[test]
+    fn required_hostbins_reads_base_and_extension() {
+        let got = required_hostbins(
+            "          REQUIRED_HOSTBINS=\"mvm-netd mvm-broker\"\n\
+             REQUIRED_HOSTBINS=\"${REQUIRED_HOSTBINS} mvm-hvf-supervisor\"\n",
+        );
+        assert!(got.contains("mvm-netd"));
+        assert!(got.contains("mvm-broker"));
+        assert!(got.contains("mvm-hvf-supervisor"));
+        assert!(!got.iter().any(|s| s.contains("REQUIRED")));
+    }
+
+    #[test]
+    fn run_passes_on_current_workspace() {
+        run(&workspace_root()).expect("registry and release.yml should agree");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -54,6 +54,7 @@ mod check_no_spec_refs_in_comments;
 mod check_no_string_backend_dispatch;
 mod check_no_vz;
 mod check_one_guest_protocol;
+mod check_per_vm_host_binaries_sync;
 mod check_plan_names;
 mod check_require_grant_token_allowlist;
 mod check_runtime_overlay_version;
@@ -367,6 +368,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_mvm_host_binaries_sync::run(&workspace)
         }
+        Some("check-per-vm-host-binaries-sync") => {
+            let workspace = workspace_root();
+            check_per_vm_host_binaries_sync::run(&workspace)
+        }
         Some("check-workflow-paths") => {
             let workspace = workspace_root();
             check_workflow_paths::run(&workspace)
@@ -407,7 +412,7 @@ fn main() -> Result<()> {
             ir_parity::check(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-vsock-only-egress, check-one-guest-protocol, check-no-gateway-names, check-uniform-vsock-egress, check-l3-expansion-freeze, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-vsock-only-egress, check-one-guest-protocol, check-no-gateway-names, check-uniform-vsock-egress, check-l3-expansion-freeze, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -541,6 +546,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-mvm-host-binaries-sync            Plan 115 / ADR-004: assert Rust manifest and Nix attrset agree"
+            );
+            eprintln!(
+                "  check-per-vm-host-binaries-sync         assert release.yml builds+packages every spawnable per-VM binary"
             );
             eprintln!(
                 "  check-no-gateway-names                  assert no reference to a removed userspace network gateway"


### PR DESCRIPTION
## The bug

`resolve_subprocess_bin` (`crates/mvm-vmm/src/host/broker_services_spawn.rs:221`) looks for the per-VM host processes in three places: an env override, **adjacent to `current_exe()`**, then `target/{release,debug}` relative to `CARGO_MANIFEST_DIR`. That last fallback only exists in a source checkout — a downloaded tarball has no `target/` dir. So the binary set a contributor gets for free is not the set a *user* gets, and the gap surfaces as a spawn failure on their machine rather than as a build error on ours.

Three hand-kept lists disagreed about that set:

| list | contents |
|---|---|
| `build_aux_helpers.rs::aux_helper_specs` (source build) | host-agent, signer-helper, network-endpoint, netd (+ macOS supervisors) |
| `release.yml` build step | network-endpoint (+ macOS supervisors) |
| `release.yml` packaging loop | hvf-supervisor, libkrun-supervisor, network-endpoint |

`host_agent_daemon_enabled()` **defaults to on**, so a plain `up` on a downloaded Linux `mvmctl` reaches for `mvm-host-agent` — and `mvm-host-agent` in turn resolves `mvm-signer-helper` adjacent to itself. Neither shipped. The documented `MVM_HOST_AGENT_DAEMON=0` fallback reaches for `mvm-broker` and `mvm-audit-signer`, which *no* list built.

This is not aarch64-specific — x86_64 tarballs have the same hole — but it is the blocker for running a downloaded `mvmctl` on an edge host, where there is no toolchain to fall back on. It was hit independently on real hardware during aarch64 bring-up: *"The guest needs the full aarch64 host-side runtime, not just `mvmctl`."*

## The fix

`PER_VM_HOST_BINARIES` in `crates/mvm-cli/src/host_binaries/manifest.rs` becomes the one source of truth, alongside the existing `HOST_BINARIES` / `SEED_BINARIES`. Each entry carries a `PerVmScope` (`Always`, `MacOsAarch64`, `RequiresLibkrun`) so applicability is data rather than branching in each consumer.

- The build script selects from the registry (`aux_helper_specs_from`), text-parsing it exactly as `build.rs` already reads `HOST_BINARIES` — a build script can't import the crate it builds. The selection stays pure and unit-tested.
- `release.yml` builds and packages the registry's set.
- Packaging **fails closed**. It was `[ -f "$src" ] && cp`, so a binary that failed to build was silently dropped from the tarball; it is now a hard error naming the binary and the target.

## The gate

`xtask check-per-vm-host-binaries-sync` mirrors the existing `check-mvm-host-binaries-sync` and fails when release.yml drifts from the registry in **either** direction — a registry entry the workflow never builds or packages, or a workflow entry that isn't in the registry. Wired into `ci.yml` and `ci-full.yml`.

This needs a gate rather than review because `release.yml` only runs on tags: a binary added to the registry but not the release job is invisible on the PR that opens the gap, and stays invisible until a user's install fails.

The gate also refuses to run vacuously — if `PER_VM_HOST_BINARIES` is ever renamed or reshaped so the text parse yields nothing, it errors rather than passing over an empty list. The same guard is asserted from the test side by `the_registry_is_not_silently_empty`.

## Verification

- `cargo nextest run --workspace` — **12,166 passed**, 0 failed
- `cargo test --workspace --doc` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all --check` — clean
- `just check-gated` — pass
- `actionlint` on all three edited workflows — pass
- `check-workflow-paths`, `check-mvm-host-binaries-sync`, `check-per-vm-host-binaries-sync`, `check-no-spec-refs-in-comments`, `check-honesty`, `check-dormant-controls` — pass

Both new gates were mutation-tested rather than merely observed green:

- removing `mvm-broker` from the registry → `every_spawnable_service_binary_builds_on_every_host` fails with `mvm-broker must build on linux/x86_64`
- dropping `--bin mvm-broker` from release.yml → `release.yml never builds \`mvm-broker\``
- adding an unknown binary to `REQUIRED_HOSTBINS` → `release.yml packages \`mvm-ghost-binary\`, which is not in PER_VM_HOST_BINARIES`

## Not covered

Whether these binaries actually *run* correctly on a downloaded install is still unwitnessed — that needs the aarch64 hardware run tracked separately. This PR closes the "the file isn't there at all" half.