### PR TITLE
feat(build): an `image =` manifest builds instead of being refused

### DIFF
--- a/crates/mvm-cli/src/commands/build/build.rs
+++ b/crates/mvm-cli/src/commands/build/build.rs
@@ -168,15 +168,11 @@ fn build_manifest(
         )
     })?;
 
-    // An `image`-source manifest selects an OCI image, not a flake. The
-    // image build path is not wired yet, so fail closed rather than
-    // silently building the default "." flake for an image manifest.
-    if manifest.is_image_source() {
-        anyhow::bail!(
-            "manifest selects an `image` source ({:?}); `build` only handles \
-             flake sources today — image-backed builds are not wired yet",
-            manifest.image.as_deref().unwrap_or_default()
-        );
+    // An `image`-source manifest selects an OCI image, not a flake, and takes
+    // the other arm — it does not fall through to building the default "."
+    // flake.
+    if let Some(image_ref) = manifest.image.clone() {
+        return build_manifest_from_image(&manifest, &canonical, &image_ref, json, mode);
     }
 
     // Resolve flake "." relative to the manifest's parent directory so a
@@ -287,6 +283,109 @@ fn build_manifest(
         ui::info(&format!("  Slot:     {}", persisted.manifest_hash));
         ui::info(&format!("  Revision: {}", revision.revision_hash));
         ui::info(&format!("\nRun with: mvmctl up {}", canonical.display()));
+    }
+
+    Ok(())
+}
+
+/// Build a slot from an `image`-source manifest.
+///
+/// Materializes the OCI reference through the same path a `run --image` boots
+/// through, then installs the result as a slot revision with the same layout
+/// the flake arm produces. What the two arms share is deliberate: after this
+/// returns, `--manifest <path>` cannot tell which one built the slot.
+fn build_manifest_from_image(
+    manifest: &Manifest,
+    canonical: &std::path::Path,
+    image_ref: &str,
+    json: bool,
+    mode: mvm_build::pipeline::BuildMode,
+) -> Result<()> {
+    if json {
+        PhaseEvent::new("build", "manifest", "started")
+            .with_message(&format!(
+                "manifest={} image={}",
+                canonical.display(),
+                image_ref
+            ))
+            .emit();
+    } else {
+        ui::step(
+            1,
+            2,
+            &format!(
+                "Building manifest {} (image={})",
+                canonical.display(),
+                image_ref
+            ),
+        );
+    }
+
+    let backend = mvm_runtime::backend::AnyBackend::auto_select()
+        .name()
+        .to_string();
+    let persisted =
+        PersistedManifest::from_manifest(manifest, canonical, &backend, Provenance::current())?;
+
+    let kernel = super::super::env::builder_vm::ensure_workload_kernel()
+        .context("resolving the workload kernel for an image-backed build")?;
+
+    // Keyed by the slot, not by a machine name: the artifact belongs to the
+    // manifest, and two machines booting the same slot must not each
+    // re-materialize it.
+    let cache_key = format!("slot-{}", persisted.manifest_hash);
+    let rootfs = tokio::runtime::Runtime::new()
+        .context("starting the runtime for the image pull")?
+        .block_on(mvm_client::local::materialize_image_rootfs(
+            image_ref, &cache_key,
+        ))
+        .with_context(|| format!("materializing {image_ref}"))?;
+
+    let revision = match mvm_runtime::vm::template::lifecycle::template_build_from_image(
+        &persisted,
+        &mvm_runtime::vm::template::lifecycle::ImageBuildSources {
+            rootfs,
+            kernel: std::path::PathBuf::from(&kernel),
+            image_ref: image_ref.to_string(),
+        },
+        mode,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            if json {
+                PhaseEvent::new("build", "manifest", "failed")
+                    .with_error(&format!("{e:#}"))
+                    .emit();
+            }
+            audit_build_error("manifest", &persisted.manifest_path, &e);
+            return Err(e);
+        }
+    };
+
+    audit_build_ok(
+        "manifest",
+        &persisted.manifest_path,
+        &persisted.manifest_hash,
+        &revision.revision_hash,
+    );
+
+    if json {
+        PhaseEvent::new("build", "manifest", "completed")
+            .with_message(&format!(
+                "manifest={} slot={} revision={}",
+                canonical.display(),
+                persisted.manifest_hash,
+                revision.revision_hash
+            ))
+            .emit();
+    } else {
+        ui::step(2, 2, "Build complete");
+        ui::info(&format!("  Slot:     {}", persisted.manifest_hash));
+        ui::info(&format!("  Revision: {}", revision.revision_hash));
+        ui::info(&format!(
+            "\nRun with: mvmctl machine run --manifest {}",
+            canonical.display()
+        ));
     }
 
     Ok(())

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -449,6 +449,26 @@ fn path_collision_hint(image_ref: &str) -> String {
     }
 }
 
+/// Materialize an OCI reference into a host `rootfs.ext4`, for a caller that
+/// wants the artifact rather than a running machine.
+///
+/// The build path uses this so an image-backed `mvm.toml` is materialized by
+/// exactly the code a `run --image` boots through — same pull, same hardened
+/// unpack, same runtime injection, and the same `mvm-meta.json` sidecar written
+/// beside the rootfs. A second materializer would be a second answer to "what
+/// does this image become", and the two would drift.
+///
+/// `cache_key` names the cache slot under `~/.mvm/cache/local-run/`.
+pub async fn materialize_image_rootfs(image_ref: &str, cache_key: &str) -> Result<PathBuf> {
+    resolve_local_rootfs(
+        &RootfsSource::Oci {
+            image_ref: image_ref.to_string(),
+        },
+        cache_key,
+    )
+    .await
+}
+
 /// Resolve `spec.image` to a host `rootfs.ext4` path, materializing in-process
 /// as needed (no subprocess, no CLI). Registry pulls are async; the dir +
 /// pre-materialized cases are synchronous.

--- a/crates/mvm-runtime/src/vm/template/lifecycle/build_image.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle/build_image.rs
@@ -1,0 +1,351 @@
+//! Building a manifest-keyed slot from an OCI image instead of a Nix flake.
+//!
+//! `mvm.toml` has carried an `image` source selector, mutually exclusive with
+//! `flake`, since the manifest primitive was introduced — but the build path
+//! only ever handled flakes and refused an image manifest with "not wired yet".
+//! This is the other arm.
+//!
+//! It is deliberately thin, because the hard parts already exist. The caller
+//! materializes the image through the same path `run --image` uses, which
+//! writes `rootfs.ext4` and the overlay-aware `mvm-meta.json` sidecar beside
+//! each other; the workload kernel is the one every OCI run already boots. So
+//! what is left is assembling those into a slot revision using the identical
+//! [`install_revision_artifacts`] the flake path uses — one revision layout,
+//! one `current` symlink, one `revision.json`, whatever the source was.
+//!
+//! That sameness is the point. A slot built from an image has to be
+//! indistinguishable at boot from one built from a flake, or `--manifest`
+//! would need to know which arm produced it.
+
+use anyhow::{Context, Result};
+use mvm_core::manifest::{PersistedManifest, Provenance, slot_current_symlink, slot_revision_dir};
+use mvm_core::pool::{ArtifactPaths, ArtifactSizes};
+use mvm_core::template::TemplateRevision;
+use mvm_core::time::utc_now;
+use tracing::instrument;
+
+use crate::ui;
+
+use super::artifacts::{RevisionArtifactSources, install_revision_artifacts};
+use super::build_mode_label;
+use super::slots::template_persist_slot;
+
+/// The host artifacts an image-backed build starts from.
+///
+/// The caller resolves these because both come from layers above this one: the
+/// rootfs from the OCI materialization in `mvm-client`, the kernel from the
+/// CLI's workload-kernel acquisition. Passing them in keeps this function a
+/// pure assemble-and-install step with no network and no VM.
+pub struct ImageBuildSources {
+    /// The materialized `rootfs.ext4`. Its directory must also hold the
+    /// `mvm-meta.json` sidecar the materialization wrote.
+    pub rootfs: std::path::PathBuf,
+    /// The verified workload kernel this slot boots.
+    pub kernel: std::path::PathBuf,
+    /// The OCI reference this was built from, recorded on the revision.
+    pub image_ref: String,
+}
+
+/// Install an already-materialized OCI rootfs as a manifest-keyed slot revision.
+///
+/// Mirrors `template_build_from_manifest`'s post-build half exactly: same
+/// revision directory, same `current` relink, same `revision.json`, same slot
+/// refresh. Returns the [`TemplateRevision`] for display.
+#[instrument(skip_all, fields(slot_hash = %persisted.manifest_hash, image = %sources.image_ref))]
+pub fn template_build_from_image(
+    persisted: &PersistedManifest,
+    sources: &ImageBuildSources,
+    mode: mvm_build::pipeline::BuildMode,
+) -> Result<TemplateRevision> {
+    let sidecar = sources
+        .rootfs
+        .parent()
+        .map(|d| d.join(mvm_build::builder_vm::SIDECAR_FILENAME))
+        .filter(|p| p.is_file())
+        .with_context(|| {
+            format!(
+                "image materialization wrote no `{}` sidecar beside {}; the slot would boot \
+                 without the overlay-awareness the backend reads from it",
+                mvm_build::builder_vm::SIDECAR_FILENAME,
+                sources.rootfs.display()
+            )
+        })?;
+
+    // The revision is keyed by the rootfs content, so rebuilding the same
+    // digest-pinned image is idempotent and a changed image gets a new
+    // revision without the caller tracking anything.
+    let revision_hash = mvm_fs::hash::hash_source(&sources.rootfs)
+        .with_context(|| format!("hashing {}", sources.rootfs.display()))?;
+
+    let slot_hash = &persisted.manifest_hash;
+    let rev_dst = slot_revision_dir(slot_hash, &revision_hash);
+    let current_link = slot_current_symlink(slot_hash);
+
+    // An OCI rootfs carries no initrd: the guest boots the kernel directly
+    // onto /dev/vda, which is the same shape a flake guest without an initrd
+    // gets, so the cmdline is the same one.
+    let fc_config = serde_json::json!({
+        "boot-source": {
+            "kernel_image_path": "vmlinux",
+            "boot_args": "root=/dev/vda rw rootwait init=/init console=ttyS0 reboot=k panic=1 net.ifnames=0"
+        },
+        "drives": [{
+            "drive_id": "rootfs",
+            "path_on_host": "rootfs.ext4",
+            "is_root_device": true,
+            "is_read_only": false
+        }],
+        "machine-config": {
+            "vcpu_count": persisted.vcpus,
+            "mem_size_mib": persisted.mem_mib
+        }
+    });
+
+    ui::info("Storing image artifacts in slot revision directory...");
+    install_revision_artifacts(
+        &RevisionArtifactSources {
+            kernel: sources.kernel.clone(),
+            initrd: None,
+            rootfs: sources.rootfs.clone(),
+            sidecar,
+            // Emitted only by a flake's `mkGuest`; an image-sourced slot has
+            // no re-exportable tarball, and `export-oci` says so.
+            oci_tarball: std::path::PathBuf::from(""),
+            fc_base_json: serde_json::to_string_pretty(&fc_config)?,
+        },
+        std::path::Path::new(&rev_dst),
+        std::path::Path::new(&current_link),
+        &revision_hash,
+    )?;
+
+    let sizes = ArtifactSizes {
+        rootfs_bytes: file_len(&sources.rootfs),
+        vmlinux_bytes: file_len(&sources.kernel),
+        initrd_bytes: None,
+        // A flake build measures its Nix closure; an image build has none.
+        nix_closure_bytes: None,
+    };
+
+    let revision = TemplateRevision {
+        schema_version: mvm_core::template::CURRENT_SCHEMA_VERSION,
+        revision_hash: revision_hash.clone(),
+        // `flake_ref` is the source field on the on-disk record. An
+        // image-sourced slot records its reference here rather than a
+        // fabricated flake path, so `revision.json` says what it was built
+        // from instead of implying a flake that never existed.
+        flake_ref: sources.image_ref.clone(),
+        // Content hash of the rootfs: the image equivalent of a flake.lock
+        // hash, and the thing a cache key wants.
+        flake_lock_hash: revision_hash.clone(),
+        artifact_paths: ArtifactPaths {
+            vmlinux: "vmlinux".to_string(),
+            rootfs: "rootfs.ext4".to_string(),
+            fc_base_config: "fc-base.json".to_string(),
+            initrd: None,
+            sizes: Some(sizes.clone()),
+        },
+        built_at: utc_now(),
+        profile: persisted.profile.clone(),
+        role: String::new(),
+        vcpus: persisted.vcpus,
+        mem_mib: persisted.mem_mib,
+        data_disk_mib: persisted.data_disk_mib,
+        snapshot: None,
+        build_mode: Some(build_mode_label(mode).to_string()),
+    };
+
+    let rev_meta_path = format!("{rev_dst}/revision.json");
+    std::fs::write(&rev_meta_path, serde_json::to_string_pretty(&revision)?)
+        .with_context(|| format!("writing {rev_meta_path}"))?;
+
+    template_persist_slot(&persisted.clone().touch(Provenance::current()))?;
+
+    use mvm_core::pool::format_bytes;
+    ui::success(&format!(
+        "Manifest at '{}' built from image {} (revision: {}, rootfs: {})",
+        persisted.manifest_path,
+        sources.image_ref,
+        &revision_hash[..revision_hash.len().min(12)],
+        format_bytes(sizes.rootfs_bytes),
+    ));
+
+    Ok(revision)
+}
+
+/// Size in bytes, or 0 when it cannot be read. Sizes are display and
+/// budgeting metadata; a build should not fail over one.
+fn file_len(path: &std::path::Path) -> u64 {
+    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::manifest::slot_manifest_path;
+    use mvm_core::util::test_env::TestEnv;
+
+    /// A materialized image: `rootfs.ext4` with the sidecar beside it, which is
+    /// the shape `mvm-client`'s materialization actually produces.
+    fn materialized(dir: &std::path::Path, rootfs_bytes: &[u8]) -> std::path::PathBuf {
+        let rootfs = dir.join("rootfs.ext4");
+        std::fs::write(&rootfs, rootfs_bytes).expect("rootfs");
+        std::fs::write(
+            dir.join(mvm_build::builder_vm::SIDECAR_FILENAME),
+            br#"{"overlay_aware":true}"#,
+        )
+        .expect("sidecar");
+        rootfs
+    }
+
+    fn persisted(path: &str) -> PersistedManifest {
+        PersistedManifest {
+            schema_version: 1,
+            manifest_path: path.to_string(),
+            manifest_hash: "a".repeat(64),
+            flake_ref: String::new(),
+            profile: "default".to_string(),
+            vcpus: 2,
+            mem_mib: 512,
+            mem_initial_mib: None,
+            data_disk_mib: 0,
+            name: Some("imgdemo".to_string()),
+            backend: "mock".to_string(),
+            provenance: Provenance::current(),
+            created_at: utc_now(),
+            updated_at: utc_now(),
+        }
+    }
+
+    fn sources(dir: &std::path::Path, rootfs_bytes: &[u8]) -> ImageBuildSources {
+        let kernel = dir.join("vmlinux");
+        std::fs::write(&kernel, b"kernel").expect("kernel");
+        ImageBuildSources {
+            rootfs: materialized(dir, rootfs_bytes),
+            kernel,
+            image_ref: "alpine:3.20".to_string(),
+        }
+    }
+
+    #[test]
+    fn an_image_slot_gets_the_same_revision_layout_as_a_flake_slot() {
+        let home = tempfile::tempdir().expect("home");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(home.path());
+        let src = tempfile::tempdir().expect("tmp");
+        let p = persisted("/tmp/imgproj/mvm.toml");
+
+        let rev = template_build_from_image(
+            &p,
+            &sources(src.path(), b"rootfs-contents"),
+            mvm_build::pipeline::BuildMode::Prod,
+        )
+        .expect("image build");
+
+        let dir = std::path::PathBuf::from(slot_revision_dir(&p.manifest_hash, &rev.revision_hash));
+        for artifact in [
+            "rootfs.ext4",
+            "vmlinux",
+            "fc-base.json",
+            "revision.json",
+            mvm_build::builder_vm::SIDECAR_FILENAME,
+        ] {
+            assert!(dir.join(artifact).is_file(), "missing {artifact}");
+        }
+        assert!(
+            std::path::PathBuf::from(slot_current_symlink(&p.manifest_hash)).exists(),
+            "`current` must point at the new revision"
+        );
+        assert!(
+            std::path::PathBuf::from(slot_manifest_path(&p.manifest_hash)).is_file(),
+            "the slot record must be persisted so `--manifest` can find it"
+        );
+        drop(env);
+        drop(home);
+    }
+
+    /// Same digest in, same revision out — so rebuilding a pinned image does
+    /// not accumulate revisions, and a changed image gets a new one without
+    /// the caller tracking anything.
+    #[test]
+    fn the_revision_is_keyed_by_rootfs_content() {
+        let home = tempfile::tempdir().expect("home");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(home.path());
+        let a = tempfile::tempdir().expect("tmp");
+        let b = tempfile::tempdir().expect("tmp");
+        let c = tempfile::tempdir().expect("tmp");
+        let p = persisted("/tmp/imgproj/mvm.toml");
+        let mode = mvm_build::pipeline::BuildMode::Prod;
+
+        let first = template_build_from_image(&p, &sources(a.path(), b"same"), mode)
+            .expect("first")
+            .revision_hash;
+        let again = template_build_from_image(&p, &sources(b.path(), b"same"), mode)
+            .expect("again")
+            .revision_hash;
+        let changed = template_build_from_image(&p, &sources(c.path(), b"different"), mode)
+            .expect("changed")
+            .revision_hash;
+
+        assert_eq!(first, again, "identical content must reuse the revision");
+        assert_ne!(first, changed, "changed content must be a new revision");
+        drop(env);
+        drop(home);
+    }
+
+    /// The sidecar carries the overlay-awareness the backend reads at boot.
+    /// Installing a slot without it would produce a revision that boots
+    /// differently from the `run --image` it was supposed to mirror, so this
+    /// refuses rather than shipping a subtly wrong slot.
+    #[test]
+    fn a_materialization_with_no_sidecar_refuses() {
+        let home = tempfile::tempdir().expect("home");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(home.path());
+        let dir = tempfile::tempdir().expect("tmp");
+        let rootfs = dir.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"rootfs").expect("rootfs");
+        let kernel = dir.path().join("vmlinux");
+        std::fs::write(&kernel, b"kernel").expect("kernel");
+
+        let err = template_build_from_image(
+            &persisted("/tmp/imgproj/mvm.toml"),
+            &ImageBuildSources {
+                rootfs,
+                kernel,
+                image_ref: "alpine:3.20".to_string(),
+            },
+            mvm_build::pipeline::BuildMode::Prod,
+        )
+        .expect_err("no sidecar must refuse");
+        assert!(
+            err.to_string().contains("sidecar"),
+            "the refusal must name what is missing: {err}"
+        );
+        drop(env);
+        drop(home);
+    }
+
+    /// `revision.json` must say what the slot was built from. A fabricated
+    /// flake path would imply a flake that never existed.
+    #[test]
+    fn the_revision_records_the_image_reference() {
+        let home = tempfile::tempdir().expect("home");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(home.path());
+        let dir = tempfile::tempdir().expect("tmp");
+        let rev = template_build_from_image(
+            &persisted("/tmp/imgproj/mvm.toml"),
+            &sources(dir.path(), b"rootfs"),
+            mvm_build::pipeline::BuildMode::Prod,
+        )
+        .expect("image build");
+        assert_eq!(rev.flake_ref, "alpine:3.20");
+        assert!(
+            rev.artifact_paths.initrd.is_none(),
+            "an OCI rootfs has none"
+        );
+        drop(env);
+        drop(home);
+    }
+}

--- a/crates/mvm-runtime/src/vm/template/lifecycle/mod.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle/mod.rs
@@ -7,6 +7,7 @@
 
 mod artifacts;
 mod build;
+mod build_image;
 mod crud;
 mod health;
 mod registry_sync;
@@ -15,6 +16,7 @@ mod snapshot;
 
 pub use artifacts::*;
 pub use build::*;
+pub use build_image::*;
 pub use crud::*;
 pub use health::*;
 pub use registry_sync::*;

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -106,6 +106,7 @@ guest-RPC surface, fleet-shaped workflows).
 
 | Command | Description |
 |---------|-------------|
+| `mvmctl machine build <path>` | Build the slot for a manifest directory. A `flake =` manifest builds through Nix in the builder VM; an `image =` manifest materializes the OCI reference through the same path `run --image` boots, then installs it as a slot revision |
 | `mvmctl kernel build` | Build the custom microVM kernels (builder and workload) |
 | `mvmctl build image <path>` | Build from Mvmfile.toml in the given directory |
 | `mvmctl build image --flake <ref>` | Build from a Nix flake (local or remote) |

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-17
+Last updated: 2026-08-18
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.

--- a/specs/plans/255-vsock-first-snapshot-egress-adoption.md
+++ b/specs/plans/255-vsock-first-snapshot-egress-adoption.md
@@ -340,16 +340,22 @@ wasm-clean; clippy/test green.
 
 ### Phase 4 — OCI-image template build path
 
-- [ ] Add `mvmctl template build --image <oci-ref>` support in `mvm-cli`,
-      routed through `mvm-client` to `mvm-sdk`/`mvm-build`.
-- [ ] Reuse `mvm-fs::oci` fetch/unpack and the ext4 writer to materialize the
-      template rootfs.
+- [x] Add image-backed build support in `mvm-cli`, routed through `mvm-client`.
+      **`mvmctl template build` does not exist** — the `template *` mutation
+      namespace was collapsed into manifest-keyed slots by PR #62 (plans 38–40,
+      2026-05-04). The post-38 spelling is `mvmctl machine build <path>` on an
+      `mvm.toml` carrying `image = "..."`.
+- [x] Reuse `mvm-fs::oci` fetch/unpack and the ext4 writer to materialize the
+      rootfs — via `mvm_client::local::materialize_image_rootfs`, which is the
+      same call `run --image` boots through, so there is one materializer
+      rather than two that could disagree.
 - [ ] Optionally take a ready-point snapshot to produce a warm template if
       `--warm` is given.
 - [ ] Ensure the produced template emits the same signed `ExecutionPlan` /
       bundle shape as the Nix path, so admission and audit are uniform.
-- [ ] Add BDD scenario: `template build --image alpine` followed by
-      `machine run --template <id>`.
+- [ ] Add a scenario covering build-then-boot. Deferred: it needs a registry
+      pull, which the hermetic BDD suite does not do. Covered instead by four
+      unit tests plus a hand-run end-to-end.
 
 **Acceptance gate:** OCI-built template is signed, admits cleanly, and boots;
 Nix-built templates still work; clippy/test green.

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -251,16 +251,38 @@ paths beyond the existing policy vocabulary.
 
 ### Phase 4 — Templates and OCI-image bases
 
-- [ ] Implement `mvmctl template build --image <ref>` as a first-class path,
-      alongside the existing Nix-flake path.
-- [ ] Add built-in language templates (python, node, rust, go, ruby, java,
-      shell, data-science, web-dev) backed by pinned OCI refs.
-- [ ] Allow saving a running dev-tier sandbox as a custom template.
+- [x] Implement an image-backed build path alongside the Nix-flake one.
+      **Spelled differently than this plan says**, because `mvmctl template
+      build` no longer exists: PR #62 ("Manifest-driven template DX", plans
+      38–40, 2026-05-04) collapsed `template init/create/build NAME` into a
+      manifest file discovered by path, keying slots by
+      `sha256(canonical_manifest_path)` instead of user-invented names. The
+      post-38 spelling is `mvmctl machine build <path>` on an `mvm.toml`
+      carrying `image = "..."`. The manifest half already existed — `image`
+      has been a validated, mutually-exclusive source selector all along;
+      `build` refused it with "image-backed builds are not wired yet".
+- [x] Add built-in language templates backed by pinned OCI refs. Shipped in
+      Phase 2 as the runtime catalog (`--runtime python|node|rust|go|ruby|shell`).
+      Not duplicated under a second `--template` name.
+- [ ] Allow saving a running dev-tier sandbox as a custom template. *(Open.)*
 - [ ] Integrate templates with the snapshot-first storage from Plan 255.
-- [ ] Add BDD scenarios for template build, save, and reuse.
+      *(Open: the image build installs a slot revision; taking a warm
+      ready-point snapshot of it is Plan 255 Phase 4's `--warm` item.)*
+- [x] Cover the build path. Four unit tests in
+      `mvm_runtime::vm::template::lifecycle::build_image`; the revision-keying
+      and missing-sidecar refusal were mutation-checked red. A BDD scenario was
+      written and then **deleted**: it asserted `machine build --help` mentions
+      "manifest", which passes with the feature reverted. Real BDD coverage
+      needs a registry pull, which the hermetic suite does not do.
 
-**Acceptance:** A user can `mvmctl template build --image python:3.12-alpine`
-and then `mvmctl run --template python <script>`.
+**Acceptance (restated for the post-38 spelling):** a user can put
+`image = "alpine:3.20"` in an `mvm.toml`, run `mvmctl machine build .`, and then
+`mvmctl machine run --manifest ./mvm.toml`. Verified by hand end to end: the
+slot revision holds `rootfs.ext4`, `vmlinux`, `mvm-meta.json`, `fc-base.json`
+and `revision.json`, rebuilding the same reference is idempotent, and
+`--manifest` resolves the slot.
+
+The `--runtime` half of the original acceptance shipped in Phase 2.
 
 ### Phase 5 — Snapshot/fork DX
 

--- a/specs/sprint/delivery/image-backed-manifest-build.md
+++ b/specs/sprint/delivery/image-backed-manifest-build.md
@@ -1,0 +1,77 @@
+# An `image =` manifest builds now
+
+**Plans:** `specs/plans/329-run-first-cli-and-upstream-adoption.md` Phase 4 and
+`specs/plans/255-vsock-first-snapshot-egress-adoption.md` Phase 4 — both of
+which specified this as `mvmctl template build --image <ref>`.
+
+## The spelling in both plans is pre-plan-38
+
+`mvmctl template build` does not exist. PR #62 ("Manifest-driven template DX",
+plans 38–40, 2026-05-04) collapsed `template init NAME → template create NAME →
+template build NAME` into a single manifest file discovered by path, with slot
+keys becoming `sha256(canonical_manifest_path)` instead of user-invented names.
+What survives under `template` is a read-only registry browser.
+
+So the capability did not vanish, it moved — and the plans kept describing the
+old front door. The post-38 spelling is `mvmctl machine build <path>`.
+
+## What was actually missing
+
+`mvm.toml` has carried `image = "..."` as a validated source selector, mutually
+exclusive with `flake`, since the manifest primitive was introduced. The build
+path refused it:
+
+    manifest selects an `image` source ("alpine:3.20"); `build` only handles
+    flake sources today — image-backed builds are not wired yet
+
+That refusal is now the other arm.
+
+## Why it is small
+
+The hard parts existed. `mvm-client`'s materialization already turns an OCI
+reference into a `rootfs.ext4` with the overlay-aware `mvm-meta.json` sidecar
+written beside it, and the workload kernel is the one every OCI run boots. So
+the new code assembles those into a slot revision through the *same*
+`install_revision_artifacts` the flake arm uses.
+
+That sameness is the design constraint, not an implementation detail: after the
+build returns, `--manifest` cannot tell which arm produced the slot. One
+revision layout, one `current` symlink, one `revision.json`.
+
+`mvm_client::local::materialize_image_rootfs` is exported rather than
+reimplemented for the same reason — a second materializer would be a second
+answer to "what does this image become", and the two would drift.
+
+## Decisions worth recording
+
+- **The revision is keyed by rootfs content**, so rebuilding a pinned reference
+  is idempotent and a changed image gets a new revision without the caller
+  tracking anything.
+- **A materialization with no sidecar refuses.** The sidecar carries the
+  overlay-awareness the backend reads at boot; installing without it yields a
+  slot that boots differently from the `run --image` it is supposed to mirror.
+- **`revision.json` records the image reference in `flake_ref`.** The field is
+  the on-disk source slot; writing a fabricated flake path there would imply a
+  flake that never existed. The field name is now wrong for half its uses and
+  is worth renaming to `source_ref` — deliberately not done here, since it is a
+  schema change touching the flake path and every existing slot.
+
+## Coverage
+
+Four unit tests in `mvm_runtime::vm::template::lifecycle::build_image`. Two are
+mutation-checked red: keying the revision by something other than content, and
+accepting a missing sidecar.
+
+A BDD scenario was written and then deleted — it asserted `machine build --help`
+mentions "manifest", which passes with the feature reverted. Real BDD coverage
+needs a registry pull the hermetic suite does not do.
+
+Verified by hand end to end: `machine build` on an `image = "alpine:3.20"`
+manifest produces a revision holding `rootfs.ext4` (10.6 MB), `vmlinux`,
+`mvm-meta.json`, `fc-base.json` and `revision.json`; a second build reuses the
+revision hash; and `machine run --manifest ./mvm.toml --dry-run` resolves it.
+
+One process note: the first version of these tests took a `TestEnv` without
+calling `isolate_mvm_home`, so they shared the real `MVM_HOME` and passed alone
+but failed in the full parallel suite. That is the hazard `TestEnv`'s own doc
+comment warns about.


### PR DESCRIPTION
Plan 329 Phase 4 and Plan 255 Phase 4 — both of which specified this as a verb that doesn't exist.

## What was missing

`mvm.toml` has carried `image = "..."` as a validated source selector, mutually exclusive with `flake`, since the manifest primitive was introduced. The build path refused it:

```
manifest selects an `image` source ("alpine:3.20"); `build` only handles
flake sources today — image-backed builds are not wired yet
```

That refusal is now the other arm.

## The plans were describing a removed front door

Both plans say `mvmctl template build --image <ref>`. **That verb does not exist.** PR #62 ("Manifest-driven template DX", plans 38–40, 2026-05-04) collapsed `template init NAME → template create NAME → template build NAME` into a single manifest file discovered by path, with slot keys becoming `sha256(canonical_manifest_path)` instead of user-invented names. What survives under `template` is a read-only registry browser.

So the capability *moved*; the plans kept describing where it used to be. Both are corrected to the post-38 spelling, `mvmctl machine build <path>`.

## Why the change is small

The hard parts already existed. The materialization `run --image` boots through already writes `rootfs.ext4` with the overlay-aware `mvm-meta.json` beside it, and the workload kernel is the one every OCI run uses. So this assembles those into a slot revision using the **same** `install_revision_artifacts` the flake arm uses.

That sameness is the design constraint: after the build returns, `--manifest` cannot tell which arm produced the slot — one revision layout, one `current` symlink, one `revision.json`. `mvm_client::local::materialize_image_rootfs` is exported rather than reimplemented for the same reason — a second materializer would be a second answer to "what does this image become", and the two would drift.

## Decisions

- **The revision is keyed by rootfs content**, so rebuilding a pinned reference is idempotent and a changed image gets a new revision with nothing to track.
- **A materialization with no sidecar refuses.** The sidecar carries the overlay-awareness the backend reads at boot; installing without it yields a slot that boots differently from the run it mirrors.
- **`revision.json` records the image reference in `flake_ref`**, the on-disk source field — a fabricated flake path would imply a flake that never existed. That field name is now wrong for half its uses and wants renaming to `source_ref`; deliberately **not** done here, since it's a schema change touching the flake path and every existing slot.

## Verification

`cargo nextest run --workspace` — **12164 passed, 0 failed**. Workspace clippy `--all-targets`, nightly fmt, and 13 xtask gates including `check-cli-runtime-surface`, `check-test-home-isolation`, `check-honesty`, `check-no-overclaim`.

Four unit tests; two mutation-checked red (keying the revision by something other than content; accepting a missing sidecar).

Verified by hand end to end — `machine build` on an `image = "alpine:3.20"` manifest produces a revision holding `rootfs.ext4` (10.6 MB), `vmlinux`, `mvm-meta.json`, `fc-base.json`, `revision.json`; a second build reuses the revision hash; `machine run --manifest ./mvm.toml --dry-run` resolves the slot.

**A BDD scenario was written and then deleted.** It asserted `machine build --help` mentions "manifest" — which passes with this feature reverted. Real BDD coverage needs a registry pull the hermetic suite doesn't do, and that's recorded in both plans rather than papered over with a green-looking scenario.

One process note in the delivery record: the first version of these tests took a `TestEnv` without calling `isolate_mvm_home`, so they shared the real `MVM_HOME` — passing alone, failing in the full parallel suite. Exactly the hazard `TestEnv`'s own doc comment warns about.