### PR TITLE
fix(bundle): refuse a foreign-arch bundle at boot and at admission

### DIFF
--- a/crates/mvm-cli/src/commands/bundle/export.rs
+++ b/crates/mvm-cli/src/commands/bundle/export.rs
@@ -47,6 +47,16 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             )
         })?;
 
+    // Carry a re-exported bundle's own architecture through rather than
+    // re-stamping this host's. `template_artifacts_dispatched` resolves an
+    // installed bundle as happily as a local slot, so an aarch64 bundle
+    // re-exported from an x86_64 host would otherwise be relabelled x86_64
+    // while still containing an aarch64 rootfs — and the label is what the
+    // boot-time gate trusts. A slot built here has no manifest, so it takes
+    // the host arch, which is correct for that case.
+    let source_arch = tmpl::installed_bundle_arch_for_export(&args.template)
+        .unwrap_or_else(|| mvm_core::arch::GuestArch::host().to_string());
+
     // Verity sidecar lives next to the rootfs by convention; the
     // backend's probe is the source of truth.
     let (verity_path, roothash) = mvm_runtime::microvm::probe_verity_sidecar(&rootfs);
@@ -175,7 +185,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         schema_version: BUNDLE_SCHEMA_VERSION,
         publisher: host_signer::host_signer_id(),
         key_id: key_id.clone(),
-        arch: std::env::consts::ARCH.to_string(),
+        arch: source_arch,
         kernel_version: None,
         profile: Some(spec.profile.clone()),
         workload_label: args.label,

--- a/crates/mvm-cli/src/commands/vm/up/policy.rs
+++ b/crates/mvm-cli/src/commands/vm/up/policy.rs
@@ -251,7 +251,7 @@ mod bundle_pin_tests {
             schema_version: BUNDLE_SCHEMA_VERSION,
             publisher: "test".to_string(),
             key_id: key_id.clone(),
-            arch: "aarch64".to_string(),
+            arch: mvm_core::arch::GuestArch::host().to_string(),
             kernel_version: None,
             profile: None,
             workload_label: None,

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1292,7 +1292,7 @@ fn resolve_image_artifacts(image: &ImageSource) -> Result<ResolvedImage> {
     match image {
         ImageSource::Template(name) => {
             let (spec, vmlinux, initrd, rootfs, rev) =
-                mvm_runtime::vm::template::lifecycle::template_artifacts_dispatched(name)
+                mvm_runtime::vm::template::lifecycle::template_artifacts_for_boot(name)
                     .with_context(|| format!("Loading template '{name}'"))?;
             let snap_info =
                 mvm_runtime::vm::template::lifecycle::template_snapshot_info_dispatched(name)
@@ -2215,7 +2215,7 @@ pub fn boot_session_vm(
     admit: Option<&SessionAdmit<'_>>,
 ) -> Result<SessionVm> {
     let (spec, vmlinux, initrd, rootfs, rev) =
-        mvm_runtime::vm::template::lifecycle::template_artifacts_dispatched(env)
+        mvm_runtime::vm::template::lifecycle::template_artifacts_for_boot(env)
             .with_context(|| format!("Loading template '{env}'"))?;
     let snap_info = mvm_runtime::vm::template::lifecycle::template_snapshot_info_dispatched(env)
         .ok()

--- a/crates/mvm-core/src/arch.rs
+++ b/crates/mvm-core/src/arch.rs
@@ -38,6 +38,41 @@ impl GuestArch {
             GuestArch::Aarch64
         }
     }
+
+    /// Parse a manifest-declared architecture and require it to match this
+    /// host.
+    ///
+    /// Fails closed on both a mismatch and an architecture this build has no
+    /// variant for, so a bundle that declares something unrecognised is refused
+    /// rather than admitted on the strength of `host()`'s non-x86_64 fallback.
+    ///
+    /// The message is deliberately subject-free — callers prepend whatever they
+    /// are refusing, since the same comparison guards an admitted plan's pinned
+    /// bundle and a registry bundle resolved at boot.
+    pub fn require_host(declared: &str) -> Result<Self, HostArchMismatch> {
+        let declared_arch = declared.parse::<Self>()?;
+        let host = Self::host();
+        if declared_arch == host {
+            Ok(declared_arch)
+        } else {
+            Err(HostArchMismatch::Mismatch {
+                declared: declared_arch,
+                host,
+            })
+        }
+    }
+}
+
+/// Why a declared architecture is not runnable on this host.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum HostArchMismatch {
+    #[error("declares architecture {declared} but this host is {host}")]
+    Mismatch {
+        declared: GuestArch,
+        host: GuestArch,
+    },
+    #[error("declares an architecture this build cannot run: {0}")]
+    Unknown(#[from] UnknownArch),
 }
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -70,6 +105,64 @@ impl std::fmt::Display for GuestArch {
 
 #[cfg(test)]
 mod tests {
+    /// The host arch, and the other one, so these tests read the same on an
+    /// x86_64 CI runner and an aarch64 dev machine.
+    fn other_than_host() -> GuestArch {
+        match GuestArch::host() {
+            GuestArch::X86_64 => GuestArch::Aarch64,
+            GuestArch::Aarch64 => GuestArch::X86_64,
+        }
+    }
+
+    #[test]
+    fn require_host_accepts_the_host_arch_and_its_aliases() {
+        let host = GuestArch::host();
+        assert_eq!(GuestArch::require_host(&host.to_string()), Ok(host));
+        let alias = match host {
+            GuestArch::X86_64 => "amd64",
+            GuestArch::Aarch64 => "arm64",
+        };
+        assert_eq!(GuestArch::require_host(alias), Ok(host));
+        // `<arch>-linux` Nix systems parse too.
+        assert_eq!(GuestArch::require_host(host.nix_system()), Ok(host));
+    }
+
+    #[test]
+    fn require_host_refuses_the_other_arch() {
+        let other = other_than_host();
+        assert_eq!(
+            GuestArch::require_host(&other.to_string()),
+            Err(HostArchMismatch::Mismatch {
+                declared: other,
+                host: GuestArch::host(),
+            })
+        );
+    }
+
+    /// Fails closed rather than falling through to `host()`, whose non-x86_64
+    /// arm would otherwise read an unsupported arch as aarch64.
+    #[test]
+    fn require_host_refuses_an_architecture_this_build_does_not_know() {
+        for declared in ["riscv64", "s390x", "", "aarch64_be"] {
+            assert!(
+                matches!(
+                    GuestArch::require_host(declared),
+                    Err(HostArchMismatch::Unknown(_))
+                ),
+                "{declared} should be refused as unknown"
+            );
+        }
+    }
+
+    #[test]
+    fn the_mismatch_message_names_both_sides() {
+        let msg = GuestArch::require_host(&other_than_host().to_string())
+            .unwrap_err()
+            .to_string();
+        assert!(msg.contains("but this host is"), "{msg}");
+        assert!(msg.contains(&GuestArch::host().to_string()), "{msg}");
+    }
+
     use super::*;
     #[test]
     fn aliases_normalize() {

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -301,8 +301,18 @@ pub fn admit_plan_for_run(
                 bundle = pin.bundle_sha256
             )
         })?;
-        verify_plan_bundle(pin, ctx.resolver, ctx.trust)
+        let verified_bundle = verify_plan_bundle(pin, ctx.resolver, ctx.trust)
             .with_context(|| format!("bundle re-verify for pin {}", pin.bundle_sha256))?;
+        // The signature-verified manifest is the only trustworthy statement of
+        // the bundle's architecture — the boot-time resolver reads an unsigned
+        // registry copy. Refuse here so a foreign-arch pin never reaches a
+        // backend, where it surfaces as an unrelated-looking boot failure.
+        mvm_core::arch::GuestArch::require_host(&verified_bundle.manifest.arch).map_err(|e| {
+            anyhow::anyhow!(
+                "plan pins bundle {bundle} which {e} — refuse",
+                bundle = pin.bundle_sha256
+            )
+        })?;
     }
 
     Ok(AdmittedPlan {
@@ -2636,6 +2646,22 @@ mod tests {
         kernel: &[u8],
         rootfs: &[u8],
     ) -> (Vec<u8>, PlanArtifact) {
+        make_test_bundle_for_arch(
+            sk,
+            kernel,
+            rootfs,
+            &mvm_core::arch::GuestArch::host().to_string(),
+        )
+    }
+
+    /// [`make_test_bundle`] with an explicit declared architecture, so the
+    /// cross-arch refusal can be exercised from either host.
+    fn make_test_bundle_for_arch(
+        sk: &ed25519_dalek::SigningKey,
+        kernel: &[u8],
+        rootfs: &[u8],
+        arch: &str,
+    ) -> (Vec<u8>, PlanArtifact) {
         use mvm_core::plan::bundle::{
             ARTIFACTS_DIR, ArtifactRole, BUNDLE_SCHEMA_VERSION, BundleArtifact, BundleManifest,
             sha256_hex,
@@ -2652,7 +2678,7 @@ mod tests {
             schema_version: BUNDLE_SCHEMA_VERSION,
             publisher: "test".to_string(),
             key_id: key_id.clone(),
-            arch: "aarch64".to_string(),
+            arch: arch.to_string(),
             kernel_version: None,
             profile: None,
             workload_label: None,
@@ -2755,6 +2781,46 @@ mod tests {
         .expect_err("must refuse without context");
         let msg = format!("{err:#}");
         assert!(msg.contains("BundleAdmissionContext"), "got: {msg}");
+    }
+
+    /// A pinned bundle built for the other architecture is refused at the trust
+    /// boundary, before any backend sees it. Without this the plan admits and
+    /// fails deep in boot with an unrelated-looking kernel error.
+    #[test]
+    fn admit_with_cross_arch_pinned_bundle_refuses() {
+        let other = match mvm_core::arch::GuestArch::host() {
+            mvm_core::arch::GuestArch::X86_64 => "aarch64",
+            mvm_core::arch::GuestArch::Aarch64 => "x86_64",
+        };
+        let (_env, _home) = host_with_ceiling(Default::default());
+        let dir = tempfile::tempdir().unwrap();
+        let sk = {
+            let mut __ed_seed = [0u8; 32];
+            rand::rng().fill_bytes(&mut __ed_seed);
+            ed25519_dalek::SigningKey::from_bytes(&__ed_seed)
+        };
+        let (archive, pin) =
+            make_test_bundle_for_arch(&sk, b"kernel-bytes", b"rootfs-bytes", other);
+        let mut map = HashMap::new();
+        map.insert(key_id_from_pubkey(&sk.verifying_key()), sk.verifying_key());
+        let trust = MapTrust(map);
+        let resolver = FixedResolver(archive);
+        let ctx = BundleAdmissionContext {
+            resolver: &resolver,
+            trust: &trust,
+        };
+        let err = admit_for_run(
+            &input_with_pin("vm-cross-arch", &pin),
+            &SystemClock,
+            &InMemoryNonceLedger::new(),
+            Some(dir.path()),
+            Some(&ctx),
+            RunPosture::without_backend(Variant::Dev),
+        )
+        .expect_err("a foreign-arch bundle must not be admitted");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("but this host is"), "{msg}");
+        assert!(msg.contains(other), "{msg}");
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/template/lifecycle/snapshot.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle/snapshot.rs
@@ -105,6 +105,63 @@ pub fn template_artifacts_dispatched(
     }
 }
 
+/// Boot-path variant of [`template_artifacts_dispatched`].
+///
+/// Identical, plus one refusal: when the key resolves to an *installed bundle*,
+/// a bundle whose declared architecture is not this host's is refused here
+/// rather than deep in the backend, where it surfaces as an unrelated-looking
+/// kernel or boot failure.
+///
+/// This is a separate entry point rather than a check inside
+/// [`template_artifacts_dispatched`] on purpose. That resolver is shared with
+/// callers that legitimately resolve foreign-arch artifacts without booting
+/// them — `bundle export` and `manifest export-oci` both reach it — so gating
+/// it there breaks cross-arch export. Boot sites call this; everyone else keeps
+/// calling the un-suffixed function.
+#[instrument(skip_all, fields(id_or_slot = id_or_slot))]
+pub fn template_artifacts_for_boot(
+    id_or_slot: &str,
+) -> Result<(TemplateSpec, String, Option<String>, String, String)> {
+    if let Some(declared) = installed_bundle_arch(id_or_slot)? {
+        mvm_core::arch::GuestArch::require_host(&declared).map_err(|e| {
+            anyhow::anyhow!(
+                "bundle {id_or_slot} {e} — install a {} build of this workload                  (`mvmctl bundle fetch` / `mvmctl bundle install`), or run it on                  a {declared} host",
+                mvm_core::arch::GuestArch::host(),
+            )
+        })?;
+    }
+    template_artifacts_dispatched(id_or_slot)
+}
+
+/// The declared arch of an installed bundle, or `None` when `id_or_slot` is not
+/// one (a named template, or a slot — a slot wins over a same-named bundle, and
+/// carries no manifest to check).
+///
+/// Reuses the same slot-or-bundle decision `template_artifacts_dispatched`
+/// makes, so the gate cannot drift from what actually gets resolved.
+pub fn installed_bundle_arch(id_or_slot: &str) -> Result<Option<String>> {
+    if !is_slot_hash_dirname(id_or_slot) {
+        return Ok(None);
+    }
+    if std::path::Path::new(&slot_dir(id_or_slot)).exists() {
+        return Ok(None);
+    }
+    let registry = mvm_core::plan::bundle::BundleRegistry::default_path()?;
+    // A registry we cannot read must not silently skip the gate: propagate,
+    // so an unparseable manifest refuses the boot rather than admitting it
+    // unchecked.
+    Ok(registry
+        .find(id_or_slot)?
+        .map(|installed| installed.manifest.arch))
+}
+
+/// The declared arch of an installed bundle, for the *export* path, which
+/// prefers a best-effort answer over a refusal — a bundle it cannot read is
+/// simply not a bundle whose arch it can carry through.
+pub fn installed_bundle_arch_for_export(id_or_slot: &str) -> Option<String> {
+    installed_bundle_arch(id_or_slot).ok().flatten()
+}
+
 /// Dispatched variant of [`super::crud::template_load`] / [`super::slots::template_load_slot`].
 /// Returns a [`TemplateSpec`] regardless of which key shape was used.
 ///
@@ -233,5 +290,159 @@ mod tests {
 
         let loaded = template_load_dispatched(&slot_hash).expect("load slot hash");
         assert_eq!(loaded.template_id, slot_hash);
+    }
+
+    /// Write a minimal installed-bundle manifest so `BundleRegistry::find`
+    /// resolves it. Only `manifest.json` is read for the arch decision — no
+    /// signature, no install step.
+    fn install_bundle_manifest(sha: &str, arch: &str) {
+        let dir = std::path::PathBuf::from(mvm_core::config::mvm_home())
+            .join("bundles")
+            .join(sha);
+        std::fs::create_dir_all(&dir).expect("bundle dir");
+        let manifest = serde_json::json!({
+            "schema_version": mvm_core::plan::bundle::BUNDLE_SCHEMA_VERSION,
+            "publisher": "test",
+            "key_id": "test-key",
+            "arch": arch,
+            "created_at": "2026-01-01T00:00:00Z",
+            "artifacts": [],
+        });
+        std::fs::write(
+            dir.join("manifest.json"),
+            serde_json::to_vec(&manifest).expect("encode manifest"),
+        )
+        .expect("write manifest");
+    }
+
+    fn other_arch() -> &'static str {
+        match mvm_core::arch::GuestArch::host() {
+            mvm_core::arch::GuestArch::X86_64 => "aarch64",
+            mvm_core::arch::GuestArch::Aarch64 => "x86_64",
+        }
+    }
+
+    /// The G2 witness: a bundle built for the other architecture is refused at
+    /// the boot resolver, naming both sides.
+    #[test]
+    fn template_artifacts_for_boot_refuses_a_foreign_arch_bundle() {
+        let _lock = crate::vm::DATA_DIR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", tmp.path());
+
+        let sha = "abcdef0123456789".repeat(4);
+        install_bundle_manifest(&sha, other_arch());
+
+        let err = template_artifacts_for_boot(&sha)
+            .expect_err("a foreign-arch bundle must not resolve for boot");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("but this host is"), "{msg}");
+        assert!(msg.contains(other_arch()), "{msg}");
+    }
+
+    /// The same call on a host-arch bundle gets past the gate. It still fails —
+    /// the fixture has no artifacts — but *not* with an architecture refusal,
+    /// which is what distinguishes the gate from a blanket rejection.
+    #[test]
+    fn template_artifacts_for_boot_does_not_refuse_a_host_arch_bundle_on_arch() {
+        let _lock = crate::vm::DATA_DIR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", tmp.path());
+
+        let sha = "beefcafe01234567".repeat(4);
+        install_bundle_manifest(&sha, &mvm_core::arch::GuestArch::host().to_string());
+
+        let msg = match template_artifacts_for_boot(&sha) {
+            Ok(_) => String::new(),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            !msg.contains("but this host is"),
+            "host-arch bundle must not be refused on architecture: {msg}"
+        );
+    }
+
+    /// A slot wins over an identically-named bundle, and a slot carries no
+    /// manifest — so the gate must not invent an architecture for it. Locks the
+    /// dispatch precedence into the gate's behaviour.
+    #[test]
+    fn template_artifacts_for_boot_ignores_arch_for_a_slot() {
+        let _lock = crate::vm::DATA_DIR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", tmp.path());
+
+        let sha = "0123456789abcdef".repeat(4);
+        // Both a slot and a foreign-arch bundle under the same name.
+        let slot = test_persisted_manifest(&sha);
+        slot.write_to_slot(std::path::Path::new(&slot_dir(&sha)))
+            .expect("write persisted slot");
+        install_bundle_manifest(&sha, other_arch());
+
+        assert_eq!(installed_bundle_arch_for_export(&sha), None);
+        let msg = match template_artifacts_for_boot(&sha) {
+            Ok(_) => String::new(),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            !msg.contains("but this host is"),
+            "a slot must not be gated on a same-named bundle's arch: {msg}"
+        );
+    }
+
+    /// The regression the first attempt at this gate broke: `bundle export` and
+    /// `manifest export-oci` legitimately resolve foreign-arch artifacts
+    /// without booting them, and reach the registry through the *un-suffixed*
+    /// resolver. Placing the gate in the shared path blocked them.
+    #[test]
+    fn the_un_suffixed_resolver_still_admits_a_foreign_arch_bundle() {
+        let _lock = crate::vm::DATA_DIR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", tmp.path());
+
+        let sha = "feedface89abcdef".repeat(4);
+        install_bundle_manifest(&sha, other_arch());
+
+        let msg = match template_artifacts_dispatched(&sha) {
+            Ok(_) => String::new(),
+            Err(e) => format!("{e:#}"),
+        };
+        assert!(
+            !msg.contains("but this host is"),
+            "export paths must not be gated on architecture: {msg}"
+        );
+    }
+
+    /// `bundle export` re-stamping the exporting host's arch onto a re-exported
+    /// foreign-arch bundle would produce a mislabelled `.mvmpkg` — and the label
+    /// is exactly what the boot gate above trusts.
+    #[test]
+    fn a_re_exported_bundle_keeps_its_own_arch() {
+        let _lock = crate::vm::DATA_DIR_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.set("MVM_HOME", tmp.path());
+
+        let sha = "0f0f0f0f89abcdef".repeat(4);
+        install_bundle_manifest(&sha, other_arch());
+
+        assert_eq!(
+            installed_bundle_arch_for_export(&sha).as_deref(),
+            Some(other_arch()),
+            "export must carry the source bundle's arch, not this host's"
+        );
     }
 }


### PR DESCRIPTION
## The gap

`BundleManifest.arch` (`crates/mvm-contract/src/plan/bundle.rs`) carries this doc comment:

> Target architecture (`x86_64`, `aarch64`). Verifiers refuse to launch a bundle whose arch doesn't match the host.

**Nothing implemented that refusal.** An `x86_64` `.mvmpkg` installed on an aarch64 host was admitted and failed deep in boot with a confusing kernel error. The field is a non-optional `String` on a `deny_unknown_fields` struct, so there is no legacy missing-value case — the gate is unambiguous.

Not to be confused with `PackManifest.target_arch`, which *is* already gated in `crates/mvm-core/src/packs.rs` — that is the builder/runtime **pack** type, a different artifact from a `.mvmpkg`.

## Why the first attempt was reverted, and what changed

The earlier attempt put the check in `bundle_artifacts_for_sha`. That is reached by five non-test callers — two that boot, and three that do not:

| caller | boots? |
|---|---|
| `exec.rs` `resolve_image_artifacts` | **yes** |
| `exec.rs` `boot_session_vm` | **yes** |
| `bundle/export.rs` | no |
| `manifest/export_oci.rs` (×2) | no |

`bundle export` and `manifest export-oci` legitimately resolve foreign-arch artifacts without booting them, so gating the shared resolver broke cross-arch export.

This PR adds `template_artifacts_for_boot` next to `template_artifacts_dispatched` and swaps only the two boot sites. Export paths keep calling the un-suffixed resolver.

It is a boot-flavoured *resolver* rather than a bare `ensure_arch()` at each call site on purpose: the "is this a slot or a bundle?" decision lives in `snapshot.rs`, and a standalone helper would need a second copy of it — one that drifts silently gates the wrong thing. Making the resolver *be* the gate also means a boot site cannot resolve-and-forget.

## Two gates, not one, and not redundant

`admit_plan_for_run` gates as well, and is the authoritative one — it holds the **signature-verified** manifest, where the boot resolver reads an unsigned registry copy.

They cover disjoint paths:

- A **pinned plan** (`--bundle-pin`) carries an arch that admission can verify. Every other plan-synthesis site passes `bundle_pin: None`.
- The **G2 path** — `bundle install` then `machine run --manifest <sha>` — carries no pin at all, so admission never sees a manifest. The runtime resolver is the only gate there.

Neither closes the gap alone.

## Two dependent fixes

The gate is only as good as the label it reads, and the label was wrong in two ways:

- `bundle export` stamped `std::env::consts::ARCH`, bypassing `GuestArch` entirely, **and re-stamped the exporting host's arch onto a re-exported bundle** — an aarch64 bundle re-exported from an x86_64 host got an `x86_64` label around an aarch64 rootfs. Writing the regression test without fixing this would have locked the bug in.
- The registry lookup swallowed errors (`.ok()?`), so an unparseable manifest would have **skipped the gate entirely** — fail-open. It propagates now.

## Blocking prerequisite handled

`make_test_bundle` hardcoded `arch: "aarch64"`. Landing the admission gate without touching it would have failed **every** claim-9 pinned-bundle test on an x86_64 runner. The fixture takes the host arch now, with `make_test_bundle_for_arch` for the negative case; same for `make_bundle_for_pin` in `up/policy.rs`.

## Verification

- `cargo nextest run --workspace` — **12,307 passed**, 0 failed
- `cargo test --workspace --doc` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all --check` — clean
- `just check-gated` — pass
- `check-test-home-isolation`, `check-single-home`, `check-dormant-controls`, `check-no-spec-refs-in-comments`, `check-honesty` — pass

Mutation-tested, not just observed green: making `template_artifacts_for_boot` skip the gate fails `template_artifacts_for_boot_refuses_a_foreign_arch_bundle` and nothing else, so the witness is load-bearing and specific.

New tests: four on `GuestArch::require_host` (aliases, mismatch, unknown-arch fail-closed, message shape); `admit_with_cross_arch_pinned_bundle_refuses`; and five in `snapshot.rs` — the G2 witness, a host-arch bundle *not* refused on arch, slot-wins-over-bundle precedence, the un-suffixed resolver still admitting foreign-arch (the revert regression), and a re-exported bundle keeping its own arch.