### PR TITLE
Ignore local specs notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ nix/images/dev-prebuilt/
 .worktrees/
 graphify-out/
 specs/scratch.md
+specs/notes.md
 
 # Default `mvmctl compile` output dir — generated flake + bundled src,
 # regenerable, never committed (header says "re-run `mvmctl compile`").


### PR DESCRIPTION
## Summary

- ignore `specs/notes.md`
- keep local development notes out of version control

## Impact

Developers can use `specs/notes.md` for local notes without it appearing as an untracked file.

## Validation

- `git diff --cached --check`
- verified the commit changes only `.gitignore`
