### PR TITLE
feat(assurance): let one ledger serve both audit routes

### DIFF
--- a/crates/mvm-hostd/src/assurance_session.rs
+++ b/crates/mvm-hostd/src/assurance_session.rs
@@ -280,7 +280,7 @@ pub fn open_on(
         trial_id: request.declaration.trial_id.clone(),
         source_digest: request.declaration.source_digest.clone(),
     };
-    let ledger = AssuranceLedger::new(request.emitter, plan);
+    let ledger = AssuranceLedger::new(request.emitter.as_ref(), plan);
     let refs = ledger
         .open_session(&identity)
         .map_err(|error| SessionRefusal::NotRecorded(error.to_string()))?;

--- a/crates/mvm-hostd/src/assurance_session.rs
+++ b/crates/mvm-hostd/src/assurance_session.rs
@@ -31,7 +31,9 @@ use mvm_core::policy::network_policy::NetworkPolicy;
 use mvm_core::protocol::broker::ServiceId;
 use sha2::{Digest, Sha256};
 
-use crate::audit::assurance::{AssuranceLedger, SessionIdentity, cite};
+use crate::audit::assurance::{
+    AssuranceAuditSink, AssuranceLedger, PlanIdentity, SessionIdentity, cite,
+};
 use crate::audit::emitter::AuditEmitter;
 use crate::broker::handlers::host_assurance_v1::{
     AssuranceSessionSpec, DeclaredDestination, HOST_ASSURANCE_SERVICE, HostAssuranceV1Handler,
@@ -280,7 +282,8 @@ pub fn open_on(
         trial_id: request.declaration.trial_id.clone(),
         source_digest: request.declaration.source_digest.clone(),
     };
-    let ledger = AssuranceLedger::new(request.emitter.as_ref(), plan);
+    let plan_identity = PlanIdentity::from(plan);
+    let ledger = AssuranceLedger::new(request.emitter.as_ref(), &plan_identity);
     let refs = ledger
         .open_session(&identity)
         .map_err(|error| SessionRefusal::NotRecorded(error.to_string()))?;
@@ -322,8 +325,8 @@ pub fn open_on(
                 port: edge.port,
             })
             .collect(),
-        plan: plan.clone(),
-        emitter: Some(Arc::clone(request.emitter)),
+        identity: PlanIdentity::from(plan),
+        sink: Some(Arc::clone(request.emitter) as Arc<dyn AssuranceAuditSink + Send + Sync>),
     });
     Ok(binding)
 }
@@ -373,7 +376,7 @@ pub fn close_on(
     verdict: &TrialVerdict,
 ) -> Result<()> {
     let _ = plane;
-    AssuranceLedger::new(emitter, admitted.plan())
+    AssuranceLedger::new(emitter, &PlanIdentity::from(admitted.plan()))
         .complete_trial(identity, verdict)
         .context("recording the trial outcome")?;
     Ok(())

--- a/crates/mvm-hostd/src/audit/assurance.rs
+++ b/crates/mvm-hostd/src/audit/assurance.rs
@@ -26,7 +26,7 @@ use sha2::{Digest, Sha256};
 
 use super::emitter::AuditEmitter;
 use super::evidence::{EmittedEvidence, EvidenceReceipt, audit_entry_digest_hex};
-use crate::supervisor::{PlanAuditEntry, for_plan};
+use crate::supervisor::PlanAuditEntry;
 
 /// Audit event emitted when a session is opened against an admitted plan.
 pub const EVENT_SESSION_OPENED: &str = "assurance.session_opened";
@@ -116,6 +116,66 @@ impl LedgerRefs {
     }
 }
 
+/// The only part of an admitted plan an assurance record quotes.
+///
+/// The broker records campaign probes but is deliberately never given the
+/// plan — it receives derived bindings, the way `services_bindings` and
+/// `capability_bindings` already travel. These six fields are exactly what a
+/// `PlanAuditEntry` carries, so passing them keeps the records identical on
+/// both routes without widening what the broker is trusted with.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlanIdentity {
+    pub tenant: mvm_core::plan::TenantId,
+    pub plan_id: mvm_core::plan::PlanId,
+    pub plan_version: u32,
+    pub image_name: String,
+    pub image_sha256: String,
+    /// Labels the plan asks to be copied onto every entry it generates.
+    #[serde(default)]
+    pub audit_labels: std::collections::BTreeMap<String, String>,
+}
+
+impl From<&ExecutionPlan> for PlanIdentity {
+    fn from(plan: &ExecutionPlan) -> Self {
+        Self {
+            tenant: plan.tenant.clone(),
+            plan_id: plan.plan_id.clone(),
+            plan_version: plan.plan_version,
+            image_name: plan.image.name.clone(),
+            image_sha256: plan.image.sha256.to_ascii_lowercase(),
+            audit_labels: plan.audit_labels.clone(),
+        }
+    }
+}
+
+impl PlanIdentity {
+    /// Build the entry this identity would produce for `event`.
+    ///
+    /// Mirrors `supervisor::for_plan` field for field; it exists separately
+    /// because that one needs a whole plan and this route has none.
+    fn entry(
+        &self,
+        event: &str,
+        extras: impl IntoIterator<Item = (String, String)>,
+    ) -> PlanAuditEntry {
+        let mut labels = self.audit_labels.clone();
+        labels.extend(extras);
+        PlanAuditEntry {
+            timestamp: chrono::Utc::now(),
+            tenant: self.tenant.clone(),
+            plan_id: self.plan_id.clone(),
+            plan_version: self.plan_version,
+            bundle_id: None,
+            bundle_version: None,
+            image_name: self.image_name.clone(),
+            image_sha256: self.image_sha256.clone(),
+            event: event.to_string(),
+            labels,
+        }
+    }
+}
+
 /// Where an assurance record is written.
 ///
 /// Two processes need to write these and they do not share an audit route. The
@@ -142,14 +202,14 @@ impl AssuranceAuditSink for AuditEmitter {
 /// Writes the records an assurance campaign cites.
 pub struct AssuranceLedger<'a> {
     sink: &'a dyn AssuranceAuditSink,
-    plan: &'a ExecutionPlan,
+    identity: &'a PlanIdentity,
 }
 
 impl<'a> AssuranceLedger<'a> {
-    /// Bind a ledger to one admitted plan, writing through `sink`.
+    /// Bind a ledger to one admitted plan's identity, writing through `sink`.
     #[must_use]
-    pub fn new(sink: &'a dyn AssuranceAuditSink, plan: &'a ExecutionPlan) -> Self {
-        Self { sink, plan }
+    pub fn new(sink: &'a dyn AssuranceAuditSink, identity: &'a PlanIdentity) -> Self {
+        Self { sink, identity }
     }
 
     /// Record that a session opened, and return what a binding may cite.
@@ -249,7 +309,7 @@ impl<'a> AssuranceLedger<'a> {
     where
         I: IntoIterator<Item = (String, String)>,
     {
-        let entry = for_plan(self.plan, None, event, labels);
+        let entry = self.identity.entry(event, labels);
         let emitted = self
             .sink
             .record(&entry, receipt)

--- a/crates/mvm-hostd/src/audit/assurance.rs
+++ b/crates/mvm-hostd/src/audit/assurance.rs
@@ -116,17 +116,40 @@ impl LedgerRefs {
     }
 }
 
+/// Where an assurance record is written.
+///
+/// Two processes need to write these and they do not share an audit route. The
+/// supervisor holds an [`AuditEmitter`] and writes chain-signed
+/// `PlanAuditEntry` lines with receipts. The broker holds neither — it records
+/// through the audit-signer, whose envelope is a category-and-fields document.
+/// A trait is the only thing that lets one ledger serve both without the
+/// caller choosing a code path per process.
+///
+/// Receipts are deliberately part of the contract rather than an implementation
+/// detail: a sink that cannot write one must say so, because a citation to a
+/// receipt nobody wrote reads as proof.
+pub trait AssuranceAuditSink {
+    /// Record one entry, and its receipt when the caller requires one.
+    fn record(&self, entry: &PlanAuditEntry, receipt: EvidenceReceipt) -> Result<EmittedEvidence>;
+}
+
+impl AssuranceAuditSink for AuditEmitter {
+    fn record(&self, entry: &PlanAuditEntry, receipt: EvidenceReceipt) -> Result<EmittedEvidence> {
+        self.emit_entry_for_evidence(entry, receipt)
+    }
+}
+
 /// Writes the records an assurance campaign cites.
 pub struct AssuranceLedger<'a> {
-    emitter: &'a AuditEmitter,
+    sink: &'a dyn AssuranceAuditSink,
     plan: &'a ExecutionPlan,
 }
 
 impl<'a> AssuranceLedger<'a> {
-    /// Bind a ledger to one admitted plan.
+    /// Bind a ledger to one admitted plan, writing through `sink`.
     #[must_use]
-    pub fn new(emitter: &'a AuditEmitter, plan: &'a ExecutionPlan) -> Self {
-        Self { emitter, plan }
+    pub fn new(sink: &'a dyn AssuranceAuditSink, plan: &'a ExecutionPlan) -> Self {
+        Self { sink, plan }
     }
 
     /// Record that a session opened, and return what a binding may cite.
@@ -228,8 +251,8 @@ impl<'a> AssuranceLedger<'a> {
     {
         let entry = for_plan(self.plan, None, event, labels);
         let emitted = self
-            .emitter
-            .emit_entry_for_evidence(&entry, receipt)
+            .sink
+            .record(&entry, receipt)
             .with_context(|| format!("emitting assurance event {event}"))?;
         LedgerRefs::from_emitted(&entry, &emitted)
     }
@@ -284,4 +307,190 @@ pub fn audit_citations_resolve(binding: &MvmBinding, chain_path: &Path) -> Resul
 #[must_use]
 pub fn is_publishable_claim(outcome: TrialOutcome) -> bool {
     outcome.is_certifying_claim()
+}
+
+/// A sink that records through the audit-signer, for a process holding no
+/// [`AuditEmitter`] — which is every broker.
+///
+/// # What this sink cannot do
+///
+/// It cannot write a receipt. Receipts are appended by the emitter's receipt
+/// store, and the broker has none, so [`EvidenceReceipt::Required`] is an
+/// error here rather than a silent `receipt_id: None`. That is the whole point
+/// of putting receipts in the trait: the split between what each process may
+/// record is enforced, not remembered. Probes are audit-only and ride this
+/// sink; session open and trial completion carry receipts and stay with the
+/// supervisor.
+pub struct SignerSink {
+    client: crate::broker::audit_client::AuditClient,
+    workload_id: String,
+    tenant_id: String,
+    session_id: String,
+}
+
+impl SignerSink {
+    /// Bind a sink to one workload's audit route.
+    #[must_use]
+    pub fn new(
+        client: crate::broker::audit_client::AuditClient,
+        workload_id: impl Into<String>,
+        tenant_id: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            client,
+            workload_id: workload_id.into(),
+            tenant_id: tenant_id.into(),
+            session_id: session_id.into(),
+        }
+    }
+
+    /// The category every assurance record is appended under.
+    pub const CATEGORY: &'static str = "assurance";
+}
+
+impl AssuranceAuditSink for SignerSink {
+    fn record(&self, entry: &PlanAuditEntry, receipt: EvidenceReceipt) -> Result<EmittedEvidence> {
+        if matches!(receipt, EvidenceReceipt::Required) {
+            anyhow::bail!(
+                "the audit-signer sink cannot write a receipt for {}; \
+                 receipt-bearing records belong to the process holding the emitter",
+                entry.event
+            );
+        }
+
+        // The digest still covers the `PlanAuditEntry`, so a reference minted
+        // here names the same logical record the emitter would have named. The
+        // signer's chain stores it inside `fields`, which is what a resolver
+        // reads on this route.
+        let audit_digest = super::evidence::audit_entry_digest_hex(entry)?;
+        let fields = serde_json::to_value(entry).context("encoding the assurance entry")?;
+        let request = mvm_core::protocol::audit_signer::AppendEntryRequest::AppendEntry {
+            request_id: format!("assurance-{audit_digest}"),
+            category: Self::CATEGORY.to_string(),
+            ts: entry.timestamp.to_rfc3339(),
+            workload_id: self.workload_id.clone(),
+            tenant_id: self.tenant_id.clone(),
+            session_id: self.session_id.clone(),
+            correlation_id: format!("assurance-{}", entry.event),
+            fields,
+        };
+
+        // The ledger is synchronous and the client is not. Mirrors the
+        // emitter's own bridge: block on a scoped thread when a runtime is
+        // already present, because blocking inside one is a tokio panic.
+        let append = || -> Result<()> {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("building a runtime for the assurance audit append")?;
+            runtime
+                .block_on(self.client.append(&request))
+                .map(|_| ())
+                .context("appending the assurance entry through the audit-signer")
+        };
+        if tokio::runtime::Handle::try_current().is_ok() {
+            std::thread::scope(|scope| {
+                scope
+                    .spawn(append)
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("assurance audit append thread panicked"))?
+            })?;
+        } else {
+            append()?;
+        }
+
+        Ok(EmittedEvidence {
+            audit_digest,
+            receipt_id: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod sink_tests {
+    use super::*;
+    use mvm_core::plan::TenantId;
+
+    fn entry(event: &str) -> PlanAuditEntry {
+        PlanAuditEntry {
+            timestamp: chrono::Utc::now(),
+            tenant: TenantId("local".to_string()),
+            plan_id: mvm_core::plan::PlanId("plan-1".to_string()),
+            plan_version: 1,
+            bundle_id: None,
+            bundle_version: None,
+            image_name: "vm".to_string(),
+            image_sha256: "a".repeat(64),
+            event: event.to_string(),
+            labels: Default::default(),
+        }
+    }
+
+    fn sink() -> SignerSink {
+        // The path is never dialled: `Required` is refused before any I/O.
+        SignerSink::new(
+            crate::broker::audit_client::AuditClient::new("/nonexistent/audit.sock"),
+            "workload",
+            "local",
+            "session-1",
+        )
+    }
+
+    #[test]
+    fn the_signer_sink_refuses_a_record_it_cannot_receipt() {
+        // The split between what each process may record is enforced here
+        // rather than remembered at the call site: a broker claiming a receipt
+        // it never wrote is the failure this trait exists to make impossible.
+        let error = sink()
+            .record(
+                &entry("assurance.session_opened"),
+                EvidenceReceipt::Required,
+            )
+            .expect_err("a sink with no receipt store must refuse");
+        let text = format!("{error:#}");
+        assert!(text.contains("cannot write a receipt"), "{text}");
+        assert!(text.contains("assurance.session_opened"), "{text}");
+    }
+
+    #[test]
+    fn the_signer_sink_refuses_before_it_dials_anything() {
+        // The socket does not exist, so a sink that attempted the append would
+        // fail with a connection error instead — which would mean the refusal
+        // above was incidental rather than a rule.
+        let error = format!(
+            "{:#}",
+            sink()
+                .record(
+                    &entry("assurance.trial_completed"),
+                    EvidenceReceipt::Required
+                )
+                .expect_err("refused")
+        );
+        assert!(
+            !error.contains("nonexistent"),
+            "it dialled the socket: {error}"
+        );
+    }
+
+    #[test]
+    fn both_sinks_agree_on_the_reference_a_record_earns() {
+        // A reference minted on either route names the same logical record, so
+        // a campaign's citations do not change meaning with the process that
+        // happened to write them.
+        let entry = entry("assurance.probe");
+        let expected = super::super::evidence::audit_entry_digest_hex(&entry).expect("digest");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let emitter = AuditEmitter::with_dir(
+            ed25519_dalek::SigningKey::from_bytes(&[51u8; 32]),
+            dir.path(),
+        )
+        .expect("emitter");
+        let via_emitter = emitter
+            .record(&entry, EvidenceReceipt::Omitted)
+            .expect("emitter records");
+        assert_eq!(via_emitter.audit_digest, expected);
+        assert!(via_emitter.receipt_id.is_none());
+    }
 }

--- a/crates/mvm-hostd/src/audit_signer/category.rs
+++ b/crates/mvm-hostd/src/audit_signer/category.rs
@@ -21,6 +21,9 @@ pub const ALLOWED_CATEGORIES: &[&str] = &[
     "dns",
     // Workload-emitted via `host.audit.v1` in `mvm-broker`.
     "workload_audit",
+    // Assurance campaign records. Emitted by the broker, which records through
+    // the audit-signer rather than an `AuditEmitter` it does not have.
+    "assurance",
 ];
 
 /// True iff `category` is in the allow-list.
@@ -35,6 +38,15 @@ mod tests {
     #[test]
     fn allowed_categories_include_workload_audit() {
         assert!(is_allowed("workload_audit"));
+    }
+
+    #[test]
+    fn the_assurance_category_is_accepted() {
+        // The broker records campaign probes through the signer, so a refused
+        // category there would mean a boundary attempt with no record — which
+        // the probe path treats as a reason to refuse the probe outright.
+        assert!(is_allowed("assurance"));
+        assert!(!is_allowed("assurance_probe"));
     }
 
     #[test]

--- a/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
@@ -344,7 +344,7 @@ impl HostAssuranceV1Handler {
             .emitter
             .as_ref()
             .ok_or(ProbeRefusal::AuditUnavailable)?;
-        let ledger = AssuranceLedger::new(emitter, &session.plan);
+        let ledger = AssuranceLedger::new(emitter.as_ref(), &session.plan);
         let refs = ledger
             .record_probe(&ProbeRecord {
                 session_id: &request.session_id,

--- a/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
@@ -20,10 +20,8 @@ use mvm_contract::assurance::{
     PROBE_OBSERVATION_SCHEMA, ProbeInvocation, ProbeObservation, ProbeRefusal, ProbeRequest,
 };
 
-use crate::audit::assurance::{AssuranceLedger, ProbeRecord};
-use crate::audit::emitter::AuditEmitter;
+use crate::audit::assurance::{AssuranceAuditSink, AssuranceLedger, PlanIdentity, ProbeRecord};
 use mvm_core::egress_broker::{EgressRequest, EgressVerdict, decide_egress};
-use mvm_core::plan::ExecutionPlan;
 use mvm_core::policy::network_policy::NetworkPolicy;
 use mvm_core::policy::security::AgentProfile;
 use mvm_core::protocol::broker::{AuditDurability, Idempotency, ServiceErrorCode, ServiceId};
@@ -59,12 +57,12 @@ pub struct AssuranceSessionSpec {
     pub policy: NetworkPolicy,
     /// Destinations the campaign declared.
     pub destinations: Vec<DeclaredDestination>,
-    /// The admitted plan every record is written against.
-    pub plan: ExecutionPlan,
+    /// The admitted plan's identity — the only part of it a record quotes.
+    pub identity: PlanIdentity,
     /// Where probe records go. `None` disables recording, which also disables
     /// probing: an unrecorded boundary attempt is not one this service will
     /// perform.
-    pub emitter: Option<Arc<AuditEmitter>>,
+    pub sink: Option<Arc<dyn AssuranceAuditSink + Send + Sync>>,
 }
 
 struct AssuranceSession {
@@ -80,8 +78,8 @@ struct AssuranceSession {
     attempted_effect: bool,
     effect_observed_in_guest: bool,
     boundary_crossed: bool,
-    plan: ExecutionPlan,
-    emitter: Option<Arc<AuditEmitter>>,
+    identity: PlanIdentity,
+    sink: Option<Arc<dyn AssuranceAuditSink + Send + Sync>>,
     evidence_refs: Vec<EvidenceRef>,
 }
 
@@ -94,7 +92,7 @@ impl std::fmt::Debug for AssuranceSessionSpec {
             .field("workload_session_id", &self.workload_session_id)
             .field("trial_id", &self.trial_id)
             .field("destinations", &self.destinations)
-            .field("recording", &self.emitter.is_some())
+            .field("recording", &self.sink.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -106,7 +104,7 @@ impl std::fmt::Debug for AssuranceSession {
             .field("trial_id", &self.trial_id)
             .field("steps_used", &self.steps_used)
             .field("blocked_edges", &self.blocked_edges)
-            .field("recording", &self.emitter.is_some())
+            .field("recording", &self.sink.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -151,8 +149,8 @@ impl HostAssuranceV1Handler {
             attempted_effect: false,
             effect_observed_in_guest: false,
             boundary_crossed: false,
-            plan: spec.plan,
-            emitter: spec.emitter,
+            identity: spec.identity,
+            sink: spec.sink,
             evidence_refs: Vec::new(),
         };
         self.sessions
@@ -340,11 +338,11 @@ impl HostAssuranceV1Handler {
         admitted: bool,
         destination_label: &AssuranceId,
     ) -> Result<Vec<EvidenceRef>, ProbeRefusal> {
-        let emitter = session
-            .emitter
+        let sink = session
+            .sink
             .as_ref()
             .ok_or(ProbeRefusal::AuditUnavailable)?;
-        let ledger = AssuranceLedger::new(emitter.as_ref(), &session.plan);
+        let ledger = AssuranceLedger::new(sink.as_ref(), &session.identity);
         let refs = ledger
             .record_probe(&ProbeRecord {
                 session_id: &request.session_id,
@@ -434,11 +432,13 @@ mod tests {
     use super::*;
 
     use crate::audit::assurance::{audit_citations_resolve, resolve_audit_ref};
+    use crate::audit::emitter::AuditEmitter;
     use mvm_contract::assurance::{
         ApprovalSet, AuthorityCeiling, AuthorityInputs, EvidenceRef, ObservationScope,
         PROBE_REQUEST_SCHEMA, RequestedAuthority, SessionGrant, Sha256Digest, ToolId,
     };
     use mvm_contract::policy::network_policy::HostPort;
+    use mvm_core::plan::ExecutionPlan;
     use mvm_core::plan::test_support::PlanFixture;
     use mvm_core::protocol::broker::CorrelationId;
 
@@ -515,7 +515,7 @@ mod tests {
         let handler = HostAssuranceV1Handler::new();
         let mut session = spec(policy, max_steps);
         session.authority = authority_expiring_at(max_steps, expiry, now);
-        session.emitter = Some(Arc::new(emitter));
+        session.sink = Some(Arc::new(emitter) as Arc<dyn AssuranceAuditSink + Send + Sync>);
         handler.open_session(session);
         // The tempdir is deliberately leaked: these tests only assert on the
         // dispatch result, and keeping the guard alive would mean threading it
@@ -551,8 +551,8 @@ mod tests {
                 host: "attacker.example.com".to_string(),
                 port: 443,
             }],
-            plan: PlanFixture::new().build(),
-            emitter: None,
+            identity: PlanIdentity::from(&PlanFixture::new().build()),
+            sink: None,
         }
     }
 
@@ -569,7 +569,7 @@ mod tests {
             .with_receipts();
         let handler = HostAssuranceV1Handler::new();
         let mut session = spec(policy, max_steps);
-        session.emitter = Some(Arc::new(emitter));
+        session.sink = Some(Arc::new(emitter) as Arc<dyn AssuranceAuditSink + Send + Sync>);
         handler.open_session(session);
         (handler, dir)
     }
@@ -978,7 +978,8 @@ mod tests {
             .expect("emitter")
             .with_receipts();
         let plan = PlanFixture::new().build();
-        let ledger = AssuranceLedger::new(&emitter, &plan);
+        let identity = PlanIdentity::from(&plan);
+        let ledger = AssuranceLedger::new(&emitter, &identity);
         let identity = crate::audit::assurance::SessionIdentity {
             session_id: id(SESSION),
             campaign_id: id("mvm-campaign-1"),
@@ -1022,7 +1023,8 @@ mod tests {
             .expect("emitter")
             .with_receipts();
         let plan = PlanFixture::new().build();
-        let ledger = AssuranceLedger::new(&emitter, &plan);
+        let identity = PlanIdentity::from(&plan);
+        let ledger = AssuranceLedger::new(&emitter, &identity);
         let refs = ledger
             .open_session(&SessionIdentity {
                 session_id: id(SESSION),


### PR DESCRIPTION
Enabling work for W9b, which needs the ledger to run in the broker.

## Why a trait

Two processes need to write assurance records and they do not share an audit
route. The supervisor holds an `AuditEmitter` and writes chain-signed
`PlanAuditEntry` lines with receipts. The broker holds neither — it records
through the audit-signer, whose envelope is a *category and typed fields*
document. `AssuranceAuditSink` is what lets one ledger serve both without the
caller picking a code path per process.

## Receipts are in the contract, deliberately

`SignerSink` **errors** on `EvidenceReceipt::Required` rather than quietly
returning `receipt_id: None`. The broker has no receipt store, and a citation to
a receipt nobody wrote reads as proof. Putting that in the trait makes the split
enforced rather than remembered at each call site:

- probes are audit-only and ride the signer;
- session open and trial completion carry receipts and stay with the supervisor.

One test points the sink at a nonexistent socket and asserts the error does
*not* mention it — so if the refusal ever became incidental (an append failing
on connection rather than a rule firing first), it goes red.

## The category question, answered

The audit-signer's allow-list turns out to be a plain in-tree `const`, not a
contract with an external binary, and per-category schema validation is not yet
enforced (`fields` is still freeform). So adding `assurance` is a schema
addition, not a protocol change — the earlier concern in this plan that it might
be the latter does not hold. The test asserts `assurance` is accepted and
`assurance_probe` is not, so the category is exact rather than a prefix.

## References stay stable across routes

The digest still covers the `PlanAuditEntry` on both sinks, so a reference
minted by either names the same logical record. A campaign's citations do not
change meaning with whichever process happened to write them.

## Scope

Enabling only. Nothing constructs a `SignerSink` in the broker yet and no
session is opened there; that is W9b, which additionally needs the supervisor to
mint the binding and pass it down.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 12,415 passed
- the `test-support` feature lane — 3,655 passed
- all 61 applicable xtask gates — pass

The two failing gate self-tests are the known `graft/`-cache issue: they scan
without honouring `.gitignore`, and `graft/` is gitignored and absent from
`main`, so CI never sees it.
