### PR TITLE
feat(assurance): run a declared campaign from the client launch path

### DIFF
--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -186,6 +186,10 @@ pub(crate) struct BootParams {
     /// The request's permission set, carried into the signed plan and — for
     /// its egress dimension — into the policy the gate enforces.
     pub(crate) grants: Option<mvm_contract::grants::Grants>,
+    /// Path to an operator-authored campaign declaration, when one was asked
+    /// for. Read and validated here, so a malformed declaration refuses the
+    /// launch instead of producing a boot with no campaign on it.
+    pub(crate) assurance_campaign: Option<std::path::PathBuf>,
 }
 
 impl LocalBackend {
@@ -253,7 +257,7 @@ impl LocalBackend {
             backend_name: backend.name().to_string(),
             volumes: params.volumes,
             destroy_on_exit: params.transient,
-            grants: params.grants,
+            grants: params.grants.clone(),
         };
 
         // A fresh per-launch ledger: local launches are one-shot from this
@@ -262,7 +266,26 @@ impl LocalBackend {
         // at the configured keys dir.
         let ledger = InMemoryNonceLedger::new();
         let clock = SystemClock;
-        let emitter = build_audit_emitter();
+        let emitter = build_audit_emitter().map(std::sync::Arc::new);
+
+        // Read the declaration before the boot: a campaign an operator asked
+        // for and that turns out to be malformed must refuse the launch, not
+        // produce a running workload with no campaign attached to it.
+        let campaign = match (&params.assurance_campaign, &emitter) {
+            (Some(path), Some(emitter)) => Some(
+                Self::build_campaign(path, emitter, &backend, params.grants.as_ref())
+                    .map_err(|e| crate::local::backend_err(format!("{e:#}")))?,
+            ),
+            (Some(_), None) => {
+                return Err(crate::local::backend_err(
+                    "an assurance campaign was declared but this process writes no audit chain, \
+                     so nothing the campaign did could be recorded"
+                        .to_string(),
+                ));
+            }
+            (None, _) => None,
+        };
+
         admit_and_boot_local(
             &backend,
             &req,
@@ -270,11 +293,47 @@ impl LocalBackend {
                 clock: &clock,
                 ledger: &ledger,
                 host_signer_keys_dir: None,
-                emitter: emitter.as_ref(),
-                assurance: None,
+                emitter: emitter.as_deref(),
+                assurance: campaign.as_ref(),
             },
         )
         .map_err(|e| crate::local::backend_err(format!("{e:#}")))
+    }
+
+    /// Load a declared campaign and bind it to this boot.
+    ///
+    /// The policy handed to the probe is the one the launch was granted, so a
+    /// probe asks the same question the workload's own egress would: an
+    /// operator cannot widen what a campaign observes by writing a different
+    /// policy into the declaration, because the declaration carries none.
+    fn build_campaign(
+        path: &std::path::Path,
+        emitter: &std::sync::Arc<AuditEmitter>,
+        backend: &AnyBackend,
+        grants: Option<&mvm_contract::grants::Grants>,
+    ) -> anyhow::Result<mvm_hostd::assurance_session::CampaignRequest> {
+        let declaration = mvm_hostd::assurance_session::load_declaration(path)?;
+        // The policy handed to the probe is the launch's own granted egress, so
+        // a probe asks exactly the question the workload's traffic would. A
+        // declaration carries no policy of its own, so an operator cannot widen
+        // what a campaign observes by writing one.
+        let policy = grants
+            .and_then(|g| g.egress.as_ref())
+            .map(|egress| {
+                mvm_core::policy::network_policy::NetworkPolicy::allow_list(egress.allow.clone())
+            })
+            .unwrap_or_else(mvm_core::policy::network_policy::NetworkPolicy::deny_all);
+        Ok(mvm_hostd::assurance_session::CampaignRequest {
+            declaration,
+            emitter: std::sync::Arc::clone(emitter),
+            policy_ceiling: mvm_hostd::assurance_session::default_policy_ceiling(),
+            policy,
+            backend: format!("{:?}", backend.kind()).to_lowercase(),
+            now_unix_ms: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+                .unwrap_or(0),
+        })
     }
 
     /// Fail-closed admission validation of typed secret references, then
@@ -647,6 +706,7 @@ impl LocalBackend {
                 volumes,
                 transient,
                 grants: request.grants.clone(),
+                assurance_campaign: request.assurance_campaign.clone(),
             })
             .await?;
         preparation.commit();

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -271,6 +271,7 @@ impl LocalBackend {
                 ledger: &ledger,
                 host_signer_keys_dir: None,
                 emitter: emitter.as_ref(),
+                assurance: None,
             },
         )
         .map_err(|e| crate::local::backend_err(format!("{e:#}")))

--- a/crates/mvm-client/src/launch/request.rs
+++ b/crates/mvm-client/src/launch/request.rs
@@ -83,6 +83,12 @@ pub struct LaunchRequest {
     /// the same plan that was signed over it, rather than by a carrier
     /// travelling alongside one.
     pub(crate) grants: Option<mvm_contract::grants::Grants>,
+    /// Path to an operator-authored assurance campaign declaration.
+    ///
+    /// `None` on every ordinary launch. Present only when an operator asked
+    /// for a campaign, which is what keeps campaign discovery off the launch
+    /// critical path rather than merely cheap on it.
+    pub(crate) assurance_campaign: Option<std::path::PathBuf>,
 }
 
 impl LaunchRequest {
@@ -108,6 +114,7 @@ impl LaunchRequest {
             secret_refs: Vec::new(),
             force: false,
             grants: mvm_contract::grants::Grants::default(),
+            assurance_campaign: None,
         }
     }
 
@@ -141,6 +148,7 @@ pub struct LaunchRequestBuilder {
     secret_refs: Vec<MachineSecretRef>,
     force: bool,
     grants: mvm_contract::grants::Grants,
+    assurance_campaign: Option<std::path::PathBuf>,
 }
 
 impl LaunchRequestBuilder {
@@ -256,6 +264,13 @@ impl LaunchRequestBuilder {
         self
     }
 
+    /// Run a declared assurance campaign against this launch.
+    #[must_use]
+    pub fn assurance_campaign(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+        self.assurance_campaign = Some(path.into());
+        self
+    }
+
     /// Attach a managed volume at `guest_path`.
     #[must_use]
     pub fn volume(mut self, spec: LaunchVolumeSpec) -> Self {
@@ -356,6 +371,7 @@ impl LaunchRequestBuilder {
             // granted nothing produces exactly the plan it produced before
             // grants were expressible.
             grants: (self.grants != mvm_contract::grants::Grants::default()).then_some(self.grants),
+            assurance_campaign: self.assurance_campaign,
         })
     }
 }

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -1245,6 +1245,7 @@ mod tests {
             memory_mib: 128,
             env: vec![],
             grants: None,
+            assurance_campaign: None,
         };
         let state = be
             .run_machine(spec)
@@ -1276,6 +1277,7 @@ mod tests {
             memory_mib: 128,
             env: vec![],
             grants: None,
+            assurance_campaign: None,
         };
         let state = be.run_machine(spec).await.expect("boot");
         assert!(
@@ -1325,6 +1327,7 @@ mod tests {
             memory_mib: 128,
             env: vec![],
             grants: None,
+            assurance_campaign: None,
         };
         let state = be.run_machine(spec).await.expect("boot");
         assert!(

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -693,6 +693,9 @@ impl MvmClient for LocalBackend {
         if let Some(grants) = spec.grants {
             builder = builder.grants(grants);
         }
+        if let Some(path) = spec.assurance_campaign {
+            builder = builder.assurance_campaign(path);
+        }
         self.create_from_request(&builder.build()?)
     }
 
@@ -715,6 +718,9 @@ impl MvmClient for LocalBackend {
         .memory_mib(spec.memory_mib);
         if let Some(grants) = spec.grants {
             builder = builder.grants(grants);
+        }
+        if let Some(path) = spec.assurance_campaign {
+            builder = builder.assurance_campaign(path);
         }
         let outcome = self.launch(builder.build()?).await?;
         Ok(outcome.machine)

--- a/crates/mvm-core/src/client/dto.rs
+++ b/crates/mvm-core/src/client/dto.rs
@@ -73,6 +73,16 @@ pub struct MachineSpec {
     pub cpus: u32,
     pub memory_mib: u32,
     pub env: Vec<(String, String)>,
+    /// Path to an operator-authored assurance campaign declaration.
+    ///
+    /// Host-local and meaningful only to a backend running on this machine: it
+    /// names a file the *host* reads, so a remote backend must refuse a spec
+    /// carrying one rather than resolve it against its own filesystem.
+    /// `#[serde(default)]` so a record written before campaigns existed still
+    /// deserializes, and skip-serialized when absent so the ordinary spec's
+    /// bytes do not move.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assurance_campaign: Option<std::path::PathBuf>,
     /// What this workload is permitted to consume or reach. `None` leaves
     /// every dimension unspecified, which each resolves its own way: no CPU
     /// cap, no wall-clock bound, and deny-all egress.
@@ -108,6 +118,7 @@ impl MachineSpec {
             memory_mib: 512,
             env: Vec::new(),
             grants: mvm_contract::grants::Grants::default(),
+            assurance_campaign: None,
         })
     }
 }
@@ -127,9 +138,20 @@ pub struct MachineSpecBuilder {
     memory_mib: u32,
     env: Vec<(String, String)>,
     grants: mvm_contract::grants::Grants,
+    assurance_campaign: Option<std::path::PathBuf>,
 }
 
 impl MachineSpecBuilder {
+    /// Run a declared assurance campaign against this machine.
+    ///
+    /// Host-local: the path is read by the backend's own process, so this is
+    /// meaningful only against a local backend.
+    #[must_use]
+    pub fn assurance_campaign(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+        self.assurance_campaign = Some(path.into());
+        self
+    }
+
     /// Set the vCPU count (default 1).
     #[must_use]
     pub fn cpus(mut self, cpus: u32) -> Self {
@@ -226,6 +248,7 @@ impl MachineSpecBuilder {
             // granted nothing is byte-identical to one written before grants
             // existed.
             grants: (self.grants != mvm_contract::grants::Grants::default()).then_some(self.grants),
+            assurance_campaign: self.assurance_campaign,
         }
     }
 }
@@ -456,6 +479,29 @@ pub struct ReconfigureRequest {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn a_declared_campaign_survives_the_builder_and_absence_changes_no_bytes() {
+        let plain = MachineSpec::builder("m", "alpine:3.20")
+            .expect("spec")
+            .build();
+        assert!(plain.assurance_campaign.is_none());
+        // Skip-serialized when absent, so an ordinary spec's bytes do not move.
+        let json = serde_json::to_string(&plain).expect("json");
+        assert!(!json.contains("assurance_campaign"), "{json}");
+
+        let declared = MachineSpec::builder("m", "alpine:3.20")
+            .expect("spec")
+            .assurance_campaign("/tmp/campaign.json")
+            .build();
+        assert_eq!(
+            declared.assurance_campaign.as_deref(),
+            Some(std::path::Path::new("/tmp/campaign.json"))
+        );
+        let round: MachineSpec =
+            serde_json::from_str(&serde_json::to_string(&declared).expect("json")).expect("parse");
+        assert_eq!(round.assurance_campaign, declared.assurance_campaign);
+    }
     use super::*;
 
     #[test]
@@ -467,6 +513,7 @@ mod tests {
             memory_mib: 512,
             env: vec![("PORT".into(), "8080".into())],
             grants: None,
+            assurance_campaign: None,
         };
         let json = serde_json::to_string(&spec).unwrap();
         let back: MachineSpec = serde_json::from_str(&json).unwrap();
@@ -538,6 +585,7 @@ mod tests {
                 memory_mib: 512,
                 env: vec![],
                 grants: None,
+                assurance_campaign: None,
             }
         );
 
@@ -576,6 +624,7 @@ mod tests {
             memory_mib: 512,
             env: vec![("PORT".into(), "8080".into())],
             grants: None,
+            assurance_campaign: None,
         };
         assert_eq!(built, literal);
     }

--- a/crates/mvm-core/src/client/gateway.rs
+++ b/crates/mvm-core/src/client/gateway.rs
@@ -678,6 +678,17 @@ impl MvmClient for GatewayBackend {
     async fn run_machine(&self, spec: MachineSpec) -> Result<MachineState> {
         // The create-sandbox endpoint has no env field; refuse rather than
         // silently drop env the workload would expect.
+        // A campaign declaration names a file on the *host's* filesystem. A
+        // remote backend has no access to it, and resolving the path against
+        // its own filesystem would run a different campaign than the one the
+        // caller wrote — so refuse rather than silently drop or mis-resolve it.
+        if spec.assurance_campaign.is_some() {
+            return Err(MvmError::InvalidSpec {
+                reason: "an assurance campaign declaration is host-local and cannot be run \
+                         against a remote backend"
+                    .into(),
+            });
+        }
         if !spec.env.is_empty() {
             return Err(MvmError::InvalidSpec {
                 reason: "gateway create-sandbox does not accept env vars; bake them into the image or leave env empty".into(),
@@ -1029,6 +1040,7 @@ mod tests {
             memory_mib: 64,
             env: vec![("A".into(), "B".into())],
             grants: None,
+            assurance_campaign: None,
         };
         // The env guard fires before any request, so no server is needed.
         let err = be.run_machine(spec).await.unwrap_err();

--- a/crates/mvm-core/src/client/mock.rs
+++ b/crates/mvm-core/src/client/mock.rs
@@ -207,6 +207,7 @@ mod tests {
             memory_mib: 128,
             env: vec![],
             grants: None,
+            assurance_campaign: None,
         };
         let started = mock.run_machine(spec).await.unwrap();
         assert_eq!(started.status, MachineStatus::Running);
@@ -230,6 +231,7 @@ mod tests {
             memory_mib: 128,
             env: vec![],
             grants: None,
+            assurance_campaign: None,
         };
 
         // create → stopped (not started).
@@ -283,6 +285,7 @@ mod tests {
                 memory_mib: 64,
                 env: vec![],
                 grants: None,
+                assurance_campaign: None,
             })
             .await
             .unwrap();
@@ -337,6 +340,7 @@ mod tests {
                 memory_mib: 64,
                 env: vec![],
                 grants: None,
+                assurance_campaign: None,
             })
             .await
             .unwrap();
@@ -363,6 +367,7 @@ mod tests {
                 memory_mib: 64,
                 env: vec![],
                 grants: None,
+                assurance_campaign: None,
             })
             .await
             .unwrap();

--- a/crates/mvm-hostd/src/assurance_session.rs
+++ b/crates/mvm-hostd/src/assurance_session.rs
@@ -404,8 +404,12 @@ pub fn edges_by_label(decl: &CampaignDeclaration) -> BTreeMap<AssuranceId, (Stri
 /// The emitter is an `Arc` because the opened session outlives this call: it
 /// records every probe for as long as the workload runs, so a borrow would tie
 /// the session's lifetime to the boot call that opened it.
-pub struct CampaignRequest<'a> {
-    pub declaration: &'a CampaignDeclaration,
+pub struct CampaignRequest {
+    /// Owned rather than borrowed: the request is assembled by a caller that
+    /// reads the declaration from disk and then hands it down through the
+    /// launch path, so tying it to that caller's frame would force a leak to
+    /// satisfy the lifetime.
+    pub declaration: CampaignDeclaration,
     pub emitter: Arc<AuditEmitter>,
     pub policy_ceiling: AuthorityCeiling,
     /// The workload's admitted egress policy, which the probe consults.
@@ -416,7 +420,7 @@ pub struct CampaignRequest<'a> {
 
 /// Open a declared campaign against a booted VM, using this process's plane.
 pub fn open_for_boot(
-    campaign: &CampaignRequest<'_>,
+    campaign: &CampaignRequest,
     vm: &str,
     admitted: &AdmittedPlan,
 ) -> Result<MvmBinding> {
@@ -430,7 +434,7 @@ pub fn open_for_boot(
         OpenSession {
             vm,
             admitted,
-            declaration: campaign.declaration,
+            declaration: &campaign.declaration,
             emitter: &campaign.emitter,
             policy_ceiling: &campaign.policy_ceiling,
             policy: campaign.policy.clone(),

--- a/crates/mvm-hostd/src/assurance_session.rs
+++ b/crates/mvm-hostd/src/assurance_session.rs
@@ -39,7 +39,8 @@ use crate::broker::handlers::host_assurance_v1::{
 use crate::plan_admission::AdmittedPlan;
 
 /// A destination an operator declared for one campaign.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeclaredEdge {
     pub label: AssuranceId,
     pub host: String,
@@ -47,7 +48,15 @@ pub struct DeclaredEdge {
 }
 
 /// What an operator authorized for one campaign against one workload.
-#[derive(Debug, Clone)]
+///
+/// Deserializable so an operator can hand one to `machine run` as a file. It is
+/// authored by a human or by the assurance planner, never by the workload, and
+/// `deny_unknown_fields` means a key this build does not understand refuses the
+/// campaign rather than being silently dropped — a dropped destination or a
+/// dropped approval is exactly the kind of quiet widening this contract exists
+/// to prevent.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CampaignDeclaration {
     pub campaign_id: AssuranceId,
     pub trial_id: AssuranceId,
@@ -61,6 +70,35 @@ pub struct CampaignDeclaration {
     pub requested: RequestedAuthority,
     /// How long the session's grant is live.
     pub grant_ttl_ms: u64,
+}
+
+/// Largest campaign declaration accepted from disk.
+pub const MAX_DECLARATION_BYTES: u64 = 64 * 1024;
+
+/// Read an operator-authored campaign declaration.
+///
+/// Size-checked before parsing, so an oversized file is refused without being
+/// deserialized.
+pub fn load_declaration(path: &std::path::Path) -> Result<CampaignDeclaration> {
+    let metadata = std::fs::metadata(path)
+        .with_context(|| format!("reading campaign declaration {}", path.display()))?;
+    if metadata.len() > MAX_DECLARATION_BYTES {
+        anyhow::bail!(
+            "campaign declaration {} is larger than the {MAX_DECLARATION_BYTES}-byte limit",
+            path.display()
+        );
+    }
+    let body = std::fs::read_to_string(path)
+        .with_context(|| format!("reading campaign declaration {}", path.display()))?;
+    let declaration: CampaignDeclaration = serde_json::from_str(&body)
+        .with_context(|| format!("parsing campaign declaration {}", path.display()))?;
+    if declaration.edges.is_empty() {
+        anyhow::bail!(
+            "campaign declaration {} declares no destination, so it can probe nothing",
+            path.display()
+        );
+    }
+    Ok(declaration)
 }
 
 /// Why no session was opened.
@@ -444,6 +482,60 @@ mod tests {
     fn bound_plan() -> ExecutionPlan {
         let service = ServiceId::parse(HOST_ASSURANCE_SERVICE).expect("service");
         PlanFixture::new().services(vec![service]).build()
+    }
+
+    fn declaration_json() -> String {
+        serde_json::to_string_pretty(&declaration()).expect("a declaration serializes")
+    }
+
+    #[test]
+    fn an_operator_declaration_round_trips_through_a_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("campaign.json");
+        std::fs::write(&path, declaration_json()).expect("write");
+
+        let loaded = load_declaration(&path).expect("a well-formed declaration loads");
+        assert_eq!(loaded.campaign_id, declaration().campaign_id);
+        assert_eq!(loaded.edges.len(), 1);
+        assert_eq!(loaded.edges[0].host, "attacker.example.com");
+        assert!(loaded.approvals.permits(ToolId::CampaignProbeV1));
+    }
+
+    #[test]
+    fn a_declaration_with_an_unknown_key_is_refused() {
+        // A key this build does not understand must refuse the campaign rather
+        // than be dropped: a silently ignored destination or approval is the
+        // quiet widening this contract exists to prevent.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("campaign.json");
+        let body = declaration_json().replace(
+            "{\n  \"campaign_id\"",
+            "{\n  \"escalate\": true,\n  \"campaign_id\"",
+        );
+        std::fs::write(&path, body).expect("write");
+        assert!(load_declaration(&path).is_err());
+    }
+
+    #[test]
+    fn a_declaration_naming_no_destination_is_refused_at_load() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("campaign.json");
+        let empty = CampaignDeclaration {
+            edges: Vec::new(),
+            ..declaration()
+        };
+        std::fs::write(&path, serde_json::to_string(&empty).expect("json")).expect("write");
+        let error = load_declaration(&path).expect_err("a campaign that can probe nothing");
+        assert!(format!("{error:#}").contains("no destination"), "{error:#}");
+    }
+
+    #[test]
+    fn an_oversized_declaration_is_refused_before_it_is_parsed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("campaign.json");
+        std::fs::write(&path, "x".repeat(MAX_DECLARATION_BYTES as usize + 1)).expect("write");
+        let error = load_declaration(&path).expect_err("oversized");
+        assert!(format!("{error:#}").contains("larger than"), "{error:#}");
     }
 
     #[test]

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1052,7 +1052,7 @@ pub struct AdmitAndStartParams<'a> {
     /// declared one. `None` — the default — is every ordinary run: extension
     /// discovery must not sit on the launch critical path, so a run that
     /// declares no campaign does no assurance work at all.
-    pub assurance: Option<&'a crate::assurance_session::CampaignRequest<'a>>,
+    pub assurance: Option<&'a crate::assurance_session::CampaignRequest>,
 }
 
 impl<'a> AdmitAndStartParams<'a> {
@@ -1078,7 +1078,7 @@ pub struct AdmitAndStartParamsBuilder<'a> {
     policy_bundle: Option<&'a PolicyBundle>,
     emitter: Option<&'a crate::audit::emitter::AuditEmitter>,
     audit_durability: Option<crate::audit::durability::AuditDurability>,
-    assurance: Option<&'a crate::assurance_session::CampaignRequest<'a>>,
+    assurance: Option<&'a crate::assurance_session::CampaignRequest>,
 }
 
 impl<'a> AdmitAndStartParamsBuilder<'a> {
@@ -1175,7 +1175,7 @@ impl<'a> AdmitAndStartParamsBuilder<'a> {
     /// Declare an assurance campaign for this boot.
     pub fn assurance(
         mut self,
-        assurance: impl Into<Option<&'a crate::assurance_session::CampaignRequest<'a>>>,
+        assurance: impl Into<Option<&'a crate::assurance_session::CampaignRequest>>,
     ) -> Self {
         self.assurance = assurance.into();
         self
@@ -3453,7 +3453,7 @@ mod tests {
         };
         let now_unix_ms = 1_800_000_000_000;
         let campaign = CampaignRequest {
-            declaration: &declaration,
+            declaration,
             emitter: Arc::clone(&emitter),
             policy_ceiling: default_policy_ceiling(),
             policy: mvm_core::policy::network_policy::NetworkPolicy::deny_all(),

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -93,7 +93,7 @@ pub struct LocalRunContext<'a> {
     /// `None` — the default everywhere except a run that explicitly asked for
     /// one — means no assurance work happens at all, so campaign discovery
     /// never sits on the ordinary launch path.
-    pub assurance: Option<&'a crate::assurance_session::CampaignRequest<'a>>,
+    pub assurance: Option<&'a crate::assurance_session::CampaignRequest>,
 }
 
 /// Build the signed-plan host-fs grant list from the launch volume set. The

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -88,6 +88,12 @@ pub struct LocalRunContext<'a> {
     /// `plan.failed` entries around this admission. `None` skips emission
     /// (the caller owns its own audit wiring, e.g. the CLI's up path).
     pub emitter: Option<&'a AuditEmitter>,
+    /// An operator-declared assurance campaign to open against this boot.
+    ///
+    /// `None` — the default everywhere except a run that explicitly asked for
+    /// one — means no assurance work happens at all, so campaign discovery
+    /// never sits on the ordinary launch path.
+    pub assurance: Option<&'a crate::assurance_session::CampaignRequest<'a>>,
 }
 
 /// Build the signed-plan host-fs grant list from the launch volume set. The
@@ -266,9 +272,7 @@ pub fn admit_and_boot_local(
             // defaulted: a run that silently picks its own audit durability is
             // how this control erodes.
             audit_durability: crate::audit::durability::AuditDurability::BestEffort,
-            // This entry point declares no campaign; assurance is opt-in and
-            // must never sit on an ordinary run's path.
-            assurance: None,
+            assurance: ctx.assurance,
         },
     )
 }
@@ -316,6 +320,7 @@ mod tests {
                 ledger: &ledger,
                 host_signer_keys_dir: Some(keys.path()),
                 emitter: None,
+                assurance: None,
             },
         )
         .expect("admit + boot over mock");
@@ -417,6 +422,7 @@ mod tests {
                 ledger: &ledger,
                 host_signer_keys_dir: Some(keys.path()),
                 emitter: Some(&emitter),
+                assurance: None,
             },
         )
         .expect("admitted boot with a volume");
@@ -482,6 +488,7 @@ mod tests {
                 ledger: &ledger,
                 host_signer_keys_dir: Some(keys.path()),
                 emitter: Some(&emitter),
+                assurance: None,
             },
         )
         .expect_err("the SDK-sidecar gate must refuse");
@@ -566,6 +573,7 @@ mod tests {
                 ledger: &ledger,
                 host_signer_keys_dir: Some(keys.path()),
                 emitter: None,
+                assurance: None,
             },
         )
         .unwrap_err();

--- a/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
+++ b/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
@@ -3,7 +3,7 @@
 Backing: shipped-source
 Validation: a_provider_cannot_smuggle_an_mvm_binding_through_the_request_parser
 
-Status: **W1–W4, W6/W7, W7b landed. W5, W8 open.**
+Status: **W1–W4, W6/W7, W7b, W9 landed. W5, W8, W9b open.**
 
 An AI workload can drive a Scout-linked assurance campaign from inside an
 admitted microVM. This plan is the MVM half of that: the typed envelope the
@@ -100,6 +100,22 @@ Three properties are structural rather than checked at runtime:
       value, so a decision path only reachable through the global would be
       testable exactly once per process.
 
+- [x] **W9 — Operator-declared campaigns reach the client launch path.** A
+      `CampaignDeclaration` is loadable from a file (`deny_unknown_fields`, so
+      a key this build does not understand refuses the campaign rather than
+      dropping a destination or an approval; size-checked before parsing;
+      refused at load if it names no destination). It threads
+      `MachineSpec` → `LaunchRequest` → `BootParams` → `LocalRunContext` →
+      `AdmitAndStartParams`, so a library caller — which is how mvmd and SDK
+      consumers drive MVM — can run a campaign against a real boot. The policy
+      handed to the probe is the launch's own granted egress, so a probe asks
+      exactly the question the workload's traffic would and a declaration
+      cannot widen what a campaign observes. A remote backend **refuses** a
+      spec carrying one: the path names a file on the host's filesystem, and
+      resolving it against the gateway's own would silently run a different
+      campaign. `None` everywhere else, so nothing changes for an ordinary
+      launch.
+
 ## Open
 
 - [ ] **W5 — Observer and cleanup evidence.** `EvidenceSet` is consumed by the
@@ -107,6 +123,14 @@ Three properties are structural rather than checked at runtime:
       `cleanup_verified` / `attestation_verified` from a real run yet. Until
       that lands every live trial evaluates to `INCONCLUSIVE`, which is the
       correct fail-closed behaviour and not a certifying result.
+
+- [ ] **W9b — The `mvmctl machine run` verb.** `machine run` does not boot
+      through `admit_and_boot_local`; it drives `AnyBackend` directly from
+      `commands/machine/lifecycle.rs`, building its own launch config. So the
+      W9 thread reaches the *library* launch path and not the CLI verb, and an
+      `--assurance-campaign` flag needs that second seam opened before it would
+      do anything. Discovered by tracing rather than assumed: `LaunchRequest`
+      has no CLI caller at all.
 
 - [ ] **W8 — Provider binary.** The counterparty's
       `assurance run --provider <path>` spawns a framed-stdio provider speaking

--- a/specs/sprint/delivery/assurance-campaign-declaration.md
+++ b/specs/sprint/delivery/assurance-campaign-declaration.md
@@ -1,0 +1,44 @@
+# Operator-declared campaigns on the client launch path
+
+Plan: `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md` (W9)
+
+## What landed
+
+A campaign declaration is now loadable from a file and threads all the way to
+the session open, so a library caller can run one against a real boot.
+
+`deny_unknown_fields` on the declaration means a key this build does not
+understand refuses the campaign rather than being dropped — a dropped
+destination or a dropped approval is the quiet widening this contract exists to
+prevent. Size is checked before parsing, and a declaration naming no
+destination is refused at load rather than becoming a session that can probe
+nothing.
+
+**The probe sees the launch's own policy.** `build_campaign` derives the
+`NetworkPolicy` from the launch's granted egress, not from the declaration —
+which carries none. So a probe asks exactly the question the workload's own
+traffic would, and an operator cannot widen what a campaign observes by writing
+a different policy beside it.
+
+**A remote backend refuses it.** The declaration path names a file on the
+host's filesystem. A gateway backend resolving it against its own would run a
+different campaign than the caller wrote, so `run_machine` refuses a spec
+carrying one instead of dropping or mis-resolving it. Absent, the field is
+skip-serialized, so an ordinary spec's bytes do not move.
+
+## What this does not reach
+
+`mvmctl machine run` boots through `AnyBackend` directly from
+`commands/machine/lifecycle.rs`; it does not go through `admit_and_boot_local`.
+So this thread serves the library/client path and **not** the CLI verb. An
+`--assurance-campaign` flag needs that second seam opened first, which is W9b.
+
+That was found by tracing rather than assumed — `LaunchRequest` turns out to
+have no CLI caller at all, only client and test ones. Worth recording, because
+"thread it to the boot path" reads like one path and is two.
+
+## A testing note
+
+`mvm-core`'s `client` module is behind a feature. `cargo test -p mvm-core --lib`
+compiles none of it, so a new test there neither runs nor fails to compile — it
+silently is not there. Use `--features client`.


### PR DESCRIPTION
Lands W9 of
`specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`.

## What this does

A campaign declaration is loadable from a file and threads all the way to the
session open: `MachineSpec` → `LaunchRequest` → `BootParams` →
`LocalRunContext` → `AdmitAndStartParams`. A library caller — which is how mvmd
and SDK consumers drive MVM — can now run an assurance campaign against a real
boot, on the seam W7b built.

`deny_unknown_fields` on the declaration means a key this build does not
understand refuses the campaign rather than being dropped: a dropped
destination or a dropped approval is the quiet widening this contract exists to
prevent. Size is checked before parsing, and a declaration naming no
destination is refused at load rather than becoming a session that can probe
nothing.

**The probe sees the launch's own policy.** `build_campaign` derives the
`NetworkPolicy` from the launch's granted egress, not from the declaration —
which carries none. A probe therefore asks exactly the question the workload's
own traffic would, and an operator cannot widen what a campaign observes by
writing a different policy beside it.

**A remote backend refuses it.** The path names a file on the *host's*
filesystem; a gateway resolving it against its own would run a different
campaign than the caller wrote. `run_machine` refuses rather than dropping or
mis-resolving it. Absent, the field is skip-serialized, so an ordinary spec's
bytes do not move, and `None` everywhere else means nothing changes for an
ordinary launch.

`CampaignRequest` owns its declaration rather than borrowing: the caller reads
it from disk and hands it down the launch path, so a borrow would have forced a
`Box::leak` to satisfy the lifetime.

## What this deliberately does not reach

**`mvmctl machine run` is not wired.** That verb drives `AnyBackend` directly
from `commands/machine/lifecycle.rs` and never calls `admit_and_boot_local`, so
an `--assurance-campaign` flag on it needs a second seam opened first. Tracked
as W9b.

This was found by tracing rather than assumed: `LaunchRequest` turns out to have
no CLI caller at all, only client and test ones. Worth stating plainly, because
"thread it to the boot path" reads like one path and is two.

## A testing trap worth knowing

`mvm-core`'s `client` module is behind a feature, so `cargo test -p mvm-core
--lib` compiles none of it — a new test there neither runs nor fails to compile,
it silently is not there. The DTO test needs `--features client`. That cost me
a confused round-trip and is noted in the delivery write-up.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 12,368 passed
- `cargo test --workspace --doc` — pass
- All 61 applicable xtask gates — pass

Two xtask gate self-tests (`check_no_gateway_names`, `check_l3_expansion_freeze`)
fail locally only when a `graft/` index sits in the worktree: they scan without
honouring `.gitignore`, and graft's ignored cache carries the forbidden tokens.
Both pass with it moved aside; `graft/` is gitignored and absent from `main`, so
CI never sees it. Pre-existing gate gap, not fixed here.

## Still not true

No certifying campaign can run: observer and cleanup evidence have no producer
(W5), and the framed-stdio provider exists in neither repository (W8).
