### PR TITLE
fix(guest): read the mount table once, as the comment claims

### DIFF
--- a/crates/mvm-agentd/src/guest_bootstrap.rs
+++ b/crates/mvm-agentd/src/guest_bootstrap.rs
@@ -32,12 +32,19 @@ pub struct EgressClientMissing;
 /// classifying per-error would need every path to preserve an errno, and one
 /// that stopped doing so would silently go back to shouting.
 fn rootfs_is_read_only() -> bool {
-    let Ok(mounts) = std::fs::read_to_string("/proc/mounts") else {
-        // Unreadable /proc: assume writable, which keeps every failure loud.
-        // The wrong guess here costs noise, and the other one costs silence.
-        return false;
-    };
-    root_is_read_only_in(&mounts)
+    // Actually once, not once per step. Every optional step consults this, so
+    // the un-cached version read the file six times on exactly the sealed boot
+    // this exists to quieten, and the doc above claimed otherwise. The mount
+    // cannot change under a running init, so caching costs nothing.
+    static READ_ONLY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *READ_ONLY.get_or_init(|| {
+        let Ok(mounts) = std::fs::read_to_string("/proc/mounts") else {
+            // Unreadable /proc: assume writable, which keeps every failure loud.
+            // The wrong guess here costs noise, and the other one costs silence.
+            return false;
+        };
+        root_is_read_only_in(&mounts)
+    })
 }
 
 /// The `/proc/mounts` half of [`rootfs_is_read_only`], split out so it can be


### PR DESCRIPTION
Follow-up to #2709. Comment-accuracy and a small efficiency win; nothing depends
on it.

## What

`rootfs_is_read_only` documents reading `/proc/mounts` "once rather than
inferred from each failure". It is called from `note_optional_step`, so a sealed
image reads the file once per skipped step — six times on exactly the boot that
#2709 exists to quieten. Idempotent and harmless, but the comment asserted
something the code did not do.

A `OnceLock` makes the comment true. The mount cannot change under a running
init, so caching costs nothing, and the split-out `root_is_read_only_in` stays
independently testable against real mount tables.

## Why it is separate from #2709

The discrepancy was spotted while reviewing #2709, but that branch was already
in the merge queue and queued branches cannot be updated. Dequeuing evicts the
whole speculative batch and forces every other PR in it to re-run — too high a
price for a comment fix, so this waited for #2709 to merge.

## Verification

`just check-gated` (`cargo-zigbuild check --target x86_64-unknown-linux-gnu
--workspace --all-targets`) — `guest_bootstrap` is `cfg(target_os = "linux")`,
so a macOS `--all-targets` run cannot compile it and proves nothing here.
Workspace clippy clean, `cargo fmt --all` clean.

No test changes: the existing tests cover `root_is_read_only_in`, which is
untouched. The caching is in the caller.