### PR TITLE
fix(stage0): find the Nix store by label, and refuse a disk that is not one

### DIFF
--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -62,6 +62,8 @@ mod linux {
     const VSOCK_EGRESS_PROXY_LISTEN_ADDR: &str = mvm_core::guest_netd::DEFAULT_EGRESS_PROXY_LISTEN;
     const VSOCK_EGRESS_PROXY_READY_TIMEOUT: Duration = Duration::from_secs(5);
     const VSOCK_EGRESS_PORT_ENV: &str = "MVM_EGRESS_VSOCK_PORT";
+    /// Marks a store error the tmpfs fallback must not swallow.
+    const FATAL_STORE_PREFIX: &str = "FATAL-STORE: ";
     const VSOCK_EGRESS_PORT_TOKEN_PREFIX: &str = "mvm.vsock_egress_port=";
     const QEMU_STAGE0_VSOCK_MODULES: &[&str] = &[
         "/mvm-bins/vsock-modules/vsock.ko",
@@ -522,6 +524,12 @@ mod linux {
     fn setup_nix_store(qemu: bool) -> Result<(), String> {
         match setup_persistent_nix_store(qemu) {
             Ok(()) => return Ok(()),
+            // A fatal store fault is not something to degrade around: the tmpfs
+            // is sized by guest RAM, so continuing turns a nameable disk problem
+            // into an out-of-space error far from its cause.
+            Err(e) if e.starts_with(FATAL_STORE_PREFIX) => {
+                return Err(e.trim_start_matches(FATAL_STORE_PREFIX).to_string());
+            }
             Err(e) => eprintln!(
                 "stage0-init: persistent Stage 0 /nix store unavailable ({e}); falling back to tmpfs seed copy"
             ),
@@ -558,10 +566,61 @@ mod linux {
         }
     }
 
+    /// Size of a block device in bytes, via its sysfs 512-byte block count.
+    ///
+    /// Read from sysfs rather than by seeking the device: a seek would need the
+    /// device open, and the point of this check is to refuse it before trusting
+    /// it enough to mount.
+    fn block_device_bytes(device: &str) -> Option<u64> {
+        let name = Path::new(device).file_name()?.to_str()?;
+        let raw = std::fs::read_to_string(format!("/sys/class/block/{name}/size")).ok()?;
+        raw.trim().parse::<u64>().ok().map(|blocks| blocks * 512)
+    }
+
     fn setup_persistent_nix_store(qemu: bool) -> Result<(), String> {
-        let device = stage0_nix_store_device(qemu);
+        // Prefer the ext4 label. The device letter is a function of how many
+        // block devices the backend attached ahead of this one, so adding a
+        // drive silently re-letters every disk behind it — which is how this
+        // guest came to mount a 32 KiB identity image as its Nix store, fail,
+        // and fall back to a tmpfs too small for a kernel source tree. The
+        // letter stays as a fallback for a store image formatted before it
+        // carried a label.
+        let label = mvm_build::rootfs::STAGE0_NIX_STORE_EXT4_LABEL;
+        let by_label = find_labeled_ext4_disk(STAGE0_DISK_CANDIDATES, label)
+            .map(|d| d.to_string_lossy().into_owned());
+        let device: &str = match by_label.as_deref() {
+            Some(dev) => {
+                eprintln!("stage0-init: Stage 0 Nix store is {dev} (label {label:?})");
+                dev
+            }
+            None => {
+                let dev = stage0_nix_store_device(qemu);
+                eprintln!(
+                    "stage0-init: no disk carries the ext4 label {label:?}; \
+                     falling back to {dev} by enumeration order"
+                );
+                dev
+            }
+        };
         if !Path::new(device).exists() {
             return Err(format!("{device} is not present"));
+        }
+
+        // A device that is present but far too small is a misidentified disk,
+        // not an empty store. Refuse it here rather than letting the caller
+        // degrade to a RAM-sized tmpfs whose exhaustion surfaces thousands of
+        // lines later as an unrelated-looking build error.
+        if let Some(bytes) = block_device_bytes(device)
+            && bytes < mvm_build::store_readiness::MIN_PLAUSIBLE_STORE_BYTES
+        {
+            return Err(FATAL_STORE_PREFIX.to_string()
+                + &mvm_build::store_readiness::store_readiness_outcome(
+                    mvm_build::store_readiness::StoreProbe::ImplausiblySmall {
+                        device: device.to_string(),
+                        bytes,
+                    },
+                )
+                .expect_err("an undersized store device must refuse"));
         }
 
         std::fs::create_dir_all(STAGE0_NIX_STORE_MOUNT)

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -74,6 +74,8 @@ pub mod rootfs_inject;
 pub mod run_image;
 pub mod runtime_identity;
 pub mod stage0;
+/// Whether a builder guest may fall back to a tmpfs Nix store, or must stop.
+pub mod store_readiness;
 pub mod template_reuse;
 pub mod verity_initrd;
 /// Persistent ext4 image materialization for user-attached block volumes.

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2777,7 +2777,11 @@ pub(crate) fn prepopulate_stage0_nix_store_image(
         "prepopulating Stage 0 Nix store image with host mkfs.ext4"
     );
     let status = Command::new(&mkfs)
-        .args(["-F", "-q", "-b", "4096", "-d"])
+        // `-L` so the guest can find this disk by label instead of by device
+        // letter, which shifts whenever a backend attaches another drive.
+        .args(["-F", "-q", "-b", "4096", "-L"])
+        .arg(crate::rootfs::STAGE0_NIX_STORE_EXT4_LABEL)
+        .args(["-d"])
         .arg(&seed_nix)
         .arg(store_image)
         .arg(blocks_4k.to_string())
@@ -2830,7 +2834,12 @@ fn format_stage0_store_empty_in_process(store_image: &Path) -> Result<(), Builde
     file.set_len(device_size).map_err(|e| {
         BuilderVmError::ExtractionFailed(format!("resize {}: {e}", store_image.display()))
     })?;
-    let summary = mvm_fs::ext4::mkfs::format_empty_ext4(&mut file, size_bytes).map_err(|e| {
+    let summary = mvm_fs::ext4::mkfs::format_empty_ext4_labeled(
+        &mut file,
+        size_bytes,
+        crate::rootfs::STAGE0_NIX_STORE_EXT4_LABEL.as_bytes(),
+    )
+    .map_err(|e| {
         BuilderVmError::ExtractionFailed(format!(
             "pure-Rust ext4 format of {}: {e}",
             store_image.display()

--- a/crates/mvm-build/src/rootfs.rs
+++ b/crates/mvm-build/src/rootfs.rs
@@ -34,6 +34,16 @@ const DEFAULT_GUEST_OUTPUT_DEVICE: &str = "/dev/vdc";
 /// regardless of which features its own build enables.
 pub const STAGE0_WORK_EXT4_LABEL: &str = "mvm-work";
 
+/// ext4 volume label on the persistent Stage 0 Nix store image.
+///
+/// The store used to be located by device letter, which couples it to how many
+/// block devices the backend happens to attach ahead of it. Adding one drive —
+/// the FlowMux identity disk — shifted every device behind it, so the guest
+/// mounted a 32 KiB identity image as its Nix store, failed, and silently fell
+/// back to a RAM-backed tmpfs that cannot hold a kernel source tree. The build
+/// then died thousands of lines later on `No space left on device`.
+pub const STAGE0_NIX_STORE_EXT4_LABEL: &str = "mvm-nix-store";
+
 /// Inputs for [`materialize_ext4`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MaterializeExt4Input {

--- a/crates/mvm-build/src/store_readiness.rs
+++ b/crates/mvm-build/src/store_readiness.rs
@@ -1,0 +1,155 @@
+//! Whether a builder guest may fall back to a tmpfs Nix store, or must stop.
+//!
+//! Stage 0 prefers a persistent ext4 store disk and falls back to copying the
+//! seed into a tmpfs when there is none. That fallback is deliberate — it keeps
+//! bootstrap working on a host with no `mkfs.ext4` and a blank disk — but it is
+//! only correct when the store is genuinely *absent*.
+//!
+//! When a disk is present and unusable the fallback is actively harmful: the
+//! tmpfs is sized by guest RAM, so a large build dies thousands of lines later
+//! on `No space left on device`, naming neither the disk nor the fallback. That
+//! is exactly how a re-lettered device — a 32 KiB identity image mounted as the
+//! Nix store — cost an afternoon to diagnose.
+//!
+//! The decision is a pure function over [`StoreProbe`] so the part that has to
+//! be right is testable without booting a guest, mirroring
+//! [`crate::egress_readiness`].
+
+/// A store disk smaller than this cannot hold a builder closure, so a device
+/// this size is a misidentified disk rather than an empty store.
+///
+/// Deliberately far below any real store (they are gigabytes) and far above the
+/// identity drive that was actually being mounted (32 KiB), so the check
+/// catches a wrong device without second-guessing a legitimately small one.
+pub const MIN_PLAUSIBLE_STORE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// How the search for a persistent store ended.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoreProbe {
+    /// A usable store disk was mounted.
+    Mounted { device: String },
+    /// No disk carries the store label and no fallback device exists. The
+    /// tmpfs copy is the intended behaviour here.
+    Absent,
+    /// A device was identified as the store but is too small to be one.
+    ImplausiblySmall { device: String, bytes: u64 },
+    /// A store device was found but could not be mounted or prepared.
+    Unusable { device: String, why: String },
+}
+
+/// Decide whether the guest may proceed, and on what.
+///
+/// `Ok(Some(dev))` mounts that store, `Ok(None)` takes the tmpfs fallback, and
+/// `Err` stops the build while the cause is still on screen.
+pub fn store_readiness_outcome(probe: StoreProbe) -> Result<Option<String>, String> {
+    let cost = "the tmpfs fallback is sized by guest RAM and cannot hold a large build";
+    match probe {
+        StoreProbe::Mounted { device } => Ok(Some(device)),
+        StoreProbe::Absent => Ok(None),
+        StoreProbe::ImplausiblySmall { device, bytes } => Err(format!(
+            "{device} was selected as the Stage 0 Nix store but is {bytes} bytes, \
+             below the {MIN_PLAUSIBLE_STORE_BYTES}-byte floor for a store disk; \
+             it is a different device, not an empty store, so refusing rather than \
+             falling back — {cost}"
+        )),
+        StoreProbe::Unusable { device, why } => Err(format!(
+            "the Stage 0 Nix store disk {device} is present but unusable ({why}); \
+             refusing rather than falling back — {cost}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_mounted_store_is_used() {
+        assert_eq!(
+            store_readiness_outcome(StoreProbe::Mounted {
+                device: "/dev/vdg".into()
+            }),
+            Ok(Some("/dev/vdg".to_string()))
+        );
+    }
+
+    /// The fallback exists for this case and must keep working: a host with no
+    /// `mkfs.ext4` and no store disk still bootstraps.
+    #[test]
+    fn an_absent_store_falls_back_to_tmpfs() {
+        assert_eq!(store_readiness_outcome(StoreProbe::Absent), Ok(None));
+    }
+
+    /// The regression this module exists for: a re-lettered device handed the
+    /// guest a 32 KiB identity image, which it accepted as an empty store.
+    #[test]
+    fn an_identity_sized_device_is_refused_rather_than_treated_as_an_empty_store() {
+        let err = store_readiness_outcome(StoreProbe::ImplausiblySmall {
+            device: "/dev/vde".into(),
+            bytes: 32 * 1024,
+        })
+        .expect_err("a 32 KiB disk is not a Nix store");
+        assert!(err.contains("/dev/vde"), "{err}");
+        assert!(err.contains("32768"), "{err}");
+        assert!(err.contains("different device"), "{err}");
+    }
+
+    #[test]
+    fn a_present_but_unmountable_store_refuses_instead_of_degrading() {
+        let err = store_readiness_outcome(StoreProbe::Unusable {
+            device: "/dev/vdg".into(),
+            why: "EACCES: Permission denied".into(),
+        })
+        .expect_err("an unusable store must stop the build");
+        assert!(err.contains("/dev/vdg"), "{err}");
+        assert!(err.contains("EACCES"), "{err}");
+    }
+
+    /// Every refusal has to say why falling back would be worse, because the
+    /// failure it prevents surfaces far from here.
+    #[test]
+    fn every_refusal_names_the_cost_of_the_fallback() {
+        for probe in [
+            StoreProbe::ImplausiblySmall {
+                device: "/dev/vde".into(),
+                bytes: 1,
+            },
+            StoreProbe::Unusable {
+                device: "/dev/vdg".into(),
+                why: "bad superblock".into(),
+            },
+        ] {
+            let err = store_readiness_outcome(probe.clone()).expect_err("must refuse");
+            assert!(
+                err.contains("sized by guest RAM"),
+                "{probe:?} must explain the fallback's limit: {err}"
+            );
+        }
+    }
+
+    /// The floor must sit between a real store and the identity drive that was
+    /// being mistaken for one. Asserted through the decision rather than on the
+    /// constant, so this stays a behavioural test rather than a tautology.
+    #[test]
+    fn the_floor_refuses_an_identity_drive_and_admits_a_real_store() {
+        let verdict = |bytes: u64| {
+            if bytes < MIN_PLAUSIBLE_STORE_BYTES {
+                store_readiness_outcome(StoreProbe::ImplausiblySmall {
+                    device: "/dev/vdx".into(),
+                    bytes,
+                })
+            } else {
+                store_readiness_outcome(StoreProbe::Mounted {
+                    device: "/dev/vdx".into(),
+                })
+            }
+        };
+        // The drive that was actually being mounted as the store.
+        assert!(verdict(32 * 1024).is_err(), "a 32 KiB disk must be refused");
+        // A real store, orders of magnitude larger.
+        assert!(
+            verdict(64 * 1024 * 1024 * 1024).is_ok(),
+            "a 64 GiB store must be admitted"
+        );
+    }
+}

--- a/crates/mvm-fs/src/ext4/mkfs.rs
+++ b/crates/mvm-fs/src/ext4/mkfs.rs
@@ -206,9 +206,28 @@ pub fn format_empty_ext4<W: Write + Seek>(
     dev: &mut W,
     size_bytes: u64,
 ) -> Result<FormatSummary, MkfsError> {
+    format_empty_ext4_labeled(dev, size_bytes, b"")
+}
+
+/// [`format_empty_ext4`], stamping `volume_label` into the superblock.
+///
+/// A guest that locates a disk by label instead of by device letter is immune
+/// to another backend attaching one more drive ahead of it — which is how the
+/// Stage 0 Nix store came to be mounted from a 32 KiB identity image. Labels
+/// longer than the 16-byte ext4 field are truncated, as `mkfs.ext4` does.
+pub fn format_empty_ext4_labeled<W: Write + Seek>(
+    dev: &mut W,
+    size_bytes: u64,
+    volume_label: &[u8],
+) -> Result<FormatSummary, MkfsError> {
     let geom = Geometry::plan(size_bytes)?;
 
-    let superblock = build_superblock(&geom);
+    let mut superblock = build_superblock(&geom);
+    // s_volume_name: 16 bytes at 0x78 within the superblock, the same field
+    // the directory-tree writer stamps via BuildOptions::volume_name.
+    let label_len = volume_label.len().min(16);
+    superblock[0x78..0x78 + label_len].copy_from_slice(&volume_label[..label_len]);
+    let superblock = superblock;
     let gdt = build_gdt(&geom);
 
     // Primary superblock: at byte offset 1024, inside block 0 (which also holds
@@ -482,5 +501,47 @@ mod tests {
             format_empty_ext4(&mut cur, 1024 * 1024),
             Err(MkfsError::TooSmall { .. })
         ));
+    }
+}
+
+#[cfg(test)]
+mod label_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// A guest locates the Stage 0 store by this label, so it has to land in
+    /// the superblock's s_volume_name field where blkid and the guest's own
+    /// probe read it.
+    #[test]
+    fn the_label_lands_in_the_superblock_volume_name() {
+        let mut cur = Cursor::new(vec![0u8; 16 * 1024 * 1024]);
+        format_empty_ext4_labeled(&mut cur, 16 * 1024 * 1024, b"mvm-nix-store").expect("format");
+        let img = cur.into_inner();
+        assert_eq!(&img[1024 + 0x78..1024 + 0x78 + 13], b"mvm-nix-store");
+    }
+
+    /// The unlabeled entry point must stay byte-identical, so the volume
+    /// caller that does not want a label is unaffected.
+    #[test]
+    fn an_unlabeled_format_leaves_the_volume_name_empty() {
+        let size = 16 * 1024 * 1024;
+        let mut a = Cursor::new(vec![0u8; size as usize]);
+        format_empty_ext4(&mut a, size).expect("format");
+        let mut b = Cursor::new(vec![0u8; size as usize]);
+        format_empty_ext4_labeled(&mut b, size, b"").expect("format");
+        assert_eq!(a.into_inner(), b.into_inner());
+    }
+
+    /// ext4's field is 16 bytes; a longer label truncates rather than
+    /// corrupting the fields that follow it.
+    #[test]
+    fn an_overlong_label_truncates_without_overrunning_the_field() {
+        let size = 16 * 1024 * 1024;
+        let mut cur = Cursor::new(vec![0u8; size as usize]);
+        format_empty_ext4_labeled(&mut cur, size, b"0123456789abcdefOVERRUN").expect("format");
+        let img = cur.into_inner();
+        assert_eq!(&img[1024 + 0x78..1024 + 0x88], b"0123456789abcdef");
+        // s_last_mounted (0x88) must not have been clobbered.
+        assert_eq!(&img[1024 + 0x88..1024 + 0x90], &[0u8; 8]);
     }
 }


### PR DESCRIPTION
## The bug

The Stage 0 guest located its persistent Nix store by **device letter**, which couples it to how many block devices the backend attaches ahead of it. The FlowMux identity disk is attached immediately before the store, so every device behind it shifted:

| dev | size | file |
|---|---|---|
| vda–vdd | 30 GiB / 1.24 GiB / 4 GiB / 256 MiB | seed, work, out, mvm-bins |
| **vde** | **32 KiB** | `flowmux-identity.ext4` ← mounted as the Nix store |
| vdf | 32 KiB | second identity-sized drive |
| **vdg** | **64 GiB** | the actual store |

The guest then did the reasonable thing with an unusable disk — fell back to a tmpfs seed copy — and the build died thousands of lines later:

```
error: write of 65536 bytes: No space left on device
```

unpacking a kernel source tree into a filesystem sized by guest RAM. Nothing in that message names the disk, the fallback, or the drive that displaced it. The existing test was even called `stage0_nix_store_device_matches_backend_disk_order`, naming the coupling as though it were a property rather than a hazard.

## Two changes

**1. Find it by label.** The store now carries `mvm-nix-store` and the guest locates it through `find_labeled_ext4_disk` — the same way it already finds `/work` and the identity drive. The store was the last disk still using enumeration order. The device letter stays as a fallback for a store formatted before it had a label.

Both format paths stamp it: host `mkfs.ext4` gains `-L`, and the pure-Rust formatter gains `format_empty_ext4_labeled`. I added the variant rather than hand-patching the superblock because the guest init's own comment warns that "a second copy of the superblock layout is exactly the kind of duplicate that drifts."

**2. Refuse a disk that is not a store.** Labelling alone fixes this instance and leaves the next one to be found the same way. `store_readiness` makes the degrade-or-refuse decision explicit, mirroring `egress_readiness`:

- **Absent** → still falls back. That is what the fallback is *for*; a host with no `mkfs.ext4` and a blank disk still bootstraps.
- **Present and wrong** → refuses, naming the device and its size, while the cause is still on screen.

The floor is 64 MiB — far below any real store, far above the 32 KiB drive that was being mistaken for one.

## Tests

Nine, all pure:

- label lands in `s_volume_name`; the **unlabeled path stays byte-identical** so the unrelated volume caller is unaffected; an overlong label truncates at 16 bytes without clobbering `s_last_mounted`
- absent falls back; implausibly-small and unusable both refuse
- every refusal explains why falling back would be worse ("sized by guest RAM"), because the failure it prevents surfaces far from its cause
- the floor is asserted **through the decision**, not on the constant, so it is a behavioural test rather than a tautology

## Verification

`cargo nextest run --workspace` — **12,088 passed**. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo +nightly fmt --all -- --check` clean. `stage0-init` cross-checked for Linux with `cargo zigbuild`, since it does not compile on macOS at all.

**Not yet verified end to end on hardware.** The reference builder needs #2629 (merged) and #2640 (open) to get far enough to exercise this, and its `stage0-init` is a content-hashed cached binary that has to rebuild first. The unit coverage is real; the integration proof is pending.