### PR TITLE
fix(ci): verify the boot-latency manifest's signature before trusting its digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -957,6 +957,13 @@ jobs:
         with:
           packages: lld
 
+      # This lane anchors on a checksum manifest it downloads. Whoever could
+      # swap the artifact could swap its recorded digest too, so the manifest
+      # is only worth anchoring on once its signature is checked — which is the
+      # same reasoning that made these manifests signed in the first place.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
       # Building the root package runs `crates/mvm-cli/build.rs`, which
       # cross-compiles the embedded host binaries and needs the pinned zig.
       # Without it the lane fails before it ever boots anything.
@@ -989,9 +996,18 @@ jobs:
           ls -la /dev/kvm
 
       - name: Fetch and verify the pinned bootable image
-        # Hash-verified against the release's own checksum manifest — the same
-        # posture every other artifact fetch in this repo uses. A corrupted
-        # download must fail here rather than surface as a boot-time mystery.
+        # Signature-verified, then hash-verified against the release's own
+        # checksum manifest — the same posture every other artifact fetch in
+        # this repo uses. A corrupted download must fail here rather than
+        # surface as a boot-time mystery, and a substituted one must fail here
+        # rather than boot.
+        env:
+          # The boot image ships on its own train, so its manifests are signed
+          # by release-boot-image.yml rather than release.yml. Pinning the
+          # wrong workflow here would accept a signature from any other
+          # workflow in this repo.
+          COSIGN_IDENTITY_REGEXP: "^https://github.com/${{ github.repository }}/.github/workflows/release-boot-image.yml@refs/tags/.*$"
+          COSIGN_OIDC_ISSUER: "https://token.actions.githubusercontent.com"
         run: |
           set -euo pipefail
           mkdir -p /tmp/boot-image && cd /tmp/boot-image
@@ -1009,6 +1025,31 @@ jobs:
             "$base/runtime-overlay-x86_64.tar.gz"
           curl -fL --retry 3 -o checksums.txt \
             "$base/default-microvm-x86_64-checksums-sha256.txt"
+          # Both signature bundles, published beside what they sign.
+          curl -fL --retry 3 -o checksums.txt.bundle \
+            "$base/default-microvm-x86_64-checksums-sha256.txt.bundle"
+          curl -fL --retry 3 -o runtime-overlay-x86_64.tar.gz.bundle \
+            "$base/runtime-overlay-x86_64.tar.gz.bundle"
+          # Signature before digest, in that order and not the other way round:
+          # a digest comparison only says the bytes match what the manifest
+          # claims, and an attacker who can replace the artifact can replace the
+          # manifest beside it. `release-boot-image.yml` cosign-signs both of
+          # these on the tag push that publishes them, so the identity below is
+          # that workflow at a tag ref — the same keyless-OIDC check
+          # `verify-release-assets.sh` applies to every other manifest in this
+          # repo. Nothing here is verified against a signature this lane fetched
+          # from the same place as the thing it signs *without* pinning who
+          # signed it.
+          cosign verify-blob \
+            --bundle checksums.txt.bundle \
+            --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+            --certificate-oidc-issuer "$COSIGN_OIDC_ISSUER" \
+            checksums.txt
+          cosign verify-blob \
+            --bundle runtime-overlay-x86_64.tar.gz.bundle \
+            --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+            --certificate-oidc-issuer "$COSIGN_OIDC_ISSUER" \
+            runtime-overlay-x86_64.tar.gz
           grep -E ' (default-microvm-vmlinux-x86_64|default-microvm-rootfs-x86_64\.ext4|default-microvm-meta-x86_64\.json)$' \
             checksums.txt > expected.txt
           test -s expected.txt


### PR DESCRIPTION
Closes #2625.

## The gap

The `boot-latency` lane downloads the image, downloads the checksum manifest,
and compares one against the other. Both come from the same release. Whoever
could substitute the artifact could substitute its recorded digest beside it,
and `sha256sum -c` would still pass.

That is precisely the reasoning #2549 used when it signed these manifests, and
`nix/packaging/release/verify-release-assets.sh` already enforces it everywhere
else through `require_signed_manifest`. This lane was the remaining consumer
anchoring on a manifest without checking who wrote it.

## The change

Verify **both** blobs this lane actually anchors on, before any digest is
compared:

- `default-microvm-x86_64-checksums-sha256.txt` — the manifest the kernel,
  rootfs and meta sidecar are checked against.
- `runtime-overlay-x86_64.tar.gz` — the overlay tarball carries its own
  `checksums-sha256.txt` *inside*, so verifying that inner manifest against the
  archive it came from proves only self-consistency. The archive is the anchor,
  and it is signed.

Signature first, then digest. A digest says the bytes match what the manifest
claims; it says nothing about who made the claim.

## The identity has to be the right workflow

Pinned to `release-boot-image.yml`, not `release.yml`. The boot image ships on
its own tag train (`boot-image/v*`) and is signed by that workflow's publish
job. Pinning `release.yml` would still "verify a signature" while accepting one
from a different workflow in this repo — most of the value gone, and silently.

## Severity, honestly

As #2625 says: a CI lane fetching this repo's own releases, so practical
exposure is small. Worth closing because a uniform signing posture with one
undocumented exception is how the posture quietly stops being true.

`check-workflow-paths` clean, `ci.yml` parses. The lane exercises this on its
next run against a published boot image.