### PR TITLE
fix(ci): drop the dead libcap-ng dep, and repair the mirrorlist apt actually uses

### DIFF
--- a/.github/actions/apt-deps/action.yml
+++ b/.github/actions/apt-deps/action.yml
@@ -44,11 +44,33 @@ runs:
         sudo rm -f /etc/apt/sources.list.d/microsoft*.list \
                    /etc/apt/sources.list.d/azure*.list
 
+        # Removing those source lists was not enough, because the Ubuntu
+        # archive is not reached through one. The runner image points apt at a
+        # *mirrorlist* (`Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist`) whose
+        # first entry is `azure.archive.ubuntu.com`. When that host stops
+        # answering, every index line comes back `Ign:` and apt keeps retrying
+        # it, so `apt-get update` burns the entire per-attempt budget and all
+        # three attempts fail against a mirror no source list mentions. Point
+        # the mirrorlist at the archive that answers.
+        if [ -f /etc/apt/apt-mirrors.txt ]; then
+          echo "apt: mirrorlist was: $(tr '\n' ' ' < /etc/apt/apt-mirrors.txt)"
+          echo "https://archive.ubuntu.com/ubuntu/" | sudo tee /etc/apt/apt-mirrors.txt >/dev/null
+        fi
+
         export DEBIAN_FRONTEND=noninteractive
 
+        # Bound the per-host wait as well as the per-attempt one. Without
+        # these, a single unreachable host absorbs the whole timeout with its
+        # own backoff and the retry loop never gets to try anything different.
+        apt_opts=(
+          -o Acquire::Retries=2
+          -o Acquire::http::Timeout=15
+          -o Acquire::https::Timeout=15
+        )
+
         for attempt in $(seq 1 "$MVM_APT_ATTEMPTS"); do
-          if timeout "$MVM_APT_TIMEOUT" sudo -E apt-get update \
-            && timeout "$MVM_APT_TIMEOUT" sudo -E apt-get install -y --no-install-recommends $MVM_APT_PACKAGES; then
+          if timeout "$MVM_APT_TIMEOUT" sudo -E apt-get "${apt_opts[@]}" update \
+            && timeout "$MVM_APT_TIMEOUT" sudo -E apt-get "${apt_opts[@]}" install -y --no-install-recommends $MVM_APT_PACKAGES; then
             echo "apt: installed on attempt $attempt"
             exit 0
           fi
@@ -59,5 +81,5 @@ runs:
         # Say what happened rather than letting the caller infer it from a
         # missing binary several steps later.
         echo "::error::apt failed ${MVM_APT_ATTEMPTS} times installing: ${MVM_APT_PACKAGES}." >&2
-        echo "Each attempt was bounded at ${MVM_APT_TIMEOUT}s. A mirror is unreachable or slow; this is infrastructure, not the diff under test." >&2
+        echo "Each attempt was bounded at ${MVM_APT_TIMEOUT}s. A mirror is unreachable or slow; this is infrastructure, not the diff under test. The mirrorlist apt was given is echoed above." >&2
         exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
 
       - uses: ./.github/actions/apt-deps
         with:
-          packages: libcap-ng-dev lld
+          packages: lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -236,7 +236,7 @@ jobs:
       # compiler lint lane, so start them on their own runner.
       - uses: ./.github/actions/apt-deps
         with:
-          packages: libcap-ng-dev lld ripgrep shellcheck
+          packages: lld ripgrep shellcheck
 
       # Nothing else validates the workflow files. A wrong `if:`, a typo'd
       # `needs:` job name, or a bad `${{ }}` reference does not fail a PR — it
@@ -544,7 +544,7 @@ jobs:
 
       - uses: ./.github/actions/apt-deps
         with:
-          packages: libcap-ng-dev lld
+          packages: lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -726,7 +726,7 @@ jobs:
 
       - uses: ./.github/actions/apt-deps
         with:
-          packages: attr cryptsetup-bin libcap-ng-dev lld
+          packages: attr cryptsetup-bin lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -785,7 +785,7 @@ jobs:
 
       - uses: ./.github/actions/apt-deps
         with:
-          packages: attr cryptsetup-bin libcap-ng-dev lld
+          packages: attr cryptsetup-bin lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -841,7 +841,7 @@ jobs:
 
       - uses: ./.github/actions/apt-deps
         with:
-          packages: attr cryptsetup-bin libcap-ng-dev lld
+          packages: attr cryptsetup-bin lld
 
       - uses: ./.github/actions/install-zigbuild
 
@@ -881,7 +881,7 @@ jobs:
 
       - uses: ./.github/actions/apt-deps
         with:
-          packages: libcap-ng-dev lld
+          packages: lld
 
       # This lane compiles a different crate set from the shared workspace key
       # and builds bpf-linker from source, so it gets its own entry rather than
@@ -955,7 +955,7 @@ jobs:
 
       - uses: ./.github/actions/apt-deps
         with:
-          packages: libcap-ng-dev lld
+          packages: lld
 
       # Building the root package runs `crates/mvm-cli/build.rs`, which
       # cross-compiles the embedded host binaries and needs the pinned zig.


### PR DESCRIPTION
Two fixes for the same red: `apt failed 3 times installing: libcap-ng-dev lld`,
which is failing lanes across every open PR.

## 1. `libcap-ng-dev` should not be installed at all

Nothing in this workspace links against it.

It arrived in May 2026 for a real reason — the **microsandbox backend** pulled
`msb_krun_devices` → `capng`, which linked `-lcap-ng`, and the runner image
ships only the runtime library, not the `-dev` symlink the linker needs. That
backend was removed in `8b7aa375d` ("Drop microsandbox backend"). The
dependency went with it. The eight apt lines did not, and have been installing
it on every Linux lane for three months.

Verified rather than assumed:

- no cap crate in `Cargo.lock` (`caps`, `capctl`, `libcap`, `cap-ng` — none)
- no build script, `#[link]`, or rustflag names it
- no `microsandbox` / `msb_krun` anywhere in `crates/` or `Cargo.lock`
- its only surviving mention in the tree is one sentence in a plan document

`lld` stays — `.cargo/config.toml` sets `-C link-arg=-fuse-ld=lld` for Linux,
so it is load-bearing. `attr` and `cryptsetup-bin` stay for the xattr and
dm-verity lanes.

## 2. The mirrorlist still points at a dead mirror

Removing the package removes this particular failure, but the underlying stall
would still hit `lld`, `attr` and `cryptsetup-bin`. From the log the bounded
step now produces:

```
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Ign:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Ign:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:2 https://archive.ubuntu.com/ubuntu noble InRelease
##[warning]apt attempt 2/3 failed or timed out after 180s
```

#2672 deleted `sources.list.d/azure*.list` — a file that was never the route to
the Ubuntu archive. The runner reaches it through a **mirrorlist**, whose first
entry is `azure.archive.ubuntu.com`. That host is not answering, apt retries it
on its own schedule, and the whole per-attempt budget goes to a host no source
list mentions. Note `Hit:2 https://archive.ubuntu.com` seconds later in the
same run: the archive that answers is reachable, so this is one dead mirror,
not an outage — waiting longer was never going to help.

So: point the mirrorlist at the archive that answers, and bound the **per-host**
wait as well as the per-attempt one (`Acquire::http::Timeout=15`,
`Acquire::https::Timeout=15`, `Acquire::Retries=2`). Without those, a single
unreachable host absorbs the entire timeout with its own backoff and the outer
loop never gets to try anything different — which is exactly why three attempts
produced three identical 180s timeouts instead of three different outcomes.

The mirrorlist is echoed before being replaced, so the next time this changes
shape the log says what apt was given rather than costing a rerun to find out.

`check-workflow-paths` clean, both YAML files parse, the `run:` body passes
`bash -n`. The proof of the second half is the lanes on this PR going green
where they are currently red for this reason.