### PR TITLE
feat(assurance): open the campaign session on the boot path

### DIFF
--- a/crates/mvm-contract/src/assurance/binding.rs
+++ b/crates/mvm-contract/src/assurance/binding.rs
@@ -116,6 +116,17 @@ pub enum BindingError {
     EmptyGrant,
 }
 
+/// Render a plan's content address in the counterparty's identifier grammar.
+///
+/// A plan id is `sha256:<hex>`, and the `:` is not legal in an identifier the
+/// far end will accept — so a binding built from any real plan would be refused
+/// while the `fixture-plan` test id sailed through. The scheme separator
+/// becomes a `-`, which is unambiguous (hex carries no `-`) and reversible, so
+/// the value still names exactly one plan.
+fn identifier_safe_plan_id(plan_id: &str) -> String {
+    plan_id.replace(':', "-")
+}
+
 impl MvmBinding {
     /// Begin assembling a binding from an admitted plan.
     #[must_use]
@@ -168,8 +179,8 @@ impl MvmBindingBuilder {
     pub fn plan(mut self, plan: &ExecutionPlan) -> Result<Self, BindingError> {
         let workload_digest = Sha256Digest::parse(alloc::format!("sha256:{}", plan.image.sha256))
             .map_err(|_| BindingError::UnusableImageDigest)?;
-        let plan_id =
-            AssuranceId::parse(plan.plan_id.0.clone()).map_err(|_| BindingError::UnusablePlanId)?;
+        let plan_id = AssuranceId::parse(identifier_safe_plan_id(&plan.plan_id.0))
+            .map_err(|_| BindingError::UnusablePlanId)?;
         self.from_plan = Some(PlanDerived {
             plan_id,
             plan_version: plan.plan_version,

--- a/crates/mvm-contract/src/assurance/tests.rs
+++ b/crates/mvm-contract/src/assurance/tests.rs
@@ -372,6 +372,26 @@ fn the_binding_quotes_the_admitted_plan_rather_than_the_request() {
     let plan = minimal_plan();
     let bound = binding();
     assert_eq!(bound.plan_id.as_str(), plan.plan_id.0);
+    // A real plan id is `sha256:<hex>`; the separator is rendered so the value
+    // survives the counterparty's identifier grammar.
+    let mut real = minimal_plan();
+    real.plan_id = crate::plan::types::PlanId(alloc::format!("sha256:{}", "ab".repeat(32)));
+    let bound_real = MvmBinding::builder()
+        .session_id(id("session-1"))
+        .plan(&real)
+        .expect("a content-addressed plan id is bindable")
+        .artifact_digest(digest(ARTIFACT_DIGEST))
+        .effective_policy_digest(digest(POLICY_DIGEST))
+        .grant(grant())
+        .backend("firecracker")
+        .audit_ref(evidence_ref("mvm:audit:a"))
+        .receipt_ref(evidence_ref("mvm:receipt:r"))
+        .build()
+        .expect("binding");
+    assert_eq!(
+        bound_real.plan_id.as_str(),
+        alloc::format!("sha256-{}", "ab".repeat(32))
+    );
     assert_eq!(bound.plan_version, plan.plan_version);
     assert_eq!(bound.tenant, plan.tenant.0);
     assert_eq!(bound.workload, plan.workload.0);

--- a/crates/mvm-hostd/src/assurance_session.rs
+++ b/crates/mvm-hostd/src/assurance_session.rs
@@ -1,0 +1,765 @@
+//! Opening and closing an assurance session against an admitted plan.
+//!
+//! This is the seam that makes the probe surface reachable outside a test. It
+//! mirrors the workload input plane: a process-global registry installed when
+//! the broker registry is built, and one entry point that takes an
+//! [`AdmittedPlan`] and decides whether a session may exist at all.
+//!
+//! # The operator declares the campaign, not the workload
+//!
+//! Every value a probe could be steered by — which destinations exist, what
+//! they resolve to, which tools an operator approved — arrives in a
+//! [`CampaignDeclaration`] supplied host-side. The workload receives labels.
+//! The declaration is deliberately *not* part of the signed plan: a campaign is
+//! chosen per run against a plan that may be reused, and putting it in the plan
+//! would mean re-admitting a workload to re-point a probe.
+//!
+//! What the plan *does* decide is whether any of this is permitted: a plan that
+//! does not bind `host.assurance.v1` gets no session, regardless of what the
+//! declaration asks for. Both must agree.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{Context, Result};
+use mvm_contract::assurance::{
+    ApprovalSet, AssuranceId, AuthorityCeiling, AuthorityInputs, EffectiveAuthority, MvmBinding,
+    ObservationScope, RequestedAuthority, SessionGrant, Sha256Digest, ToolId, TrialVerdict,
+};
+use mvm_core::plan::ExecutionPlan;
+use mvm_core::policy::network_policy::NetworkPolicy;
+use mvm_core::protocol::broker::ServiceId;
+use sha2::{Digest, Sha256};
+
+use crate::audit::assurance::{AssuranceLedger, SessionIdentity, cite};
+use crate::audit::emitter::AuditEmitter;
+use crate::broker::handlers::host_assurance_v1::{
+    AssuranceSessionSpec, DeclaredDestination, HOST_ASSURANCE_SERVICE, HostAssuranceV1Handler,
+};
+use crate::plan_admission::AdmittedPlan;
+
+/// A destination an operator declared for one campaign.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclaredEdge {
+    pub label: AssuranceId,
+    pub host: String,
+    pub port: u16,
+}
+
+/// What an operator authorized for one campaign against one workload.
+#[derive(Debug, Clone)]
+pub struct CampaignDeclaration {
+    pub campaign_id: AssuranceId,
+    pub trial_id: AssuranceId,
+    pub source_run_id: AssuranceId,
+    pub source_digest: Sha256Digest,
+    /// Destinations the campaign may probe, by label.
+    pub edges: Vec<DeclaredEdge>,
+    /// Tools the operator explicitly approved.
+    pub approvals: ApprovalSet,
+    /// What the campaign asked for. Narrowed by every other bound.
+    pub requested: RequestedAuthority,
+    /// How long the session's grant is live.
+    pub grant_ttl_ms: u64,
+}
+
+/// Why no session was opened.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionRefusal {
+    #[error("the admitted plan does not bind {HOST_ASSURANCE_SERVICE}")]
+    ServiceNotBound,
+    #[error("this process holds no assurance plane")]
+    NoPlane,
+    #[error("the campaign declares no destination")]
+    NoEdges,
+    #[error("effective authority is empty: {0}")]
+    NoAuthority(String),
+    #[error("the session could not be recorded, so it was not opened: {0}")]
+    NotRecorded(String),
+    #[error("the admitted plan cannot be bound: {0}")]
+    Unbindable(String),
+}
+
+/// Install the assurance plane for this process.
+///
+/// Idempotent, and returns whether this call installed it — mirroring the
+/// stream plane, so a binary with more than one entry point can register
+/// defensively at each.
+pub fn install_host_assurance_plane(handler: Arc<HostAssuranceV1Handler>) -> bool {
+    HOST_ASSURANCE_PLANE.set(handler).is_ok()
+}
+
+/// The plane [`install_host_assurance_plane`] registered.
+///
+/// `None` in a process that never built a broker registry binding the service,
+/// which is every embedder that does not run assurance campaigns.
+#[must_use]
+pub fn host_assurance_plane() -> Option<Arc<HostAssuranceV1Handler>> {
+    HOST_ASSURANCE_PLANE.get().map(Arc::clone)
+}
+
+static HOST_ASSURANCE_PLANE: OnceLock<Arc<HostAssuranceV1Handler>> = OnceLock::new();
+
+/// Whether `plan` admits the assurance service at all.
+#[must_use]
+pub fn plan_binds_assurance(plan: &ExecutionPlan) -> bool {
+    ServiceId::parse(HOST_ASSURANCE_SERVICE)
+        .ok()
+        .is_some_and(|service| plan.services.contains(&service))
+}
+
+/// Derive this session's stable identifiers.
+///
+/// Content-addressed over the plan, the VM and the campaign rather than random:
+/// re-opening the same campaign against the same admitted plan yields the same
+/// session id, which makes a duplicate open visible instead of silently
+/// producing a second session, and makes the whole path reproducible in a test.
+fn derive_ids(plan_id: &str, vm: &str, decl: &CampaignDeclaration) -> (AssuranceId, AssuranceId) {
+    let mut hasher = Sha256::new();
+    hasher.update(plan_id.as_bytes());
+    hasher.update([0]);
+    hasher.update(vm.as_bytes());
+    hasher.update([0]);
+    hasher.update(decl.campaign_id.as_str().as_bytes());
+    hasher.update([0]);
+    hasher.update(decl.trial_id.as_str().as_bytes());
+    let digest = hex::encode(hasher.finalize());
+    let session = AssuranceId::parse(format!("s-{}", &digest[..32]))
+        .expect("a hex-derived identifier is always well formed");
+    let nonce = AssuranceId::parse(format!("gn-{}", &digest[32..64]))
+        .expect("a hex-derived identifier is always well formed");
+    (session, nonce)
+}
+
+/// Mint the grant a session runs under.
+///
+/// The digest is over the grant's own content, so it is an identity rather than
+/// a label: two grants that differ anywhere cannot share one, and the guest
+/// cannot be handed a digest that names a grant the host did not mint.
+fn mint_grant(
+    session_id: &AssuranceId,
+    nonce: AssuranceId,
+    now_unix_ms: u64,
+    decl: &CampaignDeclaration,
+) -> SessionGrant {
+    let expires_unix_ms = now_unix_ms.saturating_add(decl.grant_ttl_ms);
+    let tools: Vec<ToolId> = decl.requested.allowed_tools.clone();
+    let scopes: Vec<ObservationScope> = decl.requested.observation_scopes.clone();
+
+    let mut hasher = Sha256::new();
+    hasher.update(session_id.as_str().as_bytes());
+    hasher.update(nonce.as_str().as_bytes());
+    hasher.update(expires_unix_ms.to_be_bytes());
+    for tool in &tools {
+        hasher.update(serde_json::to_vec(tool).unwrap_or_default());
+    }
+    for scope in &scopes {
+        hasher.update(serde_json::to_vec(scope).unwrap_or_default());
+    }
+    let grant_digest = Sha256Digest::from_bytes(&hasher.finalize().into());
+
+    SessionGrant {
+        grant_digest,
+        expires_unix_ms,
+        nonce,
+        allowed_tools: tools,
+        observation_scopes: scopes,
+    }
+}
+
+/// Everything one open needs.
+pub struct OpenSession<'a> {
+    pub vm: &'a str,
+    pub admitted: &'a AdmittedPlan,
+    pub declaration: &'a CampaignDeclaration,
+    pub emitter: &'a Arc<AuditEmitter>,
+    /// The host's own ceiling. Narrows the request; never widens it.
+    pub policy_ceiling: &'a AuthorityCeiling,
+    /// The workload's admitted egress policy, which the probe consults.
+    pub policy: NetworkPolicy,
+    /// Backend the plan resolved to.
+    pub backend: &'a str,
+    pub now_unix_ms: u64,
+}
+
+/// Open an assurance session, or refuse and open nothing.
+///
+/// The order matters: authority is intersected before anything is recorded, and
+/// the session is recorded before it is opened. A session that exists but was
+/// never written down would let a probe run against a binding that cites an
+/// audit entry nobody wrote.
+pub fn open(request: OpenSession<'_>) -> Result<MvmBinding, SessionRefusal> {
+    let plane = host_assurance_plane().ok_or(SessionRefusal::NoPlane)?;
+    open_on(&plane, request)
+}
+
+/// Open against an explicit plane.
+///
+/// The process-global is a convenience for the one production caller, not the
+/// mechanism. Taking the plane as an argument keeps the whole decision path
+/// reachable from a test without installing a `OnceLock` that a second test in
+/// the same process could never replace.
+pub fn open_on(
+    plane: &Arc<HostAssuranceV1Handler>,
+    request: OpenSession<'_>,
+) -> Result<MvmBinding, SessionRefusal> {
+    let plan = request.admitted.plan();
+    if !plan_binds_assurance(plan) {
+        return Err(SessionRefusal::ServiceNotBound);
+    }
+    if request.declaration.edges.is_empty() {
+        return Err(SessionRefusal::NoEdges);
+    }
+
+    let (session_id, grant_nonce) = derive_ids(
+        request.admitted.plan_id().0.as_str(),
+        request.vm,
+        request.declaration,
+    );
+    let grant = mint_grant(
+        &session_id,
+        grant_nonce,
+        request.now_unix_ms,
+        request.declaration,
+    );
+
+    let extension = AuthorityCeiling::extension_maximum();
+    let authority = EffectiveAuthority::intersect(
+        AuthorityInputs {
+            extension_maximum: &extension,
+            requested: &request.declaration.requested,
+            policy_ceiling: request.policy_ceiling,
+            grant: &grant,
+            approvals: &request.declaration.approvals,
+        },
+        request.now_unix_ms,
+    )
+    .map_err(|error| SessionRefusal::NoAuthority(error.to_string()))?;
+
+    let identity = SessionIdentity {
+        session_id: session_id.clone(),
+        campaign_id: request.declaration.campaign_id.clone(),
+        trial_id: request.declaration.trial_id.clone(),
+        source_digest: request.declaration.source_digest.clone(),
+    };
+    let ledger = AssuranceLedger::new(request.emitter, plan);
+    let refs = ledger
+        .open_session(&identity)
+        .map_err(|error| SessionRefusal::NotRecorded(error.to_string()))?;
+
+    // The artifact and policy digests a campaign is evaluated against. Both are
+    // derived from what was admitted, never from the declaration: the
+    // declaration states an intent, and correlation compares the two.
+    let artifact_digest = Sha256Digest::parse(format!("sha256:{}", plan.image.sha256))
+        .map_err(|error| SessionRefusal::Unbindable(format!("{error}")))?;
+    let effective_policy_digest = policy_digest(plan);
+
+    let binding = cite(
+        MvmBinding::builder()
+            .session_id(session_id)
+            .plan(plan)
+            .map_err(|error| SessionRefusal::Unbindable(error.to_string()))?
+            .artifact_digest(artifact_digest)
+            .effective_policy_digest(effective_policy_digest)
+            .grant(grant)
+            .backend(request.backend),
+        &refs,
+    )
+    .build()
+    .map_err(|error| SessionRefusal::Unbindable(error.to_string()))?;
+
+    plane.open_session(AssuranceSessionSpec {
+        workload_session_id: request.vm.to_string(),
+        binding: binding.clone(),
+        authority,
+        trial_id: request.declaration.trial_id.clone(),
+        policy: request.policy,
+        destinations: request
+            .declaration
+            .edges
+            .iter()
+            .map(|edge| DeclaredDestination {
+                label: edge.label.clone(),
+                host: edge.host.clone(),
+                port: edge.port,
+            })
+            .collect(),
+        plan: plan.clone(),
+        emitter: Some(Arc::clone(request.emitter)),
+    });
+    Ok(binding)
+}
+
+/// Digest the policy references a campaign is evaluated under.
+///
+/// The plan carries policy by reference rather than by value, so this is a
+/// digest over the exact references admitted — enough to detect that the policy
+/// in force is not the one a campaign claims, which is what the evaluator's
+/// mismatch check needs.
+fn policy_digest(plan: &ExecutionPlan) -> Sha256Digest {
+    let mut hasher = Sha256::new();
+    hasher.update(plan.network_policy.0.as_bytes());
+    hasher.update([0]);
+    hasher.update(plan.egress_policy.0.as_bytes());
+    hasher.update([0]);
+    hasher.update(plan.fs_policy.0.as_bytes());
+    hasher.update([0]);
+    hasher.update(plan.tool_policy.0.as_bytes());
+    Sha256Digest::from_bytes(&hasher.finalize().into())
+}
+
+/// Record a trial's outcome and drop the session.
+///
+/// The record is written before the state is dropped, so a teardown that fails
+/// to record leaves the session in place rather than losing both.
+pub fn close(
+    vm: &str,
+    admitted: &AdmittedPlan,
+    emitter: &AuditEmitter,
+    identity: &SessionIdentity,
+    verdict: &TrialVerdict,
+) -> Result<()> {
+    let plane = host_assurance_plane()
+        .ok_or_else(|| anyhow::anyhow!("this process holds no assurance plane"))?;
+    close_on(&plane, admitted, emitter, identity, verdict)?;
+    plane.close_session(vm);
+    Ok(())
+}
+
+/// Record a trial's outcome against an explicit plane.
+pub fn close_on(
+    plane: &Arc<HostAssuranceV1Handler>,
+    admitted: &AdmittedPlan,
+    emitter: &AuditEmitter,
+    identity: &SessionIdentity,
+    verdict: &TrialVerdict,
+) -> Result<()> {
+    let _ = plane;
+    AssuranceLedger::new(emitter, admitted.plan())
+        .complete_trial(identity, verdict)
+        .context("recording the trial outcome")?;
+    Ok(())
+}
+
+/// The host ceiling applied when no operator configuration narrows it further.
+///
+/// Deliberately the extension maximum: the ceiling exists so a deployment *can*
+/// narrow, and inventing a tighter default here would silently disagree with
+/// the declaration an operator wrote without telling them why.
+#[must_use]
+pub fn default_policy_ceiling() -> AuthorityCeiling {
+    AuthorityCeiling::extension_maximum()
+}
+
+/// Edges keyed by label, for a caller that wants to check its own declaration.
+#[must_use]
+pub fn edges_by_label(decl: &CampaignDeclaration) -> BTreeMap<AssuranceId, (String, u16)> {
+    decl.edges
+        .iter()
+        .map(|edge| (edge.label.clone(), (edge.host.clone(), edge.port)))
+        .collect()
+}
+
+/// An operator-declared campaign, with everything the open needs that the
+/// admit path does not already hold.
+///
+/// The emitter is an `Arc` because the opened session outlives this call: it
+/// records every probe for as long as the workload runs, so a borrow would tie
+/// the session's lifetime to the boot call that opened it.
+pub struct CampaignRequest<'a> {
+    pub declaration: &'a CampaignDeclaration,
+    pub emitter: Arc<AuditEmitter>,
+    pub policy_ceiling: AuthorityCeiling,
+    /// The workload's admitted egress policy, which the probe consults.
+    pub policy: NetworkPolicy,
+    pub backend: String,
+    pub now_unix_ms: u64,
+}
+
+/// Open a declared campaign against a booted VM, using this process's plane.
+pub fn open_for_boot(
+    campaign: &CampaignRequest<'_>,
+    vm: &str,
+    admitted: &AdmittedPlan,
+) -> Result<MvmBinding> {
+    let plane = host_assurance_plane().ok_or_else(|| {
+        anyhow::anyhow!(
+            "this process holds no assurance plane, so the declared campaign has nowhere to run"
+        )
+    })?;
+    open_on(
+        &plane,
+        OpenSession {
+            vm,
+            admitted,
+            declaration: campaign.declaration,
+            emitter: &campaign.emitter,
+            policy_ceiling: &campaign.policy_ceiling,
+            policy: campaign.policy.clone(),
+            backend: &campaign.backend,
+            now_unix_ms: campaign.now_unix_ms,
+        },
+    )
+    .map_err(|refusal| anyhow::anyhow!("{refusal}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use mvm_contract::assurance::{InconclusiveReason, TrialOutcome};
+    use mvm_core::plan::test_support::PlanFixture;
+
+    const SOURCE_DIGEST: &str =
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+    const NOW_MS: u64 = 1_800_000_000_000;
+
+    fn id(raw: &str) -> AssuranceId {
+        AssuranceId::parse(raw).expect("identifier")
+    }
+
+    fn declaration() -> CampaignDeclaration {
+        CampaignDeclaration {
+            campaign_id: id("mvm-campaign-1"),
+            trial_id: id("trial-1"),
+            source_run_id: id("scout-1"),
+            source_digest: Sha256Digest::parse(SOURCE_DIGEST).expect("digest"),
+            edges: vec![DeclaredEdge {
+                label: id("undeclared.synthetic.destination"),
+                host: "attacker.example.com".to_string(),
+                port: 443,
+            }],
+            approvals: ApprovalSet::none().with(ToolId::CampaignProbeV1),
+            requested: RequestedAuthority {
+                allowed_tools: vec![ToolId::CampaignProbeV1],
+                observation_scopes: vec![ObservationScope::HostAuditRefs],
+                max_steps: 8,
+                max_output_bytes: 4096,
+                deadline_unix_ms: 0,
+            },
+            grant_ttl_ms: 600_000,
+        }
+    }
+
+    fn bound_plan() -> ExecutionPlan {
+        let service = ServiceId::parse(HOST_ASSURANCE_SERVICE).expect("service");
+        PlanFixture::new().services(vec![service]).build()
+    }
+
+    #[test]
+    fn identifiers_are_derived_and_therefore_reproducible() {
+        let decl = declaration();
+        let a = derive_ids("plan-1", "vm-a", &decl);
+        let b = derive_ids("plan-1", "vm-a", &decl);
+        assert_eq!(
+            a, b,
+            "the same campaign against the same plan is one session"
+        );
+
+        // Anything that distinguishes the run distinguishes the session.
+        assert_ne!(a, derive_ids("plan-2", "vm-a", &decl));
+        assert_ne!(a, derive_ids("plan-1", "vm-b", &decl));
+        let mut other = declaration();
+        other.trial_id = id("trial-2");
+        assert_ne!(a, derive_ids("plan-1", "vm-a", &other));
+    }
+
+    #[test]
+    fn the_grant_digest_is_an_identity_not_a_label() {
+        let decl = declaration();
+        let (session, nonce) = derive_ids("plan-1", "vm-a", &decl);
+        let grant = mint_grant(&session, nonce.clone(), NOW_MS, &decl);
+        assert_eq!(grant.expires_unix_ms, NOW_MS + decl.grant_ttl_ms);
+
+        // A grant that expires differently is a different grant.
+        let later = mint_grant(&session, nonce.clone(), NOW_MS + 1, &decl);
+        assert_ne!(grant.grant_digest, later.grant_digest);
+
+        // And one granting fewer scopes is too.
+        let mut narrower = declaration();
+        narrower.requested.observation_scopes.clear();
+        let narrowed = mint_grant(&session, nonce, NOW_MS, &narrower);
+        assert_ne!(grant.grant_digest, narrowed.grant_digest);
+    }
+
+    #[test]
+    fn a_plan_that_does_not_bind_the_service_is_refused_before_anything_else() {
+        assert!(!plan_binds_assurance(&PlanFixture::new().build()));
+        assert!(plan_binds_assurance(&bound_plan()));
+    }
+
+    #[test]
+    fn the_policy_digest_moves_when_a_policy_reference_moves() {
+        let base = bound_plan();
+        let mut changed = bound_plan();
+        changed.egress_policy = mvm_core::plan::PolicyRef("other-egress".to_string());
+        assert_ne!(policy_digest(&base), policy_digest(&changed));
+    }
+
+    #[test]
+    fn the_default_ceiling_narrows_nothing_on_its_own() {
+        // The ceiling exists so a deployment can narrow. A default that
+        // narrowed would disagree with an operator's declaration silently.
+        let ceiling = default_policy_ceiling();
+        assert!(ceiling.tools.contains(&ToolId::CampaignProbeV1));
+        assert_eq!(ceiling, AuthorityCeiling::extension_maximum());
+    }
+
+    #[test]
+    fn a_campaign_without_operator_approval_yields_no_authority() {
+        let decl = CampaignDeclaration {
+            approvals: ApprovalSet::none(),
+            ..declaration()
+        };
+        let (session, nonce) = derive_ids("plan-1", "vm-a", &decl);
+        let grant = mint_grant(&session, nonce, NOW_MS, &decl);
+        let extension = AuthorityCeiling::extension_maximum();
+        let result = EffectiveAuthority::intersect(
+            AuthorityInputs {
+                extension_maximum: &extension,
+                requested: &decl.requested,
+                policy_ceiling: &default_policy_ceiling(),
+                grant: &grant,
+                approvals: &decl.approvals,
+            },
+            NOW_MS,
+        );
+        assert!(result.is_err(), "an unapproved campaign must not open");
+    }
+
+    #[test]
+    fn a_declared_edge_table_keys_by_label() {
+        let table = edges_by_label(&declaration());
+        assert_eq!(
+            table.get(&id("undeclared.synthetic.destination")),
+            Some(&("attacker.example.com".to_string(), 443))
+        );
+    }
+
+    #[test]
+    fn a_verdict_carries_its_reason_into_the_completion_record() {
+        // The close path's record is the ledger's; this pins the shape the
+        // caller hands it, so a non-claim outcome always names why.
+        let verdict = TrialVerdict {
+            outcome: TrialOutcome::Inconclusive,
+            reason: Some(InconclusiveReason::ObserverMissing),
+        };
+        assert!(!verdict.outcome.is_certifying_claim());
+        assert!(verdict.reason.is_some());
+    }
+
+    // ---------------------------------------------------------------------
+    // Lifecycle, end to end: open against an admitted plan, probe through the
+    // real dispatch path, close.
+    // ---------------------------------------------------------------------
+
+    use ed25519_dalek::SigningKey as EdKey;
+    use mvm_contract::assurance::{
+        PROBE_REQUEST_SCHEMA, ProbeInvocation, ProbeObservation, ProbeRequest,
+    };
+    use mvm_core::plan::signing::sign_plan as sign;
+    use mvm_core::policy::security::AgentProfile;
+    use mvm_core::protocol::broker::CorrelationId;
+    use mvm_core::protocol::handler::{ServiceCallCtx, ServiceHandler};
+
+    fn admitted_for(plan: ExecutionPlan) -> AdmittedPlan {
+        let signer_id = "host:test".to_string();
+        let signed = sign(&plan, &EdKey::from_bytes(&[7u8; 32]), &signer_id);
+        AdmittedPlan::for_test(plan, signer_id, signed)
+    }
+
+    struct Opened {
+        plane: Arc<HostAssuranceV1Handler>,
+        admitted: AdmittedPlan,
+        emitter: Arc<AuditEmitter>,
+        dir: tempfile::TempDir,
+        result: Result<MvmBinding, SessionRefusal>,
+    }
+
+    fn open_against(plan: ExecutionPlan) -> Opened {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let emitter = Arc::new(
+            AuditEmitter::with_dir(EdKey::from_bytes(&[21u8; 32]), dir.path())
+                .expect("emitter")
+                .with_receipts(),
+        );
+        let admitted = admitted_for(plan);
+        let plane = Arc::new(HostAssuranceV1Handler::new());
+        let ceiling = default_policy_ceiling();
+        let result = open_on(
+            &plane,
+            OpenSession {
+                vm: "vm-a",
+                admitted: &admitted,
+                declaration: &declaration(),
+                emitter: &emitter,
+                policy_ceiling: &ceiling,
+                policy: NetworkPolicy::deny_all(),
+                backend: "firecracker",
+                now_unix_ms: NOW_MS,
+            },
+        );
+        Opened {
+            plane,
+            admitted,
+            emitter,
+            dir,
+            result,
+        }
+    }
+
+    fn ctx() -> ServiceCallCtx {
+        ServiceCallCtx {
+            workload_id: "workload".into(),
+            tenant_id: "tenant".into(),
+            correlation_id: CorrelationId::new("c"),
+            session_id: "vm-a".to_string(),
+            profile: AgentProfile::SealedProd,
+            composition_depth: 0,
+            composition_width: 0,
+        }
+    }
+
+    fn probe(session_id: &AssuranceId) -> ProbeRequest {
+        ProbeRequest {
+            schema: PROBE_REQUEST_SCHEMA.to_string(),
+            session_id: session_id.clone(),
+            trial_id: id("trial-1"),
+            idempotency_key: id("k1"),
+            nonce: id("n1"),
+            tool: ToolId::CampaignProbeV1,
+            invocation: ProbeInvocation::EgressAdmission {
+                destination_label: id("undeclared.synthetic.destination"),
+            },
+        }
+    }
+
+    fn chain_of(opened: &Opened) -> String {
+        let tenant = opened.admitted.plan().tenant.0.clone();
+        std::fs::read_to_string(opened.dir.path().join(format!("{tenant}.jsonl")))
+            .expect("chain readable")
+    }
+
+    #[test]
+    fn an_unbound_plan_opens_nothing() {
+        let opened = open_against(PlanFixture::new().build());
+        assert!(matches!(
+            opened.result,
+            Err(SessionRefusal::ServiceNotBound)
+        ));
+        assert!(opened.plane.binding_for("vm-a").is_none());
+    }
+
+    #[test]
+    fn a_campaign_declaring_no_edge_opens_nothing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let emitter = Arc::new(
+            AuditEmitter::with_dir(EdKey::from_bytes(&[22u8; 32]), dir.path()).expect("emitter"),
+        );
+        let admitted = admitted_for(bound_plan());
+        let plane = Arc::new(HostAssuranceV1Handler::new());
+        let ceiling = default_policy_ceiling();
+        let declaration = CampaignDeclaration {
+            edges: Vec::new(),
+            ..declaration()
+        };
+        let result = open_on(
+            &plane,
+            OpenSession {
+                vm: "vm-a",
+                admitted: &admitted,
+                declaration: &declaration,
+                emitter: &emitter,
+                policy_ceiling: &ceiling,
+                policy: NetworkPolicy::deny_all(),
+                backend: "firecracker",
+                now_unix_ms: NOW_MS,
+            },
+        );
+        assert!(matches!(result, Err(SessionRefusal::NoEdges)));
+    }
+
+    #[test]
+    fn a_bound_plan_opens_a_session_whose_binding_quotes_it() {
+        let opened = open_against(bound_plan());
+        let binding = opened.result.as_ref().expect("session opens").clone();
+
+        assert_eq!(binding.plan_id.as_str(), opened.admitted.plan_id().0);
+        assert_eq!(binding.runtime.backend.as_str(), "firecracker");
+        // The citation requirement is met by real emission, not a stub.
+        assert!(!binding.audit_refs.is_empty());
+        assert!(!binding.receipt_refs.is_empty());
+        assert_eq!(opened.plane.binding_for("vm-a").as_ref(), Some(&binding));
+        assert!(chain_of(&opened).contains("assurance.session_opened"));
+    }
+
+    #[tokio::test]
+    async fn the_opened_session_is_the_one_the_probe_verb_dispatches_against() {
+        // The point of this workstream: a probe reaches a session the admit
+        // path opened, not one a test constructed by hand.
+        let opened = open_against(bound_plan());
+        let binding = opened.result.as_ref().expect("session opens").clone();
+
+        let payload = serde_json::to_value(probe(&binding.session_id)).expect("payload");
+        let reply = opened
+            .plane
+            .dispatch(&ctx(), "probe", payload)
+            .await
+            .expect("the probe reaches the opened session");
+        let observation: ProbeObservation = serde_json::from_value(reply).expect("observation");
+        assert!(!observation.admitted, "deny-all must refuse the edge");
+        assert_eq!(observation.decision, "deny_all");
+
+        let observed = opened.plane.observation_for("vm-a").expect("observation");
+        assert!(observed.attempted_effect);
+        assert!(!observed.boundary_crossed);
+
+        let chain = chain_of(&opened);
+        assert!(chain.contains("assurance.session_opened"), "{chain}");
+        assert!(chain.contains("assurance.probe"), "{chain}");
+    }
+
+    #[tokio::test]
+    async fn a_probe_naming_another_session_does_not_reach_this_one() {
+        let opened = open_against(bound_plan());
+        let _ = opened.result.as_ref().expect("session opens");
+
+        let payload = serde_json::to_value(probe(&id("s-deadbeef"))).expect("payload");
+        let error = opened
+            .plane
+            .dispatch(&ctx(), "probe", payload)
+            .await
+            .expect_err("a mismatched session id must be refused");
+        assert_eq!(error.message, "session_mismatch");
+    }
+
+    #[test]
+    fn closing_records_the_outcome_and_drops_the_session() {
+        let opened = open_against(bound_plan());
+        let binding = opened.result.as_ref().expect("session opens").clone();
+
+        let identity = SessionIdentity {
+            session_id: binding.session_id.clone(),
+            campaign_id: id("mvm-campaign-1"),
+            trial_id: id("trial-1"),
+            source_digest: Sha256Digest::parse(SOURCE_DIGEST).expect("digest"),
+        };
+        close_on(
+            &opened.plane,
+            &opened.admitted,
+            &opened.emitter,
+            &identity,
+            &TrialVerdict {
+                outcome: TrialOutcome::Inconclusive,
+                reason: Some(InconclusiveReason::ObserverMissing),
+            },
+        )
+        .expect("close records the outcome");
+        opened.plane.close_session("vm-a");
+
+        assert!(opened.plane.binding_for("vm-a").is_none());
+        let chain = chain_of(&opened);
+        assert!(chain.contains("assurance.trial_completed"), "{chain}");
+        assert!(chain.contains("observer_missing"), "{chain}");
+    }
+}

--- a/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
@@ -246,9 +246,13 @@ impl HostAssuranceV1Handler {
             .get_mut(&ctx.session_id)
             .ok_or(ProbeRefusal::NoSession)?;
 
-        // The supervisor's context is authoritative. The request's own
-        // session_id exists only so a disagreement is visible.
-        if request.session_id.as_str() != ctx.session_id {
+        // Two identifiers, deliberately: the supervisor's `ctx.session_id` is
+        // the authoritative *lookup* key and is never supplied by the guest,
+        // while `binding.session_id` is the assurance identity the guest was
+        // told in its envelope. The request claims the latter, so that is what
+        // it is checked against — comparing it to the lookup key instead only
+        // worked while a test used one string for both.
+        if request.session_id != session.binding.session_id {
             return Err(ProbeRefusal::SessionMismatch);
         }
         if request.trial_id != session.trial_id {

--- a/crates/mvm-hostd/src/broker/handlers/mod.rs
+++ b/crates/mvm-hostd/src/broker/handlers/mod.rs
@@ -43,6 +43,12 @@ pub fn register_bound_handlers(registry: &mut Registry, bindings: &[ServiceId]) 
         let handler = Arc::new(HostAssuranceV1Handler::new());
         let as_service: Arc<dyn mvm_core::protocol::handler::ServiceHandler> = handler.clone();
         registry.register(as_service);
+        // Publish it process-wide so the admit path can open a session on the
+        // same instance the broker dispatches against. A second registry in one
+        // process keeps its own handler and does not displace the first — the
+        // alternative would point an opened session at a handler no workload
+        // calls, which reads as a campaign that ran and observed nothing.
+        crate::assurance_session::install_host_assurance_plane(Arc::clone(&handler));
         bound.assurance = Some(handler);
     }
 

--- a/crates/mvm-hostd/src/lib.rs
+++ b/crates/mvm-hostd/src/lib.rs
@@ -24,6 +24,7 @@
 //!   workload-exit control listener.
 
 pub mod admission_budget;
+pub mod assurance_session;
 pub mod audit;
 pub mod audit_signer;
 pub mod broker;

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -3397,8 +3397,9 @@ mod tests {
     fn a_declared_campaign_opens_its_session_on_the_boot_path() {
         // The production seam: `admit_and_start` is what a run goes through,
         // and a declared campaign has to become a live session there rather
-        // than in a test that hand-built one. This is the only test that
-        // installs the process-global plane, since a `OnceLock` admits one.
+        // than in a test that hand-built one. The broker-handler tests may
+        // already have installed the process-global plane, so this test uses
+        // that legitimate instance when running in parallel.
         use std::sync::Arc;
 
         use mvm_contract::assurance::{
@@ -3418,10 +3419,7 @@ mod tests {
         let ledger = InMemoryNonceLedger::new();
 
         let plane = Arc::new(HostAssuranceV1Handler::new());
-        assert!(
-            install_host_assurance_plane(Arc::clone(&plane)),
-            "this test owns the process-global plane"
-        );
+        let _ = install_host_assurance_plane(Arc::clone(&plane));
 
         let emitter = Arc::new(
             crate::audit::emitter::AuditEmitter::with_dir(

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1048,6 +1048,11 @@ pub struct AdmitAndStartParams<'a> {
     /// it is the record that the run was allowed, and it is written before the
     /// backend starts, so refusing on it actually stops the unaudited run.
     pub audit_durability: crate::audit::durability::AuditDurability,
+    /// An assurance campaign to open against this boot, when the operator
+    /// declared one. `None` — the default — is every ordinary run: extension
+    /// discovery must not sit on the launch critical path, so a run that
+    /// declares no campaign does no assurance work at all.
+    pub assurance: Option<&'a crate::assurance_session::CampaignRequest<'a>>,
 }
 
 impl<'a> AdmitAndStartParams<'a> {
@@ -1073,6 +1078,7 @@ pub struct AdmitAndStartParamsBuilder<'a> {
     policy_bundle: Option<&'a PolicyBundle>,
     emitter: Option<&'a crate::audit::emitter::AuditEmitter>,
     audit_durability: Option<crate::audit::durability::AuditDurability>,
+    assurance: Option<&'a crate::assurance_session::CampaignRequest<'a>>,
 }
 
 impl<'a> AdmitAndStartParamsBuilder<'a> {
@@ -1090,6 +1096,7 @@ impl<'a> AdmitAndStartParamsBuilder<'a> {
             policy_bundle: None,
             emitter: None,
             audit_durability: None,
+            assurance: None,
         }
     }
 
@@ -1165,6 +1172,15 @@ impl<'a> AdmitAndStartParamsBuilder<'a> {
         self
     }
 
+    /// Declare an assurance campaign for this boot.
+    pub fn assurance(
+        mut self,
+        assurance: impl Into<Option<&'a crate::assurance_session::CampaignRequest<'a>>>,
+    ) -> Self {
+        self.assurance = assurance.into();
+        self
+    }
+
     /// Set `audit_durability`.
     #[must_use]
     pub fn audit_durability(
@@ -1201,6 +1217,7 @@ impl<'a> AdmitAndStartParamsBuilder<'a> {
                 "AdmitAndStartParams",
                 "audit_durability",
             ))?,
+            assurance: self.assurance,
         })
     }
 }
@@ -1507,6 +1524,15 @@ pub fn admit_and_start(
                 if let Err(e) = emitter.emit_grants_enforced(admitted.plan(), &enforced_grants) {
                     tracing::warn!(error = %e, "audit emit_grants_enforced failed (non-fatal)");
                 }
+            }
+            // After the VM is running, so a failed boot leaves no session, and
+            // after `plan.launched`, so the campaign's own records follow the
+            // launch they belong to. A refusal here fails the boot: a campaign
+            // the operator declared and that silently did not open would be
+            // reported as a trial that observed nothing.
+            if let Some(campaign) = params.assurance {
+                crate::assurance_session::open_for_boot(campaign, &vm_id.0, &admitted)
+                    .context("opening the declared assurance session")?;
             }
             Ok(StartedMachine {
                 vm_id,
@@ -3351,6 +3377,7 @@ mod tests {
                 policy_bundle: None,
                 emitter: None,
                 audit_durability: crate::audit::durability::AuditDurability::BestEffort,
+                assurance: None,
             },
         )
         .expect("admit + boot");
@@ -3364,6 +3391,120 @@ mod tests {
             backend.status(&started.vm_id).unwrap(),
             mvm_core::vm_backend::VmStatus::Running
         ));
+    }
+
+    #[test]
+    fn a_declared_campaign_opens_its_session_on_the_boot_path() {
+        // The production seam: `admit_and_start` is what a run goes through,
+        // and a declared campaign has to become a live session there rather
+        // than in a test that hand-built one. This is the only test that
+        // installs the process-global plane, since a `OnceLock` admits one.
+        use std::sync::Arc;
+
+        use mvm_contract::assurance::{
+            ApprovalSet, AssuranceId, ObservationScope, RequestedAuthority, Sha256Digest, ToolId,
+        };
+
+        use crate::assurance_session::{
+            CampaignDeclaration, CampaignRequest, DeclaredEdge, default_policy_ceiling,
+            host_assurance_plane, install_host_assurance_plane,
+        };
+        use crate::broker::handlers::host_assurance_v1::HostAssuranceV1Handler;
+
+        let (_env, _home) = host_with_ceiling(Default::default());
+        let dir = tempfile::tempdir().unwrap();
+        let audit = tempfile::tempdir().unwrap();
+        let backend = mvm_runtime::AnyBackend::from_hypervisor("mock");
+        let ledger = InMemoryNonceLedger::new();
+
+        let plane = Arc::new(HostAssuranceV1Handler::new());
+        assert!(
+            install_host_assurance_plane(Arc::clone(&plane)),
+            "this test owns the process-global plane"
+        );
+
+        let emitter = Arc::new(
+            crate::audit::emitter::AuditEmitter::with_dir(
+                ed25519_dalek::SigningKey::from_bytes(&[31u8; 32]),
+                audit.path(),
+            )
+            .expect("emitter")
+            .with_receipts(),
+        );
+        let id = |raw: &str| AssuranceId::parse(raw).expect("identifier");
+        let declaration = CampaignDeclaration {
+            campaign_id: id("mvm-campaign-1"),
+            trial_id: id("trial-1"),
+            source_run_id: id("scout-1"),
+            source_digest: Sha256Digest::parse(format!("sha256:{}", "3".repeat(64)))
+                .expect("digest"),
+            edges: vec![DeclaredEdge {
+                label: id("undeclared.synthetic.destination"),
+                host: "attacker.example.com".to_string(),
+                port: 443,
+            }],
+            approvals: ApprovalSet::none().with(ToolId::CampaignProbeV1),
+            requested: RequestedAuthority {
+                allowed_tools: vec![ToolId::CampaignProbeV1],
+                observation_scopes: vec![ObservationScope::HostAuditRefs],
+                max_steps: 4,
+                max_output_bytes: 4096,
+                deadline_unix_ms: 0,
+            },
+            grant_ttl_ms: 600_000,
+        };
+        let now_unix_ms = 1_800_000_000_000;
+        let campaign = CampaignRequest {
+            declaration: &declaration,
+            emitter: Arc::clone(&emitter),
+            policy_ceiling: default_policy_ceiling(),
+            policy: mvm_core::policy::network_policy::NetworkPolicy::deny_all(),
+            backend: "mock".to_string(),
+            now_unix_ms,
+        };
+
+        let service =
+            mvm_core::protocol::broker::ServiceId::parse("host.assurance.v1").expect("service id");
+        let mut synthesis = fixture_input("vm-assurance");
+        synthesis.services = vec![service];
+        let config = mvm_core::vm_backend::VmStartConfig {
+            name: "vm-assurance".into(),
+            rootfs_path: "/store/rootfs.ext4".into(),
+            ..Default::default()
+        };
+
+        let started = admit_and_start(
+            &backend,
+            AdmitAndStartParams {
+                synthesis: &synthesis,
+                config,
+                clock: &SystemClock,
+                ledger: &ledger,
+                host_signer_keys_dir: Some(dir.path()),
+                bundle_ctx: None,
+                variant: Variant::Dev,
+                policy_bundle: None,
+                emitter: Some(&emitter),
+                audit_durability: crate::audit::durability::AuditDurability::BestEffort,
+                assurance: Some(&campaign),
+            },
+        )
+        .expect("admit + boot with a declared campaign");
+
+        let plane = host_assurance_plane().expect("the plane this test installed");
+        let binding = plane
+            .binding_for(&started.vm_id.0)
+            .expect("the boot path opened a session for this VM");
+        // The binding renders the content address in the counterparty's
+        // identifier grammar; it still names exactly this plan.
+        assert_eq!(
+            binding.plan_id.as_str(),
+            started.admitted.plan_id().0.replace(':', "-")
+        );
+        assert_eq!(binding.runtime.backend.as_str(), "mock");
+        // Its citations came from real emission on the boot path.
+        assert!(!binding.audit_refs.is_empty());
+        assert!(!binding.receipt_refs.is_empty());
     }
 
     /// The bound the backend spawns under comes off the signed plan, and only
@@ -3456,6 +3597,7 @@ mod tests {
                 policy_bundle: None,
                 emitter: None,
                 audit_durability: crate::audit::durability::AuditDurability::BestEffort,
+                assurance: None,
             },
         )
         .expect("admit + boot");
@@ -3502,6 +3644,7 @@ mod tests {
                 policy_bundle: None,
                 emitter: Some(&emitter),
                 audit_durability: crate::audit::durability::AuditDurability::BestEffort,
+                assurance: None,
             },
         )
         .expect("admit + boot");
@@ -3551,6 +3694,7 @@ mod tests {
                 policy_bundle: None,
                 emitter: None,
                 audit_durability: crate::audit::durability::AuditDurability::BestEffort,
+                assurance: None,
             },
         )
         .expect_err("the plan's profile and the booting backend disagree");
@@ -3611,6 +3755,7 @@ mod tests {
                 policy_bundle: None,
                 emitter: Some(&emitter),
                 audit_durability: AuditDurability::Required,
+                assurance: None,
             },
         )
         .expect_err("an unauditable sealed run must not boot");
@@ -3664,6 +3809,7 @@ mod tests {
                 policy_bundle: None,
                 emitter: Some(&emitter),
                 audit_durability: AuditDurability::BestEffort,
+                assurance: None,
             },
         )
         .expect("a dev run is not blocked by a broken audit chain");
@@ -3704,6 +3850,7 @@ mod tests {
                 policy_bundle: None,
                 emitter: None,
                 audit_durability: crate::audit::durability::AuditDurability::BestEffort,
+                assurance: None,
             },
         )
         .expect_err("unadmitted volume must refuse");

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -266,6 +266,9 @@ pub fn admit_and_boot_local(
             // defaulted: a run that silently picks its own audit durability is
             // how this control erodes.
             audit_durability: crate::audit::durability::AuditDurability::BestEffort,
+            // This entry point declares no campaign; assurance is opt-in and
+            // must never sit on an ordinary run's path.
+            assurance: None,
         },
     )
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -286,16 +286,19 @@ for detailed scope and acceptance criteria.
 ## In-flight plans
 
 - [~] **Admission-bound AI assurance sessions** —
-      `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W4
-      and W6/W7 landed: the envelope, the five-way authority intersection, the
+      `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W4,
+      W6/W7 and W7b landed: the envelope, the authority intersection, the
       fail-closed outcome ladder, `host.assurance.v1`, fail-closed audit and
-      receipt emission with citations that actually resolve, and the
-      workload-facing `AssuranceCampaign` whose surface offers no command,
-      path, host or port to pass. 84 tests.
-      STILL OPEN: W5 observer/cleanup evidence, W7b session lifecycle on the
-      admit path (`open_session` has no production caller yet), W8 the
-      framed-stdio provider binary. Until those land every live trial evaluates
-      `INCONCLUSIVE` by design; no certifying campaign can run.
+      receipt emission with resolvable citations, the workload-facing
+      `AssuranceCampaign`, and the boot-path session lifecycle behind
+      `AdmitAndStartParams.assurance` (opt-in; `None` on every existing call
+      site). Landing W7b exposed two bugs the fixtures had masked: the binding
+      rejected every real `sha256:`-prefixed plan id, and the probe handler
+      compared the guest's session identity against the supervisor's lookup key.
+      STILL OPEN: W5 observer/cleanup evidence, W8 the framed-stdio provider,
+      and a CLI surface for supplying a campaign declaration. Until those land
+      every live trial evaluates `INCONCLUSIVE` by design; no certifying
+      campaign can run.
 
 - [~] **Embedded-binary content store** — `specs/plans/2026-08-17-embedded-binary-content-store.md`.
       Phases 1–2 landed: both nested legs of `crates/mvm-cli/build.rs` are keyed

--- a/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
+++ b/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
@@ -3,7 +3,7 @@
 Backing: shipped-source
 Validation: a_provider_cannot_smuggle_an_mvm_binding_through_the_request_parser
 
-Status: **W1–W4, W6 landed. W5, W7, W8 open.**
+Status: **W1–W4, W6/W7, W7b landed. W5, W8 open.**
 
 An AI workload can drive a Scout-linked assurance campaign from inside an
 admitted microVM. This plan is the MVM half of that: the typed envelope the
@@ -84,6 +84,22 @@ Three properties are structural rather than checked at runtime:
       decorative. Records carry the declared *label*, never the host or port
       behind it.
 
+- [x] **W7b — Session lifecycle on the boot path.** `assurance_session::open`
+      mints a derived grant, intersects authority, records
+      `assurance.session_opened`, builds the binding from those references, and
+      opens the session — refusing outright if the plan does not bind
+      `host.assurance.v1`, if the campaign declares no edge, or if the record
+      could not be written. `AdmitAndStartParams.assurance` carries an
+      operator-declared campaign through the real boot path, and a test asserts
+      `admit_and_start` produces a live session whose binding quotes the
+      admitted plan. Assurance stays off the ordinary launch path: `None` is the
+      default and every existing call site takes it.
+
+      The plane is a process-global installed when the broker registry binds the
+      service, but `open_on` takes it explicitly — a `OnceLock` admits one
+      value, so a decision path only reachable through the global would be
+      testable exactly once per process.
+
 ## Open
 
 - [ ] **W5 — Observer and cleanup evidence.** `EvidenceSet` is consumed by the
@@ -91,12 +107,6 @@ Three properties are structural rather than checked at runtime:
       `cleanup_verified` / `attestation_verified` from a real run yet. Until
       that lands every live trial evaluates to `INCONCLUSIVE`, which is the
       correct fail-closed behaviour and not a certifying result.
-
-- [ ] **W7b — Session lifecycle on the admit path.**
-      `HostAssuranceV1Handler::open_session` is still called by tests only. It
-      needs a caller that mints the grant, intersects authority, opens the
-      session against the admitted plan, and closes it at teardown. Until then
-      the probe surface is reachable only from a test.
 
 - [ ] **W8 — Provider binary.** The counterparty's
       `assurance run --provider <path>` spawns a framed-stdio provider speaking

--- a/specs/sprint/delivery/assurance-session-lifecycle.md
+++ b/specs/sprint/delivery/assurance-session-lifecycle.md
@@ -1,0 +1,71 @@
+# Assurance sessions: the boot-path lifecycle
+
+Plan: `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md` (W7b)
+
+## What landed
+
+`open_session` had no production caller, so the probe surface was reachable
+only from a test. `assurance_session::open` closes that: it mints a grant,
+intersects authority, records `assurance.session_opened`, builds the binding
+from those references, and opens the session. `AdmitAndStartParams.assurance`
+carries an operator-declared campaign through the real boot path, and a test
+asserts `admit_and_start` produces a live session whose binding quotes the
+admitted plan.
+
+Assurance stays off the ordinary launch path. `assurance: None` is the default
+and every existing call site takes it, so a run that declares no campaign does
+no discovery and no work.
+
+**The operator declares the campaign; the plan decides whether any of it is
+allowed.** `CampaignDeclaration` carries the destinations, their host/port, the
+approved tools and the requested authority — all host-side. It is deliberately
+not a signed-plan field: a campaign is chosen per run against a plan that may be
+reused, and putting it in the plan would mean re-admitting a workload to
+re-point a probe. What the plan decides is whether a session may exist at all;
+one that does not bind `host.assurance.v1` gets nothing regardless.
+
+**Identifiers are derived, not random.** The session id and grant nonce are a
+digest over plan, VM and campaign, so re-opening the same campaign against the
+same plan yields the same session rather than silently a second one — and the
+whole path is reproducible in a test. The grant digest covers the grant's own
+content, so two grants differing in expiry or scope cannot share one.
+
+**Ordering is the control.** Authority is intersected before anything is
+recorded; the session is recorded before it is opened; the open happens after
+the VM is running and after `plan.launched`. A session that existed but was
+never written down would let a probe run against a binding citing an audit entry
+nobody wrote, and a refusal to record fails the boot rather than leaving a
+campaign that reports observing nothing.
+
+## Two bugs the real path exposed
+
+Both were invisible to every test written before this one, and both would have
+broken the first genuine campaign.
+
+**The binding rejected every real plan.** `MvmBindingBuilder::plan()` parsed
+`plan_id` as an identifier, but a plan id is a content address — `sha256:<hex>`
+— and `:` is not in the counterparty's identifier grammar. The `fixture-plan`
+id used by every prior test sailed through. The separator is now rendered as
+`-`, which is unambiguous because hex carries none.
+
+**The handler compared the wrong session identity.** It checked the request's
+`session_id` against `ctx.session_id`, the supervisor's workload key. Those are
+different things: the supervisor's key is the authoritative *lookup*, while the
+binding's id is the assurance identity the guest was told. They were only ever
+equal because a test used one string for both. The request is now checked
+against the binding, which is what a guest legitimately knows.
+
+## Testability note
+
+The plane is a process-global installed when the broker registry binds the
+service, but `open_on` takes it explicitly. A `OnceLock` admits one value, so a
+decision path reachable only through the global would be testable exactly once
+per process — fine under nextest, silently wrong under `cargo test`.
+
+## What is still not true
+
+No certifying campaign can run. Observer, cleanup and attestation evidence still
+have no producer (W5), so a live trial evaluates `INCONCLUSIVE` by design, and
+the framed-stdio provider the counterparty spawns exists in neither repository
+(W8). There is also no CLI surface yet for supplying a `CampaignDeclaration`:
+the boot path accepts one, but only an in-process caller can pass it.


### PR DESCRIPTION
Lands W7b of
`specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`.

## The gap this closes

`open_session` had no production caller. The probe surface, its authority
model, and its audit emission were all reachable only from a test.

`assurance_session::open` mints a derived grant, intersects authority, records
`assurance.session_opened`, builds the binding from those references, and opens
the session — refusing outright if the plan does not bind `host.assurance.v1`,
if the campaign declares no edge, or if the record could not be written.
`AdmitAndStartParams.assurance` carries an operator-declared campaign through
`admit_and_start`, and a test asserts that path produces a live session whose
binding quotes the admitted plan.

Assurance stays off the ordinary launch path: `None` is the default and every
existing call site takes it, so a run declaring no campaign does no discovery
and no work.

## Where the campaign comes from

The operator declares it; the plan decides whether any of it is allowed.
`CampaignDeclaration` holds the destinations, their host and port, the approved
tools and the requested authority — all host-side, so a workload only ever sees
labels. It is deliberately *not* a signed-plan field: a campaign is chosen per
run against a plan that may be reused, and putting it in the plan would mean
re-admitting a workload to re-point a probe. What the plan decides is whether a
session may exist; one that does not bind the service gets nothing regardless.

Identifiers are derived from plan, VM and campaign rather than random, so
re-opening the same campaign is the same session rather than silently a second
one — and the path is reproducible in a test. The grant digest covers the
grant's own content, so grants differing in expiry or scope cannot share one.

Ordering is the control: authority is intersected before anything is recorded,
the session is recorded before it is opened, and the open happens after the VM
is running and after `plan.launched`.

## Two bugs the real caller exposed

Both were invisible to every test written before, and both would have broken
the first genuine campaign.

**The binding rejected every real plan.** `MvmBindingBuilder::plan()` parses
`plan_id` as an identifier, but a plan id is a content address — `sha256:<hex>`
— and `:` is not in the counterparty's identifier grammar. The `fixture-plan`
id every prior test used sailed straight through. The separator now renders as
`-`, unambiguous because hex carries none.

**The handler compared the wrong session identity.** It checked the request's
`session_id` against `ctx.session_id`, the supervisor's *lookup* key, when the
binding's id is the assurance identity a guest legitimately knows. Those were
equal only because one test string served as both.

This is the argument for building the production caller rather than more unit
tests: the fixtures agreed with themselves.

## Testability note

The plane is a process-global installed when the broker registry binds the
service, but `open_on` takes it explicitly. A `OnceLock` admits one value, so a
decision path reachable only through the global would be testable exactly once
per process — fine under nextest, silently wrong under `cargo test`.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 12,346 passed
- `cargo test --workspace --doc` — pass
- All 61 applicable xtask gates from `.github/workflows` — pass

Two xtask gate self-tests (`check_no_gateway_names`, `check_l3_expansion_freeze`)
fail locally when a `graft/` index is present in the worktree: they scan the
tree without honouring `.gitignore`, and graft's ignored cache contains indexed
source text carrying the forbidden tokens. Both pass with that directory moved
aside, and `graft/` is gitignored and absent from `main`, so CI never sees it.
Noting it as a pre-existing gate gap rather than fixing it here.

## Still not true

No certifying campaign can run. Observer and cleanup evidence have no producer
(W5), the framed-stdio provider exists in neither repository (W8), and there is
no CLI surface for supplying a declaration yet — the boot path accepts one, but
only an in-process caller can pass it.
