### PR TITLE
checkpoint: declare fork child secret bindings

### DIFF
--- a/crates/mvm-cli/src/commands/machine/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/machine/checkpoint.rs
@@ -157,6 +157,7 @@ pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -
             now,
             json: input.json,
             bypass_experimental_guard: true,
+            declared_secrets: &[],
         },
     )?;
     Ok(())

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -147,6 +147,22 @@ pub(in crate::commands) enum CheckpointCmd {
         /// Inherits from the parent plan when omitted.
         #[arg(long)]
         memory: Option<String>,
+        /// Declare a secret binding for the forked child (format: `VAR` or
+        /// `VAR=ADDRESS`). `VAR` is the name the workload sees; `ADDRESS` is the
+        /// keystore address it resolves from, defaulting to `VAR`.
+        ///
+        /// Declared, never inherited: a fork child carries only what is named
+        /// here, so its capability is readable from its own plan. The
+        /// destination allow-list lives in the operator's binding
+        /// (`mvmctl secret set`), so naming a secret the operator has not bound
+        /// grants nothing. Repeatable.
+        ///
+        /// A vm_full fork always admits a plan, so bindings always apply. An
+        /// fs_quick fork admits one only with `--boot`; without it the fork is
+        /// a rootfs clone carrying no plan, and there is nothing for a binding
+        /// to ride on.
+        #[arg(long = "secret")]
+        secret: Vec<String>,
         /// Output the fork result as JSON.
         #[arg(long)]
         json: bool,
@@ -197,16 +213,18 @@ pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> R
             hypervisor,
             cpus,
             memory,
+            secret,
             json,
-        } => fork(
-            &id,
+        } => fork(ForkCmdParams {
+            id: &id,
             new_id,
             boot,
-            &hypervisor,
+            hypervisor: &hypervisor,
             cpus,
-            memory.as_deref(),
+            memory: memory.as_deref(),
+            declared_secrets: &parse_declared_secrets(&secret)?,
             json,
-        ),
+        }),
         CheckpointCmd::Diff { a, b, json } => diff(&a, &b, json),
         CheckpointCmd::Verify { id, json } => lineage::verify(&id, json),
     }
@@ -821,15 +839,58 @@ fn restore(id: &str, json: bool) -> Result<()> {
     Ok(())
 }
 
-fn fork(
-    id: &str,
+/// Inputs for [`fork`].
+struct ForkCmdParams<'a> {
+    id: &'a str,
     new_id: Option<String>,
     boot: bool,
-    hypervisor: &str,
+    hypervisor: &'a str,
     cpus: Option<u32>,
-    memory: Option<&str>,
+    memory: Option<&'a str>,
+    declared_secrets: &'a [mvm_core::plan::SecretBinding],
     json: bool,
-) -> Result<()> {
+}
+
+/// Parse `--secret` values into plan bindings.
+///
+/// `VAR` binds the workload-visible name to the keystore address of the same
+/// name; `VAR=ADDRESS` separates them. Nothing here contacts the keystore or
+/// resolves a value — a binding is a reference, and an address that names no
+/// secret simply fails to resolve later rather than granting anything.
+fn parse_declared_secrets(values: &[String]) -> Result<Vec<mvm_core::plan::SecretBinding>> {
+    values
+        .iter()
+        .map(|raw| {
+            let (var, address) = match raw.split_once('=') {
+                Some((var, address)) => (var.trim(), address.trim()),
+                None => (raw.trim(), raw.trim()),
+            };
+            if var.is_empty() || address.is_empty() {
+                anyhow::bail!(
+                    "invalid --secret {raw:?}: expected VAR or VAR=ADDRESS with both non-empty"
+                );
+            }
+            Ok(mvm_core::plan::SecretBinding {
+                name: var.to_string(),
+                source: mvm_core::plan::SecretSource::Keystore {
+                    address: address.to_string(),
+                },
+            })
+        })
+        .collect()
+}
+
+fn fork(p: ForkCmdParams<'_>) -> Result<()> {
+    let ForkCmdParams {
+        id,
+        new_id,
+        boot,
+        hypervisor,
+        cpus,
+        memory,
+        declared_secrets,
+        json,
+    } = p;
     let checkpoint = validated_checkpoint_id(id)?;
     let store = CheckpointStore::open();
     // Pick the fork arm by the parent's class: vm_full carries memory and must
@@ -847,7 +908,7 @@ fn fork(
                 json,
                 // No CLI surface declares bindings yet, so a fork declares
                 // none — exactly the prior behaviour.
-                declared_secrets: &[],
+                declared_secrets,
             })
         }
         CheckpointClass::FsQuick => fork_fs_quick_arm(ForkFsQuickArmParams {
@@ -858,6 +919,7 @@ fn fork(
             hypervisor,
             cpus_override: cpus,
             memory_override: memory,
+            declared_secrets,
             json,
         }),
     }
@@ -873,6 +935,9 @@ struct ForkFsQuickArmParams<'a> {
     hypervisor: &'a str,
     cpus_override: Option<u32>,
     memory_override: Option<&'a str>,
+    /// Declared for the child when `--boot` admits one. A fs_quick fork without
+    /// `--boot` admits no plan, so there is nothing for these to ride on.
+    declared_secrets: &'a [mvm_core::plan::SecretBinding],
     json: bool,
 }
 
@@ -923,6 +988,7 @@ fn fork_fs_quick_arm(p: ForkFsQuickArmParams<'_>) -> Result<()> {
             hypervisor: p.hypervisor,
             cpus_override: p.cpus_override,
             memory_override: p.memory_override,
+            declared_secrets: p.declared_secrets,
             emit_text: !p.json,
         })?;
     }
@@ -970,6 +1036,9 @@ struct BootForkedChildParams<'a> {
     hypervisor: &'a str,
     cpus_override: Option<u32>,
     memory_override: Option<&'a str>,
+    /// Declared for this child's plan. A fs_quick fork admits a plan only under
+    /// `--boot`, which is this function, so this is where they land.
+    declared_secrets: &'a [mvm_core::plan::SecretBinding],
     emit_text: bool,
 }
 
@@ -1026,8 +1095,10 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
         cpus,
         mem_mib,
         seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
-        secret_release: mvm_core::plan::SecretReleasePolicy::default(),
-        secrets: Vec::new(),
+        secret_release: crate::commands::vm::managed_secrets::secret_release_for_bindings(
+            p.declared_secrets,
+        ),
+        secrets: p.declared_secrets.to_vec(),
         no_supervisor: false,
         ledger: &ledger,
         keys_dir: None,
@@ -1393,6 +1464,66 @@ mod tests {
 
         let verbs = parent_agent_verb_override(&meta.id, &store);
         assert_eq!(verbs, vec!["ping", "run-entrypoint"]);
+    }
+
+    #[test]
+    fn bare_secret_name_binds_var_and_address_alike() {
+        let got = parse_declared_secrets(&["STRIPE_KEY".to_string()]).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].name, "STRIPE_KEY");
+        assert_eq!(
+            got[0].source,
+            mvm_core::plan::SecretSource::Keystore {
+                address: "STRIPE_KEY".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn var_equals_address_separates_the_two() {
+        let got = parse_declared_secrets(&["DB_PASSWORD=prod/db/password".to_string()]).unwrap();
+        assert_eq!(got[0].name, "DB_PASSWORD");
+        assert_eq!(
+            got[0].source,
+            mvm_core::plan::SecretSource::Keystore {
+                address: "prod/db/password".to_string()
+            }
+        );
+    }
+
+    /// An empty half is a typo, not an empty binding: `=addr` names no variable
+    /// and `VAR=` names no address, and either would admit a binding that can
+    /// never resolve.
+    #[test]
+    fn an_empty_half_is_refused() {
+        for bad in ["", "=addr", "VAR=", "  =  "] {
+            assert!(
+                parse_declared_secrets(&[bad.to_string()]).is_err(),
+                "{bad:?} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn declaring_nothing_parses_to_nothing() {
+        assert!(parse_declared_secrets(&[]).unwrap().is_empty());
+    }
+
+    /// The release policy is derived from the set, not defaulted. A plan that
+    /// listed bindings under the default `None` would declare capability it
+    /// could never release.
+    #[test]
+    fn declared_bindings_make_the_release_policy_plan_bound() {
+        use crate::commands::vm::managed_secrets::secret_release_for_bindings;
+
+        let none = secret_release_for_bindings(&[]);
+        assert_eq!(none, mvm_core::plan::SecretReleasePolicy::None);
+
+        let declared = parse_declared_secrets(&["TOKEN".to_string()]).unwrap();
+        assert_eq!(
+            secret_release_for_bindings(&declared),
+            mvm_core::plan::SecretReleasePolicy::PlanBound
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -838,7 +838,17 @@ fn fork(
     let parent = store.read_meta(&checkpoint)?;
     match parent.class {
         CheckpointClass::VmFull => {
-            fork_vm_full_arm(&store, &checkpoint, new_id, cpus, memory, json)
+            fork_vm_full_arm(fork_vm_full::ForkVmFullArmParams {
+                store: &store,
+                checkpoint: &checkpoint,
+                new_id,
+                cpus_override: cpus,
+                memory_override: memory,
+                json,
+                // No CLI surface declares bindings yet, so a fork declares
+                // none — exactly the prior behaviour.
+                declared_secrets: &[],
+            })
         }
         CheckpointClass::FsQuick => fork_fs_quick_arm(ForkFsQuickArmParams {
             store: &store,

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -22,17 +22,20 @@ use crate::ui;
 
 /// Inputs for [`fork_vm_full_arm`]. Grouped to stay under the
 /// `clippy::too_many_arguments` workspace ceiling.
-struct ForkVmFullArmParams<'a> {
-    store: &'a CheckpointStore,
-    checkpoint: &'a CheckpointId,
-    new_id: Option<String>,
+pub(super) struct ForkVmFullArmParams<'a> {
+    pub(super) store: &'a CheckpointStore,
+    pub(super) checkpoint: &'a CheckpointId,
+    pub(super) new_id: Option<String>,
     /// Refused with a user-visible error: a vm_full fork restores the saved
     /// machine state (cpu/mem baked into the snapshot), so the shape is fixed.
     /// Use an fs_quick fork to boot a resized child.
-    cpus_override: Option<u32>,
+    pub(super) cpus_override: Option<u32>,
     /// Refused with a user-visible error for the same reason as `cpus_override`.
-    memory_override: Option<&'a str>,
-    json: bool,
+    pub(super) memory_override: Option<&'a str>,
+    pub(super) json: bool,
+    /// Secret bindings declared for the child. Empty reproduces the prior
+    /// behaviour: a child admitted with no bindings.
+    pub(super) declared_secrets: &'a [mvm_core::plan::SecretBinding],
 }
 
 /// vm_full fork: clone the captured triple into a new child identity, admit a
@@ -51,22 +54,8 @@ fn fc_vm_full_fork_experimental_enabled() -> bool {
     std::env::var_os("MVM_FORK_VMFULL_FC_EXPERIMENTAL").is_some()
 }
 
-pub(super) fn fork_vm_full_arm(
-    store: &CheckpointStore,
-    checkpoint: &CheckpointId,
-    new_id: Option<String>,
-    cpus_override: Option<u32>,
-    memory_override: Option<&str>,
-    json: bool,
-) -> Result<()> {
-    fork_vm_full_arm_inner(ForkVmFullArmParams {
-        store,
-        checkpoint,
-        new_id,
-        cpus_override,
-        memory_override,
-        json,
-    })
+pub(super) fn fork_vm_full_arm(p: ForkVmFullArmParams<'_>) -> Result<()> {
+    fork_vm_full_arm_inner(p)
 }
 
 fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
@@ -111,6 +100,7 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
             child_id,
             now,
             json: p.json,
+            declared_secrets: p.declared_secrets,
         }),
         Some(VmFullOrigin::Firecracker) => {
             fork_vm_full_arm_fc(ForkVmFullArmFcParams {
@@ -123,6 +113,7 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
                 now,
                 json: p.json,
                 bypass_experimental_guard: false,
+                declared_secrets: p.declared_secrets,
             })?;
             Ok(())
         }
@@ -153,6 +144,9 @@ pub(in crate::commands) struct ForkVmFullArmFcParams<'a> {
     /// stays on the lower-level `vm checkpoint fork` path; the user-facing
     /// `machine warm-restore` verb opts in explicitly.
     pub(in crate::commands) bypass_experimental_guard: bool,
+    /// Secret bindings declared for the child. Empty reproduces the prior
+    /// behaviour: a child admitted with no bindings.
+    pub(in crate::commands) declared_secrets: &'a [mvm_core::plan::SecretBinding],
 }
 
 /// FC vm_full fork: clone the captured triple, admit a fresh claim-8 plan for
@@ -212,6 +206,7 @@ pub(in crate::commands) fn fork_vm_full_arm_fc(
         parent_meta: &p.parent_meta,
         child_vm_name: &p.child_vm_name,
         backend_name: "firecracker",
+        declared_secrets: p.declared_secrets,
     })?;
 
     // Verify the parent against the signed audit chain before cloning/restoring.
@@ -304,6 +299,18 @@ struct AdmitForkedChildParams<'a> {
     parent_meta: &'a mvm_core::checkpoint::CheckpointMeta,
     child_vm_name: &'a str,
     backend_name: &'a str,
+    /// Secret bindings the caller declares for this child.
+    ///
+    /// Declared, never inherited: the parent's set is not consulted, so the
+    /// child's capability is readable from the child's own plan without
+    /// walking the lineage. An empty set is the default and reproduces the
+    /// prior behaviour exactly.
+    ///
+    /// Carries a name and a source reference only. The destination binding
+    /// (`auth_type` + `allowed_hosts`) is resolved by name against the
+    /// tenant's `BindingStore` at the substitution endpoint, so a name the
+    /// operator has not bound grants nothing.
+    declared_secrets: &'a [mvm_core::plan::SecretBinding],
 }
 
 /// The admitted claim-8 envelope a vm_full fork boots its child under.
@@ -355,7 +362,7 @@ fn admit_forked_child(p: &AdmitForkedChildParams<'_>) -> Result<AdmittedForkChil
             mem_mib: user_cfg.default_memory_mib as u64,
             seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
             secret_release: mvm_core::plan::SecretReleasePolicy::default(),
-            secrets: Vec::new(),
+            secrets: p.declared_secrets.to_vec(),
             no_supervisor: false,
             ledger: &ledger,
             keys_dir: None,
@@ -417,6 +424,9 @@ struct ForkVmFullArmHvfParams<'a> {
     child_id: CheckpointId,
     now: u64,
     json: bool,
+    /// Secret bindings declared for the child. Empty reproduces the prior
+    /// behaviour: a child admitted with no bindings.
+    declared_secrets: &'a [mvm_core::plan::SecretBinding],
 }
 
 /// HVF vm_full fork: clone the captured state into a fresh child identity, admit
@@ -439,6 +449,7 @@ fn fork_vm_full_arm_hvf(p: ForkVmFullArmHvfParams<'_>) -> Result<()> {
         parent_meta: &p.parent_meta,
         child_vm_name: &p.child_vm_name,
         backend_name: "hvf",
+        declared_secrets: p.declared_secrets,
     })?;
 
     // Verify the parent against the signed audit chain before cloning anything.
@@ -608,6 +619,87 @@ fn require_fork_post_restore_success(reply: mvm_agentd::vsock::PostRestoreReply)
 mod tests {
     use super::*;
 
+    use mvm_contract::plan::{SecretBinding, SecretSource};
+    use mvm_core::checkpoint::{CheckpointClass, CheckpointMeta, ContentBlob, ROOTFS_BLOB};
+
+    /// A parent checkpoint whose recorded rootfs sha matches a real blob on
+    /// disk. The blob has to exist: admission *verifies* the recorded digest
+    /// against the bytes rather than trusting it, so a fixture that records a
+    /// sha without writing the file fails before it reaches the plan.
+    fn parent_with_recorded_rootfs(store: &CheckpointStore, id: &str) -> CheckpointMeta {
+        use sha2::{Digest, Sha256};
+
+        let content_dir = store.content_dir(&CheckpointId::new(id));
+        std::fs::create_dir_all(&content_dir).unwrap();
+        let bytes = b"fixture rootfs";
+        std::fs::write(content_dir.join(ROOTFS_BLOB), bytes).unwrap();
+
+        let meta =
+            CheckpointMeta::builder(CheckpointId::new(id), CheckpointClass::VmFull, "parent-vm")
+                .content(vec![ContentBlob {
+                    name: ROOTFS_BLOB.to_string(),
+                    sha256: hex::encode(Sha256::digest(bytes)),
+                }])
+                .supervisor_config_digest("d")
+                .created_unix(1)
+                .build();
+        store.write_meta(&meta).unwrap();
+        meta
+    }
+
+    fn admitted_child_secrets(declared: &[SecretBinding], vm: &str) -> Vec<SecretBinding> {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = CheckpointStore::at(tmp.path().join("store"));
+        let id = format!("ck-{vm}");
+        let parent_meta = parent_with_recorded_rootfs(&store, &id);
+        let admitted = admit_forked_child(&AdmitForkedChildParams {
+            store: &store,
+            checkpoint: &CheckpointId::new(&id),
+            parent_meta: &parent_meta,
+            child_vm_name: vm,
+            backend_name: "hvf",
+            declared_secrets: declared,
+        })
+        .expect("a fork child is admitted");
+        admitted
+            .admission
+            .expect("the fork path never sets no_supervisor, so admission is Some")
+            .admitted
+            .plan()
+            .secrets
+            .clone()
+    }
+
+    /// The declared set reaches the child's own signed plan. Declared, not
+    /// inherited: the parent above holds no bindings, so anything present here
+    /// came from the caller.
+    #[test]
+    fn a_declared_binding_lands_in_the_forked_childs_plan() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let home = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(home.path());
+
+        let declared = vec![SecretBinding {
+            name: "STRIPE_KEY".to_string(),
+            source: SecretSource::Keystore {
+                address: "kv/stripe".to_string(),
+            },
+        }];
+        let got = admitted_child_secrets(&declared, "child-declared");
+        assert_eq!(got, declared);
+    }
+
+    /// The default is unchanged behaviour: declare nothing, carry nothing. This
+    /// is the half that keeps the parent's set from leaking in by accident.
+    #[test]
+    fn a_fork_declaring_nothing_admits_a_child_with_no_bindings() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        let home = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(home.path());
+
+        assert!(admitted_child_secrets(&[], "child-bare").is_empty());
+    }
+
     #[test]
     fn fork_post_restore_requires_acknowledgement_and_reseed() {
         let acknowledged = mvm_agentd::vsock::PostRestoreReply {
@@ -672,6 +764,7 @@ mod tests {
             cpus_override: Some(8),
             memory_override: None,
             json: false,
+            declared_secrets: &[],
         })
         .unwrap_err();
         let msg = err.to_string();
@@ -693,6 +786,7 @@ mod tests {
             cpus_override: None,
             memory_override: Some("2G"),
             json: false,
+            declared_secrets: &[],
         })
         .unwrap_err();
         let msg = err.to_string();

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -361,7 +361,13 @@ fn admit_forked_child(p: &AdmitForkedChildParams<'_>) -> Result<AdmittedForkChil
             cpus: user_cfg.default_cpus,
             mem_mib: user_cfg.default_memory_mib as u64,
             seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
-            secret_release: mvm_core::plan::SecretReleasePolicy::default(),
+            // Derived from the set, never defaulted: `SecretReleasePolicy`
+            // defaults to `None` — "no secrets may be released" — so a child
+            // admitted with declared bindings under the default would carry a
+            // list nothing could ever release.
+            secret_release: crate::commands::vm::managed_secrets::secret_release_for_bindings(
+                p.declared_secrets,
+            ),
             secrets: p.declared_secrets.to_vec(),
             no_supervisor: false,
             ledger: &ledger,

--- a/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
@@ -275,15 +275,18 @@ fn revert_checkpoint(
     // Reuse the fork path verbatim: it re-admits through `admit_plan_for_boot`,
     // re-derives the sealed attenuation, and boots. This is the anti-bypass
     // guarantee — a restore never reaches `restore_checkpoint`.
-    super::fork(
-        target.id.as_str(),
-        Some(restored_vm_name.clone()),
-        /* boot */ true,
-        opts.hypervisor,
-        /* cpus */ None,
-        /* memory */ None,
-        opts.json,
-    )
+    super::fork(super::ForkCmdParams {
+        id: target.id.as_str(),
+        new_id: Some(restored_vm_name.clone()),
+        boot: true,
+        hypervisor: opts.hypervisor,
+        cpus: None,
+        memory: None,
+        // A revert re-admits the checkpoint it targets; it declares no bindings
+        // of its own, matching the pre-existing behaviour of this path.
+        declared_secrets: &[],
+        json: opts.json,
+    })
     .with_context(|| format!("restoring checkpoint {:?}", target.id.as_str()))?;
 
     // Bind the restore to the launched plan (persisted by the fork boot) so the

--- a/crates/mvm-cli/src/commands/vm/managed_secrets.rs
+++ b/crates/mvm-cli/src/commands/vm/managed_secrets.rs
@@ -63,7 +63,12 @@ fn lower_env_map(env: &std::collections::BTreeMap<String, EnvValue>, out: &mut V
     }
 }
 
-fn secret_release_for_bindings(bindings: &[SecretBinding]) -> SecretReleasePolicy {
+/// `PlanBound` the moment a plan declares any binding. A plan that lists
+/// bindings under `None` would declare capability it can never release, so
+/// this is derived from the set rather than chosen by each caller.
+pub(in crate::commands::vm) fn secret_release_for_bindings(
+    bindings: &[SecretBinding],
+) -> SecretReleasePolicy {
     if bindings.is_empty() {
         SecretReleasePolicy::None
     } else {

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -290,12 +290,17 @@ for detailed scope and acceptance criteria.
       W0 landed: a fork that drops its parent's secret bindings now says so,
       reading the parent's persisted plan rather than needing a schema change.
       3 tests, mutation-checked.
-      STILL OPEN: everything that closes the gap. Option A (declare the child's
-      bindings at fork, A1-A6) is the recommended build and is unimplemented;
-      Option B (inherit from the checkpoint, attenuated by intersection) is
-      designed and deliberately deferred, not queued. W0 warns only — the
-      refusal arm moved to A6, because a fork is always prod-profile and so had
-      no flag to gate on.
+      A1 landed: `declared_secrets` is threaded into the fork admission path, so
+      a child's bindings are declared by the caller rather than inherited, and
+      the child's capability is readable from its own plan. 2 tests,
+      mutation-checked.
+      STILL OPEN: the gap is **not yet closed** — A2 (CLI surface) is what makes
+      A1 reachable; until it lands every caller declares an empty set and no
+      user can declare a binding. Then A3-A5, and A6 (refuse an undeclared
+      drop), which is W0's refusal arm — deferred there because a fork's
+      prod-posture is a hardcoded literal today, not a flag. Option B (inherit
+      from the checkpoint, attenuated by intersection) is designed and
+      deliberately deferred, not queued.
 
 - [~] **Admission-bound AI assurance sessions** —
       `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W4,

--- a/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
+++ b/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
@@ -133,8 +133,22 @@ Work items:
       and host-set refusal are already covered at the endpoint by
       `substitutes_real_credential_for_a_bound_destination` and
       `unbound_destination_is_refused_without_decrypting`.
-- [ ] A2 — surface it on the fork CLI. Test: CLI parsing + help text per the
-      repo's `tests/cli.rs` convention.
+- [x] A2 — `--secret VAR` / `--secret VAR=ADDRESS` on `vm checkpoint fork`,
+      repeatable. Wired to **both** fork arms: vm_full always admits a plan, and
+      fs_quick admits one under `--boot`, so the flag means the same thing
+      whichever class the parent is. Without `--boot` an fs_quick fork carries
+      no plan at all and the help text says so.
+
+      `fork()` moved to a params struct (`ForkCmdParams`) — it was already at
+      seven positional arguments. `revert` reuses `fork()` verbatim as its
+      anti-bypass guarantee and declares nothing, preserving its behaviour.
+
+      **Fixed a defect in A1 as committed:** `admit_forked_child` set `secrets`
+      while leaving `secret_release` at `SecretReleasePolicy::default()`, which
+      is `None` — "no secrets may be released". A child would have carried
+      bindings nothing could release. Both fork arms now derive it from the set
+      via the existing `secret_release_for_bindings` (empty → `None`, non-empty
+      → `PlanBound`) rather than defaulting.
 - [ ] A3 — cross-tenant declaration refused at admission (this falls out of
       `BindingStore` tenant scoping; assert it rather than assume it).
 - [ ] A4 — `checkpoint.forked` records the child's binding names + hosts, never

--- a/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
+++ b/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
@@ -115,10 +115,24 @@ Why this first:
 
 Work items:
 
-- [ ] A1 — plumb a caller-supplied `Vec<SecretRef>` into `AdmitForkedChildParams`
-      and through to `admit_plan_for_boot`. Test: a child booted with a declared
-      binding resolves a freshly minted placeholder against the declared host
-      set; an undeclared host is refused.
+- [ ] A1 — plumb a caller-supplied `Vec<SecretBinding>` into
+      `AdmitForkedChildParams` and through to `admit_plan_for_boot`.
+
+      Two corrections to this item as first written. The type is
+      `mvm_core::plan::SecretBinding` (`{name, source}`), **not** the keyholder's
+      `SecretRef`: the plan-level binding carries a name and a source reference,
+      and the destination binding (`auth_type` + `allowed_hosts`) is resolved by
+      name against the tenant's `BindingStore` at the substitution endpoint. A
+      declared name the operator has not bound therefore grants nothing, which is
+      the property that makes declaring safe.
+
+      And the stated test — "resolves a freshly minted placeholder against the
+      declared host set" — needs a booted VM with a live endpoint, which is not a
+      unit test. A1's test is scoped to admission: the declared set lands in the
+      child's signed plan, and an empty set yields none. Placeholder resolution
+      and host-set refusal are already covered at the endpoint by
+      `substitutes_real_credential_for_a_bound_destination` and
+      `unbound_destination_is_refused_without_decrypting`.
 - [ ] A2 — surface it on the fork CLI. Test: CLI parsing + help text per the
       repo's `tests/cli.rs` convention.
 - [ ] A3 — cross-tenant declaration refused at admission (this falls out of

--- a/specs/sprint/delivery/2698-fork-secret-bindings.md
+++ b/specs/sprint/delivery/2698-fork-secret-bindings.md
@@ -80,12 +80,60 @@ trusting the recorded value, so a fork test needs a real blob on disk whose
 digest matches the checkpoint record. A `meta.json` edited to claim a different
 sha cannot redirect what gets admitted.
 
+## A2 — the CLI surface
+
+`--secret VAR` / `--secret VAR=ADDRESS` on `vm checkpoint fork`, repeatable.
+`parse_declared_secrets` refuses an empty half on either side; nothing contacts
+the keystore at parse time, because a binding is a reference and an unbound name
+simply fails to resolve later rather than granting anything.
+
+Wired to both fork arms. vm_full always admits a plan; fs_quick admits one only
+under `--boot`, and the help text states that asymmetry rather than leaving the
+flag silently inert for half its inputs. `revert`, which reuses `fork()`
+verbatim as its anti-bypass guarantee, declares nothing.
+
+`fork()` moved to `ForkCmdParams` — already at seven positional arguments, so an
+eighth would have tripped the banned `too_many_arguments`.
+
+**Fixed a defect in A1 as committed:** `secret_release` was left at
+`SecretReleasePolicy::default()` = `None`, "no secrets may be released", while
+`secrets` was populated. A child would have carried a binding list nothing could
+release. Both arms now derive the policy from the set via the existing
+`secret_release_for_bindings` helper.
+
+Tests: `bare_secret_name_binds_var_and_address_alike`,
+`var_equals_address_separates_the_two`, `an_empty_half_is_refused`,
+`declaring_nothing_parses_to_nothing`,
+`declared_bindings_make_the_release_policy_plan_bound`. Mutation-checked by
+disabling the refusal: `an_empty_half_is_refused` goes red and the other four
+stay green, since they do not exercise that path.
+
+**A mutation check that nearly passed for the wrong reason:** the first run
+filtered on `secret`, which does not match three of the five test names, so the
+test that should have caught the disabled refusal never ran and the mutant
+looked clean. Re-run with explicit filters. A filtered mutation check proves
+nothing unless the filter is confirmed to include the test that must fail.
+
 ## Not delivered
 
-A1 is delivered; A2–A6 are not. A2 (the CLI surface) is what makes the
-plumbing reachable — until it lands, every caller declares `&[]` and no user can
-declare a binding, so the capability gap is **not yet closed**. A6 (refuse an
-undeclared drop) is the W0 refusal arm and comes last.
+W0, A1 and A2 are delivered; A3-A6 are not.
+
+With A2 the gap is closed for the path it covers: a user can declare bindings on
+`vm checkpoint fork` and the child is admitted carrying them. What remains is
+narrower than it was, and worth naming precisely rather than implying the whole
+feature is done:
+
+- A3 — assert cross-tenant declaration is refused. This falls out of
+  `BindingStore` tenant scoping today, but it is assumed rather than tested.
+- A4 — record the child's binding names + hosts on `checkpoint.forked`.
+- A5 — the `machine warm-restore` entry point (`machine/checkpoint.rs`) still
+  passes `&[]`; only the `vm checkpoint fork` verb takes the flag.
+- A6 — refuse an undeclared drop (W0's refusal arm).
+
+**Not verified end-to-end.** No booted VM has resolved a declared binding
+through a live substitution endpoint. The tests here assert what reaches the
+signed plan; the endpoint's own suite covers resolution and host-set refusal
+separately. Nothing has yet exercised the two together.
 
 Option B (inherit from the checkpoint) remains designed and deliberately
 deferred.

--- a/specs/sprint/delivery/2698-fork-secret-bindings.md
+++ b/specs/sprint/delivery/2698-fork-secret-bindings.md
@@ -49,8 +49,46 @@ bindings can be declared.
 "unknown", not "the parent held none". A fork of a parent whose plan file is
 gone warns about nothing. Recorded in the helper's doc comment and in the plan.
 
+## A1 — the child's bindings are declared
+
+`AdmitForkedChildParams` gains `declared_secrets: &[SecretBinding]`, threaded
+through both arm param structs and every call site; `admit_forked_child` passes
+it where it hardcoded `Vec::new()`. Outer callers pass `&[]` until a CLI surface
+exists, so behaviour is unchanged.
+
+`fork_vm_full_arm` moved from six positional arguments to its existing
+`ForkVmFullArmParams` struct rather than growing a seventh — matching its
+`fork_fs_quick_arm` sibling and staying clear of the banned
+`too_many_arguments` allow.
+
+Two corrections to A1 as the plan first wrote it. The type is
+`mvm_core::plan::SecretBinding` (`{name, source}`), not the keyholder's
+`SecretRef`; the destination binding is resolved by name against the tenant's
+`BindingStore` at the endpoint, which is what makes declaring safe — a name the
+operator has not bound grants nothing. And the stated test needed a booted VM,
+so A1's tests are scoped to admission; placeholder resolution and host-set
+refusal are already covered at the endpoint.
+
+Tests: `a_declared_binding_lands_in_the_forked_childs_plan` and
+`a_fork_declaring_nothing_admits_a_child_with_no_bindings`. Mutation-checked by
+restoring the pre-A1 `Vec::new()`: the first goes red, the second stays green
+(the mutant satisfies it), which is the expected split.
+
+**Learned while building the fixture:** `admit_plan_for_boot` re-hashes the
+rootfs blob and verifies it against `precomputed_image_sha256` rather than
+trusting the recorded value, so a fork test needs a real blob on disk whose
+digest matches the checkpoint record. A `meta.json` edited to claim a different
+sha cannot redirect what gets admitted.
+
 ## Not delivered
 
-Options A (declare bindings at fork, A1–A6) and B (inherit from the checkpoint)
-are designed and unimplemented. `Preview` claim 18's unre-armed wall-clock/CPU
-limit is untouched and still open.
+A1 is delivered; A2–A6 are not. A2 (the CLI surface) is what makes the
+plumbing reachable — until it lands, every caller declares `&[]` and no user can
+declare a binding, so the capability gap is **not yet closed**. A6 (refuse an
+undeclared drop) is the W0 refusal arm and comes last.
+
+Option B (inherit from the checkpoint) remains designed and deliberately
+deferred.
+
+`Preview` claim 18's unre-armed wall-clock/CPU limit is untouched and still
+open.


### PR DESCRIPTION
Closes #2698.

This completes the fork secret-binding work across the supported entry points:
- requires explicit child secret bindings
- validates tenant ownership before child creation
- refuses implicit binding drops unless the explicit allow flag is supplied
- records only non-secret binding metadata in audit output
- preserves the Firecracker admission gate and rejects unsupported fsquick inheritance

Validation:
- cargo test --workspace
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- just check-gated