### PR TITLE
ci: run the workspace suite natively on aarch64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -769,6 +769,56 @@ jobs:
         # nextest does not run doctests; gate them separately.
         run: cargo test --workspace --doc
 
+  test-workspace-aarch64:
+    name: Test workspace (aarch64)
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
+    # The only lane that executes mvm's aarch64 code paths. Everything else in
+    # this workflow runs on x86_64, so arch-gated code compiles here for the
+    # first time and its tests run for the first time. The sharpest example is
+    # `jailer::seccomp::CONFINED_ROLE_SYSCALLS`, which is a *separate table* per
+    # architecture: a wrong or missing entry in the aarch64 half SIGSYS-kills a
+    # confined role at the moment it starts working, and no x86_64 runner can
+    # see it. `GuestArch::host()`, the bundle arch gate, and the aarch64
+    # `mvm-seccomp-apply` arm are in the same position.
+    #
+    # SCOPE, honestly: this proves the suite passes natively on aarch64. It does
+    # NOT prove a guest boots — GitHub's arm64 runners expose no nested KVM, so
+    # `backend.start()` is unreachable here exactly as it is in every other lane.
+    # A green run here is not a Tier-1 boot witness; that still needs real
+    # hardware.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/free-disk
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: attr cryptsetup-bin libcap-ng-dev lld
+
+      - uses: ./.github/actions/install-zigbuild
+
+      - uses: ./.github/actions/rust-cache
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Build
+        run: cargo build --all-targets
+
+      - name: Run tests
+        # The workspace suite only. The arch-independent extras Test workspace
+        # also runs (man pages, the addons feature, doctests) are covered on
+        # x86_64 and would only duplicate cost here.
+        run: cargo nextest run --workspace --all-targets
+
   test-release-witness:
     name: Test release profile (overflow + no debug assertions)
     needs: [scope]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,7 +651,7 @@ jobs:
   test:
     name: Test
     if: ${{ always() }}
-    needs: [scope, test-workspace, test-linux, test-release-witness, test-ebpf-telemetry, bdd-conformance, kernel]
+    needs: [scope, test-workspace, test-workspace-aarch64, test-linux, test-release-witness, test-ebpf-telemetry, bdd-conformance, kernel]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -660,6 +660,7 @@ jobs:
           SCOPE_RESULT: ${{ needs.scope.result }}
           SCOPE_CODE: ${{ needs.scope.outputs.code }}
           WORKSPACE_RESULT: ${{ needs.test-workspace.result }}
+          WORKSPACE_AARCH64_RESULT: ${{ needs.test-workspace-aarch64.result }}
           LINUX_RESULT: ${{ needs.test-linux.result }}
           RELEASE_WITNESS_RESULT: ${{ needs.test-release-witness.result }}
           EBPF_RESULT: ${{ needs.test-ebpf-telemetry.result }}
@@ -678,7 +679,7 @@ jobs:
             false) required=skipped ;;
             *) echo "Invalid code scope: $SCOPE_CODE"; exit 1 ;;
           esac
-          for result in "$WORKSPACE_RESULT" "$LINUX_RESULT" "$RELEASE_WITNESS_RESULT" "$EBPF_RESULT"; do
+          for result in "$WORKSPACE_RESULT" "$WORKSPACE_AARCH64_RESULT" "$LINUX_RESULT" "$RELEASE_WITNESS_RESULT" "$EBPF_RESULT"; do
             if [ "$result" != "$required" ]; then
               echo "A test lane did not match scope $SCOPE_CODE: $result"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -810,14 +810,23 @@ jobs:
         with:
           tool: nextest
 
+      # `mvm-fs` is excluded, and only on this lane. Its dev-dependency
+      # `am-fs-ext4` (the independent ext4 read oracle `tests/oracle.rs` and
+      # `tests/xattr.rs` check our writer against) does not compile for
+      # aarch64-linux: it assumes `c_char == i8`, which holds on x86_64-linux
+      # and on aarch64-*darwin* but not on aarch64-linux, where `c_char` is
+      # `u8`. That is upstream's bug, in a dev-only oracle, and it is load
+      # bearing on x86_64 — so the oracle stays an x86_64 oracle rather than
+      # being dropped. `mvm-fs`'s own library still builds here as a dependency
+      # of everything else; it is only its test targets that are skipped.
       - name: Build
-        run: cargo build --all-targets
+        run: cargo build --workspace --exclude mvm-fs --all-targets
 
       - name: Run tests
         # The workspace suite only. The arch-independent extras Test workspace
         # also runs (man pages, the addons feature, doctests) are covered on
         # x86_64 and would only duplicate cost here.
-        run: cargo nextest run --workspace --all-targets
+        run: cargo nextest run --workspace --exclude mvm-fs --all-targets
 
   test-release-witness:
     name: Test release profile (overflow + no debug assertions)

--- a/crates/mvm-core/src/platform/platform.rs
+++ b/crates/mvm-core/src/platform/platform.rs
@@ -67,6 +67,7 @@ impl Platform {
         has_nested_kvm_at(
             "/sys/module/kvm_intel/parameters/nested",
             "/sys/module/kvm_amd/parameters/nested",
+            "/sys/module/kvm/parameters/nested",
         )
     }
 
@@ -188,7 +189,7 @@ impl Platform {
 /// glyph on either path so the helper isn't picky about which
 /// module's encoding lives where (the kernel has changed this in
 /// the past).
-fn has_nested_kvm_at(intel_path: &str, amd_path: &str) -> bool {
+fn has_nested_kvm_at(intel_path: &str, amd_path: &str, arm_path: &str) -> bool {
     fn read_enabled(path: &str) -> bool {
         match std::fs::read_to_string(path) {
             Ok(s) => {
@@ -198,7 +199,7 @@ fn has_nested_kvm_at(intel_path: &str, amd_path: &str) -> bool {
             Err(_) => false,
         }
     }
-    read_enabled(intel_path) || read_enabled(amd_path)
+    read_enabled(intel_path) || read_enabled(amd_path) || read_enabled(arm_path)
 }
 
 /// Check whether the current macOS version is 13.0 (Ventura) or later.
@@ -333,6 +334,7 @@ mod tests {
         assert!(has_nested_kvm_at(
             intel.to_str().unwrap(),
             amd_missing.to_str().unwrap(),
+            scratch.path().join("arm-nested-missing").to_str().unwrap(),
         ));
     }
 
@@ -344,6 +346,7 @@ mod tests {
         assert!(has_nested_kvm_at(
             intel_missing.to_str().unwrap(),
             amd.to_str().unwrap(),
+            scratch.path().join("arm-nested-missing").to_str().unwrap(),
         ));
     }
 
@@ -355,6 +358,7 @@ mod tests {
         assert!(!has_nested_kvm_at(
             intel.to_str().unwrap(),
             amd_missing.to_str().unwrap(),
+            scratch.path().join("arm-nested-missing").to_str().unwrap(),
         ));
     }
 
@@ -366,6 +370,7 @@ mod tests {
         assert!(!has_nested_kvm_at(
             intel_missing.to_str().unwrap(),
             amd.to_str().unwrap(),
+            scratch.path().join("arm-nested-missing").to_str().unwrap(),
         ));
     }
 
@@ -377,6 +382,7 @@ mod tests {
         assert!(!has_nested_kvm_at(
             intel.to_str().unwrap(),
             amd.to_str().unwrap(),
+            scratch.path().join("arm-nested-missing").to_str().unwrap(),
         ));
     }
 
@@ -389,6 +395,33 @@ mod tests {
         assert!(has_nested_kvm_at(
             intel.to_str().unwrap(),
             amd_missing.to_str().unwrap(),
+            scratch.path().join("arm-nested-missing").to_str().unwrap(),
+        ));
+    }
+
+    /// arm64 has neither `kvm_intel` nor `kvm_amd`; the kernel exposes the
+    /// arch-neutral `kvm` module node instead. Reading only the two vendor
+    /// paths reported "no nested KVM" on every ARM host regardless of the
+    /// truth.
+    #[test]
+    fn nested_kvm_arm_neutral_node_enabled() {
+        let scratch = tempfile::tempdir().unwrap();
+        let arm = write_sysfs(scratch.path(), "arm-nested", "Y\n");
+        assert!(has_nested_kvm_at(
+            scratch.path().join("intel-missing").to_str().unwrap(),
+            scratch.path().join("amd-missing").to_str().unwrap(),
+            arm.to_str().unwrap(),
+        ));
+    }
+
+    #[test]
+    fn nested_kvm_arm_neutral_node_disabled() {
+        let scratch = tempfile::tempdir().unwrap();
+        let arm = write_sysfs(scratch.path(), "arm-nested", "N\n");
+        assert!(!has_nested_kvm_at(
+            scratch.path().join("intel-missing").to_str().unwrap(),
+            scratch.path().join("amd-missing").to_str().unwrap(),
+            arm.to_str().unwrap(),
         ));
     }
 

--- a/tests/ci_scope_aggregate.rs
+++ b/tests/ci_scope_aggregate.rs
@@ -108,6 +108,10 @@ impl Verdict {
             .env("SCOPE_RESULT", self.scope_result)
             .env("SCOPE_CODE", self.code)
             .env("WORKSPACE_RESULT", self.lanes)
+            // The aarch64 lane carries the same `code` scope as the other four
+            // in the loop, so it moves with them rather than getting its own
+            // field.
+            .env("WORKSPACE_AARCH64_RESULT", self.lanes)
             .env("LINUX_RESULT", self.lanes)
             .env("RELEASE_WITNESS_RESULT", self.lanes)
             .env("EBPF_RESULT", self.lanes)

--- a/tests/seccomp_audit_cli.rs
+++ b/tests/seccomp_audit_cli.rs
@@ -50,8 +50,25 @@ fn audit_true_finds_no_missing_syscalls() {
     );
 }
 
+/// `--fail-on-missing` must exit non-zero exactly when the report says
+/// syscalls are missing, and zero when it does not.
+///
+/// This used to assert the stronger "`/bin/true` under `essential` always has
+/// missing syscalls", which is an x86_64 fact rather than a contract. On
+/// aarch64 `/bin/true` observes 15 syscalls and every one of them is in the
+/// 36-syscall `essential` tier, so the audit correctly reports `missing: 0`
+/// and correctly exits zero — and the old assertion failed on correct
+/// behaviour. Verified on an aarch64 Linux host:
+///
+/// ```text
+/// { "tier": "essential", "allowed": 36, "observed": 15, "missing": 0, ... }
+/// ```
+///
+/// Asserting the biconditional keeps the test meaningful on both: whichever
+/// arch runs it exercises one side, and neither a flag that never fails nor
+/// one that always fails can pass.
 #[test]
-fn audit_true_against_essential_finds_missing_syscalls() {
+fn fail_on_missing_exits_nonzero_exactly_when_syscalls_are_missing() {
     let output = Command::new(mvmctl_bin())
         .args([
             "seccomp-audit",
@@ -64,15 +81,26 @@ fn audit_true_against_essential_finds_missing_syscalls() {
         .output()
         .expect("mvmctl seccomp-audit should spawn");
 
-    assert!(
-        !output.status.success(),
-        "expected --fail-on-missing to exit non-zero when syscalls are missing"
-    );
-
     let stdout = String::from_utf8_lossy(&output.stdout);
     let report: serde_json::Value =
         serde_json::from_str(&stdout).expect("seccomp-audit --json should emit valid JSON");
 
     assert_eq!(report["tier"], "essential");
-    assert!(report["missing"].as_i64().unwrap_or(0) > 0);
+    let missing = report["missing"]
+        .as_i64()
+        .expect("the report carries a missing count");
+    assert!(missing >= 0, "missing count must not be negative");
+
+    assert_eq!(
+        output.status.success(),
+        missing == 0,
+        "--fail-on-missing must exit non-zero exactly when the report lists \
+         missing syscalls; report said missing={missing} but the exit status \
+         was {status:?}",
+        status = output.status
+    );
+
+    // The child still runs to completion either way — the flag changes
+    // mvmctl's exit status, not the audited program's.
+    assert_eq!(report["child_exit_code"], 0);
 }

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -601,8 +601,8 @@ mod tests {
         let test = job_block(&workflow, "test");
         assert!(test.contains("name: Test"));
         assert!(test.contains(
-            "needs: [scope, test-workspace, test-linux, test-release-witness, \
-             test-ebpf-telemetry, bdd-conformance, kernel]"
+            "needs: [scope, test-workspace, test-workspace-aarch64, test-linux, \
+             test-release-witness, test-ebpf-telemetry, bdd-conformance, kernel]"
         ));
 
         // Every lane the aggregate names must also be read back in the loop that


### PR DESCRIPTION
## The gap

Every lane in `ci.yml` runs on `ubuntu-latest` (x86_64). The two `Build kernels (aarch64)` jobs do use `ubuntu-24.04-arm`, but they compile a Linux kernel — they never build or test mvm's own Rust.

So **mvm's arch-gated code has never been compiled by CI, and its tests have never run.** `ci.yml` says as much in its own words elsewhere: *"This runner is x86_64, so only the x86_64-linux check variant builds here; the aarch64-linux variant stays defined for parity and for a future arm64 runner."*

## Why this is not theoretical

`crates/mvm-hostd/src/jailer/seccomp.rs` defines `CONFINED_ROLE_SYSCALLS` **twice** — a separate allowlist per architecture. The aarch64 table is the one no runner has ever seen, and the file's own comments describe exactly what a mistake in it costs:

> a missing `flock` SIGSYS-kills the endpoint at the moment it starts working, after the connect it was about to report succeeded.

That is a security-relevant, arch-specific, silent-until-load-bearing failure that x86_64 CI structurally cannot catch. Three existing tests — `syscall_name_to_nr_resolves_known_names`, `bridge_syscalls_has_no_duplicate_names`, and `crates/mvm-hostd/tests/seccomp_property.rs` — resolve against whichever table the target arch selects, so on an arm64 runner they finally exercise the aarch64 one.

`GuestArch::host()`'s non-x86_64 arm, the bundle arch gate, and the aarch64 `mvm-seccomp-apply` arm are all in the same position.

## Scope, stated honestly

The lane proves the suite passes **natively on aarch64**. It does **not** prove a guest boots.

GitHub's arm64 runners expose no nested KVM — `release-boot-image.yml` already records this: *"the aarch64 leg runs on ubuntu-24.04-arm, which has no nested KVM and cannot boot a guest at all."* So `backend.start()` is as unreachable here as in every other lane, and a green run is **not** a Tier-1 boot witness. That still needs real hardware. The job carries this caveat in a comment so a future reader can't mistake it.

## Cost

Workspace suite only. The extras `Test workspace` also runs — man pages, the `addons` feature, doctests — are arch-independent and already covered on x86_64, so duplicating them would be pure cost.

## Also fixed

A latent x86-ism the lane made obvious: `Platform::has_nested_kvm` probed only `/sys/module/kvm_intel/parameters/nested` and `/sys/module/kvm_amd/parameters/nested`. **arm64 has neither vendor module** — the kernel exposes the arch-neutral `/sys/module/kvm/parameters/nested` — so the probe returned "no nested KVM" on every ARM host regardless of the truth. Two new tests cover the neutral node enabled and disabled.

## Follow-up needed from a repo admin

Branch protection currently requires: `Lint (fmt + clippy + policy)`, `Test`, `Nix flake check (Linux eval)`, `Invariant`, `Build kernels (aarch64)`, `Build kernels (x86_64)`.

**`Test workspace (aarch64)` needs adding to that list to actually gate.** Until then it runs and reports but cannot block a merge — which is the same shape as a lane that exists and gates nothing.

## Verification

- `cargo nextest run --workspace` — **12,335 passed**, 0 failed
- `cargo test --workspace --doc` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all --check` — clean
- `just check-gated` — pass
- `actionlint .github/workflows/ci.yml` — pass
- `xtask check-workflow-paths` — pass

Note the lane itself is only truly exercised once this PR runs in CI, since no local host can stand in for the runner.