### PR TITLE
feat(cli): `mvmctl bench` — give the latency harness a front door

### DIFF
--- a/crates/mvm-cli/src/commands/bench.rs
+++ b/crates/mvm-cli/src/commands/bench.rs
@@ -1,0 +1,266 @@
+//! `mvmctl bench` — measure this host's launch latency against the published
+//! budgets.
+//!
+//! The measurement substrate has existed for a while: lanes, percentile
+//! statistics, a versioned JSON report, and the budgets the docs publish. What
+//! it did not have was a way for a user to run it. Only the CI gate and the
+//! conformance suite drove it, so "is this host meeting the contract?" was a
+//! question only the project could ask about its own runners, and the numbers
+//! in the docs were unfalsifiable by the person they most concerned.
+//!
+//! This verb drives the same harness the gate does, against the same budgets,
+//! and writes the same report shape — deliberately, so a user's report and a
+//! CI report are comparable artifacts rather than two formats that happen to
+//! carry similar numbers.
+
+use anyhow::{Context, Result};
+use clap::Args as ClapArgs;
+
+use crate::bench::cold_launch::{LaunchLane, MIN_MATRIX_SAMPLES};
+use crate::bench::cold_launch_runner::ColdLaunchBench;
+use crate::ui;
+
+/// Selectable lanes. Mirrors [`LaunchLane`] rather than re-deriving `ValueEnum`
+/// on it: the bench module is a library surface and should not grow a clap
+/// dependency to be selectable from one verb.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(in crate::commands) enum LaneArg {
+    /// Cached artifacts, no mount image — the headline cold number.
+    PreparedCold,
+    /// The same launch with an unchanged cached read-only mount image.
+    PreparedColdMountHit,
+    /// Directory fingerprint plus first mount-image materialization.
+    MountMiss,
+    /// Image acquisition, unpack, verification, and preparation.
+    ArtifactMiss,
+    /// A claimed warm standby. Never folded into a cold number.
+    WarmClaim,
+}
+
+impl From<LaneArg> for LaunchLane {
+    fn from(arg: LaneArg) -> Self {
+        match arg {
+            LaneArg::PreparedCold => LaunchLane::PreparedCold,
+            LaneArg::PreparedColdMountHit => LaunchLane::PreparedColdMountHit,
+            LaneArg::MountMiss => LaunchLane::MountMiss,
+            LaneArg::ArtifactMiss => LaunchLane::ArtifactMiss,
+            LaneArg::WarmClaim => LaunchLane::WarmClaim,
+        }
+    }
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Which launch lane to measure.
+    #[arg(long, value_enum, default_value = "prepared-cold")]
+    pub lane: LaneArg,
+    /// Measured launches. Below 20 the report is not publication-grade.
+    #[arg(long, default_value_t = 20)]
+    pub runs: u32,
+    /// Warm-up launches, discarded before measuring.
+    #[arg(long, default_value_t = 2)]
+    pub warmup: u32,
+    /// Write the report here instead of under `~/.mvm/state/bench/`.
+    #[arg(long, value_name = "PATH")]
+    pub out: Option<std::path::PathBuf>,
+    /// Print the report as JSON instead of a human summary.
+    #[arg(long)]
+    pub json: bool,
+    /// Measure even from a debug build, whose numbers mean nothing.
+    #[arg(long)]
+    pub allow_debug_build: bool,
+    /// The launch to measure, after `--`. Defaults to the reproducible
+    /// baseline below.
+    #[arg(trailing_var_arg = true)]
+    pub launch: Vec<String>,
+}
+
+/// The launch measured when the caller names none.
+///
+/// Chosen to be the same on every host rather than to be representative: the
+/// bundled default image so nothing is pulled, `--no-detect` so the working
+/// directory cannot change which image boots, and a trivial command so the
+/// number is the launch rather than the workload. A baseline that varies with
+/// where it was run is not a baseline.
+const DEFAULT_LAUNCH: [&str; 4] = ["run", "--no-detect", "--", "/bin/true"];
+
+pub(in crate::commands) fn run(args: Args) -> Result<()> {
+    // A debug binary is 5-10x slower on the same work, so its percentiles are
+    // not this host's latency — they are this build profile's. Publishing or
+    // comparing them would be worse than having no number, so refuse by
+    // default and say exactly what to do instead.
+    if cfg!(debug_assertions) && !args.allow_debug_build {
+        anyhow::bail!(
+            "refusing to measure from a debug build — its timings are the build profile's, \
+             not this host's. Build with `--release` and run that binary, or pass \
+             `--allow-debug-build` if you only want the shape of the report."
+        );
+    }
+
+    let lane: LaunchLane = args.lane.into();
+
+    // The harness shells out to a built `mvmctl`, and the one running this is
+    // exactly that — no path to guess and no chance of measuring a different
+    // binary than the user invoked.
+    let mvmctl = std::env::current_exe().context("resolving this mvmctl binary's path")?;
+
+    if !args.json {
+        ui::info(&format!(
+            "Measuring lane `{}` ({}) — {} run(s), {} warm-up(s)",
+            lane.as_str(),
+            lane.description(),
+            args.runs,
+            args.warmup
+        ));
+        if args.runs < MIN_MATRIX_SAMPLES {
+            ui::warn(&format!(
+                "{} runs is below the {MIN_MATRIX_SAMPLES}-sample publication floor; \
+                 this report is indicative only",
+                args.runs
+            ));
+        }
+    }
+
+    let launch: Vec<String> = if args.launch.is_empty() {
+        DEFAULT_LAUNCH.iter().map(|s| s.to_string()).collect()
+    } else {
+        args.launch.clone()
+    };
+
+    if !args.json {
+        ui::info(&format!("Launch: mvmctl {}", launch.join(" ")));
+        // Every lane but `artifact_miss` assumes the artifacts are already
+        // there. On a cold `~/.mvm` the first launch pays a one-time builder
+        // bootstrap, and folding that into a launch percentile would overstate
+        // this host's latency by orders of magnitude. The runner's lane
+        // validation refuses such a sample rather than publishing it, so the
+        // failure is loud — but saying so first turns a confusing refusal into
+        // one instruction.
+        if lane != LaunchLane::ArtifactMiss {
+            ui::info(
+                "This lane measures launches against a warm cache. Run `mvmctl prepare` first \
+                 if this host has not launched before, or the first sample pays a one-time \
+                 bootstrap and the runner will refuse it.",
+            );
+        }
+    }
+
+    let report = ColdLaunchBench::builder(&mvmctl, lane)
+        .args(launch)
+        .runs(args.runs)
+        .warmup(args.warmup)
+        .build()?
+        .run()
+        .context("running the launch benchmark")?;
+
+    let out_path = crate::bench::write_report_with_latest(&report, args.out.clone(), "bench")
+        .context("writing the benchmark report")?;
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    print_summary(&report);
+    ui::info(&format!("\nReport: {}", out_path.display()));
+    Ok(())
+}
+
+/// Print each measured percentile beside the budget it is judged against, so
+/// the verdict is visible rather than something the reader has to look up.
+fn print_summary(report: &crate::bench::cold_launch::ColdLaunchReport) {
+    let budgets = report.lane.budgets();
+    println!("\nlane: {}", report.lane.as_str());
+    println!("samples: {}", report.stats.dispatch_window_ms.samples);
+    println!("\n  percentile   measured     budget   verdict");
+
+    let measured = report.stats.dispatch_window_ms.by_percentile();
+    for ((label, value), (_, budget)) in measured.iter().zip(budgets.by_percentile().iter()) {
+        let measured_s = value.map_or_else(|| "—".to_string(), |v| format!("{v:.1} ms"));
+        let budget_s = budget.map_or_else(|| "—".to_string(), |b| format!("{b:.0} ms"));
+        let verdict = match (value, budget) {
+            (Some(v), Some(b)) if *v <= *b => "ok",
+            (Some(_), Some(_)) => "OVER",
+            _ => "",
+        };
+        println!("  {label:<11}{measured_s:>10}{budget_s:>11}   {verdict}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(argv: &[&str]) -> Result<Args> {
+        let mut full = vec!["mvmctl", "bench"];
+        full.extend_from_slice(argv);
+        let cli = crate::commands::Cli::try_parse_from(full)?;
+        match cli.command {
+            crate::commands::Commands::Bench(a) => Ok(a),
+            _ => panic!("expected Commands::Bench"),
+        }
+    }
+
+    #[test]
+    fn the_default_lane_is_the_headline_cold_number() {
+        let args = parse(&[]).expect("bare `bench` parses");
+        assert_eq!(args.lane, LaneArg::PreparedCold);
+        assert_eq!(args.runs, MIN_MATRIX_SAMPLES);
+        assert!(!args.json);
+        assert!(
+            args.launch.is_empty(),
+            "the default launch is applied later"
+        );
+    }
+
+    /// The default has to be host-independent or the baseline is not one.
+    #[test]
+    fn the_default_launch_pulls_nothing_and_ignores_the_directory() {
+        assert!(
+            DEFAULT_LAUNCH.contains(&"--no-detect"),
+            "the working directory must not choose the measured image"
+        );
+        assert!(
+            !DEFAULT_LAUNCH.contains(&"--image"),
+            "the baseline must not depend on a registry pull"
+        );
+    }
+
+    #[test]
+    fn a_caller_supplied_launch_wins() {
+        let args = parse(&["--", "run", "--image", "alpine", "--", "true"]).expect("parses");
+        assert_eq!(args.launch.first().map(String::as_str), Some("run"));
+        assert!(args.launch.iter().any(|a| a == "alpine"));
+    }
+
+    #[test]
+    fn every_lane_is_selectable_and_maps_to_its_harness_lane() {
+        // A lane the CLI cannot select is a lane a user cannot measure, and
+        // the two enums are separate declarations that could drift.
+        for lane in LaunchLane::ALL {
+            let flag = lane.as_str().replace('_', "-");
+            let args = parse(&["--lane", &flag])
+                .unwrap_or_else(|e| panic!("lane `{flag}` must be selectable: {e}"));
+            assert_eq!(
+                LaunchLane::from(args.lane),
+                lane,
+                "`--lane {flag}` must map to {lane:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_debug_build_refuses_unless_the_caller_opts_in() {
+        // Guarded on the profile this test is compiled in: under `--release`
+        // there is nothing to refuse.
+        if !cfg!(debug_assertions) {
+            return;
+        }
+        let err = run(parse(&[]).expect("parses")).expect_err("a debug build must refuse");
+        assert!(
+            err.to_string().contains("debug build"),
+            "the refusal must say why: {err}"
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -209,6 +209,7 @@ impl Commands {
             #[cfg(feature = "builder-vm")]
             Commands::BuilderShellJob(_) => "__builder-shell-job",
             Commands::Explain(_) => "explain",
+            Commands::Bench(_) => "bench",
             Commands::Run(_) => "run",
             Commands::SdkNoVm(_) => "__sdk-no-vm",
             Commands::Doctor(_) => "doctor",

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -23,6 +23,7 @@ impl TopLevelCommand for Commands {
             Commands::BuilderShellJob(a) => builder_shell_job::run(cli, a, cfg),
             Commands::Explain(a) => vm::explain::run(a),
             Commands::Run(a) => vm::exec::run_transient(cli, a, cfg),
+            Commands::Bench(a) => bench::run(a),
             Commands::SdkNoVm(a) => vm::sdk_no_vm::run(&a),
             Commands::Doctor(a) => env::doctor::run(cli, a, cfg),
             Commands::Dashboard(a) => dashboard::run(a),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod bench;
 mod bootstrap;
 mod build;
 #[cfg(feature = "builder-vm")]
@@ -145,6 +146,9 @@ pub(in crate::commands) enum Commands {
     /// Explain a run after the fact from the chain-signed audit log
     #[command(display_order = 7)]
     Explain(vm::explain::Args),
+    /// Measure this host's launch latency against the published budgets
+    #[command(display_order = 7)]
+    Bench(bench::Args),
     /// Rebuild a workload when its local inputs change
     #[command(display_order = 8)]
     Watch(watch::Args),

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -1028,6 +1028,11 @@ running microVM.
 | `mvmctl deploy <ir.json>` | Build, seal, and record a workload into a local deployment directory (`image.tar.gz`, `rootfs.ext4`, `deploy.json`); optionally ship it to mvmd |
 | `mvmctl deploy --from-ir <path>` | Read the Workload IR from a file instead of a positional path or stdin |
 | `mvmctl prepare` | Report whether a verified runtime pack is ready for instant launch |
+| `mvmctl bench` | Measure this host's launch latency against the published budgets, printing each percentile beside the budget it is judged against |
+| `mvmctl bench --lane <lane>` | Pick the lane: `prepared-cold` (default), `prepared-cold-mount-hit`, `mount-miss`, `artifact-miss`, `warm-claim` |
+| `mvmctl bench --runs <n> --warmup <n>` | Sample counts. Below 20 measured runs the report is indicative only, not publication-grade |
+| `mvmctl bench --json` | Emit the versioned report JSON — the same shape the CI gate produces, so the two are comparable |
+| `mvmctl bench -- <launch>` | Measure a specific launch instead of the reproducible default (`run --no-detect -- /bin/true`) |
 | `mvmctl explain <run>` | Explain a run after the fact from the chain-signed audit log |
 | `mvmctl watch <ir.json>` | Rebuild a workload when its local inputs change |
 

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -330,15 +330,30 @@ audited like any other run.
 
 ### Phase 7 — Observability and performance
 
-- [ ] Add `mvmctl doctor --benchmark` (or a new `mvmctl benchmark` verb) that
-      measures cold start, warm claim, and density on the current host.
-- [ ] Emit structured JSON output for CI and regression tracking.
-- [ ] Define warm-start and density SLOs once Plan 298/Plan 255 measurements
-      are stable.
-- [ ] Publish the SLOs in the docs and add a CI gate that fails on regression.
+- [x] Add a benchmark verb: `mvmctl bench`, a separate verb rather than a
+      `doctor` flag — doctor reports posture without side effects, and this
+      boots VMs. Cold start and warm claim are selectable lanes
+      (`--lane prepared-cold|warm-claim|…`). **Density is not covered**; it is
+      Plan 265 WS3 and needs a different harness.
+- [x] Emit structured JSON output for CI and regression tracking — `--json`
+      prints, and every run writes, the same versioned report the CI gate
+      produces, so a user's report and a CI report are comparable artifacts.
+- [x] Warm-start budgets were already defined and published (200/250/300 ms
+      prepared-cold p50/p95/p99; 30/50 ms warm-claim p50/p99). `bench` now
+      prints each measured percentile beside the budget judging it. Density
+      SLOs remain undefined — Plan 265 WS3.
+- [x] Published and gated already (the launch-budget page and the
+      boot-latency lane). This adds the user-facing way to check a host
+      against them.
 
-**Acceptance:** `mvmctl doctor --benchmark --json` produces reproducible numbers;
-SLOs are documented.
+**Acceptance:** `mvmctl bench --json` produces a versioned report against
+documented budgets. Two deliberate refusals keep the numbers meaningful: a
+debug build refuses to measure (its percentiles are the build profile's, not
+the host's), and a run below 20 samples is labelled indicative rather than
+publication-grade.
+
+**Not done:** density. `mvmctl bench` measures latency only; Plan 265 WS3 and
+Phase 4 own density and remain open.
 
 ### Phase 8 — Distribution polish
 

--- a/specs/sprint/delivery/bench-verb.md
+++ b/specs/sprint/delivery/bench-verb.md
@@ -1,0 +1,66 @@
+# `mvmctl bench` — the harness gets a front door
+
+**Plan:** `specs/plans/329-run-first-cli-and-upstream-adoption.md` Phase 7.
+
+## What existed and what did not
+
+The measurement substrate has been in `crates/mvm-cli/src/bench/` for a while:
+five launch lanes, percentile statistics, a versioned JSON report, baseline
+regression gating, and the budgets the docs publish (200/250/300 ms
+prepared-cold p50/p95/p99; 30/50 ms warm-claim p50/p99).
+
+What it did not have was a caller outside the project. Only the CI gate, the
+conformance suite and two `#[ignore]`d tests drove it — so "is my host meeting
+this contract?" was a question only the project could ask about its own
+runners, and the published numbers were unfalsifiable by the people they most
+concerned.
+
+`mvmctl bench` drives the same harness against the same budgets and writes the
+same report shape, deliberately: a user's report and a CI report should be
+comparable artifacts, not two formats carrying similar numbers.
+
+## Why a verb and not `doctor --benchmark`
+
+Plan 329 offered either. `doctor` reports posture without side effects; this
+boots VMs, repeatedly, and takes minutes. Folding it into `doctor` would mean
+the diagnostic command sometimes launches twenty microVMs.
+
+## Three refusals that keep a number honest
+
+- **A debug build refuses to measure.** A debug binary is several times slower
+  on the same work, so its percentiles describe the build profile, not the
+  host. Publishing or comparing them is worse than having no number.
+  `--allow-debug-build` exists for looking at the report's shape.
+- **Below 20 samples is labelled indicative**, matching the harness's own
+  publication floor, rather than being silently emitted as if comparable.
+- **The default launch is host-independent**: the bundled image (no registry
+  pull), `--no-detect` so the working directory cannot change which image
+  boots, and `/bin/true` so the number is the launch rather than the workload.
+  A baseline that varies with where it was run is not a baseline. `-- <launch>`
+  overrides it.
+
+The verb also warns, before measuring, that the prepared lanes assume a warm
+cache — on a cold `~/.mvm` the first launch pays a one-time builder bootstrap.
+The runner's lane validation already refuses such a sample, so the failure was
+loud but confusing; saying it first turns that into one instruction
+(`mvmctl prepare`).
+
+## Audit posture
+
+`bench` emits nothing itself. It spawns `mvmctl run` once per sample, and each
+of those carries its own `cmd.run` envelope and its own signed-plan admission,
+so auditing the harness on top would double-count the launches it exists to
+measure. Declared `InteractiveOrControl`; the total-coverage test caught the
+omission before it could ship undeclared.
+
+## Not done
+
+**Density.** This measures latency only. Plan 265 WS3 and Phase 4 own density
+and stay open; the plan is updated to say so rather than implying Phase 7 is
+finished.
+
+Verified against the built binary: help renders, every lane is selectable, the
+debug-build refusal fires, and the verb drives a real launch end to end. A full
+20-sample publication-grade measurement was **not** obtained on this host — the
+run reached a cold-cache builder bootstrap, which is the case the new warning
+now describes.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -493,6 +493,11 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // and `init`.
     ("bootstrap", AuditPosture::InteractiveOrControl),
     ("doctor", AuditPosture::ReadOnly),
+    // `bench` emits nothing itself: it spawns `mvmctl run` once per sample,
+    // and each of those launches carries its own `cmd.run` envelope and its
+    // own signed-plan admission. Auditing the harness on top would double-count
+    // the launches it exists to measure.
+    ("bench", AuditPosture::InteractiveOrControl),
     // Resolves and validates the Studio install; spawns nothing today.
     ("dashboard", AuditPosture::ReadOnly),
     // Deploy mutates the local sealed-artifact store and is wrapped by the


### PR DESCRIPTION
Plan 329 Phase 7. **Stacked on #2650** (needs `--no-detect` for its default launch) — retarget to `main` once that merges; review the top commit only.

## The gap

`crates/mvm-cli/src/bench/` has held the measurement substrate for a while: five launch lanes, percentile statistics, a versioned JSON report, baseline regression gating, and the budgets the docs publish (200/250/300 ms prepared-cold p50/p95/p99; 30/50 ms warm-claim p50/p99).

What it lacked was a caller outside the project. Only the CI gate, the conformance suite and two `#[ignore]`d tests drove it — so **"is my host meeting this contract?" was a question only the project could ask about its own runners**, and the published numbers were unfalsifiable by the people they most concerned.

```console
$ mvmctl bench --lane prepared-cold
[mvm] Measuring lane `prepared_cold` (Cached artifacts, no mount image…) — 20 run(s), 2 warm-up(s)
[mvm] Launch: mvmctl run --no-detect -- /bin/true

  percentile   measured     budget   verdict
  p50            —          200 ms
  p95            —          250 ms
  p99            —          300 ms
```

Same harness, same budgets, same report shape as the gate — so a user's report and a CI report are comparable artifacts rather than two formats carrying similar numbers.

## A verb, not `doctor --benchmark`

Plan 329 offered either. `doctor` reports posture without side effects; this boots twenty microVMs and takes minutes.

## Three refusals that keep a number honest

- **A debug build refuses to measure.** Its percentiles describe the build profile, not the host — publishing or comparing them is worse than having no number. `--allow-debug-build` is there for looking at the report's shape.
- **Below 20 samples is labelled indicative**, matching the harness's own publication floor, instead of being emitted silently as if comparable.
- **The default launch is host-independent**: bundled image (no registry pull), `--no-detect` so the working directory can't change which image boots, `/bin/true` so the number is the launch and not the workload. A baseline that varies with where it ran isn't one. `-- <launch>` overrides.

It also warns *before* measuring that prepared lanes assume a warm cache. On a cold `~/.mvm` the first launch pays a one-time builder bootstrap; the runner's lane validation already refused that sample, so the failure was loud but confusing. Saying it first makes it one instruction (`mvmctl prepare`).

## Audit posture

`bench` emits nothing itself — it spawns `mvmctl run` per sample, and each carries its own `cmd.run` envelope and signed-plan admission, so auditing the harness would double-count the launches it exists to measure. Declared `InteractiveOrControl`. The total-coverage test caught the missing declaration before it could ship.

## Not done: density

This measures **latency only**. Plan 265 WS3 and Phase 4 own density and stay open — Phase 7's checkboxes now say so rather than reading as finished.

## Verification

`cargo nextest run --workspace` — **12188 passed, 0 failed**. Workspace clippy `--all-targets`, nightly fmt, `check-cli-help-matches-docs` and four more gates.

Against the built binary: help renders, every lane is selectable (a test walks `LaunchLane::ALL` and asserts each maps through, since the CLI enum and the harness enum are separate declarations that could drift), the debug-build refusal fires, and the verb drives a real launch end to end.

**A full 20-sample publication-grade measurement was not obtained on this host** — the run reached a cold-cache builder bootstrap, which is exactly the case the new warning describes. Saying so rather than implying the numbers were validated here.