### PR TITLE
feat(broker): derive the tool catalog from admission, constrain arguments, and make refusals teach

### DIFF
--- a/crates/mvm-contract/src/protocol/agent_capability.rs
+++ b/crates/mvm-contract/src/protocol/agent_capability.rs
@@ -7,6 +7,7 @@
 //! Payload bytes, credentials, and handler errors never enter the audit DTOs.
 
 use alloc::string::String;
+use alloc::vec::Vec;
 use core::fmt;
 
 use serde::{Deserialize, Serialize};
@@ -130,6 +131,109 @@ impl CapabilityLimits {
     }
 }
 
+/// One constraint on one argument position inside a capability payload.
+///
+/// Deliberately a closed, bounded vocabulary rather than an embedded
+/// expression language: a policy an operator cannot read is a policy nobody
+/// audits, and an evaluator with loops is an evaluator with a denial of
+/// service in it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub enum ArgumentConstraint {
+    /// The value must be a string drawn from this exact set.
+    OneOf {
+        /// Permitted values.
+        values: Vec<String>,
+    },
+    /// The value must be a string under one of these prefixes, carrying no
+    /// `..` segment.
+    PathUnder {
+        /// Permitted path prefixes.
+        prefixes: Vec<String>,
+    },
+    /// The value's UTF-8 length must not exceed this.
+    MaxLen {
+        /// Inclusive upper bound in bytes.
+        bytes: u32,
+    },
+}
+
+impl ArgumentConstraint {
+    /// A stable, value-free label for audit and refusal messages.
+    #[must_use]
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::OneOf { .. } => "one_of",
+            Self::PathUnder { .. } => "path_under",
+            Self::MaxLen { .. } => "max_len",
+        }
+    }
+}
+
+/// A constraint bound to one location in the payload.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct ArgumentRule {
+    /// RFC 6901 JSON pointer into the payload, e.g. `/destination`.
+    pub pointer: String,
+    /// The constraint the value at that pointer must satisfy.
+    pub constraint: ArgumentConstraint,
+}
+
+/// Why an argument policy refused a call. Carries the location and the rule
+/// kind, never the offending value: a refusal is audited, and an audited
+/// refusal that quotes the argument re-publishes whatever the argument held.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArgumentRefusal {
+    /// Pointer of the rule that refused.
+    pub pointer: String,
+    /// Stable kind label of the constraint that refused.
+    pub kind: &'static str,
+}
+
+/// Evaluate an argument policy against a payload.
+///
+/// A pointer that resolves to nothing is a refusal rather than a pass: a rule
+/// naming an argument the payload omits would otherwise be satisfied by
+/// leaving the argument out, which is the opposite of what the rule says.
+///
+/// # Errors
+///
+/// Returns the first rule that refuses, in policy order.
+pub fn evaluate_argument_policy(
+    rules: &[ArgumentRule],
+    payload: &serde_json::Value,
+) -> Result<(), ArgumentRefusal> {
+    for rule in rules {
+        let refusal = || ArgumentRefusal {
+            pointer: rule.pointer.clone(),
+            kind: rule.constraint.kind(),
+        };
+        let Some(value) = payload.pointer(&rule.pointer) else {
+            return Err(refusal());
+        };
+        let Some(text) = value.as_str() else {
+            return Err(refusal());
+        };
+        let ok = match &rule.constraint {
+            ArgumentConstraint::OneOf { values } => values.iter().any(|v| v == text),
+            ArgumentConstraint::PathUnder { prefixes } => {
+                !text.split('/').any(|segment| segment == "..")
+                    && prefixes
+                        .iter()
+                        .any(|prefix| text.starts_with(prefix.as_str()))
+            }
+            ArgumentConstraint::MaxLen { bytes } => text.len() <= *bytes as usize,
+        };
+        if !ok {
+            return Err(refusal());
+        }
+    }
+    Ok(())
+}
+
 /// Host-advertised metadata for one capability.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -145,6 +249,9 @@ pub struct CapabilityDescriptor {
     pub output_schema: SchemaRef,
     /// Enforced execution and payload bounds.
     pub limits: CapabilityLimits,
+    /// Host-side constraints on argument values, evaluated before dispatch.
+    #[serde(default)]
+    pub argument_policy: Vec<ArgumentRule>,
 }
 
 impl CapabilityDescriptor {
@@ -179,6 +286,7 @@ pub struct CapabilityDescriptorBuilder {
     input_schema: Option<SchemaRef>,
     output_schema: Option<SchemaRef>,
     limits: Option<CapabilityLimits>,
+    argument_policy: Vec<ArgumentRule>,
 }
 
 impl CapabilityDescriptorBuilder {
@@ -212,6 +320,13 @@ impl CapabilityDescriptorBuilder {
         self
     }
 
+    /// Set the host-side argument policy. Absent means no constraint beyond
+    /// the payload bounds in [`CapabilityLimits`].
+    pub fn argument_policy(mut self, rules: Vec<ArgumentRule>) -> Self {
+        self.argument_policy = rules;
+        self
+    }
+
     /// Validate and build the descriptor.
     pub fn build(self) -> Result<CapabilityDescriptor, CapabilityError> {
         let description = self
@@ -230,6 +345,7 @@ impl CapabilityDescriptorBuilder {
                 .output_schema
                 .ok_or(CapabilityError::MissingField("output_schema"))?,
             limits: self.limits.ok_or(CapabilityError::MissingField("limits"))?,
+            argument_policy: self.argument_policy,
         })
     }
 }
@@ -315,6 +431,7 @@ pub enum CapabilityFailureCode {
     InputDigestMismatch,
     InputTooLarge,
     InvalidInput,
+    ArgumentRefused,
     OutputTooLarge,
     Timeout,
     Canceled,
@@ -479,5 +596,116 @@ mod tests {
         let encoded = serde_json::to_string(&event).expect("serialize");
         assert!(!encoded.contains(secret));
         assert!(!encoded.contains("payload"));
+    }
+
+    fn rule(pointer: &str, constraint: ArgumentConstraint) -> ArgumentRule {
+        ArgumentRule {
+            pointer: pointer.into(),
+            constraint,
+        }
+    }
+
+    #[test]
+    fn one_of_admits_a_listed_value_and_refuses_anything_else() {
+        let rules = [rule(
+            "/destination",
+            ArgumentConstraint::OneOf {
+                values: alloc::vec!["api.example.com".into()],
+            },
+        )];
+        let ok = serde_json::json!({"destination": "api.example.com"});
+        assert!(evaluate_argument_policy(&rules, &ok).is_ok());
+
+        let bad = serde_json::json!({"destination": "attacker.example.com"});
+        let refusal = evaluate_argument_policy(&rules, &bad).expect_err("must refuse");
+        assert_eq!(refusal.pointer, "/destination");
+        assert_eq!(refusal.kind, "one_of");
+    }
+
+    #[test]
+    fn path_under_refuses_a_traversal_segment_even_below_the_prefix() {
+        let rules = [rule(
+            "/path",
+            ArgumentConstraint::PathUnder {
+                prefixes: alloc::vec!["/work/".into()],
+            },
+        )];
+        let ok = serde_json::json!({"path": "/work/report.txt"});
+        assert!(evaluate_argument_policy(&rules, &ok).is_ok());
+
+        let escape = serde_json::json!({"path": "/work/../etc/shadow"});
+        assert!(
+            evaluate_argument_policy(&rules, &escape).is_err(),
+            "a prefix match is not containment once `..` is in play"
+        );
+    }
+
+    #[test]
+    fn path_under_refuses_a_value_outside_every_prefix() {
+        let rules = [rule(
+            "/path",
+            ArgumentConstraint::PathUnder {
+                prefixes: alloc::vec!["/work/".into()],
+            },
+        )];
+        let outside = serde_json::json!({"path": "/etc/shadow"});
+        assert!(evaluate_argument_policy(&rules, &outside).is_err());
+    }
+
+    #[test]
+    fn max_len_is_inclusive_at_the_bound() {
+        let rules = [rule("/q", ArgumentConstraint::MaxLen { bytes: 4 })];
+        assert!(evaluate_argument_policy(&rules, &serde_json::json!({"q": "abcd"})).is_ok());
+        assert!(evaluate_argument_policy(&rules, &serde_json::json!({"q": "abcde"})).is_err());
+    }
+
+    #[test]
+    fn a_pointer_resolving_to_nothing_is_refused_not_skipped() {
+        let rules = [rule(
+            "/destination",
+            ArgumentConstraint::OneOf {
+                values: alloc::vec!["api.example.com".into()],
+            },
+        )];
+        let missing = serde_json::json!({"other": "api.example.com"});
+        assert!(
+            evaluate_argument_policy(&rules, &missing).is_err(),
+            "omitting the argument must not satisfy a rule about it"
+        );
+    }
+
+    #[test]
+    fn a_non_string_value_is_refused() {
+        let rules = [rule("/q", ArgumentConstraint::MaxLen { bytes: 64 })];
+        let numeric = serde_json::json!({"q": 7});
+        assert!(evaluate_argument_policy(&rules, &numeric).is_err());
+    }
+
+    #[test]
+    fn argument_policy_participates_in_the_descriptor_digest() {
+        fn build(policy: Vec<ArgumentRule>) -> CapabilityDescriptor {
+            CapabilityDescriptor::builder()
+                .id(CapabilityId::new(
+                    ServiceId::parse("host.dev.echo.v1").expect("service"),
+                    "echo",
+                )
+                .expect("capability"))
+                .description("echo")
+                .input_schema(SchemaRef::new("in.v1", [1; 32]).expect("schema"))
+                .output_schema(SchemaRef::new("out.v1", [2; 32]).expect("schema"))
+                .limits(CapabilityLimits::new(64, 64, 10).expect("limits"))
+                .argument_policy(policy)
+                .build()
+                .expect("descriptor")
+        }
+        assert_ne!(
+            build(alloc::vec![]).digest(),
+            build(alloc::vec![rule(
+                "/q",
+                ArgumentConstraint::MaxLen { bytes: 4 }
+            )])
+            .digest(),
+            "a policy outside the digest could be swapped after admission"
+        );
     }
 }

--- a/crates/mvm-hostd/src/broker/registry.rs
+++ b/crates/mvm-hostd/src/broker/registry.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 
 use mvm_contract::protocol::agent_capability::{
     CapabilityAuditEvent, CapabilityBinding, CapabilityDescriptor, CapabilityFailureCode,
-    CapabilityId, CapabilityInvocation, payload_digest,
+    CapabilityId, CapabilityInvocation, evaluate_argument_policy, payload_digest,
 };
 use mvm_contract::protocol::agent_session::AgentRequestId;
 use mvm_core::protocol::broker::{ServiceErrorCode, ServiceId};
@@ -264,6 +264,22 @@ impl Registry {
             );
             return Err(capability_error(CapabilityFailureCode::InputTooLarge));
         }
+        if let Err(refusal) =
+            evaluate_argument_policy(&registration.descriptor.argument_policy, &payload)
+        {
+            self.record_refusal(
+                &capability,
+                invocation,
+                CapabilityFailureCode::ArgumentRefused,
+            );
+            return Err(ServiceError::new(
+                ServiceErrorCode::BadRequest,
+                format!(
+                    "argument at `{}` refused by the {} policy for {}",
+                    refusal.pointer, refusal.kind, capability
+                ),
+            ));
+        }
         let replay_key = (capability.clone(), invocation.invocation_id.clone());
         let inserted = self
             .consumed_invocations
@@ -395,7 +411,9 @@ fn capability_error(code: CapabilityFailureCode) -> ServiceError {
             ServiceErrorCode::CapabilityBindingMismatch
         }
         CapabilityFailureCode::InputTooLarge => ServiceErrorCode::CapabilityInputTooLarge,
-        CapabilityFailureCode::InvalidInput => ServiceErrorCode::BadRequest,
+        CapabilityFailureCode::InvalidInput | CapabilityFailureCode::ArgumentRefused => {
+            ServiceErrorCode::BadRequest
+        }
         CapabilityFailureCode::OutputTooLarge => ServiceErrorCode::CapabilityOutputTooLarge,
         CapabilityFailureCode::Timeout => ServiceErrorCode::Timeout,
         CapabilityFailureCode::Canceled => ServiceErrorCode::CapabilityCanceled,
@@ -425,8 +443,8 @@ mod tests {
     use std::time::Duration;
 
     use mvm_contract::protocol::agent_capability::{
-        CapabilityAuditEvent, CapabilityDescriptor, CapabilityId, CapabilityInvocation,
-        CapabilityLimits, SchemaRef,
+        ArgumentConstraint, ArgumentRule, CapabilityAuditEvent, CapabilityDescriptor, CapabilityId,
+        CapabilityInvocation, CapabilityLimits, SchemaRef,
     };
     use mvm_contract::protocol::agent_session::AgentRequestId;
     use mvm_core::policy::security::AgentProfile;
@@ -1090,5 +1108,127 @@ mod tests {
             .map(|d| d.id.verb)
             .collect();
         assert_eq!(verbs, vec!["echo".to_string(), "echo2".to_string()]);
+    }
+
+    fn descriptor_with_policy(rules: Vec<ArgumentRule>) -> CapabilityDescriptor {
+        CapabilityDescriptor::builder()
+            .id(CapabilityId::new(
+                ServiceId::parse("host.dev.echo.v1").expect("service id"),
+                "echo",
+            )
+            .expect("capability id"))
+            .description("echo a bounded test value")
+            .input_schema(SchemaRef::new("host.dev.echo.input.v1", [1; 32]).expect("schema"))
+            .output_schema(SchemaRef::new("host.dev.echo.output.v1", [2; 32]).expect("schema"))
+            .limits(CapabilityLimits::new(128, 128, 50).expect("limits"))
+            .argument_policy(rules)
+            .build()
+            .expect("descriptor")
+    }
+
+    async fn dispatch_with_policy(
+        rules: Vec<ArgumentRule>,
+        payload: serde_json::Value,
+        audit: &TestAudit,
+    ) -> ServiceDispatchResult {
+        let descriptor = descriptor_with_policy(rules);
+        let binding = descriptor.binding();
+        let mut registry = Registry::new().with_capability_audit_sink(Arc::new(audit.clone()));
+        registry
+            .register_capability(Arc::new(EchoHandler), descriptor)
+            .expect("register");
+        registry
+            .admit_capabilities([binding.clone()])
+            .expect("admit");
+        let invocation = CapabilityInvocation::from_payload(
+            binding,
+            AgentRequestId::parse("typed-request-policy").expect("request id"),
+            &payload,
+        )
+        .expect("invocation");
+        registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "echo",
+                &invocation,
+                payload,
+                &CancellationToken::new(),
+            )
+            .await
+    }
+
+    #[tokio::test]
+    async fn an_argument_outside_the_policy_is_refused_before_the_handler_runs() {
+        let audit = TestAudit::default();
+        let rules = vec![ArgumentRule {
+            pointer: "/destination".into(),
+            constraint: ArgumentConstraint::OneOf {
+                values: vec!["api.example.com".into()],
+            },
+        }];
+        let err = dispatch_with_policy(
+            rules,
+            serde_json::json!({"destination": "attacker.example.com"}),
+            &audit,
+        )
+        .await
+        .expect_err("an out-of-policy argument is refused");
+
+        assert_eq!(err.code, ServiceErrorCode::BadRequest);
+        assert!(
+            err.message.contains("/destination"),
+            "the refusal names the field: {}",
+            err.message
+        );
+        assert!(
+            !err.message.contains("attacker.example.com"),
+            "a refusal that quotes the argument republishes whatever it held: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn an_in_policy_argument_still_reaches_the_handler() {
+        let audit = TestAudit::default();
+        let rules = vec![ArgumentRule {
+            pointer: "/destination".into(),
+            constraint: ArgumentConstraint::OneOf {
+                values: vec!["api.example.com".into()],
+            },
+        }];
+        let payload = serde_json::json!({"destination": "api.example.com"});
+        let out = dispatch_with_policy(rules, payload.clone(), &audit)
+            .await
+            .expect("an in-policy argument dispatches");
+        assert_eq!(out, payload);
+    }
+
+    #[tokio::test]
+    async fn a_policy_refusal_is_audited_without_the_argument_value() {
+        let audit = TestAudit::default();
+        let rules = vec![ArgumentRule {
+            pointer: "/path".into(),
+            constraint: ArgumentConstraint::PathUnder {
+                prefixes: vec!["/work/".into()],
+            },
+        }];
+        dispatch_with_policy(rules, serde_json::json!({"path": "/etc/shadow"}), &audit)
+            .await
+            .expect_err("refused");
+
+        let events = audit.0.lock().expect("audit mutex");
+        let refused = events
+            .iter()
+            .any(|e| matches!(e, CapabilityAuditEvent::Refused { code, .. } if *code == CapabilityFailureCode::ArgumentRefused));
+        assert!(
+            refused,
+            "the refusal is evidence, so it is recorded: {events:?}"
+        );
+        let rendered = format!("{events:?}");
+        assert!(
+            !rendered.contains("/etc/shadow"),
+            "audit carries the code, never the value: {rendered}"
+        );
     }
 }

--- a/crates/mvm-hostd/src/broker/registry.rs
+++ b/crates/mvm-hostd/src/broker/registry.rs
@@ -2,9 +2,11 @@
 //! `ServiceCall` to the right [`ServiceHandler`].
 //!
 //! The registry starts with zero handlers registered (every call
-//! returns `Err(NotBound)`); `host.time.v1`, the `host.cost.v1`
-//! workload verb, and the `broker.v1/list_services` introspection verb
-//! wire in their handlers via [`Registry::register`].
+//! returns `Err(NotBound)`); `host.time.v1` and the `host.cost.v1`
+//! workload verb wire in their handlers via [`Registry::register`].
+//!
+//! [`Registry::admitted_catalog`] is the only projection of this state a
+//! guest may be shown.
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -158,6 +160,30 @@ impl Registry {
             descriptor_digest,
         });
         Ok(())
+    }
+
+    /// The capability set a guest may be shown: those registered here whose
+    /// descriptor still digests to what the host-signed admission bound.
+    ///
+    /// The intersection carries the weight. A registration is local to this
+    /// subprocess and can drift; an admission is signed and derives from the
+    /// workload's plan. Projecting the registered set instead would let a
+    /// local registration advertise authority the plan never granted, which
+    /// inverts the direction the binding model depends on.
+    #[must_use]
+    pub fn admitted_catalog(&self) -> Vec<CapabilityDescriptor> {
+        let mut catalog: Vec<CapabilityDescriptor> = self
+            .capabilities
+            .iter()
+            .filter(|(id, registration)| {
+                self.admitted
+                    .get(*id)
+                    .is_some_and(|admitted| *admitted == registration.descriptor.digest())
+            })
+            .map(|(_, registration)| registration.descriptor.clone())
+            .collect();
+        catalog.sort_by_key(|descriptor| descriptor.id.to_string());
+        catalog
     }
 
     /// Dispatch a call. Returns `Err(NotBound)` for any service not in
@@ -959,5 +985,110 @@ mod tests {
             !registry.is_empty(),
             "a registry holding a handler is not empty"
         );
+    }
+
+    fn descriptor_named(verb: &str, description: &str) -> CapabilityDescriptor {
+        CapabilityDescriptor::builder()
+            .id(CapabilityId::new(
+                ServiceId::parse("host.dev.echo.v1").expect("service id"),
+                verb,
+            )
+            .expect("capability id"))
+            .description(description)
+            .input_schema(SchemaRef::new("host.dev.echo.input.v1", [1; 32]).expect("schema"))
+            .output_schema(SchemaRef::new("host.dev.echo.output.v1", [2; 32]).expect("schema"))
+            .limits(CapabilityLimits::new(128, 128, 50).expect("limits"))
+            .build()
+            .expect("descriptor")
+    }
+
+    #[test]
+    fn the_catalog_is_admitted_intersected_with_registered() {
+        let mut registry = Registry::new();
+        let d = descriptor();
+        registry
+            .register_capability(Arc::new(EchoHandler), d.clone())
+            .expect("register");
+        registry.admit_capabilities([d.binding()]).expect("admit");
+
+        let catalog = registry.admitted_catalog();
+        assert_eq!(
+            catalog,
+            vec![d],
+            "an admitted, registered capability is shown"
+        );
+    }
+
+    #[test]
+    fn a_registered_capability_that_was_not_admitted_is_invisible() {
+        let mut registry = Registry::new();
+        registry
+            .register_capability(Arc::new(EchoHandler), descriptor())
+            .expect("register");
+
+        assert!(
+            registry.admitted_catalog().is_empty(),
+            "registration is local to this subprocess; only a signed admission may show a tool"
+        );
+    }
+
+    #[test]
+    fn an_admitted_capability_with_no_registered_handler_is_invisible() {
+        let mut registry = Registry::new();
+        registry
+            .admit_capabilities([descriptor().binding()])
+            .expect("admit");
+
+        assert!(
+            registry.admitted_catalog().is_empty(),
+            "a tool with nothing to dispatch to is not a tool"
+        );
+    }
+
+    #[test]
+    fn a_descriptor_that_drifted_from_its_admitted_digest_is_invisible() {
+        let mut registry = Registry::new();
+        let admitted = descriptor_named("echo", "echo a bounded test value");
+        let registered = descriptor_named("echo", "echo a bounded test value, but wider");
+        assert_ne!(
+            admitted.digest(),
+            registered.digest(),
+            "the fixture must actually differ or this test proves nothing"
+        );
+
+        registry
+            .register_capability(Arc::new(EchoHandler), registered)
+            .expect("register");
+        registry
+            .admit_capabilities([admitted.binding()])
+            .expect("admit");
+
+        assert!(
+            registry.admitted_catalog().is_empty(),
+            "a registration may not advertise a descriptor the admission never bound"
+        );
+    }
+
+    #[test]
+    fn the_catalog_is_ordered_deterministically() {
+        let mut registry = Registry::new();
+        let second = descriptor_named("echo2", "a second verb");
+        let first = descriptor_named("echo", "the first verb");
+        registry
+            .register_capability(Arc::new(EchoHandler), second.clone())
+            .expect("register second");
+        registry
+            .register_capability(Arc::new(EchoHandler), first.clone())
+            .expect("register first");
+        registry
+            .admit_capabilities([second.binding(), first.binding()])
+            .expect("admit");
+
+        let verbs: Vec<String> = registry
+            .admitted_catalog()
+            .into_iter()
+            .map(|d| d.id.verb)
+            .collect();
+        assert_eq!(verbs, vec!["echo".to_string(), "echo2".to_string()]);
     }
 }

--- a/crates/mvm-hostd/src/broker/registry.rs
+++ b/crates/mvm-hostd/src/broker/registry.rs
@@ -23,6 +23,22 @@ use mvm_core::protocol::handler::{
     ServiceCallCtx, ServiceDispatchResult, ServiceError, ServiceHandler,
 };
 
+/// How many times one unbound name may be refused with a teaching message
+/// before further attempts are answered tersely.
+///
+/// A planner that has been told its surface and keeps calling the same absent
+/// name is in a loop, and each attempt costs a dispatch and an audit line.
+const MAX_UNBOUND_ATTEMPTS_PER_NAME: u32 = 8;
+
+/// How many distinct refused names are tracked at once.
+///
+/// The counter is keyed by a guest-supplied string, so the counter is itself
+/// an exhaustion surface: a guest enumerating names would otherwise grow this
+/// map without bound. Past the cap, untracked names are answered as
+/// rate-bounded rather than admitted to the map — enumeration on a workload
+/// whose real catalog is a handful of entries is already pathological.
+const MAX_TRACKED_REFUSAL_NAMES: usize = 64;
+
 /// Minimal cancellation primitive for one host-side capability invocation.
 #[derive(Clone, Default)]
 pub struct CancellationToken {
@@ -80,6 +96,7 @@ pub struct Registry {
     capabilities: HashMap<CapabilityId, CapabilityRegistration>,
     admitted: HashMap<CapabilityId, [u8; 32]>,
     consumed_invocations: std::sync::Mutex<HashSet<(CapabilityId, AgentRequestId)>>,
+    refusal_counts: std::sync::Mutex<HashMap<String, u32>>,
     audit: Arc<dyn CapabilityAuditSink>,
 }
 
@@ -90,6 +107,7 @@ impl Registry {
             capabilities: HashMap::new(),
             admitted: HashMap::new(),
             consumed_invocations: std::sync::Mutex::new(HashSet::new()),
+            refusal_counts: std::sync::Mutex::new(HashMap::new()),
             audit: Arc::new(NoopCapabilityAuditSink),
         }
     }
@@ -186,6 +204,61 @@ impl Registry {
         catalog
     }
 
+    /// Render the admitted catalog as a refusal suffix.
+    ///
+    /// A refusal that only says "no" leaves a planner guessing, and a guessing
+    /// planner retries. Naming the surface it *does* have turns the wall into
+    /// a fact it can plan around. This discloses nothing: the catalog is the
+    /// projection of the workload's own admission.
+    fn surface_hint(&self) -> String {
+        let names: Vec<String> = self
+            .admitted_catalog()
+            .into_iter()
+            .map(|descriptor| descriptor.id.to_string())
+            .collect();
+        if names.is_empty() {
+            "this workload has no capabilities bound".to_string()
+        } else {
+            format!("bound capabilities: {}", names.join(", "))
+        }
+    }
+
+    /// Count one refusal of `name` and say whether to keep teaching.
+    ///
+    /// Returns `true` while the caller should still receive the surface hint.
+    fn should_still_teach(&self, name: &str) -> bool {
+        let mut counts = self.refusal_counts.lock().expect("refusal mutex");
+        if let Some(count) = counts.get_mut(name) {
+            *count = count.saturating_add(1);
+            return *count <= MAX_UNBOUND_ATTEMPTS_PER_NAME;
+        }
+        if counts.len() < MAX_TRACKED_REFUSAL_NAMES {
+            counts.insert(name.to_string(), 1);
+            return true;
+        }
+        // The map is full. Refuse tersely rather than admit another
+        // guest-chosen key; see MAX_TRACKED_REFUSAL_NAMES.
+        false
+    }
+
+    /// Build a refusal that teaches while that is still useful, and stays
+    /// terse once the caller has demonstrably stopped listening.
+    fn teaching_refusal(
+        &self,
+        code: ServiceErrorCode,
+        subject: &str,
+        detail: String,
+    ) -> ServiceError {
+        if self.should_still_teach(subject) {
+            ServiceError::new(code, format!("{detail}; {}", self.surface_hint()))
+        } else {
+            ServiceError::new(
+                code,
+                format!("{detail}; further attempts on `{subject}` are rate-bounded"),
+            )
+        }
+    }
+
     /// Dispatch a call. Returns `Err(NotBound)` for any service not in
     /// the registry. Per-handler `parse_payload` (gate 5) happens
     /// inside the handler's `dispatch`; the registry just routes.
@@ -197,8 +270,9 @@ impl Registry {
         payload: serde_json::Value,
     ) -> ServiceDispatchResult {
         let Some(handler) = self.handlers.get(service) else {
-            return Err(ServiceError::new(
+            return Err(self.teaching_refusal(
                 ServiceErrorCode::NotBound,
+                &service.to_string(),
                 format!(
                     "service `{}` not bound to workload `{}`",
                     service, ctx.workload_id
@@ -224,8 +298,17 @@ impl Registry {
             Ok(capability) => capability,
             Err(_) => return Err(capability_error(CapabilityFailureCode::ProtocolMismatch)),
         };
+        // Both misses below are surface-discovery failures rather than
+        // malformed requests, so they teach: see `teaching_refusal`.
         let Some(registration) = self.capabilities.get(&capability) else {
-            return Err(capability_error(CapabilityFailureCode::NotRegistered));
+            return Err(self.teaching_refusal(
+                ServiceErrorCode::NotBound,
+                &capability.to_string(),
+                format!(
+                    "typed capability request refused: {:?}",
+                    CapabilityFailureCode::NotRegistered
+                ),
+            ));
         };
         let Some(admitted_digest) = self.admitted.get(&capability) else {
             self.record_refusal(
@@ -233,7 +316,14 @@ impl Registry {
                 invocation,
                 CapabilityFailureCode::AdmissionDenied,
             );
-            return Err(capability_error(CapabilityFailureCode::AdmissionDenied));
+            return Err(self.teaching_refusal(
+                ServiceErrorCode::CapabilityDenied,
+                &capability.to_string(),
+                format!(
+                    "typed capability request refused: {:?}",
+                    CapabilityFailureCode::AdmissionDenied
+                ),
+            ));
         };
         if *admitted_digest != invocation.binding.descriptor_digest
             || !invocation.binding.matches(&registration.descriptor)
@@ -1229,6 +1319,139 @@ mod tests {
         assert!(
             !rendered.contains("/etc/shadow"),
             "audit carries the code, never the value: {rendered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unbound_call_names_what_the_workload_does_have() {
+        let mut registry = Registry::new();
+        let d = descriptor();
+        registry
+            .register_capability(Arc::new(EchoHandler), d.clone())
+            .expect("register");
+        registry.admit_capabilities([d.binding()]).expect("admit");
+
+        let err = registry
+            .dispatch(
+                &ctx(),
+                &ServiceId::parse("host.time.v1").unwrap(),
+                "now",
+                serde_json::json!({}),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, ServiceErrorCode::NotBound);
+        assert!(
+            err.message.contains("host.dev.echo.v1::echo"),
+            "a refusal that does not say what IS available teaches nothing: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unbound_call_with_an_empty_catalog_says_so_plainly() {
+        let registry = Registry::new();
+        let err = registry
+            .dispatch(
+                &ctx(),
+                &ServiceId::parse("host.time.v1").unwrap(),
+                "now",
+                serde_json::json!({}),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.message.contains("no capabilities"),
+            "an empty catalog is a statement, not an empty list: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_unbound_calls_to_one_name_become_rate_bounded() {
+        let registry = Registry::new();
+        let svc = ServiceId::parse("host.time.v1").unwrap();
+        let mut saw_rate_bound = false;
+        for _ in 0..(MAX_UNBOUND_ATTEMPTS_PER_NAME + 2) {
+            let err = registry
+                .dispatch(&ctx(), &svc, "now", serde_json::json!({}))
+                .await
+                .unwrap_err();
+            if err.message.contains("rate-bounded") {
+                saw_rate_bound = true;
+            }
+        }
+        assert!(
+            saw_rate_bound,
+            "a model retrying one unbound name forever is a denial of service"
+        );
+    }
+
+    #[tokio::test]
+    async fn refusal_tracking_cannot_be_grown_without_bound() {
+        let registry = Registry::new();
+        for i in 0..(MAX_TRACKED_REFUSAL_NAMES * 3) {
+            let svc = ServiceId::parse(format!("host.enum{i}.v1")).expect("service");
+            let _ = registry
+                .dispatch(&ctx(), &svc, "now", serde_json::json!({}))
+                .await;
+        }
+        let tracked = registry.refusal_counts.lock().expect("refusal mutex").len();
+        assert!(
+            tracked <= MAX_TRACKED_REFUSAL_NAMES,
+            "a counter keyed by a guest-supplied name is itself a memory exhaustion \
+             surface; tracked {tracked}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_bound_call_is_unaffected_by_refusal_tracking() {
+        let mut registry = Registry::new();
+        registry.register(Arc::new(EchoHandler));
+        let svc = ServiceId::parse("host.dev.echo.v1").unwrap();
+        for _ in 0..(MAX_UNBOUND_ATTEMPTS_PER_NAME + 5) {
+            registry
+                .dispatch(&ctx(), &svc, "echo", serde_json::json!({"k": "v"}))
+                .await
+                .expect("a bound call never becomes rate-bounded");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_typed_call_to_an_unregistered_capability_names_the_surface() {
+        let mut registry = Registry::new();
+        let d = descriptor();
+        registry
+            .register_capability(Arc::new(EchoHandler), d.clone())
+            .expect("register");
+        registry.admit_capabilities([d.binding()]).expect("admit");
+
+        let payload = serde_json::json!({});
+        let invocation = CapabilityInvocation::from_payload(
+            d.binding(),
+            AgentRequestId::parse("typed-absent-verb").expect("request id"),
+            &payload,
+        )
+        .expect("invocation");
+
+        let err = registry
+            .dispatch_capability(
+                &ctx(),
+                &ServiceId::parse("host.dev.echo.v1").expect("service"),
+                "absent",
+                &invocation,
+                payload,
+                &CancellationToken::new(),
+            )
+            .await
+            .expect_err("an unregistered verb is refused");
+
+        assert!(
+            err.message.contains("host.dev.echo.v1::echo"),
+            "the typed path is the real one; its refusal must teach too: {}",
+            err.message
         );
     }
 }


### PR DESCRIPTION
WS1, WS2 and WS4 of `specs/plans/2026-08-18-agent-tool-and-memory-planes.md`. Implements ADR-045 §18–19 for the host-mediated tool surface.

## WS1 — the catalog derives from the signed admission

A registry holds two things that are easy to confuse: handlers registered by this subprocess, and capabilities admitted by the workload's host-signed plan. Nothing projected either to a guest, so there was no catalog at all.

`Registry::admitted_catalog()` is that projection, and it is the **intersection**: a capability appears only if it is registered here *and* its descriptor still digests to what the admission bound. A registration is local to the subprocess and can drift; an admission is signed. Projecting the registered set would let a local registration advertise authority the plan never granted, which is the binding model pointed backwards.

The drift case is the one worth having: a descriptor that no longer matches its admitted digest is *invisible* rather than merely unusable, so a guest is never shown a tool whose call would be refused. Removing the digest comparison fails that test and no other.

## WS2 — arguments are constrained beside the binding gate

Binding decided which capability a workload may call. Nothing decided what it may pass. Size and timeout were already bounded centrally by `CapabilityLimits`, but semantic constraints lived behind each handler's own `parse_payload` — so a bound capability with an unconstrained argument was effectively unbound: the gate named the verb and let the destination, the path and the length through.

`CapabilityDescriptor` gains an argument policy — a closed vocabulary of `OneOf`, `PathUnder` and `MaxLen` bound to RFC 6901 pointers — evaluated in `dispatch_capability` alongside the binding, digest and size gates, and ahead of replay consumption so a refused call does not burn its invocation id.

- The policy sits **inside the descriptor digest**, so it cannot be swapped after admission without breaking the binding.
- A pointer that resolves to nothing **refuses rather than passes** — a rule about an argument must not be satisfied by omitting it.
- A refusal names the pointer and rule kind but **never the value**, because refusals are audited and an audited refusal that quotes the argument republishes whatever it held.

`PathUnder` rejects any `..` segment rather than trusting the prefix match, since a prefix match stops being containment the moment traversal is allowed.

## WS4 — a refusal teaches instead of ending the turn

A planner told only "not bound" has learned nothing actionable, so it guesses again — and the guesses look exactly like the enumeration attack the refusal exists to stop. WS1's catalog is the answer: name what the workload *does* have. This discloses nothing new, since the catalog is the projection of that workload's own admission.

Applied to the typed path as well as the untyped one. `NotRegistered` and `AdmissionDenied` teach; `BindingMismatch` and `Replay` deliberately do not, because those are not surface-discovery failures.

Bounding the retry loop needs a per-name refusal counter, which introduces its own problem: the counter is keyed by a guest-supplied string, so it is an exhaustion surface. Distinct tracked names are capped, and past the cap an untracked name is refused tersely rather than admitted to the map.

## Note

The registry module header claimed it wired in a `broker.v1/list_services` introspection verb. That verb appears nowhere in the workspace and never did; the header now points at the real projection.

## Verification

`12386/12386` workspace tests, `just check-gated`, doctests, and workspace clippy at `-D warnings` via the pre-commit hook. The new `CapabilityFailureCode` variant is why this needed a full-workspace run rather than `-p`.

Four guards are mutation-checked — the catalog digest comparison, the argument-policy evaluation, the per-name rate bound, and the refusal-map cap. Each fails its own test and no other.

Plan checkboxes for WS1/WS2/WS4 are ticked in a follow-up, to avoid colliding with #2704 which is editing that same file.