### PR TITLE
docs: decide the agent tool surface and the memory plane

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -312,6 +312,20 @@ for detailed scope and acceptance criteria.
       tree-sitter grammars off the serial path; the `mvm-hostd` audit cluster),
       Phase 5 (sccache 4.2% Rust hit rate, worktree hygiene)
 
+- [~] **Agent tool and memory planes**
+      (`specs/plans/2026-08-18-agent-tool-and-memory-planes.md`). Opened
+      2026-08-18; no workstream started. Design only: ADR-045 gained sections
+      18-19 (an agent's tool surface is broker dispatch, and the catalog
+      derives from `ExecutionPlan.services` rather than from anything the guest
+      or its model says) and ADR-047 defines the memory plane. Sequenced behind
+      `specs/plans/2026-08-18-durable-agent-sessions.md` WS1, which owns the
+      session identity memory keys on and is itself unmerged.
+  - [ ] WS1-WS4 — tool plane: catalog derivation, argument policy, host-side
+        dynamic-namespace adapter, refusal as a planning signal
+  - [ ] WS5-WS9 — memory plane: store + record, `host.memory.v1`, write scan
+        and ceilings, audit + retention, bounded recall
+  - [ ] WS10 — `mvmctl memory` read-only surface, tests + BDD
+
 - [~] **Launch path as declared stages**
       (`specs/plans/2026-08-15-launch-path-as-declared-stages.md`). Opened
       2026-08-15; no workstream started. Split out of the artifact-derived

--- a/specs/adrs/045-capability-secure-intelligent-workflow-controllers.md
+++ b/specs/adrs/045-capability-secure-intelligent-workflow-controllers.md
@@ -6,7 +6,8 @@ Validation: none — this is a proposed design; no code implements it and no tes
 **Status:** Proposed  
 **Date:** 2026-08-13  
 **Related:** ADR-001, ADR-014, ADR-020, ADR-022, ADR-031, ADR-035,
-ADR-037 (`mvmd` production authority), ADR-040, ADR-041, ADR-042; Plan 296,
+ADR-037 (`mvmd` production authority), ADR-040, ADR-041, ADR-042,
+ADR-047 (the agent memory plane); Plan 296,
 Plan 298, Plan 308, and Plan 329.  
 **Research basis:**
 `specs/research/intelligent-capability-secure-microvm-workflows.md`.
@@ -457,6 +458,85 @@ Repository signatures prove publication authorship, not truth or
 authorization. CIDs identify bytes, not principals or permissions. The local
 chain-signed audit remains authoritative forensic evidence.
 
+### 18. Agent tool calling is broker dispatch, and the catalog derives from the plan
+
+Section 8 governs what a *controller's planner* may do to the workflow graph.
+It does not govern the tool surface of an ordinary AI workload: an agent
+inside an admitted microVM emitting tool calls at a model's direction. That
+surface is not a new plane. It is the host services broker of ADR-020, and it
+stays there.
+
+Every tool an agent may call is a `ServiceId` (`host.<name>.v<n>`) bound in
+`ExecutionPlan.services` and enforced before handler dispatch (claim 12).
+
+The direction of derivation is the decision:
+
+```text
+ExecutionPlan.services  ->  the tool catalog presented to the model
+```
+
+never the reverse. An agent does not register, declare, or negotiate a tool
+into existence. A model emitting a call to an unbound name meets the existing
+binding gate, and the refusal is audited — a planning signal rather than an
+error condition.
+
+An agent may implement whatever internal capability-negotiation pattern it
+likes: a permission prompt, a self-issued scope, a tool-use policy of its own
+design. Those are planner heuristics. They terminate at the `Requestable`
+class of section 8, where a request is not a grant and a grant requires a
+replacement signed constraint snapshot. **An agent's model of its own
+permissions and the host's binding of them are separate objects, and are never
+unified.**
+
+Dynamic tool namespaces — Model Context Protocol and equivalents — are
+admitted host-side only:
+
+- The host runs the client; no guest speaks the protocol outward.
+- Each upstream tool compiles to a `ServiceId` at admission, inside the plan
+  digest.
+- Discovery verbs are served from the plan binding, not proxied upstream.
+
+An upstream server that adds, renames, or redefines a tool mid-session
+therefore cannot widen a running guest's surface. A guest-side client would
+reintroduce an unaudited egress path and a mutable namespace, which the
+vsock-only posture of ADR-001 claim 10 and ADR-003 exists to prevent.
+
+A tool surface is fixed for the lifetime of an admission. It changes at an
+epoch boundary, by re-admission, or not at all. A mid-epoch mutable namespace
+is unauditable by construction: there is no finite set to have checked.
+
+### 19. Tool results are data, and injection cannot widen the action set
+
+A tool result is attacker-influenced content — a fetched page, a repository
+issue, a sibling's message, a file written by an earlier untrusted step. It
+arrives as data on the stream and mailbox planes of section 11, under the rule
+that section already applies to stdout and stderr: untrusted data, not a
+control protocol.
+
+That yields a bound worth stating plainly:
+
+```text
+worst case under prompt injection
+  = the agent selects a different action from its bound set
+ != the agent obtains an action outside that set
+```
+
+An injected instruction may change which bound tool is called, with which
+arguments, in which order. It cannot mint a binding, widen egress, raise a
+ceiling, or reach a `Requestable` or `Invisible` action. The blast radius is
+the section 5 intersection, and it is the same bound whether the agent is
+honest, confused, or wholly steered by its input.
+
+Two consequences the implementation must not erode:
+
+- Argument values drawn from a tool result remain untrusted. Binding gates the
+  *tool*; per-tool argument policy — destination allow-lists, path scoping,
+  size bounds — constrains the *call*, and is host-side. A bound tool with an
+  unconstrained argument is an unbound tool wearing a name.
+- A tool result is never a channel for authority. Approvals, capability
+  grants, and constraint snapshots arrive as signed host-side records under
+  section 8, never as content an agent reads and acts upon.
+
 ## Security invariants
 
 The implementation must preserve all of the following:
@@ -487,6 +567,13 @@ The implementation must preserve all of the following:
 20. Semantic assertions cannot widen a live constraint snapshot.
 21. A used workload VM never reenters shared warm capacity.
 22. Guest-visible handles do not expose physical host routes or authority.
+23. Every agent-callable tool is a plan-bound service; the catalog presented to
+    a model derives from that binding and never the reverse.
+24. No guest speaks a tool-discovery protocol outward; upstream tools compile
+    host-side at admission, inside the plan digest.
+25. A tool surface is fixed for the lifetime of an admission.
+26. Tool results are data on the stream and mailbox planes, and carry no
+    authority.
 ```
 
 ## Consequences
@@ -611,6 +698,11 @@ Before implementation reaches production:
    reservation, placement, routing, semantic outbox, and projector boundaries.
 7. Keep true AT Protocol compatibility behind a separate optional ADR after the
    AT-shaped internal model turns out to be useful.
+8. Settle per-tool argument policy (section 19) as a typed, host-side schema
+   per `ServiceId`, rather than per-handler validation that each new service
+   reimplements.
+9. Decide whether a controller's own planner tools and a workload agent's
+   tools share one catalog derivation, or stay two surfaces with one rule.
 
 ## Acceptance boundary
 
@@ -630,4 +722,7 @@ The first shipped claim requires:
 - Formal/reference-model vectors for authority, budget, and graph validation.
 
 Implementation is planned in
-`specs/plans/329-capability-secure-intelligent-workflows.md`.
+`specs/plans/2026-08-18-capability-secure-intelligent-workflows.md`.
+
+Sections 18 and 19 are implemented in
+`specs/plans/2026-08-18-agent-tool-and-memory-planes.md`.

--- a/specs/adrs/047-agent-memory-plane.md
+++ b/specs/adrs/047-agent-memory-plane.md
@@ -1,0 +1,271 @@
+# ADR-047 — The agent memory plane
+
+Backing: preview
+Validation: none
+
+**Status:** Proposed
+**Date:** 2026-08-18
+**Related:** ADR-001 (claims 8, 10, 11, 12, 13, 15; Preview claims 17, 18),
+ADR-014, ADR-020 (host services broker), ADR-023 (secrets subsystem — egress
+substitution), ADR-035 (workload stream plane), ADR-045 (sections 8, 18, 19),
+ADR-046 (sections 7, 13, 14).
+**Depends on:** the durable agent sessions design,
+`specs/plans/2026-08-18-durable-agent-sessions.md`, which is unmerged at the
+time of writing — it exists on `docs/durable-agent-sessions` and has no open
+pull request. Every reference to it below is a forward reference to a design
+that may still change, not to a landed document.
+**Implemented by:** `specs/plans/2026-08-18-agent-tool-and-memory-planes.md`.
+
+## Context
+
+Two different things get called an agent's memory, and conflating them is how
+the authority story leaks.
+
+The first is **substrate**: machine state the host captures and restores. The
+durable agent sessions design owns it — a hibernation record, a
+content-addressed parent checkpoint, a journal cursor, a signed approval
+ledger head — and it resumes a task across disposable sandboxes. Its D6 is
+explicit that a restored image resumes the agent's reasoning state while its
+communication and authority state is torn down and rebuilt.
+
+The second is **content**: what an agent deliberately writes down and reads
+back. Notes, findings, learned constraints, a record of what it already tried
+and what failed. Long-horizon work is not workable without it, and nothing in
+the current documents defines it.
+
+The two have different properties. Substrate is host-captured, opaque, and
+verified by digest. Content is guest-authored, semantic, read back into a
+context window and acted upon, and crosses epoch boundaries by design —
+precisely what D6 tears down for the memory image.
+
+In the absence of a definition, an agent will use whatever writable surface it
+can reach: a mounted volume, an artifact, a self-addressed mailbox message, a
+file in its own rootfs overlay. Each puts unbounded, unattributed,
+guest-authored bytes across an epoch boundary with no record of what crossed.
+
+## Threat model
+
+What memory uniquely enables, beyond what an ordinary workload already can:
+
+1. **Cross-epoch authority laundering.** Epoch N writes; epoch N+1 reads. The
+   agent in N+1 is admitted under a freshly synthesized plan whose grants may
+   be narrower. If memory carries capability state, handles, or credentials,
+   that narrowing is cosmetic.
+
+2. **Stored injection.** A poisoned tool result written in epoch N is read
+   back as context in epoch N+1, after its untrusted provenance has been
+   forgotten. This is the most likely failure in practice and the cheapest one
+   to get wrong: it converts a bounded, in-epoch injection (ADR-045 section
+   19) into a durable one.
+
+3. **Secret exfiltration by recall.** Egress substitution keeps raw
+   credentials out of the guest (claim 13), but a guest observing a
+   substituted response can write a derived value into memory and read it back
+   after the destination binding has lapsed.
+
+4. **Unbounded accumulation.** Memory is the one durable, agent-controlled,
+   per-task growth surface, and an agent under injection has an obvious
+   denial-of-service in it.
+
+5. **Attribution loss.** A remembered finding that later changes an operator
+   decision needs to be traceable to the admission that produced it.
+
+## Decision
+
+### 1. Memory is a broker service, not a writable mount
+
+Memory is `host.memory.v1`, plan-bound like every other service under ADR-045
+section 18. Writes and reads are typed RPCs. There is no writable filesystem
+surface and no shared volume.
+
+A mount is refused because a mount keeps no record of what was remembered.
+Byte-level diffs against an opaque tree are not attribution, and every
+property below needs the write to be an observable, typed event with a
+host-side decision point.
+
+### 2. Memory is keyed by task, not by sandbox
+
+The store is keyed by session ID — the durable unit of the durable agent
+sessions design — and never by `VmId`, boot ID, or checkpoint digest. A
+sandbox is a bounded lease; the task is the thing that remembers.
+
+### 3. Memory carries facts; it never carries authority
+
+This is the load-bearing decision.
+
+A resumed sandbox derives every grant from its freshly synthesized
+`ExecutionPlan` and its signed constraint snapshot. Nothing in memory
+contributes to that derivation. Mechanically:
+
+- No memory record is an input to admission, binding, egress, or budget.
+- The host never parses memory content for policy meaning.
+- A record naming a capability is a string, not a request.
+
+This is ADR-045 section 9's advisory-versus-signed split applied across time
+instead of across the graph, and it matches what ADR-046 section 14 and
+durable-sessions D6 already require of a restored image — extended to content
+the guest authored on purpose.
+
+### 4. Every record carries host-stamped provenance and a trust class
+
+```text
+record = {
+    session_id,
+    generation,
+    admission_digest,      // which plan wrote it
+    authored_at,           // host monotonic
+    trust,                 // Observed | Derived
+    content_digest,
+    content,
+}
+```
+
+`Observed` is content the agent took from a tool result or other external
+input. `Derived` is the agent's own conclusion. Where a derivation reads
+`Observed` input, the result is `Observed` — the class does not launder by
+being restated.
+
+Provenance is stamped by the host, not declared by the guest. A guest cannot
+claim a record was authored by an earlier, more privileged epoch.
+
+Recall returns the class alongside the content. An agent reading `Observed`
+content is reading attacker-influenced data with the standing it had on
+arrival. Forgetting provenance is exactly what upgrades a bounded injection
+into a durable one, so the class travels with the bytes or the whole
+distinction is decorative.
+
+### 5. Writes are scanned, bounded, and audited
+
+- A secret-fingerprint scan runs on the write path, reusing the input-gate
+  mechanism of Preview claim 17 and inheriting its stated limits: a
+  fingerprint match is a length-and-hash match, not an identity, and encoding,
+  derivation, and splitting defeat it. It raises the cost of threat 3. It does
+  not close it, and this ADR does not claim otherwise.
+- Per-record and per-session ceilings are charged against the session budget
+  of ADR-045 section 6, so memory competes for the same accounting as every
+  other resource rather than growing beside it.
+- Every write emits a chain-signed entry naming session, generation, admission
+  digest, size, trust class, and content digest — never content bytes. This is
+  the payload-freedom rule the stream plane already follows.
+
+### 6. Memory is append-only; forgetting is host-side retention
+
+A guest cannot delete or rewrite a record. Compaction — which agents genuinely
+need, since unbounded history is unusable — is a host-run operation that emits
+a *new* record naming the records it summarizes, with the originals retained
+until retention expires.
+
+A guest-driven rewrite would let an agent, or whatever is steering it, erase
+the evidence of what it did. Retention rides the durable-sessions ladder
+rather than growing a second one, and cryptographic erasure at session close
+remains ADR-046 section 7, unchanged.
+
+### 7. Recall is a bounded query, not a mount
+
+A read is a query with a host-enforced result ceiling. Unbounded recall is a
+denial of service against the agent's own context window as much as against
+the host.
+
+Recall is scoped to the session. Cross-session recall is a distinct
+capability, off by default, because it is the mechanism by which one task's
+memory becomes another's, and it needs its own grant and its own audit entry.
+
+### 8. Memory does not resurrect a lapsed credential
+
+A corollary of decisions 3 and 5, stated separately because it is the case
+most likely to be built wrong.
+
+The substitution endpoint mints destination-bound and time-bound credentials
+(claim 13, ADR-023). Memory is not a place credentials may be kept, and a
+record whose fingerprint matches a live secret is refused at write. A workload
+needing a credential in epoch N+1 obtains it the way it did in epoch N: from
+the endpoint, under the new plan. The guest never held the raw value in either
+epoch, so there is nothing for it to have remembered.
+
+## Alternatives rejected
+
+### A writable volume or artifact the agent manages itself
+
+Rejected. No attribution of what crossed the epoch boundary, no write-path
+scan, no ceiling, and no way to distinguish a summary from a stored injection.
+This is the default outcome if this ADR does not exist, which is the reason it
+does.
+
+### Fold memory into the checkpoint image
+
+Rejected. It conflates substrate with content. A `Cold` resume — boot and
+replay, per durable-sessions D5 — has no memory image at all, and D6
+deliberately tears down restored state that memory is supposed to survive.
+
+### Let the host read memory to make better decisions
+
+Rejected. It makes guest-authored semantic content an input to authority,
+which is decision 3 inverted. The value is real and the failure mode is
+unbounded: a host that reads memory for policy meaning can be argued into a
+decision by an agent that writes persuasively.
+
+### A guest-side vector store with its own persistence
+
+Rejected. That is the writable volume with extra steps and an embedding model
+in front of it. Retrieval ranking is also a soft channel: what gets recalled
+becomes steerable by whoever controls the corpus.
+
+### Carry approvals in memory so a resumed agent knows what it may do
+
+Rejected. An approval is a signed host-side record with its own ledger.
+Duplicating it into memory creates a second answer to the same question, and
+the second one is guest-held.
+
+## Consequences
+
+### Positive
+
+- A long-horizon task keeps its findings without any epoch inheriting the
+  previous epoch's authority.
+- Stored injection stays visible: `Observed` content is still labelled
+  `Observed` on the day it is recalled.
+- Every remembered fact is attributable to the admission that produced it, so
+  an operator decision informed by agent memory is reviewable after the fact.
+- Memory competes in the existing budget rather than growing outside it.
+
+### Negative
+
+- Recall becomes a host round trip on the hot path of agent reasoning, where
+  a local file read would have been immediate.
+- Host-side compaction can only summarize structurally, because the host must
+  understand nothing about content. Semantic compaction has to be a `Derived`
+  write by the agent, costing a full write cycle.
+- The fingerprint scan will both miss real secrets and refuse innocuous
+  records; Preview claim 17's limits apply unchanged.
+- Append-only plus retention means the store grows, and disk pressure is an
+  operational cost that lands on the same host budget.
+- An agent framework that expects a filesystem-backed memory needs an adapter.
+
+### Neutral but important
+
+- Nothing here makes remembered content true. Memory is bounded and
+  attributable, not correct.
+- Trust classes are coarse by design. Two classes that are always applied
+  correctly are worth more than five that are applied by guess.
+- Cross-session recall is where the useful and the dangerous both live; it is
+  deferred rather than solved.
+
+## Claim witnesses required before promotion
+
+Promotion of any part of this ADR into ADR-001's numbered claims requires
+witnesses that exist and are named in the ledger table:
+
+- A memory write from a guest without a `host.memory.v1` binding is refused.
+- A record written in epoch N contributes nothing to the grants admitted in
+  epoch N+1.
+- An `Observed` record recalled in a later epoch is still classified
+  `Observed`.
+- A record derived from `Observed` input is not classified `Derived`.
+- A write whose content fingerprint-matches a live substituted secret is
+  refused, and the refusal is audited.
+- A chain-signed memory entry carries the binding and no content bytes.
+- A guest cannot delete or rewrite a record; host compaction retains the
+  originals.
+- Recall is bounded by the host ceiling regardless of the query the guest
+  sends.
+- Cross-session recall without its capability is refused.

--- a/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
+++ b/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
@@ -1,0 +1,235 @@
+# Agent tool and memory planes
+
+Backing: preview
+Validation: none
+
+**Status:** Design. Not implemented.
+**Date:** 2026-08-18
+**Implements:** ADR-045 sections 18 and 19 (agent tool calling), ADR-047 (the
+agent memory plane).
+**Depends on:** ADR-020 (host services broker), ADR-023 (egress substitution),
+`specs/plans/2026-08-18-durable-agent-sessions.md` (session identity and the
+retention ladder) — unmerged at the time of writing, living on
+`docs/durable-agent-sessions` with no open pull request.
+
+## The problem
+
+Two gaps sit between the workflow documents and an AI agent actually running
+inside an admitted microVM.
+
+**Tool calling has no defined surface.** ADR-045 section 8 governs what a
+controller's *planner* may do to the workflow graph. It says nothing about an
+ordinary workload agent emitting tool calls at a model's direction. Without a
+decision, a framework will reach for a guest-side client to whatever tool
+protocol it prefers, which is an unaudited egress path and a namespace that
+mutates under a running admission.
+
+**Memory has no defined surface either.** The durable agent sessions design
+carries the *substrate* across sandboxes — checkpoint, journal cursor,
+approval head. It does not define what an agent writes down on purpose and
+reads back three days later. In the absence of a definition an agent uses
+whatever writable surface it can reach, and guest-authored bytes cross an
+epoch boundary with no attribution, no scan, and no ceiling.
+
+Both gaps have the same shape: a place where an LLM's output or an LLM's input
+could become authority if nobody decides that it does not.
+
+## What already exists
+
+The mechanism for the tool plane is largely built. What is missing is the
+derivation rule and the refusal to grow a second path.
+
+| Piece | Where | State |
+|---|---|---|
+| `ServiceId` (`host.<name>.v<n>`) | `crates/mvm-contract/src/protocol/broker.rs:31` | Shipped |
+| Plan-bound service list | `crates/mvm-contract/src/plan/execution_plan.rs:257` | Shipped |
+| Binding-gated dispatch | `crates/mvm-hostd/src/broker/registry.rs:163` | Shipped |
+| Handler convention | `crates/mvm-hostd/src/broker/handlers/host_{time,audit,assurance}_v1.rs` | Shipped |
+| Secret fingerprint scanner | `crates/mvm-hostd/src/stream/secret_scan.rs:82` | Shipped, `pub(crate)` |
+| Input gate (Preview claim 17) | `crates/mvm-hostd/src/stream/input_gate.rs` | Shipped |
+| Session identity, retention ladder | `specs/plans/2026-08-18-durable-agent-sessions.md` | Design, unmerged |
+
+The memory plane has no existing piece beyond the broker it rides on.
+
+## Part A — The tool plane
+
+### WS1 — Catalog derivation
+
+- [ ] **WS1 — Derive the presented catalog from the plan.** One function from
+      an admitted `ExecutionPlan` to the tool descriptor set a guest may see,
+      in `mvm-hostd`'s broker. No other path produces a catalog. A guest asking
+      what tools it has receives the projection of its own binding.
+- [ ] Descriptor content — name, argument schema, human description — is
+      host-held and versioned with the `ServiceId`, so what the model reads
+      cannot be authored by the guest.
+
+### WS2 — Per-tool argument policy
+
+- [ ] **WS2 — Typed argument policy per `ServiceId`.** ADR-045 section 19 is
+      explicit that binding gates the tool while argument policy constrains the
+      call. Today each handler validates its own arguments; a bound tool with
+      an unconstrained argument is an unbound tool wearing a name.
+- [ ] One host-side schema per service — destination allow-lists, path scoping,
+      size bounds — enforced before handler dispatch, beside the binding check
+      rather than inside each handler.
+- [ ] Refusals audited with the service, the rejected field, and no argument
+      values.
+
+### WS3 — Host-side dynamic tool adapter
+
+- [ ] **WS3 — Compile an upstream tool namespace at admission.** The host runs
+      the client. Each upstream tool compiles to a `ServiceId` recorded inside
+      the plan digest, so the surface is fixed for the admission's lifetime.
+- [ ] Discovery verbs answer from the plan binding. An upstream server that
+      adds or redefines a tool mid-session cannot widen a running guest.
+- [ ] A gate — in the `xtask check-*` family — refusing an outbound tool
+      protocol client on any guest-reachable path, in the manner of
+      `check-vsock-only-egress`. Without it this decision decays the first time
+      a framework is vendored into a guest image.
+
+### WS4 — Refusal is a signal
+
+- [ ] **WS4 — Unbound calls are planning signals, not errors.** The existing
+      `NotBound` path already refuses. Add the audit entry shape and a
+      structured refusal the agent runtime can hand back to the model, so an
+      unbound call teaches the model its actual surface instead of surfacing as
+      an opaque failure.
+- [ ] Repeated unbound calls to the same name are rate-bounded; a model in a
+      retry loop is a denial-of-service against the broker.
+
+## Part B — The memory plane
+
+### WS5 — Store and record
+
+- [ ] **WS5 — `mvm_core::config::memory_dir()` and the record type.** Follows
+      the existing `checkpoints_dir()` / `snapshots_dir()` convention at
+      `crates/mvm-core/src/config.rs:766`; never an inline `$HOME` join.
+- [ ] Record per ADR-047 section 4: session ID, generation, admission digest,
+      host monotonic `authored_at`, trust class, content digest, content.
+      Provenance fields are host-stamped and rejected if guest-supplied.
+- [ ] Keyed by session ID, never `VmId` or boot ID.
+
+### WS6 — `host.memory.v1`
+
+- [ ] **WS6 — The handler.** `crates/mvm-hostd/src/broker/handlers/
+      host_memory_v1.rs`, following the three existing handlers. Verbs: append,
+      query. No delete verb exists for the guest.
+- [ ] Bound like any other service, so an unbound guest gets `NotBound` from
+      the shipped path with no new gate.
+- [ ] Trust class on append: `Observed` where the agent declares external
+      input, and `Observed` for any record the agent derives from `Observed`
+      input. The class does not launder by restatement.
+
+### WS7 — Write-path scan and ceilings
+
+- [ ] **WS7 — Reuse `SecretScanner` on the write path.** It is `pub(crate)` in
+      the crate the handler lives in, so no visibility change is needed. Its
+      semantics differ: the stream plane withholds on match, memory **refuses
+      the write**. Wire the refusal, do not reshape the scanner.
+- [ ] Fingerprints come from the per-VM substitution endpoint's resolved set,
+      the same source `StreamPlane::open_input` uses. Only length, rolling
+      hash, and category cross the process boundary.
+- [ ] Per-record and per-session ceilings charged against the session budget of
+      ADR-045 section 6.
+- [ ] Document the limit where the code enforces it: a fingerprint match is a
+      length-and-hash match, and encoding, derivation, and splitting defeat it.
+      This raises the cost of exfiltration by recall; it does not end it.
+
+### WS8 — Audit and retention
+
+- [ ] **WS8 — Chain-signed write entries.** Session, generation, admission
+      digest, size, trust class, content digest. No content bytes, matching the
+      stream plane's payload-freedom rule.
+- [ ] Append-only enforcement: no guest path mutates or removes a record.
+- [ ] Host-side compaction emitting a new record that names what it summarizes,
+      originals retained until retention expires.
+- [ ] Retention rides the durable-sessions ladder (its WS5) rather than growing
+      a second GC. Cryptographic erasure at session close stays ADR-046
+      section 7.
+
+### WS9 — Bounded recall
+
+- [ ] **WS9 — Query with a host ceiling**, independent of what the guest asks
+      for. Results carry their trust class.
+- [ ] Scoped to the session. Cross-session recall is a separate capability, off
+      by default, separately audited.
+
+### WS10 — CLI and tests
+
+- [ ] **WS10 — `mvmctl memory {ls,show,stats}`**, read-only, reading sidecars
+      without a VM spawn, in the manner of `mvmctl deps inspect`.
+- [ ] Tests and BDD per the Testing section.
+
+## Reconciliation required
+
+- The durable agent sessions design owns session identity, generation, and the
+  retention ladder. This plan consumes them and defines neither. If WS5 here
+  lands before that plan's WS1, memory has no session ID to key on, so the two
+  sequence: durable-sessions WS1 first. That plan is not merged and has no open
+  pull request, so this is a dependency on a document that could still move.
+- Numbering was settled against the merge queue rather than against `main`:
+  ADR-045 and ADR-046 land via #2691, which makes 047 the next free number on
+  the `main` line. Four long-lived branches (`berg`, `cleanup-rearchitecture`,
+  `release/0-17-0-prep`, `release/v0.17.0`) carry an unrelated historical
+  scheme in which 045-049 name entirely different documents. That scheme never
+  came back to `main` and is not a live claim on these numbers, but a future
+  renumbering that merges one of those branches would collide with all three
+  of these ADRs, not just this one.
+- ADR-045's `Related` list cites a bare "Plan 329", a number held by three
+  existing files. Left alone here; it needs the original author's intent.
+- ADR-047 section 5 leans on Preview claim 17's scanner. If that claim's limits
+  note changes, this plan's WS7 text changes with it — one statement of the
+  limit, cited twice, not two statements that drift.
+
+## Testing
+
+Negative paths carry this design, so they are named individually:
+
+- A guest without a `host.memory.v1` binding is refused by the shipped
+  `NotBound` path.
+- A record written in epoch N contributes nothing to the grants admitted in
+  epoch N+1 — asserted against a synthesized plan, not against prose.
+- An `Observed` record recalled in a later epoch is still `Observed`.
+- A record derived from `Observed` input is not classified `Derived`.
+- A write whose content fingerprint-matches a live substituted secret is
+  refused and audited.
+- A memory audit entry carries the binding and no content bytes.
+- A guest cannot delete or rewrite; compaction retains originals.
+- Recall is bounded by the host ceiling regardless of the guest's query.
+- Cross-session recall without its capability is refused.
+- A tool call to an unbound `ServiceId` is refused and audited.
+- A bound tool with an out-of-policy argument is refused before dispatch.
+- A tool descriptor set presented to a guest matches its plan binding exactly.
+- An upstream namespace that adds a tool after admission does not widen a
+  running guest's surface.
+
+Each of these must be checked against a mutation that turns it red. A test
+that passes with the enforcement removed is the failure mode this repository
+has already paid for more than once.
+
+## Out of scope
+
+- Semantic quality of remembered content. Memory is bounded and attributable,
+  not correct.
+- Cross-session and cross-tenant memory sharing beyond refusing it by default.
+- Embedding, ranking, and retrieval strategy. Recall here is a bounded query;
+  anything smarter is a `Derived` write the agent performs itself.
+- The controller planner's own tool surface, which stays under ADR-045
+  section 8 until follow-up decision 9 settles whether the two share one
+  derivation.
+- Fleet-side memory replication and placement (`mvmd`).
+
+## Open questions
+
+- Whether the trust class should be a lattice rather than two values. Two
+  classes applied correctly beat five applied by guess, so this starts at two
+  and widens only against a case that needs it.
+- Whether host compaction should be scheduled or agent-triggered. Scheduled
+  compaction can summarize a record the agent was about to cite; triggered
+  compaction gives the guest a lever on host work.
+- Whether a memory write should be admissible while a session is hibernated.
+  Nothing is running, so the answer is probably no, but a park-time flush of
+  in-flight findings is the obvious counter-case.
+- What a memory ceiling does when it is hit mid-task: refuse the write and let
+  the agent decide, or force compaction. Refusing is honest and may strand a
+  long investigation.


### PR DESCRIPTION
An LLM-driven agent inside an admitted microVM has two undecided surfaces, and both are places where model output or model input could become authority if nobody writes down that it does not.

## ADR-045 sections 18-19 — the tool plane

Section 8 governs a *controller's planner*, not an ordinary workload agent emitting tool calls at a model's direction. Sections 18 and 19 close that gap:

- An agent's tool surface is the ADR-020 host services broker. Not a new plane.
- The catalog presented to a model **derives from `ExecutionPlan.services`**, never the reverse. An agent cannot register, declare, or negotiate a tool into existence.
- Dynamic namespaces (MCP and kin) compile host-side at admission, inside the plan digest. An upstream server that adds or redefines a tool mid-session cannot widen a running guest.
- Tool results are data on the stream and mailbox planes, under the rule section 11 already applies to stdout.

That yields a bound worth stating plainly: under prompt injection the agent selects a *different action from its bound set*, never one outside it. The blast radius is the section 5 intersection whether the agent is honest, confused, or wholly steered by its input. Invariants 23-26 carry it.

## ADR-047 — the memory plane

Two different things get called agent memory, and conflating them is how the authority story leaks. The durable-sessions design owns the **substrate** — checkpoint, journal cursor, approval head. This ADR covers **content**: what an agent writes down on purpose and reads back three days later.

`host.memory.v1`, keyed by task rather than sandbox, append-only, host-stamped with provenance and a trust class so stored injection stays labelled, scanned and bounded on write, audited without content bytes. The load-bearing decision is section 3: memory carries facts and never authority — the same advisory-versus-signed split ADR-045 section 9 draws across the graph, drawn across time instead.

## Numbering

Rests on the merge queue rather than on `main`: 045 and 046 landed via #2691, which makes 047 the next free number. Four long-lived branches carry an unrelated historical scheme where 045-049 name different documents; that never came back to `main` and is recorded in the plan rather than left as tribal knowledge.

The acceptance boundary still cited `specs/plans/329-capability-secure-intelligent-workflows.md`, which resolves to nothing after the rename to dated slugs. It now names the real path.

## Status

Both documents are `Backing: preview` / `Validation: none`. Nothing here is enforced by code yet; ADR-045 follow-up 1 (Preview claim rows in ADR-001 with real witnesses) remains open. The durable agent sessions design this sequences behind is unmerged with no open PR, and every reference to it says so.

Implementation is `specs/plans/2026-08-18-agent-tool-and-memory-planes.md`. WS1-WS4 (tool plane) depend on nothing beyond shipped broker code; WS5-WS9 (memory) are blocked on durable-sessions WS1, which owns the session identity memory keys on.