### PR TITLE
Secret bindings for forked children: design + W0 diagnostic

### DIFF
--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -976,6 +976,7 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
     AnyBackend::require_hypervisor_selectable(&effective_hypervisor)?;
     let parent_agent_verbs = parent_agent_verb_override(p.parent_checkpoint, p.store);
     let parent_meta = p.store.read_meta(p.parent_checkpoint)?;
+    warn_dropped_parent_secrets(p.parent_checkpoint, p.store);
 
     // Resource shape: flag > parent plan > global defaults.
     let (parent_cpus, parent_mem) = parent_plan_resources(p.parent_checkpoint, p.store);
@@ -1230,6 +1231,47 @@ fn parent_network_mode(
     plan.network_mode
 }
 
+/// The secret binding *names* the parent was admitted with, for diagnostics.
+///
+/// A fork child is admitted with no secrets, so every binding the parent held
+/// is dropped. Without a diagnostic that presents as an upstream that stopped
+/// answering rather than as a capability the child never got.
+///
+/// Names only: `SecretBinding` carries a name and a source reference, never a
+/// value, and only the name is echoed.
+///
+/// An unreadable parent plan yields an empty set, matching the sibling
+/// inheritance helpers. Absence of a plan file is not evidence the parent held
+/// no secrets, so silence here means "unknown", not "none".
+fn parent_secret_names(parent_checkpoint: &CheckpointId, store: &CheckpointStore) -> Vec<String> {
+    let Ok(parent_meta) = store.read_meta(parent_checkpoint) else {
+        return Vec::new();
+    };
+    let Ok(plan) = super::plan_persist::read_plan(&parent_meta.vm_name) else {
+        return Vec::new();
+    };
+    plan.secrets.into_iter().map(|b| b.name).collect()
+}
+
+/// Warn that a fork drops the parent's secret bindings.
+///
+/// Not a refusal: a fork is always prod-profile, so there is no flag to gate a
+/// refusal on, and hard-failing would break forks whose child never needed the
+/// parent's credentials.
+fn warn_dropped_parent_secrets(parent_checkpoint: &CheckpointId, store: &CheckpointStore) {
+    let dropped = parent_secret_names(parent_checkpoint, store);
+    if dropped.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        secrets = %dropped.join(", "),
+        count = dropped.len(),
+        "fork child is admitted with no secret bindings; the parent's are not carried, \
+         so outbound requests to their bound destinations will be refused by the \
+         substitution endpoint"
+    );
+}
+
 fn parent_plan_resources(
     parent_checkpoint: &CheckpointId,
     store: &CheckpointStore,
@@ -1341,6 +1383,121 @@ mod tests {
 
         let verbs = parent_agent_verb_override(&meta.id, &store);
         assert_eq!(verbs, vec!["ping", "run-entrypoint"]);
+    }
+
+    #[test]
+    fn parent_secret_names_lists_the_parent_bindings_by_name() {
+        use mvm_contract::plan::{SecretBinding, SecretSource};
+        use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
+        use mvm_core::plan::test_support::PlanFixture;
+
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(tmp.path());
+
+        let mut plan = PlanFixture::new()
+            .tenant("local")
+            .plan_id("parent-plan")
+            .build();
+        plan.secrets = vec![
+            SecretBinding {
+                name: "STRIPE_KEY".to_string(),
+                source: SecretSource::Keystore {
+                    address: "kv/stripe".to_string(),
+                },
+            },
+            SecretBinding {
+                name: "DB_PASSWORD".to_string(),
+                source: SecretSource::External {
+                    provider: "vault".to_string(),
+                    path: "secret/db".to_string(),
+                },
+            },
+        ];
+        mvm_hostd::audit::plan_persist::write_plan("secretful-parent", &plan).unwrap();
+
+        let store = mvm_runtime::checkpoint::CheckpointStore::open();
+        let meta = mvm_core::checkpoint::CheckpointMeta::builder(
+            CheckpointId::new("ckpt-secretful"),
+            CheckpointClass::FsQuick,
+            "secretful-parent",
+        )
+        .content(vec![])
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+        store.write_meta(&meta).unwrap();
+
+        assert_eq!(
+            parent_secret_names(&meta.id, &store),
+            vec!["STRIPE_KEY".to_string(), "DB_PASSWORD".to_string()],
+        );
+    }
+
+    /// The source half of a binding names a provider and an address. Neither is
+    /// a secret value, but neither is echoed either: the diagnostic is names.
+    #[test]
+    fn parent_secret_names_echoes_no_source_addresses() {
+        use mvm_contract::plan::{SecretBinding, SecretSource};
+        use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
+        use mvm_core::plan::test_support::PlanFixture;
+
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(tmp.path());
+
+        let mut plan = PlanFixture::new().tenant("local").plan_id("p").build();
+        plan.secrets = vec![SecretBinding {
+            name: "TOKEN".to_string(),
+            source: SecretSource::External {
+                provider: "vault".to_string(),
+                path: "secret/very/specific/path".to_string(),
+            },
+        }];
+        mvm_hostd::audit::plan_persist::write_plan("p-vm", &plan).unwrap();
+
+        let store = mvm_runtime::checkpoint::CheckpointStore::open();
+        let meta = mvm_core::checkpoint::CheckpointMeta::builder(
+            CheckpointId::new("ckpt-src"),
+            CheckpointClass::FsQuick,
+            "p-vm",
+        )
+        .content(vec![])
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+        store.write_meta(&meta).unwrap();
+
+        let names = parent_secret_names(&meta.id, &store);
+        assert_eq!(names, vec!["TOKEN".to_string()]);
+        let joined = names.join(", ");
+        assert!(!joined.contains("vault"), "provider leaked: {joined}");
+        assert!(!joined.contains("secret/"), "address leaked: {joined}");
+    }
+
+    /// A parent whose plan cannot be read is "unknown", not "held none" — the
+    /// helper stays quiet rather than asserting the parent was secretless.
+    #[test]
+    fn parent_secret_names_is_empty_when_the_parent_plan_is_unreadable() {
+        use mvm_core::checkpoint::{CheckpointClass, CheckpointId};
+
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let tmp = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(tmp.path());
+
+        let store = mvm_runtime::checkpoint::CheckpointStore::open();
+        let meta = mvm_core::checkpoint::CheckpointMeta::builder(
+            CheckpointId::new("ckpt-planless"),
+            CheckpointClass::FsQuick,
+            "planless-vm",
+        )
+        .content(vec![])
+        .supervisor_config_digest("d")
+        .created_unix(1)
+        .build();
+        store.write_meta(&meta).unwrap();
+
+        assert!(parent_secret_names(&meta.id, &store).is_empty());
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -339,6 +339,7 @@ fn admit_forked_child(p: &AdmitForkedChildParams<'_>) -> Result<AdmittedForkChil
         .find(|b| b.name == mvm_core::checkpoint::ROOTFS_BLOB)
         .map(|b| b.sha256.clone());
     let parent_agent_verbs = parent_agent_verb_override(p.checkpoint, p.store);
+    super::warn_dropped_parent_secrets(p.checkpoint, p.store);
     let tenant = crate::commands::vm::tenant_resolution::resolve_tenant(None);
     let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::new();
     let admission = crate::commands::vm::up::admit_plan_for_boot(

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -285,6 +285,18 @@ for detailed scope and acceptance criteria.
 
 ## In-flight plans
 
+- [~] **Secret bindings for forked children** —
+      `specs/plans/2026-08-18-fork-inherits-secret-bindings.md`, issue #2698.
+      W0 landed: a fork that drops its parent's secret bindings now says so,
+      reading the parent's persisted plan rather than needing a schema change.
+      3 tests, mutation-checked.
+      STILL OPEN: everything that closes the gap. Option A (declare the child's
+      bindings at fork, A1-A6) is the recommended build and is unimplemented;
+      Option B (inherit from the checkpoint, attenuated by intersection) is
+      designed and deliberately deferred, not queued. W0 warns only — the
+      refusal arm moved to A6, because a fork is always prod-profile and so had
+      no flag to gate on.
+
 - [~] **Admission-bound AI assurance sessions** —
       `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W4
       and W6/W7 landed: the envelope, the five-way authority intersection, the

--- a/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
+++ b/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
@@ -1,12 +1,18 @@
-# A forked child inherits its parent's secret bindings, re-bound to its own identity
+# A forked child gets its parent's secret bindings
 
 Backing: preview
 Validation: none — this is a proposed design; no code implements it and no test exercises it.
 
 ## Status
 
-**READY FOR IMPLEMENTATION.** No code has been written. The mechanism this
-extends (`grants` on `CheckpointMeta`) is shipped and is the template.
+**READY FOR IMPLEMENTATION, OPTION A ONLY.**
+
+Two designs are recorded here. **Option A (explicit at fork) is the recommended
+build.** Option B (inherited from the checkpoint) is the more ergonomic design
+and is deliberately deferred — it is recorded so the decision is legible, not
+because it is queued.
+
+Nothing here is implemented.
 
 ## The gap
 
@@ -31,143 +37,156 @@ is the behaviour `placeholder_from_another_session_does_not_resolve`
 cross-session case.
 
 That is fail-closed and therefore not a security bug. It is a **capability
-bug**: the fork-per-run pattern — warm a parent to steady state, fork a child
-per unit of work — cannot be used for any workload that talks to an
-authenticated upstream, which is most of them. The warm-start work makes fork
-the primary launch path, so this stops being a corner case.
+bug**: a forked child cannot reach any authenticated upstream its parent could,
+so the fork-per-run pattern is unavailable to most real workloads. Warm-claim
+fork is becoming the primary launch path (#2336, the blocker previously
+believed to be BUG-2, closed 2026-08-14 — see #2343 for the corrected
+diagnosis), so this moves from latent to load-bearing.
 
-## Why the obvious fix is wrong
+### The part that is worth fixing today, under either option
 
-"Copy the parent's plan onto the child" is wrong for the reason the existing
-comment in `admit_forked_child` gives:
+The current failure is **silent**. Forking a parent that held secrets yields a
+child that cannot reach anything, with no diagnostic — it presents as a network
+fault, not a missing capability. That is a bad failure mode independent of
+which design wins, and fixing it needs no schema change:
+
+- [ ] W0 — when `admit_forked_child` drops a non-empty parent secret set, warn
+      with the dropped names; refuse under `--prod`. Test: a fork of a
+      secret-holding parent emits the diagnostic, and the `--prod` arm refuses.
+
+W0 is worth landing on its own, before either option below is chosen.
+
+## Why not simply copy the parent's plan
+
+Recorded because it is the first thing anyone proposes. It is wrong for the
+reason the existing comment in `admit_forked_child` gives:
 
 > The child's plan is its own, never the parent's: a distinct nonce, a distinct
 > VM name, and `deny_all` networking.
 
 and for the reason recorded against `Preview` claim 18 — a child's kill audited
 under its parent's plan identity writes a *wrong* audit entry, which is worse
-than a missing one. Plan identity must not be shared.
+than a missing one. Plan identity must not be shared. Both options below keep
+the child's plan wholly its own.
 
-The insight that makes this tractable: **a secret binding is not a secret, and
-it is not a plan.** `SecretRef` (`crates/mvm-contract/src/ir/workload.rs`)
-carries `name`, `mount`, `auth_type`, `allowed_hosts`, and optional non-secret
-`sigv4` params. Every field is a *reference and a constraint*. The value lives
-in the secret store and is resolved by `LocalResolver` inside the per-VM
-substitution endpoint, which is the one process holding it in the clear. So a
-binding can be inherited by value without any secret material moving, exactly
-as `grants` is today.
+The enabling observation for both: **a secret binding is not a secret.**
+`SecretRef` (`crates/mvm-contract/src/ir/workload.rs`) carries `name`, `mount`,
+`auth_type`, `allowed_hosts`, and optional non-secret `sigv4` params. Every
+field is a reference and a constraint. The value lives in the secret store and
+is resolved by `LocalResolver` inside the per-VM substitution endpoint, which is
+the one process holding it in the clear. So bindings can move without any secret
+material moving.
 
-## Design
+## Option A — explicit at fork (recommended)
 
-### 1. Record the bindings on the checkpoint
+The requester declares which secrets the child gets, at fork time, the same way
+any other VM declares them at admission. `admit_forked_child` stops hardcoding
+`Vec::new()` and instead threads a caller-supplied set through the existing
+`admit_plan_for_boot` `secrets` parameter, validated against `BindingStore` for
+the child's tenant exactly as a normal boot would.
 
-Add to `CheckpointMeta` (`crates/mvm-core/src/checkpoint.rs:221`), adjacent to
-`grants` and sharing its doc rationale verbatim:
+Why this first:
+
+- **No `CheckpointMeta` change**, so no content-address change and no migration
+  (see the hazard section below, which Option A does not incur at all).
+- **No new inheritance edge** in the claim-12 binding graph. The child's
+  capability is visible in the child's own plan; reading that plan is sufficient
+  to know what it holds and why.
+- **Strictly additive.** It closes the capability gap using machinery that
+  already exists and is already tested on the normal boot path.
+- The ergonomic cost — re-declaring on each fork — is an *empirical* question.
+  Once fork-per-run is real, you will know within days whether it bites.
+
+Work items:
+
+- [ ] A1 — plumb a caller-supplied `Vec<SecretRef>` into `AdmitForkedChildParams`
+      and through to `admit_plan_for_boot`. Test: a child booted with a declared
+      binding resolves a freshly minted placeholder against the declared host
+      set; an undeclared host is refused.
+- [ ] A2 — surface it on the fork CLI. Test: CLI parsing + help text per the
+      repo's `tests/cli.rs` convention.
+- [ ] A3 — cross-tenant declaration refused at admission (this falls out of
+      `BindingStore` tenant scoping; assert it rather than assume it).
+- [ ] A4 — `checkpoint.forked` records the child's binding names + hosts, never
+      values. Mirror the assertion shape of
+      `stream_audit_entries_carry_the_binding_and_no_payload_bytes`.
+- [ ] A5 — HVF arm wired (`fork_vm_full_arm_hvf`); FC arm wired behind its
+      existing `fc_vm_full_fork_experimental_enabled` gate, which stays.
+
+## Option B — inherited from the checkpoint (deferred)
+
+Record the admitted binding set on `CheckpointMeta` beside `grants`, and re-bind
+it onto the child by **intersection** with the operator binding currently in
+`BindingStore`, so a checkpoint can never pin a capability wider than what is
+presently granted. Cross-tenant refs dropped. Nothing minted — the child's
+registry mints its own placeholders, so
+`placeholder_from_another_session_does_not_resolve` stays green unchanged.
+
+Why it is deferred rather than built:
+
+Its entire value over Option A is ergonomic — you do not re-declare. It buys
+that with an **implicit capability flow**: reading the child's plan no longer
+tells you why it holds what it holds. You must walk the lineage and reconstruct
+an intersection against mutable operator state to answer "why can this VM reach
+that host?". For a codebase whose posture is that capability is explicit,
+signed, and legible at the point of admission, silent inheritance is the wrong
+default to adopt before the friction it removes has actually been felt.
+
+If re-declaration turns out to be painful in practice, this is the design to
+build, and
+the intersection rule is the load-bearing part of it — never a union, never the
+recorded set alone.
+
+### Digest migration, if Option B is ever built
+
+`compute_meta_digest` (`crates/mvm-core/src/checkpoint.rs:281`) feeds a fixed
+field list into `CheckpointDigestInput`, and `verify_lineage` recomputes and
+compares against what is stored on disk. A new field naively added to that input
+changes the digest of **every checkpoint already on disk**, which surfaces as
+`meta_digest drift` — i.e. as *tampered* — for records nobody touched.
+
+This is already solved once, one field above where the new one would go:
 
 ```rust
-/// The secret bindings the captured VM was admitted under. Load-bearing for
-/// the same reason as `grants`: the digest covers this field, the signed
-/// chain covers the digest, so a record edited to widen `allowed_hosts` or
-/// name a secret the parent never held stops verifying before it can
-/// justify a wider child.
-#[serde(default, skip_serializing_if = "Vec::is_empty")]
-pub secrets: Vec<SecretRef>,
+/// Skipped when absent so a record that seals no grant hashes exactly as it
+/// did before the field existed. […] The check is meant to be believed, so
+/// it must not cry tamper over a field nobody touched.
+#[serde(skip_serializing_if = "Option::is_none")]
+grants: &'a Option<mvm_contract::grants::Grants>,
 ```
 
-`#[serde(default)]` per the repo's no-schema-bump rule. Critically, the field
-must be folded into `meta_digest` in the same commit — a field outside the
-content-address is an unauthenticated field, and this one grants capability.
+So the requirement is not novel risk, it is a documented pattern to follow:
+`#[serde(skip_serializing_if = "Vec::is_empty")]` on the **digest input** field,
+not merely on the `CheckpointMeta` field, so an empty set serializes to nothing
+and pre-existing records hash byte-identically. Getting this wrong is loud and
+immediate rather than subtle, but it would brick lineage verification for every
+existing checkpoint, so it belongs in the first commit with a test that seals a
+pre-field record and asserts its digest is unchanged.
 
-`services` gets the same treatment; the claim-12 binding-gated dispatch is the
-same shape of constraint and has the same problem.
+## What neither option buys
 
-### 2. Re-bind, don't copy, at admission
-
-`admit_forked_child` stops passing `secrets: Vec::new()` and instead passes the
-parent's recorded set through an **attenuating** re-bind:
-
-```rust
-secrets: rebind_for_child(&p.parent_meta.secrets, &child_tenant),
-```
-
-`rebind_for_child` lives in `crates/mvm-hostd/src/keyholder/binding.rs` beside
-`BindingStore`, and enforces three rules:
-
-1. **Tenant-scoped.** A `SecretRef` whose `name` does not resolve in the child's
-   tenant via `BindingStore::get(child_tenant, name)` is dropped, not carried.
-   A fork across a tenant boundary must not smuggle a binding.
-2. **Attenuation only.** The child's `allowed_hosts` is the *intersection* of
-   the parent's recorded set and the operator binding currently in
-   `BindingStore`. If the operator narrowed or revoked a binding after the
-   parent was captured, the child gets the narrowed set — a checkpoint cannot
-   pin a stale-wide capability. Never a union; never the recorded set alone.
-3. **Nothing minted.** `rebind_for_child` returns `SecretRef`s only. The child's
-   `SubstitutionRegistry` mints its own placeholders at its own boot, so a
-   placeholder token from the parent's session still does not resolve in the
-   child. That test stays green unchanged, and it should — the guest re-reads
-   its placeholders from the environment the endpoint hands it.
-
-The child plan is still wholly its own: distinct nonce, distinct VM name,
-distinct plan_id, `deny_all` network policy. Only the binding *constraints*
-carry.
-
-### 3. Audit the inheritance
-
-`bind_checkpoint_forked` (`crates/mvm-hostd/src/audit/bind.rs`) gains the
-inherited binding set — names and `allowed_hosts` only, never values — in the
-`checkpoint.forked` entry, so the chain records what capability the child was
-granted and on whose authority. An inheritance that could not be audited
-refuses the fork, matching the `.context("refusing an unaudited fork")` policy
-already on that path.
-
-### 4. Where it does not apply
-
-- **`bind_checkpoint_restored` / time-travel restore.** Out of scope. A restore
-  re-admits under a fresh plan for a user-driven reason; inheritance there is a
-  separate decision and this plan does not make it.
-- **Firecracker.** `fork_vm_full_arm_fc` is behind
-  `fc_vm_full_fork_experimental_enabled`. Wire it, but the gate stays.
-- **`FsQuick` checkpoints.** No live guest state, so no live placeholder set to
-  keep meaningful. Record the field; do not consume it.
-
-## What this does *not* buy
-
-Deliberately out of scope, and worth stating so the plan is not read as more
-than it is:
-
-- No tag-based binding groups. Inheritance here is parent→child down a
-  lineage, not "attach a credential to a label and every VM wearing it gets it."
-  That is a separate, larger design and it needs an operator-facing surface.
+- No tag-based binding groups — "attach a credential to a label and every VM
+  wearing it gets it." That is a larger design needing an operator-facing
+  surface, and it is not this.
 - No revocation propagation to *running* children. Narrowing a binding affects
   the next fork, not a child already booted. Killing a live capability is the
   endpoint's job and is unchanged.
-
-## Work items
-
-- [ ] W1 — `CheckpointMeta.secrets` + `.services`, folded into `meta_digest`.
-      Test: a record with a hand-edited `allowed_hosts` fails `verify_lineage`.
-- [ ] W2 — `rebind_for_child` in `keyholder/binding.rs`. Tests: cross-tenant
-      binding dropped; post-capture narrowing wins over the recorded set;
-      revoked binding yields no ref; intersection is never a union.
-- [ ] W3 — capture path records the admitted `secrets`/`services` onto the meta.
-- [ ] W4 — `admit_forked_child` consumes W2. Test: a child booted from a parent
-      with a bound secret resolves a *freshly minted* placeholder against the
-      inherited host set, and a host outside the intersection is refused.
-- [ ] W5 — `checkpoint.forked` carries the inherited binding names + hosts;
-      chain verifies; no value bytes present. Mirror the assertion shape of
-      `stream_audit_entries_carry_the_binding_and_no_payload_bytes`.
-- [ ] W6 — HVF arm wired (`fork_vm_full_arm_hvf`); FC arm wired behind its
-      existing experimental gate.
-- [ ] W7 — ADR-023 §egress-substitution gains a "fork lineage" subsection;
-      `specs/REFACTOR-STATUS.md` + `specs/SPRINT.md` updated in the same change.
+- Nothing for time-travel restore (`bind_checkpoint_restored`). A restore
+  re-admits under a fresh plan for a user-driven reason; capability there is a
+  separate decision this plan does not make.
+- Nothing for `FsQuick` checkpoints — no live guest state, so no live
+  placeholder set to keep meaningful.
 
 ## Claims impact
 
-No numbered claim changes. Claim 13 (no raw secret over the broker channel) is
-untouched — no value crosses any new boundary, and the endpoint remains the only
-process holding cleartext. Claim 12's binding-gated dispatch gains an
-inheritance edge that is strictly attenuating, so no admission that was
-previously refused becomes admitted. `Preview` claim 18's "a restored or warm-
-claimed child is admission-bounded without its host-side CPU control or its
-wall-clock timer being re-armed" limit is **unaffected and still open** — this
-plan does not re-arm anything, and must not be read as closing it.
+No numbered claim changes under either option. Claim 13 (no raw secret over the
+broker channel) is untouched — no value crosses any new boundary, and the
+endpoint remains the only process holding cleartext. Claim 12's binding-gated
+dispatch gains no new admission under Option A, and under Option B gains only a
+strictly attenuating edge, so no admission previously refused becomes admitted.
+
+`Preview` claim 18's limit — "a restored or warm-claimed child is
+admission-bounded without its host-side CPU control **or its wall-clock timer**
+being re-armed" — is **unaffected and still open**. Neither option re-arms
+anything. A change touching fork admission is exactly the kind of work that gets
+misread as having closed it; it does not.

--- a/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
+++ b/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
@@ -1,7 +1,9 @@
 # A forked child gets its parent's secret bindings
 
 Backing: preview
-Validation: none — this is a proposed design; no code implements it and no test exercises it.
+Validation: W0 only — `parent_secret_names` and its three tests in
+`crates/mvm-cli/src/commands/vm/checkpoint.rs`. Options A and B are proposed
+design; no code implements them and no test exercises them.
 
 ## Status
 
@@ -12,7 +14,7 @@ build.** Option B (inherited from the checkpoint) is the more ergonomic design
 and is deliberately deferred — it is recorded so the decision is legible, not
 because it is queued.
 
-Nothing here is implemented.
+W0 (the diagnostic) is implemented. Nothing in Option A or Option B is.
 
 ## The gap
 
@@ -50,11 +52,25 @@ child that cannot reach anything, with no diagnostic — it presents as a networ
 fault, not a missing capability. That is a bad failure mode independent of
 which design wins, and fixing it needs no schema change:
 
-- [ ] W0 — when `admit_forked_child` drops a non-empty parent secret set, warn
-      with the dropped names; refuse under `--prod`. Test: a fork of a
-      secret-holding parent emits the diagnostic, and the `--prod` arm refuses.
+- [x] W0 — when a fork drops a non-empty parent secret set, warn with the
+      dropped names. Source of truth is the parent's **persisted plan**
+      (`plan_persist::read_plan(parent_meta.vm_name).secrets`), which
+      `bind_checkpoint_forked` already reads — so W0 needs no schema change and
+      does not depend on Option B's `CheckpointMeta` field.
 
 W0 is worth landing on its own, before either option below is chosen.
+
+**W0 warns; it does not refuse.** The plan originally said "refuse under
+`--prod`". There is no `--prod` on this path — a fork is *always* prod-profile
+(see the comment on `restrict_agent_verbs` in `admit_forked_child`), so the
+refusal has no flag to hang on, and making it unconditional would turn every
+existing fork of a secret-holding parent from degraded-but-working into a hard
+failure. Refusal belongs to Option A's world: once the child's bindings can be
+declared, refusing an *undeclared* drop is coherent. It is item A6 below.
+
+A caveat the diagnostic cannot avoid: an unreadable parent plan yields an empty
+set, so silence means "unknown", not "the parent held none". A fork of a parent
+whose plan file is gone warns about nothing.
 
 ## Why not simply copy the parent's plan
 
@@ -112,6 +128,9 @@ Work items:
       `stream_audit_entries_carry_the_binding_and_no_payload_bytes`.
 - [ ] A5 — HVF arm wired (`fork_vm_full_arm_hvf`); FC arm wired behind its
       existing `fc_vm_full_fork_experimental_enabled` gate, which stays.
+- [ ] A6 — refuse a fork that drops parent bindings the caller did not
+      re-declare, now that re-declaring is possible. This is W0's refusal arm,
+      deferred to here because it is incoherent before A1.
 
 ## Option B — inherited from the checkpoint (deferred)
 

--- a/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
+++ b/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
@@ -1,0 +1,173 @@
+# A forked child inherits its parent's secret bindings, re-bound to its own identity
+
+Backing: preview
+Validation: none — this is a proposed design; no code implements it and no test exercises it.
+
+## Status
+
+**READY FOR IMPLEMENTATION.** No code has been written. The mechanism this
+extends (`grants` on `CheckpointMeta`) is shipped and is the template.
+
+## The gap
+
+`admit_forked_child` (`crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs:327`)
+mints a fresh plan for a vm_full fork child. Selective inheritance from the
+parent is already the established shape there:
+
+| field | inherited from parent | how |
+| --- | --- | --- |
+| `grants` | yes | `p.parent_meta.grants.clone()` |
+| `agent_verb_override` | yes | `parent_agent_verb_override(...)` |
+| `network_mode` | yes | `super::parent_network_mode(...)` |
+| `network_policy` | no — hardcoded `deny_all()` | deliberate |
+| `secrets` | **no — hardcoded `Vec::new()`** | not deliberate |
+| `services` | **no — hardcoded `Vec::new()`** | not deliberate |
+
+The child therefore boots with an empty `SubstitutionRegistry`. Every
+placeholder the parent's workload minted before capture is dead in the child:
+`SubstitutionRegistry::resolve` returns `None` and the endpoint refuses, which
+is the behaviour `placeholder_from_another_session_does_not_resolve`
+(`crates/mvm-hostd/src/keyholder/substitution.rs:449`) already pins for the
+cross-session case.
+
+That is fail-closed and therefore not a security bug. It is a **capability
+bug**: the fork-per-run pattern — warm a parent to steady state, fork a child
+per unit of work — cannot be used for any workload that talks to an
+authenticated upstream, which is most of them. The warm-start work makes fork
+the primary launch path, so this stops being a corner case.
+
+## Why the obvious fix is wrong
+
+"Copy the parent's plan onto the child" is wrong for the reason the existing
+comment in `admit_forked_child` gives:
+
+> The child's plan is its own, never the parent's: a distinct nonce, a distinct
+> VM name, and `deny_all` networking.
+
+and for the reason recorded against `Preview` claim 18 — a child's kill audited
+under its parent's plan identity writes a *wrong* audit entry, which is worse
+than a missing one. Plan identity must not be shared.
+
+The insight that makes this tractable: **a secret binding is not a secret, and
+it is not a plan.** `SecretRef` (`crates/mvm-contract/src/ir/workload.rs`)
+carries `name`, `mount`, `auth_type`, `allowed_hosts`, and optional non-secret
+`sigv4` params. Every field is a *reference and a constraint*. The value lives
+in the secret store and is resolved by `LocalResolver` inside the per-VM
+substitution endpoint, which is the one process holding it in the clear. So a
+binding can be inherited by value without any secret material moving, exactly
+as `grants` is today.
+
+## Design
+
+### 1. Record the bindings on the checkpoint
+
+Add to `CheckpointMeta` (`crates/mvm-core/src/checkpoint.rs:221`), adjacent to
+`grants` and sharing its doc rationale verbatim:
+
+```rust
+/// The secret bindings the captured VM was admitted under. Load-bearing for
+/// the same reason as `grants`: the digest covers this field, the signed
+/// chain covers the digest, so a record edited to widen `allowed_hosts` or
+/// name a secret the parent never held stops verifying before it can
+/// justify a wider child.
+#[serde(default, skip_serializing_if = "Vec::is_empty")]
+pub secrets: Vec<SecretRef>,
+```
+
+`#[serde(default)]` per the repo's no-schema-bump rule. Critically, the field
+must be folded into `meta_digest` in the same commit — a field outside the
+content-address is an unauthenticated field, and this one grants capability.
+
+`services` gets the same treatment; the claim-12 binding-gated dispatch is the
+same shape of constraint and has the same problem.
+
+### 2. Re-bind, don't copy, at admission
+
+`admit_forked_child` stops passing `secrets: Vec::new()` and instead passes the
+parent's recorded set through an **attenuating** re-bind:
+
+```rust
+secrets: rebind_for_child(&p.parent_meta.secrets, &child_tenant),
+```
+
+`rebind_for_child` lives in `crates/mvm-hostd/src/keyholder/binding.rs` beside
+`BindingStore`, and enforces three rules:
+
+1. **Tenant-scoped.** A `SecretRef` whose `name` does not resolve in the child's
+   tenant via `BindingStore::get(child_tenant, name)` is dropped, not carried.
+   A fork across a tenant boundary must not smuggle a binding.
+2. **Attenuation only.** The child's `allowed_hosts` is the *intersection* of
+   the parent's recorded set and the operator binding currently in
+   `BindingStore`. If the operator narrowed or revoked a binding after the
+   parent was captured, the child gets the narrowed set — a checkpoint cannot
+   pin a stale-wide capability. Never a union; never the recorded set alone.
+3. **Nothing minted.** `rebind_for_child` returns `SecretRef`s only. The child's
+   `SubstitutionRegistry` mints its own placeholders at its own boot, so a
+   placeholder token from the parent's session still does not resolve in the
+   child. That test stays green unchanged, and it should — the guest re-reads
+   its placeholders from the environment the endpoint hands it.
+
+The child plan is still wholly its own: distinct nonce, distinct VM name,
+distinct plan_id, `deny_all` network policy. Only the binding *constraints*
+carry.
+
+### 3. Audit the inheritance
+
+`bind_checkpoint_forked` (`crates/mvm-hostd/src/audit/bind.rs`) gains the
+inherited binding set — names and `allowed_hosts` only, never values — in the
+`checkpoint.forked` entry, so the chain records what capability the child was
+granted and on whose authority. An inheritance that could not be audited
+refuses the fork, matching the `.context("refusing an unaudited fork")` policy
+already on that path.
+
+### 4. Where it does not apply
+
+- **`bind_checkpoint_restored` / time-travel restore.** Out of scope. A restore
+  re-admits under a fresh plan for a user-driven reason; inheritance there is a
+  separate decision and this plan does not make it.
+- **Firecracker.** `fork_vm_full_arm_fc` is behind
+  `fc_vm_full_fork_experimental_enabled`. Wire it, but the gate stays.
+- **`FsQuick` checkpoints.** No live guest state, so no live placeholder set to
+  keep meaningful. Record the field; do not consume it.
+
+## What this does *not* buy
+
+Deliberately out of scope, and worth stating so the plan is not read as more
+than it is:
+
+- No tag-based binding groups. Inheritance here is parent→child down a
+  lineage, not "attach a credential to a label and every VM wearing it gets it."
+  That is a separate, larger design and it needs an operator-facing surface.
+- No revocation propagation to *running* children. Narrowing a binding affects
+  the next fork, not a child already booted. Killing a live capability is the
+  endpoint's job and is unchanged.
+
+## Work items
+
+- [ ] W1 — `CheckpointMeta.secrets` + `.services`, folded into `meta_digest`.
+      Test: a record with a hand-edited `allowed_hosts` fails `verify_lineage`.
+- [ ] W2 — `rebind_for_child` in `keyholder/binding.rs`. Tests: cross-tenant
+      binding dropped; post-capture narrowing wins over the recorded set;
+      revoked binding yields no ref; intersection is never a union.
+- [ ] W3 — capture path records the admitted `secrets`/`services` onto the meta.
+- [ ] W4 — `admit_forked_child` consumes W2. Test: a child booted from a parent
+      with a bound secret resolves a *freshly minted* placeholder against the
+      inherited host set, and a host outside the intersection is refused.
+- [ ] W5 — `checkpoint.forked` carries the inherited binding names + hosts;
+      chain verifies; no value bytes present. Mirror the assertion shape of
+      `stream_audit_entries_carry_the_binding_and_no_payload_bytes`.
+- [ ] W6 — HVF arm wired (`fork_vm_full_arm_hvf`); FC arm wired behind its
+      existing experimental gate.
+- [ ] W7 — ADR-023 §egress-substitution gains a "fork lineage" subsection;
+      `specs/REFACTOR-STATUS.md` + `specs/SPRINT.md` updated in the same change.
+
+## Claims impact
+
+No numbered claim changes. Claim 13 (no raw secret over the broker channel) is
+untouched — no value crosses any new boundary, and the endpoint remains the only
+process holding cleartext. Claim 12's binding-gated dispatch gains an
+inheritance edge that is strictly attenuating, so no admission that was
+previously refused becomes admitted. `Preview` claim 18's "a restored or warm-
+claimed child is admission-bounded without its host-side CPU control or its
+wall-clock timer being re-armed" limit is **unaffected and still open** — this
+plan does not re-arm anything, and must not be read as closing it.

--- a/specs/sprint/delivery/2698-fork-secret-bindings.md
+++ b/specs/sprint/delivery/2698-fork-secret-bindings.md
@@ -1,0 +1,56 @@
+# 2698 — forked children are admitted with no secret bindings
+
+Issue: #2698. Plan: `specs/plans/2026-08-18-fork-inherits-secret-bindings.md`.
+PR: #2696.
+
+## Delivered
+
+**W0 — the drop is loud.** A vm_full fork mints a fresh plan for its child with
+`secrets: Vec::new()`, so every binding the parent held is dropped and the child
+cannot reach any authenticated upstream the parent could. That was silent, and
+presented as an upstream that stopped answering rather than as a capability the
+child never received.
+
+- `parent_secret_names(parent_checkpoint, store) -> Vec<String>` in
+  `crates/mvm-cli/src/commands/vm/checkpoint.rs`. Reads the parent's persisted
+  plan (`plan_persist::read_plan(parent_meta.vm_name).secrets`) — the same
+  source `bind_checkpoint_forked` already uses — so no schema change was needed.
+  Shape matches the three sibling helpers `parent_agent_verb_override`,
+  `parent_network_mode` and `parent_plan_resources`.
+- `warn_dropped_parent_secrets` emits the diagnostic. Wired into both admit
+  sites: `checkpoint.rs` (`--boot` arm) and
+  `checkpoint/fork_vm_full.rs::admit_forked_child`.
+
+Names only. `SecretBinding` carries a name and a source reference and never a
+value; the diagnostic echoes only the name, asserted by a dedicated test.
+
+## Tests
+
+Three, in `crates/mvm-cli/src/commands/vm/checkpoint.rs`:
+
+- `parent_secret_names_lists_the_parent_bindings_by_name`
+- `parent_secret_names_echoes_no_source_addresses`
+- `parent_secret_names_is_empty_when_the_parent_plan_is_unreadable`
+
+Mutation-checked: forcing the helper to return `Vec::new()` turns the two
+positive tests red. Without that check they could have passed vacuously, since
+the helper returns an empty vec on every error path.
+
+## Scope deliberately not taken
+
+**W0 warns; it does not refuse.** The plan originally specified "refuse under
+`--prod`". There is no `--prod` on this path — a fork is always prod-profile —
+so the refusal had no flag to gate on, and an unconditional refusal would turn
+every existing fork of a secret-holding parent from degraded-but-working into a
+hard failure. Moved to plan item A6, where it becomes coherent once the child's
+bindings can be declared.
+
+**Known limit:** an unreadable parent plan yields an empty set, so silence means
+"unknown", not "the parent held none". A fork of a parent whose plan file is
+gone warns about nothing. Recorded in the helper's doc comment and in the plan.
+
+## Not delivered
+
+Options A (declare bindings at fork, A1–A6) and B (inherit from the checkpoint)
+are designed and unimplemented. `Preview` claim 18's unre-armed wall-clock/CPU
+limit is untouched and still open.


### PR DESCRIPTION
Closes part of #2698.

## The gap

`admit_forked_child` mints a fresh plan for a vm_full fork child and hardcodes
`secrets: Vec::new()` / `services: Vec::new()`, so the child boots with an empty
`SubstitutionRegistry` and cannot reach any authenticated upstream its parent
could. Selective inheritance is already the shape there — `grants`,
`agent_verb_override` and `network_mode` all come from the parent — so these two
read as oversights rather than decisions.

Fail-closed, so not a security bug. It is a capability bug that puts fork-per-run
out of reach for most real workloads, and warm-claim fork is becoming the primary
launch path.

## What ships here

**W0 — the drop is loud.** It was silent, and presented as an upstream that
stopped answering rather than as a capability the child never received.

- `parent_secret_names` reads the parent's **persisted plan**
  (`plan_persist::read_plan(...).secrets`) — the same source
  `bind_checkpoint_forked` already uses — so no schema change was needed. Shape
  mirrors the three sibling helpers beside it.
- `warn_dropped_parent_secrets` wired into both admit sites (`--boot` arm and
  `admit_forked_child`).
- Names only. `SecretBinding` carries a name and a source reference, never a
  value; a test asserts no provider or address is echoed.

**It warns; it does not refuse.** The plan first said "refuse under `--prod`",
but there is no `--prod` here — a fork is always prod-profile — so the refusal
had no flag to gate on, and an unconditional one would turn every existing fork
of a secret-holding parent from degraded-but-working into a hard failure. Moved
to plan item A6, coherent once the child's bindings can be declared.

**Known limit, stated in the code and the plan:** an unreadable parent plan
yields an empty set, so silence means "unknown", not "the parent held none".

## The design (doc)

- **Option A (recommended, unimplemented)** — declare the child's bindings at
  fork time, threaded through the existing `admit_plan_for_boot` `secrets`
  parameter. A1–A6.
- **Option B (deferred)** — inherit from the checkpoint, attenuated by
  intersection with the current operator binding. Recorded so the decision is
  legible, not queued: its only gain over A is ergonomic, and it costs an
  implicit capability flow that makes "why can this VM reach that host?"
  unanswerable from the child's own plan.

## Verification

- 3 new tests; full `mvm-cli` suite 1913 passed.
- Mutation-checked: forcing `parent_secret_names` to return `Vec::new()` turns
  both positive tests red, so they are not passing vacuously through the
  helper's empty-on-error paths.
- Workspace clippy clean (pre-commit hook), `cargo fmt --all` applied.
- Gates: plan-names, declared-backing, honesty, no-overclaim, doc-claims,
  deferrals, sprint-append, no-spec-refs-in-comments.

## Claims impact

None. Claim 13 untouched — no value crosses any new boundary. `Preview` claim
18's unre-armed wall-clock/CPU limit is **not** closed by this.