### PR TITLE
fix(bench): establish the host signer key the boot path requires

### DIFF
--- a/tests/runtime_boot_bench.rs
+++ b/tests/runtime_boot_bench.rs
@@ -59,12 +59,43 @@ const DEFAULT_READY: ReadySignal = ReadySignal::GuestAgent;
 const READY_TIMEOUT: Duration = Duration::from_secs(5);
 const READY_POLL: Duration = Duration::from_millis(5);
 
+/// Establish the ambient host state a real boot needs, and that a fresh
+/// machine does not have.
+///
+/// Admission mints the host signing key on demand (`load_or_init`), but the
+/// boot path also spawns the per-tenant host-agent daemon, and *that* reads the
+/// key with a plain `std::fs::read` — deliberately, since silently minting a
+/// signing key inside a spawn path would be worse than failing. So on a host
+/// that has never signed anything, the VM boots and the bench then dies with
+/// `read host signer key …: No such file or directory`, several minutes into a
+/// release run.
+///
+/// Doing it here rather than in the workflow keeps the bench runnable the same
+/// way locally and in CI, and immune to step reordering. `load_or_init` is
+/// idempotent, so an existing key is reused rather than rotated — which matters:
+/// rotating would orphan any audit chain already signed under the old key.
+fn ensure_host_signer_key() -> Result<()> {
+    ensure_host_signer_key_at(&mvm_core::config::mvm_keys_dir())
+}
+
+/// [`ensure_host_signer_key`] against an explicit keys directory, so the
+/// behaviour can be exercised without touching the ambient `MVM_HOME`.
+fn ensure_host_signer_key_at(keys_dir: &Path) -> Result<()> {
+    mvm_hostd::audit::host_keypair::load_or_init_at(keys_dir)
+        .context("initialize the host signer key the boot path requires")?;
+    Ok(())
+}
+
 #[test]
 fn prebuilt_runtime_image_boots_within_budget() -> Result<()> {
     let Some(spec) = BenchSpec::from_env()? else {
         eprintln!("[runtime_boot_bench] skipped; set {ENABLE_VAR}=1 to run the live benchmark");
         return Ok(());
     };
+
+    // After the skip check on purpose: a bench that is not running must not
+    // leave a signing key behind on a developer's machine.
+    ensure_host_signer_key()?;
 
     let serial = measure_serial(&spec)?;
     let serial_summary = summarize(&serial);
@@ -790,5 +821,37 @@ fn the_default_policy_emits_no_overlay_device_token() {
     assert!(
         !cmdline.unwrap_or_default().contains("mvm.runtime_data="),
         "RootfsOnly must not name an overlay device; the bug was that it names none"
+    );
+}
+
+/// The precondition must actually produce the key the boot path reads, and must
+/// not rotate one that already exists.
+///
+/// Pins the fix for a release-blocking failure: the boot-latency lane booted a
+/// VM and then died on a missing host signer key, because nothing in the lane
+/// had ever signed anything.
+#[test]
+fn ensure_host_signer_key_creates_the_key_and_is_idempotent() {
+    let keys = tempfile::tempdir().expect("tempdir");
+    let key = keys
+        .path()
+        .join(mvm_hostd::audit::host_keypair::SECRET_FILENAME);
+    assert!(!key.exists(), "fixture starts without a key");
+
+    ensure_host_signer_key_at(keys.path()).expect("mint the key");
+    assert!(
+        key.exists(),
+        "the boot path reads this key with a plain read, so the precondition \
+         must create it: {}",
+        key.display()
+    );
+    let first = std::fs::read(&key).expect("read minted key");
+
+    ensure_host_signer_key_at(keys.path()).expect("second call is a no-op");
+    let second = std::fs::read(&key).expect("re-read key");
+    assert_eq!(
+        first, second,
+        "rotating an existing key would orphan any audit chain already signed \
+         under it"
     );
 }


### PR DESCRIPTION
## The next layer under #2699

With the sidecar fix merged the image boots — the 20:39 tag-push run got past the required-overlay gate, started the VM, and reached the stop path. Then:

```
warning: failed to stop mvm-boot-bench-serial-0-…: request guest filesystem flush before Firecracker stop
Error: read host signer key /home/runner/.mvm/keys/host-signer.ed25519
Caused by: No such file or directory (os error 2)
```

A fresh runner has never signed anything, so `~/.mvm/keys` does not exist.

## Two readers, deliberately disagreeing

| path | when the key is absent |
|---|---|
| `admit_plan_for_boot` | `load_or_init` — **mints it** |
| `host_agent_spawn::load_host_signing_key` | plain `std::fs::read` — **fails** |

The second is reached because `host_agent_daemon_enabled()` **defaults on**, so every admitted workload spawns the per-tenant host-agent daemon.

**That asymmetry is correct and this PR does not change it.** Silently minting a signing key inside a spawn path would be worse than failing loudly — the host tier should mint its identity at a deliberate point, not as a side effect of starting a daemon.

## Why the bench and not the workflow

The bench's other preconditions are staged artifacts named by env vars. This one is *ambient host state*. Establishing it in the test keeps the bench runnable the same way locally and in CI, and immune to workflow step reordering.

It sits **after** the skip check on purpose: a bench that is not running must not leave a signing key behind on a developer's machine.

## A wrong fix I discarded

`mvmctl doctor` looked like a ready-made "initialize the key" step. It is not — it early-returns before ever calling `load_or_init`:

```rust
if !dir.join(SECRET_FILENAME).exists() {
    return not_assessed("no host signer key yet; nothing has been signed");
}
let signer = match load_or_init() { ... }   // unreachable when absent
```

A "run doctor first" CI step would have silently done nothing and left the lane red.

## Test

Asserts both halves against an **explicit keys directory** — the seam `load_or_init_at` documents itself as providing — so it needs no `MVM_HOME` manipulation and no `test-support` feature on the root's dev-dependency.

Mutation-tested in both directions:

- helper reverted to a plain read → fails with *"the boot path reads this key with a plain read, so the precondition must create it"*
- helper made to rotate on every call → fails with *"rotating an existing key would orphan any audit chain already signed under it"*

## Verification

- `cargo nextest run --workspace` — **12,370 passed**, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all --check` — clean
- `check-test-home-isolation`, `check-single-home` — pass
- The bench still skips cleanly when `MVM_RUNTIME_BOOT_BENCH` is unset

## What this does not claim

That the lane now goes green. This is the third fix in the chain (#2683 → #2699 → this) and each one exposed the next; the honest expectation is that it gets further, not that it finishes. It can only be confirmed by a real `boot-image/v*` tag push.

Note also that publishing cannot be triggered with `workflow_dispatch --ref main`: the `boot-image-signing` environment permits only `boot-image/v*` **tags**, by design, so those jobs are refused before running a step.