### PR TITLE
perf(fc): skip sudo on the launch line when already root

### DIFF
--- a/crates/mvm-backends/src/fc/daemon.rs
+++ b/crates/mvm-backends/src/fc/daemon.rs
@@ -135,12 +135,38 @@ fn start_vm_firecracker_inner(
 /// was in fact booting normally. Writing `$$` from inside is correct whichever
 /// of `sudo`/`setsid` forks, since the `exec` makes that same pid Firecracker.
 /// The `sh -c` costs no surviving process for the same reason.
+/// The `sudo ` prefix a launch needs, or empty when the caller is already root.
+///
+/// `sudo` is on this path because the invoking user usually cannot open
+/// `/dev/kvm`. When mvmctl already runs as root it buys nothing and costs a
+/// process exec — measured at ~7 ms on the reference builder host, twice per
+/// launch, against a dispatch budget in the low hundreds.
+///
+/// Pure over the effective uid so the decision is testable without running the
+/// suite as root, which is the only way this branch could otherwise be covered.
+pub(crate) fn sudo_prefix_for_euid(euid: u32) -> &'static str {
+    if euid == 0 { "" } else { "sudo " }
+}
+
 fn firecracker_launch_script(
     abs_dir: &str,
     abs_socket: &str,
     clean_vsock: bool,
     cpu_scope: &str,
 ) -> String {
+    firecracker_launch_script_as(abs_dir, abs_socket, clean_vsock, cpu_scope, unsafe {
+        libc::geteuid()
+    })
+}
+
+fn firecracker_launch_script_as(
+    abs_dir: &str,
+    abs_socket: &str,
+    clean_vsock: bool,
+    cpu_scope: &str,
+    euid: u32,
+) -> String {
+    let sudo = sudo_prefix_for_euid(euid);
     let vsock = firecracker_vsock_uds_path(abs_dir);
     let vsock_cleanup = if clean_vsock {
         format!(
@@ -157,10 +183,10 @@ fn firecracker_launch_script(
     format!(
         r#"
         mkdir -p {q_dir}
-        sudo rm -f {q_socket}
+        {sudo}rm -f {q_socket}
         {vsock_cleanup}
         touch {q_dir}/console.log {q_dir}/firecracker.log
-        {cpu_scope}sudo setsid nohup sh -c 'echo $$ > "$0"; exec firecracker --api-sock "$1" --enable-pci' {q_pid} {q_socket} \
+        {cpu_scope}{sudo}setsid nohup sh -c 'echo $$ > "$0"; exec firecracker --api-sock "$1" --enable-pci' {q_pid} {q_socket} \
             </dev/null >{q_dir}/console.log 2>{q_dir}/firecracker.log &
         "#,
         q_dir = q_dir,
@@ -168,6 +194,7 @@ fn firecracker_launch_script(
         q_socket = q_socket,
         vsock_cleanup = vsock_cleanup,
         cpu_scope = cpu_scope,
+        sudo = sudo,
     )
 }
 
@@ -384,7 +411,8 @@ mod tests {
             scratch.path(),
             Some(&mvm_contract::grants::CpuGrant::Share { millicores: 1500 }),
         );
-        let script = firecracker_launch_script("/tmp/vm", "/tmp/vm/fc.socket", true, &prefix);
+        let script =
+            firecracker_launch_script_as("/tmp/vm", "/tmp/vm/fc.socket", true, &prefix, 1000);
 
         assert!(script.contains("CPUQuota=150%"), "{script}");
         // The unit carries a per-boot suffix, so match the stem rather than a
@@ -406,7 +434,7 @@ mod tests {
 
     #[test]
     fn an_ungranted_launch_line_carries_no_scope() {
-        let script = firecracker_launch_script("/tmp/vm", "/tmp/vm/fc.socket", true, "");
+        let script = firecracker_launch_script_as("/tmp/vm", "/tmp/vm/fc.socket", true, "", 1000);
         assert!(!script.contains("systemd-run"), "{script}");
         assert!(script.contains("sudo setsid nohup sh -c"), "{script}");
         assert!(
@@ -422,7 +450,7 @@ mod tests {
     /// liveness probe read every boot as an immediate VMM exit.
     #[test]
     fn the_pid_marker_is_written_by_the_launched_process_not_the_caller() {
-        let script = firecracker_launch_script("/tmp/vm", "/tmp/vm/fc.socket", true, "");
+        let script = firecracker_launch_script_as("/tmp/vm", "/tmp/vm/fc.socket", true, "", 1000);
 
         assert!(
             !script.contains("echo $!"),
@@ -449,5 +477,71 @@ mod tests {
         // way the boot proceeds unbounded rather than failing.
         let scratch = tempfile::tempdir().expect("scratch");
         assert_eq!(cpu_scope_prefix("vm-x", scratch.path(), None), "");
+    }
+}
+
+#[cfg(test)]
+mod sudo_elision_tests {
+    use super::*;
+
+    /// A non-root caller cannot open /dev/kvm, so the elevation must stay.
+    #[test]
+    fn a_non_root_launch_still_elevates() {
+        assert_eq!(sudo_prefix_for_euid(1000), "sudo ");
+        let script = firecracker_launch_script_as("/tmp/vm", "/tmp/vm/fc.socket", true, "", 1000);
+        assert!(script.contains("sudo setsid nohup sh -c"), "{script}");
+        assert!(script.contains("sudo rm -f"), "{script}");
+    }
+
+    /// Already root: sudo buys no privilege and costs a process exec on a path
+    /// measured in milliseconds.
+    #[test]
+    fn a_root_launch_skips_sudo_entirely() {
+        assert_eq!(sudo_prefix_for_euid(0), "");
+        let script = firecracker_launch_script_as("/tmp/vm", "/tmp/vm/fc.socket", true, "", 0);
+        assert!(
+            !script.contains("sudo"),
+            "root launch must not shell out to sudo: {script}"
+        );
+    }
+
+    /// The pid marker is the part that broke before: `$!` names sudo's monitor
+    /// under use_pty, so the pid is written from inside and made correct by the
+    /// `exec`. That has to hold whether or not sudo is in the line.
+    #[test]
+    fn both_shapes_write_the_pid_from_inside_and_exec_firecracker() {
+        for euid in [0, 1000] {
+            let script =
+                firecracker_launch_script_as("/tmp/vm", "/tmp/vm/fc.socket", true, "", euid);
+            assert!(
+                script.contains(r#"echo $$ > "$0""#),
+                "euid {euid} must write the pid from inside: {script}"
+            );
+            assert!(
+                script.contains("exec firecracker"),
+                "euid {euid} must exec so the pid names Firecracker: {script}"
+            );
+            assert!(
+                script.contains("setsid nohup sh -c"),
+                "euid {euid}: {script}"
+            );
+        }
+    }
+
+    /// A CPU grant's scope must still precede the launch in both shapes.
+    #[test]
+    fn the_cpu_scope_precedes_the_launch_with_and_without_sudo() {
+        for euid in [0, 1000] {
+            let script = firecracker_launch_script_as(
+                "/tmp/vm",
+                "/tmp/vm/fc.socket",
+                true,
+                "systemd-run --scope ",
+                euid,
+            );
+            let scope_at = script.find("systemd-run").expect("scope present");
+            let launch_at = script.find("setsid nohup sh -c").expect("launch present");
+            assert!(scope_at < launch_at, "euid {euid}: {script}");
+        }
     }
 }


### PR DESCRIPTION
## What

Firecracker is launched through `sudo` because the invoking user usually cannot open `/dev/kvm`. When `mvmctl` **already runs as root** — as it does on the reference builder host, and on any Linux deployment starting it as a service — sudo grants nothing and costs a process exec. Plan 299 measured **~7 ms per `sudo bash -c true`** on that host, and the launch line pays it twice.

The elevation is now conditional on the effective uid. A non-root caller gets exactly the line it got before.

## What is deliberately NOT changed

I originally proposed removing the `sudo setsid nohup sh -c` wrapper wholesale as an easy win. Reading the code showed that would have been a mistake, and the shape is load-bearing:

- The pid marker is written **from inside** with `echo $$`, not by the caller with `$!`, because `sudo` with `use_pty` (default since 1.9.14, which Ubuntu 24.04 ships) **forks a monitor** rather than exec'ing. `$!` then names a process whose `comm` is `sudo`, and liveness is probed by comparing `/proc/<pid>/comm` against `firecracker` — so every boot read as "the VMM exited" while the guest booted normally.
- The `sh -c` leaves no surviving process, because of the `exec`.

So **the cost on this path is `sudo`, not `sh`.** Removing the shell would save nothing and reintroduce a documented pid bug.

## Tests

The decision is a pure function over the euid, so both branches are covered without running the suite as root — otherwise the root branch could only ever be exercised by whichever machine happened to run it.

- non-root line is unchanged (`sudo setsid nohup sh -c`, `sudo rm -f`)
- root line contains **no** `sudo` at all
- **both** shapes still write the pid from inside and `exec firecracker` — the property that broke before
- a CPU grant's `systemd-run` scope still precedes the launch in both shapes

## Honest sizing

This is **~14 ms of an ~82 ms gap** on the reference host. It is worth having and it does not close that gap.

Firecracker there runs **3.08x** HVF on VMM create (36.6 ms vs 11.9 ms) and **3.04x** on guest boot (186.3 ms vs 61.2 ms) — two independent phases, same factor. That is the host's speculative-execution mitigation cost (IBRS/PTI/L1TF/MDS on a 2017 Kaby Lake), not a code path. Dividing 281.6 ms by 3 gives ~94 ms, which is where HVF actually measures.

## Verification

`cargo nextest run --workspace` — **12,164 passed**. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo +nightly fmt --all -- --check` clean.

Not yet measured end-to-end on the reference host: its builder is only now getting past the egress and store defects fixed in #2629, #2640 and #2665. The ~14 ms is derived from plan 299's `sudo` measurement on that same host, not from a before/after of this change.