### PR TITLE
feat(assurance): fail-closed evidence emission and the workload probe API

### DIFF
--- a/crates/mvm-agentd/src/assurance.rs
+++ b/crates/mvm-agentd/src/assurance.rs
@@ -1,0 +1,319 @@
+//! The workload-facing assurance API.
+//!
+//! An AI workload driving a campaign gets exactly this surface: parse the
+//! envelope it was handed, then call declared probes by *label*. There is no
+//! method here that accepts a command, a path, a host, a port, a socket, or a
+//! destination — not because callers are trusted to avoid them, but because
+//! the type system offers nothing else to pass.
+//!
+//! # This client is advisory
+//!
+//! Like the rest of [`crate::broker_client`], this runs inside the untrusted
+//! guest and is not a security boundary. A compromised workload can write raw
+//! frames to the broker port and skip it entirely. Every gate that matters —
+//! the service binding, effective authority, the declared-destination table,
+//! nonce replay, the step budget, and the audit record — is enforced by the
+//! host against the session *it* opened. The checks below exist to turn a
+//! programming mistake into a local error instead of a round-trip and a
+//! refusal, not to protect the host from the guest.
+
+use mvm_contract::assurance::{
+    AssuranceId, DeliveredSession, DeliveredSessionError, PROBE_REQUEST_SCHEMA, ProbeInvocation,
+    ProbeObservation, ProbeRequest, ToolId,
+};
+use mvm_core::protocol::broker::{CorrelationId, ServiceCall, ServiceId};
+
+use crate::broker_client::{BrokerError, broker_call};
+
+/// Wire name of the host-side assurance service.
+pub const ASSURANCE_SERVICE: &str = "host.assurance.v1";
+/// The one verb it exposes.
+pub const PROBE_VERB: &str = "probe";
+/// Wall-clock bound on one probe round-trip.
+const PROBE_TIMEOUT_SECS: u64 = 10;
+
+/// Why a workload-side probe did not happen.
+#[derive(Debug, thiserror::Error)]
+pub enum AssuranceError {
+    /// The delivered envelope could not be read.
+    #[error("delivered session is unusable: {0}")]
+    Session(#[from] DeliveredSessionError),
+    /// The session's effective authority does not include the tool.
+    #[error("this session was not granted the campaign probe tool")]
+    ToolNotGranted,
+    /// The label is not one the campaign declared.
+    #[error("destination label is not declared for this campaign")]
+    UndeclaredDestination,
+    /// The local step budget is spent. The host enforces its own.
+    #[error("the session step budget is spent")]
+    StepBudgetSpent,
+    /// The host refused, or the transport failed.
+    #[error(transparent)]
+    Broker(#[from] BrokerError),
+    /// The host's reply did not match the observation contract.
+    #[error("host observation could not be read: {0}")]
+    Observation(String),
+}
+
+/// A workload's handle on its own assurance session.
+pub struct AssuranceCampaign {
+    session: DeliveredSession,
+    steps_used: u32,
+    nonce_counter: u64,
+}
+
+impl AssuranceCampaign {
+    /// Read the envelope this workload was started with.
+    pub fn from_envelope(bytes: &[u8]) -> Result<Self, AssuranceError> {
+        Ok(Self {
+            session: DeliveredSession::parse_json(bytes)?,
+            steps_used: 0,
+            nonce_counter: 0,
+        })
+    }
+
+    /// The envelope, for a workload that wants to read its own narrative.
+    #[must_use]
+    pub fn session(&self) -> &DeliveredSession {
+        &self.session
+    }
+
+    /// Labels this campaign may probe. The only values `probe_egress` accepts.
+    #[must_use]
+    pub fn declared_destinations(&self) -> &[AssuranceId] {
+        &self.session.synthetic_inputs.destination_labels
+    }
+
+    /// Steps left in the locally-tracked budget.
+    #[must_use]
+    pub fn steps_remaining(&self) -> u32 {
+        self.session
+            .authority
+            .max_steps
+            .saturating_sub(self.steps_used)
+    }
+
+    /// Ask whether the admitted policy would admit a declared destination.
+    ///
+    /// `idempotency_key` is the caller's: presenting the same one again returns
+    /// the first answer without re-running the probe, which is what makes a
+    /// retry after a lost reply safe. The nonce is generated here and never
+    /// reused, so a replayed frame is refused by the host even when the key is
+    /// legitimately repeated.
+    pub fn probe_egress(
+        &mut self,
+        destination_label: &AssuranceId,
+        idempotency_key: &AssuranceId,
+    ) -> Result<ProbeObservation, AssuranceError> {
+        // Unreachable while `ToolId` has one variant — an envelope granting no
+        // tool is refused at parse time, and a non-empty grant can only be this
+        // one. Kept because it becomes load-bearing the moment a second tool
+        // exists, and because the alternative is a call site that silently
+        // stops checking when that happens.
+        if !self.session.permits_tool(ToolId::CampaignProbeV1) {
+            return Err(AssuranceError::ToolNotGranted);
+        }
+        if !self.session.declares_destination(destination_label) {
+            return Err(AssuranceError::UndeclaredDestination);
+        }
+        if self.steps_remaining() == 0 {
+            return Err(AssuranceError::StepBudgetSpent);
+        }
+
+        let request = ProbeRequest {
+            schema: PROBE_REQUEST_SCHEMA.to_string(),
+            session_id: self.session.mvm_binding.session_id.clone(),
+            trial_id: self.session.session.trial_id.clone(),
+            idempotency_key: idempotency_key.clone(),
+            nonce: self.next_nonce(),
+            tool: ToolId::CampaignProbeV1,
+            invocation: ProbeInvocation::EgressAdmission {
+                destination_label: destination_label.clone(),
+            },
+        };
+        let observation = self.dispatch(&request)?;
+        self.steps_used = self.steps_used.saturating_add(1);
+        Ok(observation)
+    }
+
+    fn dispatch(&self, request: &ProbeRequest) -> Result<ProbeObservation, AssuranceError> {
+        let service = ServiceId::parse(ASSURANCE_SERVICE)
+            .map_err(|error| AssuranceError::Observation(format!("{error:?}")))?;
+        let payload = serde_json::to_value(request)
+            .map_err(|error| AssuranceError::Observation(error.to_string()))?;
+        let call = ServiceCall {
+            service,
+            verb: PROBE_VERB.to_string(),
+            correlation_id: CorrelationId::new(format!(
+                "assurance-probe-{}",
+                request.idempotency_key
+            )),
+            payload,
+            capability: None,
+        };
+        let reply = broker_call(&call, PROBE_TIMEOUT_SECS)?;
+        serde_json::from_value(reply)
+            .map_err(|error| AssuranceError::Observation(error.to_string()))
+    }
+
+    /// Mint the next single-use nonce for this session.
+    ///
+    /// Session-scoped and monotonic rather than random: the guest has no
+    /// entropy requirement here, and the host's ledger only needs the values to
+    /// be distinct within the session it is tracking.
+    pub(crate) fn next_nonce(&mut self) -> AssuranceId {
+        self.nonce_counter = self.nonce_counter.saturating_add(1);
+        AssuranceId::parse(format!(
+            "{}-n{}",
+            self.session.mvm_binding.session_id, self.nonce_counter
+        ))
+        .expect("session id is a valid identifier and the suffix is alphanumeric")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DIGEST: &str = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+
+    fn envelope(max_steps: u32, tools: &str, labels: &str) -> String {
+        format!(
+            r#"{{
+  "schema": "mvm.assurance.ai-session-input/v1",
+  "session": {{
+    "request_id": "mvm-request-1", "idempotency_key": "trial-1",
+    "source_run_id": "scout-1", "campaign_id": "mvm-campaign-1", "trial_id": "trial-1"
+  }},
+  "source": {{
+    "subject_kind": "local_repository", "subject_revision": null,
+    "source_digest": "{DIGEST}", "finding_id": "SCOUT-RCE-001", "group_id": "group-1",
+    "rule_id": "SCOUT-RCE-001", "category": "command_injection", "severity": "critical",
+    "location": "src/worker.py:42:7", "evidence_refs": [], "artifact_locator": null,
+    "requested_policy_digest": "{DIGEST}"
+  }},
+  "narrative": {{
+    "narrative_id": "mvm.boundary.process-exec.v1", "objective": "attempt the effect",
+    "expected_boundary": "it cannot cross", "required_capabilities": []
+  }},
+  "authority": {{
+    "allowed_tools": {tools}, "observation_scopes": ["host.audit.refs"],
+    "max_steps": {max_steps}, "max_output_bytes": 4096, "deadline_unix_ms": 9999999999999
+  }},
+  "synthetic_inputs": {{ "canary_ids": [], "destination_labels": {labels} }},
+  "output_contract": {{ "kind": "mvm.assurance.trial-result/v1", "must_include": [] }},
+  "mvm_binding": {{
+    "session_id": "session-1", "plan_id": "plan-1", "workload_digest": "{DIGEST}",
+    "artifact_digest": "{DIGEST}", "effective_policy_digest": "{DIGEST}",
+    "session_grant_digest": "{DIGEST}", "expires_at_unix_ms": 9999999999999,
+    "nonce": "nonce-1", "allowed_tools": {tools}, "backend": "firecracker"
+  }}
+}}"#
+        )
+    }
+
+    fn campaign(max_steps: u32) -> AssuranceCampaign {
+        AssuranceCampaign::from_envelope(
+            envelope(
+                max_steps,
+                r#"["campaign_probe.v1"]"#,
+                r#"["undeclared.synthetic.destination"]"#,
+            )
+            .as_bytes(),
+        )
+        .expect("campaign")
+    }
+
+    fn label(raw: &str) -> AssuranceId {
+        AssuranceId::parse(raw).expect("label")
+    }
+
+    #[test]
+    fn a_delivered_envelope_yields_its_declared_surface() {
+        let campaign = campaign(4);
+        assert_eq!(
+            campaign.declared_destinations(),
+            &[label("undeclared.synthetic.destination")]
+        );
+        assert_eq!(campaign.steps_remaining(), 4);
+        assert_eq!(
+            campaign.session().mvm_binding.backend.as_str(),
+            "firecracker"
+        );
+    }
+
+    // The guards below must fire *before* any broker round-trip. Nothing is
+    // listening in a unit test, so a guard that failed to fire would surface as
+    // a transport error rather than the expected refusal — which is what makes
+    // these assertions meaningful rather than incidental.
+
+    #[test]
+    fn an_undeclared_label_is_refused_without_a_round_trip() {
+        let mut campaign = campaign(4);
+        assert!(matches!(
+            campaign.probe_egress(&label("some.other.host"), &label("k1")),
+            Err(AssuranceError::UndeclaredDestination)
+        ));
+        assert_eq!(campaign.steps_remaining(), 4, "a refusal spends no step");
+    }
+
+    #[test]
+    fn an_envelope_granting_no_tool_never_becomes_a_campaign() {
+        // Refused at parse time, which is stronger than refusing the call:
+        // there is no campaign object to invoke a probe on at all.
+        let result = AssuranceCampaign::from_envelope(
+            envelope(4, r#"[]"#, r#"["undeclared.synthetic.destination"]"#).as_bytes(),
+        );
+        assert!(matches!(
+            result,
+            Err(AssuranceError::Session(DeliveredSessionError::NoTools))
+        ));
+    }
+
+    #[test]
+    fn a_spent_step_budget_is_refused_without_a_round_trip() {
+        let mut campaign = campaign(1);
+        campaign.steps_used = 1;
+        assert!(matches!(
+            campaign.probe_egress(&label("undeclared.synthetic.destination"), &label("k1")),
+            Err(AssuranceError::StepBudgetSpent)
+        ));
+    }
+
+    #[test]
+    fn nonces_are_single_use_within_a_session() {
+        let mut campaign = campaign(4);
+        let first = campaign.next_nonce();
+        let second = campaign.next_nonce();
+        assert_ne!(first, second);
+        assert!(first.as_str().starts_with("session-1-n"), "{first}");
+    }
+
+    #[test]
+    fn the_probe_payload_carries_no_command_path_or_destination() {
+        let request = ProbeRequest {
+            schema: PROBE_REQUEST_SCHEMA.to_string(),
+            session_id: label("session-1"),
+            trial_id: label("trial-1"),
+            idempotency_key: label("k1"),
+            nonce: label("n1"),
+            tool: ToolId::CampaignProbeV1,
+            invocation: ProbeInvocation::EgressAdmission {
+                destination_label: label("undeclared.synthetic.destination"),
+            },
+        };
+        let json = serde_json::to_string(&request).expect("serialize");
+        for forbidden in ["command", "argv", "path", "host", "port", "socket"] {
+            assert!(!json.contains(forbidden), "{forbidden} leaked into {json}");
+        }
+        assert!(json.contains("undeclared.synthetic.destination"), "{json}");
+    }
+
+    #[test]
+    fn a_foreign_envelope_is_refused() {
+        assert!(matches!(
+            AssuranceCampaign::from_envelope(b"{}"),
+            Err(AssuranceError::Session(_))
+        ));
+    }
+}

--- a/crates/mvm-agentd/src/lib.rs
+++ b/crates/mvm-agentd/src/lib.rs
@@ -7,6 +7,8 @@ pub mod addon_dns;
 /// Loopback TCP ↔ host-vsock bridge (`mvm-addon-vsock-bridge`).
 #[cfg(feature = "addons")]
 pub mod addon_vsock_bridge;
+/// The workload-facing assurance campaign API.
+pub mod assurance;
 /// In-guest host-services broker client: dials the supervisor's guest-facing
 /// broker port over vsock and exchanges a framed `ServiceCall` for a framed
 /// `ServiceResponse`. The workload→host call half of the broker path.

--- a/crates/mvm-contract/src/assurance/mod.rs
+++ b/crates/mvm-contract/src/assurance/mod.rs
@@ -54,5 +54,6 @@ pub use probe::{
     ProbeRefusal, ProbeRequest,
 };
 pub use wire::{
-    AuthorityWire, MvmBindingWire, TrialResultDocument, TrialResultIdentity, TrialResultSession,
+    AuthorityWire, DeliveredSession, DeliveredSessionError, MvmBindingWire, TrialResultDocument,
+    TrialResultIdentity, TrialResultSession,
 };

--- a/crates/mvm-contract/src/assurance/probe.rs
+++ b/crates/mvm-contract/src/assurance/probe.rs
@@ -126,6 +126,8 @@ pub enum ProbeRefusal {
     NonceReplay,
     #[error("the destination label was not declared for this campaign")]
     UndeclaredDestination,
+    #[error("the probe could not be recorded, so it was not run")]
+    AuditUnavailable,
 }
 
 impl ProbeRefusal {
@@ -142,6 +144,7 @@ impl ProbeRefusal {
             Self::StepBudgetExhausted => "step_budget_exhausted",
             Self::NonceReplay => "nonce_replay",
             Self::UndeclaredDestination => "undeclared_destination",
+            Self::AuditUnavailable => "audit_unavailable",
         }
     }
 }

--- a/crates/mvm-contract/src/assurance/tests.rs
+++ b/crates/mvm-contract/src/assurance/tests.rs
@@ -1085,6 +1085,58 @@ fn the_emitted_record_matches_the_counterparty_field_set() {
 }
 
 #[test]
+fn the_envelope_the_host_writes_is_the_one_the_guest_reads() {
+    // The host half is serialize-only and the guest half is deserialize-only,
+    // so nothing but a test proves they describe the same document.
+    let envelope =
+        AiSessionInput::bind(request(), &binding(), &effective_for_envelope()).expect("envelope");
+    let json = envelope.to_json().expect("encode");
+
+    let delivered = wire::DeliveredSession::parse_json(json.as_bytes()).expect("guest parses");
+    assert_eq!(delivered.mvm_binding, *envelope.binding());
+    assert_eq!(delivered.authority, *envelope.authority());
+    assert_eq!(delivered.session.trial_id.as_str(), "trial-1");
+    assert_eq!(
+        delivered.mvm_binding.plan_id.as_str(),
+        minimal_plan().plan_id.0
+    );
+    assert!(delivered.permits_tool(ToolId::CampaignProbeV1));
+    assert!(delivered.declares_destination(&id("undeclared.synthetic.destination")));
+    assert!(!delivered.declares_destination(&id("some.other.label")));
+}
+
+#[test]
+fn the_guest_reader_fails_closed_on_a_foreign_or_oversized_envelope() {
+    let bad_schema = request_json().replace(
+        "mvm.assurance.ai-session-input/v1",
+        "mvm.assurance.ai-session-input/v9",
+    );
+    assert!(matches!(
+        wire::DeliveredSession::parse_json(bad_schema.as_bytes()),
+        // No `mvm_binding` key at all, so this fails as malformed before the
+        // schema check — either way it does not yield a session.
+        Err(wire::DeliveredSessionError::Malformed(_)
+            | wire::DeliveredSessionError::UnsupportedSchema(_))
+    ));
+
+    let oversized = vec![b'x'; input::MAX_SESSION_INPUT_BYTES + 1];
+    assert_eq!(
+        wire::DeliveredSession::parse_json(&oversized),
+        Err(wire::DeliveredSessionError::TooLarge)
+    );
+}
+
+#[test]
+fn a_provider_request_alone_is_not_a_deliverable_session() {
+    // The request half carries no binding, so a workload handed one directly
+    // — rather than one the host assembled — cannot read it as a session.
+    assert!(matches!(
+        wire::DeliveredSession::parse_json(request_json().as_bytes()),
+        Err(wire::DeliveredSessionError::Malformed(_))
+    ));
+}
+
+#[test]
 fn the_outcome_vocabulary_matches_the_counterparty_spelling() {
     for (outcome, spelling) in [
         (TrialOutcome::Prevented, "PREVENTED"),

--- a/crates/mvm-contract/src/assurance/wire.rs
+++ b/crates/mvm-contract/src/assurance/wire.rs
@@ -181,3 +181,73 @@ impl TrialResultDocument {
         }
     }
 }
+
+/// The envelope as a workload reads it.
+///
+/// [`super::input::AiSessionInput`] is serialize-only on purpose: the host must
+/// never be able to parse admission facts out of provider bytes. The guest has
+/// the opposite problem — it only ever *receives* an envelope, and needs the
+/// binding and effective authority to make a call at all — so reading is a
+/// separate type with a separate direction.
+///
+/// This is safe precisely because it is guest-side. Nothing the guest believes
+/// about its own binding is authoritative; the host re-derives every gate from
+/// the session it opened. A workload that forged one of these would be lying
+/// only to itself.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DeliveredSession {
+    pub schema: String,
+    pub session: super::input::SessionRef,
+    pub source: super::input::SourceRef,
+    pub narrative: super::input::Narrative,
+    pub authority: AuthorityWire,
+    pub synthetic_inputs: super::input::SyntheticInputs,
+    pub output_contract: super::input::OutputContract,
+    pub mvm_binding: MvmBindingWire,
+}
+
+/// Why a delivered envelope is unusable.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum DeliveredSessionError {
+    #[error("delivered envelope exceeds the size limit")]
+    TooLarge,
+    #[error("delivered envelope is not valid for this schema: {0}")]
+    Malformed(String),
+    #[error("unsupported schema {0:?}")]
+    UnsupportedSchema(String),
+    #[error("the delivered envelope grants no tool")]
+    NoTools,
+}
+
+impl DeliveredSession {
+    /// Parse an envelope handed to this workload.
+    pub fn parse_json(bytes: &[u8]) -> Result<Self, DeliveredSessionError> {
+        if bytes.len() > super::input::MAX_SESSION_INPUT_BYTES {
+            return Err(DeliveredSessionError::TooLarge);
+        }
+        let parsed: Self = serde_json::from_slice(bytes)
+            .map_err(|error| DeliveredSessionError::Malformed(alloc::format!("{error}")))?;
+        if parsed.schema != super::input::AI_SESSION_INPUT_SCHEMA {
+            return Err(DeliveredSessionError::UnsupportedSchema(parsed.schema));
+        }
+        if parsed.authority.allowed_tools.is_empty() {
+            return Err(DeliveredSessionError::NoTools);
+        }
+        Ok(parsed)
+    }
+
+    /// Whether `label` is one this campaign declared.
+    #[must_use]
+    pub fn declares_destination(&self, label: &AssuranceId) -> bool {
+        self.synthetic_inputs.destination_labels.contains(label)
+    }
+
+    /// Whether `tool` survived into effective authority.
+    #[must_use]
+    pub fn permits_tool(&self, tool: ToolId) -> bool {
+        self.authority.allowed_tools.contains(&tool)
+    }
+}

--- a/crates/mvm-core/src/receipt.rs
+++ b/crates/mvm-core/src/receipt.rs
@@ -52,6 +52,10 @@ pub mod receipt_type {
     pub const CHECKPOINT_FORKED: &str = "checkpoint.forked";
     /// Emitted when a workload input request is refused.
     pub const INPUT_REFUSED: &str = "stream.input_refused";
+    /// Emitted when an assurance session is opened against an admitted plan.
+    pub const ASSURANCE_SESSION_OPENED: &str = "assurance.session_opened";
+    /// Emitted when an assurance trial completes and its outcome is derived.
+    pub const ASSURANCE_TRIAL_COMPLETED: &str = "assurance.trial_completed";
 }
 
 /// Outcome of the action described by a receipt.

--- a/crates/mvm-hostd/src/audit/assurance.rs
+++ b/crates/mvm-hostd/src/audit/assurance.rs
@@ -1,0 +1,287 @@
+//! The assurance ledger: what a campaign may later cite as evidence.
+//!
+//! An assurance outcome is only as good as the records behind it, so this
+//! module exists to make the citations in an [`MvmBinding`] real. Every
+//! reference it hands back was produced by an emit that succeeded — the
+//! emitter's ordinary path treats receipts as a derived cache and swallows
+//! their errors, which is right when nothing cites them and wrong here.
+//!
+//! # References resolve
+//!
+//! An audit reference is `mvm:audit:<hex>`, where the hex is SHA-256 of the
+//! exact bytes the entry was signed as. The envelope stores those same bytes in
+//! its `canonical` field, so [`resolve_audit_ref`] can find the line by
+//! hashing what is on disk. A reference that cannot be resolved is a reference
+//! that should never have been written, and the round-trip is asserted by test
+//! rather than assumed.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use mvm_contract::assurance::{
+    AssuranceId, EvidenceRef, MvmBinding, Sha256Digest, TrialOutcome, TrialVerdict,
+};
+use mvm_core::plan::ExecutionPlan;
+use sha2::{Digest, Sha256};
+
+use super::emitter::AuditEmitter;
+use super::evidence::{EmittedEvidence, EvidenceReceipt, audit_entry_digest_hex};
+use crate::supervisor::{PlanAuditEntry, for_plan};
+
+/// Audit event emitted when a session is opened against an admitted plan.
+pub const EVENT_SESSION_OPENED: &str = "assurance.session_opened";
+/// Audit event emitted for one declared probe.
+pub const EVENT_PROBE: &str = "assurance.probe";
+/// Audit event emitted when a trial's outcome is derived.
+pub const EVENT_TRIAL_COMPLETED: &str = "assurance.trial_completed";
+
+/// Build the resolvable reference for an audit entry.
+pub fn audit_ref(entry: &PlanAuditEntry) -> Result<EvidenceRef> {
+    let digest = audit_entry_digest_hex(entry)?;
+    EvidenceRef::parse(format!("mvm:audit:{digest}"))
+        .map_err(|error| anyhow::anyhow!("audit reference is not well formed: {error}"))
+}
+
+/// Build the reference for a receipt content address.
+pub fn receipt_ref(receipt_id: &str) -> Result<EvidenceRef> {
+    EvidenceRef::parse(format!("mvm:receipt:{receipt_id}"))
+        .map_err(|error| anyhow::anyhow!("receipt reference is not well formed: {error}"))
+}
+
+/// Find the audit entry a reference names, by hashing what is on disk.
+///
+/// Returns `Ok(None)` when the chain holds no matching line — which is the
+/// answer a verifier needs, and is distinct from a malformed chain.
+pub fn resolve_audit_ref(chain_path: &Path, reference: &EvidenceRef) -> Result<Option<String>> {
+    let Some(want) = reference.as_str().strip_prefix("mvm:audit:") else {
+        return Ok(None);
+    };
+    let body = std::fs::read_to_string(chain_path)
+        .with_context(|| format!("reading audit chain {}", chain_path.display()))?;
+    for line in body.lines().filter(|line| !line.trim().is_empty()) {
+        let envelope: serde_json::Value =
+            serde_json::from_str(line).context("parsing an audit chain line")?;
+        // Prefer the exact signed bytes the envelope carries; fall back to
+        // re-serializing for lines written before `canonical` existed.
+        let bytes = match envelope
+            .get("canonical")
+            .and_then(serde_json::Value::as_str)
+        {
+            Some(encoded) => {
+                use base64::Engine;
+                base64::engine::general_purpose::URL_SAFE_NO_PAD
+                    .decode(encoded)
+                    .context("decoding an audit line's canonical bytes")?
+            }
+            None => serde_json::to_vec(
+                envelope
+                    .get("entry")
+                    .ok_or_else(|| anyhow::anyhow!("audit line carries no entry"))?,
+            )
+            .context("re-serializing an audit entry")?,
+        };
+        if hex::encode(Sha256::digest(&bytes)) == want {
+            return Ok(Some(line.to_string()));
+        }
+    }
+    Ok(None)
+}
+
+/// Identity one assurance session runs under.
+#[derive(Debug, Clone)]
+pub struct SessionIdentity {
+    pub session_id: AssuranceId,
+    pub campaign_id: AssuranceId,
+    pub trial_id: AssuranceId,
+    pub source_digest: Sha256Digest,
+}
+
+/// What an emit produced, in the form a binding cites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerRefs {
+    pub audit: EvidenceRef,
+    pub receipt: Option<EvidenceRef>,
+}
+
+impl LedgerRefs {
+    fn from_emitted(entry: &PlanAuditEntry, emitted: &EmittedEvidence) -> Result<Self> {
+        let _ = entry;
+        let audit = EvidenceRef::parse(format!("mvm:audit:{}", emitted.audit_digest))
+            .map_err(|error| anyhow::anyhow!("audit reference is not well formed: {error}"))?;
+        let receipt = match &emitted.receipt_id {
+            Some(id) => Some(receipt_ref(id)?),
+            None => None,
+        };
+        Ok(Self { audit, receipt })
+    }
+}
+
+/// Writes the records an assurance campaign cites.
+pub struct AssuranceLedger<'a> {
+    emitter: &'a AuditEmitter,
+    plan: &'a ExecutionPlan,
+}
+
+impl<'a> AssuranceLedger<'a> {
+    /// Bind a ledger to one admitted plan.
+    #[must_use]
+    pub fn new(emitter: &'a AuditEmitter, plan: &'a ExecutionPlan) -> Self {
+        Self { emitter, plan }
+    }
+
+    /// Record that a session opened, and return what a binding may cite.
+    ///
+    /// Labels carry identifiers and digests only. No prompt bytes, no probe
+    /// arguments, and no policy contents cross into the chain.
+    pub fn open_session(&self, identity: &SessionIdentity) -> Result<LedgerRefs> {
+        let labels = [
+            (
+                "assurance_session".to_string(),
+                identity.session_id.to_string(),
+            ),
+            (
+                "assurance_campaign".to_string(),
+                identity.campaign_id.to_string(),
+            ),
+            ("assurance_trial".to_string(), identity.trial_id.to_string()),
+            (
+                "assurance_source_digest".to_string(),
+                identity.source_digest.to_string(),
+            ),
+        ];
+        self.emit(EVENT_SESSION_OPENED, labels, EvidenceReceipt::Required)
+    }
+
+    /// Record one probe decision.
+    ///
+    /// `decision` is the closed token the host produced (`allowed`,
+    /// `deny_all`, `not_in_allowlist`), never a message and never the
+    /// destination behind the label.
+    pub fn record_probe(&self, probe: &ProbeRecord<'_>) -> Result<LedgerRefs> {
+        let labels = [
+            (
+                "assurance_session".to_string(),
+                probe.session_id.to_string(),
+            ),
+            ("assurance_trial".to_string(), probe.trial_id.to_string()),
+            ("assurance_probe".to_string(), probe.probe_id.to_string()),
+            ("assurance_decision".to_string(), probe.decision.to_string()),
+            (
+                "assurance_idempotency_key".to_string(),
+                probe.idempotency_key.to_string(),
+            ),
+            ("assurance_admitted".to_string(), probe.admitted.to_string()),
+            (
+                "assurance_edge".to_string(),
+                probe.destination_label.to_string(),
+            ),
+        ];
+        // Audit only: a probe is fine-grained, and the receipt a campaign
+        // publishes is the trial's, not each attempt's.
+        self.emit(EVENT_PROBE, labels, EvidenceReceipt::Omitted)
+    }
+
+    /// Record the derived outcome of a trial.
+    ///
+    /// The reason is recorded for every non-claim outcome, so a later reader
+    /// can tell "we proved nothing because the observer was missing" from
+    /// "we proved nothing because the model contradicted it".
+    pub fn complete_trial(
+        &self,
+        identity: &SessionIdentity,
+        verdict: &TrialVerdict,
+    ) -> Result<LedgerRefs> {
+        let mut labels = vec![
+            (
+                "assurance_session".to_string(),
+                identity.session_id.to_string(),
+            ),
+            (
+                "assurance_campaign".to_string(),
+                identity.campaign_id.to_string(),
+            ),
+            ("assurance_trial".to_string(), identity.trial_id.to_string()),
+            (
+                "assurance_outcome".to_string(),
+                verdict.outcome.as_str().to_string(),
+            ),
+            (
+                "assurance_certifying".to_string(),
+                verdict.outcome.is_certifying_claim().to_string(),
+            ),
+        ];
+        if let Some(reason) = verdict.reason {
+            labels.push((
+                "assurance_reason".to_string(),
+                serde_json::to_value(reason)
+                    .ok()
+                    .and_then(|value| value.as_str().map(str::to_string))
+                    .unwrap_or_else(|| "unknown".to_string()),
+            ));
+        }
+        self.emit(EVENT_TRIAL_COMPLETED, labels, EvidenceReceipt::Required)
+    }
+
+    fn emit<I>(&self, event: &str, labels: I, receipt: EvidenceReceipt) -> Result<LedgerRefs>
+    where
+        I: IntoIterator<Item = (String, String)>,
+    {
+        let entry = for_plan(self.plan, None, event, labels);
+        let emitted = self
+            .emitter
+            .emit_entry_for_evidence(&entry, receipt)
+            .with_context(|| format!("emitting assurance event {event}"))?;
+        LedgerRefs::from_emitted(&entry, &emitted)
+    }
+}
+
+/// One probe's audit-visible facts.
+#[derive(Debug, Clone)]
+pub struct ProbeRecord<'a> {
+    pub session_id: &'a AssuranceId,
+    pub trial_id: &'a AssuranceId,
+    pub probe_id: &'a str,
+    pub decision: &'a str,
+    pub idempotency_key: &'a AssuranceId,
+    pub admitted: bool,
+    /// The declared label that was probed. The label is a synthetic
+    /// identifier; what it resolves to stays host-side, so recording it ties
+    /// the entry to a blocked edge without naming a destination.
+    pub destination_label: &'a AssuranceId,
+}
+
+/// Attach ledger references to a binding under construction.
+///
+/// A binding refuses to build without at least one audit and one receipt
+/// reference, so this is the step that makes an assurance session bindable at
+/// all: no successful emit, no session.
+pub fn cite(
+    builder: mvm_contract::assurance::MvmBindingBuilder,
+    refs: &LedgerRefs,
+) -> mvm_contract::assurance::MvmBindingBuilder {
+    let builder = builder.audit_ref(refs.audit.clone());
+    match &refs.receipt {
+        Some(receipt) => builder.receipt_ref(receipt.clone()),
+        None => builder,
+    }
+}
+
+/// Whether a binding's citations all resolve against `chain_path`.
+///
+/// Receipts are content-addressed and verified by their own store, so this
+/// checks the audit half — the half whose reference is only as good as the
+/// bytes it was derived from.
+pub fn audit_citations_resolve(binding: &MvmBinding, chain_path: &Path) -> Result<bool> {
+    for reference in &binding.audit_refs {
+        if resolve_audit_ref(chain_path, reference)?.is_none() {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Whether an outcome is one a campaign may publish as a claim.
+#[must_use]
+pub fn is_publishable_claim(outcome: TrialOutcome) -> bool {
+    outcome.is_certifying_claim()
+}

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -39,6 +39,8 @@
 use std::path::{Path, PathBuf};
 
 use crate::audit::decisions::DecisionStore;
+pub use crate::audit::evidence::EmittedEvidence;
+use crate::audit::evidence::{EvidenceReceipt, audit_entry_digest_hex};
 use crate::audit::receipt_export::audit_entry_to_receipt;
 use crate::audit::receipt_store::ReceiptStore;
 use crate::supervisor::{
@@ -1218,6 +1220,18 @@ impl AuditEmitter {
     }
 
     fn emit_entry_blocking(&self, entry: &PlanAuditEntry) -> Result<()> {
+        self.sign_entry_blocking(entry)?;
+        let t_r = std::time::Instant::now();
+        self.emit_receipt_for_entry(entry);
+        tracing::debug!(ms = t_r.elapsed().as_secs_f64() * 1000.0, "emit: receipt");
+        Ok(())
+    }
+
+    /// Sign and append one entry to every chain, without its receipt.
+    ///
+    /// Split out so an evidence-bearing caller can pair the same signing with
+    /// a fail-closed receipt rather than the best-effort one below.
+    fn sign_entry_blocking(&self, entry: &PlanAuditEntry) -> Result<()> {
         let t0 = std::time::Instant::now();
         let rt = self.runtime()?;
         let t_rt = std::time::Instant::now();
@@ -1236,10 +1250,84 @@ impl AuditEmitter {
             );
         }
         audit_mirror::emit_mirror_event(entry);
-        let t_r = std::time::Instant::now();
-        self.emit_receipt_for_entry(entry);
-        tracing::debug!(ms = t_r.elapsed().as_secs_f64() * 1000.0, "emit: receipt");
         Ok(())
+    }
+
+    /// Emit one entry and its receipt, failing closed if either cannot be
+    /// written, and return references to both.
+    ///
+    /// The ordinary emit path treats receipts as a derived cache and swallows
+    /// their errors, which is right when nothing cites them. It is wrong for
+    /// evidence a later claim rests on: a citation to a receipt that was never
+    /// written is worse than no citation, because it reads as proof.
+    pub fn emit_entry_for_evidence(
+        &self,
+        entry: &PlanAuditEntry,
+        receipt: EvidenceReceipt,
+    ) -> Result<EmittedEvidence> {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            return std::thread::scope(|scope| {
+                scope
+                    .spawn(|| self.emit_entry_for_evidence_blocking(entry, receipt))
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("audit emit thread panicked"))?
+            });
+        }
+        self.emit_entry_for_evidence_blocking(entry, receipt)
+    }
+
+    fn emit_entry_for_evidence_blocking(
+        &self,
+        entry: &PlanAuditEntry,
+        receipt: EvidenceReceipt,
+    ) -> Result<EmittedEvidence> {
+        self.sign_entry_blocking(entry)?;
+        let receipt_id = match receipt {
+            EvidenceReceipt::Required => self.emit_receipt_for_entry_checked(entry)?,
+            EvidenceReceipt::Omitted => None,
+        };
+        Ok(EmittedEvidence {
+            audit_digest: audit_entry_digest_hex(entry)?,
+            receipt_id,
+        })
+    }
+
+    /// Append the receipt for `entry`, returning its content address.
+    ///
+    /// `Ok(None)` means receipts are switched off for this emitter, which is a
+    /// configuration answer rather than a failure. Every other unhappy path is
+    /// an error.
+    fn emit_receipt_for_entry_checked(&self, entry: &PlanAuditEntry) -> Result<Option<String>> {
+        if !self.receipts_enabled {
+            return Ok(None);
+        }
+        let tenant = entry.tenant.0.clone();
+        let store = self
+            .receipt_store_for_tenant(&tenant)
+            .ok_or_else(|| anyhow::anyhow!("no receipt store for tenant {tenant}"))?;
+        let host_did =
+            mvm_core::did_key::DidKey::from_verifying_key(self.signing_key.verifying_key())
+                .to_did_key();
+        let mut receipt = audit_entry_to_receipt(entry, &host_did).ok_or_else(|| {
+            anyhow::anyhow!(
+                "audit event {} has no receipt mapping; evidence cannot cite it",
+                entry.event
+            )
+        })?;
+        let mut emitted_id = None;
+        store.append_chained(|prev| {
+            receipt.prev_receipt_id = prev;
+            receipt.receipt_id = receipt.compute_id().context("computing receipt id")?;
+            emitted_id = Some(receipt.receipt_id.clone());
+            let signed_at = chrono::Utc::now().to_rfc3339();
+            mvm_core::receipt::SignedExecutionReceipt::sign(
+                receipt.clone(),
+                &self.signing_key,
+                signed_at,
+            )
+            .context("signing execution receipt")
+        })?;
+        Ok(emitted_id)
     }
 
     /// Best-effort emission of a signed [`ExecutionReceipt`] for an audit

--- a/crates/mvm-hostd/src/audit/evidence.rs
+++ b/crates/mvm-hostd/src/audit/evidence.rs
@@ -1,0 +1,82 @@
+//! The vocabulary of an evidence-bearing emit.
+//!
+//! Kept beside the emitter rather than inside it because these types are what
+//! *other* subsystems cite — the assurance ledger builds its references from
+//! them — and because "what an emit produced" is a smaller idea than "how the
+//! emitter works".
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+
+use crate::supervisor::PlanAuditEntry;
+
+/// Whether an evidence-bearing emit must also produce a receipt.
+///
+/// A probe is a frequent, fine-grained record and rides the audit chain alone;
+/// a trial completion is the unit a campaign publishes, and carries a receipt.
+/// Making the caller say which keeps "this event has no receipt mapping" an
+/// error rather than a silent `None`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvidenceReceipt {
+    /// The event must map to a receipt; a missing mapping is an error.
+    Required,
+    /// Audit chain only.
+    Omitted,
+}
+
+/// References to what one evidence-bearing emit actually wrote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmittedEvidence {
+    /// Lowercase hex SHA-256 of the exact signed entry bytes.
+    pub audit_digest: String,
+    /// Content address of the receipt, when receipts are enabled.
+    pub receipt_id: Option<String>,
+}
+
+/// Digest the exact bytes an entry is signed as.
+///
+/// `seal` signs `serde_json::to_vec(entry)` and stores those same bytes in the
+/// envelope's `canonical` field, so this digest identifies the on-disk line
+/// exactly: a reader decodes `canonical`, hashes it, and compares. That is
+/// what makes a citation to an audit entry resolvable rather than decorative.
+pub fn audit_entry_digest_hex(entry: &PlanAuditEntry) -> Result<String> {
+    let bytes = serde_json::to_vec(entry).context("serializing audit entry for its digest")?;
+    Ok(hex::encode(Sha256::digest(&bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::plan::TenantId;
+
+    fn entry(event: &str) -> PlanAuditEntry {
+        PlanAuditEntry {
+            timestamp: chrono::Utc::now(),
+            tenant: TenantId("local".to_string()),
+            plan_id: mvm_core::plan::PlanId("plan-1".to_string()),
+            plan_version: 1,
+            bundle_id: None,
+            bundle_version: None,
+            image_name: "vm".to_string(),
+            image_sha256: "a".repeat(64),
+            event: event.to_string(),
+            labels: Default::default(),
+        }
+    }
+
+    #[test]
+    fn the_digest_covers_the_bytes_the_entry_is_signed_as() {
+        let entry = entry("assurance.probe");
+        let expected = hex::encode(Sha256::digest(serde_json::to_vec(&entry).unwrap()));
+        assert_eq!(audit_entry_digest_hex(&entry).unwrap(), expected);
+    }
+
+    #[test]
+    fn a_different_event_digests_differently() {
+        // The digest is what a citation resolves on, so two entries that differ
+        // anywhere must not share one.
+        let a = audit_entry_digest_hex(&entry("assurance.probe")).unwrap();
+        let b = audit_entry_digest_hex(&entry("assurance.session_opened")).unwrap();
+        assert_ne!(a, b);
+    }
+}

--- a/crates/mvm-hostd/src/audit/mod.rs
+++ b/crates/mvm-hostd/src/audit/mod.rs
@@ -2,11 +2,13 @@
 //! keypair, plan persistence, and the checkpoint bind helpers. Library API so
 //! both the CLI and fleet consumers emit identical chain entries.
 
+pub mod assurance;
 pub mod bind;
 /// Whether a run's `plan.admitted` entry is a control or a note — the one
 /// place a failure to record an admission becomes a refused boot.
 pub mod durability;
 pub mod emitter;
+pub mod evidence;
 pub mod host_keypair;
 /// RFC 6962 Merkle transparency-log root + inclusion-proof builder over a
 /// tenant's chain-signed audit log.

--- a/crates/mvm-hostd/src/audit/receipt_export.rs
+++ b/crates/mvm-hostd/src/audit/receipt_export.rs
@@ -111,6 +111,14 @@ fn map_event_to_receipt_type(event: &str) -> Option<(&'static str, ReceiptOutcom
         "checkpoint.restored" => (receipt_type::CHECKPOINT_RESTORED, ReceiptOutcome::Succeeded),
         "checkpoint.forked" => (receipt_type::CHECKPOINT_FORKED, ReceiptOutcome::Succeeded),
         "stream.input_refused" => (receipt_type::INPUT_REFUSED, ReceiptOutcome::Refused),
+        "assurance.session_opened" => (
+            receipt_type::ASSURANCE_SESSION_OPENED,
+            ReceiptOutcome::Authorized,
+        ),
+        "assurance.trial_completed" => (
+            receipt_type::ASSURANCE_TRIAL_COMPLETED,
+            ReceiptOutcome::Succeeded,
+        ),
         _ => return None,
     };
     Some(pair)

--- a/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
@@ -12,14 +12,18 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::pin::Pin;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use mvm_contract::assurance::{
-    AssuranceId, EffectiveAuthority, HostObservation, MvmBinding, PROBE_OBSERVATION_SCHEMA,
-    ProbeInvocation, ProbeObservation, ProbeRefusal, ProbeRequest,
+    AssuranceId, EffectiveAuthority, EvidenceRef, HostObservation, MvmBinding,
+    PROBE_OBSERVATION_SCHEMA, ProbeInvocation, ProbeObservation, ProbeRefusal, ProbeRequest,
 };
+
+use crate::audit::assurance::{AssuranceLedger, ProbeRecord};
+use crate::audit::emitter::AuditEmitter;
 use mvm_core::egress_broker::{EgressRequest, EgressVerdict, decide_egress};
+use mvm_core::plan::ExecutionPlan;
 use mvm_core::policy::network_policy::NetworkPolicy;
 use mvm_core::policy::security::AgentProfile;
 use mvm_core::protocol::broker::{AuditDurability, Idempotency, ServiceErrorCode, ServiceId};
@@ -41,7 +45,7 @@ pub struct DeclaredDestination {
 }
 
 /// Everything needed to open one assurance session.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AssuranceSessionSpec {
     /// The workload session the supervisor will report in `ServiceCallCtx`.
     pub workload_session_id: String,
@@ -55,9 +59,14 @@ pub struct AssuranceSessionSpec {
     pub policy: NetworkPolicy,
     /// Destinations the campaign declared.
     pub destinations: Vec<DeclaredDestination>,
+    /// The admitted plan every record is written against.
+    pub plan: ExecutionPlan,
+    /// Where probe records go. `None` disables recording, which also disables
+    /// probing: an unrecorded boundary attempt is not one this service will
+    /// perform.
+    pub emitter: Option<Arc<AuditEmitter>>,
 }
 
-#[derive(Debug)]
 struct AssuranceSession {
     binding: MvmBinding,
     authority: EffectiveAuthority,
@@ -71,6 +80,35 @@ struct AssuranceSession {
     attempted_effect: bool,
     effect_observed_in_guest: bool,
     boundary_crossed: bool,
+    plan: ExecutionPlan,
+    emitter: Option<Arc<AuditEmitter>>,
+    evidence_refs: Vec<EvidenceRef>,
+}
+
+impl std::fmt::Debug for AssuranceSessionSpec {
+    /// The emitter owns a signing key and has no `Debug` of its own; only its
+    /// presence is printed, which is the diagnostically interesting part.
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AssuranceSessionSpec")
+            .field("workload_session_id", &self.workload_session_id)
+            .field("trial_id", &self.trial_id)
+            .field("destinations", &self.destinations)
+            .field("recording", &self.emitter.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl std::fmt::Debug for AssuranceSession {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AssuranceSession")
+            .field("trial_id", &self.trial_id)
+            .field("steps_used", &self.steps_used)
+            .field("blocked_edges", &self.blocked_edges)
+            .field("recording", &self.emitter.is_some())
+            .finish_non_exhaustive()
+    }
 }
 
 impl AssuranceSession {
@@ -113,6 +151,9 @@ impl HostAssuranceV1Handler {
             attempted_effect: false,
             effect_observed_in_guest: false,
             boundary_crossed: false,
+            plan: spec.plan,
+            emitter: spec.emitter,
+            evidence_refs: Vec::new(),
         };
         self.sessions
             .lock()
@@ -146,6 +187,17 @@ impl HostAssuranceV1Handler {
                 boundary_crossed: session.boundary_crossed,
                 blocked_edges: session.blocked_edges.clone(),
             })
+    }
+
+    /// References this session's probes actually produced.
+    #[must_use]
+    pub fn evidence_refs_for(&self, workload_session_id: &str) -> Vec<EvidenceRef> {
+        self.sessions
+            .lock()
+            .expect("assurance session map is not poisoned")
+            .get(workload_session_id)
+            .map(|session| session.evidence_refs.clone())
+            .unwrap_or_default()
     }
 
     /// Close a session, dropping its nonce ledger and recorded results.
@@ -223,7 +275,11 @@ impl HostAssuranceV1Handler {
             return Err(ProbeRefusal::NonceReplay);
         }
 
-        let observation = match &request.invocation {
+        // Decide first, record second, commit third. The decision is a pure
+        // policy query with no side effect, so a failure to record it can still
+        // refuse the probe outright rather than leave an unrecorded attempt
+        // behind — which is the whole point of recording it.
+        let (admitted, decision, destination_label) = match &request.invocation {
             ProbeInvocation::EgressAdmission { destination_label } => {
                 let (host, port) = session
                     .destinations
@@ -235,37 +291,75 @@ impl HostAssuranceV1Handler {
                     EgressVerdict::Allowed { .. } => (true, "allowed"),
                     EgressVerdict::Denied { reason } => (false, reason.label()),
                 };
-
-                session.attempted_effect = true;
-                if admitted {
-                    // The policy admitted the destination, so the edge the
-                    // campaign was probing is reachable: the effect crossed.
-                    session.boundary_crossed = true;
-                    session.effect_observed_in_guest = true;
-                } else if !session.blocked_edges.contains(destination_label) {
-                    session.blocked_edges.push(destination_label.clone());
-                }
-
-                ProbeObservation {
-                    schema: PROBE_OBSERVATION_SCHEMA.to_string(),
-                    probe: request.invocation.probe_id().to_string(),
-                    admitted,
-                    blocked_edge: (!admitted).then(|| destination_label.clone()),
-                    decision: decision.to_string(),
-                    steps_remaining: 0,
-                }
+                (admitted, decision, destination_label.clone())
             }
         };
 
+        let recorded = Self::record(session, request, decision, admitted, &destination_label)?;
+
+        session.attempted_effect = true;
+        if admitted {
+            // The policy admitted the destination, so the edge the campaign was
+            // probing is reachable: the effect crossed.
+            session.boundary_crossed = true;
+            session.effect_observed_in_guest = true;
+        } else if !session.blocked_edges.contains(&destination_label) {
+            session.blocked_edges.push(destination_label.clone());
+        }
+        session.evidence_refs.extend(recorded);
         session.steps_used = session.steps_used.saturating_add(1);
+
         let observation = ProbeObservation {
+            schema: PROBE_OBSERVATION_SCHEMA.to_string(),
+            probe: request.invocation.probe_id().to_string(),
+            admitted,
+            blocked_edge: (!admitted).then(|| destination_label.clone()),
+            decision: decision.to_string(),
             steps_remaining: session.steps_remaining(),
-            ..observation
         };
         session
             .results
             .insert(request.idempotency_key.clone(), observation.clone());
         Ok(observation)
+    }
+
+    /// Write the probe's audit record, returning the references it produced.
+    ///
+    /// A session with no emitter records nothing and therefore probes nothing:
+    /// the refusal is `AuditUnavailable` either way, so "recording is off" and
+    /// "recording failed" are not distinguishable to the caller, and neither
+    /// yields a boundary attempt that happened without a record of it.
+    fn record(
+        session: &AssuranceSession,
+        request: &ProbeRequest,
+        decision: &str,
+        admitted: bool,
+        destination_label: &AssuranceId,
+    ) -> Result<Vec<EvidenceRef>, ProbeRefusal> {
+        let emitter = session
+            .emitter
+            .as_ref()
+            .ok_or(ProbeRefusal::AuditUnavailable)?;
+        let ledger = AssuranceLedger::new(emitter, &session.plan);
+        let refs = ledger
+            .record_probe(&ProbeRecord {
+                session_id: &request.session_id,
+                trial_id: &request.trial_id,
+                probe_id: request.invocation.probe_id(),
+                decision,
+                idempotency_key: &request.idempotency_key,
+                admitted,
+                destination_label,
+            })
+            .map_err(|error| {
+                tracing::warn!(error = %error, "assurance probe record failed; refusing the probe");
+                ProbeRefusal::AuditUnavailable
+            })?;
+        let mut out = vec![refs.audit];
+        if let Some(receipt) = refs.receipt {
+            out.push(receipt);
+        }
+        Ok(out)
     }
 }
 
@@ -335,6 +429,7 @@ impl ServiceHandler for HostAssuranceV1Handler {
 mod tests {
     use super::*;
 
+    use crate::audit::assurance::{audit_citations_resolve, resolve_audit_ref};
     use mvm_contract::assurance::{
         ApprovalSet, AuthorityCeiling, AuthorityInputs, EvidenceRef, ObservationScope,
         PROBE_REQUEST_SCHEMA, RequestedAuthority, SessionGrant, Sha256Digest, ToolId,
@@ -408,10 +503,20 @@ mod tests {
     fn live_handler(policy: NetworkPolicy, max_steps: u32) -> HostAssuranceV1Handler {
         let now = HostAssuranceV1Handler::now_unix_ms();
         let expiry = now + 3_600_000;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = ed25519_dalek::SigningKey::from_bytes(&[9u8; 32]);
+        let emitter = AuditEmitter::with_dir(key, dir.path())
+            .expect("emitter")
+            .with_receipts();
         let handler = HostAssuranceV1Handler::new();
         let mut session = spec(policy, max_steps);
         session.authority = authority_expiring_at(max_steps, expiry, now);
+        session.emitter = Some(Arc::new(emitter));
         handler.open_session(session);
+        // The tempdir is deliberately leaked: these tests only assert on the
+        // dispatch result, and keeping the guard alive would mean threading it
+        // through every caller for nothing.
+        std::mem::forget(dir);
         handler
     }
 
@@ -442,7 +547,31 @@ mod tests {
                 host: "attacker.example.com".to_string(),
                 port: 443,
             }],
+            plan: PlanFixture::new().build(),
+            emitter: None,
         }
+    }
+
+    /// A handler whose probes are recorded to a real chain, with the tempdir
+    /// kept alive for the caller.
+    fn audited(
+        policy: NetworkPolicy,
+        max_steps: u32,
+    ) -> (HostAssuranceV1Handler, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let emitter = AuditEmitter::with_dir(key, dir.path())
+            .expect("emitter")
+            .with_receipts();
+        let handler = HostAssuranceV1Handler::new();
+        let mut session = spec(policy, max_steps);
+        session.emitter = Some(Arc::new(emitter));
+        handler.open_session(session);
+        (handler, dir)
+    }
+
+    fn chain_path(dir: &tempfile::TempDir, plan: &ExecutionPlan) -> std::path::PathBuf {
+        dir.path().join(format!("{}.jsonl", plan.tenant.0))
     }
 
     fn handler(policy: NetworkPolicy, max_steps: u32) -> HostAssuranceV1Handler {
@@ -479,7 +608,7 @@ mod tests {
 
     #[test]
     fn a_deny_all_policy_refuses_the_declared_destination_and_records_a_blocked_edge() {
-        let handler = handler(NetworkPolicy::deny_all(), 4);
+        let (handler, _dir) = audited(NetworkPolicy::deny_all(), 4);
         let observation = handler
             .decide(
                 &context(),
@@ -509,7 +638,7 @@ mod tests {
     #[test]
     fn an_allowlisted_destination_records_a_crossed_boundary() {
         let policy = NetworkPolicy::allow_list(vec![HostPort::new("attacker.example.com", 443)]);
-        let handler = handler(policy, 4);
+        let (handler, _dir) = audited(policy, 4);
         let observation = handler
             .decide(
                 &context(),
@@ -529,7 +658,7 @@ mod tests {
 
     #[test]
     fn a_retry_with_the_same_idempotency_key_returns_the_first_result_and_burns_no_step() {
-        let handler = handler(NetworkPolicy::deny_all(), 4);
+        let (handler, _dir) = audited(NetworkPolicy::deny_all(), 4);
         let first = handler
             .decide(
                 &context(),
@@ -556,7 +685,7 @@ mod tests {
 
     #[test]
     fn a_replayed_nonce_under_a_new_idempotency_key_is_refused() {
-        let handler = handler(NetworkPolicy::deny_all(), 4);
+        let (handler, _dir) = audited(NetworkPolicy::deny_all(), 4);
         handler
             .decide(
                 &context(),
@@ -624,7 +753,7 @@ mod tests {
 
     #[test]
     fn the_step_budget_is_enforced() {
-        let handler = handler(NetworkPolicy::deny_all(), 1);
+        let (handler, _dir) = audited(NetworkPolicy::deny_all(), 1);
         handler
             .decide(
                 &context(),
@@ -731,6 +860,194 @@ mod tests {
         handler.close_session(SESSION);
         assert!(handler.binding_for(SESSION).is_none());
         assert!(handler.observation_for(SESSION).is_none());
+    }
+
+    #[test]
+    fn a_session_that_cannot_record_does_not_probe() {
+        // `spec()` attaches no emitter, so recording is off.
+        let handler = handler(NetworkPolicy::deny_all(), 4);
+        assert_eq!(
+            handler.decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS
+            ),
+            Err(ProbeRefusal::AuditUnavailable)
+        );
+        // The refusal must leave no trace of an attempt: a boundary probe that
+        // could not be recorded must not later read as one that happened.
+        let observed = handler.observation_for(SESSION).expect("observation");
+        assert!(!observed.attempted_effect);
+        assert!(observed.blocked_edges.is_empty());
+        assert!(handler.evidence_refs_for(SESSION).is_empty());
+    }
+
+    #[test]
+    fn a_recorded_probe_produces_a_reference_that_resolves_to_its_chain_line() {
+        let (handler, dir) = audited(NetworkPolicy::deny_all(), 4);
+        handler
+            .decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS,
+            )
+            .expect("probe runs");
+
+        let refs = handler.evidence_refs_for(SESSION);
+        assert_eq!(refs.len(), 1, "a probe records audit only, not a receipt");
+
+        let plan = PlanFixture::new().build();
+        let path = chain_path(&dir, &plan);
+        let line = resolve_audit_ref(&path, &refs[0])
+            .expect("chain readable")
+            .expect("the reference must resolve to a line on disk");
+        assert!(line.contains("assurance.probe"), "{line}");
+    }
+
+    #[test]
+    fn a_probe_record_carries_no_destination_host_or_port() {
+        let (handler, dir) = audited(NetworkPolicy::deny_all(), 4);
+        handler
+            .decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS,
+            )
+            .expect("probe runs");
+
+        let plan = PlanFixture::new().build();
+        let chain = std::fs::read_to_string(chain_path(&dir, &plan)).expect("chain");
+        let line = chain.lines().next().expect("one line");
+        let envelope: serde_json::Value = serde_json::from_str(line).expect("parse");
+        let labels = envelope["entry"]["labels"]
+            .as_object()
+            .expect("labels")
+            .clone();
+
+        // Assert over the decoded labels rather than the raw file: the file
+        // also carries a base64 copy of the same entry, and a digit sequence
+        // can appear inside base64 by coincidence, which would make this pass
+        // or fail for a reason unrelated to what crossed.
+        let rendered = serde_json::to_string(&labels).expect("labels json");
+        assert!(
+            rendered.contains("undeclared.synthetic.destination"),
+            "{rendered}"
+        );
+        assert!(!rendered.contains("attacker.example.com"), "{rendered}");
+        assert!(!rendered.contains("443"), "{rendered}");
+        // Only identifiers and closed decision tokens are recorded.
+        assert_eq!(labels["assurance_decision"], "deny_all");
+        assert_eq!(labels["assurance_probe"], "egress.admission.v1");
+    }
+
+    #[test]
+    fn a_reference_from_one_chain_does_not_resolve_against_another() {
+        let (handler, dir) = audited(NetworkPolicy::deny_all(), 4);
+        handler
+            .decide(
+                &context(),
+                &request("k1", "n1", "undeclared.synthetic.destination"),
+                NOW_MS,
+            )
+            .expect("probe runs");
+        let refs = handler.evidence_refs_for(SESSION);
+
+        let other = tempfile::tempdir().expect("tempdir");
+        let empty = other.path().join("empty.jsonl");
+        std::fs::write(&empty, "").expect("write");
+        assert!(
+            resolve_audit_ref(&empty, &refs[0])
+                .expect("readable")
+                .is_none(),
+            "a citation must not resolve against a chain that never carried it"
+        );
+        drop(dir);
+    }
+
+    #[test]
+    fn a_trial_completion_records_its_outcome_and_a_receipt() {
+        use mvm_contract::assurance::{InconclusiveReason, TrialOutcome, TrialVerdict};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = ed25519_dalek::SigningKey::from_bytes(&[11u8; 32]);
+        let emitter = AuditEmitter::with_dir(key, dir.path())
+            .expect("emitter")
+            .with_receipts();
+        let plan = PlanFixture::new().build();
+        let ledger = AssuranceLedger::new(&emitter, &plan);
+        let identity = crate::audit::assurance::SessionIdentity {
+            session_id: id(SESSION),
+            campaign_id: id("mvm-campaign-1"),
+            trial_id: id("trial-1"),
+            source_digest: Sha256Digest::parse(format!("sha256:{}", "3".repeat(64)))
+                .expect("digest"),
+        };
+
+        let refs = ledger
+            .complete_trial(
+                &identity,
+                &TrialVerdict {
+                    outcome: TrialOutcome::Inconclusive,
+                    reason: Some(InconclusiveReason::ObserverMissing),
+                },
+            )
+            .expect("trial recorded");
+        assert!(
+            refs.receipt.is_some(),
+            "a published trial outcome must carry a receipt"
+        );
+
+        let chain = std::fs::read_to_string(chain_path(&dir, &plan)).expect("chain");
+        assert!(chain.contains("assurance.trial_completed"), "{chain}");
+        assert!(chain.contains("INCONCLUSIVE"), "{chain}");
+        assert!(chain.contains("observer_missing"), "{chain}");
+        // An inconclusive outcome is explicitly not a claim.
+        assert!(
+            chain.contains("\"assurance_certifying\":\"false\""),
+            "{chain}"
+        );
+    }
+
+    #[test]
+    fn a_binding_citing_recorded_evidence_resolves_end_to_end() {
+        use crate::audit::assurance::{SessionIdentity, cite};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let key = ed25519_dalek::SigningKey::from_bytes(&[13u8; 32]);
+        let emitter = AuditEmitter::with_dir(key, dir.path())
+            .expect("emitter")
+            .with_receipts();
+        let plan = PlanFixture::new().build();
+        let ledger = AssuranceLedger::new(&emitter, &plan);
+        let refs = ledger
+            .open_session(&SessionIdentity {
+                session_id: id(SESSION),
+                campaign_id: id("mvm-campaign-1"),
+                trial_id: id("trial-1"),
+                source_digest: Sha256Digest::parse(format!("sha256:{}", "3".repeat(64)))
+                    .expect("digest"),
+            })
+            .expect("session recorded");
+        assert!(refs.receipt.is_some());
+
+        let bound = cite(
+            MvmBinding::builder()
+                .session_id(id(SESSION))
+                .plan(&plan)
+                .expect("plan")
+                .artifact_digest(digest(ARTIFACT_DIGEST))
+                .effective_policy_digest(digest(POLICY_DIGEST))
+                .grant(grant())
+                .backend("firecracker"),
+            &refs,
+        )
+        .build()
+        .expect("a binding citing recorded evidence builds");
+
+        assert!(
+            audit_citations_resolve(&bound, &chain_path(&dir, &plan)).expect("readable"),
+            "every audit citation on the binding must resolve"
+        );
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -286,19 +286,16 @@ for detailed scope and acceptance criteria.
 ## In-flight plans
 
 - [~] **Admission-bound AI assurance sessions** —
-      `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W3
-      landed: the `mvm.assurance.ai-session-input/v1` envelope (provider half
-      cannot carry admission facts; the assembled envelope has no
-      `Deserialize`), the five-way `EffectiveAuthority` intersection, the
-      host-derived fail-closed outcome ladder, and `host.assurance.v1` — one
-      declared probe verb, binding-gated, taking a destination *label* the host
-      resolves rather than anything the model composed. Conformed to the
-      counterparty's exact key sets, which disagreed with the implementation
-      prompt in three places (see the plan's drift note). 65 tests.
-      STILL OPEN: W4 guest-side API, W5 observer/cleanup evidence, W6 session
-      lifecycle on the admit path, W7 receipt/audit emission, W8 the
-      framed-stdio provider binary. Until W5–W8 land every live trial
-      evaluates `INCONCLUSIVE` by design; no certifying campaign can run.
+      `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W4
+      and W6/W7 landed: the envelope, the five-way authority intersection, the
+      fail-closed outcome ladder, `host.assurance.v1`, fail-closed audit and
+      receipt emission with citations that actually resolve, and the
+      workload-facing `AssuranceCampaign` whose surface offers no command,
+      path, host or port to pass. 84 tests.
+      STILL OPEN: W5 observer/cleanup evidence, W7b session lifecycle on the
+      admit path (`open_session` has no production caller yet), W8 the
+      framed-stdio provider binary. Until those land every live trial evaluates
+      `INCONCLUSIVE` by design; no certifying campaign can run.
 
 - [~] **Embedded-binary content store** — `specs/plans/2026-08-17-embedded-binary-content-store.md`.
       Phases 1–2 landed: both nested legs of `crates/mvm-cli/build.rs` are keyed

--- a/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
+++ b/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
@@ -3,7 +3,7 @@
 Backing: shipped-source
 Validation: a_provider_cannot_smuggle_an_mvm_binding_through_the_request_parser
 
-Status: **W1–W3 landed. W4–W8 open.**
+Status: **W1–W4, W6 landed. W5, W7, W8 open.**
 
 An AI workload can drive a Scout-linked assurance campaign from inside an
 admitted microVM. This plan is the MVM half of that: the typed envelope the
@@ -40,12 +40,14 @@ Three properties are structural rather than checked at runtime:
       length, collection, budget and control-character limits. Nesting depth is
       fixed by the schema — there is no recursive type and no free-form
       `Value` — so there is no depth counter to get wrong.
+
 - [x] **W2 — Admission binding and authority.** `MvmBinding::builder().plan(&plan)`
       quotes the admitted plan; the builder refuses a binding that cites no
       audit entry or no receipt. `EffectiveAuthority::intersect` narrows
       extension maximum ∩ request ∩ policy ceiling ∩ signed grant ∩ explicit
       approval, and a `campaign_probe.v1` without operator approval does not
       survive it.
+
 - [x] **W3 — Probe surface.** `host.assurance.v1` in `mvm-hostd`, registered
       only when `ExecutionPlan.services` names it, exposing one verb. The AI
       selects a declared destination *label*; the host resolves it against the
@@ -53,28 +55,49 @@ Three properties are structural rather than checked at runtime:
       `mvm_core::egress_broker::decide_egress`. Idempotency-key replay returns
       the first result without burning a step; nonce replay, session/trial
       mismatch, step exhaustion and deadline expiry each refuse distinctly.
+
 - [x] **W3.1 — Counterparty wire conformance.** `assurance::wire` projects the
       exact key sets `apps/mvm-security/src/ai_session.rs` validates, and the
       envelope reports *effective* authority — the counterparty rejects the
       `deadline_unix_ms: 0` a request may carry to mean "none set".
 
+- [x] **W4 — Guest-side API.** `mvm_agentd::assurance::AssuranceCampaign`
+      reads the delivered envelope and calls declared probes by *label*. The
+      surface offers no method taking a command, path, host, port, or socket —
+      not by convention, but because no such parameter exists on it. Local
+      guards fire before any round-trip, and nonces are session-scoped and
+      single-use. Reading the envelope needed a direction-specific type:
+      `AiSessionInput` is serialize-only so the host can never parse admission
+      facts out of provider bytes, so the guest reads `DeliveredSession`, and a
+      test asserts the two describe the same document.
+
+- [x] **W6/W7 — Audit and receipt emission.** `mvm_hostd::audit::assurance`
+      writes `assurance.session_opened`, `assurance.probe` and
+      `assurance.trial_completed`; the first and last carry an execution
+      receipt. Emission is **fail-closed**: the ordinary emit path treats
+      receipts as a derived cache and swallows their errors, which is wrong for
+      evidence a claim rests on, so an evidence-bearing emit errors instead. A
+      probe whose record cannot be written is refused (`AuditUnavailable`) and
+      leaves no trace of an attempt. References are content digests of the
+      exact signed entry bytes, and `resolve_audit_ref` finds the line back on
+      disk — asserted by test, so a citation is resolvable rather than
+      decorative. Records carry the declared *label*, never the host or port
+      behind it.
+
 ## Open
 
-- [ ] **W4 — Guest-side API.** A workload-facing helper over
-      `mvm-agentd`'s broker client so an in-guest SDK calls the probe verb
-      without hand-rolling the envelope. The transport already exists
-      (`broker_client.rs`); only the typed wrapper is missing.
 - [ ] **W5 — Observer and cleanup evidence.** `EvidenceSet` is consumed by the
       evaluator but nothing populates `observer_verified` /
       `cleanup_verified` / `attestation_verified` from a real run yet. Until
       that lands every live trial evaluates to `INCONCLUSIVE`, which is the
       correct fail-closed behaviour and not a certifying result.
-- [ ] **W6 — Session lifecycle wiring.** `HostAssuranceV1Handler::open_session`
-      is called by tests only. It needs a caller on the admit path that mints
-      the grant, intersects authority, and closes the session at teardown.
-- [ ] **W7 — Receipt and audit emission.** The binding cites audit and receipt
-      references; emitting `assurance.probe` entries into the chain-signed log
-      and an execution receipt per trial is not wired.
+
+- [ ] **W7b — Session lifecycle on the admit path.**
+      `HostAssuranceV1Handler::open_session` is still called by tests only. It
+      needs a caller that mints the grant, intersects authority, opens the
+      session against the admitted plan, and closes it at teardown. Until then
+      the probe surface is reachable only from a test.
+
 - [ ] **W8 — Provider binary.** The counterparty's
       `assurance run --provider <path>` spawns a framed-stdio provider speaking
       `mvm.security.campaign-request/v1`. MVM ships no such binary, so no

--- a/specs/sprint/delivery/assurance-audit-receipts-and-guest-api.md
+++ b/specs/sprint/delivery/assurance-audit-receipts-and-guest-api.md
@@ -1,0 +1,64 @@
+# Assurance sessions: audit/receipt emission and the workload-facing API
+
+Plan: `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md` (W4, W6/W7)
+
+## What landed
+
+The layer that shipped first had a hole worth naming: `MvmBinding` required an
+audit and a receipt reference to build, and nothing produced one. The builder
+enforced a citation that no code could satisfy outside a test. These two
+workstreams close that, and give the guest something to call.
+
+**Emission is fail-closed, and that is the whole point.** The existing emit
+path treats receipts as a derived cache and logs-and-swallows their failures,
+which is right when nothing cites them. It is wrong for evidence a later claim
+rests on: a citation to a receipt that was never written reads as proof.
+`emit_entry_for_evidence` therefore errors where the ordinary path warns, and
+the caller says whether a receipt is `Required` or `Omitted` — a probe is
+fine-grained and rides the audit chain alone, a trial completion is the unit a
+campaign publishes and carries a receipt.
+
+**A probe that cannot be recorded does not happen.** The handler decides,
+records, then commits: the egress decision is a pure policy query with no side
+effect, so a failed record refuses the probe outright and leaves
+`attempted_effect` false. A session with no emitter attached probes nothing at
+all. Both paths answer `AuditUnavailable`, which is deliberate — "recording is
+off" and "recording failed" should not be distinguishable to a workload, and
+neither may yield a boundary attempt with no record of it.
+
+**Citations resolve.** An audit reference is `mvm:audit:<hex>` over the exact
+bytes `seal` signs, and the envelope stores those same bytes in `canonical`, so
+`resolve_audit_ref` finds the line back on disk. A test emits, then resolves,
+then checks the reference does *not* resolve against a different chain. A
+reference that resolves to nothing is the same failure mode the
+`check-declared-backing` gate exists to prevent, one layer down.
+
+**Records name the label, never the destination.** A probe entry carries the
+declared synthetic label, the closed decision token, and identifiers. It does
+not carry the host or port the label resolves to. The test for this asserts
+over the decoded labels rather than the raw file — the file also holds a base64
+copy of the same entry, and grepping that for a digit sequence would pass or
+fail for reasons unrelated to what crossed.
+
+**The guest API offers nothing to misuse.** `AssuranceCampaign` exposes
+`probe_egress(label, idempotency_key)` and no method taking a command, path,
+host, port, or socket. That is a property of the type, not a convention. Local
+guards fire before any round-trip, so a mistake is an error rather than a
+refusal after a round-trip; the host re-derives every gate regardless, because
+this client runs in the untrusted guest and is advisory.
+
+## A direction problem worth recording
+
+`AiSessionInput` is serialize-only on purpose, so the host can never parse
+admission facts out of provider bytes. The guest has the opposite need — it
+only ever receives an envelope — so it reads a separate `DeliveredSession`.
+Two types, two directions, and a test asserting they describe the same
+document, because nothing else would catch them drifting apart.
+
+## What is still not true
+
+No certifying campaign can run. `open_session` is still called only by tests,
+so the probe surface has no production caller yet (W7b); observer, cleanup and
+attestation evidence have no producer (W5), so a live trial still evaluates
+`INCONCLUSIVE` by design; and the framed-stdio provider the counterparty spawns
+does not exist in either repository (W8).


### PR DESCRIPTION
Continues `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`,
landing W4 (guest-side API) and W6/W7 (audit and receipt emission).

## The hole this closes

The layer that shipped in #2668 required an `MvmBinding` to cite an audit entry
and a receipt before it would build — and nothing produced either. The builder
enforced a citation that no code outside a test could satisfy.

## Emission is fail-closed, and that is the point

The existing emit path treats receipts as a derived cache and logs-and-swallows
their failures. That is right when nothing cites them, and wrong for evidence a
claim rests on: a citation to a receipt that was never written reads as proof.
`emit_entry_for_evidence` therefore errors where the ordinary path warns, and
the caller states whether a receipt is `Required` or `Omitted` — a probe is
fine-grained and rides the audit chain alone; a trial completion is the unit a
campaign publishes and carries a receipt.

**A probe that cannot be recorded does not happen.** The handler decides,
records, then commits. The egress decision is a pure policy query with no side
effect, so a failed record refuses the probe outright and leaves
`attempted_effect` false. A session with no emitter attached probes nothing.
Both paths answer `AuditUnavailable`, deliberately: "recording is off" and
"recording failed" should not be distinguishable to a workload, and neither may
yield a boundary attempt with no record of it.

**Citations resolve.** An audit reference is a digest over the exact bytes
`seal` signs, and the envelope stores those same bytes in `canonical`, so
`resolve_audit_ref` finds the line back on disk. A test emits, resolves, and
then checks the reference does *not* resolve against a different chain. A
reference that resolves to nothing is the failure mode `check-declared-backing`
exists to prevent, one layer down.

**Records name the label, never the destination.** A probe entry carries the
declared synthetic label, a closed decision token, and identifiers — not the
host or port the label resolves to. That test asserts over the decoded labels
rather than the raw file, because the file also holds a base64 copy of the same
entry and grepping it for a digit sequence would pass or fail for reasons
unrelated to what crossed. (It caught a real gap on the way: the record did not
name the probed edge at all, so it could not be tied to a blocked edge.)

## The guest API offers nothing to misuse

`AssuranceCampaign::probe_egress(label, idempotency_key)` — and no method
taking a command, path, host, port, or socket. That is a property of the type,
not a convention. Local guards fire before any round-trip, so a mistake is an
error rather than a refusal after one; the host re-derives every gate
regardless, because this client runs in the untrusted guest and is advisory.

Reading the envelope needed a direction-specific type. `AiSessionInput` is
serialize-only so the host can never parse admission facts out of provider
bytes; the guest only ever receives an envelope, so it reads `DeliveredSession`
instead. Two types, two directions, and a test asserting they describe the same
document — nothing else would catch them drifting.

## Incidental

`emitter.rs` crossed the 1500-line `check-file-size` gate, so the evidence
vocabulary moved to a sibling module with its own tests. Private struct fields
are not visible to a sibling, so the types and free function moved and the
`impl` block stayed.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace -j 6` — 12,315 passed, 0 failed
- `cargo test --workspace --doc` — pass
- `cargo check -p mvm-conformance --all-targets --features bdd` — pass
- `just check-embedded` (riscv32 bare-metal no_std) — pass
- All 61 applicable xtask gates from `.github/workflows` — pass

An interim run showed 6 failures in `mvm-core user_config::tests`; that was the
gate loop racing the same `MVM_HOME` those tests read, not a defect. They pass
isolated and in a clean full run.

## Still not true

No certifying campaign can run. `open_session` has no production caller yet
(W7b), observer and cleanup evidence have no producer (W5), and the
framed-stdio provider the counterparty spawns exists in neither repository (W8).
A live trial therefore still evaluates `INCONCLUSIVE` by design.
