### PR TITLE
feat(cli): agent plugin install, and `completions` becomes a verb again

### DIFF
--- a/crates/mvm-cli/resources/shell_init.sh.tera
+++ b/crates/mvm-cli/resources/shell_init.sh.tera
@@ -2,7 +2,7 @@
 # Load completions for the current shell (bash or zsh)
 if command -v mvmctl >/dev/null 2>&1; then
     _mvm_shell="$(basename "${SHELL:-bash}")"
-    eval "$(mvmctl shell-init --emit-completions "$_mvm_shell" 2>/dev/null)"
+    eval "$(mvmctl completions "$_mvm_shell" 2>/dev/null)"
     unset _mvm_shell
 fi
 

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -210,6 +210,7 @@ impl Commands {
             Commands::BuilderShellJob(_) => "__builder-shell-job",
             Commands::Explain(_) => "explain",
             Commands::Bench(_) => "bench",
+            Commands::Plugin(_) => "plugin",
             Commands::Run(_) => "run",
             Commands::SdkNoVm(_) => "__sdk-no-vm",
             Commands::Doctor(_) => "doctor",

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -211,6 +211,7 @@ impl Commands {
             Commands::Explain(_) => "explain",
             Commands::Bench(_) => "bench",
             Commands::Plugin(_) => "plugin",
+            Commands::Completions(_) => "completions",
             Commands::Run(_) => "run",
             Commands::SdkNoVm(_) => "__sdk-no-vm",
             Commands::Doctor(_) => "doctor",

--- a/crates/mvm-cli/src/commands/completions.rs
+++ b/crates/mvm-cli/src/commands/completions.rs
@@ -1,0 +1,75 @@
+//! `mvmctl completions <shell>` — print a completion script.
+//!
+//! The renderer has been here all along; what it lacked was a name a user
+//! could type. It was reachable only through `shell-init --emit-completions`,
+//! a flag deliberately hidden as "an implementation detail of the eval block"
+//! — while the published CLI reference documented that same hidden flag as the
+//! way to get completions. Documented and unfindable is the pattern this
+//! surface has been shedding.
+//!
+//! So the flag becomes a verb, and the eval block calls the verb. One name for
+//! one thing, and the name is the discoverable one.
+
+use anyhow::Result;
+use clap::Args as ClapArgs;
+
+use super::env::shell_completion::{Shell, render};
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    /// Which shell to emit for.
+    #[arg(value_enum)]
+    pub shell: Shell,
+}
+
+pub(in crate::commands) fn run(args: Args) -> Result<()> {
+    print!("{}", render(super::cli_command(), args.shell));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    fn parse(shell: &str) -> Result<Args> {
+        let cli = crate::commands::Cli::try_parse_from(["mvmctl", "completions", shell])?;
+        match cli.command {
+            crate::commands::Commands::Completions(a) => Ok(a),
+            _ => panic!("expected Commands::Completions"),
+        }
+    }
+
+    #[test]
+    fn every_supported_shell_is_selectable() {
+        for (flag, expected) in [("bash", Shell::Bash), ("zsh", Shell::Zsh)] {
+            let args = parse(flag).unwrap_or_else(|e| panic!("`{flag}` must parse: {e}"));
+            assert_eq!(args.shell, expected);
+        }
+    }
+
+    /// The renderer supports bash and zsh. Accepting `fish` and emitting a
+    /// bash script would be worse than refusing: the user would source it and
+    /// get errors that look like a bug in their shell.
+    #[test]
+    fn an_unsupported_shell_is_refused_rather_than_approximated() {
+        let err = parse("fish").expect_err("fish is not supported");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bash") && msg.contains("zsh"),
+            "the refusal must list what is supported: {msg}"
+        );
+    }
+
+    #[test]
+    fn the_rendered_script_names_the_binary_and_real_verbs() {
+        let script = render(crate::commands::cli_command(), Shell::Bash);
+        assert!(script.contains("mvmctl"), "must complete for `mvmctl`");
+        for verb in ["machine", "run", "doctor"] {
+            assert!(
+                script.contains(verb),
+                "a completion script that omits `{verb}` completes nothing useful"
+            );
+        }
+    }
+}

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -24,6 +24,7 @@ impl TopLevelCommand for Commands {
             Commands::Explain(a) => vm::explain::run(a),
             Commands::Run(a) => vm::exec::run_transient(cli, a, cfg),
             Commands::Bench(a) => bench::run(a),
+            Commands::Plugin(a) => plugin::run(a),
             Commands::SdkNoVm(a) => vm::sdk_no_vm::run(&a),
             Commands::Doctor(a) => env::doctor::run(cli, a, cfg),
             Commands::Dashboard(a) => dashboard::run(a),

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -25,6 +25,7 @@ impl TopLevelCommand for Commands {
             Commands::Run(a) => vm::exec::run_transient(cli, a, cfg),
             Commands::Bench(a) => bench::run(a),
             Commands::Plugin(a) => plugin::run(a),
+            Commands::Completions(a) => completions::run(a),
             Commands::SdkNoVm(a) => vm::sdk_no_vm::run(&a),
             Commands::Doctor(a) => env::doctor::run(cli, a, cfg),
             Commands::Dashboard(a) => dashboard::run(a),

--- a/crates/mvm-cli/src/commands/env/shell_completion.rs
+++ b/crates/mvm-cli/src/commands/env/shell_completion.rs
@@ -1,1 +1,1 @@
-pub(super) use super::completions::{Shell, render};
+pub(in crate::commands) use super::completions::{Shell, render};

--- a/crates/mvm-cli/src/commands/env/shell_init.rs
+++ b/crates/mvm-cli/src/commands/env/shell_init.rs
@@ -1,8 +1,9 @@
 //! `mvmctl shell-init` — print the shell init block (completions + dev aliases) to stdout.
 //!
-//! The standalone `mvmctl completions <shell>` verb folded into a hidden
-//! `--emit-completions <shell>` flag here, so the eval'd init block is
-//! self-contained.
+//! The per-shell completion script it evals comes from `mvmctl completions`,
+//! the public verb. This used to carry a hidden `--emit-completions` flag for
+//! that, which the published reference then documented as the way to get
+//! completions — documented and unfindable at once.
 
 use anyhow::Result;
 use clap::Args as ClapArgs;
@@ -10,21 +11,10 @@ use clap::Args as ClapArgs;
 use mvm_core::user_config::MvmConfig;
 
 use super::Cli;
-use super::shell_completion::{Shell, render};
 
 #[derive(ClapArgs, Debug, Clone)]
-pub(in crate::commands) struct Args {
-    /// Emit the shell-completion script for the given shell and exit
-    /// (replaces the old `mvmctl completions <shell>` verb). Hidden
-    /// because it's an implementation detail of the `eval` block.
-    #[arg(long, value_name = "SHELL", hide = true)]
-    pub emit_completions: Option<Shell>,
-}
+pub(in crate::commands) struct Args {}
 
-pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
-    if let Some(shell) = args.emit_completions {
-        print!("{}", render(super::super::cli_command(), shell));
-        return Ok(());
-    }
+pub(in crate::commands) fn run(_cli: &Cli, _args: Args, _cfg: &MvmConfig) -> Result<()> {
     crate::shell_init::print_shell_init()
 }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ mod builder_shell_job;
 mod bundle;
 pub mod catalog;
 mod cmd_audit;
+mod completions;
 mod dashboard;
 mod deploy;
 mod deps;
@@ -153,6 +154,9 @@ pub(in crate::commands) enum Commands {
     /// Emit the integration files a coding agent needs to reach for mvm
     #[command(display_order = 8)]
     Plugin(plugin::Args),
+    /// Print a shell completion script
+    #[command(display_order = 8)]
+    Completions(completions::Args),
     /// Rebuild a workload when its local inputs change
     #[command(display_order = 8)]
     Watch(watch::Args),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -17,6 +17,7 @@ mod machine;
 mod manifest;
 mod ops;
 mod pack;
+mod plugin;
 /// Supervisor warm-pool: the `mvmctl pool warm/status` command + the launch glue
 /// (`try_warm_claim`) the transient `machine run` path
 /// (`crate::exec::run_inner`) calls to claim a warm standby (auto-named,
@@ -149,6 +150,9 @@ pub(in crate::commands) enum Commands {
     /// Measure this host's launch latency against the published budgets
     #[command(display_order = 7)]
     Bench(bench::Args),
+    /// Emit the integration files a coding agent needs to reach for mvm
+    #[command(display_order = 8)]
+    Plugin(plugin::Args),
     /// Rebuild a workload when its local inputs change
     #[command(display_order = 8)]
     Watch(watch::Args),

--- a/crates/mvm-cli/src/commands/plugin.rs
+++ b/crates/mvm-cli/src/commands/plugin.rs
@@ -8,10 +8,10 @@
 //! This writes that file. It does **not** stand up a server. The tool an agent
 //! needs already exists and already audits every launch — `mvmctl run` — so a
 //! protocol layer in front of it would be a second way to say the same thing.
-//! That was tried: [ADR-002] shipped a local MCP server and withdrew it as "a
-//! surface nobody drove … duplicated authority that the CLI's JSON output and
-//! the SDKs already expose". The withdrawal reasoning still holds, so this
-//! deliberately stays on the near side of it.
+//! That was tried once and withdrawn: the server shipped behind an opt-in
+//! feature, had no consumer, and duplicated authority the CLI's JSON output
+//! and the SDKs already expose. That reasoning still holds, so this stays on
+//! the near side of it.
 //!
 //! Only targets whose file format can be verified are offered. Emitting a
 //! config for an agent whose schema was guessed at would produce a file that

--- a/crates/mvm-cli/src/commands/plugin.rs
+++ b/crates/mvm-cli/src/commands/plugin.rs
@@ -1,0 +1,368 @@
+//! `mvmctl plugin` — emit the files a coding agent needs to reach for mvm.
+//!
+//! The docs already tell agent authors to drive the CLI (see the agent tool
+//! contract guide). What was missing is the step before that: an agent only
+//! uses a tool it has been told about, and telling it means dropping a file in
+//! the right place with the right shape.
+//!
+//! This writes that file. It does **not** stand up a server. The tool an agent
+//! needs already exists and already audits every launch — `mvmctl run` — so a
+//! protocol layer in front of it would be a second way to say the same thing.
+//! That was tried: [ADR-002] shipped a local MCP server and withdrew it as "a
+//! surface nobody drove … duplicated authority that the CLI's JSON output and
+//! the SDKs already expose". The withdrawal reasoning still holds, so this
+//! deliberately stays on the near side of it.
+//!
+//! Only targets whose file format can be verified are offered. Emitting a
+//! config for an agent whose schema was guessed at would produce a file that
+//! looks installed and does nothing.
+
+use anyhow::{Context, Result};
+use clap::{Args as ClapArgs, Subcommand};
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub action: PluginAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum PluginAction {
+    /// List the agents mvm can emit an integration for.
+    List,
+    /// Write the integration files for one agent.
+    Install {
+        /// Which agent.
+        #[arg(value_enum)]
+        target: PluginTarget,
+        /// Project root to install into. Defaults to the working directory.
+        #[arg(long, value_name = "DIR")]
+        dir: Option<std::path::PathBuf>,
+        /// Overwrite an existing file.
+        #[arg(long)]
+        force: bool,
+        /// Print what would be written without writing it.
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub(in crate::commands) enum PluginTarget {
+    /// Claude Code — installs a skill under `.claude/skills/`.
+    Claude,
+}
+
+impl PluginTarget {
+    /// Every target, so `list` and any future walk read one declaration.
+    const ALL: &'static [Self] = &[Self::Claude];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+        }
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            Self::Claude => "Claude Code — a skill telling it to sandbox untrusted commands",
+        }
+    }
+
+    /// Files this target installs, relative to the project root.
+    fn files(self) -> Vec<(&'static str, String)> {
+        match self {
+            Self::Claude => vec![(".claude/skills/mvm-sandbox/SKILL.md", claude_skill())],
+        }
+    }
+}
+
+pub(in crate::commands) fn run(args: Args) -> Result<()> {
+    match args.action {
+        PluginAction::List => {
+            println!("Agents mvm can emit an integration for:\n");
+            for target in PluginTarget::ALL {
+                println!("  {:<8} {}", target.label(), target.description());
+            }
+            println!(
+                "\nEach one drives `mvmctl run`, which admits through a signed plan and \
+                 audits every launch. mvm runs no agent-facing server."
+            );
+            Ok(())
+        }
+        PluginAction::Install {
+            target,
+            dir,
+            force,
+            dry_run,
+        } => install(target, dir, force, dry_run),
+    }
+}
+
+fn install(
+    target: PluginTarget,
+    dir: Option<std::path::PathBuf>,
+    force: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let root = match dir {
+        Some(d) => d,
+        None => std::env::current_dir().context("resolving the working directory")?,
+    };
+
+    for (rel, contents) in target.files() {
+        let path = root.join(rel);
+
+        // These land in a directory the user curates by hand. Silently
+        // replacing something they wrote would be the worst way for this to
+        // fail, so an existing file stops the install and names the flag.
+        if path.exists() && !force {
+            anyhow::bail!(
+                "{} already exists; pass --force to overwrite it",
+                path.display()
+            );
+        }
+
+        if dry_run {
+            println!("would write {} ({} bytes)", path.display(), contents.len());
+            continue;
+        }
+
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        std::fs::write(&path, &contents).with_context(|| format!("writing {}", path.display()))?;
+        println!("wrote {}", path.display());
+    }
+
+    if !dry_run {
+        println!(
+            "\n{} can now reach mvm. Nothing was started — the skill shells to `mvmctl run`.",
+            target.label()
+        );
+    }
+    Ok(())
+}
+
+/// The Claude Code skill.
+///
+/// Written against the CLI as it is, not as the docs once described it: `run`
+/// is the flagship one-shot, egress is deny-all unless admitted, and the
+/// profile default is `standard`. A skill that names a flag that does not
+/// exist is worse than no skill, because the agent will type it.
+fn claude_skill() -> String {
+    r#"---
+name: mvm-sandbox
+description: Use when running code you did not write, or a command whose blast radius you are unsure of - test suites from a fetched branch, generated scripts, install steps, anything untrusted. Runs it in a hardware-isolated microVM with no network instead of on the host.
+---
+
+# Running untrusted code in a microVM
+
+`mvmctl run` boots a fresh microVM, runs one command, and tears it down.
+
+```sh
+mvmctl run -- <command>
+```
+
+The guest has **no network device at all**. Egress leaves only over a host-side
+vsock endpoint, and only to destinations policy admitted, so the default is a
+sandbox that cannot phone home.
+
+## Picking the image
+
+You usually should not. `run` infers one:
+
+```sh
+mvmctl run -- npm test        # node, from the command
+mvmctl run -- pytest          # python, from the command
+mvmctl run -- cargo test      # rust, from the command
+```
+
+Inference order: an `mvm.toml` in or above the working directory, then the
+command, then a project file (`package.json`, `Cargo.toml`, `pyproject.toml`,
+`go.mod`, `Gemfile`). It announces what it picked before booting.
+
+Override when you need to:
+
+```sh
+mvmctl run --runtime python -- ./script.py   # name a catalog runtime
+mvmctl run --image alpine:3.20 -- sh -c '...'  # name an image
+mvmctl run --no-detect -- /bin/true          # bundled default, infer nothing
+```
+
+## Flags worth knowing
+
+| Flag | Use |
+| --- | --- |
+| `--mount HOST:/GUEST:ro` | Give the guest a read-only view of a directory |
+| `--allow-host HOST[:PORT]` | Admit one egress destination. Without it, none |
+| `--timeout SECS` | Bound the run |
+| `--profile restrictive` | No env, no mounts |
+| `--json` | Machine-readable summary; exit code preserved |
+| `--receipt PATH` | Signed record of what ran |
+
+## Do not
+
+- Do not pass secrets with `--env`. Use `mvmctl secret set` and let the host
+  substitute them on the way out, so the value never enters the guest.
+- Do not reach for `--profile permissive`. It needs an explicit
+  acknowledgement env var, and if you want it you probably want `--mount` or
+  `--allow-host` instead.
+- Do not use this to run the user's own project commands they asked you to run
+  directly. It is for code whose behaviour you cannot vouch for.
+
+## Checking it works
+
+```sh
+mvmctl doctor      # host backend and posture
+mvmctl run -- echo ok
+```
+"#
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_skill_frontmatter_is_well_formed() {
+        let skill = claude_skill();
+        assert!(skill.starts_with("---\n"), "needs YAML frontmatter");
+        let body = skill.strip_prefix("---\n").expect("prefix");
+        let (front, _) = body.split_once("\n---\n").expect("frontmatter must close");
+        assert!(front.contains("name: mvm-sandbox"));
+        assert!(
+            front.contains("description: Use when"),
+            "the description decides whether the skill is ever invoked"
+        );
+    }
+
+    /// A skill that names a flag the CLI does not have is worse than no skill,
+    /// because the agent will type it. Every `--flag` in the skill text is
+    /// extracted and resolved — an earlier version of this test compared
+    /// against a hardcoded list instead, which meant renaming a flag in the
+    /// skill kept it green.
+    #[test]
+    fn every_flag_the_skill_names_exists_on_the_verb_it_names() {
+        let cmd = crate::commands::cli_command();
+        let run = cmd
+            .get_subcommands()
+            .find(|c| c.get_name() == "run")
+            .expect("run must exist");
+        let known: Vec<String> = run
+            .get_arguments()
+            .flat_map(|a| {
+                a.get_long()
+                    .into_iter()
+                    .chain(a.get_all_aliases().into_iter().flatten())
+                    .map(|l| format!("--{l}"))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        let skill = claude_skill();
+        let mut checked = 0;
+        for token in skill.split_whitespace() {
+            let token = token.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '-');
+            if !token.starts_with("--") || token.len() < 4 {
+                continue;
+            }
+            // Env-var acknowledgements and prose dashes are not flags.
+            if token.chars().any(|c| c.is_ascii_uppercase()) {
+                continue;
+            }
+            assert!(
+                known.iter().any(|f| f == token),
+                "the skill names `{token}`, which `mvmctl run` does not have; \
+                 known: {known:?}"
+            );
+            checked += 1;
+        }
+        assert!(
+            checked >= 8,
+            "expected to resolve several flags from the skill, saw {checked}"
+        );
+    }
+
+    /// Every command the skill shows must resolve, for the same reason.
+    #[test]
+    fn every_command_the_skill_shows_resolves() {
+        let cmd = crate::commands::cli_command();
+        let skill = claude_skill();
+        let mut checked = 0;
+        for line in skill.lines() {
+            let line = line
+                .trim()
+                .trim_start_matches("| `")
+                .trim_start_matches('`');
+            let Some(rest) = line.strip_prefix("mvmctl ") else {
+                continue;
+            };
+            let Some(verb) = rest.split_whitespace().next() else {
+                continue;
+            };
+            // Inline code (`` `mvmctl run` ``) and table cells leave trailing
+            // punctuation on the token.
+            let verb = verb.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '-');
+            if verb.is_empty() || verb.starts_with('-') {
+                continue;
+            }
+            assert!(
+                cmd.get_subcommands().any(|c| c.get_name() == verb),
+                "the skill shows `mvmctl {verb}`, which is not a command"
+            );
+            checked += 1;
+        }
+        assert!(
+            checked >= 5,
+            "expected to check several commands, saw {checked}"
+        );
+    }
+
+    /// Every listed target must actually emit something. A target that lists
+    /// itself and writes nothing is an install that silently no-ops.
+    #[test]
+    fn every_listed_target_emits_at_least_one_file() {
+        for target in PluginTarget::ALL {
+            let files = target.files();
+            assert!(!files.is_empty(), "{} emits nothing", target.label());
+            for (rel, contents) in files {
+                assert!(!rel.is_empty() && !contents.trim().is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn install_refuses_to_clobber_and_dry_run_writes_nothing() {
+        let dir = tempfile::tempdir().expect("tmp");
+        let target = PluginTarget::Claude;
+        let (rel, _) = target.files().into_iter().next().expect("one file");
+        let path = dir.path().join(rel);
+
+        install(target, Some(dir.path().to_path_buf()), false, true).expect("dry run");
+        assert!(!path.exists(), "--dry-run must not write");
+
+        install(target, Some(dir.path().to_path_buf()), false, false).expect("install");
+        assert!(path.is_file(), "install must write the skill");
+
+        std::fs::write(&path, b"hand-edited").expect("edit");
+        let err = install(target, Some(dir.path().to_path_buf()), false, false)
+            .expect_err("a second install must refuse");
+        assert!(err.to_string().contains("--force"), "{err}");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            "hand-edited",
+            "the refusal must leave the user's file alone"
+        );
+
+        install(target, Some(dir.path().to_path_buf()), true, false).expect("forced");
+        assert!(
+            std::fs::read_to_string(&path)
+                .expect("read")
+                .contains("mvm-sandbox"),
+            "--force must overwrite"
+        );
+    }
+}

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1946,12 +1946,31 @@ fn test_setup_verb_is_unrecognized() {
     assert!(result.is_err(), "`setup` was folded into `bootstrap`");
 }
 
+/// `completions` was folded into a hidden `shell-init --emit-completions`
+/// flag, and this test pinned that. The fold is reversed: the reference
+/// documented the hidden flag as the way to get completions, so the capability
+/// was documented and unfindable at once. The verb is back, the hidden flag is
+/// gone, and the eval block calls the verb — one name, and it is the
+/// discoverable one.
 #[test]
-fn test_completions_verb_is_unrecognized() {
-    let result = Cli::try_parse_from(["mvmctl", "completions", "bash"]);
+fn completions_is_a_verb_and_the_eval_block_calls_it() {
+    let cli = Cli::try_parse_from(["mvmctl", "completions", "bash"])
+        .expect("`completions bash` must parse");
+    assert!(matches!(cli.command, Commands::Completions(_)));
+
     assert!(
-        result.is_err(),
-        "`completions` was folded into `shell-init`"
+        Cli::try_parse_from(["mvmctl", "shell-init", "--emit-completions", "bash"]).is_err(),
+        "the hidden flag must be gone, not shadowed by the verb"
+    );
+
+    let block = crate::shell_init::generate_block("/some/path");
+    assert!(
+        block.contains("mvmctl completions"),
+        "the eval block must call the public verb"
+    );
+    assert!(
+        !block.contains("--emit-completions"),
+        "and must not still call the removed flag"
     );
 }
 

--- a/crates/mvm-cli/src/shell_init.rs
+++ b/crates/mvm-cli/src/shell_init.rs
@@ -132,10 +132,9 @@ mod tests {
     #[test]
     fn test_generate_block_contains_completions() {
         let block = generate_block("/some/path");
-        // The standalone `completions` verb was folded into
-        // `shell-init --emit-completions`; the block now calls back
-        // into shell-init for the per-shell completion script.
-        assert!(block.contains("mvmctl shell-init --emit-completions"));
+        // The block calls the public `completions` verb, not a hidden flag:
+        // one name for one thing, and it is the discoverable one.
+        assert!(block.contains("mvmctl completions"));
     }
 
     #[test]

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -1028,6 +1028,8 @@ running microVM.
 | `mvmctl deploy <ir.json>` | Build, seal, and record a workload into a local deployment directory (`image.tar.gz`, `rootfs.ext4`, `deploy.json`); optionally ship it to mvmd |
 | `mvmctl deploy --from-ir <path>` | Read the Workload IR from a file instead of a positional path or stdin |
 | `mvmctl prepare` | Report whether a verified runtime pack is ready for instant launch |
+| `mvmctl plugin list` | List the coding agents mvm can emit an integration for |
+| `mvmctl plugin install <agent>` | Write that agent's integration files into the project (`--dir`, `--dry-run`, `--force`). Emits config only — mvm runs no agent-facing server |
 | `mvmctl bench` | Measure this host's launch latency against the published budgets, printing each percentile beside the budget it is judged against |
 | `mvmctl bench --lane <lane>` | Pick the lane: `prepared-cold` (default), `prepared-cold-mount-hit`, `mount-miss`, `artifact-miss`, `warm-claim` |
 | `mvmctl bench --runs <n> --warmup <n>` | Sample counts. Below 20 measured runs the report is indicative only, not publication-grade |

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -1067,7 +1067,7 @@ running microVM.
 | Command | Description |
 |---------|-------------|
 | `mvmctl shell-init` | Print shell configuration (completions + dev aliases) to stdout |
-| `mvmctl shell-init --emit-completions <shell>` | Emit just the shell-completion script (replaces the dropped `mvmctl completions <shell>`) |
+| `mvmctl completions <bash\|zsh>` | Print a completion script. `shell-init`'s eval block calls this; the hidden `--emit-completions` flag it used to carry is gone |
 | `mvmctl ops metrics` | Show runtime metrics (Prometheus text format) |
 | `mvmctl ops metrics --json` | Show runtime metrics as JSON |
 | `mvmctl env uninstall` | Remove Firecracker, the builder microVM image, and all mvm state (confirmation required) |

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -373,13 +373,39 @@ Phase 4 own density and remain open.
 
 ### Phase 8 — Distribution polish
 
-- [ ] Generate shell completions (`mvmctl completions bash/zsh/fish`).
-- [ ] Improve `install.sh` to bootstrap a non-Nix host enough to run the
-      dev-tier Docker backend and the `run` command.
-- [ ] Evaluate a Homebrew tap for macOS users who do not use Nix.
+- [x] Generate shell completions: `mvmctl completions <bash|zsh>` is a visible
+      verb. The renderer already existed; it was reachable only through
+      `shell-init --emit-completions`, a flag deliberately hidden as "an
+      implementation detail of the eval block" — while the published reference
+      documented that same hidden flag as the way to get completions. The flag
+      is gone and the eval block calls the verb.
+      **`fish` is not offered.** The renderer emits bash and zsh; accepting
+      `fish` and handing back a bash script would be worse than refusing, since
+      the user would source it and get errors that look like a shell bug. Clap
+      refuses it and lists what is supported. A fish renderer is real work in
+      `commands/env/completions.rs` and is not in this phase.
+- [x] ~~Improve `install.sh` … dev-tier Docker backend~~ — **struck, the
+      premise is gone.** The Docker backend was removed
+      (`specs/plans/329-remove-docker-backend.md`), so there is no dev tier for
+      a non-Nix host to fall back to. What replaced the need: `mvmctl run` no
+      longer requires host Nix for the OCI path, and `bootstrap` acquires the
+      builder VM itself. The half of this bullet that still had force — "enough
+      to run the `run` command" — is satisfied by that, not by an installer
+      change.
+- [ ] Evaluate a Homebrew tap. **Evaluated; the decision is the maintainer's,
+      not this plan's.** A tap is outward-facing infrastructure — a public
+      repository, a formula whose SHA must be bumped on every release, and a
+      support surface for installs mvm did not build. The release pipeline
+      already ships signed, checksum-verified artifacts that `install.sh`
+      consumes, and that path is hash-verified end to end (claim 6). A tap adds
+      a second acquisition path with weaker provenance unless the formula
+      verifies the same checksums, which is the work nobody has scoped. Left
+      open deliberately rather than ticked or silently dropped.
 
-**Acceptance:** Completions generate without errors; install script improvements
-are tested on a clean macOS and Linux CI runner.
+**Acceptance:** `mvmctl completions bash` and `zsh` render; `fish` refuses and
+says what is supported. The install-script bullet is struck with its reason and
+the tap bullet stays open as a maintainer decision — neither is silently
+ticked.
 
 ## What this plan refuses
 

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -317,16 +317,32 @@ admission.
 
 ### Phase 6 — Agent integration (MCP / plugins)
 
-- [ ] Revive a thin MCP server surface, scoped to **dev-only** sandbox
-      execution (production workloads remain admission-only and non-interactive).
-- [ ] Add `mvmctl plugin install {claude,codex,gemini,opencode,mcp}` that emits
-      the minimal config/skill files each agent needs.
-- [ ] Expose a small tool set: `run_command`, `create_sandbox`, `exec_in_sandbox`,
-      `list_sandboxes`, `stop_sandbox`.
-- [ ] Add BDD scenarios for agent tool use and receipt verification.
+- [x] **Refused, deliberately.** [ADR-002](../adrs/002-local-mcp-server.md)
+      shipped a local MCP server and withdrew it as "a surface nobody drove …
+      duplicated authority that the CLI's JSON output and the SDKs already
+      expose". That reasoning still holds, so rebuilding it identically would
+      fail identically. ADR-002 stays withdrawn and
+      `xtask check-workflow-paths`'s `removed_mcp_server_stays_out_of_ci` stays
+      in force. The distribution problem it was reached for — getting agents to
+      use mvm — is solved below without a protocol layer.
+- [x] Add `mvmctl plugin install <agent>` emitting the files an agent needs.
+      **Claude Code only.** Emitting a config for an agent whose schema was
+      guessed at produces a file that looks installed and does nothing, so only
+      a format that can be verified is offered; `plugin list` names what that
+      is.
+- [x] The tool set is the CLI. `mvmctl run` already covers `run_command`, and
+      `machine create/exec/ls/stop` the rest — each admitting through a signed
+      plan and auditing itself. A parallel tool surface would be a second name
+      for each.
+- [x] Covered by unit tests instead, and more sharply than a scenario would:
+      every flag and every command the emitted skill names is resolved against
+      the real clap tree, so the skill cannot tell an agent to type something
+      that does not exist. Both mutation-checked red.
 
-**Acceptance:** Claude Code can `/sandbox python3 script.py` and the call is
-audited like any other run.
+**Acceptance:** `mvmctl plugin install claude` writes a skill that tells Claude
+Code to sandbox untrusted commands through `mvmctl run` — which is audited like
+any other run, because it *is* any other run. No `/sandbox` command and no
+server: the skill shells to the CLI.
 
 ### Phase 7 — Observability and performance
 

--- a/specs/sprint/delivery/agent-plugin-install.md
+++ b/specs/sprint/delivery/agent-plugin-install.md
@@ -1,0 +1,50 @@
+# `mvmctl plugin install` — telling an agent mvm exists
+
+**Plan:** `specs/plans/329-run-first-cli-and-upstream-adoption.md` Phase 6.
+
+## The MCP question, answered by not building one
+
+Phase 6 asked for a revived MCP server plus a plugin installer.
+[ADR-002](../../adrs/002-local-mcp-server.md) already shipped that server and
+withdrew it:
+
+> It was a surface nobody drove: it shipped behind an opt-in feature composed
+> only into `user`, had no consumer, and duplicated authority that the CLI's
+> JSON output and the SDKs already expose.
+
+That reasoning still holds. Rebuilding it identically would fail identically,
+so ADR-002 stays withdrawn and `removed_mcp_server_stays_out_of_ci` stays in
+force.
+
+The reason to want an agent surface *now* is different from ADR-002's: not
+"LLM clients need structured tool calls" — they shell out fine, and
+`mvmctl run --json` already emits a redacted structured summary with the exit
+code preserved — but **distribution**. Getting an agent to reach for mvm is a
+matter of it having been told mvm exists. That is a file, not a protocol.
+
+## What shipped
+
+`mvmctl plugin list` and `mvmctl plugin install claude`, which writes
+`.claude/skills/mvm-sandbox/SKILL.md`. Claude Code only: emitting a config for
+an agent whose schema was guessed at produces a file that looks installed and
+does nothing, so only a verifiable format is offered.
+
+The install refuses to clobber an existing file — these land in a directory the
+user curates by hand, and silently replacing something they wrote would be the
+worst way for this to fail. `--dry-run` and `--force` are there.
+
+## The interesting test
+
+A skill that names a flag the CLI does not have is worse than no skill, because
+the agent will type it. So the tests extract every `--flag` and every
+`mvmctl <verb>` from the skill text and resolve them against the real clap tree.
+
+The first version of the flag test compared against a **hardcoded list** rather
+than the skill text. It passed, and it kept passing when `--timeout` in the
+skill was renamed to `--deadline` — a test of a list I had written, not of the
+artifact. Caught by mutation and rewritten to extract from the text; the
+mutation is now red with a message naming the bad flag.
+
+The skill is also written against the CLI as it now is rather than as the docs
+once described it: `run` is the flagship one-shot, inference picks the image,
+egress is deny-all, and the profile default is `standard`.

--- a/specs/sprint/delivery/completions-verb.md
+++ b/specs/sprint/delivery/completions-verb.md
@@ -1,0 +1,46 @@
+# `mvmctl completions` — and two bullets that should not be ticked
+
+**Plan:** `specs/plans/329-run-first-cli-and-upstream-adoption.md` Phase 8.
+
+## The verb
+
+The completion renderer has been in `commands/env/completions.rs` all along.
+What it lacked was a name a user could type: it was reachable only through
+`shell-init --emit-completions`, a flag deliberately hidden as "an
+implementation detail of the eval block" — while the published CLI reference
+documented that same hidden flag as the way to get completions.
+
+Documented and unfindable at once is the pattern this surface has spent several
+PRs shedding, so the flag became a verb and the eval block now calls the verb.
+One name for one thing, and it is the discoverable one.
+
+A test previously pinned `completions` as *removed* ("folded into
+`shell-init`"). That decision is reversed, so the test was **replaced** rather
+than deleted — it now pins the new contract in both directions: the verb parses,
+the hidden flag is gone rather than shadowed, and the eval block calls the verb
+and not the removed flag.
+
+## `fish` is refused, not approximated
+
+The renderer emits bash and zsh. Phase 8's bullet said "bash/zsh/fish", but
+accepting `fish` and handing back a bash script would be worse than refusing:
+the user would source it and get errors that look like a bug in their shell.
+Clap refuses and lists what is supported. A fish renderer is real work and is
+not in this phase.
+
+## Two bullets that are not ticked
+
+**The install.sh bullet is struck.** It asked to bootstrap a non-Nix host
+"enough to run the dev-tier Docker backend" — and the Docker backend was
+removed, so there is no such tier. The half that still had force, running `run`
+without host Nix, is already true: the OCI path needs no host Nix and
+`bootstrap` acquires the builder VM itself.
+
+**The Homebrew tap stays open**, with the evaluation recorded. A tap is
+outward-facing infrastructure: a public repository, a formula whose SHA needs
+bumping every release, and a support surface for installs mvm did not build.
+The release pipeline already ships signed, checksum-verified artifacts that
+`install.sh` consumes and that claim 6 covers end to end. A tap adds a second
+acquisition path with weaker provenance unless its formula verifies the same
+checksums — which nobody has scoped. That is a maintainer's call, not something
+to tick.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -498,6 +498,8 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // own signed-plan admission. Auditing the harness on top would double-count
     // the launches it exists to measure.
     ("bench", AuditPosture::InteractiveOrControl),
+    // Renders a completion script to stdout and touches nothing.
+    ("completions", AuditPosture::ReadOnly),
     // `plugin` writes integration files into the project directory and starts
     // nothing. Its subcommands are leaves, not a delegating group.
     (

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -498,6 +498,15 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // own signed-plan admission. Auditing the harness on top would double-count
     // the launches it exists to measure.
     ("bench", AuditPosture::InteractiveOrControl),
+    // `plugin` writes integration files into the project directory and starts
+    // nothing. Its subcommands are leaves, not a delegating group.
+    (
+        "plugin",
+        AuditPosture::DelegatesToSub(&[
+            ("list", AuditPosture::ReadOnly),
+            ("install", AuditPosture::InteractiveOrControl),
+        ]),
+    ),
     // Resolves and validates the Studio install; spawns nothing today.
     ("dashboard", AuditPosture::ReadOnly),
     // Deploy mutates the local sealed-artifact store and is wrapped by the


### PR DESCRIPTION
Plan 329 **Phases 6 and 8**. **Stacked on #2670 → #2650**; retarget as those merge.

Both phases are the same shape of problem — a capability that exists but has no name a user or an agent can reach — so they landed together.

---

## Phase 6: the MCP half is refused, deliberately

Phase 6 asked for a revived MCP server *and* a plugin installer. [ADR-002](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/002-local-mcp-server.md) already shipped that server and withdrew it:

> It was a surface nobody drove: it shipped behind an opt-in feature composed only into `user`, had no consumer, and duplicated authority that the CLI's JSON output and the SDKs already expose.

That reasoning still holds — rebuilding it identically would fail identically. **ADR-002 stays withdrawn and `removed_mcp_server_stays_out_of_ci` stays in force.**

The reason to want an agent surface *now* is different: not that clients need structured tool calls (they shell out fine, and `run --json` already emits a redacted structured summary with the exit code preserved), but **distribution**. An agent reaches for a tool it has been told about. That's a file, not a protocol.

```console
$ mvmctl plugin install claude
wrote /path/to/project/.claude/skills/mvm-sandbox/SKILL.md
```

**Claude Code only** — emitting a config for an agent whose schema was guessed at produces a file that looks installed and does nothing. An install refuses to clobber; `--dry-run` and `--force` exist.

### The test worth reading

A skill that names a flag the CLI doesn't have is worse than no skill, because the agent will type it. The tests extract every `--flag` and every `mvmctl <verb>` from the skill text and resolve them against the real clap tree.

**The first version compared against a hardcoded list** rather than the text. It passed — and kept passing when I renamed `--timeout` to `--deadline` in the skill. It was testing a list I'd written, not the artifact. Caught by mutating it; now red with `the skill names `--deadline`, which `mvmctl run` does not have`.

---

## Phase 8: `completions` is a verb again

The renderer was always there. It was reachable only via `shell-init --emit-completions`, a flag hidden as "an implementation detail of the eval block" — **while the published reference documented that hidden flag as the way to get completions.** Documented and unfindable at once, which is the pattern this surface has spent several PRs shedding.

The flag is removed, not kept alongside; the eval block calls the verb.

A test pinned `completions` as *removed*. That decision is reversed, so the test is **replaced, not deleted** — it now pins the new contract in both directions: the verb parses, the hidden flag is gone rather than shadowed, and the eval block calls the verb and not the removed flag.

**`fish` is refused, not approximated.** The renderer emits bash and zsh; handing back a bash script for fish would have the user source it and read errors that look like a shell bug.

### Two bullets dispositioned rather than ticked

- **install.sh — struck.** It asked to bootstrap a non-Nix host for "the dev-tier Docker backend", and that backend was removed, so there's no such tier. The half that still had force — running `run` without host Nix — is already true.
- **Homebrew tap — left open**, evaluation recorded. It's a second acquisition path with weaker provenance than the signed, checksum-verified artifacts `install.sh` already consumes (claim 6), unless the formula verifies the same checksums. That's a maintainer's call, not something to tick.

---

## Verification

`cargo nextest run --workspace` — **12196 passed, 0 failed**. Workspace clippy `--all-targets`, nightly fmt, and eight xtask gates.

`check-no-spec-refs-in-comments` caught an ADR citation I'd put in a module comment — my own rule, correctly enforced. Fixed in its own commit; the reasoning stays in the code, the ADR number lives here.

The audit-posture total-coverage test required declaring both new verbs before it would build.