### PR TITLE
fix(nix): serialize runtimeLean into the sidecar the admission gate reads

### DIFF
--- a/crates/mvm-vmm/src/host/runtime_meta.rs
+++ b/crates/mvm-vmm/src/host/runtime_meta.rs
@@ -592,4 +592,53 @@ mod tests {
             assert_eq!(meta.rootfs_path.as_deref(), Some(rootfs.to_str().unwrap()));
         });
     }
+
+    /// Every sidecar field this module's admission gate reads has to survive
+    /// the trip from `mkGuest` into `mvm-meta.json`, and one did not.
+    ///
+    /// `nix/lib/mk-guest.nix` sets `runtimeLean = true`, but
+    /// `nix/images/default-tenant/flake.nix` serializes the sidecar from an
+    /// explicit `inherit (mvm) …` list that omitted it. A dropped field is not
+    /// a parse error — it takes serde's `false` default — so a rootfs carrying
+    /// no baked agent at all reached the gate looking like one that might
+    /// silently degrade to one, and was refused. That cost five release runs
+    /// because the only place it shows up is a real boot.
+    ///
+    /// Reading the flake is the point: the gate and the serializer are in
+    /// different languages and different repositories of truth, and nothing
+    /// else makes them disagree loudly.
+    #[test]
+    fn the_default_tenant_sidecar_serializes_every_field_this_gate_reads() {
+        // Grow this list whenever the gate above learns to read a new field.
+        const READ_BY_THE_GATE: &[&str] = &["overlayAware", "runtimeLean"];
+
+        let flake = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../nix/images/default-tenant/flake.nix");
+        let body = std::fs::read_to_string(&flake)
+            .unwrap_or_else(|e| panic!("reading {}: {e}", flake.display()));
+
+        // The `inherit (mvm) … ;` block inside `sidecarJson`, which is the only
+        // thing that decides what reaches the JSON.
+        let start = body
+            .find("sidecarJson = mvm:")
+            .expect("default-tenant flake still defines sidecarJson");
+        let inherit_start = body[start..]
+            .find("inherit (mvm)")
+            .map(|i| start + i)
+            .expect("sidecarJson still serializes via `inherit (mvm)`");
+        let inherit_end = body[inherit_start..]
+            .find(';')
+            .map(|i| inherit_start + i)
+            .expect("the inherit list is terminated");
+        let inherited = &body[inherit_start..inherit_end];
+
+        for field in READ_BY_THE_GATE {
+            assert!(
+                inherited.split_whitespace().any(|w| w == *field),
+                "`{field}` is read by the required-overlay admission gate but is not in \
+                 default-tenant's sidecar `inherit (mvm)` list, so it serializes as its \
+                 default and the gate sees the wrong answer. List was: {inherited}"
+            );
+        }
+    }
 }

--- a/nix/images/default-tenant/flake.nix
+++ b/nix/images/default-tenant/flake.nix
@@ -103,9 +103,15 @@
       # overwritten by the fetch path, for which it is no longer true.
       sidecarJson = mvm:
         builtins.toJSON {
+          # `runtimeLean` belongs in this list for the same reason
+          # `overlayAware` does: the required-overlay admission gate reads both,
+          # and a field mkGuest sets but this serializer drops reaches the gate
+          # as its `false` default. That is how a rootfs carrying no baked agent
+          # at all came to be refused as one that might silently degrade to one.
           inherit (mvm)
             name accessible sealed entrypointKind initSystem
-            expectedBootMs agentBinary rootlessEntrypoint hypervisor overlayAware;
+            expectedBootMs agentBinary rootlessEntrypoint hypervisor overlayAware
+            runtimeLean;
           imageTag = bootImageTag;
           source = "built-local";
           builtAt = "";


### PR DESCRIPTION
The next layer of the boot-image release chain, and the last one before it
publishes. Blocks #2684, #2542 and the `v0.18.0` release.

## Where the gate got to

With #2683 merged, the boot gate stopped panicking in the guest and started
failing at **admission**, before the VM starts:

```
Error: starting benchmark VM mvm-boot-bench-serial-0-… with backend firecracker
Caused by:
    refusing to start VM: rootfs at staging is marked `overlayAware: true` but
    not `runtimeLean: true` in its `mvm-meta.json` sidecar. Required-overlay
    boots must use a rootfs that intentionally omits the baked … fallback
```

That is progress — the overlay is attached, the guest is told where it is, and
the fail-closed policy #2683 introduced is doing exactly what it was added to
do. It is refusing the right image for the wrong reason.

## The rootfs is not the problem; the metadata is

`nix/lib/mk-guest.nix` sets `runtimeLean = true`, and means it. The earlier
failure on this same image — `no guest agent resolved from /mvm/runtime and no
baked fallback` — is that rootfs demonstrating it bakes no agent.

What drops it is the serializer. `nix/images/default-tenant/flake.nix` builds
`mvm-meta.json` from an explicit list:

```nix
inherit (mvm)
  name accessible sealed entrypointKind initSystem
  expectedBootMs agentBinary rootlessEntrypoint hypervisor overlayAware;
```

`runtimeLean` is not in it. A field missing from the JSON is **not a parse
error** — it takes serde's `false` default — so a rootfs that omits the baked
agent entirely arrived at the gate looking like one that might silently degrade
to one. `missing runtimeLean field must default to false` is even an existing
unit test; nothing connected that default to the flake that triggers it.

The gate is correct. The metadata was lying to it. Add the field.

## The witness reads the flake, deliberately

The gate is Rust, the serializer is Nix. They are separate repositories of
truth about the same wire shape, and nothing in the build makes them disagree
out loud — this cost five release runs, because a dropped sidecar field only
shows up on a real boot.

`the_default_tenant_sidecar_serializes_every_field_this_gate_reads` reads
`default-tenant/flake.nix`, extracts the `inherit (mvm) …` list from
`sidecarJson`, and asserts every field the admission gate reads appears in it.
It carries `READ_BY_THE_GATE` as an explicit list to extend when the gate
learns to read a new field.

Proven to discriminate: deleting the `runtimeLean` line turns it red.

`cargo test -p mvm-vmm --lib runtime_meta::` 14/14; workspace clippy
`--all-targets -D warnings` clean.