### PR TITLE
fix(doctor): derive the builder-backend line from the platform it is given

### DIFF
--- a/crates/mvm-cli/src/doctor/builder.rs
+++ b/crates/mvm-cli/src/doctor/builder.rs
@@ -286,11 +286,20 @@ pub(super) fn builder_transport_check(_plat: Platform) -> Check {
 pub(super) fn builder_backend_check(plat: Platform) -> Check {
     use mvm_build::builder_backend_select::{
         BuilderBackendChoice, MVM_BUILDER_BACKEND_ENV, MVM_LINUX_BUILDER_VM_ENV,
-        auto_detect_default, linux_builder_vm_requested, resolve_env_override,
+        auto_detect_default_for, linux_builder_vm_requested, resolve_env_override,
     };
 
     let env_override = resolve_env_override();
-    let auto = auto_detect_default();
+    // Derive the whole line from the `plat` we were handed, not from a second,
+    // independent probe of the live host. `auto_detect_default()` re-probes;
+    // using it here made the backend half of this line describe the real host
+    // while the availability half described `plat`, so the two could disagree
+    // and the report would be internally inconsistent. It also made the
+    // function untestable for any platform other than the one running it.
+    let auto = auto_detect_default_for(
+        plat,
+        plat.is_hvf_default_tier() && cfg!(target_arch = "aarch64"),
+    );
     let resolved = env_override.unwrap_or(auto);
 
     // Best-effort: detect whether the override came from the
@@ -725,6 +734,39 @@ mod tests {
         assert_eq!(c.name, "builder transport");
         assert!(c.info.contains("unsupported legacy"), "got {:?}", c.info);
         assert!(c.info.contains("qemu"), "got {:?}", c.info);
+    }
+
+    /// The report line must derive entirely from the platform it is handed.
+    ///
+    /// This pins the fix for a real inconsistency: the check used to resolve
+    /// the backend from a second, independent probe of the live host
+    /// (`auto_detect_default()`) while deriving the availability half from the
+    /// `plat` argument, so on a host whose real platform differed from `plat`
+    /// the two halves of one line described different machines.
+    ///
+    /// It is also the assertion that fails on *any* host if that regresses:
+    /// a Linux box with `/dev/kvm` re-probes to qemu, one without re-probes to
+    /// libkrun, so whichever machine runs this, one of the two cases below
+    /// contradicts the live probe.
+    #[cfg(all(target_os = "linux", feature = "builder-vm"))]
+    #[test]
+    fn builder_backend_check_derives_the_backend_from_the_platform_it_is_given() {
+        let mut env = TestEnv::new();
+        env.remove("MVM_BUILDER_BACKEND");
+
+        let native = builder_backend_check(Platform::LinuxNative);
+        assert!(
+            native.info.starts_with("qemu — "),
+            "LinuxNative must resolve qemu regardless of the running host; got: {}",
+            native.info
+        );
+
+        let no_kvm = builder_backend_check(Platform::LinuxNoKvm);
+        assert!(
+            no_kvm.info.starts_with("libkrun — "),
+            "LinuxNoKvm must resolve libkrun regardless of the running host; got: {}",
+            no_kvm.info
+        );
     }
 
     #[cfg(all(target_os = "linux", feature = "builder-vm"))]


### PR DESCRIPTION
## Not a test bug

I expected this to be a test that probed the host. It isn't — the test passes `Platform::LinuxNative` explicitly. The production function ignores it:

```rust
pub(super) fn builder_backend_check(plat: Platform) -> Check {
    let auto = auto_detect_default();          // <- re-probes the LIVE host
    ...
    let availability = match resolved {
        BuilderBackendChoice::Libkrun => {
            if plat.has_libkrun() { ... }      // <- uses the ARGUMENT
```

So the **backend** half of the line comes from the running host and the **availability** half from `plat`. On any host where those differ, one report line describes two different machines.

## How it surfaced

The new native aarch64 lane (#2682) runs on a GitHub arm64 runner, which has **no `/dev/kvm`**. So `builder_backend_check(Platform::LinuxNative)` re-probed to `LinuxNoKvm` and answered libkrun where the caller had asked about a KVM host:

```
expected qemu-resolved line; got: libkrun — auto-detected (default: libkrun) — libkrun NOT available
```

## The fix

Derive the whole line from the platform passed in. One argument, one answer.

## Why the old test could never have caught it

It asserts only `LinuxNative → qemu`. On any machine with `/dev/kvm` a live probe *also* says qemu, so the assertion agrees with the bug. It fails only on a non-KVM Linux host — which no CI lane was until now.

The new test asserts **both** directions, so whichever kind of host runs it, one arm contradicts a live probe:

- on a KVM host, `LinuxNoKvm` must still answer libkrun
- on a non-KVM host, `LinuxNative` must still answer qemu

## Verified on real aarch64 Linux

The module is `cfg(target_os = "linux")`, so no macOS run reaches it. Cross-built for `aarch64-unknown-linux-gnu` and executed on an aarch64 Linux host:

```
test doctor::builder::tests::builder_backend_check_derives_the_backend_from_the_platform_it_is_given ... ok
test doctor::builder::tests::builder_backend_check_linux_reports_qemu_auto_detected ... ok
test result: ok. 10 passed; 0 failed
```

Mutation-tested on that same host — reverting to `auto_detect_default()` fails the new test **alone**, and the old test passes right beside it:

```
builder_backend_check_derives_the_backend_from_the_platform_it_is_given ... FAILED
builder_backend_check_linux_reports_qemu_auto_detected ... ok
  LinuxNoKvm must resolve libkrun regardless of the running host;
  got: qemu — auto-detected (default: qemu) — QEMU NOT available
```

## Verification

`cargo +nightly fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `just check-linux` — clean.

## Related

The second of three failures the aarch64 lane found on its first green run. The seccomp one is #2697; the third (`seccomp_audit_cli`) follows from that same resolution gap and should clear with it.