### PR TITLE
ci: boot a tree-built guest image before it reaches main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1181,6 +1181,158 @@ jobs:
             staging/kernel-metrics-${{ matrix.arch }}.json
             staging/workload-config-${{ matrix.arch }}
 
+  guest-image-boot:
+    name: Guest image boots (tree-built)
+    # The gap #2635 names: nothing builds the guest image generator's output and
+    # starts it before the change is on main. The only lane that boots a
+    # tree-built image runs on a `boot-image/v*` tag, which is after the merge.
+    # That is how a rootfs whose /init the kernel could not exec shipped for five
+    # weeks with every checksum verifying clean, and how five successive release
+    # runs each surfaced exactly one more layer — an unattached overlay, a guest
+    # never told where the overlay was, a sidecar field the serializer dropped —
+    # none of which any static check can see, because each one needs a guest that
+    # actually runs.
+    #
+    # Merge queue, not per-PR, and the cost argument is wall-clock rather than
+    # runner-minutes: this job takes ~33 minutes, and the merge-group CI it joins
+    # already takes 32-36, so running in parallel it adds close to nothing to how
+    # long a merge takes. Per-PR it would be pure addition on every push.
+    # `nix-flake-check` above sets the same precedent for the same reason.
+    needs: [scope]
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/free-disk
+        if: needs.scope.outputs.nix == 'true'
+
+      - name: Install Nix
+        if: needs.scope.outputs.nix == 'true'
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Install Rust toolchain
+        if: needs.scope.outputs.nix == 'true'
+        uses: dtolnay/rust-toolchain@1.96.0
+
+      - uses: ./.github/actions/apt-deps
+        if: needs.scope.outputs.nix == 'true'
+        with:
+          packages: lld
+
+      # `cargo test` below builds mvmctl, whose build.rs cross-compiles the
+      # embedded host binaries as static musl and needs the pinned zig. Without
+      # it this dies at compile time, before it starts a guest — which reads as
+      # "the image does not boot" and is nothing of the kind.
+      - uses: ./.github/actions/install-zigbuild
+        if: needs.scope.outputs.nix == 'true'
+
+      - name: Build the guest image from this tree
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          nix build "./nix/images/default-tenant#packages.x86_64-linux.default" \
+            --impure --no-link --print-out-paths > /tmp/store-path.txt
+          STORE_PATH=$(head -1 /tmp/store-path.txt)
+          mkdir -p staging
+          # cp -L so each artifact resolves through its nix-store symlink.
+          cp -L "$STORE_PATH/vmlinux"       staging/vmlinux
+          cp -L "$STORE_PATH/rootfs.ext4"   staging/rootfs.ext4
+          cp -L "$STORE_PATH/mvm-meta.json" staging/mvm-meta.json
+
+      - name: Assert the tree-built rootfs has an exec'able /init
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          # The cheap half, and the one that catches the defect that actually
+          # shipped. Runs before the boot so a rootfs the kernel cannot exec
+          # fails here, where the message says so, rather than as a panic.
+          command -v debugfs >/dev/null 2>&1 \
+            || { sudo apt-get update && sudo apt-get install -y e2fsprogs; }
+          bash nix/packaging/release/assert-init-shebang.sh \
+            staging/rootfs.ext4 "tree-built x86_64"
+          bash nix/packaging/release/assert-kernel-format.sh \
+            staging/vmlinux x86_64 "tree-built x86_64 kernel"
+
+      # The prod rootfs bakes no agent — /init resolves it from /mvm/runtime,
+      # the runtime overlay attached as a second virtio-blk drive. The nix store
+      # is warm from the image build, so this is usually a store lookup rather
+      # than a build.
+      - name: Build the runtime overlay
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          OVERLAY_PATH=$(nix build "./nix/images/runtime-overlay#packages.x86_64-linux.default" \
+            --no-link --print-out-paths | head -1)
+          mkdir -p overlay-staging
+          cp -L "$OVERLAY_PATH/overlay.ext4"     overlay-staging/overlay.ext4
+          cp -L "$OVERLAY_PATH/overlay.verity"   overlay-staging/overlay.verity
+          cp -L "$OVERLAY_PATH/overlay.roothash" overlay-staging/overlay.roothash
+          echo "MVM_RUNTIME_BOOT_OVERLAY_ROOTHASH=$(tr -d '[:space:]' < overlay-staging/overlay.roothash)" \
+            >> "$GITHUB_ENV"
+
+      - name: Install firecracker
+        if: needs.scope.outputs.nix == 'true'
+        env:
+          # Tracks `crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT`.
+          FC_VERSION: v1.14.1
+        run: |
+          set -euo pipefail
+          curl -fL -o firecracker.tgz \
+            "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-x86_64.tgz"
+          tar -xzf firecracker.tgz
+          sudo install -m 0755 "release-${FC_VERSION}-x86_64/firecracker-${FC_VERSION}-x86_64" /usr/bin/firecracker
+          /usr/bin/firecracker --version
+
+      - name: Grant /dev/kvm access for the job
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm missing on this runner — the boot gate cannot run." >&2
+            exit 1
+          fi
+          sudo chmod 666 /dev/kvm
+
+      - name: Boot the tree-built image
+        if: needs.scope.outputs.nix == 'true'
+        # Not a latency assertion. The budget is an order of magnitude above the
+        # observed median and RUNS/CONCURRENT are 1, because the only question
+        # here is whether this tree's image reaches userspace and binds its
+        # agent. Latency belongs to `boot-latency`, which pins a *published*
+        # image deliberately so a regression is unambiguous between host code
+        # and image — the two lanes answer different questions and neither
+        # substitutes for the other.
+        env:
+          MVM_RUNTIME_BOOT_BENCH: "1"
+          MVM_RUNTIME_BOOT_BACKEND: firecracker
+          MVM_RUNTIME_BOOT_KERNEL: staging/vmlinux
+          MVM_RUNTIME_BOOT_ROOTFS: staging/rootfs.ext4
+          MVM_RUNTIME_BOOT_OVERLAY: overlay-staging/overlay.ext4
+          MVM_RUNTIME_BOOT_OVERLAY_VERITY: overlay-staging/overlay.verity
+          MVM_RUNTIME_BOOT_READY: guest-agent
+          MVM_RUNTIME_BOOT_RUNS: "1"
+          MVM_RUNTIME_BOOT_CONCURRENT: "1"
+          MVM_RUNTIME_BOOT_BUDGET_MS: "60000"
+        run: |
+          set -euo pipefail
+          # No copy needed: the runtime-overlay admission gate reads
+          # `mvm-meta.json` from the rootfs's own directory, and the build step
+          # already staged it beside `rootfs.ext4`.
+          test -f staging/mvm-meta.json
+          cargo test --test runtime_boot_bench \
+            prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
+
+      - name: Guest console on failure
+        if: ${{ failure() && needs.scope.outputs.nix == 'true' }}
+        run: |
+          for d in "$HOME"/.mvm/vms/*/; do
+            echo "===== $d ====="
+            ls -la "$d" || true
+            [ -f "$d/console.log" ] && cat "$d/console.log" || true
+          done
+
   nix-flake-check:
     name: Nix flake check (Linux eval)
     # Nix eval/build is heavy; run it in the merge queue and on manual dispatch,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1330,7 +1330,12 @@ jobs:
           for d in "$HOME"/.mvm/vms/*/; do
             echo "===== $d ====="
             ls -la "$d" || true
-            [ -f "$d/console.log" ] && cat "$d/console.log" || true
+            # `if`, not `A && B || C`: with the latter the `|| true` also runs
+            # when `cat` itself fails, which would hide a console.log that
+            # exists but cannot be read — the one case worth seeing here.
+            if [ -f "$d/console.log" ]; then
+              cat "$d/console.log"
+            fi
           done
 
   nix-flake-check:


### PR DESCRIPTION
Closes #2635 — specifically its third item, the one it deliberately left open
pending a call on cost. Items 1 (scope globs) and 2 (the stale
`crates/mvm-host-vm-init/**` filter) are already on main; I verified both rather
than assuming.

## The gap

Nothing built the guest image generator's output and started it before the
change landed. Per #2635's own table, the only lane that boots a **tree-built**
image runs on a `boot-image/v*` tag push — after the merge.

The evidence that this matters is the last two days. Five successive release
runs each surfaced exactly one more layer, and every one needed a guest that
actually runs:

| | died on | catchable statically? |
|---|---|---|
| 1 | no pinned zig | yes |
| 2 | overlay never attached | **no** |
| 3 | wrong signing environment | yes |
| 4 | overlay attached, guest never told where it is (#2683) | **no** |
| 5 | `runtimeLean` dropped by the sidecar serializer (#2699) | only by a purpose-built cross-language test |
| 6 | host signer key never minted (#2714) | **no** |

That is the same mechanism that let #2539 ship a rootfs the kernel could not
exec, for five weeks, with every checksum verifying clean the whole time.

## The cost call

**Merge queue, not per-PR** — and the argument is wall-clock, not runner-minutes:

- this job takes **~33 min** (measured: the release lane's `default-microvm`
  x86_64 leg, 20:58 → 21:31)
- the merge-group CI it joins already takes **32–36 min** (measured across the
  last five merge-group runs)

Running in parallel it therefore adds ≈0 to how long a merge takes. Per-PR it
would be pure addition on every push, which matters because merge throughput is
already the bottleneck. `nix-flake-check` sets exactly this precedent —
*"Nix eval/build is heavy; run it in the merge queue and on manual dispatch,
not on every PR update"* — and this job follows its shape.

x86_64 only, like the release gate: `ubuntu-24.04-arm` has no nested KVM.

## Ordering

The static `assert-init-shebang.sh` / `assert-kernel-format.sh` checks run
**before** the boot, so a rootfs the kernel cannot exec fails on the line that
says so rather than as a kernel panic several minutes later. On failure the
guest console is dumped, since that is the only artifact that explains a boot
failure.

## What this is not

It does not replace `boot-latency`, and they are not interchangeable. That lane
pins a *published* image deliberately, so a latency regression is unambiguous
between host code and image — it is a control variable. This one varies the
image and asks only whether it reaches userspace. #2635 makes the same point.

`check-workflow-paths` clean, `ci.yml` parses, the new job is present in the
parsed job set.