### PR TITLE
fix(release): gate the CLI signing job on the environment that admits v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,6 +261,15 @@ jobs:
     # (the `build` job) but never reaches this publish job — only a tag push or
     # an explicit dry_run=false dispatch publishes.
     if: ${{ !cancelled() && needs.bdd.result == 'success' && needs.build.result == 'success' && (github.event_name == 'push' || github.event.inputs.dry_run == 'false') }}
+    # This job mints the one keyless identity every installed mvmctl trusts:
+    # `release.yml@refs/tags/v{version}`, the sole entry in
+    # RELEASE_IDENTITY_TEMPLATES. The environment's policy admits `v*` tags and
+    # nothing else, so a branch push or a workflow_dispatch from an arbitrary
+    # ref cannot produce a signature the shipped verifier accepts. The boot
+    # image train is gated the same way against `boot-image/v*`, and
+    # revocations against its own tag; this was the last of the three trusted
+    # identities that anything could mint.
+    environment: release-signing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -589,3 +589,61 @@ fn the_boot_gate_installs_the_toolchain_its_test_needs() {
          without it the gate fails before reaching a guest"
     );
 }
+
+/// Every workflow that can mint an identity a shipped binary trusts must be
+/// gated on a protected environment, so the ref allowed to produce a valid
+/// signature is constrained by that environment's tag policy rather than by
+/// whoever can trigger the workflow.
+///
+/// This is not theoretical. `release-boot-image.yml` asked for an environment
+/// scoped to `v*` while firing on `boot-image/v*`; the mismatch blocked every
+/// gated job one second in, with no steps and nothing in the log to read. And
+/// `release.yml` — which mints the one identity `RELEASE_IDENTITY_TEMPLATES`
+/// names, the identity every installed mvmctl verifies against — declared no
+/// environment at all.
+///
+/// The environments' tag policies live in repository settings and cannot be
+/// asserted from here. What is assertable, and what regressed, is that the
+/// declaration exists at all.
+#[test]
+fn workflows_minting_trusted_identities_are_gated_on_an_environment() {
+    for (path, expected_env) in [
+        (".github/workflows/release.yml", "release-signing"),
+        (
+            ".github/workflows/release-boot-image.yml",
+            "boot-image-signing",
+        ),
+        (".github/workflows/revocations.yml", "revocations-signing"),
+    ] {
+        let body = fs::read_to_string(Path::new(path))
+            .unwrap_or_else(|e| panic!("{path} must be readable: {e}"));
+        assert!(
+            body.contains(&format!("environment: {expected_env}")),
+            "{path} mints an identity in mvm_core::release_trust, so it must \
+             declare `environment: {expected_env}`. Without it any ref that can \
+             trigger the workflow can mint a signature the shipped verifier \
+             accepts."
+        );
+    }
+}
+
+/// The two signing environments are deliberately distinct. Sharing one would
+/// let a boot image signature validate a CLI tarball and the reverse, which is
+/// the exact confusion `BOOT_IMAGE_IDENTITY_TEMPLATES` is kept separate from
+/// `RELEASE_IDENTITY_TEMPLATES` to prevent.
+#[test]
+fn the_two_release_trains_do_not_share_a_signing_environment() {
+    let cli = fs::read_to_string(Path::new(".github/workflows/release.yml"))
+        .expect("release.yml must be readable");
+    let boot = fs::read_to_string(Path::new(".github/workflows/release-boot-image.yml"))
+        .expect("release-boot-image.yml must be readable");
+    assert!(
+        !cli.contains("environment: boot-image-signing"),
+        "the CLI train must not sign under the boot image train's environment"
+    );
+    assert!(
+        !boot.contains("environment: release-signing"),
+        "the boot image train must not sign under the CLI train's environment; \
+         its tags are boot-image/v*, which a v*-scoped policy refuses outright"
+    );
+}


### PR DESCRIPTION
Closes the last of the three trusted signing identities that anything could mint.

`mvm_core::release_trust` names exactly three identities a shipped binary will
verify:

| workflow | environment | before |
|---|---|---|
| `release.yml@refs/tags/v*` | `release-signing` | **none — anything could mint it** |
| `release-boot-image.yml@refs/tags/boot-image/v*` | `boot-image-signing` | fixed in #2671 |
| `revocations.yml@refs/tags/revocations` | `revocations-signing` | already gated |

`release.yml`'s `release` job mints `RELEASE_IDENTITY_TEMPLATES`' sole entry —
the identity every installed `mvmctl` checks its packs against — and declared no
environment at all. Any ref that could trigger the workflow could produce a
signature the shipped verifier accepts.

`kernel-build.yml` also cosign-signs, but its identity is not in the trust list;
it is provenance for that train and deliberately left alone.

## Behaviour change worth knowing

The environment's policy admits `v*` tags and nothing else, so a
`workflow_dispatch` with `dry_run=false` from a branch is now refused. That is
the point of the gate, but it does close an escape hatch that previously worked.

It cannot block a legitimate release: `release-signing` carries only a branch
policy — no required reviewers, no wait timer — and a `vN.N.N` tag satisfies it.

## Tests

Two regression tests, both of which would have caught the two defects this
series ran into:

- every workflow minting an identity in `release_trust` declares an environment
- the two trains never share one — sharing would let a boot image signature
  validate a CLI tarball and the reverse, the exact confusion the separate
  template lists exist to prevent

`actionlint` clean.

Related: #2655, #2671.
