### PR TITLE
fix(bench): mint the host signer identity the readiness probe signs with

### DIFF
--- a/tests/runtime_boot_bench.rs
+++ b/tests/runtime_boot_bench.rs
@@ -66,6 +66,8 @@ fn prebuilt_runtime_image_boots_within_budget() -> Result<()> {
         return Ok(());
     };
 
+    ensure_host_signer()?;
+
     let serial = measure_serial(&spec)?;
     let serial_summary = summarize(&serial);
     eprintln!(
@@ -223,6 +225,26 @@ struct Summary {
     p50: Duration,
     p95: Duration,
     max: Duration,
+}
+
+/// Mint the host signing identity if this machine has none yet.
+///
+/// The readiness probe opens an *authenticated* session with the guest, and the
+/// host half of that handshake signs with `~/.mvm/keys/host-signer.ed25519`.
+/// A real `mvmctl` run reaches that key through `load_or_init`, which creates it
+/// on first use; the harness went straight to the probe, so on a fresh CI runner
+/// the boot succeeded and the readiness check then failed with
+/// `read host signer key … No such file or directory` — a working guest reported
+/// as a broken one.
+///
+/// Minting it here rather than teaching the read path to create it on demand:
+/// the host's signing identity is the anchor the guest pins, and a read that
+/// silently mints one would make "the key was missing" indistinguishable from
+/// "the key was replaced".
+fn ensure_host_signer() -> Result<()> {
+    mvm_hostd::audit::host_keypair::load_or_init()
+        .map(|_| ())
+        .context("initializing the host signer identity the readiness probe signs with")
 }
 
 fn measure_serial(spec: &BenchSpec) -> Result<Vec<BootMeasurement>> {


### PR DESCRIPTION
The next — and, on the evidence, last — layer of the boot-image release chain.

## The guest now boots

This run got further than any before it. The VM started, ran, and the teardown
reported a guest-filesystem flush, which only a live guest produces. Then:

```
Error: read host signer key /home/runner/.mvm/keys/host-signer.ed25519
Caused by: No such file or directory (os error 2)
```

The readiness probe opens an **authenticated** session, and the host half of
that handshake signs with that key. A real `mvmctl` run reaches it through
`host_keypair::load_or_init`, which mints it on first use. The harness went
straight to the probe, so on a fresh runner — which is every CI runner — a
working guest was reported as a broken image.

Call the same initializer once, before the first boot.

## Why not make the read path mint it

`open_authenticated_session_stream` could create the key when it is missing, and
that would be the smaller diff. It would also be wrong.

That key is the host's signing identity and the anchor the guest pins in
`/run/mvm/host-signer.pub`. A read path that silently mints one makes "there is
no key yet" indistinguishable from "the key was replaced" — which is exactly the
distinction the pinning exists to detect. The caller that wants an identity asks
for one; the caller that wants to *use* an identity should fail when there
isn't one.

## Progress through this chain, for the record

Each fix exposed the next, and every one was a real defect:

| | died on |
|---|---|
| 1 | no pinned zig — `cargo test` would not compile |
| 2 | overlay never attached |
| 3 | `release-signing` environment refused a `boot-image/v*` tag |
| 4 | overlay attached, guest never told where it is (#2683) |
| 5 | `runtimeLean` dropped by the sidecar serializer (#2699) |
| 6 | host signer key never minted — **this PR** |

Layers 4 and 5 both required a real boot to observe, which is what #2635 is
about.

`cargo test --test runtime_boot_bench` 13/13.