### PR TITLE
fix(hooks): lint workflow files in pre-commit, where CI already does

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -277,4 +277,30 @@ if [ "$has_nix" -eq 1 ] && command -v nix >/dev/null 2>&1; then
     fi
 fi
 
+# ── Workflow files ──────────────────────────────────────────────────────
+#
+# CI lints every workflow with actionlint, and a failure there is expensive
+# out of proportion to the mistake: a typo'd `needs:` name or a bad
+# `${{ }}` reference does not fail loudly, it silently disables a lane that
+# still reads as covered. Catching it here costs milliseconds.
+#
+# Runs over every workflow rather than just the staged ones, exactly as CI
+# does, because a changed job can break a `needs:` reference in a file this
+# commit does not touch. Skipped silently when actionlint is not installed —
+# the hook's job is to catch what it can, not to demand a toolchain.
+workflow_files=$(git diff --cached --name-only --diff-filter=ACM \
+    | grep -E '^\.github/(workflows/.*\.ya?ml|actions/.*/action\.ya?ml)$' || true)
+if [ -n "$workflow_files" ]; then
+    if command -v actionlint >/dev/null 2>&1; then
+        echo "pre-commit: actionlint .github/workflows/*.yml"
+        if ! actionlint .github/workflows/*.yml; then
+            echo "  actionlint failed — fix the workflow before committing." >&2
+            exit 1
+        fi
+    else
+        echo "pre-commit: actionlint not installed; skipping workflow lint" \
+             "(brew install actionlint, or see the Install actionlint step in ci.yml)"
+    fi
+fi
+
 exit 0


### PR DESCRIPTION
Workflow mistakes have been failing PRs repeatedly, and they are the most
expensive kind to catch late relative to how small they are.

A typo'd `needs:` name or a bad `${{ }}` reference does not fail loudly — it
silently disables a lane that still reads as covered to anyone auditing the
file. `ci.yml` says exactly this above its own actionlint step:

> Nothing else validates the workflow files. A wrong `if:`, a typo'd `needs:`
> job name, or a bad `${{ }}` reference does not fail a PR — it silently
> disables the lane, which still reads as covered to anyone auditing the file.

The hook did not run it, so that feedback arrived a full CI round-trip later.

## Details

- Runs over **every** workflow, not just staged ones, matching CI — a changed
  job can break a `needs:` reference in a file the commit does not touch, which
  is the case this is most likely to catch.
- Triggers on `.github/workflows/*.yml` **and** `.github/actions/*/action.yml`,
  since composite actions are workflow surface too.
- Skipped with a pointer when actionlint is absent. The hook catches what it can
  locally; it does not demand a toolchain, and CI still gates the merge.

## Verified both directions

```
$ actionlint .github/workflows/*.yml
ALL WORKFLOWS CLEAN

$ sed -i 's/needs: \[scope\]/needs: [scoop]/' ci.yml && actionlint ci.yml
.github/workflows/ci.yml:166:3: job "lint-core" needs job "scoop" which does
not exist in this workflow [job-needs]
```

Local actionlint is 1.7.12 — the same version `ci.yml` pins and
checksum-verifies, so the hook and the gate agree on what counts as an error.