### PR TITLE
fix(guest): an abandoned readiness probe is not a failed authentication

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
@@ -171,6 +171,20 @@ fn handle_client(
     let mut session =
         match AuthenticatedSession::guest(&mut file, guest_signing_key.clone(), &host_signer_key) {
             Ok(session) => session,
+            // A peer that hangs up part-way through the handshake did not fail
+            // to authenticate — it produced no signature at all, and the read
+            // hit end-of-stream. On this socket that is the host's readiness
+            // poll, which connects on a backoff while the guest boots and drops
+            // each probe once it has its answer. Reporting it as a failed
+            // authentication put a security-relevant line on every healthy
+            // boot, which is how a real one gets skipped.
+            Err(error) if error.is_peer_hangup() => {
+                eprintln!(
+                    "mvm-guest-agent: control peer disconnected before completing the \
+                     handshake (readiness probe); no session opened"
+                );
+                return;
+            }
             Err(error) => {
                 eprintln!("mvm-guest-agent: authenticated control handshake failed: {error}");
                 return;

--- a/crates/mvm-agentd/src/vsock/framing.rs
+++ b/crates/mvm-agentd/src/vsock/framing.rs
@@ -8,7 +8,7 @@ use std::os::unix::net::UnixStream;
 use super::*;
 use anyhow::{Context, Result, bail};
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
-use mvm_core::net::session::{SealedFrame, Session};
+use mvm_core::net::session::{SealedFrame, Session, SessionError};
 use mvm_core::security::{
     AuthenticatedFrame, PROTOCOL_VERSION_AUTHENTICATED, SIG_ALG_ED25519, SessionHello,
     SessionHelloAck,
@@ -351,13 +351,19 @@ impl AuthenticatedSession {
     }
 
     /// Establish a guest session and require the host identity to match `anchor`.
+    ///
+    /// The error is returned typed rather than flattened into `anyhow`, because
+    /// one of its cases is not a failure to authenticate: a peer that hangs up
+    /// mid-handshake produced no bad signature and no wrong identity, and on
+    /// the control socket that is the host's readiness poll. Callers separate
+    /// the two with [`SessionError::is_peer_hangup`]; flattening the type here
+    /// left the agent nothing to branch on but the message text.
     pub fn guest<S: Read + Write>(
         stream: &mut S,
         signing_key: SigningKey,
         anchor: &VerifyingKey,
-    ) -> Result<Self> {
-        let (inner, _session_id) = Session::guest(stream, signing_key, anchor)
-            .map_err(|error| anyhow::anyhow!("guest session handshake failed: {error}"))?;
+    ) -> std::result::Result<Self, SessionError> {
+        let (inner, _session_id) = Session::guest(stream, signing_key, anchor)?;
         Ok(Self { inner })
     }
 
@@ -837,5 +843,34 @@ mod tests {
         // This is correct: we verify the guest controls the key it claims.
         let result = host_handle.join().unwrap();
         assert!(result.is_ok());
+    }
+
+    /// The reported bug, reproduced at the seam it comes from.
+    ///
+    /// A peer that connects and goes away without sending anything is exactly
+    /// what `wait_for_agent` does while the guest boots — it probes on a
+    /// backoff and drops each stream. The guest must classify that as a
+    /// vanished peer, not as a failed authentication, or every healthy boot
+    /// logs a security-relevant failure.
+    #[test]
+    fn a_peer_that_sends_nothing_is_a_hangup_not_an_auth_failure() {
+        use std::io::Cursor;
+
+        let guest_key = SigningKey::from_bytes(&[7u8; 32]);
+        let host_anchor = SigningKey::from_bytes(&[9u8; 32]).verifying_key();
+
+        // Reads hit end-of-stream immediately: the peer is gone.
+        let mut vanished = Cursor::new(Vec::new());
+        // `AuthenticatedSession` holds key material and deliberately has no
+        // `Debug`, so unwrap the Result by hand rather than deriving one.
+        let err = match AuthenticatedSession::guest(&mut vanished, guest_key, &host_anchor) {
+            Ok(_) => panic!("no handshake can complete against a peer that sent nothing"),
+            Err(e) => e,
+        };
+
+        assert!(
+            err.is_peer_hangup(),
+            "an abandoned probe must not read as an authentication failure: {err}"
+        );
     }
 }

--- a/crates/mvm-core/src/net/session.rs
+++ b/crates/mvm-core/src/net/session.rs
@@ -75,6 +75,34 @@ pub enum SessionError {
     Io(#[from] std::io::Error),
 }
 
+impl SessionError {
+    /// Whether the peer went away rather than failed to authenticate.
+    ///
+    /// These are different events and only one of them is security-relevant. A
+    /// peer that disconnects part-way through the handshake produced no bad
+    /// signature, no wrong identity and no replayed sequence — it produced
+    /// nothing, and the read hit end-of-stream. On the guest's control socket
+    /// that is the ordinary shape of the host's readiness poll, which connects
+    /// on a backoff while the guest boots and drops each probe it has finished
+    /// with.
+    ///
+    /// Callers use this to keep "someone tried to authenticate and failed"
+    /// meaning what it says. A failure that fires on every healthy boot trains
+    /// its audience to skip the line, and the next real one arrives to an
+    /// audience that already knows to.
+    pub fn is_peer_hangup(&self) -> bool {
+        let Self::Io(e) = self else {
+            return false;
+        };
+        matches!(
+            e.kind(),
+            std::io::ErrorKind::UnexpectedEof
+                | std::io::ErrorKind::BrokenPipe
+                | std::io::ErrorKind::ConnectionReset
+        )
+    }
+}
+
 impl From<anyhow::Error> for SessionError {
     fn from(value: anyhow::Error) -> Self {
         // Preserve the most common case as a generic variant; callers that
@@ -1146,5 +1174,51 @@ mod tests {
             },
             SessionRole::Host,
         )
+    }
+
+    /// The whole point of the predicate is what it refuses to classify. A
+    /// signature that did not verify, an identity that did not match, a
+    /// replayed sequence — those are the events the log line exists for, and
+    /// none of them may be quietly reclassified as "the peer went away".
+    #[test]
+    fn only_a_vanished_peer_counts_as_a_hangup() {
+        use std::io::ErrorKind;
+
+        for kind in [
+            ErrorKind::UnexpectedEof,
+            ErrorKind::BrokenPipe,
+            ErrorKind::ConnectionReset,
+        ] {
+            assert!(
+                SessionError::Io(std::io::Error::from(kind)).is_peer_hangup(),
+                "{kind:?} is a peer that went away"
+            );
+        }
+
+        // Other I/O failures are real failures: the peer is still there and
+        // something else broke.
+        for kind in [ErrorKind::PermissionDenied, ErrorKind::InvalidData] {
+            assert!(
+                !SessionError::Io(std::io::Error::from(kind)).is_peer_hangup(),
+                "{kind:?} is not a hangup"
+            );
+        }
+
+        // Every authentication failure stays an authentication failure.
+        for err in [
+            SessionError::PeerIdentityMismatch("wrong key".into()),
+            SessionError::SignatureVerificationFailed("bad sig".into()),
+            SessionError::Replay {
+                got: 1,
+                expected: 9,
+            },
+            SessionError::UnsupportedVersion { got: 9, want: 1 },
+            SessionError::InvalidHandshake("truncated".into()),
+        ] {
+            assert!(
+                !err.is_peer_hangup(),
+                "{err} must not be reclassified as a hangup"
+            );
+        }
     }
 }


### PR DESCRIPTION
Addresses the first ask of #2633: *identify what connects to the control socket
and abandons the handshake.*

## It is our own readiness poll

`wait_for_agent_timed` (`crates/mvm-cli/src/exec.rs`) connects to
`GUEST_AGENT_PORT` on a backoff while the guest boots. Three facts from that
function's own comments make it the peer:

- *"the VMM binds the agent port before the guest kernel starts"* — so
  `connect()` succeeds for the whole of boot, including before the agent serves.
- each attempt sets a **3 second read timeout**, deliberately, so a
  still-booting guest cannot block the loop past its deadline.
- *"The stream is a throwaway probe (dropped below)"* — the host hangs up.

The guest accepts one of those and reads EOF mid-handshake.
`failed to fill whole buffer` is `read_exact` hitting end-of-stream, which is
exactly that.

#2633 already established this is not on the launch critical path. The cost is
that **every healthy boot logs a security-relevant failure** — the worst kind of
log line, because it trains its audience to skip it, and the next real
authentication failure arrives to an audience that already knows to.

## The change

A peer that hangs up part-way through produced no bad signature, no wrong
identity and no replayed sequence. It produced nothing.

`SessionError::is_peer_hangup` draws that line — `UnexpectedEof`, `BrokenPipe`,
`ConnectionReset` — and the agent says what actually happened:

```
mvm-guest-agent: control peer disconnected before completing the handshake
  (readiness probe); no session opened
```

`AuthenticatedSession::guest` now returns `SessionError` rather than flattening
into `anyhow`, because flattening left callers nothing to branch on but the
message text.

## Witnesses

The load-bearing one is negative. Reclassifying a real failure as a hangup is
the only way this change could do harm, so that is what it pins:
`only_a_vanished_peer_counts_as_a_hangup` asserts identity mismatch, signature
verification failure, replay, unsupported version and malformed handshake all
stay failures, and that `PermissionDenied`/`InvalidData` do too — only a
vanished peer qualifies.

`a_peer_that_sends_nothing_is_a_hangup_not_an_auth_failure` reproduces the bug
end to end: a stream that EOFs immediately, which is what an abandoned probe
looks like from the guest, classifies as a hangup.

## Not in this PR

The second half of #2633 — `machine run -d` attaching no FlowMux identity drive
— is a separate question: whether that path is incomplete, or the message is
wrong about needing one. #2633 stays open for it.

`cargo test -p mvm-core --lib net::session` 15/15, `-p mvm-agentd --lib
vsock::framing` 12/12, workspace clippy `--all-targets -D warnings` clean.