### PR TITLE
fix(ci): attach the runtime overlay to the boot gates, which is where the agent lives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1001,6 +1001,13 @@ jobs:
                    default-microvm-meta-x86_64.json; do
             curl -fL --retry 3 -o "$f" "$base/$f"
           done
+          # The prod rootfs has no baked agent — /init resolves it from
+          # /mvm/runtime, the runtime overlay attached as a second virtio-blk
+          # drive. Fetching kernel and rootfs alone boots a guest that panics at
+          # `Attempted to kill init!` before the agent binds vsock, which reads
+          # as a broken image rather than an incomplete fetch.
+          curl -fL --retry 3 -o runtime-overlay-x86_64.tar.gz \
+            "$base/runtime-overlay-x86_64.tar.gz"
           curl -fL --retry 3 -o checksums.txt \
             "$base/default-microvm-x86_64-checksums-sha256.txt"
           grep -E ' (default-microvm-vmlinux-x86_64|default-microvm-rootfs-x86_64\.ext4|default-microvm-meta-x86_64\.json)$' \
@@ -1013,6 +1020,11 @@ jobs:
           # to be put back under the name the gate looks for. Verified above
           # under its asset name before being renamed.
           cp default-microvm-meta-x86_64.json mvm-meta.json
+          # The overlay tarball carries its own checksum manifest; verify
+          # against that rather than trusting the archive.
+          mkdir -p overlay && tar -C overlay -xzf runtime-overlay-x86_64.tar.gz
+          ( cd overlay && sha256sum -c checksums-sha256.txt )
+          ls -la overlay
           ls -la
 
       - name: Boot within the ceiling
@@ -1027,11 +1039,15 @@ jobs:
           MVM_RUNTIME_BOOT_BACKEND: firecracker
           MVM_RUNTIME_BOOT_KERNEL: /tmp/boot-image/default-microvm-vmlinux-x86_64
           MVM_RUNTIME_BOOT_ROOTFS: /tmp/boot-image/default-microvm-rootfs-x86_64.ext4
+          MVM_RUNTIME_BOOT_OVERLAY: /tmp/boot-image/overlay/overlay.ext4
+          MVM_RUNTIME_BOOT_OVERLAY_VERITY: /tmp/boot-image/overlay/overlay.verity
           MVM_RUNTIME_BOOT_READY: guest-agent
           MVM_RUNTIME_BOOT_RUNS: "5"
           MVM_RUNTIME_BOOT_CONCURRENT: "3"
           MVM_RUNTIME_BOOT_BUDGET_MS: "6000"
         run: |
+          MVM_RUNTIME_BOOT_OVERLAY_ROOTHASH="$(tr -d '[:space:]' \
+            < /tmp/boot-image/overlay/overlay.roothash)" \
           cargo test --test runtime_boot_bench \
             prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
 

--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -493,6 +493,30 @@ jobs:
       - uses: ./.github/actions/install-zigbuild
         if: matrix.arch == 'x86_64'
 
+      # The prod rootfs resolves its agent from /mvm/runtime, which is the
+      # runtime overlay attached as a second virtio-blk drive. It is built by a
+      # sibling job on a different runner, so this one has to build its own
+      # copy — the nix store is already warm from the image build above, so
+      # this is a store lookup far more often than a build. Without it the
+      # guest panics at `Attempted to kill init!` and the gate reports a broken
+      # image when the image is fine and the harness was incomplete.
+      - name: Build the runtime overlay for the boot gate
+        if: matrix.arch == 'x86_64'
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          SYSTEM="${ARCH}-linux"
+          OVERLAY_PATH=$(nix build "./nix/images/runtime-overlay#packages.${SYSTEM}.default" \
+            --no-link --print-out-paths | head -1)
+          mkdir -p overlay-staging
+          # cp -L so `overlay.*` resolve through nix-store symlinks.
+          cp -L "$OVERLAY_PATH/overlay.ext4"     overlay-staging/overlay.ext4
+          cp -L "$OVERLAY_PATH/overlay.verity"   overlay-staging/overlay.verity
+          cp -L "$OVERLAY_PATH/overlay.roothash" overlay-staging/overlay.roothash
+          echo "MVM_RUNTIME_BOOT_OVERLAY_ROOTHASH=$(tr -d '[:space:]' < overlay-staging/overlay.roothash)" \
+            >> "$GITHUB_ENV"
+
       - name: Boot the staged image before it becomes a release asset
         if: matrix.arch == 'x86_64'
         # Boots the artifact in `staging/`, never a published one — the whole
@@ -508,6 +532,8 @@ jobs:
           MVM_RUNTIME_BOOT_BACKEND: firecracker
           MVM_RUNTIME_BOOT_KERNEL: staging/default-microvm-vmlinux-x86_64
           MVM_RUNTIME_BOOT_ROOTFS: staging/default-microvm-rootfs-x86_64.ext4
+          MVM_RUNTIME_BOOT_OVERLAY: overlay-staging/overlay.ext4
+          MVM_RUNTIME_BOOT_OVERLAY_VERITY: overlay-staging/overlay.verity
           MVM_RUNTIME_BOOT_READY: guest-agent
           MVM_RUNTIME_BOOT_RUNS: "1"
           MVM_RUNTIME_BOOT_CONCURRENT: "1"

--- a/tests/runtime_boot_bench.rs
+++ b/tests/runtime_boot_bench.rs
@@ -41,6 +41,15 @@ const BUDGET_VAR: &str = "MVM_RUNTIME_BOOT_BUDGET_MS";
 const READY_VAR: &str = "MVM_RUNTIME_BOOT_READY";
 const CPUS_VAR: &str = "MVM_RUNTIME_BOOT_CPUS";
 const MEMORY_MIB_VAR: &str = "MVM_RUNTIME_BOOT_MEMORY_MIB";
+/// The prod guest rootfs carries no baked agent: `/init` resolves it from
+/// `/mvm/runtime`, which is the runtime overlay attached as a second
+/// virtio-blk drive. Booting one without the overlay panics the guest at
+/// `Attempted to kill init!` before the agent can bind vsock, so a harness that
+/// cannot attach an overlay cannot boot a prod image at all. All three are
+/// required together, matching what the backend demands.
+const OVERLAY_VAR: &str = "MVM_RUNTIME_BOOT_OVERLAY";
+const OVERLAY_VERITY_VAR: &str = "MVM_RUNTIME_BOOT_OVERLAY_VERITY";
+const OVERLAY_ROOTHASH_VAR: &str = "MVM_RUNTIME_BOOT_OVERLAY_ROOTHASH";
 
 const DEFAULT_BACKEND: &str = "firecracker";
 const DEFAULT_RUNS: usize = 5;
@@ -99,6 +108,17 @@ struct BenchSpec {
     ready: ReadySignal,
     cpus: u32,
     memory_mib: u32,
+    overlay: Option<OverlaySpec>,
+}
+
+/// All three or none. The backend attaches the overlay only when the path, the
+/// verity sidecar and the roothash are all present, so accepting a partial set
+/// here would boot without an overlay and fail as though none was configured.
+#[derive(Debug, Clone)]
+struct OverlaySpec {
+    path: PathBuf,
+    verity: PathBuf,
+    roothash: String,
 }
 
 impl BenchSpec {
@@ -109,6 +129,7 @@ impl BenchSpec {
         }
         let config = config.unwrap_or_default();
 
+        let overlay = overlay_spec(&config)?;
         let kernel = required_path(KERNEL_VAR, config.kernel)?;
         let rootfs = required_path(ROOTFS_VAR, config.rootfs)?;
         let ready =
@@ -130,6 +151,7 @@ impl BenchSpec {
             ready,
             cpus: env_u32(CPUS_VAR, config.cpus, 1)?,
             memory_mib: env_u32(MEMORY_MIB_VAR, config.memory_mib, 256)?,
+            overlay,
         }))
     }
 }
@@ -148,6 +170,11 @@ struct RawBenchConfig {
     cpus: Option<u32>,
     #[serde(alias = "memory_mib")]
     memory_mib: Option<u32>,
+    overlay: Option<PathBuf>,
+    #[serde(alias = "overlay_verity")]
+    overlay_verity: Option<PathBuf>,
+    #[serde(alias = "overlay_roothash")]
+    overlay_roothash: Option<String>,
 }
 
 impl RawBenchConfig {
@@ -242,6 +269,15 @@ fn measure_one(spec: &BenchSpec, name: String) -> Result<BootMeasurement> {
         memory_mib: spec.memory_mib,
         revision_hash: "runtime-boot-bench".to_string(),
         flake_ref: "prebuilt-runtime-image".to_string(),
+        runtime_overlay_path: spec
+            .overlay
+            .as_ref()
+            .map(|o| o.path.to_string_lossy().into_owned()),
+        runtime_overlay_verity_path: spec
+            .overlay
+            .as_ref()
+            .map(|o| o.verity.to_string_lossy().into_owned()),
+        runtime_overlay_roothash: spec.overlay.as_ref().map(|o| o.roothash.clone()),
         ..Default::default()
     };
 
@@ -396,6 +432,53 @@ fn assert_within_budget(label: &str, actual: Duration, budget: Duration) {
     );
 }
 
+/// Resolve the overlay triple, refusing a partial one. A silently-dropped
+/// overlay is indistinguishable at the console from an image with no agent, so
+/// name the missing piece here rather than let the guest panic explain it.
+fn overlay_spec(config: &RawBenchConfig) -> Result<Option<OverlaySpec>> {
+    let path = env_path_opt(OVERLAY_VAR, config.overlay.clone());
+    let verity = env_path_opt(OVERLAY_VERITY_VAR, config.overlay_verity.clone());
+    let roothash = env_string_opt(OVERLAY_ROOTHASH_VAR, config.overlay_roothash.clone());
+    match (path, verity, roothash) {
+        (None, None, None) => Ok(None),
+        (Some(path), Some(verity), Some(roothash)) => {
+            let roothash = roothash.trim().to_string();
+            if roothash.is_empty() {
+                anyhow::bail!("{OVERLAY_ROOTHASH_VAR} is set but empty");
+            }
+            Ok(Some(OverlaySpec {
+                path,
+                verity,
+                roothash,
+            }))
+        }
+        (path, verity, roothash) => {
+            let mut missing = Vec::new();
+            if path.is_none() {
+                missing.push(OVERLAY_VAR);
+            }
+            if verity.is_none() {
+                missing.push(OVERLAY_VERITY_VAR);
+            }
+            if roothash.is_none() {
+                missing.push(OVERLAY_ROOTHASH_VAR);
+            }
+            anyhow::bail!(
+                "runtime overlay is half-configured; the backend attaches it only \
+                 when all three are set. Missing: {}",
+                missing.join(", ")
+            )
+        }
+    }
+}
+
+fn env_path_opt(var: &str, configured: Option<PathBuf>) -> Option<PathBuf> {
+    std::env::var_os(var)
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or(configured)
+}
+
 fn required_path(var: &str, configured: Option<PathBuf>) -> Result<PathBuf> {
     let path = std::env::var_os(var)
         .map(PathBuf::from)
@@ -520,4 +603,71 @@ fn live_bench_is_disabled_by_default() -> Result<()> {
     }
     assert!(BenchSpec::from_env()?.is_none());
     Ok(())
+}
+
+/// The overlay is what carries the guest agent for a prod image. A half-set
+/// triple used to be indistinguishable from an unset one, and the backend
+/// silently declined to attach it — the first visible symptom was a kernel
+/// panic that blamed the image.
+#[test]
+fn overlay_spec_is_absent_when_nothing_is_configured() {
+    let config = RawBenchConfig::default();
+    assert!(
+        overlay_spec(&config)
+            .expect("no overlay is valid")
+            .is_none()
+    );
+}
+
+#[test]
+fn overlay_spec_accepts_the_complete_triple() {
+    let config = RawBenchConfig {
+        overlay: Some(PathBuf::from("/tmp/overlay.ext4")),
+        overlay_verity: Some(PathBuf::from("/tmp/overlay.verity")),
+        overlay_roothash: Some("  deadbeef\n".to_string()),
+        ..RawBenchConfig::default()
+    };
+    let spec = overlay_spec(&config)
+        .expect("complete triple is valid")
+        .expect("complete triple yields an overlay");
+    assert_eq!(spec.path, PathBuf::from("/tmp/overlay.ext4"));
+    assert_eq!(spec.verity, PathBuf::from("/tmp/overlay.verity"));
+    // Trimmed: the roothash is read from a file that ends in a newline.
+    assert_eq!(spec.roothash, "deadbeef");
+}
+
+#[test]
+fn overlay_spec_refuses_a_half_configured_overlay_and_names_what_is_missing() {
+    let config = RawBenchConfig {
+        overlay: Some(PathBuf::from("/tmp/overlay.ext4")),
+        ..RawBenchConfig::default()
+    };
+    let err = overlay_spec(&config)
+        .expect_err("a partial overlay must not silently boot without one")
+        .to_string();
+    // Compare the missing list exactly. `contains(OVERLAY_VAR)` would always
+    // hold — it is a prefix of the other two names — so a substring check here
+    // would pass no matter which variables the message actually named.
+    let listed = err
+        .split_once("Missing: ")
+        .map(|(_, rest)| rest.trim().to_string())
+        .unwrap_or_else(|| panic!("error should name what is missing: {err}"));
+    assert_eq!(
+        listed,
+        format!("{OVERLAY_VERITY_VAR}, {OVERLAY_ROOTHASH_VAR}")
+    );
+}
+
+#[test]
+fn overlay_spec_refuses_a_blank_roothash() {
+    let config = RawBenchConfig {
+        overlay: Some(PathBuf::from("/tmp/overlay.ext4")),
+        overlay_verity: Some(PathBuf::from("/tmp/overlay.verity")),
+        overlay_roothash: Some("   \n".to_string()),
+        ..RawBenchConfig::default()
+    };
+    let err = overlay_spec(&config)
+        .expect_err("a blank roothash is not a roothash")
+        .to_string();
+    assert!(err.contains(OVERLAY_ROOTHASH_VAR), "{err}");
 }


### PR DESCRIPTION
The first boot gate to actually run against a tree-built image failed, and it
read as a broken image. It was not. The console said exactly what happened:

```
mvm-init: no guest agent resolved from /mvm/runtime and no baked fallback
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
```

`/init` ran — which is itself the proof that the shebang fix works and lands on
byte 0. What it could not find was the agent.

## Root cause

A prod rootfs carries no baked agent. `mk-guest.nix`'s ladder resolves it from
`/mvm/runtime`, and that is the **runtime overlay**, attached as a second
virtio-blk drive. Both boot lanes supplied a kernel and a rootfs and nothing
else, so the guest reached userspace and died there.

Underneath, `tests/runtime_boot_bench.rs` built its `VmStartConfig` with
`..Default::default()`, leaving `runtime_overlay_path`,
`runtime_overlay_verity_path` and `runtime_overlay_roothash` unset — and the
backend attaches the overlay only when all three are `Some`. So the harness could
not boot a prod image at all, whatever it was pointed at.

This is why `boot-latency` has never once passed since it was added: parked
immediately for a broken published image, and incomplete underneath. #2542
restores it to gating PRs, and without this it would fail on every one.

## What changed

- **`tests/runtime_boot_bench.rs`** takes the overlay triple from
  `MVM_RUNTIME_BOOT_OVERLAY`, `_OVERLAY_VERITY`, `_OVERLAY_ROOTHASH` (and the
  TOML equivalents), and refuses a half-set one **by name**. A dropped overlay
  and an image with no agent produce identical console output, so the difference
  has to be reported before the boot rather than inferred from the panic after.
- **`release-boot-image.yml`** builds its own overlay for the gate. The sibling
  job that publishes one runs on a different runner, and the nix store is warm
  from the image build directly above, so this is a store lookup far more often
  than a build.
- **`ci.yml`**'s `boot-latency` fetches the published `runtime-overlay-x86_64.tar.gz`
  and verifies it against its own checksum manifest — same posture as every other
  artifact fetch in that lane.

## Verification

`cargo test --test runtime_boot_bench` → **9 passed**. Four are new: absent,
complete, half-configured, blank roothash.

The half-configured test asserts the missing list **exactly** rather than with
`contains()`. `MVM_RUNTIME_BOOT_OVERLAY` is a prefix of the other two names, so a
substring check passes regardless of which variables the message actually names —
I wrote it that way first and it failed for that reason, which is the useful kind
of failure.

Confirmed by mutation: making `overlay_spec` accept a partial triple turns
`overlay_spec_refuses_a_half_configured_overlay_and_names_what_is_missing` red.

`actionlint` on both workflows, nightly `cargo fmt --all`, and
`cargo clippy --test runtime_boot_bench -- -D warnings` clean.

## What this does not do

It does not prove the image boots — only that the harness can now attach what the
image needs. The next `boot-image/v*` tag is what answers that, and it will refuse
to publish if the answer is no.

Related: #2539, #2542, #2635, #2655.
