### PR TITLE
fix(hostd): witness the fail-closed audit the mutation lane caught

### DIFF
--- a/crates/mvm-hostd/src/supervisor/network_endpoint_proxy.rs
+++ b/crates/mvm-hostd/src/supervisor/network_endpoint_proxy.rs
@@ -861,6 +861,45 @@ pub struct SubstitutionService {
     /// gate (the run loop's gate is still active); a `Some` gate fails closed.
     egress_gate: Option<mvm_runtime::vmm::egress_gate::EgressGate>,
 }
+/// Which audit an error path owes, given the cause and whether the request
+/// carried a placeholder.
+///
+/// Every error on these paths is fail-closed — the socket closes WITHOUT
+/// forwarding — but the causes are not equally interesting. A refusal that
+/// dropped a placeholder and a fail-closed refusal are both claim-bearing
+/// events an operator must be able to see; a parse or forward failure is not
+/// secret-relevant and gets no entry.
+///
+/// Extracted from the two call sites that had this match inline and identical.
+/// Two copies of a security classification is how they drift, and it is why
+/// deleting either one's `FailClosed` arm changed no test: the classification
+/// had no name and so nothing could assert on it directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ErrorAudit<'a> {
+    /// claim-12: a placeholder was dropped rather than substituted.
+    PlaceholderDropped,
+    /// A fail-closed refusal, carrying the reason to record.
+    FailClosed(&'a str),
+    /// Not secret-relevant; nothing to record.
+    Silent,
+}
+
+pub(crate) fn error_audit(
+    error: &crate::supervisor::terminator::error::TerminatorError,
+    carried_placeholder: bool,
+) -> ErrorAudit<'_> {
+    match error {
+        crate::supervisor::terminator::error::TerminatorError::Refused(_)
+            if carried_placeholder =>
+        {
+            ErrorAudit::PlaceholderDropped
+        }
+        crate::supervisor::terminator::error::TerminatorError::FailClosed(reason) => {
+            ErrorAudit::FailClosed(reason)
+        }
+        _ => ErrorAudit::Silent,
+    }
+}
 
 impl SubstitutionService {
     pub fn new(
@@ -1239,14 +1278,14 @@ impl SubstitutionService {
                 // forwarding. Audit per cause so a claim-12 drop / fail-closed
                 // refusal is observable; a parse / forward failure isn't
                 // secret-relevant.
-                match &e {
-                    terminator::error::TerminatorError::Refused(_) if carried_placeholder => {
+                match error_audit(&e, carried_placeholder) {
+                    ErrorAudit::PlaceholderDropped => {
                         self.audit_placeholder_dropped(destination.as_deref()).await;
                     }
-                    terminator::error::TerminatorError::FailClosed(reason) => {
+                    ErrorAudit::FailClosed(reason) => {
                         self.audit_fail_closed(destination.as_deref(), reason).await;
                     }
-                    _ => {}
+                    ErrorAudit::Silent => {}
                 }
                 tracing::warn!(error = %e, "terminator refused or forward failed; closing");
                 return Ok(());
@@ -1278,7 +1317,7 @@ impl SubstitutionService {
         timeout: std::time::Duration,
     ) -> anyhow::Result<()> {
         use crate::keyholder::NetworkEndpoint;
-        use crate::supervisor::terminator::{self, tls};
+        use crate::supervisor::terminator::tls;
 
         // Peek the SNI without consuming the stream (blocking).
         let (std_stream, sni) = tokio::task::spawn_blocking(move || {
@@ -1357,14 +1396,14 @@ impl SubstitutionService {
             Err(e) => {
                 // Every error path is fail-closed (the socket closes WITHOUT
                 // forwarding); audit per cause exactly like the `:80` path.
-                match &e {
-                    terminator::error::TerminatorError::Refused(_) if carried_placeholder => {
+                match error_audit(&e, carried_placeholder) {
+                    ErrorAudit::PlaceholderDropped => {
                         self.audit_placeholder_dropped(Some(&dest)).await;
                     }
-                    terminator::error::TerminatorError::FailClosed(reason) => {
+                    ErrorAudit::FailClosed(reason) => {
                         self.audit_fail_closed(Some(&dest), reason).await;
                     }
-                    _ => {}
+                    ErrorAudit::Silent => {}
                 }
                 tracing::warn!(error = %e, "https terminator refused or failed; closing");
                 Ok(())
@@ -3318,5 +3357,54 @@ mod server_tests {
             "audit chain must not carry the secret value: {logged}"
         );
         server.abort();
+    }
+}
+
+#[cfg(test)]
+mod error_audit_tests {
+    use super::*;
+    use crate::supervisor::terminator::error::TerminatorError;
+
+    /// A fail-closed refusal must be audited. This is the one the mutation lane
+    /// caught: deleting the `FailClosed` arm left every test passing, because a
+    /// missing audit entry is invisible to anything that only checks the socket
+    /// closed — and every one of these paths closes the socket either way.
+    #[test]
+    fn a_fail_closed_refusal_is_audited_with_its_reason() {
+        let err = TerminatorError::FailClosed("body not scannable in cleartext");
+        assert_eq!(
+            error_audit(&err, false),
+            ErrorAudit::FailClosed("body not scannable in cleartext")
+        );
+        // The reason travels regardless of whether a placeholder was carried:
+        // fail-closed is about what could not be scanned, not about substitution.
+        assert_eq!(
+            error_audit(&err, true),
+            ErrorAudit::FailClosed("body not scannable in cleartext")
+        );
+    }
+
+    /// A refusal is claim-12 relevant only when a placeholder was actually
+    /// dropped. Refusing a request that carried none is not a secret event.
+    #[test]
+    fn a_refusal_is_audited_only_when_it_dropped_a_placeholder() {
+        let err = TerminatorError::Refused("unbound destination".into());
+        assert_eq!(error_audit(&err, true), ErrorAudit::PlaceholderDropped);
+        assert_eq!(error_audit(&err, false), ErrorAudit::Silent);
+    }
+
+    /// Parse and forward failures are fail-closed like everything else here,
+    /// but they are not secret-relevant and must not manufacture audit entries
+    /// — an audit log that records ordinary I/O failures as security events is
+    /// as unreadable as one that records nothing.
+    #[test]
+    fn parse_and_forward_failures_record_nothing() {
+        for err in [
+            TerminatorError::Parse("bad request line".into()),
+            TerminatorError::Forward("connection reset".into()),
+        ] {
+            assert_eq!(error_audit(&err, false), ErrorAudit::Silent, "{err}");
+            assert_eq!(error_audit(&err, true), ErrorAudit::Silent, "{err}");
+        }
     }
 }


### PR DESCRIPTION
Closes #2623.

The Security workflow's mutation lane (`mvm-hostd/2of4`) is red on exactly two
**new** survivors, both the same shape:

```
delete match arm TerminatorError::FailClosed(reason)
  in SubstitutionService::handle_https_terminator
delete match arm TerminatorError::FailClosed(reason)
  in SubstitutionService::handle_terminator_connection
```

## Why nothing caught it

This is a real gap, not an equivalent mutant. **Every** error path on these two
functions is fail-closed — the socket closes without forwarding — so a test
that asserts the socket closed passes with the arm deleted. The audit entry is
the only observable difference between "refused and recorded" and "refused
silently", and nothing asserted on it.

The deeper reason is that the classification had no name. Both call sites
carried the same `match &e { … }` inline, so there was nothing to test directly
— only two async paths with sockets and TLS in front of them.

## The change

Give it a name: `error_audit(&e, carried_placeholder)` returns
`PlaceholderDropped` / `FailClosed(reason)` / `Silent`, and both sites dispatch
on it. That also removes a duplicated security classification, which is how the
two drift apart.

## Witnesses

One per outcome, and the two negatives are the ones that keep it honest:

- `a_fail_closed_refusal_is_audited_with_its_reason` — the reason travels, and
  travels whether or not a placeholder was carried, because fail-closed is about
  what could not be scanned rather than about substitution.
- `a_refusal_is_audited_only_when_it_dropped_a_placeholder` — refusing a request
  carrying no placeholder is not a claim-12 event.
- `parse_and_forward_failures_record_nothing` — an audit log that records
  ordinary I/O failures as security events is as unreadable as one that records
  none.

Proven to discriminate: applying the lane's own mutation — deleting the
`FailClosed` arm — fails `a_fail_closed_refusal_is_audited_with_its_reason`.

`cargo test -p mvm-hostd --lib network_endpoint_proxy` 48/48, clippy
`--all-targets -D warnings` clean (the extraction left an unused `self` import
behind; removed).

The remaining `MISSED` lines in that run — the `>`/`<` comparison mutants in
`audit_redactions` and the vsock `bind`/`accept`/`read_frame_sync` helpers — are
already accepted misses in `xtask/mutation-witness-baseline.json`. The lane
fails only on *new* survivors, which is why these two are what turned it red.