### PR TITLE
fix(seccomp): restore epoll for confined roles on aarch64

### DIFF
--- a/crates/mvm-core/src/crypto/seccomp/mod.rs
+++ b/crates/mvm-core/src/crypto/seccomp/mod.rs
@@ -8,7 +8,10 @@ pub mod syscall_table;
 /// Cumulative seccomp profile tiers. Each tier is a strict superset of the
 /// previous one, adding more syscall permissions for broader workload needs.
 ///
-/// The syscall lists target x86_64 Linux. Tier membership is defined by
+/// The syscall lists cover x86_64 and aarch64 Linux. A name that does not
+/// exist on the target arch is skipped when the filter is built, so a tier
+/// may name both a legacy syscall and its `*at` replacement; both are needed
+/// for the capability to survive on both arches. Tier membership is defined by
 /// [`SeccompTier::syscalls`], which returns the full set of allowed syscall
 /// names for that tier.
 #[derive(
@@ -342,6 +345,13 @@ fn minimal_extra() -> &'static [&'static str] {
         "epoll_create1",
         "epoll_ctl",
         "epoll_wait",
+        // aarch64 has no `epoll_wait`; glibc's `epoll_wait()` dispatches
+        // `epoll_pwait` there. Without this the entry above resolves to
+        // nothing on aarch64 and every epoll call in a confined role takes
+        // EPERM — the capability is granted on x86_64 and silently absent on
+        // ARM. Listing both names grants one capability on both, which is what
+        // the jailer's own table already does.
+        "epoll_pwait",
         "poll",
         "select",
         // Dir

--- a/crates/mvm-core/src/crypto/seccomp/syscall_table.rs
+++ b/crates/mvm-core/src/crypto/seccomp/syscall_table.rs
@@ -312,14 +312,130 @@ mod tests {
         assert!(syscall_name(i64::MAX).is_none());
     }
 
+    /// Legacy syscalls that exist on x86_64 and genuinely do not exist on
+    /// aarch64, which only has the `*at` / `p*` variants. A tier may name
+    /// these — `apply_filter` skips a name that does not resolve, by design —
+    /// but the set has to be *declared*, so that a name resolving nowhere is a
+    /// typo rather than a silent no-op.
+    const LEGACY_X86_ONLY: &[&str] = &[
+        "access",
+        "arch_prctl",
+        "chmod",
+        "chown",
+        "dup2",
+        "epoll_wait",
+        "fork",
+        "futimesat",
+        "getdents",
+        "getpgrp",
+        "lchown",
+        "link",
+        "lstat",
+        "mkdir",
+        "open",
+        "pipe",
+        "poll",
+        "readlink",
+        "rename",
+        "rmdir",
+        "select",
+        "sendfile",
+        "stat",
+        "symlink",
+        "unlink",
+        "vfork",
+    ];
+
+    /// Every tier name either resolves here or is a declared legacy name.
+    ///
+    /// This replaces an assertion that every name resolves on every arch,
+    /// which was stronger than the design: `mvm-seccomp-apply::apply_filter`
+    /// deliberately skips a name it cannot resolve ("the tier is best-effort
+    /// coarse-grained"). The old form passed on x86_64 and could only ever
+    /// fail on aarch64, where it flagged correct behaviour.
     #[test]
-    fn all_tier_syscalls_resolve() {
+    fn every_tier_name_resolves_or_is_a_declared_legacy_name() {
         use crate::crypto::seccomp::SeccompTier;
         for tier in SeccompTier::ALL {
             for name in tier.syscalls() {
                 assert!(
+                    syscall_number(name).is_some() || LEGACY_X86_ONLY.contains(&name),
+                    "{name} in tier {tier} resolves on no architecture and is not \
+                     declared in LEGACY_X86_ONLY — typo, or a name that needs adding \
+                     to the syscall table"
+                );
+            }
+        }
+    }
+
+    /// The assertion with teeth, and the one that would have caught the epoll
+    /// hole: when a tier grants a capability through a legacy name, it must
+    /// also grant the name that carries that capability on aarch64. Otherwise
+    /// the capability exists on x86_64 and is silently EPERM on ARM.
+    ///
+    /// `arch_prctl` and `sendfile` are absent: the first is genuinely x86-only
+    /// with no ARM equivalent, and the second's 64-bit form is used implicitly.
+    #[test]
+    fn a_legacy_name_never_grants_a_capability_that_aarch64_then_lacks() {
+        use crate::crypto::seccomp::SeccompTier;
+        const REPLACEMENT: &[(&str, &str)] = &[
+            ("access", "faccessat"),
+            ("chmod", "fchmodat"),
+            ("chown", "fchownat"),
+            ("dup2", "dup3"),
+            ("epoll_wait", "epoll_pwait"),
+            ("fork", "clone"),
+            ("futimesat", "utimensat"),
+            ("getdents", "getdents64"),
+            ("getpgrp", "getpgid"),
+            ("lchown", "fchownat"),
+            ("link", "linkat"),
+            ("lstat", "newfstatat"),
+            ("mkdir", "mkdirat"),
+            ("open", "openat"),
+            ("pipe", "pipe2"),
+            ("poll", "ppoll"),
+            ("readlink", "readlinkat"),
+            ("rename", "renameat"),
+            ("rmdir", "unlinkat"),
+            ("select", "pselect6"),
+            ("stat", "newfstatat"),
+            ("symlink", "symlinkat"),
+            ("unlink", "unlinkat"),
+            ("vfork", "clone"),
+        ];
+
+        for tier in SeccompTier::ALL {
+            let granted = tier.syscalls();
+            for (legacy, modern) in REPLACEMENT {
+                if !granted.contains(legacy) {
+                    continue;
+                }
+                assert!(
+                    granted.contains(modern),
+                    "tier {tier} allows the legacy `{legacy}` but not `{modern}`, \
+                     which is what carries that capability on aarch64 — the tier \
+                     would grant it on x86_64 and EPERM it on ARM"
+                );
+            }
+        }
+    }
+
+    /// Each declared replacement has to be resolvable, or the check above is
+    /// asserting against a name the table cannot supply.
+    #[test]
+    fn declared_legacy_names_are_actually_absent_here_or_present_everywhere() {
+        for name in LEGACY_X86_ONLY {
+            if cfg!(target_arch = "aarch64") {
+                assert!(
+                    syscall_number(name).is_none(),
+                    "{name} is declared x86-only but resolves on aarch64 — drop it \
+                     from LEGACY_X86_ONLY"
+                );
+            } else {
+                assert!(
                     syscall_number(name).is_some(),
-                    "{name} in tier {tier} must resolve on this arch"
+                    "{name} is declared x86-only but does not resolve on x86_64"
                 );
             }
         }


### PR DESCRIPTION
## The hole

`minimal_extra()` allows `epoll_create1`, `epoll_ctl`, `epoll_wait`. It never listed `epoll_pwait`.

**aarch64 has no `epoll_wait` syscall.** glibc's `epoll_wait()` dispatches `SYS_epoll_pwait` there. `apply_filter` skips a name it cannot resolve — deliberately, and documented as such:

```rust
let nr = syscall_nr(name);
if nr < 0 {
    // Unknown / unavailable on this arch; skip silently.
    // The tier is best-effort coarse-grained.
    continue;
}
```

So on an aarch64 host, a process confined by this tier took **EPERM on every epoll call**. The capability was granted on x86_64 and silently absent on ARM.

The jailer's own table already handles precisely this case, mapping the *name* to the right aarch64 *number*:

```rust
// crates/mvm-hostd/src/jailer/seccomp.rs, aarch64 block
("epoll_wait",  libc::SYS_epoll_pwait),
("epoll_pwait", libc::SYS_epoll_pwait),
```

The tier table did not. **Listing both names grants one capability on both architectures, not a new one on either** — which is the relevant question for a file whose header says never to relax the list without review.

## The test that hid it

`all_tier_syscalls_resolve` asserted every tier name resolves on every arch. That is a stronger claim than the design makes, and it is false by construction: **26** legacy x86 names the tiers list — `open`, `stat`, `lstat`, `mkdir`, `unlink`, `readlink`, `poll`, `select`, … — cannot resolve on aarch64, because aarch64 only has the `*at` / `p*` variants.

So the assertion could only ever fire on aarch64, and when it did it flagged *correct* behaviour (`open` being skipped) while saying nothing about the one case that was a genuine hole. It failed on the noise and passed on the bug.

Three assertions replace it:

1. **every tier name resolves here, or is in a declared `LEGACY_X86_ONLY` set** — a name that resolves nowhere is a typo, not a silent no-op
2. **a tier granting a capability via a legacy name must also grant the aarch64 carrier** — the one with teeth, and what catches this bug class in general
3. **the declared legacy set is accurate** on whichever arch runs it, so (1) can't drift into a rubber stamp

## Verified on real hardware

Not inferred. The `mvm-core` test binary was cross-built for `aarch64-unknown-linux-gnu` and executed on an aarch64 Linux host (the module is `cfg(target_os = "linux")`, so no macOS run can reach it):

```
test crypto::seccomp::syscall_table::tests::a_legacy_name_never_grants_a_capability_that_aarch64_then_lacks ... ok
test crypto::seccomp::syscall_table::tests::declared_legacy_names_are_actually_absent_here_or_present_everywhere ... ok
test crypto::seccomp::syscall_table::tests::every_tier_name_resolves_or_is_a_declared_legacy_name ... ok
test result: ok. 25 passed; 0 failed
```

Mutation-tested on the same host — with `epoll_pwait` removed again, **exactly one** test fails:

```
tier minimal allows the legacy `epoll_wait` but not `epoll_pwait`, which is what
carries that capability on aarch64 — the tier would grant it on x86_64 and EPERM it on ARM
```

## Review note

This adds one entry to a seccomp allowlist. The file's header says never to relax it without security review, so, explicitly: `epoll_pwait` is the same capability as the already-allowed `epoll_wait`, it is what that capability *is* on aarch64, and the jailer's table already allows both on both arches. On x86_64 this makes `epoll_pwait` allowed alongside `epoll_wait`, which glibc may already use for a timeout-with-sigmask wait.

## Verification

`cargo +nightly fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `just check-linux` (x86_64), `just check-linux aarch64-unknown-linux-gnu` — all clean.

## Related

One of three failures the new aarch64 lane (#2682) found on its first green run. The other two are a doctor test that probes the host instead of driving the pure function, and a CLI audit test that follows from this same resolution gap.