### PR TITLE
chore(just): add docs-publish, so publishing the site is a documented step

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -515,6 +515,19 @@ docs-dev: demo-assets
 docs-build: demo-assets
     cd public && pnpm build
 
+# Publish the docs site to GitHub Pages (dispatches pages.yml on main)
+docs-publish:
+    # `pages.yml` is workflow_dispatch-only on purpose — the old
+    # `push: branches:[main] paths:[public/**]` trigger was dropped in the CI
+    # cost reduction — so a docs change reaches the site only when someone asks
+    # for it. That is why this recipe exists: otherwise publishing is an
+    # undocumented `gh workflow run` you have to already know about.
+    #
+    # `--ref main`, never the current branch: Pages serves what is on main, and
+    # dispatching from a branch would publish something nobody has merged.
+    gh workflow run pages.yml --ref main
+    @echo "Dispatched pages.yml on main. Watch it with: gh run watch \$(gh run list --workflow=pages.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+
 # Build the browser-tier microVM demo assets (wasm core + guest + fixtures)
 demo-build:
     ./web/mvm-demo/build.sh


### PR DESCRIPTION
There was no recipe for this, which is the whole point of adding one.

`pages.yml` is `workflow_dispatch`-only by design — its
`push: branches:[main] paths:[public/**]` trigger was dropped in the CI cost
reduction, and the workflow says so. So a docs change reaches the site only when
someone explicitly asks. Nothing recorded *where* that ask lives, which made
publishing an undocumented `gh workflow run` you had to already know about.

```
just docs-publish
```

`--ref main`, never the current branch: Pages serves what is on main, and
dispatching from a branch would publish something nobody has merged.

Sits beside the existing `docs-install` / `docs-dev` / `docs-build`, which are
all local-only and stop short of the one step that actually ships anything.