### PR TITLE
feat(assurance): let the ledger record without receiving a plan

### DIFF
--- a/crates/mvm-hostd/src/assurance_session.rs
+++ b/crates/mvm-hostd/src/assurance_session.rs
@@ -31,7 +31,9 @@ use mvm_core::policy::network_policy::NetworkPolicy;
 use mvm_core::protocol::broker::ServiceId;
 use sha2::{Digest, Sha256};
 
-use crate::audit::assurance::{AssuranceLedger, SessionIdentity, cite};
+use crate::audit::assurance::{
+    AssuranceAuditSink, AssuranceLedger, PlanIdentity, SessionIdentity, cite,
+};
 use crate::audit::emitter::AuditEmitter;
 use crate::broker::handlers::host_assurance_v1::{
     AssuranceSessionSpec, DeclaredDestination, HOST_ASSURANCE_SERVICE, HostAssuranceV1Handler,
@@ -280,7 +282,8 @@ pub fn open_on(
         trial_id: request.declaration.trial_id.clone(),
         source_digest: request.declaration.source_digest.clone(),
     };
-    let ledger = AssuranceLedger::new(request.emitter.as_ref(), plan);
+    let plan_identity = PlanIdentity::from(plan);
+    let ledger = AssuranceLedger::new(request.emitter.as_ref(), &plan_identity);
     let refs = ledger
         .open_session(&identity)
         .map_err(|error| SessionRefusal::NotRecorded(error.to_string()))?;
@@ -322,8 +325,8 @@ pub fn open_on(
                 port: edge.port,
             })
             .collect(),
-        plan: plan.clone(),
-        emitter: Some(Arc::clone(request.emitter)),
+        identity: PlanIdentity::from(plan),
+        sink: Some(Arc::clone(request.emitter) as Arc<dyn AssuranceAuditSink + Send + Sync>),
     });
     Ok(binding)
 }
@@ -373,7 +376,7 @@ pub fn close_on(
     verdict: &TrialVerdict,
 ) -> Result<()> {
     let _ = plane;
-    AssuranceLedger::new(emitter, admitted.plan())
+    AssuranceLedger::new(emitter, &PlanIdentity::from(admitted.plan()))
         .complete_trial(identity, verdict)
         .context("recording the trial outcome")?;
     Ok(())

--- a/crates/mvm-hostd/src/audit/assurance.rs
+++ b/crates/mvm-hostd/src/audit/assurance.rs
@@ -26,7 +26,7 @@ use sha2::{Digest, Sha256};
 
 use super::emitter::AuditEmitter;
 use super::evidence::{EmittedEvidence, EvidenceReceipt, audit_entry_digest_hex};
-use crate::supervisor::{PlanAuditEntry, for_plan};
+use crate::supervisor::PlanAuditEntry;
 
 /// Audit event emitted when a session is opened against an admitted plan.
 pub const EVENT_SESSION_OPENED: &str = "assurance.session_opened";
@@ -116,6 +116,66 @@ impl LedgerRefs {
     }
 }
 
+/// The only part of an admitted plan an assurance record quotes.
+///
+/// The broker records campaign probes but is deliberately never given the
+/// plan — it receives derived bindings, the way `services_bindings` and
+/// `capability_bindings` already travel. These six fields are exactly what a
+/// `PlanAuditEntry` carries, so passing them keeps the records identical on
+/// both routes without widening what the broker is trusted with.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlanIdentity {
+    pub tenant: mvm_core::plan::TenantId,
+    pub plan_id: mvm_core::plan::PlanId,
+    pub plan_version: u32,
+    pub image_name: String,
+    pub image_sha256: String,
+    /// Labels the plan asks to be copied onto every entry it generates.
+    #[serde(default)]
+    pub audit_labels: std::collections::BTreeMap<String, String>,
+}
+
+impl From<&ExecutionPlan> for PlanIdentity {
+    fn from(plan: &ExecutionPlan) -> Self {
+        Self {
+            tenant: plan.tenant.clone(),
+            plan_id: plan.plan_id.clone(),
+            plan_version: plan.plan_version,
+            image_name: plan.image.name.clone(),
+            image_sha256: plan.image.sha256.to_ascii_lowercase(),
+            audit_labels: plan.audit_labels.clone(),
+        }
+    }
+}
+
+impl PlanIdentity {
+    /// Build the entry this identity would produce for `event`.
+    ///
+    /// Mirrors `supervisor::for_plan` field for field; it exists separately
+    /// because that one needs a whole plan and this route has none.
+    fn entry(
+        &self,
+        event: &str,
+        extras: impl IntoIterator<Item = (String, String)>,
+    ) -> PlanAuditEntry {
+        let mut labels = self.audit_labels.clone();
+        labels.extend(extras);
+        PlanAuditEntry {
+            timestamp: chrono::Utc::now(),
+            tenant: self.tenant.clone(),
+            plan_id: self.plan_id.clone(),
+            plan_version: self.plan_version,
+            bundle_id: None,
+            bundle_version: None,
+            image_name: self.image_name.clone(),
+            image_sha256: self.image_sha256.clone(),
+            event: event.to_string(),
+            labels,
+        }
+    }
+}
+
 /// Where an assurance record is written.
 ///
 /// Two processes need to write these and they do not share an audit route. The
@@ -142,14 +202,14 @@ impl AssuranceAuditSink for AuditEmitter {
 /// Writes the records an assurance campaign cites.
 pub struct AssuranceLedger<'a> {
     sink: &'a dyn AssuranceAuditSink,
-    plan: &'a ExecutionPlan,
+    identity: &'a PlanIdentity,
 }
 
 impl<'a> AssuranceLedger<'a> {
-    /// Bind a ledger to one admitted plan, writing through `sink`.
+    /// Bind a ledger to one admitted plan's identity, writing through `sink`.
     #[must_use]
-    pub fn new(sink: &'a dyn AssuranceAuditSink, plan: &'a ExecutionPlan) -> Self {
-        Self { sink, plan }
+    pub fn new(sink: &'a dyn AssuranceAuditSink, identity: &'a PlanIdentity) -> Self {
+        Self { sink, identity }
     }
 
     /// Record that a session opened, and return what a binding may cite.
@@ -249,7 +309,7 @@ impl<'a> AssuranceLedger<'a> {
     where
         I: IntoIterator<Item = (String, String)>,
     {
-        let entry = for_plan(self.plan, None, event, labels);
+        let entry = self.identity.entry(event, labels);
         let emitted = self
             .sink
             .record(&entry, receipt)

--- a/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
@@ -20,10 +20,8 @@ use mvm_contract::assurance::{
     PROBE_OBSERVATION_SCHEMA, ProbeInvocation, ProbeObservation, ProbeRefusal, ProbeRequest,
 };
 
-use crate::audit::assurance::{AssuranceLedger, ProbeRecord};
-use crate::audit::emitter::AuditEmitter;
+use crate::audit::assurance::{AssuranceAuditSink, AssuranceLedger, PlanIdentity, ProbeRecord};
 use mvm_core::egress_broker::{EgressRequest, EgressVerdict, decide_egress};
-use mvm_core::plan::ExecutionPlan;
 use mvm_core::policy::network_policy::NetworkPolicy;
 use mvm_core::policy::security::AgentProfile;
 use mvm_core::protocol::broker::{AuditDurability, Idempotency, ServiceErrorCode, ServiceId};
@@ -59,12 +57,12 @@ pub struct AssuranceSessionSpec {
     pub policy: NetworkPolicy,
     /// Destinations the campaign declared.
     pub destinations: Vec<DeclaredDestination>,
-    /// The admitted plan every record is written against.
-    pub plan: ExecutionPlan,
+    /// The admitted plan's identity — the only part of it a record quotes.
+    pub identity: PlanIdentity,
     /// Where probe records go. `None` disables recording, which also disables
     /// probing: an unrecorded boundary attempt is not one this service will
     /// perform.
-    pub emitter: Option<Arc<AuditEmitter>>,
+    pub sink: Option<Arc<dyn AssuranceAuditSink + Send + Sync>>,
 }
 
 struct AssuranceSession {
@@ -80,8 +78,8 @@ struct AssuranceSession {
     attempted_effect: bool,
     effect_observed_in_guest: bool,
     boundary_crossed: bool,
-    plan: ExecutionPlan,
-    emitter: Option<Arc<AuditEmitter>>,
+    identity: PlanIdentity,
+    sink: Option<Arc<dyn AssuranceAuditSink + Send + Sync>>,
     evidence_refs: Vec<EvidenceRef>,
 }
 
@@ -94,7 +92,7 @@ impl std::fmt::Debug for AssuranceSessionSpec {
             .field("workload_session_id", &self.workload_session_id)
             .field("trial_id", &self.trial_id)
             .field("destinations", &self.destinations)
-            .field("recording", &self.emitter.is_some())
+            .field("recording", &self.sink.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -106,7 +104,7 @@ impl std::fmt::Debug for AssuranceSession {
             .field("trial_id", &self.trial_id)
             .field("steps_used", &self.steps_used)
             .field("blocked_edges", &self.blocked_edges)
-            .field("recording", &self.emitter.is_some())
+            .field("recording", &self.sink.is_some())
             .finish_non_exhaustive()
     }
 }
@@ -151,8 +149,8 @@ impl HostAssuranceV1Handler {
             attempted_effect: false,
             effect_observed_in_guest: false,
             boundary_crossed: false,
-            plan: spec.plan,
-            emitter: spec.emitter,
+            identity: spec.identity,
+            sink: spec.sink,
             evidence_refs: Vec::new(),
         };
         self.sessions
@@ -340,11 +338,11 @@ impl HostAssuranceV1Handler {
         admitted: bool,
         destination_label: &AssuranceId,
     ) -> Result<Vec<EvidenceRef>, ProbeRefusal> {
-        let emitter = session
-            .emitter
+        let sink = session
+            .sink
             .as_ref()
             .ok_or(ProbeRefusal::AuditUnavailable)?;
-        let ledger = AssuranceLedger::new(emitter.as_ref(), &session.plan);
+        let ledger = AssuranceLedger::new(sink.as_ref(), &session.identity);
         let refs = ledger
             .record_probe(&ProbeRecord {
                 session_id: &request.session_id,
@@ -434,11 +432,13 @@ mod tests {
     use super::*;
 
     use crate::audit::assurance::{audit_citations_resolve, resolve_audit_ref};
+    use crate::audit::emitter::AuditEmitter;
     use mvm_contract::assurance::{
         ApprovalSet, AuthorityCeiling, AuthorityInputs, EvidenceRef, ObservationScope,
         PROBE_REQUEST_SCHEMA, RequestedAuthority, SessionGrant, Sha256Digest, ToolId,
     };
     use mvm_contract::policy::network_policy::HostPort;
+    use mvm_core::plan::ExecutionPlan;
     use mvm_core::plan::test_support::PlanFixture;
     use mvm_core::protocol::broker::CorrelationId;
 
@@ -515,7 +515,7 @@ mod tests {
         let handler = HostAssuranceV1Handler::new();
         let mut session = spec(policy, max_steps);
         session.authority = authority_expiring_at(max_steps, expiry, now);
-        session.emitter = Some(Arc::new(emitter));
+        session.sink = Some(Arc::new(emitter) as Arc<dyn AssuranceAuditSink + Send + Sync>);
         handler.open_session(session);
         // The tempdir is deliberately leaked: these tests only assert on the
         // dispatch result, and keeping the guard alive would mean threading it
@@ -551,8 +551,8 @@ mod tests {
                 host: "attacker.example.com".to_string(),
                 port: 443,
             }],
-            plan: PlanFixture::new().build(),
-            emitter: None,
+            identity: PlanIdentity::from(&PlanFixture::new().build()),
+            sink: None,
         }
     }
 
@@ -569,7 +569,7 @@ mod tests {
             .with_receipts();
         let handler = HostAssuranceV1Handler::new();
         let mut session = spec(policy, max_steps);
-        session.emitter = Some(Arc::new(emitter));
+        session.sink = Some(Arc::new(emitter) as Arc<dyn AssuranceAuditSink + Send + Sync>);
         handler.open_session(session);
         (handler, dir)
     }
@@ -978,7 +978,8 @@ mod tests {
             .expect("emitter")
             .with_receipts();
         let plan = PlanFixture::new().build();
-        let ledger = AssuranceLedger::new(&emitter, &plan);
+        let identity = PlanIdentity::from(&plan);
+        let ledger = AssuranceLedger::new(&emitter, &identity);
         let identity = crate::audit::assurance::SessionIdentity {
             session_id: id(SESSION),
             campaign_id: id("mvm-campaign-1"),
@@ -1022,7 +1023,8 @@ mod tests {
             .expect("emitter")
             .with_receipts();
         let plan = PlanFixture::new().build();
-        let ledger = AssuranceLedger::new(&emitter, &plan);
+        let identity = PlanIdentity::from(&plan);
+        let ledger = AssuranceLedger::new(&emitter, &identity);
         let refs = ledger
             .open_session(&SessionIdentity {
                 session_id: id(SESSION),


### PR DESCRIPTION
Stacked on #2724 (the audit sink). Part of W9b.

## What this does

The broker records campaign probes but is deliberately never given the plan —
it receives derived bindings, the way `services_bindings` and
`capability_bindings` already travel. `AssuranceLedger` wanted a whole
`ExecutionPlan`, which would have meant widening exactly that.

`supervisor::for_plan` reads six fields. `PlanIdentity` carries those and
nothing else, the ledger takes an identity instead of a plan, and it builds the
same `PlanAuditEntry` either way — so records are identical on both routes and
the moat does not move. The session spec follows: an identity and an
`AssuranceAuditSink`, rather than a plan and an emitter.

With this plus #2724, a session can exist in the process a probe actually
reaches.

## What I reverted, and why it matters

The first attempt at this added the session to `SubprocessConfig` and had
`mvm-broker` open it. That was wrong twice:

- **Dead path.** Nothing in production constructs a
  `broker::config::SubprocessConfig`. The live path is the `mvm-host-agent`
  daemon registering per-VM through `RegisterVm`; the `mvm-broker` subprocess is
  not spawned.
- **Wrong trust envelope.** `SubprocessConfig`'s own docs note it is unsigned
  and that a compromised supervisor could redirect the audit back-channel.
  `RegisterVm` is host-signed — the daemon comments on exactly that.

Adding a security-relevant field to an unsigned envelope on a path production
does not use is strictly worse than adding none, so it came out. The plan
records the finding so the next change targets `RegisterVm`.

## Still open in W9b

Carry the admitted session on `RegisterVm`, and have `daemon::register` open it
against the handler it just built.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 12,419 passed, 0 failed
- the `test-support` feature lane — 3,655 passed
- `cargo nextest run -p mvm-hostd` after the revert — 2,012 passed
