### PR TITLE
fix(hvf): say which check failed instead of "BadKernel"

### DIFF
--- a/crates/mvm-runtime/src/backends/hvf/boot_smoke.rs
+++ b/crates/mvm-runtime/src/backends/hvf/boot_smoke.rs
@@ -47,6 +47,50 @@ pub struct BootProof {
     pub syndrome: u64,
 }
 
+/// Why an HVF boot could not be set up.
+///
+/// One variant per distinguishable cause. `BadKernel` used to be a single unit
+/// variant returned from more than twenty places, so "the kernel file is
+/// missing", "the kernel is empty", "the image does not fit in guest RAM" and
+/// "too many disks were attached" all printed as the same four words, and the
+/// operator had to read the source and guess which one they had.
+///
+/// [`HvfError`] is `Copy` — it is returned through the vCPU run loop — so this
+/// carries an [`std::io::ErrorKind`] and sizes rather than a `PathBuf` and an
+/// `io::Error`. That is enough to tell the causes apart; the path is known to
+/// whoever supplied it and belongs where the error is rendered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootFault {
+    /// Opening or stat-ing the kernel image failed.
+    KernelOpen(std::io::ErrorKind),
+    /// Reading the kernel image header failed (short file, I/O error).
+    KernelRead(std::io::ErrorKind),
+    /// The image is zero bytes.
+    KernelEmpty,
+    /// The bytes are not a usable arm64 `Image` (bad magic or header).
+    KernelNotArm64Image,
+    /// The image does not fit the window it must load into.
+    KernelTooLarge { needed: usize, available: usize },
+    /// A load offset is not page-aligned.
+    Misaligned { offset: usize },
+    /// A length or address computation overflowed.
+    Overflow,
+    /// Guest RAM is too small to hold even the DTB window.
+    GuestRamTooSmall { ram: usize, needed: usize },
+    /// No gap between the kernel and the DTB window for the initramfs.
+    InitrdNoRoom {
+        kernel_end: usize,
+        initrd_len: usize,
+        dtb_offset: usize,
+    },
+    /// More disks than the device model has MMIO slots for.
+    TooManyDisks { given: usize, max: usize },
+    /// More virtiofs shares than the device model has MMIO slots for.
+    TooManyFilesystems { given: usize, max: usize },
+    /// The generated device tree exceeds its reserved window.
+    DtbTooLarge { needed: usize, max: usize },
+}
+
 /// Failure points along the HVF boot path, each carrying the raw `hv_return_t`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HvfError {
@@ -65,8 +109,8 @@ pub enum HvfError {
     UnexpectedExit(hv_exit_reason_t),
     /// An exception with an unexpected class (ESR `EC`).
     UnexpectedException(u32),
-    /// The supplied kernel image is not a usable arm64 `Image`.
-    BadKernel,
+    /// The boot could not be set up. Carries which check failed.
+    BadBoot(BootFault),
     /// In-kernel GICv3 creation failed (needs macOS 15+).
     GicCreate(hv_return_t),
     /// Serialized HVF state failed structural validation.

--- a/crates/mvm-runtime/src/backends/hvf/guest_ram.rs
+++ b/crates/mvm-runtime/src/backends/hvf/guest_ram.rs
@@ -11,7 +11,7 @@ use std::os::fd::AsRawFd;
 use std::path::Path;
 use std::ptr::NonNull;
 
-use super::HvfError;
+use super::{BootFault, HvfError};
 use zeroize::Zeroize;
 
 /// Apple-silicon hypervisor page size; `hv_vm_map` and `MAP_FIXED` sub-maps
@@ -177,9 +177,10 @@ impl GuestRam {
     pub fn map_private_file(&mut self, path: &Path) -> Result<(), HvfError> {
         let file_len = File::open(path)
             .and_then(|file| file.metadata())
-            .map_err(|_| HvfError::BadKernel)?
+            .map_err(|e| HvfError::BadBoot(BootFault::KernelOpen(e.kind())))?
             .len();
-        let file_len = usize::try_from(file_len).map_err(|_| HvfError::BadKernel)?;
+        let file_len =
+            usize::try_from(file_len).map_err(|_| HvfError::BadBoot(BootFault::Overflow))?;
         if file_len != self.len || !file_len.is_multiple_of(HVF_PAGE_SIZE) {
             return Err(HvfError::SnapshotState("snapshot RAM file length mismatch"));
         }
@@ -192,7 +193,10 @@ impl GuestRam {
             .checked_add(bytes.len())
             .is_none_or(|end| end > self.len)
         {
-            return Err(HvfError::BadKernel);
+            return Err(HvfError::BadBoot(BootFault::KernelTooLarge {
+                needed: offset.saturating_add(bytes.len()),
+                available: self.len,
+            }));
         }
         // SAFETY: destination bounds are checked above, and a borrowed slice
         // cannot overlap this owned mmap reservation.
@@ -214,14 +218,20 @@ impl GuestRam {
         len: usize,
     ) -> Result<(), HvfError> {
         let mapped_len = page_rounded_len(len)?;
-        if !offset.is_multiple_of(HVF_PAGE_SIZE)
-            || offset
-                .checked_add(mapped_len)
-                .is_none_or(|end| end > self.len)
-        {
-            return Err(HvfError::BadKernel);
+        if !offset.is_multiple_of(HVF_PAGE_SIZE) {
+            return Err(HvfError::BadBoot(BootFault::Misaligned { offset }));
         }
-        let file = File::open(path).map_err(|_| HvfError::BadKernel)?;
+        if offset
+            .checked_add(mapped_len)
+            .is_none_or(|end| end > self.len)
+        {
+            return Err(HvfError::BadBoot(BootFault::KernelTooLarge {
+                needed: offset.saturating_add(mapped_len),
+                available: self.len,
+            }));
+        }
+        let file =
+            File::open(path).map_err(|e| HvfError::BadBoot(BootFault::KernelOpen(e.kind())))?;
         let dst = unsafe { self.ptr.as_ptr().add(offset) };
         // SAFETY: dst is page-aligned inside this owned reservation, and
         // mapped_len is page-rounded. MAP_FIXED intentionally replaces only the
@@ -245,11 +255,11 @@ impl GuestRam {
 
 pub(crate) fn page_rounded_len(len: usize) -> Result<usize, HvfError> {
     if len == 0 {
-        return Err(HvfError::BadKernel);
+        return Err(HvfError::BadBoot(BootFault::KernelEmpty));
     }
     len.checked_add(HVF_PAGE_SIZE - 1)
         .map(|n| n / HVF_PAGE_SIZE * HVF_PAGE_SIZE)
-        .ok_or(HvfError::BadKernel)
+        .ok_or(HvfError::BadBoot(BootFault::Overflow))
 }
 
 impl Drop for GuestRam {

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -30,7 +30,7 @@ use super::hv_impl::{HvfHandle, HvfVcpu};
 use super::snapshot::HVF_SNAPSHOT_BACKEND_KIND;
 use super::sys::*;
 use super::vcpu::esr_ec;
-use super::{default_bootargs, default_virtiofs_bootargs};
+use super::{BootFault, default_bootargs, default_virtiofs_bootargs};
 use crate::vmm::device::Pl011;
 use crate::vmm::device_state::capture_device_states;
 use crate::vmm::hv::{CoreReg, HypervisorVcpu, SysReg, VcpuHandle};
@@ -426,7 +426,7 @@ enum KernelImageSource<'a> {
     File(&'a Path),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct KernelImageMeta {
     file_len: usize,
     reserved_len: usize,
@@ -434,7 +434,8 @@ struct KernelImageMeta {
 
 impl KernelImageMeta {
     fn new(file_len: usize, image_size: u64, file_backed: bool) -> Result<Self, HvfError> {
-        let image_size = usize::try_from(image_size).map_err(|_| HvfError::BadKernel)?;
+        let image_size =
+            usize::try_from(image_size).map_err(|_| HvfError::BadBoot(BootFault::Overflow))?;
         let mapped_len = if file_backed {
             page_rounded_len(file_len)?
         } else {
@@ -451,21 +452,24 @@ impl KernelImageSource<'_> {
     fn metadata(self) -> Result<KernelImageMeta, HvfError> {
         match self {
             Self::Bytes(image) => {
-                let hdr = kernel_image::parse(image).map_err(|_| HvfError::BadKernel)?;
+                let hdr = kernel_image::parse(image)
+                    .map_err(|_| HvfError::BadBoot(BootFault::KernelNotArm64Image))?;
                 KernelImageMeta::new(image.len(), hdr.image_size, false)
             }
             Self::File(path) => {
-                let mut file = File::open(path).map_err(|_| HvfError::BadKernel)?;
+                let mut file = File::open(path)
+                    .map_err(|e| HvfError::BadBoot(BootFault::KernelOpen(e.kind())))?;
                 let mut header = [0_u8; 64];
                 file.read_exact(&mut header)
-                    .map_err(|_| HvfError::BadKernel)?;
-                let hdr = kernel_image::parse(&header).map_err(|_| HvfError::BadKernel)?;
+                    .map_err(|e| HvfError::BadBoot(BootFault::KernelRead(e.kind())))?;
+                let hdr = kernel_image::parse(&header)
+                    .map_err(|_| HvfError::BadBoot(BootFault::KernelNotArm64Image))?;
                 let len = file
                     .metadata()
-                    .map_err(|_| HvfError::BadKernel)?
+                    .map_err(|e| HvfError::BadBoot(BootFault::KernelOpen(e.kind())))?
                     .len()
                     .try_into()
-                    .map_err(|_| HvfError::BadKernel)?;
+                    .map_err(|_| HvfError::BadBoot(BootFault::Overflow))?;
                 KernelImageMeta::new(len, hdr.image_size, true)
             }
         }
@@ -499,14 +503,18 @@ fn initrd_load_offset(
     let fallback = kernel_end
         .checked_add(INITRD_ALIGNMENT - 1)
         .map(|value| value / INITRD_ALIGNMENT * INITRD_ALIGNMENT)
-        .ok_or(HvfError::BadKernel)?;
+        .ok_or(HvfError::BadBoot(BootFault::Overflow))?;
     if fallback
         .checked_add(initrd_len)
         .is_some_and(|end| end <= dtb_offset)
     {
         Ok(fallback)
     } else {
-        Err(HvfError::BadKernel)
+        Err(HvfError::BadBoot(BootFault::InitrdNoRoom {
+            kernel_end,
+            initrd_len,
+            dtb_offset,
+        }))
     }
 }
 
@@ -524,7 +532,10 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
         quota_record,
     } = params;
     if disks.len() > MAX_DISKS {
-        return Err(HvfError::BadKernel);
+        return Err(HvfError::BadBoot(BootFault::TooManyDisks {
+            given: disks.len(),
+            max: MAX_DISKS,
+        }));
     }
     // Validate it's an arm64 Image; we load at the fixed boot-protocol offset.
     let kernel_meta = kernel.metadata()?;
@@ -532,12 +543,18 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
     let load_off = KERNEL_LOAD_OFFSET as usize;
     let dtb_off = ram_size
         .checked_sub(FDT_MAX_SIZE as usize)
-        .ok_or(HvfError::BadKernel)?; // DTB window at top of RAM
+        .ok_or(HvfError::BadBoot(BootFault::GuestRamTooSmall {
+            ram: ram_size,
+            needed: FDT_MAX_SIZE as usize,
+        }))?; // DTB window at top of RAM
     let kernel_end = load_off
         .checked_add(kernel_meta.reserved_len)
-        .ok_or(HvfError::BadKernel)?;
+        .ok_or(HvfError::BadBoot(BootFault::Overflow))?;
     if kernel_end > dtb_off {
-        return Err(HvfError::BadKernel);
+        return Err(HvfError::BadBoot(BootFault::KernelTooLarge {
+            needed: kernel_end,
+            available: dtb_off,
+        }));
     }
     // Keep the stable 256 MiB placement when it fits, but support constrained
     // guests by placing the initramfs immediately after the kernel.
@@ -597,7 +614,10 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
     let has_virtiofs_root = channels.virtiofs_root.is_some();
     let fs_count = usize::from(has_virtiofs_root) + channels.virtiofs_shares.len();
     if fs_count > MAX_VIRTIOFS_SHARES + 1 {
-        return Err(HvfError::BadKernel);
+        return Err(HvfError::BadBoot(BootFault::TooManyFilesystems {
+            given: fs_count,
+            max: MAX_VIRTIOFS_SHARES + 1,
+        }));
     }
     for index in 0..fs_count {
         virtio_nodes.push((
@@ -618,7 +638,10 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
         Some(&rng_seed),
     );
     if dtb.len() > FDT_MAX_SIZE as usize {
-        return Err(HvfError::BadKernel);
+        return Err(HvfError::BadBoot(BootFault::DtbTooLarge {
+            needed: dtb.len(),
+            max: FDT_MAX_SIZE as usize,
+        }));
     }
 
     if channels.restore_frame.is_none() {
@@ -1438,5 +1461,75 @@ mod tests {
         assert_eq!(std::fs::read(&kernel).unwrap(), b"abcdefgh");
         let mapped = unsafe { std::slice::from_raw_parts(ram.as_ptr().add(HVF_PAGE_SIZE), 8) };
         assert_eq!(mapped, b"Zbcdefgh");
+    }
+
+    /// The point of the split: the four things an operator can actually do
+    /// something about must not print the same. Before this, a missing kernel,
+    /// an empty one, a truncated one and one that is not an arm64 image were
+    /// all `BadKernel` — the operator had to read the source and guess.
+    #[test]
+    fn each_kernel_failure_names_itself() {
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let missing = dir.path().join("not-here");
+        assert_eq!(
+            KernelImageSource::File(&missing).metadata(),
+            Err(HvfError::BadBoot(BootFault::KernelOpen(
+                std::io::ErrorKind::NotFound
+            )))
+        );
+
+        // Zero bytes: the header read cannot be satisfied.
+        let empty = dir.path().join("empty");
+        std::fs::write(&empty, b"").expect("write empty");
+        assert!(matches!(
+            KernelImageSource::File(&empty).metadata(),
+            Err(HvfError::BadBoot(BootFault::KernelRead(_)))
+        ));
+
+        // A full header's worth of bytes that is not an arm64 Image.
+        let garbage = dir.path().join("garbage");
+        std::fs::write(&garbage, [0x5a_u8; 128]).expect("write garbage");
+        assert_eq!(
+            KernelImageSource::File(&garbage).metadata(),
+            Err(HvfError::BadBoot(BootFault::KernelNotArm64Image))
+        );
+
+        // In-memory bytes take the same header check.
+        assert_eq!(
+            KernelImageSource::Bytes(&[0x5a_u8; 128]).metadata(),
+            Err(HvfError::BadBoot(BootFault::KernelNotArm64Image))
+        );
+    }
+
+    /// A zero-length mapping and an overflowing one are different faults, and
+    /// `page_rounded_len` is where both are decided.
+    #[test]
+    fn page_rounding_separates_an_empty_image_from_an_overflowing_one() {
+        assert_eq!(
+            page_rounded_len(0),
+            Err(HvfError::BadBoot(BootFault::KernelEmpty))
+        );
+        assert_eq!(
+            page_rounded_len(usize::MAX),
+            Err(HvfError::BadBoot(BootFault::Overflow))
+        );
+        assert_eq!(page_rounded_len(1), Ok(HVF_PAGE_SIZE));
+    }
+
+    /// The initramfs placement failure carries the three numbers needed to see
+    /// why it did not fit, instead of asserting that the kernel is bad.
+    #[test]
+    fn no_room_for_the_initramfs_reports_the_window_it_could_not_fit() {
+        // Kernel ends past where the DTB window starts: nothing can fit.
+        let err = initrd_load_offset(4096, 1 << 20, 8192).expect_err("cannot fit");
+        assert_eq!(
+            err,
+            HvfError::BadBoot(BootFault::InitrdNoRoom {
+                kernel_end: 4096,
+                initrd_len: 1 << 20,
+                dtb_offset: 8192,
+            })
+        );
     }
 }

--- a/crates/mvm-runtime/src/backends/hvf/mod.rs
+++ b/crates/mvm-runtime/src/backends/hvf/mod.rs
@@ -18,7 +18,7 @@ pub use mvm_backends::driver::hvf_bootargs::{
 };
 pub use mvm_vmm::vmm::virtio::DiskImage;
 
-pub use boot_smoke::{BootProof, HvfError, MAGIC, boot_smoke, probe_available};
+pub use boot_smoke::{BootFault, BootProof, HvfError, MAGIC, boot_smoke, probe_available};
 pub use console_smoke::{ConsoleProof, console_smoke};
 pub use hv_impl::{HvfHandle, HvfVcpu, HvfVm};
 pub use kernel_boot::{


### PR DESCRIPTION
Closes #2676.

`hvf boot failed: BadKernel` was the entire diagnostic — no path, no errno, no
size, no indication of which check rejected the boot.

## What the survey found

#2676 counted seven return sites in `guest_ram.rs`. There are **more than
twenty**, across `guest_ram.rs` and `kernel_boot.rs`, and several of them are
not about the kernel at all:

| site | actual failure | reported as |
|---|---|---|
| `disks.len() > MAX_DISKS` | too many disks attached | `BadKernel` |
| `fs_count > MAX_VIRTIOFS_SHARES + 1` | too many virtiofs shares | `BadKernel` |
| `dtb.len() > FDT_MAX_SIZE` | device tree exceeds its window | `BadKernel` |
| `ram_size.checked_sub(FDT_MAX_SIZE)` | guest RAM too small for the DTB window | `BadKernel` |
| `initrd_load_offset` fallback | no gap for the initramfs | `BadKernel` |

So the variant was not just opaque, it was miscategorising. Someone whose real
problem was "I attached too many disks" was told their kernel was bad.

## The change

`HvfError::BadKernel` → `HvfError::BadBoot(BootFault)`, one variant per cause an
operator can act on, each carrying what identifies it:

```
KernelOpen(ErrorKind)   KernelRead(ErrorKind)   KernelEmpty
KernelNotArm64Image     KernelTooLarge { needed, available }
Misaligned { offset }   Overflow
GuestRamTooSmall { ram, needed }
InitrdNoRoom { kernel_end, initrd_len, dtb_offset }
TooManyDisks { given, max }   TooManyFilesystems { given, max }
DtbTooLarge { needed, max }
```

`HvfError` is `Copy` — it travels back through the vCPU run loop — so this
carries an `ErrorKind` and sizes rather than the `PathBuf` and `io::Error` the
issue suggested. That still separates every cause the issue asked to separate;
the path is known to whoever supplied it and belongs where the error is
rendered, not duplicated into an error that is matched in a hot loop.

The rename is deliberate rather than incidental: keeping `BadKernel` on the
disk-count and DTB-size sites would have preserved the miscategorisation that
made this hard to read.

## Witnesses

- `each_kernel_failure_names_itself` — a missing file gives
  `KernelOpen(NotFound)`, an empty one `KernelRead(_)`, 128 bytes of garbage
  `KernelNotArm64Image`, and in-memory bytes take the same header check. All
  four used to be the same value.
- `page_rounding_separates_an_empty_image_from_an_overflowing_one` — `0` and
  `usize::MAX` are distinct faults, plus the success case.
- `no_room_for_the_initramfs_reports_the_window_it_could_not_fit` — asserts the
  three numbers travel, rather than a claim that the kernel is bad.

## Scope

This does **not** diagnose the specific `mvmctl machine build examples/sleeper`
failure in the issue. It makes the next run of it say which of the twelve
causes it is, which is what the issue asked for:

> The one-instance bug matters less than the fact that nobody can diagnose it.

`cargo nextest run -p mvm-runtime` 805/805, workspace clippy clean.