### PR TITLE
fix(release): publish the initramfs, so a sealed boot is reachable from a release

### DIFF
--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -547,6 +547,21 @@ jobs:
           echo "MVM_RUNTIME_BOOT_OVERLAY_ROOTHASH=$(tr -d '[:space:]' < overlay-staging/overlay.roothash)" \
             >> "$GITHUB_ENV"
 
+      # Build the raw initramfs from the same source revision as the staged
+      # image. Publication belongs to release.yml's version train; this local
+      # copy exists only so the pre-publish gate can exercise the sealed path.
+      - name: Build the universal initramfs for the boot gate
+        if: matrix.arch == 'x86_64'
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          SYSTEM="${ARCH}-linux"
+          INITRAMFS_PATH=$(nix build "./nix/images/initramfs#packages.${SYSTEM}.default" \
+            --no-link --print-out-paths | head -1)
+          mkdir -p initramfs-staging
+          cp -L "$INITRAMFS_PATH/initramfs.cpio.gz" initramfs-staging/initramfs.cpio.gz
+
       - name: Boot the staged image before it becomes a release asset
         if: matrix.arch == 'x86_64'
         # Boots the artifact in `staging/`, never a published one — the whole
@@ -577,6 +592,11 @@ jobs:
           cp "staging/default-microvm-meta-${ARCH}.json" staging/mvm-meta.json
           cargo test --test runtime_boot_bench \
             prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
+          MVM_RUNTIME_BOOT_INITRD=initramfs-staging/initramfs.cpio.gz \
+          MVM_RUNTIME_BOOT_ROOTFS_VERITY="staging/default-microvm-rootfs-${ARCH}.verity" \
+          MVM_RUNTIME_BOOT_ROOTFS_ROOTHASH="$(tr -d '[:space:]' < "staging/default-microvm-rootfs-${ARCH}.roothash")" \
+            cargo test --test runtime_boot_bench \
+              prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
 
       - name: Dump VMM diagnostics on failure
         if: ${{ failure() && matrix.arch == 'x86_64' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,8 +248,80 @@ jobs:
             staging/*.tar.gz
             staging/*.sha256
 
+  # The universal initramfs, without which a published prod image cannot be
+  # sealed-booted from its own release assets.
+  #
+  # `mvm-verity-init` runs from this as PID 1: it sets up the dm-verity target
+  # over the rootfs, mounts the runtime overlay at /sysroot/mvm/runtime, and
+  # switch_roots. A source checkout builds one locally
+  # (`resolve_or_build_local_initramfs`); an installed binary calls
+  # `download_initramfs`, which fetches `initramfs-<arch>.tar.gz` from this
+  # release. That download has never once succeeded, because nothing published
+  # the file — so every installed mvmctl has been unable to boot the sealed path
+  # its own rootfs is built for.
+  #
+  # This train, not `boot-image/v*`: `release_base_url` builds `{base}/v{version}`,
+  # and the initramfs bundles this workspace's guest agent, so it versions with
+  # the CLI rather than with the image.
+  initramfs-image:
+    if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
+    strategy:
+      # One arch must not cancel the other; the completeness check in `release`
+      # refuses a partial set, so letting both finish tells the truth about
+      # which one failed.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+          - arch: x86_64
+            runner: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build the universal initramfs
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          SYSTEM="${ARCH}-linux"
+          STORE_PATH=$(nix build "./nix/images/initramfs#packages.${SYSTEM}.default" \
+            --no-link --print-out-paths | head -1)
+          mkdir -p "staging/initramfs-${ARCH}"
+          # cp -L so each file resolves through its nix-store symlink.
+          for f in initramfs.cpio.gz initramfs.hash initramfs.size VERSION; do
+            cp -L "$STORE_PATH/$f" "staging/initramfs-${ARCH}/$f"
+          done
+          # The derivation emits four of the five members `download_initramfs`
+          # requires; the manifest over them is packaging's job, exactly as it
+          # is for the runtime overlay.
+          (
+            cd "staging/initramfs-${ARCH}"
+            sha256sum initramfs.cpio.gz initramfs.hash initramfs.size VERSION \
+              > checksums-sha256.txt
+          )
+          tar -C "staging/initramfs-${ARCH}" \
+            -czf "staging/initramfs-${ARCH}.tar.gz" \
+            initramfs.cpio.gz initramfs.hash initramfs.size VERSION checksums-sha256.txt
+          (
+            cd staging
+            sha256sum "initramfs-${ARCH}.tar.gz" > "initramfs-${ARCH}.tar.gz.sha256"
+          )
+
+      - name: Upload initramfs artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: initramfs-image-${{ matrix.arch }}
+          path: |
+            staging/initramfs-${{ matrix.arch }}.tar.gz
+            staging/initramfs-${{ matrix.arch }}.tar.gz.sha256
+
   release:
-    needs: [bdd, build]
+    needs: [bdd, build, initramfs-image]
     # Gate the published release on the mvmctl binary build ONLY. The boot
     # image artifacts are attached when the boot image train has published
     # them (see the dual-publish step below), but their absence must not
@@ -553,6 +625,8 @@ jobs:
             artifacts/builder-vm-*-checksums-sha256.txt.bundle
             artifacts/runtime-overlay-*.tar.gz
             artifacts/runtime-overlay-*.tar.gz.sha256
+            artifacts/initramfs-*.tar.gz
+            artifacts/initramfs-*.tar.gz.sha256
             artifacts/sdk-sidecar-*.tar.gz
             artifacts/sdk-sidecar-*.tar.gz.sha256
             artifacts/runtime-overlay-*.tar.gz.bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,17 +322,14 @@ jobs:
 
   release:
     needs: [bdd, build, initramfs-image]
-    # Gate the published release on the mvmctl binary build ONLY. The boot
-    # image artifacts are attached when the boot image train has published
-    # them (see the dual-publish step below), but their absence must not
-    # block the binary download (mvmctl tarballs + checksums) that
-    # install.sh / `mvmctl update` / the Homebrew tap consume. `!cancelled()`
-    # keeps that posture; the result check keeps the binary build a hard
-    # requirement.
+    # The CLI binary and universal initramfs form one usable release. Waiting
+    # for the job is not enough under `!cancelled()`: its result must be a hard
+    # success requirement or a failed initramfs build can still publish a tag
+    # whose sealed-boot downloader always returns 404.
     # Dry-run guard: a `workflow_dispatch` with dry_run=true builds + packages
     # (the `build` job) but never reaches this publish job — only a tag push or
     # an explicit dry_run=false dispatch publishes.
-    if: ${{ !cancelled() && needs.bdd.result == 'success' && needs.build.result == 'success' && (github.event_name == 'push' || github.event.inputs.dry_run == 'false') }}
+    if: ${{ !cancelled() && needs.bdd.result == 'success' && needs.build.result == 'success' && needs.initramfs-image.result == 'success' && (github.event_name == 'push' || github.event.inputs.dry_run == 'false') }}
     # This job mints the one keyless identity every installed mvmctl trusts:
     # `release.yml@refs/tags/v{version}`, the sole entry in
     # RELEASE_IDENTITY_TEMPLATES. The environment's policy admits `v*` tags and

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,6 +17,13 @@ for detailed scope and acceptance criteria.
       absolute `/bin/ping` mediated-tool proof. Together with PRs #2690,
       #2709, and #2720, this closes the NIC-less and read-only boot-noise issue.
 
+- [x] **Issue #2684 — a sealed boot is reachable and proven before release.**
+      The CLI release train publishes both universal-initramfs archives under
+      the downloader's exact versioned names and refuses to publish when that
+      build fails. The boot-image train exercises its staged x86_64 production
+      image both plainly and with the complete initramfs + dm-verity triple
+      before upload; the harness refuses partial or malformed integrity input.
+
 - [x] **Plan 337 COMPLETE — the SDK surface is generated from Rust.** Sessions
       finished Tier C. Python's `contextvars` + `Token` has no
       `AsyncLocalStorage` equivalent, so the shape was a choice, not a

--- a/specs/sprint/delivery/2684-release-initramfs.md
+++ b/specs/sprint/delivery/2684-release-initramfs.md
@@ -1,0 +1,40 @@
+# Publish and live-gate the universal initramfs
+
+Issue #2684 exposed a release-contract gap: installed `mvmctl` knows how to
+download the universal initramfs for a CLI version, but the `v*` release train
+never published that archive. A production rootfs could therefore be shipped
+with its dm-verity sidecars while the initramfs required to mount it was an
+unreachable 404.
+
+The CLI release workflow now builds both architectures, packages every member
+the existing extractor requires, uploads the exact names produced by
+`InitramfsArtifactNames`, and attaches the archives and checksums to the release.
+The release job checks the initramfs job's result explicitly: `needs` alone is
+not a hard gate when the job uses `!cancelled()`.
+
+## The staged artifact is exercised both ways
+
+Publication makes the sealed path reachable, but it does not prove it boots.
+The boot-image train's existing x86_64 KVM gate now runs the staged production
+image twice before upload:
+
+1. the existing plain rootfs boot, preserving the independent compatibility
+   witness;
+2. a sealed boot with the universal initramfs, rootfs verity sidecar, and
+   root hash from the same staged build.
+
+The runtime boot harness treats those three sealed inputs as an atomic set and
+validates the root hash before constructing `VmStartConfig`. Partial or malformed
+configuration fails at the boundary instead of silently degrading to an
+unsealed boot.
+
+The boot-image workflow builds only a raw local initramfs for this gate. It does
+not publish that copy: versioned initramfs archives belong to the CLI `v*`
+release train because that is the version namespace used by the downloader.
+
+## Regression coverage
+
+Workflow tests pin the producer/consumer asset names, both architectures, all
+archive members, the hard release-result gate, the two boot invocations, and
+the complete sealed environment. Focused harness tests cover absent, complete,
+partial, and malformed integrity inputs plus the final launch configuration.

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -317,6 +317,43 @@ fn the_staged_microvm_image_is_booted_before_it_is_uploaded() {
     );
 }
 
+/// A plain boot proves the release image reaches userspace, but it does not
+/// exercise the initramfs or dm-verity sidecars. The pre-publish gate must run
+/// the exact same staged image a second time with the complete sealed triple.
+#[test]
+fn the_staged_microvm_boot_gate_covers_plain_and_sealed_boots() {
+    let workflow = boot_image_workflow();
+    let job = workflow
+        .split("  default-microvm:")
+        .nth(1)
+        .expect("release-boot-image.yml must define the default-microvm job");
+    let boot = job
+        .find("- name: Boot the staged image before it becomes a release asset")
+        .expect("the default-microvm job must define its boot gate");
+    let rest = &job[boot..];
+    let step_end = rest[1..]
+        .find("\n      - name:")
+        .map_or(rest.len(), |offset| offset + 1);
+    let step = &rest[..step_end];
+
+    assert_eq!(
+        step.matches("prebuilt_runtime_image_boots_within_budget")
+            .count(),
+        2,
+        "the gate must boot once plainly and once through the sealed path"
+    );
+    for variable in [
+        "MVM_RUNTIME_BOOT_INITRD=",
+        "MVM_RUNTIME_BOOT_ROOTFS_VERITY=",
+        "MVM_RUNTIME_BOOT_ROOTFS_ROOTHASH=",
+    ] {
+        assert!(
+            step.contains(variable),
+            "the sealed boot invocation must set {variable}"
+        );
+    }
+}
+
 /// The four jobs that build a boot image. They move as a set: splitting them
 /// across two release trains would mean a `boot-image/vN` release that is
 /// missing a piece the same tag is supposed to carry.
@@ -694,6 +731,11 @@ fn the_release_job_builds_and_attaches_the_initramfs() {
     assert!(
         workflow.contains("needs: [bdd, build, initramfs-image]"),
         "the release job must wait for initramfs-image, or it publishes without it"
+    );
+    let release = job_block(&workflow, "release");
+    assert!(
+        release.contains("needs.initramfs-image.result == 'success'"),
+        "the release job must fail closed when the initramfs build fails"
     );
     for pattern in [
         "artifacts/initramfs-*.tar.gz",

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -662,3 +662,76 @@ fn the_two_release_trains_do_not_share_a_signing_environment() {
          its tags are boot-image/v*, which a v*-scoped policy refuses outright"
     );
 }
+
+/// The initramfs is what `mvm-verity-init` runs as PID 1 to set up dm-verity
+/// and mount the runtime overlay before `switch_root`. Without it a published
+/// prod image cannot be sealed-booted from its own release assets — and nothing
+/// published it, so `download_initramfs` had never once succeeded.
+///
+/// Pinned against the Rust constructor rather than against a literal, because
+/// the failure this prevents is a rename on one side only, which produces a 404
+/// at install time and nothing at build time.
+#[test]
+fn release_publishes_every_initramfs_asset_the_downloader_requests() {
+    let workflow = release_workflow();
+    for token in [SHELL_ARCH_TOKEN, MATRIX_ARCH_TOKEN] {
+        let names = mvmctl::build::initramfs::InitramfsArtifactNames::for_arch(token);
+        assert_publishes(&workflow, &names.archive);
+        assert_publishes(&workflow, &names.archive_checksum);
+    }
+}
+
+/// Publishing is not attaching. A job whose artifacts upload but never appear
+/// in `gh release create` leaves the downloader with the same 404 a rename
+/// would, and the release still reports success.
+#[test]
+fn the_release_job_builds_and_attaches_the_initramfs() {
+    let workflow = release_workflow();
+    assert!(
+        workflow.contains("  initramfs-image:"),
+        "release.yml must define the initramfs-image job"
+    );
+    assert!(
+        workflow.contains("needs: [bdd, build, initramfs-image]"),
+        "the release job must wait for initramfs-image, or it publishes without it"
+    );
+    for pattern in [
+        "artifacts/initramfs-*.tar.gz",
+        "artifacts/initramfs-*.tar.gz.sha256",
+    ] {
+        assert!(
+            workflow.contains(pattern),
+            "the release job's asset list must include {pattern:?}"
+        );
+    }
+    // Both arches, or an install on the other one 404s exactly as before.
+    let block = job_block(&workflow, "initramfs-image");
+    for arch in ["aarch64", "x86_64"] {
+        assert!(
+            block.contains(&format!("arch: {arch}")),
+            "the initramfs-image matrix must build {arch}"
+        );
+    }
+}
+
+/// Every member `extract_initramfs_archive` requires must actually be put in
+/// the tarball. Four come from the derivation and the fifth is generated at
+/// packaging; leaving any out fails at install time with
+/// `missing required archive member`, on a host that cannot debug it.
+#[test]
+fn the_initramfs_tarball_carries_every_member_the_extractor_requires() {
+    let workflow = release_workflow();
+    let block = job_block(&workflow, "initramfs-image");
+    for member in [
+        mvm_fs::initramfs::INITRAMFS_IMAGE_FILE,
+        mvm_fs::initramfs::INITRAMFS_HASH_FILE,
+        mvm_fs::initramfs::INITRAMFS_SIZE_FILE,
+        mvm_fs::initramfs::VERSION_FILE,
+        mvm_fs::initramfs::CHECKSUM_MANIFEST_FILE,
+    ] {
+        assert!(
+            block.contains(member),
+            "the initramfs tarball must carry {member:?}, which the extractor requires"
+        );
+    }
+}

--- a/tests/runtime_boot_bench.rs
+++ b/tests/runtime_boot_bench.rs
@@ -18,6 +18,8 @@
 //! - `MVM_RUNTIME_BOOT_CONCURRENT=3` for fan-out width.
 //! - `MVM_RUNTIME_BOOT_BUDGET_MS=200` for the per-VM max budget.
 //! - `MVM_RUNTIME_BOOT_READY=start-return|guest-agent`.
+//! - `MVM_RUNTIME_BOOT_INITRD`, `MVM_RUNTIME_BOOT_ROOTFS_VERITY`, and
+//!   `MVM_RUNTIME_BOOT_ROOTFS_ROOTHASH` to exercise a sealed rootfs boot.
 
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier};
@@ -35,6 +37,9 @@ const CONFIG_VAR: &str = "MVM_RUNTIME_BOOT_CONFIG";
 const BACKEND_VAR: &str = "MVM_RUNTIME_BOOT_BACKEND";
 const KERNEL_VAR: &str = "MVM_RUNTIME_BOOT_KERNEL";
 const ROOTFS_VAR: &str = "MVM_RUNTIME_BOOT_ROOTFS";
+const INITRD_VAR: &str = "MVM_RUNTIME_BOOT_INITRD";
+const ROOTFS_VERITY_VAR: &str = "MVM_RUNTIME_BOOT_ROOTFS_VERITY";
+const ROOTFS_ROOTHASH_VAR: &str = "MVM_RUNTIME_BOOT_ROOTFS_ROOTHASH";
 const RUNS_VAR: &str = "MVM_RUNTIME_BOOT_RUNS";
 const CONCURRENT_VAR: &str = "MVM_RUNTIME_BOOT_CONCURRENT";
 const BUDGET_VAR: &str = "MVM_RUNTIME_BOOT_BUDGET_MS";
@@ -140,6 +145,17 @@ struct BenchSpec {
     cpus: u32,
     memory_mib: u32,
     overlay: Option<OverlaySpec>,
+    rootfs_integrity: Option<RootfsIntegritySpec>,
+}
+
+/// The initramfs and both dm-verity inputs are one boot mode. Supplying only
+/// part of the set would either bypass rootfs verification or leave PID 1
+/// without the sidecar it needs to mount the verified root.
+#[derive(Debug, Clone)]
+struct RootfsIntegritySpec {
+    initrd: PathBuf,
+    verity: PathBuf,
+    roothash: String,
 }
 
 /// All three or none. The backend attaches the overlay only when the path, the
@@ -161,6 +177,7 @@ impl BenchSpec {
         let config = config.unwrap_or_default();
 
         let overlay = overlay_spec(&config)?;
+        let rootfs_integrity = rootfs_integrity_spec(&config)?;
         let kernel = required_path(KERNEL_VAR, config.kernel)?;
         let rootfs = required_path(ROOTFS_VAR, config.rootfs)?;
         let ready =
@@ -183,6 +200,7 @@ impl BenchSpec {
             cpus: env_u32(CPUS_VAR, config.cpus, 1)?,
             memory_mib: env_u32(MEMORY_MIB_VAR, config.memory_mib, 256)?,
             overlay,
+            rootfs_integrity,
         }))
     }
 }
@@ -193,6 +211,11 @@ struct RawBenchConfig {
     backend: Option<String>,
     kernel: Option<PathBuf>,
     rootfs: Option<PathBuf>,
+    initrd: Option<PathBuf>,
+    #[serde(alias = "rootfs_verity")]
+    rootfs_verity: Option<PathBuf>,
+    #[serde(alias = "rootfs_roothash")]
+    rootfs_roothash: Option<String>,
     runs: Option<usize>,
     concurrent: Option<usize>,
     #[serde(alias = "budget_ms")]
@@ -317,6 +340,18 @@ fn start_config(spec: &BenchSpec, name: String) -> VmStartConfig {
         name,
         rootfs_path: spec.rootfs.to_string_lossy().into_owned(),
         kernel_path: Some(spec.kernel.to_string_lossy().into_owned()),
+        initrd_path: spec
+            .rootfs_integrity
+            .as_ref()
+            .map(|integrity| integrity.initrd.to_string_lossy().into_owned()),
+        verity_path: spec
+            .rootfs_integrity
+            .as_ref()
+            .map(|integrity| integrity.verity.to_string_lossy().into_owned()),
+        roothash: spec
+            .rootfs_integrity
+            .as_ref()
+            .map(|integrity| integrity.roothash.clone()),
         cpus: spec.cpus,
         memory_mib: spec.memory_mib,
         revision_hash: "runtime-boot-bench".to_string(),
@@ -530,6 +565,41 @@ fn overlay_spec(config: &RawBenchConfig) -> Result<Option<OverlaySpec>> {
     }
 }
 
+/// Resolve the sealed-rootfs triple, refusing partial or malformed inputs.
+fn rootfs_integrity_spec(config: &RawBenchConfig) -> Result<Option<RootfsIntegritySpec>> {
+    let initrd = env_path_opt(INITRD_VAR, config.initrd.clone());
+    let verity = env_path_opt(ROOTFS_VERITY_VAR, config.rootfs_verity.clone());
+    let roothash = env_string_opt(ROOTFS_ROOTHASH_VAR, config.rootfs_roothash.clone());
+    match (initrd, verity, roothash) {
+        (None, None, None) => Ok(None),
+        (Some(initrd), Some(verity), Some(roothash)) => {
+            let roothash = roothash.trim().to_string();
+            mvm_agentd::guest_mount::validate_roothash(&roothash, ROOTFS_ROOTHASH_VAR)?;
+            Ok(Some(RootfsIntegritySpec {
+                initrd,
+                verity,
+                roothash,
+            }))
+        }
+        (initrd, verity, roothash) => {
+            let mut missing = Vec::new();
+            if initrd.is_none() {
+                missing.push(INITRD_VAR);
+            }
+            if verity.is_none() {
+                missing.push(ROOTFS_VERITY_VAR);
+            }
+            if roothash.is_none() {
+                missing.push(ROOTFS_ROOTHASH_VAR);
+            }
+            bail!(
+                "sealed rootfs is half-configured; all three inputs are required. Missing: {}",
+                missing.join(", ")
+            )
+        }
+    }
+}
+
 fn env_path_opt(var: &str, configured: Option<PathBuf>) -> Option<PathBuf> {
     std::env::var_os(var)
         .filter(|v| !v.is_empty())
@@ -730,9 +800,66 @@ fn overlay_spec_refuses_a_blank_roothash() {
     assert!(err.contains(OVERLAY_ROOTHASH_VAR), "{err}");
 }
 
+#[test]
+fn rootfs_integrity_is_absent_when_nothing_is_configured() {
+    assert!(
+        rootfs_integrity_spec(&RawBenchConfig::default())
+            .expect("an unsealed boot is valid")
+            .is_none()
+    );
+}
+
+#[test]
+fn rootfs_integrity_accepts_the_complete_triple() {
+    let config = RawBenchConfig {
+        initrd: Some(PathBuf::from("/img/initramfs.cpio.gz")),
+        rootfs_verity: Some(PathBuf::from("/img/rootfs.verity")),
+        rootfs_roothash: Some(format!("  {}\n", "a".repeat(64))),
+        ..RawBenchConfig::default()
+    };
+    let integrity = rootfs_integrity_spec(&config)
+        .expect("the complete sealed-rootfs triple is valid")
+        .expect("the complete triple selects a sealed boot");
+    assert_eq!(integrity.initrd, PathBuf::from("/img/initramfs.cpio.gz"));
+    assert_eq!(integrity.verity, PathBuf::from("/img/rootfs.verity"));
+    assert_eq!(integrity.roothash, "a".repeat(64));
+}
+
+#[test]
+fn rootfs_integrity_refuses_a_partial_triple_and_names_the_missing_inputs() {
+    let config = RawBenchConfig {
+        initrd: Some(PathBuf::from("/img/initramfs.cpio.gz")),
+        ..RawBenchConfig::default()
+    };
+    let error = rootfs_integrity_spec(&config)
+        .expect_err("a partial sealed-rootfs triple must fail closed")
+        .to_string();
+    let listed = error
+        .split_once("Missing: ")
+        .map(|(_, rest)| rest.trim().to_string())
+        .unwrap_or_else(|| panic!("error should name what is missing: {error}"));
+    assert_eq!(
+        listed,
+        format!("{ROOTFS_VERITY_VAR}, {ROOTFS_ROOTHASH_VAR}")
+    );
+}
+
+#[test]
+fn rootfs_integrity_refuses_a_malformed_roothash() {
+    let config = RawBenchConfig {
+        initrd: Some(PathBuf::from("/img/initramfs.cpio.gz")),
+        rootfs_verity: Some(PathBuf::from("/img/rootfs.verity")),
+        rootfs_roothash: Some("A".repeat(64)),
+        ..RawBenchConfig::default()
+    };
+    let error = rootfs_integrity_spec(&config)
+        .expect_err("uppercase hexadecimal must not reach the kernel cmdline")
+        .to_string();
+    assert!(error.contains("64 lowercase hex"), "{error}");
+}
+
 /// A spec shaped like the released prod artifact set: kernel + lean rootfs +
-/// the overlay triple, and no rootfs verity (the gate boots the rootfs
-/// directly, since no release publishes the initramfs a sealed boot needs).
+/// the overlay triple, optionally with the complete sealed-rootfs triple.
 #[cfg(test)]
 fn prod_shaped_spec(overlay: Option<OverlaySpec>) -> BenchSpec {
     BenchSpec {
@@ -746,6 +873,7 @@ fn prod_shaped_spec(overlay: Option<OverlaySpec>) -> BenchSpec {
         cpus: 1,
         memory_mib: 256,
         overlay,
+        rootfs_integrity: None,
     }
 }
 
@@ -756,6 +884,29 @@ fn overlay_fixture() -> OverlaySpec {
         verity: PathBuf::from("/img/overlay.verity"),
         roothash: "b".repeat(64),
     }
+}
+
+#[cfg(test)]
+fn rootfs_integrity_fixture() -> RootfsIntegritySpec {
+    RootfsIntegritySpec {
+        initrd: PathBuf::from("/img/initramfs.cpio.gz"),
+        verity: PathBuf::from("/img/rootfs.verity"),
+        roothash: "a".repeat(64),
+    }
+}
+
+#[test]
+fn start_config_carries_the_complete_sealed_rootfs_inputs() {
+    let mut spec = prod_shaped_spec(Some(overlay_fixture()));
+    spec.rootfs_integrity = Some(rootfs_integrity_fixture());
+    let config = start_config(&spec, "sealed-bench".to_string());
+
+    assert_eq!(
+        config.initrd_path.as_deref(),
+        Some("/img/initramfs.cpio.gz")
+    );
+    assert_eq!(config.verity_path.as_deref(), Some("/img/rootfs.verity"));
+    assert_eq!(config.roothash, Some("a".repeat(64)));
 }
 
 #[test]


### PR DESCRIPTION
Closes #2684.

## Summary

- Publish the universal initramfs on the CLI `v*` release train under the exact versioned names requested by `download_initramfs`.
- Package every archive member required by `extract_initramfs_archive` for both supported architectures.
- Fail the release closed unless the initramfs job succeeds; `needs` plus `!cancelled()` alone does not make a failed dependency fatal.
- Boot the staged x86_64 production image twice before upload: once plainly and once through the complete initramfs + dm-verity path.
- Reject partial or malformed sealed-boot inputs in the runtime boot harness instead of silently degrading to an unsealed boot.

The initramfs belongs to the CLI train rather than `boot-image/v*`: the downloader resolves `{release_base}/v{cli_version}`, and the archive contains the guest agent built from that same source revision.

## Verification

- `cargo fmt --check`
- `actionlint .github/workflows/release.yml .github/workflows/release-boot-image.yml`
- `cargo test --test release_assets --test runtime_boot_bench` (41 passed)
- regular workspace tests (all non-doctest targets passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace`
- `just check-gated`

Regression tests pin the producer/consumer asset names, required archive members, both architectures, hard release dependency, plain and sealed boot invocations, complete launch configuration, and fail-closed partial/malformed input behavior.
