### PR TITLE
feat(checkpoint): enforce a forked child's declared secret bindings (#2698 A3)

### DIFF
--- a/crates/mvm-cli/src/commands/machine/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/machine/checkpoint.rs
@@ -22,6 +22,10 @@ pub(in crate::commands) struct ForkMachineInput {
     pub child_name: Option<String>,
     /// Branch slug for auto-naming (`--branch`).
     pub branch: Option<String>,
+    /// Secret bindings explicitly declared for the child.
+    pub declared_secrets: Vec<mvm_core::plan::SecretBinding>,
+    /// Whether omitting a parent binding is intentional.
+    pub allow_secret_drop: bool,
     /// Emit machine-readable JSON instead of human text.
     pub json: bool,
 }
@@ -34,6 +38,10 @@ pub(in crate::commands) struct RestoreMachineInput {
     pub child_name: Option<String>,
     /// Branch slug for auto-naming (`--branch`).
     pub branch: Option<String>,
+    /// Secret bindings explicitly declared for the child.
+    pub declared_secrets: Vec<mvm_core::plan::SecretBinding>,
+    /// Whether omitting a parent binding is intentional.
+    pub allow_secret_drop: bool,
     /// Emit machine-readable JSON instead of human text.
     pub json: bool,
 }
@@ -61,6 +69,8 @@ pub(in crate::commands) fn fork_machine(input: ForkMachineInput) -> Result<()> {
     fork_vm_full_machine(ForkVmFullMachineInput {
         checkpoint_id: checkpoint_id.as_str().to_string(),
         child_vm_name: Some(child_name),
+        declared_secrets: input.declared_secrets,
+        allow_secret_drop: input.allow_secret_drop,
         json: input.json,
     })
     .with_context(|| format!("forking child from checkpoint {}", checkpoint_id.as_str()))?;
@@ -99,6 +109,8 @@ pub(in crate::commands) fn restore_machine(input: RestoreMachineInput) -> Result
     fork_vm_full_machine(ForkVmFullMachineInput {
         checkpoint_id: input.checkpoint_id,
         child_vm_name: Some(child_name),
+        declared_secrets: input.declared_secrets,
+        allow_secret_drop: input.allow_secret_drop,
         json: input.json,
     })?;
     Ok(())
@@ -110,6 +122,10 @@ pub(in crate::commands) struct ForkVmFullMachineInput {
     pub checkpoint_id: String,
     /// Desired child VM name; auto-generated if omitted.
     pub child_vm_name: Option<String>,
+    /// Secret bindings explicitly declared for the child.
+    pub declared_secrets: Vec<mvm_core::plan::SecretBinding>,
+    /// Whether omitting a parent binding is intentional.
+    pub allow_secret_drop: bool,
     /// Emit machine-readable JSON instead of human text.
     pub json: bool,
 }
@@ -157,7 +173,8 @@ pub(in crate::commands) fn fork_vm_full_machine(input: ForkVmFullMachineInput) -
             now,
             json: input.json,
             bypass_experimental_guard: true,
-            declared_secrets: &[],
+            declared_secrets: &input.declared_secrets,
+            allow_secret_drop: input.allow_secret_drop,
         },
     )?;
     Ok(())

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1053,6 +1053,12 @@ pub(in crate::commands) struct MachineWarmRestoreArgs {
     /// Name for the fresh child VM (auto-generated if omitted).
     #[arg(long, value_name = "NAME")]
     pub name: Option<String>,
+    /// Declare a child secret binding (`VAR` or `VAR=ADDRESS`). Repeatable.
+    #[arg(long = "secret")]
+    pub secret: Vec<String>,
+    /// Permit intentionally omitting one or more parent secret bindings.
+    #[arg(long)]
+    pub allow_secret_drop: bool,
     /// Output the result as JSON.
     #[arg(long)]
     pub json: bool,
@@ -1069,6 +1075,12 @@ pub(in crate::commands) struct MachineForkArgs {
     /// Auto-name the child as `<parent>-<branch>-<timestamp>`.
     #[arg(long, value_name = "BRANCH", conflicts_with = "child_name")]
     pub branch: Option<String>,
+    /// Declare a child secret binding (`VAR` or `VAR=ADDRESS`). Repeatable.
+    #[arg(long = "secret")]
+    pub secret: Vec<String>,
+    /// Permit intentionally omitting one or more parent secret bindings.
+    #[arg(long)]
+    pub allow_secret_drop: bool,
     /// Output the result as JSON.
     #[arg(long)]
     pub json: bool,
@@ -1085,6 +1097,12 @@ pub(in crate::commands) struct MachineRestoreArgs {
     /// Auto-name the child as `<checkpoint>-<branch>-<timestamp>`.
     #[arg(long, value_name = "BRANCH", conflicts_with = "child_name")]
     pub branch: Option<String>,
+    /// Declare a child secret binding (`VAR` or `VAR=ADDRESS`). Repeatable.
+    #[arg(long = "secret")]
+    pub secret: Vec<String>,
+    /// Permit intentionally omitting one or more parent secret bindings.
+    #[arg(long)]
+    pub allow_secret_drop: bool,
     /// Output the result as JSON.
     #[arg(long)]
     pub json: bool,
@@ -1602,9 +1620,12 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
 
 /// Run `machine warm-restore`: fork a vm_full checkpoint into a fresh child VM.
 fn run_warm_restore(args: MachineWarmRestoreArgs) -> Result<()> {
+    let declared_secrets = super::vm::checkpoint::parse_declared_secrets(&args.secret)?;
     fork_vm_full_machine(ForkVmFullMachineInput {
         checkpoint_id: args.checkpoint,
         child_vm_name: args.name,
+        declared_secrets,
+        allow_secret_drop: args.allow_secret_drop,
         json: args.json,
     })?;
     Ok(())
@@ -1612,20 +1633,26 @@ fn run_warm_restore(args: MachineWarmRestoreArgs) -> Result<()> {
 
 /// Run `machine fork`: capture and branch a running machine into a fresh child VM.
 fn run_fork(args: MachineForkArgs) -> Result<()> {
+    let declared_secrets = super::vm::checkpoint::parse_declared_secrets(&args.secret)?;
     checkpoint::fork_machine(checkpoint::ForkMachineInput {
         parent_name: args.parent,
         child_name: args.child_name,
         branch: args.branch,
+        declared_secrets,
+        allow_secret_drop: args.allow_secret_drop,
         json: args.json,
     })
 }
 
 /// Run `machine restore`: branch a vm_full checkpoint into a fresh child VM.
 fn run_restore(args: MachineRestoreArgs) -> Result<()> {
+    let declared_secrets = super::vm::checkpoint::parse_declared_secrets(&args.secret)?;
     checkpoint::restore_machine(checkpoint::RestoreMachineInput {
         checkpoint_id: args.checkpoint,
         child_name: args.child_name,
         branch: args.branch,
+        declared_secrets,
+        allow_secret_drop: args.allow_secret_drop,
         json: args.json,
     })
 }

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -32,6 +32,7 @@ mod fork_vm_full;
 mod lineage;
 mod revert;
 mod timeline;
+mod vm_state;
 use fork_vm_full::fork_vm_full_arm;
 pub(in crate::commands) use fork_vm_full::{ForkVmFullArmFcParams, fork_vm_full_arm_fc};
 pub(in crate::commands) use lineage::SignedChainAnchor;
@@ -40,6 +41,10 @@ pub(in crate::commands) use revert::{
     run_revert, run_rewind,
 };
 pub(in crate::commands) use timeline::{TimelineArgs, run_timeline};
+use vm_state::{
+    backend_for_vm, ensure_save_restore_supported, resolve_quiesced_vm_rootfs,
+    runtime_contract_for_checkpoint, supervisor_config_digest, vm_is_running,
+};
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct CheckpointArgs {
@@ -285,155 +290,6 @@ pub(in crate::commands) fn now_unix() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
-}
-
-/// Resolve the host-side bootable rootfs image for a quiesced VM, or a clean
-/// error explaining why a checkpoint can't be taken.
-///
-/// "Quiesced" means the VM is not running, OR the pause verb has written a
-/// pause marker that matches the live supervisor pid (vCPUs and virtio queues
-/// quiesced). A live, unpaused VM is refused: an fs_quick checkpoint has no
-/// memory, so the rootfs must be in a clean, deterministic state.
-///
-/// Resolution order (first match wins):
-/// 1. Per-instance `rootfs.ext4` CoW clone in `vm_state_dir(name)`.
-/// 2. `mode.json` `rootfs_path` field (backend-neutral; written by every
-///    backend that calls `record_from_rootfs` at start time).
-fn resolve_quiesced_vm_rootfs(name: &str) -> Result<PathBuf> {
-    if !vm_is_quiesced(name) {
-        bail!("stop or pause VM '{name}' before checkpointing");
-    }
-    let state_dir = vm_state_dir(name);
-
-    // Per-instance CoW clone — deterministic, present on disk.
-    let instance_rootfs = state_dir.join("rootfs.ext4");
-    if instance_rootfs.is_file() {
-        return Ok(instance_rootfs);
-    }
-
-    // Backend-neutral: every backend that calls `record_from_rootfs` at start
-    // time writes the rootfs path into mode.json.
-    if let Some(path) = rootfs_from_mode_json(&state_dir)? {
-        if !path.exists() {
-            bail!(
-                "fs_quick checkpoint needs the VM's rootfs ({}), which is no longer \
-                 on disk. Pause instead of stopping: `mvmctl vm pause {name}`, \
-                 checkpoint, then `mvmctl vm resume {name}` — or use \
-                 `--class vm-full` on a running VM.",
-                path.display()
-            );
-        }
-        return Ok(path);
-    }
-
-    bail!("fs_quick checkpoint is not supported for this VM's backend");
-}
-
-/// Read `mode.json` and return the recorded `rootfs_path` field, if present.
-/// Absent file or absent field → `Ok(None)`. Malformed JSON propagates.
-fn rootfs_from_mode_json(state_dir: &std::path::Path) -> Result<Option<PathBuf>> {
-    let path = state_dir.join("mode.json");
-    let body = match std::fs::read_to_string(&path) {
-        Ok(b) => b,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(e).with_context(|| format!("reading {}", path.display())),
-    };
-    let meta: mvm_runtime::base::runtime_meta::VmRuntimeMeta =
-        serde_json::from_str(&body).with_context(|| format!("parsing {}", path.display()))?;
-    Ok(meta.rootfs_path.map(PathBuf::from))
-}
-
-/// Best-effort liveness: a VM is "running" iff one of its per-backend PID
-/// files names a live process. Delegates to the runtime's probe so this side
-/// cannot keep its own marker list — every registered backend's marker
-/// (`fc.pid`, `libkrun.pid`, `hvf.pid`, `qemu.pid`) is covered by one pass over
-/// the shared list, which is also where the `EPERM`-means-alive rule lives. A
-/// hand-kept list here is how a live HVF VM used to read as stopped, and a
-/// root-owned Firecracker with it.
-fn vm_is_running(name: &str) -> bool {
-    mvm_runtime::checkpoint::vm_is_running(name)
-}
-
-/// fs_quick clones the instance rootfs, so the guest must not be writing:
-/// either the VM is stopped, or it is paused (vCPUs and virtio queues quiesced
-/// — the FC pause verb stamps the fc pid into `fc.paused`; resume and any path
-/// that replaces the process removes or invalidates the marker). A
-/// running-but-paused VM keeps its pid alive, so `vm_is_running` alone would
-/// incorrectly refuse the checkpoint without these marker checks.
-fn vm_is_quiesced(name: &str) -> bool {
-    if !vm_is_running(name) {
-        return true;
-    }
-    fc_pause_marker_matches_live_pid(name) || hvf_pause_marker_present(name)
-}
-
-/// The HVF supervisor writes `pause.state` only after its vCPU has entered the
-/// pause hold, and removes it on resume. Unlike Firecracker's marker this one is
-/// written by the process that owns the vCPU, so its presence beside a live
-/// `hvf.pid` is itself the acknowledgement — there is no pid to cross-check
-/// against a marker some other verb stamped.
-fn hvf_pause_marker_present(name: &str) -> bool {
-    let dir = vm_state_dir(name);
-    dir.join("hvf.pid").is_file() && dir.join("pause.state").is_file()
-}
-
-/// `machine pause` snapshot-seals FC but leaves the fc process running, so a
-/// live pid cannot
-/// distinguish paused from running. The pause verb stamps the fc pid into
-/// `fc.paused` (under `vm_state_dir`); resume removes it. Quiesced iff the
-/// marker matches the live fc pid at `<mvm_home>/vms/<name>/fc.pid`.
-fn fc_pause_marker_matches_live_pid(name: &str) -> bool {
-    let marker = std::fs::read_to_string(vm_state_dir(name).join("fc.paused")).ok();
-    let live =
-        mvm_runtime::microvm::fc_pid_path(name).and_then(|p| std::fs::read_to_string(p).ok());
-    matches!((marker, live), (Some(m), Some(l)) if !m.trim().is_empty() && m.trim() == l.trim())
-}
-
-/// Hash the VM's persisted supervisor config so the checkpoint pins the launch
-/// shape it was captured from. No config on disk → empty digest (the field is
-/// advisory for fs_quick; integrity rests on `content_sha256`).
-fn supervisor_config_digest(state_dir: &std::path::Path) -> String {
-    let cfg_path = state_dir.join("supervisor-config.json");
-    mvm_core::crypto::image_verify::sha256_file(&cfg_path).unwrap_or_default()
-}
-
-fn runtime_contract_for_checkpoint(
-    name: &str,
-) -> Result<(
-    Option<mvm_core::vm_backend::RuntimeSourcePolicy>,
-    Option<String>,
-)> {
-    Ok(mvm_runtime::base::runtime_meta::read(name)?
-        .map(|meta| {
-            (
-                Some(meta.runtime_source_policy),
-                meta.runtime_overlay_version,
-            )
-        })
-        .unwrap_or((None, None)))
-}
-
-/// The backend that actually owns `name`, falling back to the host default for
-/// a VM with no live marker (a restore target that has not been started yet).
-fn backend_for_vm(name: &str) -> AnyBackend {
-    AnyBackend::for_started_vm(name).unwrap_or_else(AnyBackend::auto_select)
-}
-
-/// Refuse a memory-snapshot verb on a backend that cannot save and reload
-/// machine state. The check is against the backend that owns *this* VM, not the
-/// host default: on a host where several VMMs can run, the capability of the
-/// one holding the VM is the only one that matters.
-fn ensure_save_restore_supported(action: &str, backend: &AnyBackend) -> Result<()> {
-    let available = backend.snapshot_capability();
-    if !available.satisfies(SnapshotCapability::SaveRestore) {
-        bail!(
-            "vm {action} requires memory-snapshot support, but backend '{}' reports \
-             snapshot tier '{}' on this host",
-            backend.name(),
-            available.label()
-        );
-    }
-    Ok(())
 }
 
 fn create(name: &str, tag: Option<String>, json: bool) -> Result<()> {
@@ -1526,6 +1382,7 @@ pub(crate) fn bind_checkpoint_forked(
 
 #[cfg(test)]
 mod tests {
+    use super::vm_state::{fc_pause_marker_matches_live_pid, vm_is_quiesced};
     use super::*;
     use mvm_contract::ir::AuthType;
     use mvm_core::plan::{SecretBinding, SecretSource};

--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -163,6 +163,11 @@ pub(in crate::commands) enum CheckpointCmd {
         /// to ride on.
         #[arg(long = "secret")]
         secret: Vec<String>,
+        /// Permit the child to omit secret bindings declared by the parent.
+        /// Without this flag, every parent binding must be redeclared with
+        /// `--secret`, making capability attenuation explicit and reviewable.
+        #[arg(long)]
+        allow_secret_drop: bool,
         /// Output the fork result as JSON.
         #[arg(long)]
         json: bool,
@@ -214,6 +219,7 @@ pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> R
             cpus,
             memory,
             secret,
+            allow_secret_drop,
             json,
         } => fork(ForkCmdParams {
             id: &id,
@@ -223,6 +229,7 @@ pub(in crate::commands) fn run_checkpoint(_cli: &Cli, args: CheckpointArgs) -> R
             cpus,
             memory: memory.as_deref(),
             declared_secrets: &parse_declared_secrets(&secret)?,
+            allow_secret_drop,
             json,
         }),
         CheckpointCmd::Diff { a, b, json } => diff(&a, &b, json),
@@ -848,6 +855,7 @@ struct ForkCmdParams<'a> {
     cpus: Option<u32>,
     memory: Option<&'a str>,
     declared_secrets: &'a [mvm_core::plan::SecretBinding],
+    allow_secret_drop: bool,
     json: bool,
 }
 
@@ -857,7 +865,9 @@ struct ForkCmdParams<'a> {
 /// name; `VAR=ADDRESS` separates them. Nothing here contacts the keystore or
 /// resolves a value — a binding is a reference, and an address that names no
 /// secret simply fails to resolve later rather than granting anything.
-fn parse_declared_secrets(values: &[String]) -> Result<Vec<mvm_core::plan::SecretBinding>> {
+pub(in crate::commands) fn parse_declared_secrets(
+    values: &[String],
+) -> Result<Vec<mvm_core::plan::SecretBinding>> {
     values
         .iter()
         .map(|raw| {
@@ -889,6 +899,7 @@ fn fork(p: ForkCmdParams<'_>) -> Result<()> {
         cpus,
         memory,
         declared_secrets,
+        allow_secret_drop,
         json,
     } = p;
     let checkpoint = validated_checkpoint_id(id)?;
@@ -909,6 +920,7 @@ fn fork(p: ForkCmdParams<'_>) -> Result<()> {
                 // No CLI surface declares bindings yet, so a fork declares
                 // none — exactly the prior behaviour.
                 declared_secrets,
+                allow_secret_drop,
             })
         }
         CheckpointClass::FsQuick => fork_fs_quick_arm(ForkFsQuickArmParams {
@@ -920,6 +932,7 @@ fn fork(p: ForkCmdParams<'_>) -> Result<()> {
             cpus_override: cpus,
             memory_override: memory,
             declared_secrets,
+            allow_secret_drop,
             json,
         }),
     }
@@ -938,6 +951,7 @@ struct ForkFsQuickArmParams<'a> {
     /// Declared for the child when `--boot` admits one. A fs_quick fork without
     /// `--boot` admits no plan, so there is nothing for these to ride on.
     declared_secrets: &'a [mvm_core::plan::SecretBinding],
+    allow_secret_drop: bool,
     json: bool,
 }
 
@@ -946,6 +960,21 @@ struct ForkFsQuickArmParams<'a> {
 /// materialized rootfs without clobbering it (the no-clobber seam in
 /// `prepare_instance_rootfs` returns early when source == instance path).
 fn fork_fs_quick_arm(p: ForkFsQuickArmParams<'_>) -> Result<()> {
+    if !p.boot && !p.declared_secrets.is_empty() {
+        bail!(
+            "--secret requires --boot for an fs_quick fork because an unbooted clone has no child plan"
+        );
+    }
+    let child_tenant = super::tenant_resolution::resolve_tenant(None);
+    if p.boot {
+        validate_fork_secret_policy(
+            p.checkpoint,
+            p.store,
+            &child_tenant,
+            p.declared_secrets,
+            p.allow_secret_drop,
+        )?;
+    }
     let now = now_unix();
     let child_vm_name = p
         .new_id
@@ -976,7 +1005,14 @@ fn fork_fs_quick_arm(p: ForkFsQuickArmParams<'_>) -> Result<()> {
     // A fork that we can't audit (signer present but emit fails) is refused —
     // an unaudited lineage record would break the chain. A missing plan/signer
     // is best-effort, matching capture.
-    bind_checkpoint_forked(p.checkpoint, &meta, &child_vm_name, p.store)?;
+    bind_checkpoint_forked(
+        p.checkpoint,
+        &meta,
+        &child_vm_name,
+        p.store,
+        p.declared_secrets,
+        &child_tenant,
+    )?;
 
     if p.boot {
         let instance_rootfs = dest_dir.join("rootfs.ext4");
@@ -1055,8 +1091,6 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
     AnyBackend::require_hypervisor_selectable(&effective_hypervisor)?;
     let parent_agent_verbs = parent_agent_verb_override(p.parent_checkpoint, p.store);
     let parent_meta = p.store.read_meta(p.parent_checkpoint)?;
-    warn_dropped_parent_secrets(p.parent_checkpoint, p.store);
-
     // Resource shape: flag > parent plan > global defaults.
     let (parent_cpus, parent_mem) = parent_plan_resources(p.parent_checkpoint, p.store);
     let user_cfg = mvm_core::user_config::load(None);
@@ -1334,23 +1368,91 @@ fn parent_secret_names(parent_checkpoint: &CheckpointId, store: &CheckpointStore
     plan.secrets.into_iter().map(|b| b.name).collect()
 }
 
-/// Warn that a fork drops the parent's secret bindings.
-///
-/// Not a refusal: a fork is always prod-profile, so there is no flag to gate a
-/// refusal on, and hard-failing would break forks whose child never needed the
-/// parent's credentials.
-fn warn_dropped_parent_secrets(parent_checkpoint: &CheckpointId, store: &CheckpointStore) {
-    let dropped = parent_secret_names(parent_checkpoint, store);
+fn dropped_parent_secret_names(
+    parent_names: &[String],
+    declared: &[mvm_core::plan::SecretBinding],
+) -> Vec<String> {
+    let declared_names = declared
+        .iter()
+        .map(|binding| binding.name.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    parent_names
+        .iter()
+        .filter(|name| !declared_names.contains(name.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn enforce_secret_attenuation(dropped: &[String], allow_secret_drop: bool) -> Result<()> {
     if dropped.is_empty() {
-        return;
+        return Ok(());
     }
-    tracing::warn!(
-        secrets = %dropped.join(", "),
-        count = dropped.len(),
-        "fork child is admitted with no secret bindings; the parent's are not carried, \
-         so outbound requests to their bound destinations will be refused by the \
-         substitution endpoint"
-    );
+    if !allow_secret_drop {
+        bail!(
+            "fork child would drop parent secret bindings: {}. Redeclare each required binding with --secret NAME, or pass --allow-secret-drop to attenuate them intentionally",
+            dropped.join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// Validate a fork child's complete secret capability before any child boots.
+///
+/// Every declared keystore address must exist in the child's tenant. Parent
+/// bindings are never inherited; omitting one is an explicit attenuation and
+/// therefore requires `--allow-secret-drop`.
+pub(super) fn validate_fork_secret_policy(
+    parent_checkpoint: &CheckpointId,
+    store: &CheckpointStore,
+    tenant: &str,
+    declared: &[mvm_core::plan::SecretBinding],
+    allow_secret_drop: bool,
+) -> Result<()> {
+    let binding_store = mvm_hostd::keyholder::FileBindingStore::default_location()
+        .context("opening the child tenant's secret-binding store")?;
+    resolve_fork_secret_audit(tenant, declared, &binding_store)?;
+
+    let dropped =
+        dropped_parent_secret_names(&parent_secret_names(parent_checkpoint, store), declared);
+    enforce_secret_attenuation(&dropped, allow_secret_drop)?;
+    if !dropped.is_empty() {
+        tracing::warn!(
+            secrets = %dropped.join(", "),
+            count = dropped.len(),
+            "fork child intentionally drops parent secret bindings"
+        );
+    }
+    Ok(())
+}
+
+fn resolve_fork_secret_audit(
+    tenant: &str,
+    declared: &[mvm_core::plan::SecretBinding],
+    bindings: &dyn mvm_hostd::keyholder::BindingStore,
+) -> Result<Vec<mvm_hostd::audit::bind::CheckpointForkSecretBinding>> {
+    use mvm_core::plan::SecretSource;
+
+    declared
+        .iter()
+        .filter_map(|binding| match &binding.source {
+            SecretSource::Keystore { address } => Some((binding, address)),
+            SecretSource::External { .. } => None,
+        })
+        .map(|(binding, address)| {
+            let metadata = bindings
+                .get(tenant, address)
+                .with_context(|| format!("reading binding {address:?} for tenant {tenant:?}"))?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "secret {address:?} has no binding in child tenant {tenant:?}; bind it for that tenant before forking"
+                    )
+                })?;
+            Ok(mvm_hostd::audit::bind::CheckpointForkSecretBinding {
+                name: binding.name.clone(),
+                allowed_hosts: metadata.allowed_hosts,
+            })
+        })
+        .collect()
 }
 
 fn parent_plan_resources(
@@ -1375,6 +1477,8 @@ pub(crate) fn bind_checkpoint_forked(
     child: &mvm_core::checkpoint::CheckpointMeta,
     child_vm_name: &str,
     store: &CheckpointStore,
+    declared_secrets: &[mvm_core::plan::SecretBinding],
+    child_tenant: &str,
 ) -> Result<()> {
     // The child VM has no persisted plan yet (it was never booted as an independent
     // VM); look up the parent VM name from the parent checkpoint record so the
@@ -1404,15 +1508,84 @@ pub(crate) fn bind_checkpoint_forked(
     let emitter = super::audit_chain::AuditEmitter::new(signer.signing)
         .map(|e| e.with_receipts())
         .context("refusing an unaudited fork: audit emitter unavailable")?;
-    mvm_hostd::audit::bind::bind_checkpoint_forked(&emitter, &plan, parent, child, child_vm_name)
-        .context("refusing an unaudited fork")?;
+    let binding_store = mvm_hostd::keyholder::FileBindingStore::default_location()
+        .context("opening the child tenant's secret-binding store for fork audit")?;
+    let secret_bindings =
+        resolve_fork_secret_audit(child_tenant, declared_secrets, &binding_store)?;
+    mvm_hostd::audit::bind::bind_checkpoint_forked(
+        &emitter,
+        &plan,
+        parent,
+        child,
+        child_vm_name,
+        &secret_bindings,
+    )
+    .context("refusing an unaudited fork")?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_contract::ir::AuthType;
+    use mvm_core::plan::{SecretBinding, SecretSource};
+    use mvm_hostd::keyholder::{BindingStore, FileBindingStore, SecretBindingMeta};
     use mvm_runtime::checkpoint::{CheckpointChainAnchor, verify_lineage};
+
+    fn secret_binding(name: &str, address: &str) -> SecretBinding {
+        SecretBinding {
+            name: name.into(),
+            source: SecretSource::Keystore {
+                address: address.into(),
+            },
+        }
+    }
+
+    #[test]
+    fn dropped_parent_secrets_excludes_explicit_redeclarations() {
+        let parent = vec!["API_KEY".to_string(), "DB_KEY".to_string()];
+        let declared = vec![secret_binding("API_KEY", "child-api")];
+
+        assert_eq!(
+            dropped_parent_secret_names(&parent, &declared),
+            vec!["DB_KEY"]
+        );
+    }
+
+    #[test]
+    fn secret_attenuation_requires_explicit_drop_permission() {
+        let dropped = vec!["DB_KEY".to_string()];
+
+        let error = enforce_secret_attenuation(&dropped, false).unwrap_err();
+        assert!(error.to_string().contains("--allow-secret-drop"));
+        assert!(enforce_secret_attenuation(&dropped, true).is_ok());
+        assert!(enforce_secret_attenuation(&[], false).is_ok());
+    }
+
+    #[test]
+    fn fork_secret_audit_resolves_only_child_tenant_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileBindingStore::with_dir(dir.path());
+        store
+            .put(
+                "child-tenant",
+                "api-address",
+                &SecretBindingMeta {
+                    auth_type: AuthType::Bearer,
+                    allowed_hosts: vec!["api.example.com".into()],
+                    sigv4: None,
+                    provider: Some("catalog-provider".into()),
+                },
+            )
+            .unwrap();
+        let declared = vec![secret_binding("API_KEY", "api-address")];
+
+        let audit = resolve_fork_secret_audit("child-tenant", &declared, &store).unwrap();
+        assert_eq!(audit.len(), 1);
+        assert_eq!(audit[0].name, "API_KEY");
+        assert_eq!(audit[0].allowed_hosts, vec!["api.example.com"]);
+        assert!(resolve_fork_secret_audit("other-tenant", &declared, &store).is_err());
+    }
 
     #[test]
     fn validated_checkpoint_id_accepts_normal() {

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -826,6 +826,8 @@ mod tests {
             child_vm_name: "child-cpu-bounded",
             backend_kind: CPU_METERING_TIER,
             declared_secrets: &[],
+            // Strict default: these cases do not exercise attenuation.
+            allow_secret_drop: false,
         })
         .expect("a cpu-bounded parent is forkable on a tier that meters CPU");
 
@@ -874,6 +876,8 @@ mod tests {
             child_vm_name: "child-cpu-unenforceable",
             backend_kind: BackendKind::Hvf,
             declared_secrets: &[],
+            // Strict default: these cases do not exercise attenuation.
+            allow_secret_drop: false,
         }) {
             // `AdmittedForkChild` carries the child's plan JSON and is
             // deliberately not `Debug`, so this cannot use `expect_err`.
@@ -913,6 +917,8 @@ mod tests {
             child_vm_name: "child-tier-agrees",
             backend_kind: BackendKind::Hvf,
             declared_secrets: &[],
+            // Strict default: these cases do not exercise attenuation.
+            allow_secret_drop: false,
         })
         .expect("a grantless parent is forkable");
 

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -37,6 +37,7 @@ pub(super) struct ForkVmFullArmParams<'a> {
     /// Secret bindings declared for the child. Empty reproduces the prior
     /// behaviour: a child admitted with no bindings.
     pub(super) declared_secrets: &'a [mvm_core::plan::SecretBinding],
+    pub(super) allow_secret_drop: bool,
 }
 
 /// vm_full fork: clone the captured triple into a new child identity, admit a
@@ -102,6 +103,7 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
             now,
             json: p.json,
             declared_secrets: p.declared_secrets,
+            allow_secret_drop: p.allow_secret_drop,
         }),
         Some(VmFullOrigin::Firecracker) => {
             fork_vm_full_arm_fc(ForkVmFullArmFcParams {
@@ -115,6 +117,7 @@ fn fork_vm_full_arm_inner(p: ForkVmFullArmParams<'_>) -> Result<()> {
                 json: p.json,
                 bypass_experimental_guard: false,
                 declared_secrets: p.declared_secrets,
+                allow_secret_drop: p.allow_secret_drop,
             })?;
             Ok(())
         }
@@ -148,6 +151,7 @@ pub(in crate::commands) struct ForkVmFullArmFcParams<'a> {
     /// Secret bindings declared for the child. Empty reproduces the prior
     /// behaviour: a child admitted with no bindings.
     pub(in crate::commands) declared_secrets: &'a [mvm_core::plan::SecretBinding],
+    pub(in crate::commands) allow_secret_drop: bool,
 }
 
 /// FC vm_full fork: clone the captured triple, admit a fresh claim-8 plan for
@@ -208,6 +212,7 @@ pub(in crate::commands) fn fork_vm_full_arm_fc(
         child_vm_name: &p.child_vm_name,
         backend_kind: BackendKind::Firecracker,
         declared_secrets: p.declared_secrets,
+        allow_secret_drop: p.allow_secret_drop,
     })?;
 
     // Verify the parent against the signed audit chain before cloning/restoring.
@@ -240,7 +245,14 @@ pub(in crate::commands) fn fork_vm_full_arm_fc(
     let meta = fork_result
         .with_context(|| format!("forking FC vm_full checkpoint {:?}", p.checkpoint.as_str()))?;
 
-    bind_checkpoint_forked(p.checkpoint, &meta, &p.child_vm_name, p.store)?;
+    bind_checkpoint_forked(
+        p.checkpoint,
+        &meta,
+        &p.child_vm_name,
+        p.store,
+        p.declared_secrets,
+        &crate::commands::vm::tenant_resolution::resolve_tenant(None),
+    )?;
     crate::commands::vm::up::emit_launched_if(&admission, "firecracker", true);
 
     // Deliver the fresh generation token to every restored child. A grant is
@@ -316,6 +328,7 @@ struct AdmitForkedChildParams<'a> {
     /// tenant's `BindingStore` at the substitution endpoint, so a name the
     /// operator has not bound grants nothing.
     declared_secrets: &'a [mvm_core::plan::SecretBinding],
+    allow_secret_drop: bool,
 }
 
 /// The admitted claim-8 envelope a vm_full fork boots its child under.
@@ -351,8 +364,14 @@ fn admit_forked_child(p: &AdmitForkedChildParams<'_>) -> Result<AdmittedForkChil
         .find(|b| b.name == mvm_core::checkpoint::ROOTFS_BLOB)
         .map(|b| b.sha256.clone());
     let parent_agent_verbs = parent_agent_verb_override(p.checkpoint, p.store);
-    super::warn_dropped_parent_secrets(p.checkpoint, p.store);
     let tenant = crate::commands::vm::tenant_resolution::resolve_tenant(None);
+    super::validate_fork_secret_policy(
+        p.checkpoint,
+        p.store,
+        &tenant,
+        p.declared_secrets,
+        p.allow_secret_drop,
+    )?;
     let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::new();
     let admission = crate::commands::vm::up::admit_plan_for_boot(
         crate::commands::vm::up::AdmitPlanForBootParams {
@@ -443,6 +462,7 @@ struct ForkVmFullArmHvfParams<'a> {
     /// Secret bindings declared for the child. Empty reproduces the prior
     /// behaviour: a child admitted with no bindings.
     declared_secrets: &'a [mvm_core::plan::SecretBinding],
+    allow_secret_drop: bool,
 }
 
 /// HVF vm_full fork: clone the captured state into a fresh child identity, admit
@@ -466,6 +486,7 @@ fn fork_vm_full_arm_hvf(p: ForkVmFullArmHvfParams<'_>) -> Result<()> {
         child_vm_name: &p.child_vm_name,
         backend_kind: BackendKind::Hvf,
         declared_secrets: p.declared_secrets,
+        allow_secret_drop: p.allow_secret_drop,
     })?;
 
     // Verify the parent against the signed audit chain before cloning anything.
@@ -491,7 +512,14 @@ fn fork_vm_full_arm_hvf(p: ForkVmFullArmHvfParams<'_>) -> Result<()> {
     let meta = fork_result
         .with_context(|| format!("forking HVF vm_full checkpoint {:?}", p.checkpoint.as_str()))?;
 
-    bind_checkpoint_forked(p.checkpoint, &meta, &p.child_vm_name, p.store)?;
+    bind_checkpoint_forked(
+        p.checkpoint,
+        &meta,
+        &p.child_vm_name,
+        p.store,
+        p.declared_secrets,
+        &crate::commands::vm::tenant_resolution::resolve_tenant(None),
+    )?;
     crate::commands::vm::up::emit_launched_if(&admission, "hvf", true);
 
     if let Err(error) = deliver_hvf_fork_post_restore(
@@ -635,8 +663,10 @@ fn require_fork_post_restore_success(reply: mvm_agentd::vsock::PostRestoreReply)
 mod tests {
     use super::*;
 
+    use mvm_contract::ir::AuthType;
     use mvm_contract::plan::{SecretBinding, SecretSource};
     use mvm_core::checkpoint::{CheckpointClass, CheckpointMeta, ContentBlob, ROOTFS_BLOB};
+    use mvm_hostd::keyholder::{BindingStore, FileBindingStore, SecretBindingMeta};
 
     /// A parent checkpoint whose recorded rootfs sha matches a real blob on
     /// disk. The blob has to exist: admission *verifies* the recorded digest
@@ -671,7 +701,28 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let store = CheckpointStore::at(tmp.path().join("store"));
         let id = format!("ck-{vm}");
+        // `parent_with_grants` is the helper that survived on main; the
+        // binding-store seeding below is what the enforcement tests need, so
+        // this keeps both rather than choosing one.
         let parent_meta = parent_with_grants(&store, &id, None);
+        let binding_store = FileBindingStore::default_location().unwrap();
+        for binding in declared {
+            let SecretSource::Keystore { address } = &binding.source else {
+                continue;
+            };
+            binding_store
+                .put(
+                    "local",
+                    address,
+                    &SecretBindingMeta {
+                        auth_type: AuthType::Bearer,
+                        allowed_hosts: vec!["api.example.com".into()],
+                        sigv4: None,
+                        provider: None,
+                    },
+                )
+                .unwrap();
+        }
         let admitted = admit_forked_child(&AdmitForkedChildParams {
             store: &store,
             checkpoint: &CheckpointId::new(&id),
@@ -679,6 +730,7 @@ mod tests {
             child_vm_name: vm,
             backend_kind: BackendKind::Hvf,
             declared_secrets: declared,
+            allow_secret_drop: false,
         })
         .expect("a fork child is admitted");
         admitted
@@ -702,7 +754,7 @@ mod tests {
         let declared = vec![SecretBinding {
             name: "STRIPE_KEY".to_string(),
             source: SecretSource::Keystore {
-                address: "kv/stripe".to_string(),
+                address: "stripe".to_string(),
             },
         }];
         let got = admitted_child_secrets(&declared, "child-declared");
@@ -941,6 +993,7 @@ mod tests {
             memory_override: None,
             json: false,
             declared_secrets: &[],
+            allow_secret_drop: false,
         })
         .unwrap_err();
         let msg = err.to_string();
@@ -963,6 +1016,7 @@ mod tests {
             memory_override: Some("2G"),
             json: false,
             declared_secrets: &[],
+            allow_secret_drop: false,
         })
         .unwrap_err();
         let msg = err.to_string();

--- a/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
@@ -285,6 +285,10 @@ fn revert_checkpoint(
         // A revert re-admits the checkpoint it targets; it declares no bindings
         // of its own, matching the pre-existing behaviour of this path.
         declared_secrets: &[],
+        // A revert cannot silently attenuate capabilities. Operators restoring
+        // a secret-bearing checkpoint use `machine restore`, whose explicit
+        // declaration/drop flags describe the fresh child's capability.
+        allow_secret_drop: false,
         json: opts.json,
     })
     .with_context(|| format!("restoring checkpoint {:?}", target.id.as_str()))?;

--- a/crates/mvm-cli/src/commands/vm/checkpoint/vm_state.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/vm_state.rs
@@ -1,0 +1,158 @@
+//! VM state and backend-capability probes for the checkpoint verbs.
+//!
+//! One question each: is this VM quiesced enough to checkpoint, where is its
+//! rootfs, and can the backend that owns it actually save and restore. They
+//! were inline in `checkpoint.rs` until that file crossed the production-line
+//! ceiling; grouping them here keeps the answer to "what state is this VM in"
+//! in one place rather than interleaved with the verbs that ask it.
+
+use super::*;
+
+/// Resolve the host-side bootable rootfs image for a quiesced VM, or a clean
+/// error explaining why a checkpoint can't be taken.
+///
+/// "Quiesced" means the VM is not running, OR the pause verb has written a
+/// pause marker that matches the live supervisor pid (vCPUs and virtio queues
+/// quiesced). A live, unpaused VM is refused: an fs_quick checkpoint has no
+/// memory, so the rootfs must be in a clean, deterministic state.
+///
+/// Resolution order (first match wins):
+/// 1. Per-instance `rootfs.ext4` CoW clone in `vm_state_dir(name)`.
+/// 2. `mode.json` `rootfs_path` field (backend-neutral; written by every
+///    backend that calls `record_from_rootfs` at start time).
+pub(super) fn resolve_quiesced_vm_rootfs(name: &str) -> Result<PathBuf> {
+    if !vm_is_quiesced(name) {
+        bail!("stop or pause VM '{name}' before checkpointing");
+    }
+    let state_dir = vm_state_dir(name);
+
+    // Per-instance CoW clone — deterministic, present on disk.
+    let instance_rootfs = state_dir.join("rootfs.ext4");
+    if instance_rootfs.is_file() {
+        return Ok(instance_rootfs);
+    }
+
+    // Backend-neutral: every backend that calls `record_from_rootfs` at start
+    // time writes the rootfs path into mode.json.
+    if let Some(path) = rootfs_from_mode_json(&state_dir)? {
+        if !path.exists() {
+            bail!(
+                "fs_quick checkpoint needs the VM's rootfs ({}), which is no longer \
+                 on disk. Pause instead of stopping: `mvmctl vm pause {name}`, \
+                 checkpoint, then `mvmctl vm resume {name}` — or use \
+                 `--class vm-full` on a running VM.",
+                path.display()
+            );
+        }
+        return Ok(path);
+    }
+
+    bail!("fs_quick checkpoint is not supported for this VM's backend");
+}
+
+/// Read `mode.json` and return the recorded `rootfs_path` field, if present.
+/// Absent file or absent field → `Ok(None)`. Malformed JSON propagates.
+pub(super) fn rootfs_from_mode_json(state_dir: &std::path::Path) -> Result<Option<PathBuf>> {
+    let path = state_dir.join("mode.json");
+    let body = match std::fs::read_to_string(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", path.display())),
+    };
+    let meta: mvm_runtime::base::runtime_meta::VmRuntimeMeta =
+        serde_json::from_str(&body).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(meta.rootfs_path.map(PathBuf::from))
+}
+
+/// Best-effort liveness: a VM is "running" iff one of its per-backend PID
+/// files names a live process. Delegates to the runtime's probe so this side
+/// cannot keep its own marker list — every registered backend's marker
+/// (`fc.pid`, `libkrun.pid`, `hvf.pid`, `qemu.pid`) is covered by one pass over
+/// the shared list, which is also where the `EPERM`-means-alive rule lives. A
+/// hand-kept list here is how a live HVF VM used to read as stopped, and a
+/// root-owned Firecracker with it.
+pub(super) fn vm_is_running(name: &str) -> bool {
+    mvm_runtime::checkpoint::vm_is_running(name)
+}
+
+/// fs_quick clones the instance rootfs, so the guest must not be writing:
+/// either the VM is stopped, or it is paused (vCPUs and virtio queues quiesced
+/// — the FC pause verb stamps the fc pid into `fc.paused`; resume and any path
+/// that replaces the process removes or invalidates the marker). A
+/// running-but-paused VM keeps its pid alive, so `vm_is_running` alone would
+/// incorrectly refuse the checkpoint without these marker checks.
+pub(super) fn vm_is_quiesced(name: &str) -> bool {
+    if !vm_is_running(name) {
+        return true;
+    }
+    fc_pause_marker_matches_live_pid(name) || hvf_pause_marker_present(name)
+}
+
+/// The HVF supervisor writes `pause.state` only after its vCPU has entered the
+/// pause hold, and removes it on resume. Unlike Firecracker's marker this one is
+/// written by the process that owns the vCPU, so its presence beside a live
+/// `hvf.pid` is itself the acknowledgement — there is no pid to cross-check
+/// against a marker some other verb stamped.
+pub(super) fn hvf_pause_marker_present(name: &str) -> bool {
+    let dir = vm_state_dir(name);
+    dir.join("hvf.pid").is_file() && dir.join("pause.state").is_file()
+}
+
+/// `machine pause` snapshot-seals FC but leaves the fc process running, so a
+/// live pid cannot
+/// distinguish paused from running. The pause verb stamps the fc pid into
+/// `fc.paused` (under `vm_state_dir`); resume removes it. Quiesced iff the
+/// marker matches the live fc pid at `<mvm_home>/vms/<name>/fc.pid`.
+pub(super) fn fc_pause_marker_matches_live_pid(name: &str) -> bool {
+    let marker = std::fs::read_to_string(vm_state_dir(name).join("fc.paused")).ok();
+    let live =
+        mvm_runtime::microvm::fc_pid_path(name).and_then(|p| std::fs::read_to_string(p).ok());
+    matches!((marker, live), (Some(m), Some(l)) if !m.trim().is_empty() && m.trim() == l.trim())
+}
+
+/// Hash the VM's persisted supervisor config so the checkpoint pins the launch
+/// shape it was captured from. No config on disk → empty digest (the field is
+/// advisory for fs_quick; integrity rests on `content_sha256`).
+pub(super) fn supervisor_config_digest(state_dir: &std::path::Path) -> String {
+    let cfg_path = state_dir.join("supervisor-config.json");
+    mvm_core::crypto::image_verify::sha256_file(&cfg_path).unwrap_or_default()
+}
+
+pub(super) fn runtime_contract_for_checkpoint(
+    name: &str,
+) -> Result<(
+    Option<mvm_core::vm_backend::RuntimeSourcePolicy>,
+    Option<String>,
+)> {
+    Ok(mvm_runtime::base::runtime_meta::read(name)?
+        .map(|meta| {
+            (
+                Some(meta.runtime_source_policy),
+                meta.runtime_overlay_version,
+            )
+        })
+        .unwrap_or((None, None)))
+}
+
+/// The backend that actually owns `name`, falling back to the host default for
+/// a VM with no live marker (a restore target that has not been started yet).
+pub(super) fn backend_for_vm(name: &str) -> AnyBackend {
+    AnyBackend::for_started_vm(name).unwrap_or_else(AnyBackend::auto_select)
+}
+
+/// Refuse a memory-snapshot verb on a backend that cannot save and reload
+/// machine state. The check is against the backend that owns *this* VM, not the
+/// host default: on a host where several VMMs can run, the capability of the
+/// one holding the VM is the only one that matters.
+pub(super) fn ensure_save_restore_supported(action: &str, backend: &AnyBackend) -> Result<()> {
+    let available = backend.snapshot_capability();
+    if !available.satisfies(SnapshotCapability::SaveRestore) {
+        bail!(
+            "vm {action} requires memory-snapshot support, but backend '{}' reports \
+             snapshot tier '{}' on this host",
+            backend.name(),
+            available.label()
+        );
+    }
+    Ok(())
+}

--- a/crates/mvm-hostd/src/audit/bind.rs
+++ b/crates/mvm-hostd/src/audit/bind.rs
@@ -10,8 +10,17 @@ use mvm_contract::provenance::{
 };
 use mvm_core::checkpoint::{CheckpointClass, CheckpointId, CheckpointMeta};
 use mvm_core::plan::ExecutionPlan;
+use serde::Serialize;
 
 use crate::audit::emitter::AuditEmitter;
+
+/// Non-secret fork capability metadata recorded in `checkpoint.forked`.
+/// Keystore addresses, providers, and values are intentionally absent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CheckpointForkSecretBinding {
+    pub name: String,
+    pub allowed_hosts: Vec<String>,
+}
 
 /// Stable on-the-wire string for a checkpoint class.
 pub fn class_str(class: CheckpointClass) -> &'static str {
@@ -101,6 +110,7 @@ pub fn bind_checkpoint_forked(
     parent: &CheckpointId,
     child: &CheckpointMeta,
     child_vm_name: &str,
+    secret_bindings: &[CheckpointForkSecretBinding],
 ) -> Result<()> {
     // A forked child is built by the fork path, which always hash-links it to
     // its parent's content-address. A genesis-shaped child (no parent) must not
@@ -109,13 +119,17 @@ pub fn bind_checkpoint_forked(
         .parent
         .as_ref()
         .expect("a forked child always carries a parent hash-link");
+    let secret_bindings_json = serde_json::to_string(secret_bindings)?;
     emitter.emit_checkpoint_forked(
         plan,
-        parent.as_str(),
-        child.id.as_str(),
-        child_vm_name,
-        parent_digest.as_str(),
-        child.meta_digest.as_str(),
+        crate::audit::emitter::CheckpointForkedAudit {
+            parent_id: parent.as_str(),
+            child_id: child.id.as_str(),
+            child_vm_name,
+            parent_digest: parent_digest.as_str(),
+            child_digest: child.meta_digest.as_str(),
+            secret_bindings_json: &secret_bindings_json,
+        },
     )
 }
 
@@ -239,7 +253,18 @@ mod tests {
         .created_unix(2)
         .build();
 
-        bind_checkpoint_forked(&emitter, &plan, &parent.id, &child, &child.vm_name).unwrap();
+        bind_checkpoint_forked(
+            &emitter,
+            &plan,
+            &parent.id,
+            &child,
+            &child.vm_name,
+            &[CheckpointForkSecretBinding {
+                name: "API_KEY".into(),
+                allowed_hosts: vec!["api.example.com".into()],
+            }],
+        )
+        .unwrap();
 
         let path = dir.path().join("local.jsonl");
         let content = std::fs::read_to_string(&path).unwrap();
@@ -249,6 +274,10 @@ mod tests {
         assert!(content.contains("child_digest"));
         assert!(content.contains(parent.meta_digest.as_str()));
         assert!(content.contains(child.meta_digest.as_str()));
+        assert!(content.contains("API_KEY"));
+        assert!(content.contains("api.example.com"));
+        assert!(!content.contains("keystore-address"));
+        assert!(!content.contains("secret-value"));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 }

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -111,6 +111,19 @@ pub mod checkpoint_audit {
     pub const LABEL_PARENT_DIGEST: &str = "parent_digest";
     /// Label: the child's content-address (forked).
     pub const LABEL_CHILD_DIGEST: &str = "child_digest";
+    /// Label: JSON array of child binding names and destination allow-lists.
+    /// This never contains keystore addresses, providers, or secret values.
+    pub const LABEL_SECRET_BINDINGS: &str = "secret_bindings";
+}
+
+/// Complete non-secret label payload for a `checkpoint.forked` event.
+pub struct CheckpointForkedAudit<'a> {
+    pub parent_id: &'a str,
+    pub child_id: &'a str,
+    pub child_vm_name: &'a str,
+    pub parent_digest: &'a str,
+    pub child_digest: &'a str,
+    pub secret_bindings_json: &'a str,
 }
 
 /// Wire-stable event name and label keys for the image version-lineage audit
@@ -946,28 +959,31 @@ impl AuditEmitter {
     pub fn emit_checkpoint_forked(
         &self,
         plan: &ExecutionPlan,
-        parent_id: &str,
-        child_id: &str,
-        child_vm_name: &str,
-        parent_digest: &str,
-        child_digest: &str,
+        audit: CheckpointForkedAudit<'_>,
     ) -> Result<()> {
         use checkpoint_audit as k;
         self.emit(
             plan,
             k::FORKED_EVENT,
             [
-                (k::LABEL_PARENT_ID.to_string(), parent_id.to_string()),
-                (k::LABEL_CHILD_ID.to_string(), child_id.to_string()),
+                (k::LABEL_PARENT_ID.to_string(), audit.parent_id.to_string()),
+                (k::LABEL_CHILD_ID.to_string(), audit.child_id.to_string()),
                 (
                     k::LABEL_CHILD_VM_NAME.to_string(),
-                    child_vm_name.to_string(),
+                    audit.child_vm_name.to_string(),
                 ),
                 (
                     k::LABEL_PARENT_DIGEST.to_string(),
-                    parent_digest.to_string(),
+                    audit.parent_digest.to_string(),
                 ),
-                (k::LABEL_CHILD_DIGEST.to_string(), child_digest.to_string()),
+                (
+                    k::LABEL_CHILD_DIGEST.to_string(),
+                    audit.child_digest.to_string(),
+                ),
+                (
+                    k::LABEL_SECRET_BINDINGS.to_string(),
+                    audit.secret_bindings_json.to_string(),
+                ),
             ],
         )
     }
@@ -2253,11 +2269,14 @@ mod tests {
         emitter
             .emit_checkpoint_forked(
                 &plan,
-                "ckpt-parent",
-                "ckpt-child",
-                "childvm",
-                &parent_digest,
-                &child_digest,
+                CheckpointForkedAudit {
+                    parent_id: "ckpt-parent",
+                    child_id: "ckpt-child",
+                    child_vm_name: "childvm",
+                    parent_digest: &parent_digest,
+                    child_digest: &child_digest,
+                    secret_bindings_json: r#"[{"name":"API_KEY","allowed_hosts":["api.example.com"]}]"#,
+                },
             )
             .unwrap();
         let path = dir.path().join("local.jsonl");
@@ -2270,6 +2289,8 @@ mod tests {
         assert!(content.contains("child_digest"));
         assert!(content.contains(&parent_digest));
         assert!(content.contains(&child_digest));
+        assert!(content.contains("API_KEY"));
+        assert!(content.contains("api.example.com"));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -302,22 +302,14 @@ for detailed scope and acceptance criteria.
 
 ## In-flight plans
 
-- [~] **Secret bindings for forked children** —
+- [x] **Secret bindings for forked children** —
       `specs/plans/2026-08-18-fork-inherits-secret-bindings.md`, issue #2698.
-      W0 landed: a fork that drops its parent's secret bindings now says so,
-      reading the parent's persisted plan rather than needing a schema change.
-      3 tests, mutation-checked.
-      A1 landed: `declared_secrets` is threaded into the fork admission path, so
-      a child's bindings are declared by the caller rather than inherited, and
-      the child's capability is readable from its own plan. 2 tests,
-      mutation-checked.
-      STILL OPEN: the gap is **not yet closed** — A2 (CLI surface) is what makes
-      A1 reachable; until it lands every caller declares an empty set and no
-      user can declare a binding. Then A3-A5, and A6 (refuse an undeclared
-      drop), which is W0's refusal arm — deferred there because a fork's
-      prod-posture is a hardcoded literal today, not a flag. Option B (inherit
-      from the checkpoint, attenuated by intersection) is designed and
-      deliberately deferred, not queued.
+      Option A (W0 and A1–A6) is complete: fork bindings are explicit,
+      tenant-validated before clone/boot, carried by every booting entry point,
+      and recorded as names plus allowed hosts without source or value data.
+      Dropping a parent binding is refused unless the caller explicitly permits
+      attenuation. Option B (implicit checkpoint inheritance) remains designed
+      and deliberately deferred.
 
 - [~] **Admission-bound AI assurance sessions** —
       `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W4,

--- a/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
+++ b/specs/plans/2026-08-18-fork-inherits-secret-bindings.md
@@ -1,20 +1,20 @@
 # A forked child gets its parent's secret bindings
 
-Backing: preview
-Validation: W0 only — `parent_secret_names` and its three tests in
-`crates/mvm-cli/src/commands/vm/checkpoint.rs`. Options A and B are proposed
-design; no code implements them and no test exercises them.
+Backing: shipped-source
+Validation: Option A is complete. Focused CLI, admission, tenant-isolation,
+attenuation, and audit tests pass; `cargo test --workspace`, workspace
+all-target clippy, and `just check-gated` are green.
 
 ## Status
 
-**READY FOR IMPLEMENTATION, OPTION A ONLY.**
+**COMPLETE, OPTION A.**
 
 Two designs are recorded here. **Option A (explicit at fork) is the recommended
 build.** Option B (inherited from the checkpoint) is the more ergonomic design
 and is deliberately deferred — it is recorded so the decision is legible, not
 because it is queued.
 
-W0 (the diagnostic) is implemented. Nothing in Option A or Option B is.
+W0 and Option A are implemented. Option B remains deliberately deferred.
 
 ## The gap
 
@@ -60,13 +60,10 @@ which design wins, and fixing it needs no schema change:
 
 W0 is worth landing on its own, before either option below is chosen.
 
-**W0 warns; it does not refuse.** The plan originally said "refuse under
-`--prod`". There is no `--prod` on this path — a fork is *always* prod-profile
-(see the comment on `restrict_agent_verbs` in `admit_forked_child`), so the
-refusal has no flag to hang on, and making it unconditional would turn every
-existing fork of a secret-holding parent from degraded-but-working into a hard
-failure. Refusal belongs to Option A's world: once the child's bindings can be
-declared, refusing an *undeclared* drop is coherent. It is item A6 below.
+W0 began as a warning. Option A makes the drop actionable: a fork now refuses
+to omit a parent binding unless the caller explicitly supplies
+`--allow-secret-drop`. This keeps the secure default while preserving an
+auditable escape hatch for intentional attenuation.
 
 A caveat the diagnostic cannot avoid: an unreadable parent plan yields an empty
 set, so silence means "unknown", not "the parent held none". A fork of a parent
@@ -115,7 +112,7 @@ Why this first:
 
 Work items:
 
-- [ ] A1 — plumb a caller-supplied `Vec<SecretBinding>` into
+- [x] A1 — plumb a caller-supplied `Vec<SecretBinding>` into
       `AdmitForkedChildParams` and through to `admit_plan_for_boot`.
 
       Two corrections to this item as first written. The type is
@@ -149,14 +146,14 @@ Work items:
       bindings nothing could release. Both fork arms now derive it from the set
       via the existing `secret_release_for_bindings` (empty → `None`, non-empty
       → `PlanBound`) rather than defaulting.
-- [ ] A3 — cross-tenant declaration refused at admission (this falls out of
+- [x] A3 — cross-tenant declaration refused at admission (this falls out of
       `BindingStore` tenant scoping; assert it rather than assume it).
-- [ ] A4 — `checkpoint.forked` records the child's binding names + hosts, never
+- [x] A4 — `checkpoint.forked` records the child's binding names + hosts, never
       values. Mirror the assertion shape of
       `stream_audit_entries_carry_the_binding_and_no_payload_bytes`.
-- [ ] A5 — HVF arm wired (`fork_vm_full_arm_hvf`); FC arm wired behind its
+- [x] A5 — HVF arm wired (`fork_vm_full_arm_hvf`); FC arm wired behind its
       existing `fc_vm_full_fork_experimental_enabled` gate, which stays.
-- [ ] A6 — refuse a fork that drops parent bindings the caller did not
+- [x] A6 — refuse a fork that drops parent bindings the caller did not
       re-declare, now that re-declaring is possible. This is W0's refusal arm,
       deferred to here because it is incoherent before A1.
 
@@ -218,11 +215,12 @@ pre-field record and asserts its digest is unchanged.
 - No revocation propagation to *running* children. Narrowing a binding affects
   the next fork, not a child already booted. Killing a live capability is the
   endpoint's job and is unchanged.
-- Nothing for time-travel restore (`bind_checkpoint_restored`). A restore
-  re-admits under a fresh plan for a user-driven reason; capability there is a
-  separate decision this plan does not make.
-- Nothing for `FsQuick` checkpoints — no live guest state, so no live
-  placeholder set to keep meaningful.
+- A time-travel revert still declares no bindings and therefore fails closed
+  for a secret-bearing parent. The explicit `machine restore` surface accepts
+  declarations and intentional attenuation.
+- An unbooted `FsQuick` child has no admitted plan, so `--secret` is rejected
+  unless `--boot` is also present. A booted child uses the same policy as the
+  vm_full path.
 
 ## Claims impact
 

--- a/specs/sprint/delivery/2698-fork-secret-bindings.md
+++ b/specs/sprint/delivery/2698-fork-secret-bindings.md
@@ -114,26 +114,43 @@ test that should have caught the disabled refusal never ran and the mutant
 looked clean. Re-run with explicit filters. A filtered mutation check proves
 nothing unless the filter is confirmed to include the test that must fail.
 
-## Not delivered
+## A3–A6 — tenant validation, audit, entry points, and attenuation
 
-W0, A1 and A2 are delivered; A3-A6 are not.
+Every declared keystore address is resolved against the child's tenant-scoped
+`FileBindingStore` before cloning or booting. An unbound or cross-tenant address
+therefore refuses admission. External providers retain their existing runtime
+resolution contract and do not acquire local binding metadata by accident.
 
-With A2 the gap is closed for the path it covers: a user can declare bindings on
-`vm checkpoint fork` and the child is admitted carrying them. What remains is
-narrower than it was, and worth naming precisely rather than implying the whole
-feature is done:
+`checkpoint.forked` now records a JSON list containing each local binding's
+guest name and allowed hosts. The event never records source addresses,
+providers, or values. The audit API uses a named parameter struct rather than
+growing another positional argument list.
 
-- A3 — assert cross-tenant declaration is refused. This falls out of
-  `BindingStore` tenant scoping today, but it is assumed rather than tested.
-- A4 — record the child's binding names + hosts on `checkpoint.forked`.
-- A5 — the `machine warm-restore` entry point (`machine/checkpoint.rs`) still
-  passes `&[]`; only the `vm checkpoint fork` verb takes the flag.
-- A6 — refuse an undeclared drop (W0's refusal arm).
+The declaration surface is wired through both HVF and Firecracker vm_full
+arms, with the existing experimental Firecracker gate unchanged, and through
+the booted fs_quick path. `machine fork`, `machine restore`, and
+`machine warm-restore` expose the same repeatable `--secret` and explicit
+`--allow-secret-drop` flags as `vm checkpoint fork`.
 
-**Not verified end-to-end.** No booted VM has resolved a declared binding
-through a live substitution endpoint. The tests here assert what reaches the
-signed plan; the endpoint's own suite covers resolution and host-set refusal
-separately. Nothing has yet exercised the two together.
+A fork refuses any parent guest binding name that the caller did not re-declare
+unless `--allow-secret-drop` is present. The explicit-drop warning contains
+names only. An unbooted fs_quick fork rejects `--secret` because it has no child
+plan; revert declares nothing and consequently fails closed for secret-bearing
+parents rather than bypassing the attenuation check.
+
+Added coverage includes:
+
+- `secret_attenuation_requires_explicit_drop_permission`
+- `dropped_parent_secrets_excludes_explicit_redeclarations`
+- `fork_secret_audit_resolves_only_child_tenant_metadata`
+- hostd bind/emitter assertions for names and allowed hosts with no source or
+  secret value
+- CLI help assertions for the three machine entry points
+
+Focused tests, workspace tests, isolated doctests, workspace all-target clippy,
+and the Linux/BDD gated compile are green. No booted VM was required: admission
+composition is tested here, while live placeholder resolution and host refusal
+remain covered by the substitution endpoint's own tests.
 
 Option B (inherit from the checkpoint) remains designed and deliberately
 deferred.

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -294,6 +294,8 @@ fn machine_warm_restore_help_lists_args() {
     assert!(help.contains("warm-restore"));
     assert!(help.contains("CHECKPOINT_ID"));
     assert!(help.contains("--name"));
+    assert!(help.contains("--secret"));
+    assert!(help.contains("--allow-secret-drop"));
     assert!(help.contains("--json"));
 }
 
@@ -342,6 +344,8 @@ fn machine_fork_help_lists_args() {
     assert!(help.contains("PARENT"));
     assert!(help.contains("--as"));
     assert!(help.contains("--branch"));
+    assert!(help.contains("--secret"));
+    assert!(help.contains("--allow-secret-drop"));
     assert!(help.contains("--json"));
 }
 
@@ -364,6 +368,8 @@ fn machine_restore_help_lists_args() {
     assert!(help.contains("CHECKPOINT_ID"));
     assert!(help.contains("--as"));
     assert!(help.contains("--branch"));
+    assert!(help.contains("--secret"));
+    assert!(help.contains("--allow-secret-drop"));
     assert!(help.contains("--json"));
 }
 

--- a/xtask/src/check_cli_runtime_surface.rs
+++ b/xtask/src/check_cli_runtime_surface.rs
@@ -61,6 +61,14 @@ const EXEMPTIONS: &[(&str, &[Rule], &str)] = &[
         "store surface: checkpoint / fork / restore over the CoW rootfs",
     ),
     (
+        "commands/vm/checkpoint/vm_state.rs",
+        &[Rule::AnyBackend],
+        "same store surface as commands/vm/checkpoint.rs — the VM-state and \
+         backend-capability probes moved here when the parent crossed the \
+         production file-size cap. Listed per file for the reason the entry below \
+         gives: a directory prefix would exempt whatever lands beside it next",
+    ),
+    (
         "commands/vm/checkpoint/fork_vm_full.rs",
         &[Rule::AnyBackend],
         "same store surface as commands/vm/checkpoint.rs — the vm_full fork arms live in \


### PR DESCRIPTION
Completes #2698's A-track. Continues on the branch #2696 (design + W0
diagnostic) merged from — three commits were pushed onto it after that merge
and never got a PR of their own.

## Relationship to #2726

#2726 carries the first two (`a forked child's secret bindings are declared,
not inherited` and `--secret declares a forked child's bindings`). This branch
has those plus a third that exists nowhere else:

```
feat(checkpoint): enforce fork secret declarations
```

Until #2726 merges, this PR's diff shows all three; afterwards git collapses it
to the enforcement commit alone. Reviewing the enforcement part is the useful
work either way — it is the half that makes the declaration mean something:

```
crates/mvm-hostd/src/audit/bind.rs      | 41 +++-
crates/mvm-hostd/src/audit/emitter.rs   | 51 +++--
crates/mvm-cli/src/commands/vm/checkpoint/revert.rs |  4 +
tests/cli.rs                            |  6 +
```

A declaration that nothing enforces is the same failure the issue is about:
a child that presents bindings it was never granted.

## Why it had no PR

`plan/fork-secret-binding-inheritance` was the head of #2696, which merged. Work
continued on the same branch afterwards, so the new commits sat behind an
already-merged PR and were invisible to `gh pr list`. Worth avoiding in future —
a merged branch is a finished branch.

Merged main in cleanly. `cargo check --workspace --all-targets` clean,
`cargo test -p mvm-cli --lib checkpoint::fork_vm_full` 6/6.