### PR TITLE
guest: mount writable runtime tmpfs

### DIFF
--- a/crates/mvm-agentd/src/guest_bootstrap.rs
+++ b/crates/mvm-agentd/src/guest_bootstrap.rs
@@ -119,10 +119,13 @@ pub fn provision_guest_environment() -> Result<(), EgressClientMissing> {
 /// Both are cosmetic-until-they-aren't: without the home the shell starts in a
 /// directory it cannot write, and without the `/etc/passwd` entry `whoami`
 /// exits nonzero and `getpwuid()` returns `NULL` to any library that asks.
-/// Neither failure is worth refusing to boot over — a read-only rootfs that
-/// takes neither write still runs the workload — so both are reported and
-/// stepped past.
+/// Neither failure is worth refusing to boot over. A read-only rootfs cannot
+/// take either write, so use its writable `/tmp` fallback and leave the image's
+/// account databases unchanged without issuing syscalls that must fail.
 fn provision_workload_identity() {
+    if !crate::guest_mount::optional_image_writes_allowed(rootfs_is_read_only()) {
+        return;
+    }
     if let Err(error) = crate::guest_mount::ensure_workload_home() {
         note_optional_step(
             &format!(

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -143,6 +143,28 @@ pub fn mount_early_filesystems() -> Result<()> {
         // branched off before the early mounts.
         ensure_dir("/dev")?;
         mount("devtmpfs", "/dev", "devtmpfs", libc::MS_NOSUID, "")?;
+
+        // The activated workload root is deliberately read-only. Runtime
+        // state and scratch files therefore need their own writable mounts,
+        // created before the pivot and carried across with the pseudofs
+        // mounts by `pivot_to_root`. OCI materialization guarantees both
+        // target directories exist in the sealed root.
+        ensure_dir("/run")?;
+        mount(
+            "tmpfs",
+            "/run",
+            "tmpfs",
+            libc::MS_NOSUID | libc::MS_NODEV,
+            "mode=0755",
+        )?;
+        ensure_dir("/tmp")?;
+        mount(
+            "tmpfs",
+            "/tmp",
+            "tmpfs",
+            libc::MS_NOSUID | libc::MS_NODEV,
+            "mode=1777",
+        )?;
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -431,21 +453,21 @@ pub fn mount_volumes(volumes: &[VolumeConfig], root: &Path) -> Result<()> {
 
 /// Pivot into the mounted rootfs, making it the active `/`.
 ///
-/// Moves `/proc`, `/sys`, and `/dev` into the new root, then performs the
-/// canonical switch_root sequence (chdir + MS_MOVE + chroot).  The agent
-/// process keeps running; it does not exec a new init.
+/// Moves `/proc`, `/sys`, `/dev`, `/run`, and `/tmp` into the new root, then
+/// performs the canonical switch_root sequence (chdir + MS_MOVE + chroot).
+/// The agent process keeps running; it does not exec a new init.
 pub fn pivot_to_root(new_root: &Path) -> Result<()> {
     #[cfg(target_os = "linux")]
     {
         // Ensure the target directories exist in the new root.
-        for sub in ["proc", "sys", "dev"] {
+        for sub in ["proc", "sys", "dev", "run", "tmp"] {
             let dst = new_root.join(sub);
             ensure_dir(&dst.to_string_lossy())?;
         }
 
         // Move the initramfs pseudo-filesystems into the new root so the
         // workload (and the agent itself) keeps seeing them.
-        for sub in ["/proc", "/sys", "/dev"] {
+        for sub in ["/proc", "/sys", "/dev", "/run", "/tmp"] {
             let dst = new_root.join(&sub[1..]).to_string_lossy().to_string();
             let _ = ensure_dir(&dst);
             move_mount(sub, &dst)
@@ -508,6 +530,17 @@ pub fn workload_home() -> &'static str {
     } else {
         WORKLOAD_HOME_FALLBACK
     }
+}
+
+/// Whether optional writes into the image-owned root can be attempted.
+///
+/// Runtime state has dedicated writable mounts. Cosmetic image changes such
+/// as creating a preferred home or naming the workload uid do not, so a
+/// sealed root skips them without issuing syscalls that must fail.
+#[must_use]
+#[cfg(any(target_os = "linux", test))]
+pub(crate) const fn optional_image_writes_allowed(rootfs_read_only: bool) -> bool {
+    !rootfs_read_only
 }
 
 /// The privilege drop as bare syscalls, allocating nothing on any path.
@@ -1361,7 +1394,7 @@ mod tests {
             .next()
             .expect("function body is delimited by the next item");
 
-        for target in ["/proc", "/sys", "/dev"] {
+        for target in ["/proc", "/sys", "/dev", "/run", "/tmp"] {
             let created = body
                 .find(&format!("ensure_dir(\"{target}\")"))
                 .unwrap_or_else(|| {
@@ -1378,6 +1411,46 @@ mod tests {
                 "{target}: ensure_dir must come before the mount, not after"
             );
         }
+    }
+
+    /// Runtime writes belong on tmpfs, and those mounts must survive the
+    /// switch from the universal initramfs to the sealed workload root.
+    #[test]
+    fn writable_runtime_mounts_are_tmpfs_and_move_into_the_workload_root() {
+        let src = include_str!("guest_mount.rs");
+        let early = src
+            .split("pub fn mount_early_filesystems")
+            .nth(1)
+            .expect("mount_early_filesystems must exist")
+            .split("\npub fn ")
+            .next()
+            .expect("function body is delimited by the next item");
+        let pivot = src
+            .split("pub fn pivot_to_root")
+            .nth(1)
+            .expect("pivot_to_root must exist")
+            .split("\npub fn ")
+            .next()
+            .expect("function body is delimited by the next item");
+
+        for target in ["/run", "/tmp"] {
+            assert!(
+                early.contains(&format!(
+                    "\"tmpfs\",\n            \"{target}\",\n            \"tmpfs\""
+                )),
+                "{target} must be mounted as tmpfs before the read-only root is activated"
+            );
+            assert!(
+                pivot.contains(&format!("\"{target}\"")),
+                "{target} must move into the activated workload root"
+            );
+        }
+    }
+
+    #[test]
+    fn sealed_roots_refuse_optional_image_writes() {
+        assert!(!optional_image_writes_allowed(true));
+        assert!(optional_image_writes_allowed(false));
     }
 
     /// devtmpfs must be mounted unconditionally, never gated on `/dev/console`.

--- a/features/suites/s5_lifecycle/transient_sandbox_boot.feature
+++ b/features/suites/s5_lifecycle/transient_sandbox_boot.feature
@@ -11,6 +11,14 @@ Feature: Transient sandbox boot
     Then the command exits with code 0
     And the output contains "mvm-bdd-oci-hello"
 
+  # The verified OCI root stays read-only. Scratch space is a dedicated tmpfs
+  # carried from the universal initramfs across the root pivot.
+  @live
+  Scenario: a sealed OCI workload has writable scratch space
+    When I run mvmctl in an isolated live home with "machine run --name bdd-oci-scratch --image alpine --timeout 120 -- mktemp /tmp/mvm-bdd.XXXXXX"
+    Then the command exits with code 0
+    And the output contains "/tmp/mvm-bdd."
+
   @live
   Scenario: machine run boots a transient sandbox from a Nix flake
     When I run mvmctl in an isolated live home with "machine run --name bdd-nix-boot --flake examples/exit_code --timeout 120"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -7,6 +7,16 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
+- [x] **Issue #2634 — sealed guests have writable runtime state without a
+      writable root.** The universal initramfs mounts `/run` and `/tmp` as
+      restricted tmpfs filesystems and moves them across the workload-root
+      pivot. Mediated tools can therefore build their `/run` overlay and
+      `/tmp` is real scratch space while the verified image stays read-only.
+      Optional home/passwd mutations are not attempted on a sealed root. The
+      live lifecycle suite covers Alpine `/tmp` writes and retains the
+      absolute `/bin/ping` mediated-tool proof. Together with PRs #2690,
+      #2709, and #2720, this closes the NIC-less and read-only boot-noise issue.
+
 - [x] **Plan 337 COMPLETE — the SDK surface is generated from Rust.** Sessions
       finished Tier C. Python's `contextvars` + `Token` has no
       `AsyncLocalStorage` equivalent, so the shape was a choice, not a

--- a/specs/sprint/delivery/2634-writable-runtime-mounts.md
+++ b/specs/sprint/delivery/2634-writable-runtime-mounts.md
@@ -1,0 +1,46 @@
+# 2634 — writable runtime mounts on a sealed guest root
+
+## Outcome
+
+The universal-initramfs guest now carries dedicated writable `/run` and `/tmp`
+tmpfs mounts across the pivot into the verified workload root. The root image
+remains read-only; runtime state and scratch files no longer depend on mutating
+it.
+
+This completes the issue together with the earlier closeout increments:
+
+- PR #2690 made a missing `eth0` an expected NIC-less topology instead of a
+  netinit failure.
+- PR #2709 consolidated unavoidable optional read-only setup skips into one
+  diagnostic.
+- PR #2720 cached the root mount-table decision so optional setup did not
+  repeatedly parse `/proc/mounts`.
+
+## Runtime contract
+
+- PID 1 mounts `/run` and `/tmp` as `tmpfs` before activating the workload.
+- Both mounts use `nosuid,nodev`; `/tmp` is mode `1777` and `/run` is mode
+  `0755`.
+- The mounts move into the workload root beside `/proc`, `/sys`, and `/dev`.
+- OCI image materialization already creates the sealed mountpoints and folds
+  their layout into the image digest.
+- Mediated tools can use `/run/mvm/overlay` for their writable overlay, making
+  the existing absolute `/bin/ping` workflow functional without changing the
+  verified lower layer.
+- Optional home and passwd edits are skipped on a read-only root rather than
+  issuing syscalls known to fail. Workloads retain writable `/tmp` scratch
+  space.
+
+## Verification
+
+- Focused unit tests pin both tmpfs mounts, their pivot participation, and the
+  read-only image-write decision.
+- The live lifecycle suite now writes a unique file with `mktemp` under `/tmp`
+  in an Alpine OCI workload.
+- The existing live mediated-tool scenario executes `/bin/ping` and covers the
+  `/run` overlay path.
+- Repository-wide format, compile, clippy, gated-target, and test commands are
+  recorded in the pull request.
+
+The live microVM scenarios remain builder-VM/merge-queue evidence: host-side
+runtime commands are intentionally not used for Linux microVM work.


### PR DESCRIPTION
Closes #2634.

Completes the read-only guest runtime fix by mounting writable, hardened tmpfs filesystems for /run and /tmp before pivot_root, moving them into the new root, and avoiding optional image mutations when the root is read-only. Adds focused unit coverage and a live Alpine /tmp workflow scenario. Earlier pieces landed in #2690, #2709, and #2720.

Validation:
- cargo test -p mvm-agentd --all-targets
- cargo test --workspace
- cargo test -p mvm-cli --doc
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- just check-gated

The workspace run reached a transient concurrent rustdoc artifact lookup failure after all executable tests passed; the isolated mvm-cli doctest then passed.