### PR TITLE
fix(release): sign boot images under the environment that admits their tags

### DIFF
--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -60,8 +60,15 @@ jobs:
     # gate on top of the tag-push trigger already enforced above — so the
     # identity a released binary trusts can't be minted from an arbitrary
     # branch or workflow_dispatch run.
-    environment: release-signing
+    environment: boot-image-signing
     strategy:
+      # One arch's build must not cancel the other's. The sibling is a separate
+      # artifact, and a transient failure on one runner used to take the other
+      # down before it produced anything — which then read as two broken arches.
+      # Publishing is still all-or-nothing: the completeness gate below refuses
+      # a partial set, so letting both finish costs nothing and tells the truth
+      # about which one actually failed.
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64
@@ -254,6 +261,13 @@ jobs:
     # Skipped on a dry-run dispatch (see builder-vm-image).
     if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
     strategy:
+      # One arch's build must not cancel the other's. The sibling is a separate
+      # artifact, and a transient failure on one runner used to take the other
+      # down before it produced anything — which then read as two broken arches.
+      # Publishing is still all-or-nothing: the completeness gate below refuses
+      # a partial set, so letting both finish costs nothing and tells the truth
+      # about which one actually failed.
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64
@@ -325,6 +339,13 @@ jobs:
     # Skipped on a dry-run dispatch (see builder-vm-image).
     if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
     strategy:
+      # One arch's build must not cancel the other's. The sibling is a separate
+      # artifact, and a transient failure on one runner used to take the other
+      # down before it produced anything — which then read as two broken arches.
+      # Publishing is still all-or-nothing: the completeness gate below refuses
+      # a partial set, so letting both finish costs nothing and tells the truth
+      # about which one actually failed.
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64
@@ -381,8 +402,15 @@ jobs:
     # runtime pack manifest under the same release.yml@<tag> identity class as
     # builder-vm-image — gating it behind the same protected environment
     # constrains which ref can mint a valid signing identity.
-    environment: release-signing
+    environment: boot-image-signing
     strategy:
+      # One arch's build must not cancel the other's. The sibling is a separate
+      # artifact, and a transient failure on one runner used to take the other
+      # down before it produced anything — which then read as two broken arches.
+      # Publishing is still all-or-nothing: the completeness gate below refuses
+      # a partial set, so letting both finish costs nothing and tells the truth
+      # about which one actually failed.
+      fail-fast: false
       matrix:
         include:
           - arch: aarch64
@@ -673,7 +701,7 @@ jobs:
     # boot-image release went out carrying one arch and no builder VM, and
     # the CLI release next door then treated its existence as sufficient.
     if: ${{ !cancelled() && (github.event_name == 'push' || github.event.inputs.dry_run == 'false') }}
-    environment: release-signing
+    environment: boot-image-signing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -435,14 +435,21 @@ fn the_two_release_trains_cannot_fire_each_other() {
     );
 }
 
-/// The protected environment survives the move.
+/// The protected environment survives the move, and it is the boot image
+/// train's own.
 ///
 /// It is what constrains which ref can mint a keyless signing identity. Losing
 /// it does not fail the job: the signing step is `continue-on-error: true`, so
 /// a broken identity means the pack quietly stops shipping and everything else
 /// looks green. Nothing else would notice.
+///
+/// Naming the *wrong* environment fails far louder but just as opaquely. This
+/// workflow fires on `boot-image/v*` and asked for `release-signing`, whose
+/// policy admits `v*` and nothing else — GitHub tag globs anchor at the start
+/// and do not cross `/`. Every gated job was refused one second in, with no
+/// steps run and nothing in the log to read.
 #[test]
-fn the_moved_jobs_keep_the_release_signing_environment() {
+fn the_moved_jobs_keep_the_boot_image_signing_environment() {
     let boot_image = boot_image_workflow();
     // The two jobs that cosign-sign a pack manifest inside the job itself.
     for job in ["builder-vm-image", "default-microvm"] {
@@ -453,14 +460,17 @@ fn the_moved_jobs_keep_the_release_signing_environment() {
              out of this list rather than dropping the assertion"
         );
         assert!(
-            block.contains("    environment: release-signing\n"),
-            "{job} must keep `environment: release-signing`, or its keyless \
-             signing identity silently stops being mintable"
+            block.contains("    environment: boot-image-signing\n"),
+            "{job} must keep `environment: boot-image-signing`, or its keyless \
+             signing identity silently stops being mintable. It must be that \
+             environment and not `release-signing`: this workflow's tags are \
+             `boot-image/v*`, which a `v*` policy refuses outright"
         );
     }
     // The publish job signs the checksum manifests every downloader anchors on.
     assert!(
-        job_block(&boot_image, "publish-boot-image").contains("    environment: release-signing\n"),
+        job_block(&boot_image, "publish-boot-image")
+            .contains("    environment: boot-image-signing\n"),
         "the boot image publish job signs, so it needs the same environment"
     );
     assert!(


### PR DESCRIPTION
Every job in the boot image train that declares an environment failed **one second
after starting, with zero steps run**. The three that declare none succeeded:

```
failure   1s   builder-vm-image (aarch64)        <- environment: release-signing
cancelled 1s   builder-vm-image (x86_64)         <- environment: release-signing
failure   1s   default-microvm (aarch64)         <- environment: release-signing
failure   1s   default-microvm (x86_64)          <- environment: release-signing
success  10m   runtime-overlay-image (aarch64)   <- no environment
success  15m   runtime-overlay-image (x86_64)    <- no environment
success   5m   sdk-sidecar-image (aarch64)       <- no environment
success   6m   sdk-sidecar-image (x86_64)        <- no environment
```

That is not a build failure. It is the deployment gate refusing the ref, before
the first step, which is why nothing in the log explains it — the job simply has
no steps.

## Cause

The repository now carries two signing environments, each scoped to its train:

| environment | allowed refs |
|---|---|
| `release-signing` | tag `v*` |
| `boot-image-signing` | tag `boot-image/v*` |

This workflow fires on `boot-image/v*` and asked for `release-signing`, which
admits `v*` only — and `v*` does not match `boot-image/v0.1.0`, since GitHub tag
globs anchor at the start and do not cross `/`. That is the same property
`tests/release_assets.rs` asserts to keep the two trains from firing each other;
here it also means one train cannot sign under the other's identity.

Point the three gated jobs at the environment whose policy matches the tag that
triggers them. The comments above those jobs, describing a protected environment
that constrains which ref can mint a signing identity, now describe something
real — until these environments existed they described an intention.

## Also: `fail-fast: false` on the four image matrices

One arch cancelling the other is wrong here. They are separate artifacts, and a
transient failure on one runner took its sibling down before it produced
anything — which then read as two broken arches instead of one. That happened on
the previous run, where `builder-vm-image (aarch64)` drowned in `cache.nixos.org`
transport errors and cancelled x86_64.

Publishing stays all-or-nothing: the completeness gate refuses a partial set
regardless. So letting both finish costs nothing and reports which one actually
failed.

## Left alone deliberately

`release.yml` declares no environment at all, so `release-signing` currently gates
nothing. Wiring it has its own blast radius and doing it here would gate the
v0.18.0 release mid-flight. Worth a follow-up.

`actionlint` clean.

Related: #2539, #2542, #2655.
