### PR TITLE
docs: scope the tool plane, and record what controller-launched children must not break

### DIFF
--- a/specs/adrs/045-capability-secure-intelligent-workflow-controllers.md
+++ b/specs/adrs/045-capability-secure-intelligent-workflow-controllers.md
@@ -458,15 +458,41 @@ Repository signatures prove publication authorship, not truth or
 authorization. CIDs identify bytes, not principals or permissions. The local
 chain-signed audit remains authoritative forensic evidence.
 
-### 18. Agent tool calling is broker dispatch, and the catalog derives from the plan
+### 18. Host-mediated tool calling is broker dispatch, and the catalog derives from the plan
+
+Two different things get called an agent's tools, and only one of them is
+this project's to govern.
+
+**In-guest tools run inside the workload's own microVM**: a shell, a browser
+driver, a test runner, an interpreter, whatever the image carries or the agent
+installs. These are processes in the agent's own sandbox. mvm does not build
+them, catalog them, enumerate them, or permission them. An agent may choose
+freely among them, and the set is unbounded and mostly third-party by design.
+
+That is safe because of what the tier already is rather than because of any
+new control. A workload microVM has no NIC, its rootfs is dm-verity sealed,
+and it reaches no host filesystem beyond its explicit shares. A browser driver
+inside that VM can render, script, and drive an engine all it likes, and none
+of it leaves. Governing the toolbox would add ceremony without adding
+containment, because the boundary already contains it.
+
+**Host-mediated tools cross that boundary**: outbound network, secrets, audit,
+memory that outlives the VM, and — under section 3 — spawning another VM.
+These are the boundary, so they are the entire subject of this section, and
+there are on the order of half a dozen of them rather than an open registry.
+
+The distinction the design rests on is that authority attaches to *effects*,
+not to *tools*. An agent's choice of browser driver is its own business; that
+driver's outbound request is admitted or refused by destination at the
+per-VM substitution endpoint. The tool stays unrestricted and its effect stays
+governed, which is why nobody has to predict the toolbox in advance.
 
 Section 8 governs what a *controller's planner* may do to the workflow graph.
-It does not govern the tool surface of an ordinary AI workload: an agent
-inside an admitted microVM emitting tool calls at a model's direction. That
-surface is not a new plane. It is the host services broker of ADR-020, and it
-stays there.
+It does not govern either category above. The host-mediated surface is not a
+new plane: it is the host services broker of ADR-020, and it stays there.
 
-Every tool an agent may call is a `ServiceId` (`host.<name>.v<n>`) bound in
+Every host-mediated tool an agent may call is a `ServiceId`
+(`host.<name>.v<n>`) bound in
 `ExecutionPlan.services` and enforced before handler dispatch (claim 12).
 
 The direction of derivation is the decision:
@@ -497,13 +523,23 @@ admitted host-side only:
 - Discovery verbs are served from the plan binding, not proxied upstream.
 
 An upstream server that adds, renames, or redefines a tool mid-session
-therefore cannot widen a running guest's surface. A guest-side client would
-reintroduce an unaudited egress path and a mutable namespace, which the
-vsock-only posture of ADR-001 claim 10 and ADR-003 exists to prevent.
+therefore cannot widen a running guest's surface. A guest-side client speaking
+outward would reintroduce an unaudited egress path and a mutable namespace,
+which the vsock-only posture of ADR-001 claim 10 and ADR-003 exists to
+prevent.
 
-A tool surface is fixed for the lifetime of an admission. It changes at an
-epoch boundary, by re-admission, or not at all. A mid-epoch mutable namespace
-is unauditable by construction: there is no finite set to have checked.
+What this does **not** restrict is a tool server running entirely inside the
+guest — a local subprocess an agent talks to over its own stdio or loopback,
+which is how much of that ecosystem is packaged. That is an in-guest tool: it
+is the image's business, it is unrestricted, and any outbound request it makes
+is admitted by destination like every other. The rule is about a guest
+originating connections to a remote server, not about the protocol.
+
+A host-mediated tool surface is fixed for the lifetime of an admission. It
+changes at an epoch boundary, by re-admission, or not at all. A mid-epoch
+mutable namespace is unauditable by construction: there is no finite set to
+have checked. The in-guest toolbox has no such rule and needs none — it is
+bounded by the VM, not by a list.
 
 ### 19. Tool results are data, and injection cannot widen the action set
 
@@ -567,11 +603,13 @@ The implementation must preserve all of the following:
 20. Semantic assertions cannot widen a live constraint snapshot.
 21. A used workload VM never reenters shared warm capacity.
 22. Guest-visible handles do not expose physical host routes or authority.
-23. Every agent-callable tool is a plan-bound service; the catalog presented to
-    a model derives from that binding and never the reverse.
+23. Every host-mediated tool is a plan-bound service; the catalog presented to
+    a model derives from that binding and never the reverse. Tools running
+    inside the guest are out of scope, and the microVM boundary is what
+    bounds them.
 24. No guest speaks a tool-discovery protocol outward; upstream tools compile
     host-side at admission, inside the plan digest.
-25. A tool surface is fixed for the lifetime of an admission.
+25. A host-mediated tool surface is fixed for the lifetime of an admission.
 26. Tool results are data on the stream and mailbox planes, and carry no
     authority.
 ```

--- a/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
+++ b/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
@@ -17,12 +17,18 @@ retention ladder) — unmerged at the time of writing, living on
 Two gaps sit between the workflow documents and an AI agent actually running
 inside an admitted microVM.
 
-**Tool calling has no defined surface.** ADR-045 section 8 governs what a
-controller's *planner* may do to the workflow graph. It says nothing about an
-ordinary workload agent emitting tool calls at a model's direction. Without a
-decision, a framework will reach for a guest-side client to whatever tool
-protocol it prefers, which is an unaudited egress path and a namespace that
-mutates under a running admission.
+**Host-mediated tool calling has no defined surface.** ADR-045 section 8
+governs what a controller's *planner* may do to the workflow graph. It says
+nothing about an ordinary workload agent emitting tool calls at a model's
+direction. Without a decision, a framework will reach for a guest-side client
+speaking outward to a remote tool server, which is an unaudited egress path
+and a namespace that mutates under a running admission.
+
+Scope, per ADR-045 section 18: this is about tools that cross the VM boundary,
+which is a handful of services. Tools running inside the guest — a shell, a
+browser driver, an interpreter, a local tool server the agent talks to over
+its own stdio — are deliberately out of scope and stay ungoverned, because the
+NIC-less, verity-sealed microVM is what bounds them.
 
 **Memory has no defined surface either.** The durable agent sessions design
 carries the *substrate* across sandboxes — checkpoint, journal cursor,
@@ -86,6 +92,12 @@ The memory plane has no existing piece beyond the broker it rides on.
       protocol client on any guest-reachable path, in the manner of
       `check-vsock-only-egress`. Without it this decision decays the first time
       a framework is vendored into a guest image.
+- [ ] The gate must catch a guest *originating a connection to a remote tool
+      server*, and must not catch a tool server running wholly inside the
+      guest over stdio or loopback — that is a supported in-guest tool, and a
+      gate that greps for the protocol's name rather than for outbound
+      connection setup would refuse it. A gate written the lazy way here
+      breaks the common packaging of that ecosystem.
 
 ### WS4 — Refusal is a signal
 

--- a/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
+++ b/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
@@ -172,6 +172,112 @@ The memory plane has no existing piece beyond the broker it rides on.
       without a VM spawn, in the manner of `mvmctl deps inspect`.
 - [ ] Tests and BDD per the Testing section.
 
+## Forward compatibility — controller-launched child microVMs
+
+ADR-045 section 3 gives a controller real lifecycle authority, and the
+research basis models a launch as `ActionTarget::ChildMicroVm`, a peer of
+`HostService` in one action vocabulary. Nothing in Part A needs redesigning to
+carry that: a launch is a `CapabilityId` like any other, its catalog entry is
+the same projection, and its `template` and `launch_mode` arguments are
+precisely what WS2's `OneOf` constrains — with the template digest pinned the
+way every descriptor digest already is.
+
+Five things have to stay true, and they are recorded here so the next author
+does not rediscover them by hitting them.
+
+- [ ] **FC1 — Reservation is transactional; these gates are not.** Every gate
+      in `dispatch_capability` is a stateless validator: check, then dispatch.
+      A launch must atomically reserve across the resource dimensions and
+      release on failure — reserve, dispatch, then commit or roll back. The
+      argument-policy gate keeps its place ahead of the reservation, but the
+      ladder has no rollback-capable slot and needs one. Putting the
+      reservation inside the handler instead leaks budget on any crash between
+      reserving and dispatching, with nobody holding the rollback.
+- [ ] **FC2 — Launch idempotency is not replay refusal.** `consumed_invocations`
+      refuses a repeated `(CapabilityId, AgentRequestId)` with `Replay`, and
+      the `Idempotency` vocabulary offers `MintFresh`, `CacheRecent { ttl_ms }`
+      and `DedupByCorrelation` — none of which means "the same key returns the
+      same child handle". A controller retrying after a dropped reply needs the
+      prior handle back, or it abandons a live child and relaunches. ADR-045
+      invariant 8 is satisfied by refusing, so the invariant will not catch
+      this; it appears only under retry. Needs a fourth variant, or launch
+      outside that vocabulary.
+- [ ] **FC3 — Launch returns a handle, not a finished child.** The capability
+      means "start a child, return its handle", with results arriving on the
+      mailbox plane. `CapabilityLimits.timeout_ms` is bounded, so modelling it
+      as "run the child to completion" breaks as soon as a child outlives one
+      call timeout.
+- [ ] **FC4 — One descriptor, derived, never two authored.** The research
+      basis's planning-layer `ActionDescriptor` overlaps this plan's
+      enforcement-layer `CapabilityDescriptor`. Authored independently they
+      drift, and then what the model is shown and what the host enforces
+      disagree. Derive the planning descriptor from the enforcement one plus
+      planning metadata, and decide that direction before the planning-snapshot
+      phase — retrofitting it means re-cutting every descriptor digest.
+- [ ] **FC5 — Fan-out is a budget, not a boolean.** See below.
+
+### FC5 — Bounding how many children a controller may start
+
+"May launch children" is a permission and the envelope answers it. "May launch
+five hundred of them right now" is not something a boolean can express. The
+envelope answers *whether*; a budget answers *how much more*, and only the
+second stops a runaway. A controller with a legitimate launch permission and no
+budget is a fork bomb with a signature on it.
+
+Four limits, because each catches a failure the others miss:
+
+- **Concurrency** — live children at once, per controller and per workflow.
+  Catches fan-out.
+- **Rate** — launches per window. Catches a crash-loop, which a concurrency cap
+  never sees: children that die immediately keep the live count near zero while
+  the host burns.
+- **Cumulative** — total attempts over the workflow's life. Catches a slow
+  bleed that stays under both of the above.
+- **Depth** — a controller launching a controller. The bound must exist even
+  while recursive delegation is deferred, because the bound is what keeps it
+  deferred.
+
+How it has to be enforced:
+
+- [ ] **Reserve, do not check.** Check-then-launch is the bug: two controllers
+      both read "under the cap", both launch, and the cap was never real. One
+      authority, one atomic reservation, released on failure — the same reason
+      the resource ledger is transactional rather than advisory.
+- [ ] **Hierarchical.** A subtree budget, so one controller cannot spend the
+      whole workflow's allowance and starve its siblings.
+- [ ] **Host-side, from the signed constraint snapshot.** Never from a count
+      the controller supplies or a limit it names.
+- [ ] **Copy `crates/mvm-hostd/src/admission_budget.rs`'s two properties**
+      rather than reinventing them. Count only *live* children, using the same
+      pid-marker probe the fork path trusts, so a child that crashed without
+      cleanup does not permanently lock its parent out — a safety check that
+      becomes a lockout is worse than the exhaustion it prevents. And charge the
+      configured maximum at admission rather than observed usage, so a child
+      that has not finished starting is already counted.
+- [ ] **Audit every refusal.** A controller repeatedly hitting its launch
+      ceiling is a signal — a crash-loop, or a planner steered into one — and it
+      should be visible without reading guest logs.
+- [ ] **Make the refusal legible to the planner** (WS4). "Launch ceiling
+      reached, N of M live, retry after T" lets a planner wait or re-plan; a
+      bare error makes it retry immediately, which is indistinguishable from the
+      attack the ceiling exists to stop.
+
+The tests that would catch a wrong implementation, since a limit with no test
+is decoration:
+
+- [ ] Two launches racing for the last slot: exactly one is admitted. This is
+      the check-then-act bug and the only test that finds it.
+- [ ] A controller at its concurrency cap is refused, and the refusal is
+      audited.
+- [ ] A child that crash-loops trips the rate limit while the live count stays
+      near zero — the case a concurrency cap alone reports as healthy.
+- [ ] A child that died without cleanup stops being counted, so its parent can
+      launch again rather than being locked out for the workflow's life.
+- [ ] A failed launch releases its reservation; N failed launches do not shrink
+      the budget by N.
+- [ ] A controller cannot exceed its subtree budget by launching through a
+      descendant.
+
 ## Reconciliation required
 
 - The durable agent sessions design owns session identity, generation, and the


### PR DESCRIPTION
Two docs commits on the tool plane, both from review questions on #2695.

## 1. Scope §18 to what actually crosses the VM boundary

Reading §18, it looked like mvm had signed up to build and permission an agent's tools — a browser driver, a shell, an interpreter. It hasn't, and the section didn't say so.

**In-guest tools** run inside the workload's own microVM. mvm does not build, catalog, enumerate, or permission any of them; the set is unbounded and mostly third-party, and that is fine — because of what the tier already is, not because of any new control. No NIC, verity-sealed rootfs, no host filesystem beyond explicit shares. A browser driver in that VM can render and script all it likes and none of it leaves. Governing the toolbox would add ceremony without adding containment.

**Host-mediated tools** cross that boundary: outbound network, secrets, audit, durable memory, sub-VM spawn. Half a dozen, and the whole subject of §18.

The line the design rests on: **authority attaches to effects, not to tools.**

The MCP rule needed the same correction in the direction that bites practically — a tool server running *wholly inside the guest* over stdio or loopback is a supported in-guest tool, since that is how much of that ecosystem ships. The rule is about a guest originating a connection to a remote server. WS3's gate is called out accordingly, because a gate that greps for the protocol's name rather than for outbound connection setup would refuse the supported case.

Invariants 23 and 25 said "tool" where they meant the host-mediated surface.

## 2. Record what a controller launching child microVMs must not break

A controller with lifecycle authority is coming. It does **not** force a redesign — a launch is a capability like any other, and its template and launch-mode arguments are what the argument policy already constrains. Five things have to stay true, each invisible until something hits it:

- **FC1** — reservation is transactional; every gate in the dispatch ladder is a stateless validator, so the ladder needs a rollback-capable slot it does not have.
- **FC2** — launch idempotency is not replay refusal. The `Idempotency` vocabulary has no "same key returns the same child handle", so a controller retrying a dropped reply abandons a live child. ADR-045 invariant 8 is satisfied by refusing, so nothing catches this except a retry.
- **FC3** — launch returns a handle, not a finished child.
- **FC4** — the planning-layer descriptor must be *derived* from the enforcement-layer one, or the model is shown something the host does not enforce.
- **FC5** — fan-out is a budget, not a boolean.

### On FC5

"May launch children" is a permission and the envelope answers it. "May launch five hundred right now" is not something a boolean can express. A legitimate launch permission with no budget is a fork bomb with a signature on it.

Four limits, because each catches what the others miss: **concurrency** for fan-out, **rate** for a crash-loop that keeps the live count near zero while the host burns, **cumulative** for a slow bleed under both, and **depth** because the bound is what keeps recursion deferred.

Enforcement copies `crates/mvm-hostd/src/admission_budget.rs` rather than reinventing it, including the two properties that module already paid for: count only live children by the same pid probe the fork path trusts, so a crashed child cannot lock its parent out for the workflow's life; and charge the configured maximum at admission, so a child that has not finished starting is already counted. Reserve rather than check — otherwise two controllers both read "under the cap" and the cap was never real.

The tests are listed. The racing-for-the-last-slot one is the only thing that finds the check-then-act bug.

Docs-only. Gates pass.