### PR TITLE
fix(ci): bound the apt step so a stalled mirror stops reading as a red PR

### DIFF
--- a/.github/actions/apt-deps/action.yml
+++ b/.github/actions/apt-deps/action.yml
@@ -1,0 +1,63 @@
+name: Install apt build dependencies
+description: |
+  `apt-get` against a stalled mirror, with a bounded wait and retries.
+
+  Every lane that compiles installs a handful of system packages first, and a
+  bare `apt-get update && apt-get install` inherits apt's own behaviour when a
+  mirror stops answering: it waits, indefinitely, until the *job* times out an
+  hour later. The job is then `cancelled`, every step after it is `skipped`,
+  and the aggregate lanes that require it report failure — so a network stall
+  on a runner reads as a red pull request, and reads identically to a real
+  break until someone opens the run and sees which step died.
+
+  Bounding the wait converts that hour into a few minutes and a legible error.
+  Retrying absorbs the common case, which is one mirror being briefly
+  unavailable rather than the network being down.
+
+inputs:
+  packages:
+    description: Space-separated package list.
+    required: true
+  attempts:
+    description: How many times to try the update+install pair.
+    required: false
+    default: "3"
+  timeout-seconds:
+    description: Per-attempt ceiling for update and for install, each.
+    required: false
+    default: "180"
+
+runs:
+  using: composite
+  steps:
+    - name: Install ${{ inputs.packages }}
+      shell: bash
+      env:
+        MVM_APT_PACKAGES: ${{ inputs.packages }}
+        MVM_APT_ATTEMPTS: ${{ inputs.attempts }}
+        MVM_APT_TIMEOUT: ${{ inputs.timeout-seconds }}
+      run: |
+        set -euo pipefail
+
+        # These two repositories are the ones observed stalling on hosted
+        # runners, and nothing here needs them.
+        sudo rm -f /etc/apt/sources.list.d/microsoft*.list \
+                   /etc/apt/sources.list.d/azure*.list
+
+        export DEBIAN_FRONTEND=noninteractive
+
+        for attempt in $(seq 1 "$MVM_APT_ATTEMPTS"); do
+          if timeout "$MVM_APT_TIMEOUT" sudo -E apt-get update \
+            && timeout "$MVM_APT_TIMEOUT" sudo -E apt-get install -y --no-install-recommends $MVM_APT_PACKAGES; then
+            echo "apt: installed on attempt $attempt"
+            exit 0
+          fi
+          echo "::warning::apt attempt $attempt/$MVM_APT_ATTEMPTS failed or timed out after ${MVM_APT_TIMEOUT}s"
+          sleep $(( attempt * 5 ))
+        done
+
+        # Say what happened rather than letting the caller infer it from a
+        # missing binary several steps later.
+        echo "::error::apt failed ${MVM_APT_ATTEMPTS} times installing: ${MVM_APT_PACKAGES}." >&2
+        echo "Each attempt was bounded at ${MVM_APT_TIMEOUT}s. A mirror is unreachable or slow; this is infrastructure, not the diff under test." >&2
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,9 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: Install system build deps
-        run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: libcap-ng-dev lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -233,8 +234,9 @@ jobs:
       # Policy checks invoke xtask, and the stub/parity checks invoke the
       # pinned Python and TypeScript generators. They are independent of the
       # compiler lint lane, so start them on their own runner.
-      - name: Install system build deps
-        run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld ripgrep shellcheck
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: libcap-ng-dev lld ripgrep shellcheck
 
       # Nothing else validates the workflow files. A wrong `if:`, a typo'd
       # `needs:` job name, or a bad `${{ }}` reference does not fail a PR — it
@@ -534,8 +536,9 @@ jobs:
         with:
           components: clippy
 
-      - name: Install system build deps
-        run: sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: libcap-ng-dev lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -715,10 +718,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Install system build deps
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
-          sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: attr cryptsetup-bin libcap-ng-dev lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -775,10 +777,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Install system build deps
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
-          sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: attr cryptsetup-bin libcap-ng-dev lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -832,10 +833,9 @@ jobs:
         with:
           targets: wasm32-wasip1
 
-      - name: Install system build deps
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
-          sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: attr cryptsetup-bin libcap-ng-dev lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -873,10 +873,9 @@ jobs:
         with:
           components: rust-src
 
-      - name: Install system build deps
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
-          sudo apt-get install -y libcap-ng-dev lld
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: libcap-ng-dev lld
 
       # This lane compiles a different crate set from the shared workspace key
       # and builds bpf-linker from source, so it gets its own entry rather than
@@ -953,10 +952,9 @@ jobs:
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install system build deps
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list; sudo apt-get update
-          sudo apt-get install -y libcap-ng-dev lld
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: libcap-ng-dev lld
 
       # Building the root package runs `crates/mvm-cli/build.rs`, which
       # cross-compiles the embedded host binaries and needs the pinned zig.


### PR DESCRIPTION
Most of the "red" pull requests right now are not broken. They are lanes that were **cancelled** after `Install system build deps` hung, and GitHub reports a cancelled lane's aggregate as `failure` — which reads identically to a real break until you open the run.

## The mechanism

```yaml
- name: Install system build deps
  run: sudo apt-get update && sudo apt-get install -y libcap-ng-dev lld
```

No ceiling. When a mirror stops answering, apt waits, the job waits with it until the 60-minute job timeout, and then:

```
4  success   Install Rust toolchain
5  cancelled Install system build deps      <-- 60 minutes here
6  skipped   Run ./.github/actions/install-zigbuild
9  skipped   Build
12 skipped   Run tests
```

Every aggregate that requires that lane then fails. On #2652 the aggregate said it plainly — `POLICY_RESULT: cancelled`, with every other lane green.

Observed on #2646, #2650, #2653, #2666 and others within a day, each costing a full diagnosis to reach "infrastructure, re-run it".

## The change

`.github/actions/apt-deps` bounds each `apt-get` at 180s, retries three times with a small backoff, and on final failure says what happened:

```
::error::apt failed 3 times installing: libcap-ng-dev lld.
Each attempt was bounded at 180s. A mirror is unreachable or slow;
this is infrastructure, not the diff under test.
```

A stalled mirror now costs about ten minutes and a legible error rather than an hour and a cancelled lane. Retrying absorbs the common case, which is one mirror being briefly unavailable.

## Conversion

All eight `ci.yml` call sites. The package lists are unchanged — worth verifying rather than trusting, and they are identical set-for-set against main:

```
libcap-ng-dev lld                              x5
libcap-ng-dev lld ripgrep shellcheck           x1
attr cryptsetup-bin libcap-ng-dev lld          x3
```

## Deliberately not converted

The same pattern exists in `release`, `security`, `kernel-build` and others. They are not on the pull-request path, so they do not produce this symptom, and converting them is a separate change with its own risk surface.

actionlint and `check-workflow-paths` clean.
