### PR TITLE
feat(assurance): assemble the evidence a trial is actually judged on

### DIFF
--- a/crates/mvm-hostd/src/assurance_session.rs
+++ b/crates/mvm-hostd/src/assurance_session.rs
@@ -403,6 +403,73 @@ pub fn open_for_boot(
     .map_err(|refusal| anyhow::anyhow!("{refusal}"))
 }
 
+/// What the host can attest about a finished trial.
+///
+/// Every field is read from something the host itself did or can check now —
+/// the probes it recorded, the plan it admitted, the state dir it can look at.
+/// Nothing here is taken from the workload or from the declaration, which is
+/// what makes the resulting [`EvidenceSet`] evidence rather than a claim.
+pub struct CollectEvidence<'a> {
+    pub vm: &'a str,
+    pub admitted: &'a AdmittedPlan,
+    pub binding: &'a MvmBinding,
+    /// The campaign's source digest, for the join back to the scan.
+    pub source_digest: &'a Sha256Digest,
+    /// Where per-VM state lives, so teardown can be confirmed.
+    pub mvm_home: &'a std::path::Path,
+}
+
+/// Assemble the evidence a trial is evaluated against.
+///
+/// The three verification flags are deliberately conservative:
+///
+/// - `observer_verified` is true only when the host actually recorded a probe
+///   for this session. A session that opened and was never exercised observed
+///   nothing, and saying otherwise would let an untested trial certify.
+/// - `cleanup_verified` is true only when the workload's state dir no longer
+///   carries a live process, checked through the same probe the admission
+///   budget trusts. A VM still running has not been cleaned up, whatever the
+///   plan intended.
+/// - `attestation_verified` stays false: no attestation provider is wired, and
+///   the evaluator only consults it when the plan demands attestation, so a
+///   `Noop` plan is unaffected and a demanding one correctly fails closed.
+#[must_use]
+pub fn collect_evidence(request: CollectEvidence<'_>) -> mvm_contract::assurance::EvidenceSet {
+    let plan = request.admitted.plan();
+    let plane = host_assurance_plane();
+    let probe_refs = plane
+        .as_ref()
+        .map(|plane| plane.evidence_refs_for(request.vm))
+        .unwrap_or_default();
+    let observed = plane
+        .as_ref()
+        .and_then(|plane| plane.observation_for(request.vm));
+
+    // A recorded probe *and* an attempt: a session whose every probe was
+    // refused before it ran has references but observed no effect.
+    let observer_verified = !probe_refs.is_empty() && observed.is_some_and(|o| o.attempted_effect);
+
+    let state_dir = mvm_core::config::vm_state_dir_at(request.mvm_home, request.vm);
+    let cleanup_verified = !mvm_vmm::host::process_liveness::state_dir_has_live_process(&state_dir);
+
+    let mut audit_refs = request.binding.audit_refs.clone();
+    audit_refs.extend(probe_refs);
+
+    mvm_contract::assurance::EvidenceSet {
+        identity_verified: request.binding.plan_id.as_str()
+            == request.admitted.plan_id().0.replace(':', "-"),
+        observer_verified,
+        cleanup_verified,
+        attestation_verified: false,
+        disposable_target: plan.post_run.destroy_on_exit,
+        artifact_digest: request.binding.artifact_digest.clone(),
+        policy_digest: request.binding.effective_policy_digest.clone(),
+        source_digest: request.source_digest.clone(),
+        audit_refs,
+        receipt_refs: request.binding.receipt_refs.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -761,5 +828,142 @@ mod tests {
         let chain = chain_of(&opened);
         assert!(chain.contains("assurance.trial_completed"), "{chain}");
         assert!(chain.contains("observer_missing"), "{chain}");
+    }
+
+    // ---------------------------------------------------------------------
+    // Evidence collection
+    // ---------------------------------------------------------------------
+
+    fn evidence_for(
+        home: &std::path::Path,
+        vm: &str,
+        binding: &MvmBinding,
+        admitted: &AdmittedPlan,
+    ) -> mvm_contract::assurance::EvidenceSet {
+        collect_evidence(CollectEvidence {
+            vm,
+            admitted,
+            binding,
+            source_digest: &Sha256Digest::parse(SOURCE_DIGEST).expect("digest"),
+            mvm_home: home,
+        })
+    }
+
+    #[test]
+    fn an_unexercised_session_observes_nothing_and_cannot_certify() {
+        let opened = open_against(bound_plan());
+        let binding = opened.result.as_ref().expect("session opens").clone();
+        let home = tempfile::tempdir().expect("tempdir");
+
+        // Opened, never probed. The plane is per-test here, so nothing this
+        // session did was recorded — which is exactly the case that must not
+        // read as an observer having watched.
+        let evidence = evidence_for(home.path(), "vm-a", &binding, &opened.admitted);
+        assert!(
+            !evidence.observer_verified,
+            "a session that ran no probe observed nothing"
+        );
+        assert!(evidence.identity_verified);
+    }
+
+    #[test]
+    fn cleanup_is_verified_only_when_no_live_process_remains() {
+        let opened = open_against(bound_plan());
+        let binding = opened.result.as_ref().expect("session opens").clone();
+        let home = tempfile::tempdir().expect("tempdir");
+
+        // No state dir at all: nothing is running, so cleanup holds.
+        let gone = evidence_for(home.path(), "vm-a", &binding, &opened.admitted);
+        assert!(gone.cleanup_verified);
+
+        // A pid marker pointing at this very process is unambiguously live.
+        let dir = mvm_core::config::vm_state_dir_at(home.path(), "vm-a");
+        std::fs::create_dir_all(&dir).expect("state dir");
+        std::fs::write(dir.join("libkrun.pid"), std::process::id().to_string())
+            .expect("pid marker");
+        let live = evidence_for(home.path(), "vm-a", &binding, &opened.admitted);
+        assert!(
+            !live.cleanup_verified,
+            "a VM still running has not been cleaned up, whatever the plan intended"
+        );
+    }
+
+    #[test]
+    fn attestation_is_never_asserted_without_a_provider() {
+        let opened = open_against(bound_plan());
+        let binding = opened.result.as_ref().expect("session opens").clone();
+        let home = tempfile::tempdir().expect("tempdir");
+        let evidence = evidence_for(home.path(), "vm-a", &binding, &opened.admitted);
+        // Nothing attests today. The evaluator only consults this when the
+        // plan demands attestation, so a Noop plan is unaffected and a
+        // demanding one fails closed rather than being waved through.
+        assert!(!evidence.attestation_verified);
+    }
+
+    #[test]
+    fn the_collected_evidence_quotes_the_binding_not_the_declaration() {
+        let opened = open_against(bound_plan());
+        let binding = opened.result.as_ref().expect("session opens").clone();
+        let home = tempfile::tempdir().expect("tempdir");
+        let evidence = evidence_for(home.path(), "vm-a", &binding, &opened.admitted);
+
+        assert_eq!(evidence.artifact_digest, binding.artifact_digest);
+        assert_eq!(evidence.policy_digest, binding.effective_policy_digest);
+        assert!(!evidence.receipt_refs.is_empty());
+        assert!(!evidence.audit_refs.is_empty());
+    }
+
+    #[test]
+    fn a_non_disposable_plan_is_reported_as_such() {
+        let mut plan = bound_plan();
+        plan.post_run.destroy_on_exit = false;
+        let opened = open_against(plan);
+        let binding = opened.result.as_ref().expect("session opens").clone();
+        let home = tempfile::tempdir().expect("tempdir");
+        let evidence = evidence_for(home.path(), "vm-a", &binding, &opened.admitted);
+        assert!(!evidence.disposable_target);
+    }
+
+    #[test]
+    fn evidence_from_a_real_session_still_evaluates_inconclusive_today() {
+        // The honest end state: everything the host can attest is assembled,
+        // and the trial is still INCONCLUSIVE because no observer ran. This
+        // pins that the gap is the observer, not the plumbing.
+        use mvm_contract::assurance::{
+            EvaluationInputs, HostObservation, InconclusiveReason, TRIAL_RESULT_CANDIDATE_SCHEMA,
+            TrialOutcome, TrialResultCandidate,
+        };
+
+        let opened = open_against(bound_plan());
+        let binding = opened.result.as_ref().expect("session opens").clone();
+        let home = tempfile::tempdir().expect("tempdir");
+        let evidence = evidence_for(home.path(), "vm-a", &binding, &opened.admitted);
+
+        let candidate = TrialResultCandidate {
+            schema: TRIAL_RESULT_CANDIDATE_SCHEMA.to_string(),
+            attempted_effect: true,
+            effect_observed_in_guest: false,
+            boundary_crossed: false,
+            blocked_edges: Vec::new(),
+            evidence_refs: Vec::new(),
+            notes: String::new(),
+        };
+        let observation = HostObservation {
+            attempted_effect: true,
+            effect_observed_in_guest: false,
+            boundary_crossed: false,
+            blocked_edges: Vec::new(),
+        };
+        let verdict = mvm_contract::assurance::evaluate(EvaluationInputs {
+            issued_binding: &binding,
+            echoed_binding: Some(&binding),
+            narrative_applicable: true,
+            planned_source_digest: &Sha256Digest::parse(SOURCE_DIGEST).expect("digest"),
+            candidate: &candidate,
+            observation: &observation,
+            evidence: &evidence,
+        });
+        assert_eq!(verdict.outcome, TrialOutcome::Inconclusive);
+        assert_eq!(verdict.reason, Some(InconclusiveReason::ObserverMissing));
     }
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -299,18 +299,22 @@ for detailed scope and acceptance criteria.
 
 - [~] **Admission-bound AI assurance sessions** —
       `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W4,
-      W6/W7 and W7b landed: the envelope, the authority intersection, the
-      fail-closed outcome ladder, `host.assurance.v1`, fail-closed audit and
-      receipt emission with resolvable citations, the workload-facing
-      `AssuranceCampaign`, and the boot-path session lifecycle behind
-      `AdmitAndStartParams.assurance` (opt-in; `None` on every existing call
-      site). Landing W7b exposed two bugs the fixtures had masked: the binding
-      rejected every real `sha256:`-prefixed plan id, and the probe handler
-      compared the guest's session identity against the supervisor's lookup key.
-      STILL OPEN: W5 observer/cleanup evidence, W8 the framed-stdio provider,
-      and a CLI surface for supplying a campaign declaration. Until those land
-      every live trial evaluates `INCONCLUSIVE` by design; no certifying
-      campaign can run.
+      W6/W7, W7b landed and W5 partial: the envelope, the authority
+      intersection, the fail-closed outcome ladder, `host.assurance.v1`,
+      resolvable audit/receipt citations, the workload-facing
+      `AssuranceCampaign`, the boot-path session lifecycle, and
+      `collect_evidence` — cleanup read through the admission budget's own
+      liveness probe, disposability off the signed plan.
+      `observer_verified` is deliberately only "MVM recorded a probe", not an
+      independent observer, and a test pins that a real session still evaluates
+      `INCONCLUSIVE` for `ObserverMissing`. Landing W7b exposed two bugs the
+      fixtures had masked: the binding rejected every real `sha256:`-prefixed
+      plan id, and the probe handler compared the guest's session identity
+      against the supervisor's lookup key.
+      STILL OPEN: W5b a guest-side observer, W8 the framed-stdio provider, W9b
+      the `mvmctl machine run` seam (`machine run` drives `AnyBackend` directly
+      and never reaches the admit path W9 threaded). No certifying campaign can
+      run.
 
 - [~] **Embedded-binary content store** — `specs/plans/2026-08-17-embedded-binary-content-store.md`.
       Phases 1–2 landed: both nested legs of `crates/mvm-cli/build.rs` are keyed

--- a/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
+++ b/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
@@ -102,11 +102,37 @@ Three properties are structural rather than checked at runtime:
 
 ## Open
 
-- [ ] **W5 — Observer and cleanup evidence.** `EvidenceSet` is consumed by the
-      evaluator but nothing populates `observer_verified` /
-      `cleanup_verified` / `attestation_verified` from a real run yet. Until
-      that lands every live trial evaluates to `INCONCLUSIVE`, which is the
-      correct fail-closed behaviour and not a certifying result.
+- [~] **W5 — Cleanup and disposability evidence (partial).**
+      `assurance_session::collect_evidence` assembles the `EvidenceSet` from
+      what the host itself did or can check now, never from the workload or the
+      declaration. Two halves are genuinely evidence:
+
+      - `cleanup_verified` reads the state dir through
+        `state_dir_has_live_process`, the same probe the admission budget
+        trusts. A VM still running has not been cleaned up, whatever the plan
+        intended.
+      - `disposable_target` comes off the signed plan's `post_run`.
+
+      `attestation_verified` stays false — no provider is wired — and the
+      evaluator only consults it when the plan demands attestation, so a
+      demanding plan fails closed rather than being waved through.
+
+      **`observer_verified` is the honest limit.** It is true when *MVM* 
+      recorded a probe and an effect was attempted. That is real evidence the
+      trial was exercised, and it stops an unexercised session reading as
+      observed — but it is not an independent observer corroborating what
+      happened inside the guest, which is what the assurance contract means by
+      the word. A test
+      (`evidence_from_a_real_session_still_evaluates_inconclusive_today`)
+      assembles everything the host can attest and asserts the verdict is
+      *still* `INCONCLUSIVE` with reason `ObserverMissing`, so nobody mistakes
+      assembled evidence for a certifying result.
+
+- [ ] **W5b — A guest-side observer.** Reporting whether the attempted effect
+      took hold *inside* the VM needs a signal from the guest, corroborated
+      host-side. That is the remaining gap behind a non-`INCONCLUSIVE` outcome,
+      and it is a larger piece than the rest of W5 — closer in shape to W8's
+      provider work than to the evidence plumbing above.
 
 - [ ] **W8 — Provider binary.** The counterparty's
       `assurance run --provider <path>` spawns a framed-stdio provider speaking

--- a/specs/sprint/delivery/assurance-cleanup-evidence.md
+++ b/specs/sprint/delivery/assurance-cleanup-evidence.md
@@ -1,0 +1,44 @@
+# Assurance evidence: what the host can actually attest
+
+Plan: `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md` (W5, partial)
+
+## What landed
+
+`assurance_session::collect_evidence` assembles the `EvidenceSet` the evaluator
+consumes. Every field is read from something the host itself did or can check
+now — the probes it recorded, the plan it admitted, the state dir it can look
+at. Nothing comes from the workload or from the declaration, which is what
+makes the result evidence rather than a claim.
+
+`cleanup_verified` reads the state dir through `state_dir_has_live_process` —
+the same probe the admission budget trusts, rather than a second liveness
+notion that could disagree with it. A VM still carrying a live pid marker has
+not been cleaned up, whatever the plan intended. `disposable_target` comes off
+the signed plan's `post_run`.
+
+`attestation_verified` stays false because no provider is wired. The evaluator
+only consults it when the plan demands attestation, so a `Noop` plan is
+unaffected and a demanding one fails closed rather than being waved through.
+
+## The honest limit, stated plainly
+
+`observer_verified` is true when **MVM** recorded a probe and an effect was
+attempted. That is real evidence the trial was exercised, and it closes a gap
+worth closing: an unexercised session can no longer read as observed.
+
+It is *not* an independent observer corroborating what happened inside the
+guest, which is what the assurance contract means by the word. Calling it one
+would be the exact overclaim this whole subsystem exists to prevent.
+
+So the remaining gap is narrower and more specific than "W5 is unfinished": it
+is a guest-side signal for whether the attempted effect took hold inside the
+VM, corroborated host-side. That is tracked as W5b, and it is closer in shape to
+W8's provider work than to the evidence plumbing here.
+
+## The test that keeps this honest
+
+`evidence_from_a_real_session_still_evaluates_inconclusive_today` opens a real
+session, assembles everything the host can attest, and asserts the verdict is
+*still* `INCONCLUSIVE` with reason `ObserverMissing`. It exists so that
+assembled evidence is never mistaken for a certifying result, and so that when
+W5b lands, the test that changes is the one that should.


### PR DESCRIPTION
Lands W5 (partially) of
`specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`.

## What this does

`collect_evidence` builds the `EvidenceSet` the evaluator consumes from what
the host itself did or can check now — the probes it recorded, the plan it
admitted, the state dir it can look at. Nothing comes from the workload or the
declaration, which is what makes the result evidence rather than a claim.

`cleanup_verified` reads the state dir through `state_dir_has_live_process` —
the same probe the admission budget trusts, rather than a second liveness
notion that could disagree with it. A VM still carrying a live pid marker has
not been cleaned up, whatever the plan intended. `disposable_target` comes off
the signed plan's `post_run`.

`attestation_verified` stays false because no provider is wired. The evaluator
only consults it when the plan demands attestation, so a `Noop` plan is
unaffected and a demanding one fails closed rather than being waved through.

## The honest limit

`observer_verified` is true when **MVM** recorded a probe and an effect was
attempted. That closes a real gap — an unexercised session can no longer read
as observed — but it is **not** an independent observer corroborating what
happened inside the guest, which is what the assurance contract means by the
word. Calling it one would be the exact overclaim this subsystem exists to
prevent, so it is documented as a limit and the rest is tracked as W5b.

`evidence_from_a_real_session_still_evaluates_inconclusive_today` opens a real
session, assembles everything the host can attest, and asserts the verdict is
*still* `INCONCLUSIVE` with reason `ObserverMissing`. It exists so assembled
evidence is never mistaken for a certifying result, and so that when W5b lands,
the test that changes is the one that should.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 12,373 passed
- the `test-support` feature lane (all three commands) — 3,649 passed
- `cargo test --workspace --doc` — pass
- All 61 applicable xtask gates — pass

The two gate self-tests that fail locally are the known `graft/`-cache issue:
they scan without honouring `.gitignore`, and `graft/` is gitignored and absent
from `main`, so CI never sees it.

## Ordering

Touches `assurance_session.rs`, which #2708 also touches. Left unarmed
deliberately so #2708 lands first; this will be rebased if it conflicts.

## Still not true

No certifying campaign can run: W5b (a guest-side observer), W8 (the provider
binary) and W9b (the `mvmctl machine run` seam) remain.
