### PR TITLE
fix(release): publish kernels on release, and tell the truth about a 404

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -589,6 +589,24 @@ jobs:
             -f tag="${TAG_NAME}" \
             -f dry_run=false
 
+      # Same rule, same fix, for the kernels. `kernel-build.yml` declares
+      # `on.push.tags: v*` and has never once run from it: whatever creates the
+      # tag does so under GITHUB_TOKEN, which emits no `push` event, so the
+      # publish arm has never fired on a release. The result is releases whose
+      # `mvmctl kernel build --source download` 404s — the only supported
+      # acquisition path for a host that cannot compile kernels. Chain it
+      # explicitly rather than relying on an event that demonstrably does not
+      # arrive.
+      - name: Trigger kernel build + publish workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          # No `-f` inputs: kernel-build.yml declares `workflow_dispatch: {}`,
+          # and `--ref <tag>` already gives it the `refs/tags/v*` github.ref its
+          # publish steps gate on.
+          gh workflow run kernel-build.yml --ref "${TAG_NAME}"
+
   # Plan 199 B2: post-publish gate. Download the just-created release and assert
   # every binary target has a tarball + matching SHA256 + cosign signature bundle
   # + an entry in the combined checksums manifest, and that the SBOM is signed.

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -225,6 +225,51 @@ fn download_release(version: &str, target: &str, tmp_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Whether a release with this tag exists at all.
+///
+/// Only ever called on the error path, so the extra request costs nothing in
+/// the success case. An unreachable or rate-limited API answers `true`: the
+/// point of the probe is to *sharpen* a message, and guessing "no release"
+/// from a failed lookup would state something false with more confidence than
+/// the vaguer wording it replaced.
+fn release_exists(tag: &str) -> bool {
+    let url = format!(
+        "{}/repos/{}/releases/tags/{}",
+        github_api_base(),
+        GITHUB_REPO,
+        tag
+    );
+    match http::fetch_json(&url) {
+        Ok(v) => v.get("tag_name").is_some(),
+        // Distinguishing "404, no such release" from "the network is down"
+        // would need a status code this helper does not get. Both land here,
+        // and both are better served by the asset-missing wording.
+        Err(_) => true,
+    }
+}
+
+/// The advice to print when a kernel download 404s.
+///
+/// A missing asset and a missing release are the same HTTP status and
+/// different problems. An in-development build always hits the second — the
+/// crate version runs ahead of the last tag, by construction — and telling
+/// that user to "cut a release that publishes kernels" points them at
+/// something that is not broken, when what they want is to compile.
+fn kernel_fetch_hint(tag: &str, asset: &str, release_exists: bool) -> String {
+    if release_exists {
+        format!(
+            "release {tag} exists but publishes no kernel asset {asset}. Build it \
+             locally with `--source compile`, or cut a release that publishes kernels."
+        )
+    } else {
+        format!(
+            "there is no release {tag} to download {asset} from. This mvmctl was \
+             built from a version that has not been released — a source checkout \
+             compiles instead: `--source compile`."
+        )
+    }
+}
+
 /// Download a published kernel (`vmlinux-<arch>-<variant>`) from the
 /// release matching this mvmctl's version, SHA-256-verify it against the
 /// release's `kernel-<arch>-checksums-sha256.txt`, and write it to
@@ -271,12 +316,7 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
     let sp = ui::spinner(&format!("Downloading {asset} ({tag})..."));
     let dl = http::download_file(&asset_url, &download);
     sp.finish_and_clear();
-    dl.with_context(|| {
-        format!(
-            "no kernel asset {asset} in release {tag}. Build it locally with \
-             `--source compile`, or cut a release that publishes kernels."
-        )
-    })?;
+    dl.with_context(|| kernel_fetch_hint(&tag, &asset, release_exists(&tag)))?;
 
     // The signature rung runs even under MVM_SKIP_HASH_VERIFY: that hatch
     // waives comparing the digest, not the question of who published the
@@ -1073,5 +1113,44 @@ mod tests {
             recorded.trim(),
             mvm_fs::overlay::compute_file_sha256(&dest).unwrap()
         );
+    }
+
+    /// The two 404s are different problems and must not read the same. A
+    /// missing release means "this build was never released, compile"; a
+    /// missing asset means "this release ships no kernels". Sending a
+    /// developer to cut a release, or a user to compile on a host with no
+    /// toolchain, is the failure this split exists to prevent.
+    #[test]
+    fn a_missing_release_and_a_missing_asset_give_different_advice() {
+        let no_release = kernel_fetch_hint("v0.18.0", "vmlinux-aarch64-workload", false);
+        let no_asset = kernel_fetch_hint("v0.17.0", "vmlinux-aarch64-workload", true);
+        assert_ne!(no_release, no_asset);
+
+        assert!(
+            no_release.contains("no release v0.18.0"),
+            "must name the absent release: {no_release}"
+        );
+        assert!(
+            !no_release.contains("cut a release"),
+            "a build that predates its own release is not fixed by cutting one: {no_release}"
+        );
+
+        assert!(
+            no_asset.contains("exists but publishes no kernel asset"),
+            "must say the release is present and the asset is not: {no_asset}"
+        );
+    }
+
+    /// Both arms name the asset and offer `--source compile`, since that is
+    /// the way forward either way.
+    #[test]
+    fn both_hints_name_the_asset_and_the_compile_escape() {
+        for hint in [
+            kernel_fetch_hint("v0.18.0", "vmlinux-x86_64-builder", false),
+            kernel_fetch_hint("v0.18.0", "vmlinux-x86_64-builder", true),
+        ] {
+            assert!(hint.contains("vmlinux-x86_64-builder"), "{hint}");
+            assert!(hint.contains("--source compile"), "{hint}");
+        }
     }
 }


### PR DESCRIPTION
Closes #2675.

## What was actually wrong

Not the URL. `kernel-build.yml` declares `on.push.tags: v*` and **has never run
from it — not once**:

```
$ gh run list --workflow=kernel-build.yml --event=push
(empty)
$ gh run list --workflow=release.yml
workflow_dispatch  ci/fix-release-smoke-and-brew  success  2026-06-30
```

Neither workflow has ever seen a `v*` tag push. The tag is created by
`gh release create` under `GITHUB_TOKEN`, which by GitHub's design emits no
`push` event — so the publish arm never fires on a release.

release.yml already documents that exact rule two steps above the change in
this PR, where it chains `publish-crates.yml` explicitly for the same reason:

> The "release: published" event fired by `gh release create` runs under
> GITHUB_TOKEN, which by design does not trigger downstream workflows.

The kernels never got the same treatment. `v0.16.0` carries
`vmlinux-{aarch64,x86_64}-{builder,workload}` only because it predates the
point where they stopped arriving; every release since has shipped without
them, which is why the issue's asset table has exactly one row that works.

## The fix

Chain `kernel-build.yml` from release.yml beside the crates.io chain. No `-f`
inputs — it declares `workflow_dispatch: {}`, and `--ref <tag>` already supplies
the `refs/tags/v*` `github.ref` that its cosign and publish steps gate on, and
the `github.ref_name` its `TAG` env reads.

## The second half: two 404s are not one problem

A missing asset and a missing release are the same HTTP status. The message
assumed the first:

> no kernel asset vmlinux-aarch64-workload in release v0.18.0. Build it locally
> with `--source compile`, or **cut a release that publishes kernels**.

An in-development build always hits the *second* — the crate version runs ahead
of the last tag by construction, so `v0.18.0` simply does not exist. That
advice sent the one person who could not act on it off to fix something that
was not broken. Now:

| situation | message |
|---|---|
| release absent | `there is no release v0.18.0 to download … from. This mvmctl was built from a version that has not been released — a source checkout compiles instead: --source compile.` |
| release present, asset absent | `release v0.17.0 exists but publishes no kernel asset … Build it locally with --source compile, or cut a release that publishes kernels.` |

The probe runs **only on the error path**, so the success path costs nothing.
An unreachable or rate-limited API answers "release exists" and keeps the
vaguer wording — guessing "no release" from a failed lookup would state
something false with more confidence than the message it replaced.

## Deliberately not done

- **The tag derivation stays `v{crate_version}`.** `download_kernel`'s contract
  is that a given mvmctl fetches only the kernel that shipped with it — "never
  a substitute for an in-tree config edit". Resolving to "newest release that
  happens to carry the asset" would break that and could hand someone a kernel
  mismatched to their CLI. The issue proposed it as one option; the pinned-tag
  alternative it also proposed is what `DEFAULT_BOOT_IMAGE_TAG` already is, and
  that constant is deliberately unread until its release exists.
- **This does not make an existing release grow assets.** `v0.17.0` stays
  unfetchable. The first release cut after this merges is the first that works.

## Witnesses

`a_missing_release_and_a_missing_asset_give_different_advice` asserts the two
differ, that the missing-release arm does **not** say "cut a release", and that
the missing-asset arm does. `both_hints_name_the_asset_and_the_compile_escape`
pins what they share.

`cargo test -p mvm-cli --lib update::` 17/17, workspace clippy clean,
`check-workflow-paths` clean, release.yml parses.