### PR TITLE
guest: silence expected missing identity drive

### DIFF
--- a/crates/mvm-agentd/src/flowmux_drive.rs
+++ b/crates/mvm-agentd/src/flowmux_drive.rs
@@ -162,6 +162,21 @@ pub enum IdentityDriveError {
     Unreadable(String),
 }
 
+impl IdentityDriveError {
+    /// Return the failures worth printing during unconditional guest setup.
+    ///
+    /// A boot with no egress policy intentionally has no identity drive, while
+    /// a drive that was attached but cannot be read is a real provisioning
+    /// failure and must stay visible.
+    #[must_use]
+    pub fn boot_warning(&self) -> Option<&Self> {
+        match self {
+            Self::NotAttached => None,
+            Self::Unreadable(_) => Some(self),
+        }
+    }
+}
+
 impl std::fmt::Display for IdentityDriveError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -501,5 +516,22 @@ mod tests {
         let rendered = IdentityDriveError::NotAttached.to_string();
         assert!(rendered.contains(IDENTITY_DRIVE_LABEL), "{rendered}");
         assert!(rendered.contains("did not attach"), "{rendered}");
+    }
+
+    #[test]
+    fn an_unattached_identity_drive_is_an_expected_secretless_boot() {
+        assert!(IdentityDriveError::NotAttached.boot_warning().is_none());
+    }
+
+    #[test]
+    fn an_attached_but_unreadable_identity_drive_stays_loud() {
+        let error = IdentityDriveError::Unreadable("mount refused".to_owned());
+        let warning = error
+            .boot_warning()
+            .expect("an unreadable attached drive must remain visible");
+        assert_eq!(
+            warning.to_string(),
+            "reading the FlowMux identity drive: mount refused"
+        );
     }
 }

--- a/crates/mvm-agentd/src/guest_bootstrap.rs
+++ b/crates/mvm-agentd/src/guest_bootstrap.rs
@@ -468,8 +468,10 @@ pub fn provision_egress_ca() {
 /// never wanted networking.
 pub fn provision_flowmux_identity() {
     #[cfg(target_os = "linux")]
-    if let Err(e) = crate::flowmux_drive::provision_identity_from_drive() {
-        eprintln!("mvm-init: FlowMux identity not provisioned: {e}");
+    if let Err(error) = crate::flowmux_drive::provision_identity_from_drive()
+        && let Some(warning) = error.boot_warning()
+    {
+        eprintln!("mvm-init: FlowMux identity not provisioned: {warning}");
     }
 }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,6 +17,13 @@ for detailed scope and acceptance criteria.
       absolute `/bin/ping` mediated-tool proof. Together with PRs #2690,
       #2709, and #2720, this closes the NIC-less and read-only boot-noise issue.
 
+- [x] **Issue #2633 — healthy boots no longer report authentication failures.**
+      PR #2707 classified an abandoned readiness probe as transport EOF rather
+      than failed authentication. The remaining no-egress path now treats an
+       unattached FlowMux identity drive as the expected secretless boot shape,
+       while an attached but unreadable drive stays loud. Two focused tests pin
+       both sides of that boundary.
+
 - [x] **Plan 337 COMPLETE — the SDK surface is generated from Rust.** Sessions
       finished Tier C. Python's `contextvars` + `Token` has no
       `AsyncLocalStorage` equivalent, so the shape was a choice, not a

--- a/specs/sprint/delivery/2633-expected-missing-flowmux-identity.md
+++ b/specs/sprint/delivery/2633-expected-missing-flowmux-identity.md
@@ -1,0 +1,30 @@
+# Issue 2633 — healthy secretless boots produce no authentication failures
+
+The two healthy-boot messages had different causes and are now classified at
+their actual boundaries.
+
+PR #2707 made an abandoned readiness connection a transport probe outcome,
+not a failed authenticated control handshake. This change closes the remaining
+identity-drive half: unconditional guest setup treats
+`IdentityDriveError::NotAttached` as the expected shape for a boot whose policy
+admits no egress, so it emits no failure line. A drive that was attached but
+cannot be mounted or read remains loud.
+
+`IdentityDriveError::boot_warning` makes the distinction explicit and testable.
+The positive and negative tests prove expected absence is silent while an
+unreadable attached drive retains its actionable diagnostic. The Linux-gated
+guest setup consumes that classifier directly.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `just check-gated`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo test --workspace -- --test-threads=1`
+- `cargo test -p mvm-cli --doc -- --test-threads=1`
+- `cargo test -p mvm-hostd --test host_agent_restart daemon_crash_mid_flight_loses_at_most_one_call_and_preserves_chain -- --test-threads=1`
+
+The workspace run passed every executable test before a transient doctest
+compile-state failure; the doctest passed when repeated in isolation. A second
+workspace run reached the unrelated host-agent restart suite and timed out once
+waiting for its socket; that exact test passed on immediate isolated retry.


### PR DESCRIPTION
Closes #2633.

Treats an absent optional identity drive as an expected guest configuration while retaining warnings for real identity read failures. The abandoned-readiness EOF portion was already addressed by #2707.

Validation:
- cargo test -p mvm-agentd --all-targets
- cargo test --workspace
- cargo test -p mvm-cli --doc
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- just check-gated