### PR TITLE
fix(ci): give cache-warm the same env as its consumers, so the cache can restore

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -37,6 +37,23 @@ on:
 permissions:
   contents: read
 
+# These have to match ci.yml's workflow-level `env:` exactly, and the reason is
+# not cosmetic. `Swatinem/rust-cache` folds every environment variable whose
+# name begins with CARGO/CC/CFLAGS/CXX/CMAKE/RUST into the hash it keys the
+# cache on, and its restore-key list stops at that hash — there is no bare
+# prefix to fall back to. So a job that sets `RUSTFLAGS: "-D warnings"` cannot
+# restore an entry written by a job that did not, no matter how identical the
+# lockfile and toolchain are. This workflow had no `env:` block at all, so the
+# one entry every other lane depends on was written under a key none of them
+# ever computes, and every CI job cold-built.
+#
+# It is also the correct cache to write on the merits: `-D warnings` is part of
+# how the artifacts are compiled, so an entry built without it is not the one
+# the consuming lanes want.
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
 # One warm at a time. Merges can land faster than a build completes, and the
 # newest main is the one worth caching — but let an in-flight build finish
 # rather than cancelling, since a half-built target dir caches nothing useful.
@@ -86,10 +103,9 @@ jobs:
           components: clippy
 
       - name: Install system build deps
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
-          sudo apt-get update
-          sudo apt-get install -y attr cryptsetup-bin libcap-ng-dev lld
+        uses: ./.github/actions/apt-deps
+        with:
+          packages: attr cryptsetup-bin lld
 
       - uses: ./.github/actions/install-zigbuild
 


### PR DESCRIPTION
Closes #2567.

## Why every job cold-builds

The one-writer design in #2567's sights is correct — main writes, everything
else restores. What is wrong is that main writes under a key **no consumer ever
computes**.

`Swatinem/rust-cache` folds every environment variable whose name begins with
`CARGO`/`CC`/`CFLAGS`/`CXX`/`CMAKE`/`RUST` into the hash it keys on, and its
restore-key list stops at that hash — there is no bare-prefix fallback below it.

`ci.yml` sets, at workflow level:

```yaml
env:
  CARGO_TERM_COLOR: always
  RUSTFLAGS: "-D warnings"
```

so every consuming job hashes both in. **`cache-warm.yml` had no `env:` block at
all.** Same lockfile, same toolchain, same `shared-key`, different env hash,
guaranteed miss — on every restore, in every lane, every time.

That also explains the shape of the symptom. A cache that was merely being
evicted, or racing, would miss *sometimes*. #2567 reports it missing
*uniformly*, which is what a key mismatch looks like and what an eviction does
not.

## Why matching them is right, not just expedient

`-D warnings` is part of how the artifacts are compiled. An entry built without
it is not the entry the consuming lanes want to restore, so aligning the warm
job's env is the correct cache to be writing, independent of the key.

## Also here

The warm job still open-coded `apt-get update && apt-get install` with no
timeout and no retry — the exact unbounded hang that #2672 bounded everywhere
else and that reads as a red PR when a mirror stalls. Moved it onto the shared
`apt-deps` action, and dropped `libcap-ng-dev`, whose only consumer was the
microsandbox backend removed in `8b7aa375d` (see #2693 for the full trace).

## Verification

The proof is a subsequent run reporting a cache hit rather than
`No cache found`, which needs this on main and one warm run after it. YAML
parses, `check-workflow-paths` clean.