### PR TITLE
fix(ci): install the wasip1 target the pages demo guest needs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,7 +44,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.96.0
-          targets: wasm32-unknown-unknown
+          # Two targets, two crates: `wasm-pack` builds the browser shim for
+          # wasm32-unknown-unknown, and `web/mvm-demo-guest/build.sh` builds the
+          # demo guest for wasm32-wasip1. Installing only the first fails the
+          # second with `can't find crate for std`, which reads like a toolchain
+          # problem rather than a missing target.
+          targets: wasm32-unknown-unknown, wasm32-wasip1
 
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked


### PR DESCRIPTION
The github-pages deploy fails at `Build wasm demo`:

```
error[E0463]: can't find crate for `std`
error: could not compile `mvm-demo-guest` (bin "mvm-demo-guest")
```

That reads like a broken toolchain and is not one.

## Cause

The step runs **two** builds against **two** targets:

| build | target |
| --- | --- |
| `wasm-pack build --target web` (browser shim) | `wasm32-unknown-unknown` |
| `web/mvm-demo-guest/build.sh` → `cargo build --target wasm32-wasip1` | `wasm32-wasip1` |

`pages.yml` installed only the first. The guest then had no `std` for its target, and `E0463` is what rustc says when a target's standard library is absent — indistinguishable at a glance from a toolchain that failed to install.

## Verified

With `wasm32-wasip1` present, `mvm-demo-guest` compiles clean. I built it rather than reasoning from the error message.

## Why nobody noticed

`pages.yml` fires only on `release: [published]` and manual dispatch. The last github-pages deployment was **2026-06-03** (`v0.15.1`), and it failed. Nothing published between then and today, so the red badge sat untouched for two and a half months.

The badge was stale; the break underneath it was real. Both are worth knowing — a workflow that only runs on release is a workflow whose failures are discovered at the worst possible moment.
