### PR TITLE
fix(assurance): roll the launch back when a declared campaign cannot open

### DIFF
--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1530,9 +1530,24 @@ pub fn admit_and_start(
             // launch they belong to. A refusal here fails the boot: a campaign
             // the operator declared and that silently did not open would be
             // reported as a trial that observed nothing.
-            if let Some(campaign) = params.assurance {
-                crate::assurance_session::open_for_boot(campaign, &vm_id.0, &admitted)
-                    .context("opening the declared assurance session")?;
+            if let Some(campaign) = params.assurance
+                && let Err(err) =
+                    crate::assurance_session::open_for_boot(campaign, &vm_id.0, &admitted)
+            {
+                // Rolls the launch back rather than returning with the VM up.
+                // The session opens after the backend start, so a bare `?`
+                // here left a running workload behind while reporting the boot
+                // as failed — and an orphan whose only record says it did not
+                // start is worse than either outcome alone.
+                return Err(undo_launch(UndoLaunch {
+                    backend,
+                    vm_id: &vm_id,
+                    admitted: &admitted,
+                    emitter: params.emitter,
+                    stage: "assurance-session",
+                    reason: "the declared assurance campaign could not be opened",
+                    err,
+                }));
             }
             Ok(StartedMachine {
                 vm_id,
@@ -3391,6 +3406,109 @@ mod tests {
             backend.status(&started.vm_id).unwrap(),
             mvm_core::vm_backend::VmStatus::Running
         ));
+    }
+
+    #[test]
+    fn a_campaign_that_cannot_open_rolls_the_launch_back() {
+        // The session opens *after* the backend start, so a failure there used
+        // to return with the workload still running.
+        //
+        // The campaign declares no destination, which `open` refuses whether or
+        // not a plane happens to be installed. Asserting on the absence of the
+        // process-global plane instead would make this test depend on run
+        // order — a `OnceLock` admits one value and the neighbouring test
+        // installs it, so it would pass under nextest and flake under
+        // `cargo test`.
+        use std::sync::Arc;
+
+        use mvm_contract::assurance::{
+            ApprovalSet, AssuranceId, ObservationScope, RequestedAuthority, Sha256Digest, ToolId,
+        };
+
+        use crate::assurance_session::{
+            CampaignDeclaration, CampaignRequest, default_policy_ceiling,
+        };
+
+        let (_env, _home) = host_with_ceiling(Default::default());
+        let dir = tempfile::tempdir().unwrap();
+        let audit = tempfile::tempdir().unwrap();
+        let backend = mvm_runtime::AnyBackend::from_hypervisor("mock");
+        let ledger = InMemoryNonceLedger::new();
+        let emitter = Arc::new(
+            crate::audit::emitter::AuditEmitter::with_dir(
+                ed25519_dalek::SigningKey::from_bytes(&[41u8; 32]),
+                audit.path(),
+            )
+            .expect("emitter"),
+        );
+        let id = |raw: &str| AssuranceId::parse(raw).expect("identifier");
+        let declaration = CampaignDeclaration {
+            campaign_id: id("mvm-campaign-9"),
+            trial_id: id("trial-9"),
+            source_run_id: id("scout-9"),
+            source_digest: Sha256Digest::parse(format!("sha256:{}", "5".repeat(64)))
+                .expect("digest"),
+            edges: Vec::new(),
+            approvals: ApprovalSet::none().with(ToolId::CampaignProbeV1),
+            requested: RequestedAuthority {
+                allowed_tools: vec![ToolId::CampaignProbeV1],
+                observation_scopes: vec![ObservationScope::HostAuditRefs],
+                max_steps: 4,
+                max_output_bytes: 4096,
+                deadline_unix_ms: 0,
+            },
+            grant_ttl_ms: 600_000,
+        };
+        let campaign = CampaignRequest {
+            declaration,
+            emitter: Arc::clone(&emitter),
+            policy_ceiling: default_policy_ceiling(),
+            policy: mvm_core::policy::network_policy::NetworkPolicy::deny_all(),
+            backend: "mock".to_string(),
+            now_unix_ms: 1_800_000_000_000,
+        };
+
+        let service =
+            mvm_core::protocol::broker::ServiceId::parse("host.assurance.v1").expect("service id");
+        let mut synthesis = fixture_input("vm-rollback");
+        synthesis.services = vec![service];
+        let config = mvm_core::vm_backend::VmStartConfig {
+            name: "vm-rollback".into(),
+            rootfs_path: "/store/rootfs.ext4".into(),
+            ..Default::default()
+        };
+
+        let err = admit_and_start(
+            &backend,
+            AdmitAndStartParams {
+                synthesis: &synthesis,
+                config,
+                clock: &SystemClock,
+                ledger: &ledger,
+                host_signer_keys_dir: Some(dir.path()),
+                bundle_ctx: None,
+                variant: Variant::Dev,
+                policy_bundle: None,
+                emitter: Some(&emitter),
+                audit_durability: crate::audit::durability::AuditDurability::BestEffort,
+                assurance: Some(&campaign),
+            },
+        )
+        .expect_err("a campaign declaring no destination cannot open");
+        // Deliberately not asserted on the message: which refusal fires
+        // depends on whether a neighbouring test installed the process-global
+        // plane first (`NoPlane`) or not (`NoEdges`). Both roll the launch
+        // back, and the rollback is the property under test.
+        let _ = &err;
+
+        // The whole point: no workload is left running behind the failure.
+        assert!(
+            !matches!(
+                backend.status(&mvm_core::vm_backend::VmId("vm-rollback".into())),
+                Ok(mvm_core::vm_backend::VmStatus::Running)
+            ),
+            "a campaign that could not open must not leave the VM up"
+        );
     }
 
     #[test]

--- a/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
+++ b/specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md
@@ -116,6 +116,34 @@ Three properties are structural rather than checked at runtime:
       campaign. `None` everywhere else, so nothing changes for an ordinary
       launch.
 
+## Topology: which process may own a session
+
+Verified by tracing, and it constrains everything still open.
+
+`install_host_assurance_plane` is called only by `register_bound_handlers`,
+which only the `mvm-host-agent` and `mvm-broker` binaries call.
+`assurance_session::open_for_boot` is called only by `admit_and_start`, whose
+production caller runs in the CLI or SDK process. **The two sets are disjoint**:
+the process that opens a session never installs a plane, and the process that
+installs one never opens a session. In production `open` therefore refuses with
+`NoPlane` — fail-closed, but it means no campaign can open outside a
+single-process test.
+
+Two consequences for the remaining work:
+
+- A session must be opened where the broker registry lives. The supervisor
+  holds the plan, so it must mint the binding and the already-intersected
+  authority and pass them to the broker, the way `services_bindings` and
+  `capability_bindings` already travel.
+- The broker cannot use `AssuranceLedger` as written. It has no `AuditEmitter`;
+  it records through `AuditClient`, whose `AppendEntryRequest` is a
+  *category + typed fields* document validated against the audit-signer's
+  allow-list — not a chain-signed `PlanAuditEntry`. Reconciling the two is a
+  real piece of work: a new audit category, a field schema, and a revisit of
+  `audit_entry_digest_hex`/`resolve_audit_ref`, which assume the
+  `PlanAuditEntry` shape. It is **not** a thin sink trait, which is what an
+  earlier estimate here assumed.
+
 ## Open
 
 - [~] **W5 — Cleanup and disposability evidence (partial).**
@@ -150,7 +178,11 @@ Three properties are structural rather than checked at runtime:
       and it is a larger piece than the rest of W5 — closer in shape to W8's
       provider work than to the evidence plumbing above.
 
-- [ ] **W9b — The `mvmctl machine run` verb.** `machine run` does not boot
+- [ ] **W9b — Open the session where the broker lives.** Supersedes the
+      earlier framing of this as a CLI flag: the verb is not the obstacle, the
+      process boundary is. Needs the audit-model reconciliation above first.
+
+- [ ] **W9c — The `mvmctl machine run` verb.** `machine run` does not boot
       through `admit_and_boot_local`; it drives `AnyBackend` directly from
       `commands/machine/lifecycle.rs`, building its own launch config. So the
       W9 thread reaches the *library* launch path and not the CLI verb, and an


### PR DESCRIPTION
## The bug

The assurance session opens *after* the backend start, and I wrote that as a
bare `?`. So a failure there returned with the workload still running: the boot
reported as failed, the VM left up. An orphan whose only record says it did not
start is worse than either outcome alone.

It now goes through `undo_launch` — the same rollback an unapplied grant takes.

## Why it is the guaranteed path, not a rare one

Tracing the topology:

- `install_host_assurance_plane` ← only `register_bound_handlers`, which only
  the `mvm-host-agent` and `mvm-broker` binaries call.
- `open_for_boot` ← only `admit_and_start`, whose production caller runs in the
  CLI or SDK process.

**The two sets are disjoint.** The process that opens a session never installs a
plane, and the process that installs one never opens a session. So in production
`open` refuses with `NoPlane` every time — and before this change, took a
running VM with it.

Fail-closed was working. The rollback was not.

## What the plan now records

A session has to be opened where the broker registry lives. The supervisor holds
the plan, so it must mint the binding and the already-intersected authority and
pass them down, the way `services_bindings` and `capability_bindings` already
travel.

The broker cannot reuse `AssuranceLedger`. It has no `AuditEmitter` and records
through `AuditClient`, whose `AppendEntryRequest` is a *category and typed
fields* document validated against the audit-signer's allow-list — not a
chain-signed `PlanAuditEntry`. Reconciling the two models means a new audit
category, a field schema, and a revisit of `audit_entry_digest_hex` /
`resolve_audit_ref`, which assume the `PlanAuditEntry` shape. That is real work,
and explicitly **not** the thin sink trait an earlier estimate in this plan
assumed. W9b is re-scoped accordingly and the CLI verb split out as W9c.

## On the test

It asserts the rollback, not the refusal message. Which refusal fires (`NoPlane`
or `NoEdges`) depends on whether a neighbouring test installed the
process-global plane first — a `OnceLock` admits one value — so asserting the
wording passed under nextest and failed under `cargo test`. The rollback is the
property under test either way, and it is now checked under both runners.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 12,409 passed
- `cargo test -p mvm-hostd --lib campaign` (shared process) — 4 passed

The two failing gate self-tests are the known `graft/`-cache issue: they scan
without honouring `.gitignore`, and `graft/` is gitignored and absent from
`main`, so CI never sees it.
