### PR TITLE
feat(assurance): admission-bound AI assurance sessions

### DIFF
--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -271,7 +271,8 @@ fn sdk_sends_host_time_request(world: &mut CliWorld) {
             let listener = tokio::net::UnixListener::bind(&server_socket)
                 .map_err(|error| error.to_string())?;
             let mut registry = mvm_hostd::broker::registry::Registry::new();
-            mvm_hostd::broker::handlers::register_bound_handlers(&mut registry, &bindings);
+            let _bound =
+                mvm_hostd::broker::handlers::register_bound_handlers(&mut registry, &bindings);
             ready_tx.send(()).map_err(|error| error.to_string())?;
             tokio::select! {
                 result = mvm_hostd::broker::server::serve_on_listener(

--- a/crates/mvm-contract/src/assurance/authority.rs
+++ b/crates/mvm-contract/src/assurance/authority.rs
@@ -1,0 +1,248 @@
+//! Effective authority: the intersection, never the union.
+//!
+//! Five things have an opinion about what a session may do — what the
+//! extension can offer at all, what the request asked for, what host/tenant
+//! policy permits, what the signed grant authorizes, and what an operator
+//! explicitly approved. Effective authority is the intersection of all five.
+//!
+//! The intersection is computed once, into [`EffectiveAuthority`], and that
+//! value is what dispatch consults. The alternative — five checks spread across
+//! the call path — fails open the moment someone adds a sixth caller and
+//! forgets one of them.
+
+use alloc::collections::BTreeSet;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use super::binding::SessionGrant;
+use super::input::{ObservationScope, RequestedAuthority, ToolId};
+
+/// A bound on what may be granted, from one source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AuthorityCeiling {
+    pub tools: BTreeSet<ToolId>,
+    pub scopes: BTreeSet<ObservationScope>,
+    pub max_steps: u32,
+    pub max_output_bytes: u32,
+}
+
+impl AuthorityCeiling {
+    /// The widest ceiling this build can offer.
+    ///
+    /// Everything the extension implements. Nothing may exceed it, and adding
+    /// a tool here without implementing its dispatch arm will not compile.
+    #[must_use]
+    pub fn extension_maximum() -> Self {
+        Self {
+            tools: [ToolId::CampaignProbeV1].into_iter().collect(),
+            scopes: [
+                ObservationScope::GuestStdoutDigest,
+                ObservationScope::HostAuditRefs,
+            ]
+            .into_iter()
+            .collect(),
+            max_steps: super::input::MAX_STEPS_CEILING,
+            max_output_bytes: super::input::MAX_OUTPUT_BYTES_CEILING,
+        }
+    }
+}
+
+impl ToolId {
+    /// Whether an operator must approve this tool explicitly.
+    ///
+    /// A campaign probe runs a declared attack narrative against a real guest.
+    /// Policy permitting it is not the same as an operator asking for it, and
+    /// the assurance contract treats campaigns as explicitly authorized work.
+    #[must_use]
+    pub const fn requires_explicit_approval(self) -> bool {
+        match self {
+            Self::CampaignProbeV1 => true,
+        }
+    }
+}
+
+/// Tools an operator approved for this session.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ApprovalSet {
+    approved: BTreeSet<ToolId>,
+}
+
+impl ApprovalSet {
+    /// An empty set. Every approval-requiring tool is refused.
+    #[must_use]
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Record an operator approval.
+    #[must_use]
+    pub fn with(mut self, tool: ToolId) -> Self {
+        self.approved.insert(tool);
+        self
+    }
+
+    /// Whether `tool` may proceed under this set.
+    #[must_use]
+    pub fn permits(&self, tool: ToolId) -> bool {
+        !tool.requires_explicit_approval() || self.approved.contains(&tool)
+    }
+}
+
+/// The five inputs to the intersection.
+#[derive(Debug, Clone)]
+pub struct AuthorityInputs<'a> {
+    pub extension_maximum: &'a AuthorityCeiling,
+    pub requested: &'a RequestedAuthority,
+    pub policy_ceiling: &'a AuthorityCeiling,
+    pub grant: &'a SessionGrant,
+    pub approvals: &'a ApprovalSet,
+}
+
+/// What a session may actually do.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct EffectiveAuthority {
+    tools: BTreeSet<ToolId>,
+    scopes: BTreeSet<ObservationScope>,
+    max_steps: u32,
+    max_output_bytes: u32,
+    deadline_unix_ms: u64,
+}
+
+/// Why no usable authority remains.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum AuthorityError {
+    #[error("no tool survives the intersection")]
+    NoToolsRemain,
+    #[error("no observation scope survives the intersection")]
+    NoScopesRemain,
+    #[error("the session grant expired before the session started")]
+    GrantExpired,
+    #[error("the intersected step or output budget is zero")]
+    EmptyBudget,
+}
+
+impl EffectiveAuthority {
+    /// Intersect all five sources.
+    pub fn intersect(
+        inputs: AuthorityInputs<'_>,
+        now_unix_ms: u64,
+    ) -> Result<Self, AuthorityError> {
+        if !inputs.grant.is_live_at(now_unix_ms) {
+            return Err(AuthorityError::GrantExpired);
+        }
+
+        let requested_tools: BTreeSet<ToolId> =
+            inputs.requested.allowed_tools.iter().copied().collect();
+        let granted_tools: BTreeSet<ToolId> = inputs.grant.allowed_tools.iter().copied().collect();
+        let tools: BTreeSet<ToolId> = requested_tools
+            .iter()
+            .copied()
+            .filter(|tool| inputs.extension_maximum.tools.contains(tool))
+            .filter(|tool| inputs.policy_ceiling.tools.contains(tool))
+            .filter(|tool| granted_tools.contains(tool))
+            .filter(|tool| inputs.approvals.permits(*tool))
+            .collect();
+        if tools.is_empty() {
+            return Err(AuthorityError::NoToolsRemain);
+        }
+
+        let requested_scopes: BTreeSet<ObservationScope> = inputs
+            .requested
+            .observation_scopes
+            .iter()
+            .copied()
+            .collect();
+        let granted_scopes: BTreeSet<ObservationScope> =
+            inputs.grant.observation_scopes.iter().copied().collect();
+        let scopes: BTreeSet<ObservationScope> = requested_scopes
+            .iter()
+            .copied()
+            .filter(|scope| inputs.extension_maximum.scopes.contains(scope))
+            .filter(|scope| inputs.policy_ceiling.scopes.contains(scope))
+            .filter(|scope| granted_scopes.contains(scope))
+            .collect();
+        if scopes.is_empty() {
+            return Err(AuthorityError::NoScopesRemain);
+        }
+
+        let max_steps = inputs
+            .requested
+            .max_steps
+            .min(inputs.extension_maximum.max_steps)
+            .min(inputs.policy_ceiling.max_steps);
+        let max_output_bytes = inputs
+            .requested
+            .max_output_bytes
+            .min(inputs.extension_maximum.max_output_bytes)
+            .min(inputs.policy_ceiling.max_output_bytes);
+        if max_steps == 0 || max_output_bytes == 0 {
+            return Err(AuthorityError::EmptyBudget);
+        }
+
+        // A requested deadline of zero means the provider set none. That is not
+        // "unbounded" — the grant's expiry is the bound in that case.
+        let deadline_unix_ms = if inputs.requested.deadline_unix_ms == 0 {
+            inputs.grant.expires_unix_ms
+        } else {
+            inputs
+                .requested
+                .deadline_unix_ms
+                .min(inputs.grant.expires_unix_ms)
+        };
+
+        Ok(Self {
+            tools,
+            scopes,
+            max_steps,
+            max_output_bytes,
+            deadline_unix_ms,
+        })
+    }
+
+    /// Whether `tool` may be dispatched.
+    #[must_use]
+    pub fn permits_tool(&self, tool: ToolId) -> bool {
+        self.tools.contains(&tool)
+    }
+
+    /// Whether `scope` may be read.
+    #[must_use]
+    pub fn permits_scope(&self, scope: ObservationScope) -> bool {
+        self.scopes.contains(&scope)
+    }
+
+    /// Tools in stable order.
+    #[must_use]
+    pub fn tools(&self) -> Vec<ToolId> {
+        self.tools.iter().copied().collect()
+    }
+
+    /// Scopes in stable order.
+    #[must_use]
+    pub fn scopes(&self) -> Vec<ObservationScope> {
+        self.scopes.iter().copied().collect()
+    }
+
+    #[must_use]
+    pub fn max_steps(&self) -> u32 {
+        self.max_steps
+    }
+
+    #[must_use]
+    pub fn max_output_bytes(&self) -> u32 {
+        self.max_output_bytes
+    }
+
+    #[must_use]
+    pub fn deadline_unix_ms(&self) -> u64 {
+        self.deadline_unix_ms
+    }
+}

--- a/crates/mvm-contract/src/assurance/binding.rs
+++ b/crates/mvm-contract/src/assurance/binding.rs
@@ -1,0 +1,273 @@
+//! What MVM admitted, as opposed to what the provider asked for.
+//!
+//! Every field here is derived from a signed [`ExecutionPlan`] or from a
+//! short-lived grant the host minted. None of it is copyable from a provider
+//! request, which is the whole point: the provider states an *intent*
+//! (`artifact_locator`, `requested_policy_digest`) and this states the *fact*.
+//! Correlation downstream compares the two, and a disagreement is a reason to
+//! refuse rather than a discrepancy to paper over.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use super::ids::{AssuranceId, EvidenceRef, Sha256Digest};
+use super::input::{ObservationScope, ToolId};
+use crate::plan::execution_plan::ExecutionPlan;
+use crate::plan::types::AttestationMode;
+
+/// The short-lived grant a session runs under.
+///
+/// Separate from the plan because it expires on a different clock: the plan is
+/// admitted once, the grant is minted per session and must be re-checked on
+/// every call. A call arriving after `expires_unix_ms` is refused even though
+/// the plan that admitted it is still perfectly valid.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SessionGrant {
+    /// Digest of the signed grant document. The grant itself stays host-side.
+    pub grant_digest: Sha256Digest,
+    /// Wall-clock expiry.
+    pub expires_unix_ms: u64,
+    /// Single-use nonce. A second call presenting it is a replay.
+    pub nonce: AssuranceId,
+    /// Tools this grant authorizes, already intersected down from the request.
+    pub allowed_tools: Vec<ToolId>,
+    /// Observation channels this grant authorizes.
+    pub observation_scopes: Vec<ObservationScope>,
+}
+
+impl SessionGrant {
+    /// Whether the grant is still live at `now_unix_ms`.
+    ///
+    /// Expiry is exclusive: a call landing exactly on the boundary is refused,
+    /// matching how the plan validity window treats `valid_until`.
+    #[must_use]
+    pub fn is_live_at(&self, now_unix_ms: u64) -> bool {
+        now_unix_ms < self.expires_unix_ms
+    }
+}
+
+/// Which runtime actually ran the workload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct RuntimeIdentity {
+    /// The plan's runtime profile.
+    pub runtime_profile: String,
+    /// The backend the profile resolved to.
+    pub backend: AssuranceId,
+}
+
+/// The authoritative, admission-derived half of a session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct MvmBinding {
+    /// Host-minted session identity.
+    pub session_id: AssuranceId,
+    /// Content address of the admitted plan.
+    ///
+    /// An [`AssuranceId`] rather than a `String` because the counterparty
+    /// validates it as an identifier; a plan id that could not survive that
+    /// check must fail here, where the plan is in hand, and not at the far end
+    /// of the join.
+    pub plan_id: AssuranceId,
+    /// Revision of the workload identity this plan carries.
+    pub plan_version: u32,
+    pub tenant: String,
+    pub workload: String,
+    /// Digest of the signed image that booted.
+    pub workload_digest: Sha256Digest,
+    /// Digest of the artifact actually admitted.
+    pub artifact_digest: Sha256Digest,
+    /// Digest of the effective policy/configuration.
+    pub effective_policy_digest: Sha256Digest,
+    pub grant: SessionGrant,
+    pub runtime: RuntimeIdentity,
+    /// Whether the plan demands attestation. Drives whether missing
+    /// attestation evidence is fatal to the outcome.
+    pub attestation_required: bool,
+    /// References into the chain-signed audit log.
+    pub audit_refs: Vec<EvidenceRef>,
+    /// References to execution receipts.
+    pub receipt_refs: Vec<EvidenceRef>,
+}
+
+/// Why a binding could not be assembled.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum BindingError {
+    #[error("binding is missing {0}")]
+    MissingField(&'static str),
+    #[error("the admitted plan carries an unusable image digest")]
+    UnusableImageDigest,
+    #[error("the admitted plan carries a plan id that is not an identifier")]
+    UnusablePlanId,
+    #[error("the resolved backend name is not an identifier")]
+    UnusableBackend,
+    #[error("a session must cite at least one audit reference")]
+    NoAuditReference,
+    #[error("a session must cite at least one execution receipt")]
+    NoReceiptReference,
+    #[error("the grant authorizes no tool")]
+    EmptyGrant,
+}
+
+impl MvmBinding {
+    /// Begin assembling a binding from an admitted plan.
+    #[must_use]
+    pub fn builder() -> MvmBindingBuilder {
+        MvmBindingBuilder::default()
+    }
+}
+
+/// Builder for [`MvmBinding`].
+///
+/// A builder rather than a constructor because the value has a dozen fields
+/// drawn from three different sources, and because `plan()` is what makes the
+/// admission-derived fields underivable by hand.
+#[derive(Debug, Default)]
+pub struct MvmBindingBuilder {
+    session_id: Option<AssuranceId>,
+    from_plan: Option<PlanDerived>,
+    artifact_digest: Option<Sha256Digest>,
+    effective_policy_digest: Option<Sha256Digest>,
+    grant: Option<SessionGrant>,
+    backend: Option<String>,
+    audit_refs: Vec<EvidenceRef>,
+    receipt_refs: Vec<EvidenceRef>,
+}
+
+/// The subset of an admitted plan a binding quotes.
+#[derive(Debug, Clone)]
+struct PlanDerived {
+    plan_id: AssuranceId,
+    plan_version: u32,
+    tenant: String,
+    workload: String,
+    workload_digest: Sha256Digest,
+    runtime_profile: String,
+    attestation_required: bool,
+}
+
+impl MvmBindingBuilder {
+    /// Set the host-minted session identity.
+    #[must_use]
+    pub fn session_id(mut self, session_id: AssuranceId) -> Self {
+        self.session_id = Some(session_id);
+        self
+    }
+
+    /// Quote the admitted plan.
+    ///
+    /// Takes the plan by reference so the caller must already hold one that
+    /// passed verification; there is no way to supply these fields loose.
+    pub fn plan(mut self, plan: &ExecutionPlan) -> Result<Self, BindingError> {
+        let workload_digest = Sha256Digest::parse(alloc::format!("sha256:{}", plan.image.sha256))
+            .map_err(|_| BindingError::UnusableImageDigest)?;
+        let plan_id =
+            AssuranceId::parse(plan.plan_id.0.clone()).map_err(|_| BindingError::UnusablePlanId)?;
+        self.from_plan = Some(PlanDerived {
+            plan_id,
+            plan_version: plan.plan_version,
+            tenant: plan.tenant.0.clone(),
+            workload: plan.workload.0.clone(),
+            workload_digest,
+            runtime_profile: plan.runtime_profile.0.clone(),
+            attestation_required: !matches!(plan.attestation.mode, AttestationMode::Noop),
+        });
+        Ok(self)
+    }
+
+    /// Set the digest of the artifact actually admitted.
+    #[must_use]
+    pub fn artifact_digest(mut self, digest: Sha256Digest) -> Self {
+        self.artifact_digest = Some(digest);
+        self
+    }
+
+    /// Set the digest of the effective policy/configuration.
+    #[must_use]
+    pub fn effective_policy_digest(mut self, digest: Sha256Digest) -> Self {
+        self.effective_policy_digest = Some(digest);
+        self
+    }
+
+    /// Set the short-lived session grant.
+    #[must_use]
+    pub fn grant(mut self, grant: SessionGrant) -> Self {
+        self.grant = Some(grant);
+        self
+    }
+
+    /// Set the resolved backend name.
+    #[must_use]
+    pub fn backend(mut self, backend: impl Into<String>) -> Self {
+        self.backend = Some(backend.into());
+        self
+    }
+
+    /// Cite an audit-log entry.
+    #[must_use]
+    pub fn audit_ref(mut self, reference: EvidenceRef) -> Self {
+        self.audit_refs.push(reference);
+        self
+    }
+
+    /// Cite an execution receipt.
+    #[must_use]
+    pub fn receipt_ref(mut self, reference: EvidenceRef) -> Self {
+        self.receipt_refs.push(reference);
+        self
+    }
+
+    /// Validate and assemble.
+    pub fn build(self) -> Result<MvmBinding, BindingError> {
+        let plan = self
+            .from_plan
+            .ok_or(BindingError::MissingField("admitted plan"))?;
+        let grant = self.grant.ok_or(BindingError::MissingField("grant"))?;
+        if grant.allowed_tools.is_empty() {
+            return Err(BindingError::EmptyGrant);
+        }
+        // A session with no audit or receipt reference cannot be evaluated as
+        // anything but INCONCLUSIVE later, so refusing here turns a guaranteed
+        // dead end into an error at the point the mistake was made.
+        if self.audit_refs.is_empty() {
+            return Err(BindingError::NoAuditReference);
+        }
+        if self.receipt_refs.is_empty() {
+            return Err(BindingError::NoReceiptReference);
+        }
+        Ok(MvmBinding {
+            session_id: self
+                .session_id
+                .ok_or(BindingError::MissingField("session_id"))?,
+            plan_id: plan.plan_id,
+            plan_version: plan.plan_version,
+            tenant: plan.tenant,
+            workload: plan.workload,
+            workload_digest: plan.workload_digest,
+            artifact_digest: self
+                .artifact_digest
+                .ok_or(BindingError::MissingField("artifact_digest"))?,
+            effective_policy_digest: self
+                .effective_policy_digest
+                .ok_or(BindingError::MissingField("effective_policy_digest"))?,
+            grant,
+            runtime: RuntimeIdentity {
+                runtime_profile: plan.runtime_profile,
+                backend: AssuranceId::parse(
+                    self.backend.ok_or(BindingError::MissingField("backend"))?,
+                )
+                .map_err(|_| BindingError::UnusableBackend)?,
+            },
+            attestation_required: plan.attestation_required,
+            audit_refs: self.audit_refs,
+            receipt_refs: self.receipt_refs,
+        })
+    }
+}

--- a/crates/mvm-contract/src/assurance/ids.rs
+++ b/crates/mvm-contract/src/assurance/ids.rs
@@ -1,0 +1,347 @@
+//! Bounded identifiers and digests shared by the assurance contract.
+//!
+//! The shapes here are fixed by the counterparty that consumes them: an
+//! identifier is at most 160 bytes of `[A-Za-z0-9._-]` and a digest is
+//! `sha256:` followed by exactly 64 lowercase-or-uppercase hex digits. They are
+//! newtypes rather than `String` because every one of these values is copied
+//! into an audit record and compared for equality against a value that came
+//! from a different process; a loose string would let a caller smuggle a
+//! newline, a path separator, or a look-alike into that comparison.
+
+use alloc::string::String;
+use core::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Longest identifier accepted on the assurance wire.
+pub const MAX_ASSURANCE_ID_BYTES: usize = 160;
+/// Exact hex-digit count in a `sha256:` digest.
+const SHA256_HEX_DIGITS: usize = 64;
+
+/// A bounded, audit-safe identifier.
+///
+/// Unlike the agent-session identifiers this contract sits beside, uppercase is
+/// legal: the finding and rule identifiers minted upstream look like
+/// `SCOUT-RCE-001`, and lowercasing them here would silently break the join
+/// back to the source finding.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AssuranceId(String);
+
+impl AssuranceId {
+    /// Parse an identifier accepted on the assurance wire.
+    pub fn parse(raw: impl Into<String>) -> Result<Self, AssuranceIdError> {
+        let raw = raw.into();
+        if raw.is_empty() {
+            return Err(AssuranceIdError::Empty);
+        }
+        if raw.len() > MAX_ASSURANCE_ID_BYTES {
+            return Err(AssuranceIdError::TooLong);
+        }
+        if !raw
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        {
+            return Err(AssuranceIdError::IllegalCharacter);
+        }
+        Ok(Self(raw))
+    }
+
+    /// Borrow the canonical wire representation.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for AssuranceId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for AssuranceId {
+    type Error = AssuranceIdError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl From<AssuranceId> for String {
+    fn from(value: AssuranceId) -> Self {
+        value.0
+    }
+}
+
+/// Why an identifier is not acceptable on the assurance wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum AssuranceIdError {
+    #[error("assurance identifier is empty")]
+    Empty,
+    #[error("assurance identifier exceeds the wire length limit")]
+    TooLong,
+    #[error("assurance identifier contains an illegal character")]
+    IllegalCharacter,
+}
+
+/// A `sha256:<64 hex>` digest.
+///
+/// Stored in its wire form rather than as `[u8; 32]` so that a digest which
+/// round-trips through this contract is byte-identical to the one the
+/// counterparty computed, including its hex case. Equality is over those exact
+/// bytes, which is what the identity checks downstream depend on.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Sha256Digest(String);
+
+impl Sha256Digest {
+    /// Parse a `sha256:`-prefixed hex digest.
+    pub fn parse(raw: impl Into<String>) -> Result<Self, DigestError> {
+        let raw = raw.into();
+        let Some(hex) = raw.strip_prefix("sha256:") else {
+            return Err(DigestError::MissingPrefix);
+        };
+        if hex.len() != SHA256_HEX_DIGITS {
+            return Err(DigestError::WrongLength);
+        }
+        if !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            return Err(DigestError::NotHex);
+        }
+        Ok(Self(raw))
+    }
+
+    /// Render raw digest bytes in the canonical wire form.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8; 32]) -> Self {
+        let mut out = String::from("sha256:");
+        for byte in bytes {
+            const HEX: &[u8; 16] = b"0123456789abcdef";
+            out.push(HEX[usize::from(byte >> 4)] as char);
+            out.push(HEX[usize::from(byte & 0x0f)] as char);
+        }
+        Self(out)
+    }
+
+    /// Borrow the canonical wire representation.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for Sha256Digest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for Sha256Digest {
+    type Error = DigestError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl From<Sha256Digest> for String {
+    fn from(value: Sha256Digest) -> Self {
+        value.0
+    }
+}
+
+/// Why a digest is not acceptable on the assurance wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum DigestError {
+    #[error("digest is not sha256:-prefixed")]
+    MissingPrefix,
+    #[error("digest does not carry exactly 64 hex digits")]
+    WrongLength,
+    #[error("digest contains a non-hex character")]
+    NotHex,
+}
+
+/// An opaque reference to evidence held elsewhere.
+///
+/// The point of the type is what it refuses to be: a host path, a socket name,
+/// or a blob of log text. It carries a scheme-qualified pointer such as
+/// `mvm:audit:<id>` that the holder of the corresponding store can resolve,
+/// and nothing a reader could act on without that store.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct EvidenceRef(String);
+
+/// Longest evidence reference accepted on the assurance wire.
+pub const MAX_EVIDENCE_REF_BYTES: usize = 256;
+
+impl EvidenceRef {
+    /// Parse a `scheme:`-qualified evidence reference.
+    pub fn parse(raw: impl Into<String>) -> Result<Self, EvidenceRefError> {
+        let raw = raw.into();
+        if raw.is_empty() {
+            return Err(EvidenceRefError::Empty);
+        }
+        if raw.len() > MAX_EVIDENCE_REF_BYTES {
+            return Err(EvidenceRefError::TooLong);
+        }
+        if !raw.contains(':') {
+            return Err(EvidenceRefError::MissingScheme);
+        }
+        // A reference is embedded in JSON and in audit entries; anything that
+        // could terminate a field or read as a filesystem path is refused.
+        if raw.bytes().any(|byte| {
+            byte.is_ascii_control() || matches!(byte, b'/' | b'\\' | b'"' | b'\'' | b' ')
+        }) {
+            return Err(EvidenceRefError::IllegalCharacter);
+        }
+        Ok(Self(raw))
+    }
+
+    /// Borrow the canonical wire representation.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for EvidenceRef {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for EvidenceRef {
+    type Error = EvidenceRefError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl From<EvidenceRef> for String {
+    fn from(value: EvidenceRef) -> Self {
+        value.0
+    }
+}
+
+/// Why an evidence reference is not acceptable on the assurance wire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum EvidenceRefError {
+    #[error("evidence reference is empty")]
+    Empty,
+    #[error("evidence reference exceeds the wire length limit")]
+    TooLong,
+    #[error("evidence reference has no scheme")]
+    MissingScheme,
+    #[error("evidence reference contains an illegal character")]
+    IllegalCharacter,
+}
+
+impl AssuranceIdError {
+    /// Stable label for audit and error text.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Empty => "empty",
+            Self::TooLong => "too_long",
+            Self::IllegalCharacter => "illegal_character",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::string::ToString;
+
+    #[test]
+    fn identifier_accepts_the_upstream_finding_shape() {
+        for raw in [
+            "SCOUT-RCE-001",
+            "mvm-campaign-1",
+            "trial-abc.def_9",
+            "scout-run-0",
+        ] {
+            assert!(AssuranceId::parse(raw).is_ok(), "{raw} should parse");
+        }
+    }
+
+    #[test]
+    fn identifier_refuses_separators_control_bytes_and_overlong_input() {
+        assert_eq!(AssuranceId::parse(""), Err(AssuranceIdError::Empty));
+        assert_eq!(
+            AssuranceId::parse("a/b"),
+            Err(AssuranceIdError::IllegalCharacter)
+        );
+        assert_eq!(
+            AssuranceId::parse("a b"),
+            Err(AssuranceIdError::IllegalCharacter)
+        );
+        assert_eq!(
+            AssuranceId::parse("a\nb"),
+            Err(AssuranceIdError::IllegalCharacter)
+        );
+        let overlong = "a".repeat(MAX_ASSURANCE_ID_BYTES + 1);
+        assert_eq!(AssuranceId::parse(overlong), Err(AssuranceIdError::TooLong));
+        // Exactly at the bound is legal, so the check is `>` and not `>=`.
+        assert!(AssuranceId::parse("a".repeat(MAX_ASSURANCE_ID_BYTES)).is_ok());
+    }
+
+    #[test]
+    fn digest_round_trips_and_refuses_malformed_input() {
+        let hex = "b".repeat(SHA256_HEX_DIGITS);
+        let digest = Sha256Digest::parse(alloc::format!("sha256:{hex}")).expect("digest");
+        assert_eq!(digest.as_str(), alloc::format!("sha256:{hex}"));
+
+        assert_eq!(
+            Sha256Digest::parse(hex.clone()),
+            Err(DigestError::MissingPrefix)
+        );
+        assert_eq!(
+            Sha256Digest::parse("sha256:abc"),
+            Err(DigestError::WrongLength)
+        );
+        assert_eq!(
+            Sha256Digest::parse(alloc::format!("sha256:{}", "z".repeat(SHA256_HEX_DIGITS))),
+            Err(DigestError::NotHex)
+        );
+    }
+
+    #[test]
+    fn digest_from_bytes_matches_the_parsed_form() {
+        let digest = Sha256Digest::from_bytes(&[0xab; 32]);
+        assert_eq!(
+            digest,
+            Sha256Digest::parse(alloc::format!("sha256:{}", "ab".repeat(32))).expect("digest")
+        );
+    }
+
+    #[test]
+    fn evidence_ref_requires_a_scheme_and_refuses_paths() {
+        assert!(EvidenceRef::parse("mvm:audit:entry-1").is_ok());
+        assert_eq!(
+            EvidenceRef::parse("no-scheme"),
+            Err(EvidenceRefError::MissingScheme)
+        );
+        assert_eq!(
+            EvidenceRef::parse("file:/etc/passwd"),
+            Err(EvidenceRefError::IllegalCharacter)
+        );
+        assert_eq!(
+            EvidenceRef::parse("mvm:audit:a b"),
+            Err(EvidenceRefError::IllegalCharacter)
+        );
+    }
+
+    #[test]
+    fn serde_rejects_an_illegal_identifier_rather_than_accepting_it() {
+        let error = serde_json::from_str::<AssuranceId>("\"bad/id\"").unwrap_err();
+        assert!(error.to_string().contains("illegal character"), "{error}");
+    }
+}

--- a/crates/mvm-contract/src/assurance/input.rs
+++ b/crates/mvm-contract/src/assurance/input.rs
@@ -1,0 +1,450 @@
+//! The `mvm.assurance.ai-session-input/v1` envelope.
+//!
+//! # Why this is two types and not one
+//!
+//! The envelope handed to an AI workload has two halves with different trust
+//! roots. [`AssuranceSessionRequest`] is supplied by the external assurance
+//! provider and is untrusted. [`MvmBinding`] states which plan was actually
+//! admitted, and is only obtainable from an admitted plan.
+//!
+//! Keeping them in one deserializable struct would mean the parser that reads
+//! provider bytes is also the parser that can populate the binding, and the
+//! only thing standing between a provider and a forged `plan_id` would be a
+//! runtime check somebody has to remember to write. So the request half derives
+//! `Deserialize` with `deny_unknown_fields` — which makes a provider that sends
+//! an `mvm_binding` key fail parsing outright — and the assembled
+//! [`AiSessionInput`] is serialize-only, constructible solely through
+//! [`AiSessionInput::bind`]. A forged binding is not a check that can fail; it
+//! is a value that cannot be built.
+//!
+//! # Depth
+//!
+//! There is no recursive type and no free-form `Value` anywhere in this
+//! envelope, so nesting depth is fixed by the schema itself rather than
+//! enforced by a counter. The remaining unbounded axes — collection lengths,
+//! string lengths, and total encoded size — are what [`validate`] bounds.
+//!
+//! [`validate`]: AssuranceSessionRequest::validate
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use super::authority::EffectiveAuthority;
+use super::binding::MvmBinding;
+use super::ids::{AssuranceId, EvidenceRef, Sha256Digest};
+use super::wire::{AuthorityWire, MvmBindingWire};
+
+/// Schema identity of the input envelope.
+pub const AI_SESSION_INPUT_SCHEMA: &str = "mvm.assurance.ai-session-input/v1";
+
+/// Largest accepted encoded request.
+pub const MAX_SESSION_INPUT_BYTES: usize = 64 * 1024;
+/// Longest accepted free-prose field.
+pub const MAX_PROSE_BYTES: usize = 512;
+/// Longest accepted source location.
+pub const MAX_LOCATION_BYTES: usize = 256;
+/// Longest accepted operator-declared artifact locator.
+pub const MAX_LOCATOR_BYTES: usize = 512;
+/// Most tools one session may be granted.
+pub const MAX_ALLOWED_TOOLS: usize = 16;
+/// Most observation scopes one session may be granted.
+pub const MAX_OBSERVATION_SCOPES: usize = 16;
+/// Most evidence references one source finding may cite.
+pub const MAX_EVIDENCE_REFS: usize = 64;
+/// Most capabilities one narrative may require.
+pub const MAX_REQUIRED_CAPABILITIES: usize = 16;
+/// Most synthetic canaries one session may declare.
+pub const MAX_CANARY_IDS: usize = 32;
+/// Most synthetic destination labels one session may declare.
+pub const MAX_DESTINATION_LABELS: usize = 32;
+/// Most fields an output contract may require.
+pub const MAX_MUST_INCLUDE: usize = 32;
+/// Most reasoning steps one trial may take.
+pub const MAX_STEPS_CEILING: u32 = 64;
+/// Largest output budget one trial may be granted.
+pub const MAX_OUTPUT_BYTES_CEILING: u32 = 1024 * 1024;
+
+/// What kind of thing was scanned upstream.
+///
+/// A closed vocabulary: an unrecognised kind fails deserialization rather than
+/// being carried through as an opaque string, because every downstream identity
+/// check is written against a kind it understands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum SubjectKind {
+    /// A repository or directory on the operator's machine.
+    LocalRepository,
+}
+
+/// Severity carried over from the source finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum Severity {
+    Info,
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+/// A tool the AI is permitted to select.
+///
+/// The AI picks a variant; it never supplies a tool name. Adding a tool is a
+/// change to this enum and therefore to the host code that dispatches it, which
+/// is the property that keeps "the model asked for an undeclared tool" out of
+/// the reachable state space.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ToolId {
+    /// The one declared assurance probe verb.
+    #[serde(rename = "campaign_probe.v1")]
+    CampaignProbeV1,
+}
+
+/// An observation channel the session may read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ObservationScope {
+    /// A digest of guest stdout — never the bytes.
+    #[serde(rename = "guest.stdout.digest")]
+    GuestStdoutDigest,
+    /// References into the chain-signed audit log — never its contents.
+    #[serde(rename = "host.audit.refs")]
+    HostAuditRefs,
+}
+
+/// Identity of the trial within the campaign.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SessionRef {
+    /// Provider-side request identity.
+    pub request_id: AssuranceId,
+    /// Retry key. Two requests carrying this key must execute at most once.
+    pub idempotency_key: AssuranceId,
+    /// The upstream scan run this trial descends from.
+    pub source_run_id: AssuranceId,
+    /// The campaign this trial belongs to.
+    pub campaign_id: AssuranceId,
+    /// This trial.
+    pub trial_id: AssuranceId,
+}
+
+/// The source finding under test.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SourceRef {
+    pub subject_kind: SubjectKind,
+    /// Revision of the scanned subject, when the subject had one.
+    pub subject_revision: Option<String>,
+    pub source_digest: Sha256Digest,
+    pub finding_id: AssuranceId,
+    pub group_id: AssuranceId,
+    pub rule_id: AssuranceId,
+    pub category: AssuranceId,
+    pub severity: Severity,
+    /// Where the finding sits, as reported upstream (`path:line:col`).
+    pub location: String,
+    pub evidence_refs: Vec<EvidenceRef>,
+    /// The artifact the operator declared for this campaign, if any. This is an
+    /// admission *input*; what was actually admitted is in [`MvmBinding`].
+    pub artifact_locator: Option<String>,
+    /// Digest of the policy inputs the provider asked for. Again an input: the
+    /// effective policy is in [`MvmBinding`].
+    pub requested_policy_digest: Sha256Digest,
+}
+
+/// What the trial is supposed to attempt, and where the boundary is.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct Narrative {
+    pub narrative_id: AssuranceId,
+    pub objective: String,
+    pub expected_boundary: String,
+    pub required_capabilities: Vec<AssuranceId>,
+}
+
+/// The ceiling on what this session may do.
+///
+/// This is the *requested* authority. Effective authority is the intersection
+/// of this with the host ceiling and the signed grant; see
+/// [`super::authority::EffectiveAuthority`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct RequestedAuthority {
+    pub allowed_tools: Vec<ToolId>,
+    pub observation_scopes: Vec<ObservationScope>,
+    pub max_steps: u32,
+    pub max_output_bytes: u32,
+    /// Wall-clock deadline. `0` means "the provider set none"; the host
+    /// substitutes its own bound rather than treating it as unbounded.
+    pub deadline_unix_ms: u64,
+}
+
+/// Synthetic stand-ins used in place of anything real.
+///
+/// Identifiers and labels only. A canary *value* never appears here, which is
+/// why the model can be told to look for a canary without being told what it
+/// is.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct SyntheticInputs {
+    pub canary_ids: Vec<AssuranceId>,
+    pub destination_labels: Vec<AssuranceId>,
+}
+
+/// The shape the trial result must take.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct OutputContract {
+    pub kind: String,
+    pub must_include: Vec<String>,
+}
+
+/// The provider-supplied half of the envelope. Untrusted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AssuranceSessionRequest {
+    /// Must equal [`AI_SESSION_INPUT_SCHEMA`].
+    pub schema: String,
+    pub session: SessionRef,
+    pub source: SourceRef,
+    pub narrative: Narrative,
+    pub authority: RequestedAuthority,
+    pub synthetic_inputs: SyntheticInputs,
+    pub output_contract: OutputContract,
+}
+
+/// Why a provider request is not acceptable.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum SessionInputError {
+    #[error("encoded request exceeds the {MAX_SESSION_INPUT_BYTES}-byte limit")]
+    TooLarge,
+    #[error("request is not valid JSON for this schema: {0}")]
+    Malformed(String),
+    #[error("unsupported schema {0:?}; expected {AI_SESSION_INPUT_SCHEMA}")]
+    UnsupportedSchema(String),
+    #[error("field {field} exceeds its length limit")]
+    FieldTooLong { field: &'static str },
+    #[error("field {field} is empty")]
+    FieldEmpty { field: &'static str },
+    #[error("collection {field} exceeds its element limit")]
+    TooManyElements { field: &'static str },
+    #[error("field {field} is outside its permitted range")]
+    OutOfRange { field: &'static str },
+    #[error("field {field} contains a control character")]
+    ControlCharacter { field: &'static str },
+}
+
+impl AssuranceSessionRequest {
+    /// Parse and validate a provider request from its encoded form.
+    ///
+    /// The size check runs before the parser so an oversized body is refused
+    /// without being deserialized.
+    pub fn parse_json(bytes: &[u8]) -> Result<Self, SessionInputError> {
+        if bytes.len() > MAX_SESSION_INPUT_BYTES {
+            return Err(SessionInputError::TooLarge);
+        }
+        let parsed: Self = serde_json::from_slice(bytes)
+            .map_err(|error| SessionInputError::Malformed(alloc::format!("{error}")))?;
+        parsed.validate()?;
+        Ok(parsed)
+    }
+
+    /// Check every bound serde cannot express.
+    pub fn validate(&self) -> Result<(), SessionInputError> {
+        if self.schema != AI_SESSION_INPUT_SCHEMA {
+            return Err(SessionInputError::UnsupportedSchema(self.schema.clone()));
+        }
+
+        bounded_prose("narrative.objective", &self.narrative.objective)?;
+        bounded_prose(
+            "narrative.expected_boundary",
+            &self.narrative.expected_boundary,
+        )?;
+        bounded("source.location", &self.source.location, MAX_LOCATION_BYTES)?;
+        if let Some(locator) = &self.source.artifact_locator {
+            bounded("source.artifact_locator", locator, MAX_LOCATOR_BYTES)?;
+        }
+        if let Some(revision) = &self.source.subject_revision {
+            bounded("source.subject_revision", revision, MAX_PROSE_BYTES)?;
+        }
+        bounded(
+            "output_contract.kind",
+            &self.output_contract.kind,
+            MAX_PROSE_BYTES,
+        )?;
+        for field in &self.output_contract.must_include {
+            bounded("output_contract.must_include[]", field, MAX_PROSE_BYTES)?;
+        }
+
+        limit(
+            "source.evidence_refs",
+            self.source.evidence_refs.len(),
+            MAX_EVIDENCE_REFS,
+        )?;
+        limit(
+            "narrative.required_capabilities",
+            self.narrative.required_capabilities.len(),
+            MAX_REQUIRED_CAPABILITIES,
+        )?;
+        limit(
+            "authority.allowed_tools",
+            self.authority.allowed_tools.len(),
+            MAX_ALLOWED_TOOLS,
+        )?;
+        limit(
+            "authority.observation_scopes",
+            self.authority.observation_scopes.len(),
+            MAX_OBSERVATION_SCOPES,
+        )?;
+        limit(
+            "synthetic_inputs.canary_ids",
+            self.synthetic_inputs.canary_ids.len(),
+            MAX_CANARY_IDS,
+        )?;
+        limit(
+            "synthetic_inputs.destination_labels",
+            self.synthetic_inputs.destination_labels.len(),
+            MAX_DESTINATION_LABELS,
+        )?;
+        limit(
+            "output_contract.must_include",
+            self.output_contract.must_include.len(),
+            MAX_MUST_INCLUDE,
+        )?;
+
+        if self.authority.max_steps == 0 || self.authority.max_steps > MAX_STEPS_CEILING {
+            return Err(SessionInputError::OutOfRange {
+                field: "authority.max_steps",
+            });
+        }
+        if self.authority.max_output_bytes == 0
+            || self.authority.max_output_bytes > MAX_OUTPUT_BYTES_CEILING
+        {
+            return Err(SessionInputError::OutOfRange {
+                field: "authority.max_output_bytes",
+            });
+        }
+        // A session with no tool can do nothing but burn a deadline; a session
+        // with no observation scope can see nothing it could report on. Both
+        // are refused as malformed rather than run to a guaranteed
+        // INCONCLUSIVE.
+        if self.authority.allowed_tools.is_empty() {
+            return Err(SessionInputError::FieldEmpty {
+                field: "authority.allowed_tools",
+            });
+        }
+        if self.authority.observation_scopes.is_empty() {
+            return Err(SessionInputError::FieldEmpty {
+                field: "authority.observation_scopes",
+            });
+        }
+        Ok(())
+    }
+}
+
+fn bounded_prose(field: &'static str, value: &str) -> Result<(), SessionInputError> {
+    bounded(field, value, MAX_PROSE_BYTES)
+}
+
+fn bounded(field: &'static str, value: &str, max: usize) -> Result<(), SessionInputError> {
+    if value.is_empty() {
+        return Err(SessionInputError::FieldEmpty { field });
+    }
+    if value.len() > max {
+        return Err(SessionInputError::FieldTooLong { field });
+    }
+    // Prose is copied into prompts and audit text; a control byte there can
+    // terminate a record or forge a line break in a rendered report.
+    if value.chars().any(char::is_control) {
+        return Err(SessionInputError::ControlCharacter { field });
+    }
+    Ok(())
+}
+
+fn limit(field: &'static str, len: usize, max: usize) -> Result<(), SessionInputError> {
+    if len > max {
+        return Err(SessionInputError::TooManyElements { field });
+    }
+    Ok(())
+}
+
+/// The complete envelope an AI workload receives.
+///
+/// Serialize-only by construction, and shaped to the counterparty's exact key
+/// set. See the module docs for why there is no `Deserialize`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AiSessionInput {
+    schema: String,
+    session: SessionRef,
+    source: SourceRef,
+    narrative: Narrative,
+    /// Effective authority, not the requested authority.
+    authority: AuthorityWire,
+    synthetic_inputs: SyntheticInputs,
+    output_contract: OutputContract,
+    mvm_binding: MvmBindingWire,
+}
+
+impl AiSessionInput {
+    /// Join a validated provider request to an admitted binding and the
+    /// authority that survived the intersection.
+    ///
+    /// This is the only way to build the envelope, so every envelope in
+    /// existence names a plan that was really admitted and states an authority
+    /// that was really granted.
+    pub fn bind(
+        request: AssuranceSessionRequest,
+        binding: &MvmBinding,
+        effective: &EffectiveAuthority,
+    ) -> Result<Self, SessionInputError> {
+        request.validate()?;
+        Ok(Self {
+            schema: request.schema,
+            session: request.session,
+            source: request.source,
+            narrative: request.narrative,
+            authority: AuthorityWire::from(effective),
+            synthetic_inputs: request.synthetic_inputs,
+            output_contract: request.output_contract,
+            mvm_binding: MvmBindingWire::from(binding),
+        })
+    }
+
+    /// The admitted half, as it appears on the wire.
+    #[must_use]
+    pub fn binding(&self) -> &MvmBindingWire {
+        &self.mvm_binding
+    }
+
+    /// The effective authority, as it appears on the wire.
+    #[must_use]
+    pub fn authority(&self) -> &AuthorityWire {
+        &self.authority
+    }
+
+    /// The trial identity.
+    #[must_use]
+    pub fn session(&self) -> &SessionRef {
+        &self.session
+    }
+
+    /// Encode the envelope for delivery.
+    pub fn to_json(&self) -> Result<alloc::string::String, SessionInputError> {
+        serde_json::to_string(self)
+            .map_err(|error| SessionInputError::Malformed(alloc::format!("{error}")))
+    }
+}

--- a/crates/mvm-contract/src/assurance/mod.rs
+++ b/crates/mvm-contract/src/assurance/mod.rs
@@ -1,0 +1,58 @@
+//! Admission-bound AI assurance sessions.
+//!
+//! An assurance campaign runs a declared attack narrative against a real guest
+//! and reports whether the attempted effect crossed a boundary. An AI drives
+//! the campaign from inside the workload. This module is the contract that
+//! makes that safe to do.
+//!
+//! Three properties are structural rather than checked:
+//!
+//! - The provider's half of the input envelope ([`AssuranceSessionRequest`])
+//!   cannot carry admission facts — `deny_unknown_fields` refuses them — and
+//!   the assembled [`AiSessionInput`] cannot be built without an
+//!   [`MvmBinding`] derived from a signed plan.
+//! - The AI's result ([`TrialResultCandidate`]) has no outcome field, so it
+//!   cannot report `PREVENTED`. [`evaluate`] derives outcomes from host
+//!   evidence.
+//! - Effective authority is one intersected value ([`EffectiveAuthority`]),
+//!   not a set of checks spread across the dispatch path.
+//!
+//! Everything crossing into the session is an identifier, a digest, or a
+//! reference. No secret value, host path, socket name, or log body appears in
+//! any type here.
+
+pub mod authority;
+pub mod binding;
+pub mod ids;
+pub mod input;
+pub mod outcome;
+pub mod probe;
+pub mod wire;
+
+#[cfg(test)]
+mod tests;
+
+pub use authority::{
+    ApprovalSet, AuthorityCeiling, AuthorityError, AuthorityInputs, EffectiveAuthority,
+};
+pub use binding::{BindingError, MvmBinding, MvmBindingBuilder, RuntimeIdentity, SessionGrant};
+pub use ids::{
+    AssuranceId, AssuranceIdError, DigestError, EvidenceRef, EvidenceRefError, Sha256Digest,
+};
+pub use input::{
+    AI_SESSION_INPUT_SCHEMA, AiSessionInput, AssuranceSessionRequest, Narrative, ObservationScope,
+    OutputContract, RequestedAuthority, SessionInputError, SessionRef, Severity, SourceRef,
+    SubjectKind, SyntheticInputs, ToolId,
+};
+pub use outcome::{
+    CandidateError, EvaluationInputs, EvidenceIdentity, EvidenceSet, HostObservation,
+    InconclusiveReason, TRIAL_EVIDENCE_SCHEMA, TRIAL_RESULT_CANDIDATE_SCHEMA, TRIAL_RESULT_SCHEMA,
+    TrialEvidenceRecord, TrialOutcome, TrialResultCandidate, TrialVerdict, evaluate,
+};
+pub use probe::{
+    PROBE_OBSERVATION_SCHEMA, PROBE_REQUEST_SCHEMA, ProbeInvocation, ProbeObservation,
+    ProbeRefusal, ProbeRequest,
+};
+pub use wire::{
+    AuthorityWire, MvmBindingWire, TrialResultDocument, TrialResultIdentity, TrialResultSession,
+};

--- a/crates/mvm-contract/src/assurance/outcome.rs
+++ b/crates/mvm-contract/src/assurance/outcome.rs
@@ -1,0 +1,419 @@
+//! The `mvm.assurance.trial-result/v1` result, and how an outcome is derived.
+//!
+//! # The model does not get a verdict field
+//!
+//! [`TrialResultCandidate`] — what the AI returns — has no outcome field at
+//! all. It reports what it attempted and what it believes it saw. `PREVENTED`
+//! and `CONTAINED` are computed by [`evaluate`] from host-held evidence, so
+//! "the model wrote PREVENTED" is not a state this contract can represent.
+//!
+//! # Disagreement is fatal, not ignored
+//!
+//! The host observes the same three facts the candidate reports. The obvious
+//! design is to ignore the candidate's version and use the host's. This one
+//! compares them and returns `INCONCLUSIVE` when they differ, because a model
+//! whose report contradicts the observer is evidence that something is wrong
+//! with the trial — and silently overwriting its answer would discard that
+//! signal.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use super::binding::MvmBinding;
+use super::ids::{AssuranceId, EvidenceRef, Sha256Digest};
+
+/// Schema identity of the host-assembled trial result.
+///
+/// This names the document *MVM* emits, not the one the AI returns. The
+/// counterparty validates it with an exact eighteen-key set that includes the
+/// verification booleans, none of which a model is in a position to assert —
+/// so the AI's reply gets its own schema below.
+pub const TRIAL_RESULT_SCHEMA: &str = "mvm.assurance.trial-result/v1";
+/// Schema identity of the AI's untrusted reply.
+pub const TRIAL_RESULT_CANDIDATE_SCHEMA: &str = "mvm.assurance.trial-result-candidate/v1";
+/// Schema identity of the evidence record handed to the assurance evaluator.
+pub const TRIAL_EVIDENCE_SCHEMA: &str = "mvm.security.trial-evidence/v1";
+
+/// Longest accepted diagnostic note.
+pub const MAX_NOTES_BYTES: usize = 2048;
+/// Most blocked edges one trial may report.
+pub const MAX_BLOCKED_EDGES: usize = 64;
+
+/// The bounded outcome vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum TrialOutcome {
+    /// The attempted effect was denied, and identity, observer, cleanup and
+    /// attestation evidence all validate.
+    #[serde(rename = "PREVENTED")]
+    Prevented,
+    /// The effect happened inside the declared boundary and did not cross it.
+    #[serde(rename = "CONTAINED")]
+    Contained,
+    /// The effect happened and crossed the boundary. No containment claim.
+    #[serde(rename = "OBSERVED")]
+    Observed,
+    /// Execution or evidence was insufficient to say anything.
+    #[serde(rename = "INCONCLUSIVE")]
+    Inconclusive,
+    /// No valid runtime narrative exists for this finding.
+    #[serde(rename = "NOT_APPLICABLE")]
+    NotApplicable,
+}
+
+impl TrialOutcome {
+    /// The wire spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Prevented => "PREVENTED",
+            Self::Contained => "CONTAINED",
+            Self::Observed => "OBSERVED",
+            Self::Inconclusive => "INCONCLUSIVE",
+            Self::NotApplicable => "NOT_APPLICABLE",
+        }
+    }
+
+    /// Whether this outcome asserts MVM held a boundary.
+    ///
+    /// Only these two are claims; the rest are reports.
+    #[must_use]
+    pub const fn is_certifying_claim(self) -> bool {
+        matches!(self, Self::Prevented | Self::Contained)
+    }
+}
+
+/// What the AI reports. Untrusted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct TrialResultCandidate {
+    /// Must equal [`TRIAL_RESULT_CANDIDATE_SCHEMA`].
+    pub schema: String,
+    /// Whether the declared effect was attempted at all.
+    pub attempted_effect: bool,
+    /// Whether the effect was seen to take hold inside the guest.
+    pub effect_observed_in_guest: bool,
+    /// Whether the effect crossed the declared boundary.
+    pub boundary_crossed: bool,
+    /// Edges the model believes were blocked.
+    pub blocked_edges: Vec<AssuranceId>,
+    /// References the model cites. Checked against host-held evidence.
+    pub evidence_refs: Vec<EvidenceRef>,
+    /// Bounded free text. Sanitized before it reaches a report.
+    pub notes: String,
+}
+
+impl TrialResultCandidate {
+    /// Check the bounds serde cannot express.
+    pub fn validate(&self) -> Result<(), CandidateError> {
+        if self.schema != TRIAL_RESULT_CANDIDATE_SCHEMA {
+            return Err(CandidateError::UnsupportedSchema(self.schema.clone()));
+        }
+        if self.notes.len() > MAX_NOTES_BYTES {
+            return Err(CandidateError::NotesTooLong);
+        }
+        if self.notes.chars().any(|c| c.is_control() && c != '\n') {
+            return Err(CandidateError::NotesControlCharacter);
+        }
+        if self.blocked_edges.len() > MAX_BLOCKED_EDGES {
+            return Err(CandidateError::TooManyBlockedEdges);
+        }
+        // An effect that was never attempted cannot have been observed or have
+        // crossed anything. A candidate claiming otherwise is incoherent, and
+        // accepting it would let a model manufacture a CONTAINED from nothing.
+        if !self.attempted_effect && (self.effect_observed_in_guest || self.boundary_crossed) {
+            return Err(CandidateError::Incoherent);
+        }
+        Ok(())
+    }
+}
+
+/// Why a candidate is unusable.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum CandidateError {
+    #[error("unsupported schema {0:?}; expected {TRIAL_RESULT_CANDIDATE_SCHEMA}")]
+    UnsupportedSchema(String),
+    #[error("notes exceed the {MAX_NOTES_BYTES}-byte limit")]
+    NotesTooLong,
+    #[error("notes contain a control character")]
+    NotesControlCharacter,
+    #[error("candidate reports more blocked edges than the limit allows")]
+    TooManyBlockedEdges,
+    #[error("candidate reports an effect it also says was never attempted")]
+    Incoherent,
+}
+
+/// What the host's own observer recorded.
+///
+/// These are the values the outcome is actually computed from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct HostObservation {
+    pub attempted_effect: bool,
+    pub effect_observed_in_guest: bool,
+    pub boundary_crossed: bool,
+    pub blocked_edges: Vec<AssuranceId>,
+}
+
+/// Host-held proof about the trial's conditions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct EvidenceSet {
+    /// The executed identity was joined to the admitted plan.
+    pub identity_verified: bool,
+    /// An observer was attached and reported.
+    pub observer_verified: bool,
+    /// The disposable target was torn down and confirmed gone.
+    pub cleanup_verified: bool,
+    /// Attestation validated. Only consulted when the plan requires it.
+    pub attestation_verified: bool,
+    /// The target was disposable.
+    pub disposable_target: bool,
+    /// Digest of the artifact that actually ran.
+    pub artifact_digest: Sha256Digest,
+    /// Digest of the policy that was actually in force.
+    pub policy_digest: Sha256Digest,
+    /// Digest of the source tree this trial descends from.
+    pub source_digest: Sha256Digest,
+    /// Audit entries covering the trial.
+    pub audit_refs: Vec<EvidenceRef>,
+    /// Execution receipts covering the trial.
+    pub receipt_refs: Vec<EvidenceRef>,
+}
+
+/// Why an outcome could not be certified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum InconclusiveReason {
+    /// The candidate echoed a binding that is not the one MVM issued.
+    BindingMismatch,
+    /// The executed identity was never joined to the admitted plan.
+    IdentityUnverified,
+    /// The artifact that ran is not the artifact that was admitted.
+    ArtifactMismatch,
+    /// The policy in force is not the effective policy that was admitted.
+    PolicyMismatch,
+    /// The trial does not descend from the scanned source tree.
+    SourceMismatch,
+    /// The target was not disposable.
+    NonDisposableTarget,
+    /// No observer evidence.
+    ObserverMissing,
+    /// No cleanup evidence.
+    CleanupMissing,
+    /// The plan requires attestation and none validated.
+    AttestationMissing,
+    /// No execution receipt covers the trial.
+    ReceiptMissing,
+    /// No audit entry covers the trial.
+    AuditMissing,
+    /// The candidate's report contradicts the host observer.
+    CandidateDisagreement,
+    /// The candidate is malformed or incoherent.
+    CandidateInvalid,
+    /// Nothing was attempted, so nothing was tested.
+    EffectNotAttempted,
+}
+
+/// The derived outcome and, when it is not a claim, why not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct TrialVerdict {
+    pub outcome: TrialOutcome,
+    /// Set for every outcome that is not a certifying claim.
+    pub reason: Option<InconclusiveReason>,
+}
+
+impl TrialVerdict {
+    fn inconclusive(reason: InconclusiveReason) -> Self {
+        Self {
+            outcome: TrialOutcome::Inconclusive,
+            reason: Some(reason),
+        }
+    }
+
+    fn claim(outcome: TrialOutcome) -> Self {
+        Self {
+            outcome,
+            reason: None,
+        }
+    }
+}
+
+/// Everything [`evaluate`] needs.
+#[derive(Debug, Clone)]
+pub struct EvaluationInputs<'a> {
+    /// The binding MVM issued for this session.
+    pub issued_binding: &'a MvmBinding,
+    /// The binding the candidate echoed back, if any.
+    pub echoed_binding: Option<&'a MvmBinding>,
+    /// Whether a valid runtime narrative exists at all.
+    pub narrative_applicable: bool,
+    /// The source digest the campaign was planned against.
+    pub planned_source_digest: &'a Sha256Digest,
+    pub candidate: &'a TrialResultCandidate,
+    pub observation: &'a HostObservation,
+    pub evidence: &'a EvidenceSet,
+}
+
+/// Derive the outcome, failing closed at every missing or mismatched step.
+///
+/// The ladder is ordered so the most fundamental failure wins: a trial whose
+/// identity cannot be joined is `INCONCLUSIVE` for that reason, not for the
+/// observer that also happened to be missing.
+#[must_use]
+pub fn evaluate(inputs: EvaluationInputs<'_>) -> TrialVerdict {
+    if !inputs.narrative_applicable {
+        return TrialVerdict {
+            outcome: TrialOutcome::NotApplicable,
+            reason: None,
+        };
+    }
+
+    if inputs.candidate.validate().is_err() {
+        return TrialVerdict::inconclusive(InconclusiveReason::CandidateInvalid);
+    }
+
+    match inputs.echoed_binding {
+        Some(echoed) if echoed == inputs.issued_binding => {}
+        _ => return TrialVerdict::inconclusive(InconclusiveReason::BindingMismatch),
+    }
+
+    let evidence = inputs.evidence;
+    if !evidence.identity_verified {
+        return TrialVerdict::inconclusive(InconclusiveReason::IdentityUnverified);
+    }
+    if evidence.artifact_digest != inputs.issued_binding.artifact_digest {
+        return TrialVerdict::inconclusive(InconclusiveReason::ArtifactMismatch);
+    }
+    if evidence.policy_digest != inputs.issued_binding.effective_policy_digest {
+        return TrialVerdict::inconclusive(InconclusiveReason::PolicyMismatch);
+    }
+    if &evidence.source_digest != inputs.planned_source_digest {
+        return TrialVerdict::inconclusive(InconclusiveReason::SourceMismatch);
+    }
+    if !evidence.disposable_target {
+        return TrialVerdict::inconclusive(InconclusiveReason::NonDisposableTarget);
+    }
+    if !evidence.observer_verified {
+        return TrialVerdict::inconclusive(InconclusiveReason::ObserverMissing);
+    }
+    if !evidence.cleanup_verified {
+        return TrialVerdict::inconclusive(InconclusiveReason::CleanupMissing);
+    }
+    if inputs.issued_binding.attestation_required && !evidence.attestation_verified {
+        return TrialVerdict::inconclusive(InconclusiveReason::AttestationMissing);
+    }
+    if evidence.receipt_refs.is_empty() {
+        return TrialVerdict::inconclusive(InconclusiveReason::ReceiptMissing);
+    }
+    if evidence.audit_refs.is_empty() {
+        return TrialVerdict::inconclusive(InconclusiveReason::AuditMissing);
+    }
+
+    let candidate = inputs.candidate;
+    let observation = inputs.observation;
+    if candidate.attempted_effect != observation.attempted_effect
+        || candidate.effect_observed_in_guest != observation.effect_observed_in_guest
+        || candidate.boundary_crossed != observation.boundary_crossed
+    {
+        return TrialVerdict::inconclusive(InconclusiveReason::CandidateDisagreement);
+    }
+
+    if !observation.attempted_effect {
+        return TrialVerdict::inconclusive(InconclusiveReason::EffectNotAttempted);
+    }
+    if observation.boundary_crossed {
+        return TrialVerdict {
+            outcome: TrialOutcome::Observed,
+            reason: None,
+        };
+    }
+    if observation.effect_observed_in_guest {
+        return TrialVerdict::claim(TrialOutcome::Contained);
+    }
+    TrialVerdict::claim(TrialOutcome::Prevented)
+}
+
+/// The record handed to the assurance evaluator.
+///
+/// Field names and the schema string are fixed by the counterparty's
+/// `mvm.security.trial-evidence/v1` reader; changing one here breaks the join
+/// silently, which is why the shape is asserted by test rather than trusted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct TrialEvidenceRecord {
+    pub schema: String,
+    pub campaign_id: AssuranceId,
+    pub trial_id: AssuranceId,
+    pub source_run_id: AssuranceId,
+    pub subject_revision: Option<String>,
+    pub source_digest: Sha256Digest,
+    pub artifact_digest: Option<Sha256Digest>,
+    pub policy_digest: Option<Sha256Digest>,
+    pub disposable_target: bool,
+    pub identity_verified: bool,
+    pub observer_verified: bool,
+    pub cleanup_verified: bool,
+    pub attestation_verified: bool,
+    pub attempted_effect: bool,
+    pub effect_observed_in_guest: bool,
+    pub boundary_crossed: bool,
+    pub blocked_edges: Vec<AssuranceId>,
+    pub evidence_refs: Vec<EvidenceRef>,
+}
+
+/// Identity the evidence record is emitted under.
+#[derive(Debug, Clone)]
+pub struct EvidenceIdentity<'a> {
+    pub campaign_id: &'a AssuranceId,
+    pub trial_id: &'a AssuranceId,
+    pub source_run_id: &'a AssuranceId,
+    pub subject_revision: Option<&'a str>,
+}
+
+impl TrialEvidenceRecord {
+    /// Emit the counterparty record for an evaluated trial.
+    ///
+    /// The booleans come from host evidence and host observation only; the
+    /// candidate contributes nothing, because by this point it has either
+    /// agreed with the observer or the verdict is already `INCONCLUSIVE`.
+    #[must_use]
+    pub fn emit(
+        identity: EvidenceIdentity<'_>,
+        evidence: &EvidenceSet,
+        observation: &HostObservation,
+    ) -> Self {
+        let mut evidence_refs = evidence.audit_refs.clone();
+        evidence_refs.extend(evidence.receipt_refs.iter().cloned());
+        Self {
+            schema: String::from(TRIAL_EVIDENCE_SCHEMA),
+            campaign_id: identity.campaign_id.clone(),
+            trial_id: identity.trial_id.clone(),
+            source_run_id: identity.source_run_id.clone(),
+            subject_revision: identity.subject_revision.map(String::from),
+            source_digest: evidence.source_digest.clone(),
+            artifact_digest: Some(evidence.artifact_digest.clone()),
+            policy_digest: Some(evidence.policy_digest.clone()),
+            disposable_target: evidence.disposable_target,
+            identity_verified: evidence.identity_verified,
+            observer_verified: evidence.observer_verified,
+            cleanup_verified: evidence.cleanup_verified,
+            attestation_verified: evidence.attestation_verified,
+            attempted_effect: observation.attempted_effect,
+            effect_observed_in_guest: observation.effect_observed_in_guest,
+            boundary_crossed: observation.boundary_crossed,
+            blocked_edges: observation.blocked_edges.clone(),
+            evidence_refs,
+        }
+    }
+}

--- a/crates/mvm-contract/src/assurance/probe.rs
+++ b/crates/mvm-contract/src/assurance/probe.rs
@@ -1,0 +1,163 @@
+//! The one declared probe surface an AI workload may call.
+//!
+//! # Why the AI sends a label and not a destination
+//!
+//! A probe invocation names a *declared label* — `undeclared.synthetic.
+//! destination` — which the host resolves against the campaign's
+//! operator-declared destination table. The model never states a host, a port,
+//! a path, or a command. Resolution failing is a refusal, not a fallback, so a
+//! label the campaign did not declare cannot reach the policy engine at all.
+//!
+//! # Why the invocation is an enum and not a bag of arguments
+//!
+//! [`ProbeInvocation`] is internally tagged, so each probe carries exactly its
+//! own arguments and nothing else. A payload with the wrong argument shape for
+//! its probe does not deserialize, which removes "handler forgot to validate
+//! argument X for probe Y" from the failure space.
+
+use alloc::string::String;
+
+use serde::{Deserialize, Serialize};
+
+use super::ids::AssuranceId;
+use super::input::ToolId;
+
+/// Schema identity of a probe request.
+pub const PROBE_REQUEST_SCHEMA: &str = "mvm.assurance.probe-request/v1";
+/// Schema identity of a probe observation.
+pub const PROBE_OBSERVATION_SCHEMA: &str = "mvm.assurance.probe-observation/v1";
+
+/// A declared probe and its arguments.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "probe", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ProbeInvocation {
+    /// Ask whether the workload's admitted egress policy would admit a
+    /// declared destination. This is the claim-10 decision point, consulted
+    /// through the same function the egress broker uses.
+    #[serde(rename = "egress.admission.v1")]
+    EgressAdmission {
+        /// A label from the session's declared destination table.
+        destination_label: AssuranceId,
+    },
+}
+
+impl ProbeInvocation {
+    /// Stable identity for audit and step accounting.
+    #[must_use]
+    pub const fn probe_id(&self) -> &'static str {
+        match self {
+            Self::EgressAdmission { .. } => "egress.admission.v1",
+        }
+    }
+}
+
+/// One bounded probe call.
+///
+/// `session_id` is present so a mismatch against the supervisor-supplied
+/// context can be *detected*; it is never the value the handler trusts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ProbeRequest {
+    /// Must equal [`PROBE_REQUEST_SCHEMA`].
+    pub schema: String,
+    pub session_id: AssuranceId,
+    pub trial_id: AssuranceId,
+    /// Retry key. A repeat returns the first result without re-executing.
+    pub idempotency_key: AssuranceId,
+    /// Single-use value. A repeat is a replay and is refused.
+    pub nonce: AssuranceId,
+    /// The tool being exercised. Checked against effective authority.
+    pub tool: ToolId,
+    /// The declared probe and its arguments.
+    ///
+    /// A nested field rather than a flattened one: serde's
+    /// `deny_unknown_fields` does not compose with `flatten`, and an unknown
+    /// key silently surviving is exactly the failure this contract cannot
+    /// afford.
+    pub invocation: ProbeInvocation,
+}
+
+/// What the host observed. Bounded, and free of policy internals.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ProbeObservation {
+    /// Always [`PROBE_OBSERVATION_SCHEMA`].
+    pub schema: String,
+    /// Which probe produced this.
+    pub probe: String,
+    /// Whether the declared destination was admitted.
+    pub admitted: bool,
+    /// The edge that was blocked, when it was blocked.
+    pub blocked_edge: Option<AssuranceId>,
+    /// Stable decision token (`allowed`, `deny_all`, `not_in_allowlist`).
+    /// A token rather than a message so nothing about the policy's contents
+    /// leaks into the session.
+    pub decision: String,
+    /// Steps left in this session's budget after this call.
+    pub steps_remaining: u32,
+}
+
+/// Why a probe call was refused.
+///
+/// A closed vocabulary: these strings reach the model, so they must say what
+/// happened without describing the policy, the host, or the other sessions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ProbeRefusal {
+    #[error("probe request schema is not supported")]
+    UnsupportedSchema,
+    #[error("no assurance session is bound to this workload session")]
+    NoSession,
+    #[error("the request names a different session than the one it arrived on")]
+    SessionMismatch,
+    #[error("the request names a different trial than the session was opened for")]
+    TrialMismatch,
+    #[error("effective authority does not permit this tool")]
+    ToolNotPermitted,
+    #[error("the session grant has expired")]
+    GrantExpired,
+    #[error("the session step budget is exhausted")]
+    StepBudgetExhausted,
+    #[error("this nonce was already used")]
+    NonceReplay,
+    #[error("the destination label was not declared for this campaign")]
+    UndeclaredDestination,
+}
+
+impl ProbeRefusal {
+    /// Stable token for audit.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::UnsupportedSchema => "unsupported_schema",
+            Self::NoSession => "no_session",
+            Self::SessionMismatch => "session_mismatch",
+            Self::TrialMismatch => "trial_mismatch",
+            Self::ToolNotPermitted => "tool_not_permitted",
+            Self::GrantExpired => "grant_expired",
+            Self::StepBudgetExhausted => "step_budget_exhausted",
+            Self::NonceReplay => "nonce_replay",
+            Self::UndeclaredDestination => "undeclared_destination",
+        }
+    }
+}
+
+impl ProbeRequest {
+    /// Check the schema string. Shape is already enforced by the parser.
+    pub fn validate(&self) -> Result<(), ProbeRefusal> {
+        if self.schema != PROBE_REQUEST_SCHEMA {
+            return Err(ProbeRefusal::UnsupportedSchema);
+        }
+        Ok(())
+    }
+
+    /// The tool this request exercises.
+    #[must_use]
+    pub const fn tool(&self) -> ToolId {
+        self.tool
+    }
+}

--- a/crates/mvm-contract/src/assurance/tests.rs
+++ b/crates/mvm-contract/src/assurance/tests.rs
@@ -1,0 +1,1102 @@
+//! Contract tests for the assurance session.
+//!
+//! The negative cases carry the weight here. Each one names a way a provider,
+//! a model, or a missing piece of evidence could produce a result that looks
+//! like proof and is not.
+
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use super::*;
+use crate::plan::execution_plan::minimal_plan;
+
+const ARTIFACT_DIGEST: &str =
+    "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+const POLICY_DIGEST: &str =
+    "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+const SOURCE_DIGEST: &str =
+    "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+const GRANT_DIGEST: &str =
+    "sha256:4444444444444444444444444444444444444444444444444444444444444444";
+
+const NOW_MS: u64 = 1_000_000;
+const EXPIRY_MS: u64 = 2_000_000;
+
+fn id(raw: &str) -> AssuranceId {
+    AssuranceId::parse(raw).expect("identifier")
+}
+
+fn digest(raw: &str) -> Sha256Digest {
+    Sha256Digest::parse(raw).expect("digest")
+}
+
+fn evidence_ref(raw: &str) -> EvidenceRef {
+    EvidenceRef::parse(raw).expect("evidence ref")
+}
+
+fn request_json() -> String {
+    alloc::format!(
+        r#"{{
+  "schema": "mvm.assurance.ai-session-input/v1",
+  "session": {{
+    "request_id": "mvm-request-1",
+    "idempotency_key": "trial-1",
+    "source_run_id": "scout-1",
+    "campaign_id": "mvm-campaign-1",
+    "trial_id": "trial-1"
+  }},
+  "source": {{
+    "subject_kind": "local_repository",
+    "subject_revision": "0123456789abcdef",
+    "source_digest": "{SOURCE_DIGEST}",
+    "finding_id": "SCOUT-RCE-001",
+    "group_id": "group-1",
+    "rule_id": "SCOUT-RCE-001",
+    "category": "command_injection",
+    "severity": "critical",
+    "location": "src/worker.py:42:7",
+    "evidence_refs": ["scout:finding:SCOUT-RCE-001"],
+    "artifact_locator": "oci:example/app:1",
+    "requested_policy_digest": "{POLICY_DIGEST}"
+  }},
+  "narrative": {{
+    "narrative_id": "mvm.boundary.process-exec.v1",
+    "objective": "attempt the declared process effect",
+    "expected_boundary": "the effect cannot cross from guest to host",
+    "required_capabilities": ["observation.stream.v1"]
+  }},
+  "authority": {{
+    "allowed_tools": ["campaign_probe.v1"],
+    "observation_scopes": ["guest.stdout.digest", "host.audit.refs"],
+    "max_steps": 12,
+    "max_output_bytes": 65536,
+    "deadline_unix_ms": 0
+  }},
+  "synthetic_inputs": {{
+    "canary_ids": ["canary.synthetic.secret.1"],
+    "destination_labels": ["undeclared.synthetic.destination"]
+  }},
+  "output_contract": {{
+    "kind": "mvm.assurance.trial-result/v1",
+    "must_include": [
+      "attempted_effect",
+      "effect_observed_in_guest",
+      "boundary_crossed",
+      "blocked_edges",
+      "evidence_refs"
+    ]
+  }}
+}}"#
+    )
+}
+
+fn request() -> AssuranceSessionRequest {
+    AssuranceSessionRequest::parse_json(request_json().as_bytes()).expect("valid request")
+}
+
+fn grant() -> SessionGrant {
+    SessionGrant {
+        grant_digest: digest(GRANT_DIGEST),
+        expires_unix_ms: EXPIRY_MS,
+        nonce: id("nonce-1"),
+        allowed_tools: vec![ToolId::CampaignProbeV1],
+        observation_scopes: vec![
+            ObservationScope::GuestStdoutDigest,
+            ObservationScope::HostAuditRefs,
+        ],
+    }
+}
+
+fn binding() -> MvmBinding {
+    MvmBinding::builder()
+        .session_id(id("session-1"))
+        .plan(&minimal_plan())
+        .expect("plan is bindable")
+        .artifact_digest(digest(ARTIFACT_DIGEST))
+        .effective_policy_digest(digest(POLICY_DIGEST))
+        .grant(grant())
+        .backend("firecracker")
+        .audit_ref(evidence_ref("mvm:audit:entry-1"))
+        .receipt_ref(evidence_ref("mvm:receipt:receipt-1"))
+        .build()
+        .expect("binding")
+}
+
+fn evidence() -> EvidenceSet {
+    EvidenceSet {
+        identity_verified: true,
+        observer_verified: true,
+        cleanup_verified: true,
+        attestation_verified: false,
+        disposable_target: true,
+        artifact_digest: digest(ARTIFACT_DIGEST),
+        policy_digest: digest(POLICY_DIGEST),
+        source_digest: digest(SOURCE_DIGEST),
+        audit_refs: vec![evidence_ref("mvm:audit:entry-1")],
+        receipt_refs: vec![evidence_ref("mvm:receipt:receipt-1")],
+    }
+}
+
+fn observation(attempted: bool, in_guest: bool, crossed: bool) -> HostObservation {
+    HostObservation {
+        attempted_effect: attempted,
+        effect_observed_in_guest: in_guest,
+        boundary_crossed: crossed,
+        blocked_edges: vec![id("undeclared.synthetic.destination")],
+    }
+}
+
+fn candidate(attempted: bool, in_guest: bool, crossed: bool) -> TrialResultCandidate {
+    TrialResultCandidate {
+        schema: TRIAL_RESULT_CANDIDATE_SCHEMA.to_string(),
+        attempted_effect: attempted,
+        effect_observed_in_guest: in_guest,
+        boundary_crossed: crossed,
+        blocked_edges: vec![id("undeclared.synthetic.destination")],
+        evidence_refs: vec![evidence_ref("mvm:audit:entry-1")],
+        notes: "probe refused at the substitution endpoint".to_string(),
+    }
+}
+
+/// Evaluate with everything healthy except what the caller perturbs.
+fn verdict_with(
+    bound: &MvmBinding,
+    evidence: &EvidenceSet,
+    observation: &HostObservation,
+    candidate: &TrialResultCandidate,
+) -> TrialVerdict {
+    evaluate(EvaluationInputs {
+        issued_binding: bound,
+        echoed_binding: Some(bound),
+        narrative_applicable: true,
+        planned_source_digest: &digest(SOURCE_DIGEST),
+        candidate,
+        observation,
+        evidence,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Input contract
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_documented_envelope_parses() {
+    let parsed = request();
+    assert_eq!(parsed.session.trial_id.as_str(), "trial-1");
+    assert_eq!(parsed.source.severity, Severity::Critical);
+    assert_eq!(parsed.source.subject_kind, SubjectKind::LocalRepository);
+    assert_eq!(
+        parsed.authority.allowed_tools,
+        vec![ToolId::CampaignProbeV1]
+    );
+    assert_eq!(parsed.source.finding_id.as_str(), "SCOUT-RCE-001");
+}
+
+#[test]
+fn a_provider_cannot_smuggle_an_mvm_binding_through_the_request_parser() {
+    // This is the attack the two-type split exists to stop: a provider that
+    // supplies its own admission facts.
+    let forged = request_json().replace(
+        "\"schema\": \"mvm.assurance.ai-session-input/v1\",",
+        "\"schema\": \"mvm.assurance.ai-session-input/v1\",\n  \"mvm_binding\": {\"plan_id\": \"forged\"},",
+    );
+    let error = AssuranceSessionRequest::parse_json(forged.as_bytes())
+        .expect_err("an mvm_binding key must be refused");
+    match error {
+        SessionInputError::Malformed(message) => {
+            assert!(message.contains("mvm_binding"), "{message}");
+        }
+        other => panic!("expected a parse refusal, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_unknown_field_anywhere_fails_closed() {
+    let forged = request_json().replace(
+        "\"max_steps\": 12,",
+        "\"max_steps\": 12,\n    \"escalate\": true,",
+    );
+    assert!(matches!(
+        AssuranceSessionRequest::parse_json(forged.as_bytes()),
+        Err(SessionInputError::Malformed(_))
+    ));
+}
+
+#[test]
+fn an_oversized_body_is_refused_before_it_is_parsed() {
+    let body = vec![b'x'; input::MAX_SESSION_INPUT_BYTES + 1];
+    assert_eq!(
+        AssuranceSessionRequest::parse_json(&body),
+        Err(SessionInputError::TooLarge)
+    );
+}
+
+#[test]
+fn an_unsupported_schema_is_refused() {
+    let forged = request_json().replace(
+        "mvm.assurance.ai-session-input/v1",
+        "mvm.assurance.ai-session-input/v2",
+    );
+    // The schema string appears twice; only the envelope's own matters here.
+    let error = AssuranceSessionRequest::parse_json(forged.as_bytes()).expect_err("v2 is unknown");
+    assert!(matches!(error, SessionInputError::UnsupportedSchema(_)));
+}
+
+#[test]
+fn a_malformed_digest_is_refused() {
+    let forged = request_json().replace(SOURCE_DIGEST, "sha256:not-hex");
+    assert!(matches!(
+        AssuranceSessionRequest::parse_json(forged.as_bytes()),
+        Err(SessionInputError::Malformed(_))
+    ));
+}
+
+#[test]
+fn an_undeclared_tool_name_is_refused() {
+    let forged = request_json().replace("campaign_probe.v1", "shell.v1");
+    assert!(matches!(
+        AssuranceSessionRequest::parse_json(forged.as_bytes()),
+        Err(SessionInputError::Malformed(_))
+    ));
+}
+
+#[test]
+fn an_undeclared_observation_scope_is_refused() {
+    let forged = request_json().replace("guest.stdout.digest", "host.filesystem.raw");
+    assert!(matches!(
+        AssuranceSessionRequest::parse_json(forged.as_bytes()),
+        Err(SessionInputError::Malformed(_))
+    ));
+}
+
+#[test]
+fn budgets_outside_their_range_are_refused() {
+    let zero_steps = request_json().replace("\"max_steps\": 12,", "\"max_steps\": 0,");
+    assert_eq!(
+        AssuranceSessionRequest::parse_json(zero_steps.as_bytes()),
+        Err(SessionInputError::OutOfRange {
+            field: "authority.max_steps"
+        })
+    );
+
+    let huge_steps = request_json().replace("\"max_steps\": 12,", "\"max_steps\": 65,");
+    assert_eq!(
+        AssuranceSessionRequest::parse_json(huge_steps.as_bytes()),
+        Err(SessionInputError::OutOfRange {
+            field: "authority.max_steps"
+        })
+    );
+
+    let huge_output = request_json().replace(
+        "\"max_output_bytes\": 65536,",
+        "\"max_output_bytes\": 2097152,",
+    );
+    assert_eq!(
+        AssuranceSessionRequest::parse_json(huge_output.as_bytes()),
+        Err(SessionInputError::OutOfRange {
+            field: "authority.max_output_bytes"
+        })
+    );
+}
+
+#[test]
+fn a_session_granted_no_tool_or_no_scope_is_refused() {
+    let no_tools = request_json().replace("[\"campaign_probe.v1\"]", "[]");
+    assert_eq!(
+        AssuranceSessionRequest::parse_json(no_tools.as_bytes()),
+        Err(SessionInputError::FieldEmpty {
+            field: "authority.allowed_tools"
+        })
+    );
+
+    let no_scopes = request_json().replace("[\"guest.stdout.digest\", \"host.audit.refs\"]", "[]");
+    assert_eq!(
+        AssuranceSessionRequest::parse_json(no_scopes.as_bytes()),
+        Err(SessionInputError::FieldEmpty {
+            field: "authority.observation_scopes"
+        })
+    );
+}
+
+#[test]
+fn prose_carrying_a_control_character_is_refused() {
+    let forged = request_json().replace(
+        "attempt the declared process effect",
+        "attempt the declared process effect\\u0000injected",
+    );
+    assert_eq!(
+        AssuranceSessionRequest::parse_json(forged.as_bytes()),
+        Err(SessionInputError::ControlCharacter {
+            field: "narrative.objective"
+        })
+    );
+}
+
+#[test]
+fn over_long_prose_is_refused() {
+    let long = "a".repeat(input::MAX_PROSE_BYTES + 1);
+    let forged = request_json().replace("attempt the declared process effect", &long);
+    assert_eq!(
+        AssuranceSessionRequest::parse_json(forged.as_bytes()),
+        Err(SessionInputError::FieldTooLong {
+            field: "narrative.objective"
+        })
+    );
+}
+
+#[test]
+fn too_many_evidence_refs_are_refused() {
+    let many: Vec<String> = (0..input::MAX_EVIDENCE_REFS + 1)
+        .map(|index| alloc::format!("\"scout:finding:F{index}\""))
+        .collect();
+    let forged = request_json().replace(
+        "[\"scout:finding:SCOUT-RCE-001\"]",
+        &alloc::format!("[{}]", many.join(",")),
+    );
+    assert_eq!(
+        AssuranceSessionRequest::parse_json(forged.as_bytes()),
+        Err(SessionInputError::TooManyElements {
+            field: "source.evidence_refs"
+        })
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Binding
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_binding_quotes_the_admitted_plan_rather_than_the_request() {
+    let plan = minimal_plan();
+    let bound = binding();
+    assert_eq!(bound.plan_id.as_str(), plan.plan_id.0);
+    assert_eq!(bound.plan_version, plan.plan_version);
+    assert_eq!(bound.tenant, plan.tenant.0);
+    assert_eq!(bound.workload, plan.workload.0);
+    assert_eq!(
+        bound.workload_digest,
+        digest(&alloc::format!("sha256:{}", plan.image.sha256))
+    );
+    assert_eq!(bound.runtime.runtime_profile, plan.runtime_profile.0);
+    // The fixture plan attests Noop, so attestation evidence is not required.
+    assert!(!bound.attestation_required);
+}
+
+#[test]
+fn a_binding_without_a_plan_cannot_be_built() {
+    let error = MvmBinding::builder()
+        .session_id(id("session-1"))
+        .artifact_digest(digest(ARTIFACT_DIGEST))
+        .effective_policy_digest(digest(POLICY_DIGEST))
+        .grant(grant())
+        .backend("firecracker")
+        .audit_ref(evidence_ref("mvm:audit:entry-1"))
+        .receipt_ref(evidence_ref("mvm:receipt:receipt-1"))
+        .build()
+        .expect_err("no plan means no binding");
+    assert_eq!(error, BindingError::MissingField("admitted plan"));
+}
+
+#[test]
+fn a_binding_citing_no_audit_or_receipt_is_refused() {
+    let base = || {
+        MvmBinding::builder()
+            .session_id(id("session-1"))
+            .plan(&minimal_plan())
+            .expect("plan")
+            .artifact_digest(digest(ARTIFACT_DIGEST))
+            .effective_policy_digest(digest(POLICY_DIGEST))
+            .grant(grant())
+            .backend("firecracker")
+    };
+    assert_eq!(
+        base()
+            .receipt_ref(evidence_ref("mvm:receipt:r"))
+            .build()
+            .expect_err("no audit ref"),
+        BindingError::NoAuditReference
+    );
+    assert_eq!(
+        base()
+            .audit_ref(evidence_ref("mvm:audit:a"))
+            .build()
+            .expect_err("no receipt ref"),
+        BindingError::NoReceiptReference
+    );
+}
+
+#[test]
+fn a_plan_requiring_attestation_marks_the_binding() {
+    let mut plan = minimal_plan();
+    plan.attestation.mode = crate::plan::types::AttestationMode::Tpm2;
+    let bound = MvmBinding::builder()
+        .session_id(id("session-1"))
+        .plan(&plan)
+        .expect("plan")
+        .artifact_digest(digest(ARTIFACT_DIGEST))
+        .effective_policy_digest(digest(POLICY_DIGEST))
+        .grant(grant())
+        .backend("firecracker")
+        .audit_ref(evidence_ref("mvm:audit:a"))
+        .receipt_ref(evidence_ref("mvm:receipt:r"))
+        .build()
+        .expect("binding");
+    assert!(bound.attestation_required);
+}
+
+fn effective_for_envelope() -> EffectiveAuthority {
+    let ceiling = AuthorityCeiling::extension_maximum();
+    let parsed = request();
+    let approvals = ApprovalSet::none().with(ToolId::CampaignProbeV1);
+    EffectiveAuthority::intersect(
+        AuthorityInputs {
+            extension_maximum: &ceiling,
+            requested: &parsed.authority,
+            policy_ceiling: &ceiling,
+            grant: &grant(),
+            approvals: &approvals,
+        },
+        NOW_MS,
+    )
+    .expect("authority")
+}
+
+fn keys_of(value: &serde_json::Value) -> Vec<String> {
+    let mut keys: Vec<String> = value.as_object().expect("object").keys().cloned().collect();
+    keys.sort();
+    keys
+}
+
+fn sorted(names: &[&str]) -> Vec<String> {
+    let mut out: Vec<String> = names.iter().map(|name| name.to_string()).collect();
+    out.sort();
+    out
+}
+
+#[test]
+fn the_envelope_matches_the_counterparty_key_set_exactly() {
+    // The counterparty validates with exact key sets, so an extra key is a
+    // hard failure at the far end rather than something it ignores. These
+    // lists mirror `apps/mvm-security/src/ai_session.rs`.
+    let envelope =
+        AiSessionInput::bind(request(), &binding(), &effective_for_envelope()).expect("envelope");
+    let value: serde_json::Value =
+        serde_json::from_str(&envelope.to_json().expect("encode")).expect("parse");
+
+    assert_eq!(
+        keys_of(&value),
+        sorted(&[
+            "schema",
+            "session",
+            "source",
+            "narrative",
+            "authority",
+            "synthetic_inputs",
+            "output_contract",
+            "mvm_binding",
+        ])
+    );
+    assert_eq!(
+        keys_of(&value["session"]),
+        sorted(&[
+            "request_id",
+            "idempotency_key",
+            "source_run_id",
+            "campaign_id",
+            "trial_id",
+        ])
+    );
+    assert_eq!(
+        keys_of(&value["mvm_binding"]),
+        sorted(&[
+            "session_id",
+            "plan_id",
+            "workload_digest",
+            "artifact_digest",
+            "effective_policy_digest",
+            "session_grant_digest",
+            "expires_at_unix_ms",
+            "nonce",
+            "allowed_tools",
+            "backend",
+        ])
+    );
+    assert_eq!(
+        keys_of(&value["authority"]),
+        sorted(&[
+            "allowed_tools",
+            "observation_scopes",
+            "max_steps",
+            "max_output_bytes",
+            "deadline_unix_ms",
+        ])
+    );
+}
+
+#[test]
+fn the_envelope_reports_effective_authority_and_a_real_deadline() {
+    // The request carried `deadline_unix_ms: 0` meaning "none set". The
+    // counterparty requires >= 1, so a raw copy would be refused.
+    let envelope =
+        AiSessionInput::bind(request(), &binding(), &effective_for_envelope()).expect("envelope");
+    assert_eq!(request().authority.deadline_unix_ms, 0);
+    assert_eq!(envelope.authority().deadline_unix_ms, EXPIRY_MS);
+    assert!(envelope.authority().deadline_unix_ms >= 1);
+}
+
+#[test]
+fn the_envelope_carries_the_admitted_plan_and_no_synthetic_values() {
+    let envelope =
+        AiSessionInput::bind(request(), &binding(), &effective_for_envelope()).expect("envelope");
+    let json = envelope.to_json().expect("encode");
+
+    assert!(json.contains(&minimal_plan().plan_id.0), "{json}");
+    assert!(json.contains("SCOUT-RCE-001"), "{json}");
+    // Canary identifiers cross; canary values do not exist in this type at all.
+    assert!(json.contains("canary.synthetic.secret.1"), "{json}");
+    assert_eq!(envelope.binding().session_id.as_str(), "session-1");
+    assert_eq!(envelope.session().campaign_id.as_str(), "mvm-campaign-1");
+    // The grant is referenced by digest; the grant document never crosses.
+    assert!(json.contains("session_grant_digest"), "{json}");
+}
+
+#[test]
+fn the_assembled_trial_result_matches_the_counterparty_key_set_exactly() {
+    let bound = binding();
+    let document = TrialResultDocument::assemble(
+        TrialResultIdentity {
+            request_id: &id("mvm-request-1"),
+            source_run_id: &id("scout-1"),
+            campaign_id: &id("mvm-campaign-1"),
+            trial_id: &id("trial-1"),
+            subject_revision: Some("0123456789abcdef"),
+        },
+        &bound,
+        &evidence(),
+        &observation(true, false, false),
+    );
+    let value = serde_json::to_value(&document).expect("serialize");
+
+    assert_eq!(
+        keys_of(&value),
+        sorted(&[
+            "schema",
+            "session",
+            "subject_revision",
+            "source_digest",
+            "artifact_digest",
+            "policy_digest",
+            "disposable_target",
+            "identity_verified",
+            "observer_verified",
+            "cleanup_verified",
+            "attestation_verified",
+            "attempted_effect",
+            "effect_observed_in_guest",
+            "boundary_crossed",
+            "blocked_edges",
+            "evidence_refs",
+            "receipt_refs",
+            "audit_refs",
+        ])
+    );
+    assert_eq!(
+        keys_of(&value["session"]),
+        sorted(&[
+            "session_id",
+            "request_id",
+            "source_run_id",
+            "campaign_id",
+            "trial_id",
+            "plan_id",
+        ])
+    );
+    assert_eq!(value["schema"], TRIAL_RESULT_SCHEMA);
+    // No outcome field: the counterparty derives the verdict, and this record
+    // cannot short-circuit it.
+    assert!(value.get("outcome").is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Authority
+// ---------------------------------------------------------------------------
+
+fn permissive_ceiling() -> AuthorityCeiling {
+    AuthorityCeiling::extension_maximum()
+}
+
+fn intersect(
+    policy_ceiling: &AuthorityCeiling,
+    grant: &SessionGrant,
+    approvals: &ApprovalSet,
+    now: u64,
+) -> Result<EffectiveAuthority, AuthorityError> {
+    let extension = AuthorityCeiling::extension_maximum();
+    let parsed = request();
+    EffectiveAuthority::intersect(
+        AuthorityInputs {
+            extension_maximum: &extension,
+            requested: &parsed.authority,
+            policy_ceiling,
+            grant,
+            approvals,
+        },
+        now,
+    )
+}
+
+#[test]
+fn effective_authority_is_the_intersection_and_takes_the_lowest_budget() {
+    let mut ceiling = permissive_ceiling();
+    ceiling.max_steps = 4;
+    ceiling.max_output_bytes = 1024;
+    let approvals = ApprovalSet::none().with(ToolId::CampaignProbeV1);
+
+    let effective = intersect(&ceiling, &grant(), &approvals, NOW_MS).expect("authority");
+    assert!(effective.permits_tool(ToolId::CampaignProbeV1));
+    assert_eq!(effective.max_steps(), 4, "the ceiling, not the request");
+    assert_eq!(effective.max_output_bytes(), 1024);
+    // The request set no deadline, so the grant expiry becomes the bound.
+    assert_eq!(effective.deadline_unix_ms(), EXPIRY_MS);
+}
+
+#[test]
+fn a_tool_the_policy_ceiling_omits_does_not_survive() {
+    let mut ceiling = permissive_ceiling();
+    ceiling.tools.clear();
+    let approvals = ApprovalSet::none().with(ToolId::CampaignProbeV1);
+    assert_eq!(
+        intersect(&ceiling, &grant(), &approvals, NOW_MS),
+        Err(AuthorityError::NoToolsRemain)
+    );
+}
+
+#[test]
+fn a_tool_the_grant_omits_does_not_survive() {
+    let mut grant = grant();
+    grant.allowed_tools.clear();
+    let approvals = ApprovalSet::none().with(ToolId::CampaignProbeV1);
+    assert_eq!(
+        intersect(&permissive_ceiling(), &grant, &approvals, NOW_MS),
+        Err(AuthorityError::NoToolsRemain)
+    );
+}
+
+#[test]
+fn a_campaign_probe_without_explicit_approval_does_not_survive() {
+    assert!(ToolId::CampaignProbeV1.requires_explicit_approval());
+    assert_eq!(
+        intersect(
+            &permissive_ceiling(),
+            &grant(),
+            &ApprovalSet::none(),
+            NOW_MS
+        ),
+        Err(AuthorityError::NoToolsRemain)
+    );
+}
+
+#[test]
+fn a_scope_the_grant_omits_does_not_survive() {
+    let mut grant = grant();
+    grant.observation_scopes.clear();
+    let approvals = ApprovalSet::none().with(ToolId::CampaignProbeV1);
+    assert_eq!(
+        intersect(&permissive_ceiling(), &grant, &approvals, NOW_MS),
+        Err(AuthorityError::NoScopesRemain)
+    );
+}
+
+#[test]
+fn an_expired_grant_refuses_before_anything_else_is_considered() {
+    let approvals = ApprovalSet::none().with(ToolId::CampaignProbeV1);
+    assert_eq!(
+        intersect(&permissive_ceiling(), &grant(), &approvals, EXPIRY_MS),
+        Err(AuthorityError::GrantExpired),
+        "expiry is exclusive: landing exactly on the boundary is refused"
+    );
+    assert_eq!(
+        intersect(&permissive_ceiling(), &grant(), &approvals, EXPIRY_MS + 1),
+        Err(AuthorityError::GrantExpired)
+    );
+}
+
+#[test]
+fn a_requested_deadline_earlier_than_the_grant_wins() {
+    let extension = AuthorityCeiling::extension_maximum();
+    let mut parsed = request();
+    parsed.authority.deadline_unix_ms = EXPIRY_MS - 500;
+    let approvals = ApprovalSet::none().with(ToolId::CampaignProbeV1);
+    let effective = EffectiveAuthority::intersect(
+        AuthorityInputs {
+            extension_maximum: &extension,
+            requested: &parsed.authority,
+            policy_ceiling: &extension,
+            grant: &grant(),
+            approvals: &approvals,
+        },
+        NOW_MS,
+    )
+    .expect("authority");
+    assert_eq!(effective.deadline_unix_ms(), EXPIRY_MS - 500);
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_denied_effect_with_complete_evidence_is_prevented() {
+    let verdict = verdict_with(
+        &binding(),
+        &evidence(),
+        &observation(true, false, false),
+        &candidate(true, false, false),
+    );
+    assert_eq!(verdict.outcome, TrialOutcome::Prevented);
+    assert_eq!(verdict.reason, None);
+    assert!(verdict.outcome.is_certifying_claim());
+}
+
+#[test]
+fn an_effect_that_stayed_inside_the_boundary_is_contained() {
+    let verdict = verdict_with(
+        &binding(),
+        &evidence(),
+        &observation(true, true, false),
+        &candidate(true, true, false),
+    );
+    assert_eq!(verdict.outcome, TrialOutcome::Contained);
+}
+
+#[test]
+fn an_effect_that_crossed_the_boundary_is_observed_and_is_not_a_claim() {
+    let verdict = verdict_with(
+        &binding(),
+        &evidence(),
+        &observation(true, true, true),
+        &candidate(true, true, true),
+    );
+    assert_eq!(verdict.outcome, TrialOutcome::Observed);
+    assert!(!verdict.outcome.is_certifying_claim());
+}
+
+#[test]
+fn a_model_claiming_prevention_against_the_observer_gets_inconclusive() {
+    // The observer saw the effect cross. The model reports a clean block.
+    let verdict = verdict_with(
+        &binding(),
+        &evidence(),
+        &observation(true, true, true),
+        &candidate(true, false, false),
+    );
+    assert_eq!(verdict.outcome, TrialOutcome::Inconclusive);
+    assert_eq!(
+        verdict.reason,
+        Some(InconclusiveReason::CandidateDisagreement)
+    );
+}
+
+#[test]
+fn each_missing_piece_of_evidence_produces_its_own_inconclusive_reason() {
+    let cases: Vec<(&str, EvidenceSet, InconclusiveReason)> = vec![
+        (
+            "identity",
+            EvidenceSet {
+                identity_verified: false,
+                ..evidence()
+            },
+            InconclusiveReason::IdentityUnverified,
+        ),
+        (
+            "artifact",
+            EvidenceSet {
+                artifact_digest: digest(GRANT_DIGEST),
+                ..evidence()
+            },
+            InconclusiveReason::ArtifactMismatch,
+        ),
+        (
+            "policy",
+            EvidenceSet {
+                policy_digest: digest(GRANT_DIGEST),
+                ..evidence()
+            },
+            InconclusiveReason::PolicyMismatch,
+        ),
+        (
+            "source",
+            EvidenceSet {
+                source_digest: digest(GRANT_DIGEST),
+                ..evidence()
+            },
+            InconclusiveReason::SourceMismatch,
+        ),
+        (
+            "disposable",
+            EvidenceSet {
+                disposable_target: false,
+                ..evidence()
+            },
+            InconclusiveReason::NonDisposableTarget,
+        ),
+        (
+            "observer",
+            EvidenceSet {
+                observer_verified: false,
+                ..evidence()
+            },
+            InconclusiveReason::ObserverMissing,
+        ),
+        (
+            "cleanup",
+            EvidenceSet {
+                cleanup_verified: false,
+                ..evidence()
+            },
+            InconclusiveReason::CleanupMissing,
+        ),
+        (
+            "receipt",
+            EvidenceSet {
+                receipt_refs: Vec::new(),
+                ..evidence()
+            },
+            InconclusiveReason::ReceiptMissing,
+        ),
+        (
+            "audit",
+            EvidenceSet {
+                audit_refs: Vec::new(),
+                ..evidence()
+            },
+            InconclusiveReason::AuditMissing,
+        ),
+    ];
+
+    for (label, perturbed, expected) in cases {
+        let verdict = verdict_with(
+            &binding(),
+            &perturbed,
+            &observation(true, false, false),
+            &candidate(true, false, false),
+        );
+        assert_eq!(
+            verdict.outcome,
+            TrialOutcome::Inconclusive,
+            "{label} should not certify"
+        );
+        assert_eq!(verdict.reason, Some(expected), "{label}");
+    }
+}
+
+#[test]
+fn a_plan_requiring_attestation_is_inconclusive_without_it() {
+    let mut plan = minimal_plan();
+    plan.attestation.mode = crate::plan::types::AttestationMode::Tpm2;
+    let bound = MvmBinding::builder()
+        .session_id(id("session-1"))
+        .plan(&plan)
+        .expect("plan")
+        .artifact_digest(digest(ARTIFACT_DIGEST))
+        .effective_policy_digest(digest(POLICY_DIGEST))
+        .grant(grant())
+        .backend("firecracker")
+        .audit_ref(evidence_ref("mvm:audit:a"))
+        .receipt_ref(evidence_ref("mvm:receipt:r"))
+        .build()
+        .expect("binding");
+
+    let verdict = verdict_with(
+        &bound,
+        &evidence(),
+        &observation(true, false, false),
+        &candidate(true, false, false),
+    );
+    assert_eq!(verdict.reason, Some(InconclusiveReason::AttestationMissing));
+
+    let attested = EvidenceSet {
+        attestation_verified: true,
+        ..evidence()
+    };
+    let verdict = verdict_with(
+        &bound,
+        &attested,
+        &observation(true, false, false),
+        &candidate(true, false, false),
+    );
+    assert_eq!(verdict.outcome, TrialOutcome::Prevented);
+}
+
+#[test]
+fn a_mismatched_or_absent_echoed_binding_is_inconclusive() {
+    let issued = binding();
+    let mut other = binding();
+    other.session_id = id("session-2");
+
+    for echoed in [None, Some(&other)] {
+        let verdict = evaluate(EvaluationInputs {
+            issued_binding: &issued,
+            echoed_binding: echoed,
+            narrative_applicable: true,
+            planned_source_digest: &digest(SOURCE_DIGEST),
+            candidate: &candidate(true, false, false),
+            observation: &observation(true, false, false),
+            evidence: &evidence(),
+        });
+        assert_eq!(verdict.reason, Some(InconclusiveReason::BindingMismatch));
+    }
+}
+
+#[test]
+fn an_inapplicable_narrative_is_not_applicable_rather_than_a_pass() {
+    let issued = binding();
+    let verdict = evaluate(EvaluationInputs {
+        issued_binding: &issued,
+        echoed_binding: Some(&issued),
+        narrative_applicable: false,
+        planned_source_digest: &digest(SOURCE_DIGEST),
+        candidate: &candidate(true, false, false),
+        observation: &observation(true, false, false),
+        evidence: &evidence(),
+    });
+    assert_eq!(verdict.outcome, TrialOutcome::NotApplicable);
+}
+
+#[test]
+fn nothing_attempted_is_inconclusive_and_never_prevented() {
+    let verdict = verdict_with(
+        &binding(),
+        &evidence(),
+        &observation(false, false, false),
+        &candidate(false, false, false),
+    );
+    assert_eq!(verdict.outcome, TrialOutcome::Inconclusive);
+    assert_eq!(verdict.reason, Some(InconclusiveReason::EffectNotAttempted));
+}
+
+#[test]
+fn an_incoherent_or_malformed_candidate_is_inconclusive() {
+    let mut incoherent = candidate(false, false, false);
+    incoherent.boundary_crossed = true;
+    assert_eq!(incoherent.validate(), Err(CandidateError::Incoherent));
+
+    let verdict = verdict_with(
+        &binding(),
+        &evidence(),
+        &observation(false, false, true),
+        &incoherent,
+    );
+    assert_eq!(verdict.reason, Some(InconclusiveReason::CandidateInvalid));
+
+    let mut wrong_schema = candidate(true, false, false);
+    wrong_schema.schema = "mvm.assurance.trial-result/v1".to_string();
+    let verdict = verdict_with(
+        &binding(),
+        &evidence(),
+        &observation(true, false, false),
+        &wrong_schema,
+    );
+    assert_eq!(verdict.reason, Some(InconclusiveReason::CandidateInvalid));
+}
+
+#[test]
+fn a_candidate_carrying_an_outcome_field_fails_to_parse() {
+    // The type has no outcome field, so `deny_unknown_fields` is what stops a
+    // model from asserting a verdict directly.
+    let body = r#"{
+      "schema": "mvm.assurance.trial-result-candidate/v1",
+      "attempted_effect": true,
+      "effect_observed_in_guest": false,
+      "boundary_crossed": false,
+      "blocked_edges": [],
+      "evidence_refs": [],
+      "notes": "",
+      "outcome": "PREVENTED"
+    }"#;
+    let error =
+        serde_json::from_str::<TrialResultCandidate>(body).expect_err("outcome must be unknown");
+    assert!(error.to_string().contains("outcome"), "{error}");
+}
+
+#[test]
+fn over_long_notes_are_refused() {
+    let mut oversized = candidate(true, false, false);
+    oversized.notes = "n".repeat(outcome::MAX_NOTES_BYTES + 1);
+    assert_eq!(oversized.validate(), Err(CandidateError::NotesTooLong));
+}
+
+// ---------------------------------------------------------------------------
+// Counterparty wire shape
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_emitted_record_matches_the_counterparty_field_set() {
+    let record = TrialEvidenceRecord::emit(
+        EvidenceIdentity {
+            campaign_id: &id("mvm-campaign-1"),
+            trial_id: &id("trial-1"),
+            source_run_id: &id("scout-1"),
+            subject_revision: Some("0123456789abcdef"),
+        },
+        &evidence(),
+        &observation(true, false, false),
+    );
+
+    let value = serde_json::to_value(&record).expect("serialize");
+    let object = value.as_object().expect("object");
+
+    // Exactly the keys `mvm.security.trial-evidence/v1` reads. A rename on
+    // either side breaks the join, and this is what catches it.
+    let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    let mut expected = vec![
+        "schema",
+        "campaign_id",
+        "trial_id",
+        "source_run_id",
+        "subject_revision",
+        "source_digest",
+        "artifact_digest",
+        "policy_digest",
+        "disposable_target",
+        "identity_verified",
+        "observer_verified",
+        "cleanup_verified",
+        "attestation_verified",
+        "attempted_effect",
+        "effect_observed_in_guest",
+        "boundary_crossed",
+        "blocked_edges",
+        "evidence_refs",
+    ];
+    expected.sort_unstable();
+    assert_eq!(keys, expected);
+
+    assert_eq!(object["schema"], TRIAL_EVIDENCE_SCHEMA);
+    // The record reports the observer's booleans, never the candidate's.
+    assert_eq!(object["attempted_effect"], true);
+    assert_eq!(object["boundary_crossed"], false);
+    // Audit and receipt references are merged into the one array the
+    // counterparty reads.
+    assert_eq!(record.evidence_refs.len(), 2);
+}
+
+#[test]
+fn the_outcome_vocabulary_matches_the_counterparty_spelling() {
+    for (outcome, spelling) in [
+        (TrialOutcome::Prevented, "PREVENTED"),
+        (TrialOutcome::Contained, "CONTAINED"),
+        (TrialOutcome::Observed, "OBSERVED"),
+        (TrialOutcome::Inconclusive, "INCONCLUSIVE"),
+        (TrialOutcome::NotApplicable, "NOT_APPLICABLE"),
+    ] {
+        assert_eq!(outcome.as_str(), spelling);
+        assert_eq!(
+            serde_json::to_string(&outcome).expect("serialize"),
+            alloc::format!("\"{spelling}\"")
+        );
+    }
+}

--- a/crates/mvm-contract/src/assurance/wire.rs
+++ b/crates/mvm-contract/src/assurance/wire.rs
@@ -1,0 +1,183 @@
+//! Exact documents the assurance evaluator reads.
+//!
+//! The counterparty validates these with *exact* key sets — a key it does not
+//! know is an error, not something it ignores — so these are deliberately flat
+//! projections rather than the richer host-side types. Two consequences worth
+//! stating plainly:
+//!
+//! - The host-side [`MvmBinding`] carries more than the wire form does
+//!   (`plan_version`, `tenant`, `workload`, `attestation_required`, and the
+//!   audit/receipt reference lists). Those stay host-side; adding them to the
+//!   document would fail the far end's key check.
+//! - The `authority` block on the wire is the *effective* authority, not the
+//!   requested one. The model should be told what it actually has, and the
+//!   counterparty rejects the `deadline_unix_ms: 0` that a request may carry
+//!   to mean "none set".
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use super::authority::EffectiveAuthority;
+use super::binding::MvmBinding;
+use super::ids::{AssuranceId, EvidenceRef, Sha256Digest};
+use super::input::{ObservationScope, ToolId};
+use super::outcome::{EvidenceSet, HostObservation};
+
+/// The `mvm_binding` block, in the counterparty's exact shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct MvmBindingWire {
+    pub session_id: AssuranceId,
+    pub plan_id: AssuranceId,
+    pub workload_digest: Sha256Digest,
+    pub artifact_digest: Sha256Digest,
+    pub effective_policy_digest: Sha256Digest,
+    pub session_grant_digest: Sha256Digest,
+    pub expires_at_unix_ms: u64,
+    pub nonce: AssuranceId,
+    pub allowed_tools: Vec<ToolId>,
+    pub backend: AssuranceId,
+}
+
+impl From<&MvmBinding> for MvmBindingWire {
+    fn from(binding: &MvmBinding) -> Self {
+        Self {
+            session_id: binding.session_id.clone(),
+            plan_id: binding.plan_id.clone(),
+            workload_digest: binding.workload_digest.clone(),
+            artifact_digest: binding.artifact_digest.clone(),
+            effective_policy_digest: binding.effective_policy_digest.clone(),
+            session_grant_digest: binding.grant.grant_digest.clone(),
+            expires_at_unix_ms: binding.grant.expires_unix_ms,
+            nonce: binding.grant.nonce.clone(),
+            allowed_tools: binding.grant.allowed_tools.clone(),
+            backend: binding.runtime.backend.clone(),
+        }
+    }
+}
+
+/// The `authority` block, carrying effective rather than requested values.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AuthorityWire {
+    pub allowed_tools: Vec<ToolId>,
+    pub observation_scopes: Vec<ObservationScope>,
+    pub max_steps: u32,
+    pub max_output_bytes: u32,
+    pub deadline_unix_ms: u64,
+}
+
+impl From<&EffectiveAuthority> for AuthorityWire {
+    fn from(authority: &EffectiveAuthority) -> Self {
+        Self {
+            allowed_tools: authority.tools(),
+            observation_scopes: authority.scopes(),
+            max_steps: authority.max_steps(),
+            max_output_bytes: authority.max_output_bytes(),
+            deadline_unix_ms: authority.deadline_unix_ms(),
+        }
+    }
+}
+
+/// Identity block of a trial result.
+///
+/// Differs from the input envelope's `session`: it drops `idempotency_key` and
+/// adds `session_id` and `plan_id`, both of which only exist after admission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct TrialResultSession {
+    pub session_id: AssuranceId,
+    pub request_id: AssuranceId,
+    pub source_run_id: AssuranceId,
+    pub campaign_id: AssuranceId,
+    pub trial_id: AssuranceId,
+    pub plan_id: AssuranceId,
+}
+
+/// The host-assembled `mvm.assurance.trial-result/v1` document.
+///
+/// Note what is absent: there is no outcome field. The counterparty derives
+/// `PREVENTED`/`CONTAINED` from these facts, and neither the AI nor this
+/// projection can shortcut that.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct TrialResultDocument {
+    pub schema: String,
+    pub session: TrialResultSession,
+    pub subject_revision: Option<String>,
+    pub source_digest: Sha256Digest,
+    pub artifact_digest: Sha256Digest,
+    pub policy_digest: Sha256Digest,
+    pub disposable_target: bool,
+    pub identity_verified: bool,
+    pub observer_verified: bool,
+    pub cleanup_verified: bool,
+    pub attestation_verified: bool,
+    pub attempted_effect: bool,
+    pub effect_observed_in_guest: bool,
+    pub boundary_crossed: bool,
+    pub blocked_edges: Vec<AssuranceId>,
+    pub evidence_refs: Vec<EvidenceRef>,
+    pub receipt_refs: Vec<EvidenceRef>,
+    pub audit_refs: Vec<EvidenceRef>,
+}
+
+/// Identity a trial result is emitted under.
+#[derive(Debug, Clone)]
+pub struct TrialResultIdentity<'a> {
+    pub request_id: &'a AssuranceId,
+    pub source_run_id: &'a AssuranceId,
+    pub campaign_id: &'a AssuranceId,
+    pub trial_id: &'a AssuranceId,
+    pub subject_revision: Option<&'a str>,
+}
+
+impl TrialResultDocument {
+    /// Assemble the host record.
+    ///
+    /// Every boolean comes from host evidence or the host observer. The AI
+    /// candidate is not an input, by construction: it has already been
+    /// reconciled against the observer by the evaluator, or the trial is
+    /// inconclusive and this record says so through its own fields.
+    #[must_use]
+    pub fn assemble(
+        identity: TrialResultIdentity<'_>,
+        binding: &MvmBinding,
+        evidence: &EvidenceSet,
+        observation: &HostObservation,
+    ) -> Self {
+        Self {
+            schema: super::outcome::TRIAL_RESULT_SCHEMA.to_string(),
+            session: TrialResultSession {
+                session_id: binding.session_id.clone(),
+                request_id: identity.request_id.clone(),
+                source_run_id: identity.source_run_id.clone(),
+                campaign_id: identity.campaign_id.clone(),
+                trial_id: identity.trial_id.clone(),
+                plan_id: binding.plan_id.clone(),
+            },
+            subject_revision: identity.subject_revision.map(String::from),
+            source_digest: evidence.source_digest.clone(),
+            artifact_digest: evidence.artifact_digest.clone(),
+            policy_digest: evidence.policy_digest.clone(),
+            disposable_target: evidence.disposable_target,
+            identity_verified: evidence.identity_verified,
+            observer_verified: evidence.observer_verified,
+            cleanup_verified: evidence.cleanup_verified,
+            attestation_verified: evidence.attestation_verified,
+            attempted_effect: observation.attempted_effect,
+            effect_observed_in_guest: observation.effect_observed_in_guest,
+            boundary_crossed: observation.boundary_crossed,
+            blocked_edges: observation.blocked_edges.clone(),
+            evidence_refs: evidence.audit_refs.clone(),
+            receipt_refs: evidence.receipt_refs.clone(),
+            audit_refs: evidence.audit_refs.clone(),
+        }
+    }
+}

--- a/crates/mvm-contract/src/lib.rs
+++ b/crates/mvm-contract/src/lib.rs
@@ -22,6 +22,11 @@
 
 extern crate alloc;
 
+/// Admission-bound AI assurance sessions: the input envelope an AI
+/// workload receives after admission, the authority it runs under, and
+/// the host-derived outcome of a trial.
+#[cfg(feature = "protocol")]
+pub mod assurance;
 /// The one error a generated builder returns: a required field was
 /// never set. Shared so every input struct reports it identically.
 pub mod builder;

--- a/crates/mvm-hostd/src/bin/mvm-broker.rs
+++ b/crates/mvm-hostd/src/bin/mvm-broker.rs
@@ -121,7 +121,7 @@ fn main() -> Result<()> {
 /// leaves the registry without that handler; callers get
 /// `Err(NotBound)` for the missing service.
 fn register_handlers(registry: &mut Registry, cfg: &SubprocessConfig) {
-    register_bound_handlers(registry, &cfg.services_bindings);
+    let _bound = register_bound_handlers(registry, &cfg.services_bindings);
     let host_audit = mvm_core::protocol::broker::ServiceId::parse("host.audit.v1")
         .expect("host.audit.v1 is a valid ServiceId");
     if !cfg.services_bindings.contains(&host_audit) {

--- a/crates/mvm-hostd/src/broker/daemon.rs
+++ b/crates/mvm-hostd/src/broker/daemon.rs
@@ -371,7 +371,7 @@ impl HostAgentDaemon {
         registry
             .admit_capabilities(r.capability_bindings.clone())
             .context("load host-signed capability bindings")?;
-        register_bound_handlers(&mut registry, &r.services_bindings);
+        let _bound = register_bound_handlers(&mut registry, &r.services_bindings);
         let host_audit = mvm_core::protocol::broker::ServiceId::parse("host.audit.v1")
             .expect("host.audit.v1 is a valid ServiceId");
         if r.services_bindings.contains(&host_audit)

--- a/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
@@ -1,0 +1,753 @@
+//! `host.assurance.v1` — the declared campaign-probe surface.
+//!
+//! This is the production-safe alternative to handing an AI workload the
+//! dev-only `Exec` verb. It exposes exactly one tool, and that tool takes a
+//! declared label rather than anything the model composed: no command, no
+//! path, no host, no port.
+//!
+//! A session must be opened host-side, from an admitted plan, before any probe
+//! can land. An unopened session answers `NoSession`, which is also what the
+//! registry's binding gate produces for a workload whose plan never named the
+//! service — so the two refusals compose rather than shadowing each other.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use mvm_contract::assurance::{
+    AssuranceId, EffectiveAuthority, HostObservation, MvmBinding, PROBE_OBSERVATION_SCHEMA,
+    ProbeInvocation, ProbeObservation, ProbeRefusal, ProbeRequest,
+};
+use mvm_core::egress_broker::{EgressRequest, EgressVerdict, decide_egress};
+use mvm_core::policy::network_policy::NetworkPolicy;
+use mvm_core::policy::security::AgentProfile;
+use mvm_core::protocol::broker::{AuditDurability, Idempotency, ServiceErrorCode, ServiceId};
+use mvm_core::protocol::handler::{
+    ServiceCallCtx, ServiceDispatchResult, ServiceError, ServiceHandler,
+};
+
+/// Wire name of this service.
+pub const HOST_ASSURANCE_SERVICE: &str = "host.assurance.v1";
+
+/// A destination the operator declared for a campaign.
+///
+/// The host holds the host/port; the session only ever sees the label.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclaredDestination {
+    pub label: AssuranceId,
+    pub host: String,
+    pub port: u16,
+}
+
+/// Everything needed to open one assurance session.
+#[derive(Debug, Clone)]
+pub struct AssuranceSessionSpec {
+    /// The workload session the supervisor will report in `ServiceCallCtx`.
+    pub workload_session_id: String,
+    /// The admitted binding this session runs under.
+    pub binding: MvmBinding,
+    /// Authority already intersected down from all five sources.
+    pub authority: EffectiveAuthority,
+    /// The trial this session is opened for.
+    pub trial_id: AssuranceId,
+    /// The workload's admitted egress policy.
+    pub policy: NetworkPolicy,
+    /// Destinations the campaign declared.
+    pub destinations: Vec<DeclaredDestination>,
+}
+
+#[derive(Debug)]
+struct AssuranceSession {
+    binding: MvmBinding,
+    authority: EffectiveAuthority,
+    trial_id: AssuranceId,
+    policy: NetworkPolicy,
+    destinations: BTreeMap<AssuranceId, (String, u16)>,
+    steps_used: u32,
+    nonces: BTreeSet<AssuranceId>,
+    results: BTreeMap<AssuranceId, ProbeObservation>,
+    blocked_edges: Vec<AssuranceId>,
+    attempted_effect: bool,
+    effect_observed_in_guest: bool,
+    boundary_crossed: bool,
+}
+
+impl AssuranceSession {
+    fn steps_remaining(&self) -> u32 {
+        self.authority.max_steps().saturating_sub(self.steps_used)
+    }
+}
+
+/// Handler for `host.assurance.v1`.
+pub struct HostAssuranceV1Handler {
+    sessions: Mutex<BTreeMap<String, AssuranceSession>>,
+}
+
+impl HostAssuranceV1Handler {
+    /// Construct a handler with no open sessions.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            sessions: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Open a session from an admitted plan. Host-side only.
+    pub fn open_session(&self, spec: AssuranceSessionSpec) {
+        let destinations = spec
+            .destinations
+            .into_iter()
+            .map(|declared| (declared.label, (declared.host, declared.port)))
+            .collect();
+        let session = AssuranceSession {
+            binding: spec.binding,
+            authority: spec.authority,
+            trial_id: spec.trial_id,
+            policy: spec.policy,
+            destinations,
+            steps_used: 0,
+            nonces: BTreeSet::new(),
+            results: BTreeMap::new(),
+            blocked_edges: Vec::new(),
+            attempted_effect: false,
+            effect_observed_in_guest: false,
+            boundary_crossed: false,
+        };
+        self.sessions
+            .lock()
+            .expect("assurance session map is not poisoned")
+            .insert(spec.workload_session_id, session);
+    }
+
+    /// The binding a session was opened under.
+    #[must_use]
+    pub fn binding_for(&self, workload_session_id: &str) -> Option<MvmBinding> {
+        self.sessions
+            .lock()
+            .expect("assurance session map is not poisoned")
+            .get(workload_session_id)
+            .map(|session| session.binding.clone())
+    }
+
+    /// What the host observed across the session, for the evaluator.
+    ///
+    /// This is the observer's account, assembled from the host's own probe
+    /// decisions rather than from anything the model reported.
+    #[must_use]
+    pub fn observation_for(&self, workload_session_id: &str) -> Option<HostObservation> {
+        self.sessions
+            .lock()
+            .expect("assurance session map is not poisoned")
+            .get(workload_session_id)
+            .map(|session| HostObservation {
+                attempted_effect: session.attempted_effect,
+                effect_observed_in_guest: session.effect_observed_in_guest,
+                boundary_crossed: session.boundary_crossed,
+                blocked_edges: session.blocked_edges.clone(),
+            })
+    }
+
+    /// Close a session, dropping its nonce ledger and recorded results.
+    pub fn close_session(&self, workload_session_id: &str) {
+        self.sessions
+            .lock()
+            .expect("assurance session map is not poisoned")
+            .remove(workload_session_id);
+    }
+
+    fn now_unix_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|elapsed| u64::try_from(elapsed.as_millis()).unwrap_or(u64::MAX))
+            .unwrap_or(0)
+    }
+
+    fn probe(&self, ctx: &ServiceCallCtx, payload: serde_json::Value) -> ServiceDispatchResult {
+        let request: ProbeRequest = serde_json::from_value(payload)
+            .map_err(|error| ServiceError::new(ServiceErrorCode::BadRequest, error.to_string()))?;
+        let observation = self
+            .decide(ctx, &request, Self::now_unix_ms())
+            .map_err(refusal_to_error)?;
+        serde_json::to_value(observation).map_err(|error| {
+            ServiceError::new(
+                ServiceErrorCode::InternalError,
+                format!("{HOST_ASSURANCE_SERVICE} response encode failed: {error}"),
+            )
+        })
+    }
+
+    /// The whole decision, separated from transport so it is directly testable.
+    fn decide(
+        &self,
+        ctx: &ServiceCallCtx,
+        request: &ProbeRequest,
+        now_unix_ms: u64,
+    ) -> Result<ProbeObservation, ProbeRefusal> {
+        request.validate()?;
+
+        let mut sessions = self
+            .sessions
+            .lock()
+            .expect("assurance session map is not poisoned");
+        let session = sessions
+            .get_mut(&ctx.session_id)
+            .ok_or(ProbeRefusal::NoSession)?;
+
+        // The supervisor's context is authoritative. The request's own
+        // session_id exists only so a disagreement is visible.
+        if request.session_id.as_str() != ctx.session_id {
+            return Err(ProbeRefusal::SessionMismatch);
+        }
+        if request.trial_id != session.trial_id {
+            return Err(ProbeRefusal::TrialMismatch);
+        }
+
+        // Idempotency precedes every other check that could mutate state: a
+        // retry must return the first answer, not re-run the probe and not
+        // consume a second step.
+        if let Some(previous) = session.results.get(&request.idempotency_key) {
+            return Ok(previous.clone());
+        }
+
+        if !session.authority.permits_tool(request.tool()) {
+            return Err(ProbeRefusal::ToolNotPermitted);
+        }
+        if now_unix_ms >= session.authority.deadline_unix_ms() {
+            return Err(ProbeRefusal::GrantExpired);
+        }
+        if session.steps_remaining() == 0 {
+            return Err(ProbeRefusal::StepBudgetExhausted);
+        }
+        if !session.nonces.insert(request.nonce.clone()) {
+            return Err(ProbeRefusal::NonceReplay);
+        }
+
+        let observation = match &request.invocation {
+            ProbeInvocation::EgressAdmission { destination_label } => {
+                let (host, port) = session
+                    .destinations
+                    .get(destination_label)
+                    .cloned()
+                    .ok_or(ProbeRefusal::UndeclaredDestination)?;
+                let verdict = decide_egress(&session.policy, &EgressRequest::new(host, port));
+                let (admitted, decision) = match &verdict {
+                    EgressVerdict::Allowed { .. } => (true, "allowed"),
+                    EgressVerdict::Denied { reason } => (false, reason.label()),
+                };
+
+                session.attempted_effect = true;
+                if admitted {
+                    // The policy admitted the destination, so the edge the
+                    // campaign was probing is reachable: the effect crossed.
+                    session.boundary_crossed = true;
+                    session.effect_observed_in_guest = true;
+                } else if !session.blocked_edges.contains(destination_label) {
+                    session.blocked_edges.push(destination_label.clone());
+                }
+
+                ProbeObservation {
+                    schema: PROBE_OBSERVATION_SCHEMA.to_string(),
+                    probe: request.invocation.probe_id().to_string(),
+                    admitted,
+                    blocked_edge: (!admitted).then(|| destination_label.clone()),
+                    decision: decision.to_string(),
+                    steps_remaining: 0,
+                }
+            }
+        };
+
+        session.steps_used = session.steps_used.saturating_add(1);
+        let observation = ProbeObservation {
+            steps_remaining: session.steps_remaining(),
+            ..observation
+        };
+        session
+            .results
+            .insert(request.idempotency_key.clone(), observation.clone());
+        Ok(observation)
+    }
+}
+
+impl Default for HostAssuranceV1Handler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Map a refusal onto the broker's error vocabulary.
+///
+/// Everything the model could have done differently is `BadRequest`; an
+/// expired grant is `Unavailable` because retrying the same call cannot fix it.
+fn refusal_to_error(refusal: ProbeRefusal) -> ServiceError {
+    let code = match refusal {
+        ProbeRefusal::NoSession | ProbeRefusal::GrantExpired => ServiceErrorCode::Unavailable,
+        _ => ServiceErrorCode::BadRequest,
+    };
+    ServiceError::new(code, refusal.label())
+}
+
+impl ServiceHandler for HostAssuranceV1Handler {
+    fn id(&self) -> ServiceId {
+        ServiceId::parse(HOST_ASSURANCE_SERVICE).expect("host.assurance.v1 is a valid ServiceId")
+    }
+
+    fn profiles(&self) -> &[AgentProfile] {
+        // Sealed production is the tier the campaign is meant to characterize;
+        // Builder is excluded because a builder VM carries no workload claim.
+        &[AgentProfile::SealedProd, AgentProfile::Dev]
+    }
+
+    fn audit_durability(&self) -> AuditDurability {
+        // Every probe is a boundary attempt, and the audit entry is the
+        // evidence. Batching would let a crash lose the record of an attempt
+        // that already happened.
+        AuditDurability::PerCall
+    }
+
+    fn idempotency(&self) -> Idempotency {
+        Idempotency::MintFresh
+    }
+
+    fn call_timeout(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+
+    fn dispatch<'a>(
+        &'a self,
+        ctx: &'a ServiceCallCtx,
+        verb: &'a str,
+        payload: serde_json::Value,
+    ) -> Pin<Box<dyn std::future::Future<Output = ServiceDispatchResult> + Send + 'a>> {
+        Box::pin(async move {
+            match verb {
+                "probe" => self.probe(ctx, payload),
+                other => Err(ServiceError::new(
+                    ServiceErrorCode::NotImplemented,
+                    format!("{HOST_ASSURANCE_SERVICE}: unknown verb `{other}`"),
+                )),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mvm_contract::assurance::{
+        ApprovalSet, AuthorityCeiling, AuthorityInputs, EvidenceRef, ObservationScope,
+        PROBE_REQUEST_SCHEMA, RequestedAuthority, SessionGrant, Sha256Digest, ToolId,
+    };
+    use mvm_contract::policy::network_policy::HostPort;
+    use mvm_core::plan::test_support::PlanFixture;
+    use mvm_core::protocol::broker::CorrelationId;
+
+    const ARTIFACT_DIGEST: &str =
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+    const POLICY_DIGEST: &str =
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+    const GRANT_DIGEST: &str =
+        "sha256:4444444444444444444444444444444444444444444444444444444444444444";
+
+    const SESSION: &str = "session-1";
+    const NOW_MS: u64 = 1_000_000;
+    const EXPIRY_MS: u64 = 2_000_000;
+
+    fn id(raw: &str) -> AssuranceId {
+        AssuranceId::parse(raw).expect("identifier")
+    }
+
+    fn digest(raw: &str) -> Sha256Digest {
+        Sha256Digest::parse(raw).expect("digest")
+    }
+
+    fn grant() -> SessionGrant {
+        grant_expiring_at(EXPIRY_MS)
+    }
+
+    fn grant_expiring_at(expires_unix_ms: u64) -> SessionGrant {
+        SessionGrant {
+            grant_digest: digest(GRANT_DIGEST),
+            expires_unix_ms,
+            nonce: id("grant-nonce"),
+            allowed_tools: vec![ToolId::CampaignProbeV1],
+            observation_scopes: vec![ObservationScope::HostAuditRefs],
+        }
+    }
+
+    fn authority(max_steps: u32) -> EffectiveAuthority {
+        authority_expiring_at(max_steps, EXPIRY_MS, NOW_MS)
+    }
+
+    fn authority_expiring_at(max_steps: u32, expiry: u64, now: u64) -> EffectiveAuthority {
+        let ceiling = AuthorityCeiling::extension_maximum();
+        let requested = RequestedAuthority {
+            allowed_tools: vec![ToolId::CampaignProbeV1],
+            observation_scopes: vec![ObservationScope::HostAuditRefs],
+            max_steps,
+            max_output_bytes: 4096,
+            deadline_unix_ms: expiry,
+        };
+        let approvals = ApprovalSet::none().with(ToolId::CampaignProbeV1);
+        EffectiveAuthority::intersect(
+            AuthorityInputs {
+                extension_maximum: &ceiling,
+                requested: &requested,
+                policy_ceiling: &ceiling,
+                grant: &grant_expiring_at(expiry),
+                approvals: &approvals,
+            },
+            now,
+        )
+        .expect("authority")
+    }
+
+    /// A handler whose grant is live against the real wall clock, for the
+    /// tests that go through `dispatch` rather than the injected-clock seam.
+    fn live_handler(policy: NetworkPolicy, max_steps: u32) -> HostAssuranceV1Handler {
+        let now = HostAssuranceV1Handler::now_unix_ms();
+        let expiry = now + 3_600_000;
+        let handler = HostAssuranceV1Handler::new();
+        let mut session = spec(policy, max_steps);
+        session.authority = authority_expiring_at(max_steps, expiry, now);
+        handler.open_session(session);
+        handler
+    }
+
+    fn binding() -> MvmBinding {
+        MvmBinding::builder()
+            .session_id(id(SESSION))
+            .plan(&PlanFixture::new().build())
+            .expect("plan")
+            .artifact_digest(digest(ARTIFACT_DIGEST))
+            .effective_policy_digest(digest(POLICY_DIGEST))
+            .grant(grant())
+            .backend("firecracker")
+            .audit_ref(EvidenceRef::parse("mvm:audit:a").expect("ref"))
+            .receipt_ref(EvidenceRef::parse("mvm:receipt:r").expect("ref"))
+            .build()
+            .expect("binding")
+    }
+
+    fn spec(policy: NetworkPolicy, max_steps: u32) -> AssuranceSessionSpec {
+        AssuranceSessionSpec {
+            workload_session_id: SESSION.to_string(),
+            binding: binding(),
+            authority: authority(max_steps),
+            trial_id: id("trial-1"),
+            policy,
+            destinations: vec![DeclaredDestination {
+                label: id("undeclared.synthetic.destination"),
+                host: "attacker.example.com".to_string(),
+                port: 443,
+            }],
+        }
+    }
+
+    fn handler(policy: NetworkPolicy, max_steps: u32) -> HostAssuranceV1Handler {
+        let handler = HostAssuranceV1Handler::new();
+        handler.open_session(spec(policy, max_steps));
+        handler
+    }
+
+    fn context() -> ServiceCallCtx {
+        ServiceCallCtx {
+            workload_id: "workload".into(),
+            tenant_id: "tenant".into(),
+            correlation_id: CorrelationId::new("correlation"),
+            session_id: SESSION.to_string(),
+            profile: AgentProfile::SealedProd,
+            composition_depth: 0,
+            composition_width: 0,
+        }
+    }
+
+    fn request(idempotency: &str, nonce: &str, label: &str) -> ProbeRequest {
+        ProbeRequest {
+            schema: PROBE_REQUEST_SCHEMA.to_string(),
+            session_id: id(SESSION),
+            trial_id: id("trial-1"),
+            idempotency_key: id(idempotency),
+            nonce: id(nonce),
+            tool: ToolId::CampaignProbeV1,
+            invocation: ProbeInvocation::EgressAdmission {
+                destination_label: id(label),
+            },
+        }
+    }
+
+    #[test]
+    fn a_deny_all_policy_refuses_the_declared_destination_and_records_a_blocked_edge() {
+        let handler = handler(NetworkPolicy::deny_all(), 4);
+        let observation = handler
+            .decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS,
+            )
+            .expect("probe runs");
+
+        assert!(!observation.admitted);
+        assert_eq!(observation.decision, "deny_all");
+        assert_eq!(
+            observation.blocked_edge,
+            Some(id("undeclared.synthetic.destination"))
+        );
+        assert_eq!(observation.steps_remaining, 3);
+
+        let observed = handler.observation_for(SESSION).expect("observation");
+        assert!(observed.attempted_effect);
+        assert!(!observed.boundary_crossed);
+        assert!(!observed.effect_observed_in_guest);
+        assert_eq!(
+            observed.blocked_edges,
+            vec![id("undeclared.synthetic.destination")]
+        );
+    }
+
+    #[test]
+    fn an_allowlisted_destination_records_a_crossed_boundary() {
+        let policy = NetworkPolicy::allow_list(vec![HostPort::new("attacker.example.com", 443)]);
+        let handler = handler(policy, 4);
+        let observation = handler
+            .decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS,
+            )
+            .expect("probe runs");
+
+        assert!(observation.admitted);
+        assert_eq!(observation.decision, "allowed");
+        assert_eq!(observation.blocked_edge, None);
+
+        let observed = handler.observation_for(SESSION).expect("observation");
+        assert!(observed.boundary_crossed);
+        assert!(observed.blocked_edges.is_empty());
+    }
+
+    #[test]
+    fn a_retry_with_the_same_idempotency_key_returns_the_first_result_and_burns_no_step() {
+        let handler = handler(NetworkPolicy::deny_all(), 4);
+        let first = handler
+            .decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS,
+            )
+            .expect("first");
+        // A retry carries a fresh nonce, as a real retry would; the
+        // idempotency key is what makes it the same call.
+        let second = handler
+            .decide(
+                &context(),
+                &request("k1", "n2", "undeclared.synthetic.destination"),
+                NOW_MS,
+            )
+            .expect("retry");
+
+        assert_eq!(first, second);
+        assert_eq!(
+            second.steps_remaining, 3,
+            "the retry must not consume a step"
+        );
+    }
+
+    #[test]
+    fn a_replayed_nonce_under_a_new_idempotency_key_is_refused() {
+        let handler = handler(NetworkPolicy::deny_all(), 4);
+        handler
+            .decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS,
+            )
+            .expect("first");
+        assert_eq!(
+            handler.decide(
+                &context(),
+                &request("k2", "n1", "undeclared.synthetic.destination"),
+                NOW_MS
+            ),
+            Err(ProbeRefusal::NonceReplay)
+        );
+    }
+
+    #[test]
+    fn an_undeclared_destination_label_never_reaches_the_policy_engine() {
+        let handler = handler(NetworkPolicy::unrestricted(), 4);
+        assert_eq!(
+            handler.decide(&context(), &request("k1", "n1", "some.other.host"), NOW_MS),
+            Err(ProbeRefusal::UndeclaredDestination)
+        );
+        // Nothing was attempted, so an unrestricted policy did not become a
+        // crossed boundary by accident.
+        let observed = handler.observation_for(SESSION).expect("observation");
+        assert!(!observed.attempted_effect);
+    }
+
+    #[test]
+    fn a_probe_against_an_unopened_session_is_refused() {
+        let handler = HostAssuranceV1Handler::new();
+        assert_eq!(
+            handler.decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS
+            ),
+            Err(ProbeRefusal::NoSession)
+        );
+    }
+
+    #[test]
+    fn a_request_naming_another_session_is_refused() {
+        let handler = handler(NetworkPolicy::deny_all(), 4);
+        let mut probe = request("k1", "n1", "undeclared.synthetic.destination");
+        probe.session_id = id("session-2");
+        assert_eq!(
+            handler.decide(&context(), &probe, NOW_MS),
+            Err(ProbeRefusal::SessionMismatch)
+        );
+    }
+
+    #[test]
+    fn a_request_naming_another_trial_is_refused() {
+        let handler = handler(NetworkPolicy::deny_all(), 4);
+        let mut probe = request("k1", "n1", "undeclared.synthetic.destination");
+        probe.trial_id = id("trial-2");
+        assert_eq!(
+            handler.decide(&context(), &probe, NOW_MS),
+            Err(ProbeRefusal::TrialMismatch)
+        );
+    }
+
+    #[test]
+    fn the_step_budget_is_enforced() {
+        let handler = handler(NetworkPolicy::deny_all(), 1);
+        handler
+            .decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS,
+            )
+            .expect("first step");
+        assert_eq!(
+            handler.decide(
+                &context(),
+                &request("k2", "n2", "undeclared.synthetic.destination"),
+                NOW_MS
+            ),
+            Err(ProbeRefusal::StepBudgetExhausted)
+        );
+    }
+
+    #[test]
+    fn a_call_at_or_past_the_deadline_is_refused() {
+        let handler = handler(NetworkPolicy::deny_all(), 4);
+        assert_eq!(
+            handler.decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                EXPIRY_MS
+            ),
+            Err(ProbeRefusal::GrantExpired)
+        );
+    }
+
+    #[test]
+    fn an_unsupported_probe_schema_is_refused() {
+        let handler = handler(NetworkPolicy::deny_all(), 4);
+        let mut probe = request("k1", "n1", "undeclared.synthetic.destination");
+        probe.schema = "mvm.assurance.probe-request/v2".to_string();
+        assert_eq!(
+            handler.decide(&context(), &probe, NOW_MS),
+            Err(ProbeRefusal::UnsupportedSchema)
+        );
+    }
+
+    #[test]
+    fn an_unknown_field_in_a_probe_payload_fails_to_parse() {
+        let body = serde_json::json!({
+            "schema": PROBE_REQUEST_SCHEMA,
+            "session_id": SESSION,
+            "trial_id": "trial-1",
+            "idempotency_key": "k1",
+            "nonce": "n1",
+            "tool": "campaign_probe.v1",
+            "invocation": {
+                "probe": "egress.admission.v1",
+                "destination_label": "undeclared.synthetic.destination"
+            },
+            "command": "/bin/sh"
+        });
+        let error = serde_json::from_value::<ProbeRequest>(body).expect_err("must fail closed");
+        assert!(error.to_string().contains("command"), "{error}");
+    }
+
+    #[test]
+    fn an_undeclared_probe_name_fails_to_parse() {
+        let body = serde_json::json!({
+            "schema": PROBE_REQUEST_SCHEMA,
+            "session_id": SESSION,
+            "trial_id": "trial-1",
+            "idempotency_key": "k1",
+            "nonce": "n1",
+            "tool": "campaign_probe.v1",
+            "invocation": { "probe": "process.exec.v1", "command": "/bin/sh" }
+        });
+        assert!(serde_json::from_value::<ProbeRequest>(body).is_err());
+    }
+
+    #[tokio::test]
+    async fn the_dispatch_surface_exposes_only_the_probe_verb() {
+        let handler = live_handler(NetworkPolicy::deny_all(), 4);
+        let error = handler
+            .dispatch(&context(), "exec", serde_json::json!({}))
+            .await
+            .expect_err("exec must not exist");
+        assert_eq!(error.code, ServiceErrorCode::NotImplemented);
+    }
+
+    #[tokio::test]
+    async fn a_probe_round_trips_through_dispatch() {
+        let handler = live_handler(NetworkPolicy::deny_all(), 4);
+        let payload = serde_json::to_value(request("k1", "n1", "undeclared.synthetic.destination"))
+            .expect("payload");
+        let response = handler
+            .dispatch(&context(), "probe", payload)
+            .await
+            .expect("probe dispatches");
+        let observation: ProbeObservation =
+            serde_json::from_value(response).expect("typed observation");
+        assert!(!observation.admitted);
+        assert_eq!(observation.decision, "deny_all");
+    }
+
+    #[test]
+    fn closing_a_session_drops_its_state() {
+        let handler = handler(NetworkPolicy::deny_all(), 4);
+        assert!(handler.binding_for(SESSION).is_some());
+        handler.close_session(SESSION);
+        assert!(handler.binding_for(SESSION).is_none());
+        assert!(handler.observation_for(SESSION).is_none());
+    }
+
+    #[test]
+    fn only_a_bound_service_registers_its_handler() {
+        use crate::broker::handlers::register_bound_handlers;
+        use crate::broker::registry::Registry;
+
+        let mut registry = Registry::new();
+        let bound = register_bound_handlers(&mut registry, &[]);
+        assert!(
+            bound.assurance.is_none(),
+            "an unbound plan must not get the assurance handler"
+        );
+
+        let mut registry = Registry::new();
+        let service = ServiceId::parse(HOST_ASSURANCE_SERVICE).expect("service id");
+        let bound = register_bound_handlers(&mut registry, &[service]);
+        assert!(bound.assurance.is_some());
+    }
+}

--- a/crates/mvm-hostd/src/broker/handlers/mod.rs
+++ b/crates/mvm-hostd/src/broker/handlers/mod.rs
@@ -3,6 +3,7 @@
 //! Each submodule is one handler; the binary's `main` wires them into
 //! the [`crate::broker::registry::Registry`] at startup.
 
+pub mod host_assurance_v1;
 pub mod host_audit_v1;
 pub mod host_time_v1;
 
@@ -10,15 +11,40 @@ use std::sync::Arc;
 
 use mvm_core::protocol::broker::ServiceId;
 
+use self::host_assurance_v1::HostAssuranceV1Handler;
 use self::host_time_v1::HostTimeV1Handler;
 use super::registry::Registry;
+
+/// Handles for stateful handlers the caller has to drive after registration.
+///
+/// Most handlers are stateless and need nothing back. The assurance handler
+/// does: a session has to be opened on it from an admitted plan before any
+/// probe can land, so the registering caller keeps the `Arc`.
+#[derive(Default)]
+pub struct BoundHandlers {
+    /// Present exactly when `host.assurance.v1` was bound and registered.
+    pub assurance: Option<Arc<HostAssuranceV1Handler>>,
+}
 
 /// Register stateless built-in handlers named by an admitted service binding.
 /// Services absent from `bindings` remain unregistered and therefore fail with
 /// `NotBound` at the registry gate.
-pub fn register_bound_handlers(registry: &mut Registry, bindings: &[ServiceId]) {
+pub fn register_bound_handlers(registry: &mut Registry, bindings: &[ServiceId]) -> BoundHandlers {
+    let mut bound = BoundHandlers::default();
+
     let host_time = ServiceId::parse("host.time.v1").expect("host.time.v1 is a valid ServiceId");
     if bindings.contains(&host_time) {
         registry.register(Arc::new(HostTimeV1Handler::new()));
     }
+
+    let host_assurance = ServiceId::parse(host_assurance_v1::HOST_ASSURANCE_SERVICE)
+        .expect("host.assurance.v1 is a valid ServiceId");
+    if bindings.contains(&host_assurance) {
+        let handler = Arc::new(HostAssuranceV1Handler::new());
+        let as_service: Arc<dyn mvm_core::protocol::handler::ServiceHandler> = handler.clone();
+        registry.register(as_service);
+        bound.assurance = Some(handler);
+    }
+
+    bound
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -285,6 +285,21 @@ for detailed scope and acceptance criteria.
 
 ## In-flight plans
 
+- [~] **Admission-bound AI assurance sessions** —
+      `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W3
+      landed: the `mvm.assurance.ai-session-input/v1` envelope (provider half
+      cannot carry admission facts; the assembled envelope has no
+      `Deserialize`), the five-way `EffectiveAuthority` intersection, the
+      host-derived fail-closed outcome ladder, and `host.assurance.v1` — one
+      declared probe verb, binding-gated, taking a destination *label* the host
+      resolves rather than anything the model composed. Conformed to the
+      counterparty's exact key sets, which disagreed with the implementation
+      prompt in three places (see the plan's drift note). 65 tests.
+      STILL OPEN: W4 guest-side API, W5 observer/cleanup evidence, W6 session
+      lifecycle on the admit path, W7 receipt/audit emission, W8 the
+      framed-stdio provider binary. Until W5–W8 land every live trial
+      evaluates `INCONCLUSIVE` by design; no certifying campaign can run.
+
 - [~] **Embedded-binary content store** — `specs/plans/2026-08-17-embedded-binary-content-store.md`.
       Phases 1–2 landed: both nested legs of `crates/mvm-cli/build.rs` are keyed
       on their real dependency closure rather than on `PROFILE == "debug"` plus

--- a/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
+++ b/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
@@ -1,0 +1,102 @@
+# Admission-bound AI assurance sessions
+
+Status: **W1–W3 landed. W4–W8 open.**
+
+An AI workload can drive a Scout-linked assurance campaign from inside an
+admitted microVM. This plan is the MVM half of that: the typed envelope the
+workload receives, the authority it runs under, the one probe verb it may
+call, and the host-derived outcome.
+
+The counterparty is `mvm-assurance` (`mvm-scout` + `mvm-security`). It owns
+source analysis, campaign planning, and the final evidence report. It does not
+own — and must not simulate — the microVM lifecycle, the isolation controls,
+the observer signals, or the admission facts.
+
+## Trust split
+
+Everything crossing into an AI session is an identifier, a digest, or a
+reference. No secret value, host path, socket name, or log body appears in any
+type in `mvm_contract::assurance`.
+
+Three properties are structural rather than checked at runtime:
+
+- The provider's half of the envelope (`AssuranceSessionRequest`) cannot carry
+  admission facts. `deny_unknown_fields` refuses an `mvm_binding` key outright,
+  and the assembled `AiSessionInput` has no `Deserialize` at all — it is only
+  constructible from an `MvmBinding` derived from a signed `ExecutionPlan`.
+- The AI's reply (`TrialResultCandidate`) has no outcome field, so
+  "the model wrote PREVENTED" is not a representable state.
+- Effective authority is one intersected value (`EffectiveAuthority`), not a
+  set of checks spread across the dispatch path.
+
+## Landed
+
+- [x] **W1 — Contract.** `mvm_contract::assurance`: bounded ids/digests/refs,
+      the `mvm.assurance.ai-session-input/v1` envelope, the AI candidate, the
+      host-assembled `mvm.assurance.trial-result/v1` document, and size,
+      length, collection, budget and control-character limits. Nesting depth is
+      fixed by the schema — there is no recursive type and no free-form
+      `Value` — so there is no depth counter to get wrong.
+- [x] **W2 — Admission binding and authority.** `MvmBinding::builder().plan(&plan)`
+      quotes the admitted plan; the builder refuses a binding that cites no
+      audit entry or no receipt. `EffectiveAuthority::intersect` narrows
+      extension maximum ∩ request ∩ policy ceiling ∩ signed grant ∩ explicit
+      approval, and a `campaign_probe.v1` without operator approval does not
+      survive it.
+- [x] **W3 — Probe surface.** `host.assurance.v1` in `mvm-hostd`, registered
+      only when `ExecutionPlan.services` names it, exposing one verb. The AI
+      selects a declared destination *label*; the host resolves it against the
+      campaign's operator-declared table and consults the live
+      `mvm_core::egress_broker::decide_egress`. Idempotency-key replay returns
+      the first result without burning a step; nonce replay, session/trial
+      mismatch, step exhaustion and deadline expiry each refuse distinctly.
+- [x] **W3.1 — Counterparty wire conformance.** `assurance::wire` projects the
+      exact key sets `apps/mvm-security/src/ai_session.rs` validates, and the
+      envelope reports *effective* authority — the counterparty rejects the
+      `deadline_unix_ms: 0` a request may carry to mean "none set".
+
+## Open
+
+- [ ] **W4 — Guest-side API.** A workload-facing helper over
+      `mvm-agentd`'s broker client so an in-guest SDK calls the probe verb
+      without hand-rolling the envelope. The transport already exists
+      (`broker_client.rs`); only the typed wrapper is missing.
+- [ ] **W5 — Observer and cleanup evidence.** `EvidenceSet` is consumed by the
+      evaluator but nothing populates `observer_verified` /
+      `cleanup_verified` / `attestation_verified` from a real run yet. Until
+      that lands every live trial evaluates to `INCONCLUSIVE`, which is the
+      correct fail-closed behaviour and not a certifying result.
+- [ ] **W6 — Session lifecycle wiring.** `HostAssuranceV1Handler::open_session`
+      is called by tests only. It needs a caller on the admit path that mints
+      the grant, intersects authority, and closes the session at teardown.
+- [ ] **W7 — Receipt and audit emission.** The binding cites audit and receipt
+      references; emitting `assurance.probe` entries into the chain-signed log
+      and an execution receipt per trial is not wired.
+- [ ] **W8 — Provider binary.** The counterparty's
+      `assurance run --provider <path>` spawns a framed-stdio provider speaking
+      `mvm.security.campaign-request/v1`. MVM ships no such binary, so no
+      certifying campaign can run today. See the blocker note below.
+
+## Cross-repository blocker
+
+`mvm-security assurance plan` reports the brokers it needs and cannot reach:
+
+```
+immutable_snapshot, builder_microvm, subject_microvm, guest_observer,
+host_observer, execution_receipts, artifact_sealing
+```
+
+Seven, of which this plan's landed work addresses none directly — W1–W3 build
+the authority and contract layer those brokers would be driven through. The
+counterparty's own milestone M3 ("broker-backed execution") is unstarted, and
+its plan 006 states plainly that an ordinary `machine run` receipt must remain
+`INCONCLUSIVE`. Until W5–W8 and M3 both land, the only provider that exists is
+`mvm-security-fixtured`, which is explicitly non-certifying.
+
+## Narrative coverage
+
+The one implemented probe is `egress.admission.v1`, which serves
+network-egress narratives. The campaign the reference scan actually emits is
+`mvm.boundary.tool-authority.v1`, which it does not serve. Adding a probe is a
+new `ProbeInvocation` variant plus its dispatch arm; the enum is closed so a
+variant without an arm does not compile.

--- a/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
+++ b/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
@@ -1,5 +1,8 @@
 # Admission-bound AI assurance sessions
 
+Backing: shipped-source
+Validation: a_provider_cannot_smuggle_an_mvm_binding_through_the_request_parser
+
 Status: **W1–W3 landed. W4–W8 open.**
 
 An AI workload can drive a Scout-linked assurance campaign from inside an

--- a/specs/sprint/delivery/assurance-ai-session-contract.md
+++ b/specs/sprint/delivery/assurance-ai-session-contract.md
@@ -1,0 +1,69 @@
+# Admission-bound AI assurance sessions — contract, authority, probe surface
+
+Plan: `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`
+
+## What landed
+
+`mvm_contract::assurance` (new module, `protocol`-gated like `plan`) and
+`host.assurance.v1` in `mvm-hostd`. 65 new tests, all green.
+
+The load-bearing decisions, and why they are shaped the way they are:
+
+**The envelope is two types, not one.** `AssuranceSessionRequest` is the
+untrusted provider half and derives `Deserialize` with `deny_unknown_fields`;
+`AiSessionInput` is the assembled envelope and derives `Serialize` only. A
+provider that sends an `mvm_binding` key fails parsing, and a forged binding is
+not a check that can fail — it is a value that cannot be built. One type with a
+runtime check would have put the parser that reads provider bytes and the
+parser that can populate admission facts in the same place.
+
+**The AI has no verdict field.** `TrialResultCandidate` reports what was
+attempted and what it believes it saw. `PREVENTED` and `CONTAINED` are computed
+by `evaluate` from host evidence.
+
+**Disagreement is fatal rather than ignored.** The host observes the same three
+facts the candidate reports. The obvious design uses the host's values and
+discards the model's; this one compares them and returns `INCONCLUSIVE` on a
+mismatch, because a model contradicting the observer is a signal that something
+is wrong with the trial, and silently overwriting it throws that signal away.
+
+**Authority is one intersected value.** `EffectiveAuthority::intersect` narrows
+extension maximum ∩ request ∩ policy ceiling ∩ signed grant ∩ explicit
+approval. Five checks spread across the dispatch path fail open the first time
+someone adds a caller and forgets one.
+
+**The probe takes a label, not a destination.** The model names a declared
+label; the host resolves it against the campaign's operator-declared table and
+calls the live `mvm_core::egress_broker::decide_egress`. An undeclared label
+never reaches the policy engine, and the test for that also asserts nothing was
+recorded as attempted — so an unrestricted policy cannot become a crossed
+boundary by accident.
+
+## Drift corrected against the counterparty
+
+The implementation prompt described `mvm.assurance.trial-result/v1` as the
+document the AI returns, carrying five fields. The counterparty's actual
+validator (`apps/mvm-security/src/ai_session.rs`) reads that schema as an
+exact **eighteen**-key host record including `identity_verified`,
+`observer_verified`, `cleanup_verified` and `attestation_verified` — none of
+which a model is in a position to assert. Conforming to the code rather than
+the prose: the AI's reply is
+`mvm.assurance.trial-result-candidate/v1`, and MVM assembles the
+eighteen-key `trial-result/v1` document.
+
+Two further shapes were wrong in the prompt and are now conformed:
+`mvm_binding` is a flat ten-key block (the grant is projected into
+`session_grant_digest` / `expires_at_unix_ms` / `nonce` / `allowed_tools`), and
+`authority.deadline_unix_ms` must be `>= 1` — so the envelope reports
+*effective* authority, since a request may legitimately carry `0` to mean "no
+deadline set". Exact key sets are asserted by test in both directions.
+
+## What this does not prove
+
+No certifying campaign can run. `mvm-security assurance plan` names seven
+brokers it cannot reach, the counterparty's broker-backed execution milestone
+is unstarted, and the only provider binary that exists anywhere is the
+explicitly non-certifying `mvm-security-fixtured`. Observer, cleanup and
+receipt evidence are consumed by the evaluator but not yet populated from a
+real run, so a live trial evaluates to `INCONCLUSIVE` — correct, fail-closed,
+and not a pass. Plan W4–W8 track the rest.


### PR DESCRIPTION
An AI workload can drive a Scout-linked assurance campaign from inside an
admitted microVM. This is the MVM half: the typed envelope the workload
receives, the authority it runs under, the one probe verb it may call, and the
host-derived outcome of a trial.

The counterparty is the separate `mvm-assurance` project (`mvm-scout` +
`mvm-security`). It owns source analysis, campaign planning, and the final
evidence report. It does not own — and must not simulate — the microVM
lifecycle, the isolation controls, the observer signals, or the admission facts.

## Three properties are structural, not checked

**The envelope is two types.** `AssuranceSessionRequest` is the untrusted
provider half and derives `Deserialize` with `deny_unknown_fields`, so a
provider that sends an `mvm_binding` key fails parsing outright.
`AiSessionInput` derives `Serialize` only and is constructible solely from an
`MvmBinding` derived from a signed `ExecutionPlan`. A forged binding is not a
check that can fail; it is a value that cannot be built. One type with a runtime
guard would have put the parser that reads provider bytes and the parser that
can populate admission facts in the same place.

**The AI has no verdict field.** `TrialResultCandidate` reports what was
attempted and what it believes it saw; `evaluate` derives `PREVENTED` and
`CONTAINED` from host evidence. Where the candidate contradicts the host
observer the trial is `INCONCLUSIVE` rather than silently corrected — a model
disagreeing with the observer is a signal about the trial, and overwriting its
answer discards that signal.

**Effective authority is one intersected value.** `EffectiveAuthority::intersect`
narrows extension maximum ∩ request ∩ policy ceiling ∩ signed grant ∩ explicit
approval. Five checks spread across the dispatch path fail open the first time a
caller is added and one is missed.

## The probe surface

`host.assurance.v1` registers only when `ExecutionPlan.services` names it, and
exposes one verb. The model selects a declared destination *label*; the host
resolves it against the campaign's operator-declared table and consults the live
`mvm_core::egress_broker::decide_egress`. An undeclared label never reaches the
policy engine, and the test for that also asserts nothing was recorded as
attempted — so an unrestricted policy cannot become a crossed boundary by
accident. Idempotency-key replay returns the first result without burning a
step; nonce replay, session/trial mismatch, step exhaustion and deadline expiry
each refuse distinctly.

This is the production-safe alternative to handing an AI workload the dev-only
`Exec` verb: no command, no path, no host, no port ever crosses.

## Wire conformance corrected the written spec

The counterparty validates with *exact* key sets, and its live validator
(`apps/mvm-security/src/ai_session.rs`) disagreed with the spec I was working
from in three places. Conforming to the code rather than the prose:

- `mvm.assurance.trial-result/v1` is the eighteen-key **host** record, including
  `identity_verified` / `observer_verified` / `cleanup_verified` /
  `attestation_verified` — none of which a model is in a position to assert. So
  the AI's reply is `mvm.assurance.trial-result-candidate/v1`, and MVM assembles
  the real document.
- `mvm_binding` is a flat ten-key block; the grant is projected into
  `session_grant_digest` / `expires_at_unix_ms` / `nonce` / `allowed_tools`.
- `authority.deadline_unix_ms` must be `>= 1`, but a request legitimately
  carries `0` to mean "none set" — so the envelope reports **effective**
  authority rather than requested, which is also the better answer for the model.

Exact key sets are asserted by test in both directions.

## What this does not prove

No certifying campaign can run yet, and nothing here claims otherwise.
`mvm-security assurance plan` names seven brokers it cannot reach
(`immutable_snapshot`, `builder_microvm`, `subject_microvm`, `guest_observer`,
`host_observer`, `execution_receipts`, `artifact_sealing`), the counterparty's
broker-backed execution milestone is unstarted, and the only provider binary
that exists anywhere is the explicitly non-certifying `mvm-security-fixtured`.

Observer, cleanup and receipt evidence are consumed by the evaluator but not yet
populated from a real run, so a live trial evaluates `INCONCLUSIVE` — correct,
fail-closed, and not a pass. W4–W8 in the plan track the rest: guest-side API,
observer/cleanup evidence, session lifecycle on the admit path, receipt/audit
emission, and the framed-stdio provider binary.

The one implemented probe is `egress.admission.v1`, which serves network-egress
narratives. The campaign the reference scan emits is
`mvm.boundary.tool-authority.v1`, which it does not serve. Adding a probe is a
new `ProbeInvocation` variant plus its dispatch arm; the enum is closed, so a
variant without an arm does not compile.

## Verification

- `cargo fmt --all -- --check` (stable and nightly) — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace -j 6` — 12,225 passed, 0 failed
- `cargo test --workspace --doc` — pass
- `cargo check -p mvm-conformance --all-targets --features bdd` — pass (the
  `--all-targets` blind spot this PR's signature change touches)
- `just check-embedded` (riscv32 bare-metal no_std) — pass, so the new
  `mvm-contract` module is genuinely no_std + alloc clean
- 10 xtask gates including `check-no-spec-refs-in-comments`, `check-honesty`,
  `check-deferrals`, `check-claim-catalog`, `check-conformance` — all pass

65 new tests. Plan:
`specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`.
