### PR TITLE
fix(nix): carry runtimeLean into the default-microvm sidecar

### DIFF
--- a/nix/images/default-tenant/flake.nix
+++ b/nix/images/default-tenant/flake.nix
@@ -105,7 +105,8 @@
         builtins.toJSON {
           inherit (mvm)
             name accessible sealed entrypointKind initSystem
-            expectedBootMs agentBinary rootlessEntrypoint hypervisor overlayAware;
+            expectedBootMs agentBinary rootlessEntrypoint hypervisor overlayAware
+            runtimeLean;
           imageTag = bootImageTag;
           source = "built-local";
           builtAt = "";

--- a/nix/tests/mk-guest-eval.nix
+++ b/nix/tests/mk-guest-eval.nix
@@ -196,6 +196,17 @@ in
   # before the boot regression surfaces, giving CI a tight signal
   # for the load-bearing invariant.
 
+  # A rootfs that claims `overlayAware` without `runtimeLean` is refused at
+  # boot: required-overlay boots must omit the baked agent fallback, so the
+  # contract cannot silently degrade. The two fields therefore have to travel
+  # together — the default-microvm sidecar once inherited only the first, and
+  # the boot gate rejected every published image as a result.
+  runtime_lean_travels_with_overlay_aware_on_shell =
+    (meta shellGuest).runtimeLean == (meta shellGuest).overlayAware;
+  runtime_lean_travels_with_overlay_aware_on_command =
+    (meta commandGuest).runtimeLean == (meta commandGuest).overlayAware;
+  runtime_lean_travels_with_overlay_aware_on_services =
+    (meta servicesGuest).runtimeLean == (meta servicesGuest).overlayAware;
   overlay_aware_metadata_set_on_shell = (meta shellGuest).overlayAware == true;
   overlay_aware_metadata_set_on_command = (meta commandGuest).overlayAware == true;
   overlay_aware_metadata_set_on_services = (meta servicesGuest).overlayAware == true;

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -1574,3 +1574,41 @@ fn default_tenant_exports_and_ci_counts_the_rootfs_closure() {
         "the footprint CI gate must consume the exported closure inventory"
     );
 }
+
+/// The published boot image's sidecar must carry every field the boot gate
+/// reads, not just some of them.
+///
+/// `mvm-meta.json` for the default microVM is projected from `passthru.mvm` by
+/// an explicit `inherit` list in `nix/images/default-tenant/flake.nix`. A field
+/// missing from that list is absent from the JSON, and an absent field reads as
+/// `false` — so omitting one silently inverts its meaning rather than failing.
+///
+/// That is not hypothetical: the list once carried `overlayAware` without
+/// `runtimeLean`, so every published image claimed to require the runtime
+/// overlay while also claiming to carry a baked agent fallback. The
+/// required-overlay gate refused it, and `release-boot-image` failed on every
+/// tag push — the release could not be cut at all.
+#[test]
+fn default_microvm_sidecar_carries_every_field_the_boot_gate_reads() {
+    let flake = fs::read_to_string(nix_dir().join("images/default-tenant/flake.nix"))
+        .expect("read default-tenant flake");
+    let sidecar = flake
+        .split_once("sidecarJson = mvm:")
+        .expect("default-tenant flake defines sidecarJson")
+        .1
+        .split_once("};")
+        .expect("sidecarJson body is brace-terminated")
+        .0;
+
+    // The two fields the required-overlay admission gate reads
+    // (`mvm_vmm::host::runtime_meta`). They describe one decision — whether the
+    // rootfs omits the baked agent fallback — so they have to travel together.
+    for field in ["overlayAware", "runtimeLean"] {
+        assert!(
+            sidecar.contains(field),
+            "default-tenant sidecarJson omits `{field}`; an absent field reads as \
+             false, so the published image would misdescribe its own boot contract \
+             and the required-overlay gate would refuse to boot it"
+        );
+    }
+}


### PR DESCRIPTION
## Why the boot image cannot be published

`release-boot-image` has failed on **every tag push today** — 07:07, 11:54 and 17:22. So `boot-image/v0.1.0` exists as a git tag but not as a release, and "Boot latency ceiling" is consequently red on every PR in the repo.

Re-pushing the tag would not have helped. The build is broken.

## One field, missing from one list

`mvm-meta.json` for the default microVM is projected from `passthru.mvm` by an explicit `inherit` list in `nix/images/default-tenant/flake.nix`:

```nix
inherit (mvm)
  name accessible sealed entrypointKind initSystem
  expectedBootMs agentBinary rootlessEntrypoint hypervisor overlayAware;
```

`mkGuest` sets **both** `overlayAware = true` and `runtimeLean = true`. The projection carried only the first.

An absent field reads as `false` (`missing runtimeLean field must default to false`), so this doesn't fail loudly — it **inverts the field's meaning**. Every published image claimed to require the runtime overlay while also claiming to carry a baked agent fallback.

The required-overlay gate refused precisely that combination, which is the gate doing its job:

```
refusing to start VM: rootfs at staging is marked `overlayAware: true` but not
`runtimeLean: true` in its `mvm-meta.json` sidecar. Required-overlay boots must use
a rootfs that intentionally omits the baked `/usr/local/bin/mvm-guest-agent` +
`mvm-guest-netinit` fallback so the boot contract cannot silently degrade.
```

## A related gap worth noting separately

On the same run, `default-microvm (aarch64)` reported **success** while `default-microvm (x86_64)` failed on this. The boot gate is x86_64-only — arm64 runners have no nested KVM and cannot boot a guest at all, which `release-boot-image.yml` already documents.

So half the release matrix publishes unverified. That is a stated compromise rather than a defect, but it means an aarch64-only regression of this exact kind would ship. Not addressed here.

## Where the guard goes

Not where the field is set. The existing `nix/tests/mk-guest-eval.nix` assertions cover `passthru.mvm`, which was **already correct** — guarding harder there would have caught nothing.

The new test reads the flake's `sidecarJson` body directly and requires every field the boot gate reads, so it fails at the projection, which is where the field was lost. Mutation-tested — restoring the omission fails it with the field name and the consequence:

```
default-tenant sidecarJson omits `runtimeLean`; an absent field reads as false,
so the published image would misdescribe its own boot contract and the
required-overlay gate would refuse to boot it
```

Eval assertions are also added to `mk-guest-eval.nix` requiring `runtimeLean` and `overlayAware` to agree, since they describe one decision.

## After this merges

The release still needs a trigger. The tag already points at current-ish main, so a plain re-push is a no-op; it needs deleting and re-pushing, or a `workflow_dispatch` with `dry_run=false`.

## Verification

`cargo nextest run -E 'test(default_microvm_sidecar)'` and `test(mk_guest_eval)` pass (host `nix` present, so the eval assertions really evaluated). `cargo +nightly fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.