### PR TITLE
feat(mcp): route MCP through MvmClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3058,6 +3058,7 @@ dependencies = [
  "mvm-fs",
  "mvm-hostd",
  "mvm-http",
+ "mvm-mcp",
  "mvm-net",
  "mvm-observability",
  "mvm-runtime",
@@ -3317,6 +3318,18 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "mvm-mcp"
+version = "0.18.0"
+dependencies = [
+ "chrono",
+ "mvm-client",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/mvm-cli",
     "crates/mvm-hostd",
     "crates/mvm-client",
+    "crates/mvm-mcp",
     # plan 74 W1 — OCI image distribution client (registry resolution,
     # manifest fetch, digest verification; layer fetch + ext4 unpack +
     # verity generation land in subsequent W1 PRs). Anonymous-only at
@@ -354,6 +355,7 @@ tree-sitter-typescript = "0.23.2"
 mvm-contract = { path = "crates/mvm-contract", version = "0.18.0", default-features = false, features = ["protocol"] }
 mvm-core = { path = "crates/mvm-core", version = "0.18.0" }
 mvm-client = { path = "crates/mvm-client", version = "0.18.0" }
+mvm-mcp = { path = "crates/mvm-mcp", version = "0.18.0" }
 mvm-agentd = { path = "crates/mvm-agentd", version = "0.18.0" }
 mvm-build = { path = "crates/mvm-build", version = "0.18.0", default-features = false }
 mvm-runtime = { path = "crates/mvm-runtime", version = "0.18.0", default-features = false }

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -26,6 +26,7 @@ mvm-hostd.workspace = true
 # The `MvmClient` facade: read-only listing/inspect commands route through
 # `mvm_client::LocalBackend` instead of reaching `mvm_runtime` internals.
 mvm-client.workspace = true
+mvm-mcp.workspace = true
 # `mvmctl compile` reads the Workload IR (mvm_contract::ir, re-exported from
 # mvm_contract::ir) and routes it through the compile pipeline.
 mvm-sdk.workspace = true

--- a/crates/mvm-cli/src/commands/GROUPING.md
+++ b/crates/mvm-cli/src/commands/GROUPING.md
@@ -41,7 +41,7 @@ is `env::sign`, install/entitlement re-signing → `env sign`. `bundle`/`deps`
 already own subcommands → keep top-level; fold in only if it reads better.
 The clear single-verb wins are `attest`/`receipt`/`audit`.)
 
-**`ops/`** — `ops metrics` · `bench` · `config`.
+**`ops/`** — `ops metrics` · `ops config` · `ops mcp`.
 
 **`env/`** (D5) — `env bootstrap` · `cleanup` · `uninstall` · `update`
 · `sign` (`env::sign` — re-sign mvmctl+supervisors with the VMM entitlements).

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -232,7 +232,7 @@ impl Commands {
             Commands::Build(a) => a.action.verb_name(),
             Commands::Deploy(_) => "deploy",
             Commands::ShellInit(_) => "shell-init",
-            // `ops <sub>` delegates to the per-op verb (metrics/bench/config).
+            // `ops <sub>` delegates to the per-op verb (metrics/config/MCP).
             Commands::Ops(a) => a.action.verb_name(),
             Commands::Network(_) => "network",
             Commands::Catalog(_) => "catalog",

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -212,7 +212,7 @@ pub(in crate::commands) enum Commands {
     /// Print shell configuration (completions + dev aliases) to stdout
     #[command(display_order = 14)]
     ShellInit(env::shell_init::Args),
-    /// Operational / observability commands (metrics, config)
+    /// Operational / observability commands (metrics, config, MCP)
     #[command(display_order = 14)]
     Ops(ops::group::Args),
     /// Manage named dev networks

--- a/crates/mvm-cli/src/commands/ops/group.rs
+++ b/crates/mvm-cli/src/commands/ops/group.rs
@@ -1,6 +1,6 @@
 //! `mvmctl ops <sub>` — operational / observability commands.
 //!
-//! `metrics` and `config` collapse under one `ops` namespace.
+//! `metrics`, `config`, and `mcp` live under one `ops` namespace.
 //! Leaf modules are unchanged.
 
 use anyhow::Result;
@@ -9,7 +9,7 @@ use clap::{Args as ClapArgs, Subcommand};
 use mvm_core::user_config::MvmConfig;
 
 use super::Cli;
-use super::{config, metrics};
+use super::{config, mcp, metrics};
 
 #[derive(ClapArgs, Debug, Clone)]
 pub(in crate::commands) struct Args {
@@ -23,6 +23,8 @@ pub(in crate::commands) enum OpsCmd {
     Metrics(metrics::Args),
     /// Read or write global operator config (~/.mvm/config.toml)
     Config(config::Args),
+    /// Serve MvmClient operations to local MCP clients
+    Mcp(mcp::Args),
 }
 
 impl OpsCmd {
@@ -31,6 +33,7 @@ impl OpsCmd {
         match self {
             OpsCmd::Metrics(_) => "metrics",
             OpsCmd::Config(_) => "config",
+            OpsCmd::Mcp(_) => "mcp",
         }
     }
 }
@@ -39,5 +42,6 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, cfg: &MvmConfig) -> Result
     match args.action {
         OpsCmd::Metrics(a) => metrics::run(cli, a, cfg),
         OpsCmd::Config(a) => config::run(cli, a, cfg),
+        OpsCmd::Mcp(a) => mcp::run(a),
     }
 }

--- a/crates/mvm-cli/src/commands/ops/mcp.rs
+++ b/crates/mvm-cli/src/commands/ops/mcp.rs
@@ -1,0 +1,32 @@
+//! Local MCP process transport. The protocol and dispatch live in `mvm-mcp`;
+//! this module only selects the local `MvmClient` and connects stdio.
+
+use std::io;
+use std::sync::Arc;
+
+use anyhow::Result;
+use clap::{Args as ClapArgs, Subcommand};
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub transport: Transport,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum Transport {
+    /// Read and write newline-delimited JSON-RPC on stdin/stdout
+    Stdio,
+}
+
+pub(in crate::commands) fn run(args: Args) -> Result<()> {
+    match args.transport {
+        Transport::Stdio => {
+            let server = mvm_mcp::McpServer::new(Arc::new(mvm_client::LocalBackend::new()));
+            let stdin = io::stdin();
+            let stdout = io::stdout();
+            server.serve(stdin.lock(), stdout.lock())?;
+            Ok(())
+        }
+    }
+}

--- a/crates/mvm-cli/src/commands/ops/mod.rs
+++ b/crates/mvm-cli/src/commands/ops/mod.rs
@@ -1,4 +1,4 @@
-//! Operational commands — config, networks, audit, metrics, cache.
+//! Operational commands — config, networks, audit, metrics, MCP, cache.
 //! (`mvmctl security` is folded into `mvmctl doctor`.)
 
 pub(super) mod attest;
@@ -7,6 +7,7 @@ pub(super) mod audit_posture;
 pub(super) mod cache;
 pub(super) mod config;
 pub(super) mod group;
+pub(super) mod mcp;
 pub(super) mod metrics;
 pub(super) mod network;
 pub(super) mod reconcile;

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -2052,6 +2052,20 @@ fn test_metrics_command_parses() {
 }
 
 #[test]
+fn mcp_stdio_command_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "ops", "mcp", "stdio"])
+        .expect("the named MCP stdio consumer must parse");
+    assert!(matches!(
+        cli.command,
+        Commands::Ops(ops::group::Args {
+            action: ops::group::OpsCmd::Mcp(ops::mcp::Args {
+                transport: ops::mcp::Transport::Stdio
+            })
+        })
+    ));
+}
+
+#[test]
 fn test_metrics_json_flag_parses() {
     let cli = Cli::try_parse_from(["mvmctl", "ops", "metrics", "--json"]).unwrap();
     assert!(matches!(

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -39,7 +39,11 @@ pub use mvm_core::client::dto::{
 #[cfg(feature = "remote")]
 pub use mvm_core::client::gateway;
 pub use mvm_core::client::mock::{self, MockBackend};
-pub use mvm_core::client::{MvmClient, MvmError, Result};
+pub use mvm_core::client::{
+    BackendCapabilityReport, ClientOperationCapabilities, ClientOperationCapabilitiesBuilder,
+    MvmClient, MvmError, Result,
+};
+pub use mvm_core::naming::validate_vm_name;
 
 pub use boot::{
     backend_is_running, backend_kind_for, backend_stop_by_name, enforced_grants_after_start,

--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -28,11 +28,11 @@ use mvm_fs::oci::{
 };
 use mvm_runtime::AnyBackend;
 
-use mvm_core::client::BackendCapabilityReport;
 use mvm_core::client::dto::{
     ExecResult, LogOpts, MachineFilter, MachineId, MachineSpec, MachineState, MachineStatus,
     PauseOpts, PauseOutcome, PortMapping, ResumeOpts, ResumeOutcome,
 };
+use mvm_core::client::{BackendCapabilityReport, ClientOperationCapabilities};
 use mvm_core::client::{MvmClient, MvmError, Result};
 use mvm_core::config::vm_state_dir;
 use mvm_core::vm_backend::{SnapshotCapability, VmStartConfig, WarmStartError};
@@ -603,10 +603,26 @@ impl MvmClient for LocalBackend {
     async fn backend_capabilities(&self) -> Result<BackendCapabilityReport> {
         // Straight from the backend that will actually run the workload, so
         // the report cannot drift from the thing it describes.
-        Ok(BackendCapabilityReport::new(
-            self.backend.kind(),
-            self.backend.capabilities(),
-        ))
+        let capabilities = self.backend.capabilities();
+        Ok(
+            BackendCapabilityReport::new(self.backend.kind(), capabilities.clone())
+                .with_operations(
+                    ClientOperationCapabilities::builder()
+                        .list(true)
+                        .inspect(true)
+                        .create(true)
+                        .run(true)
+                        .start(true)
+                        .stop(true)
+                        .pause(capabilities.pause_resume)
+                        .resume(capabilities.pause_resume)
+                        .remove(true)
+                        .logs(true)
+                        .reconfigure(true)
+                        .set_ttl(true)
+                        .build(),
+                ),
+        )
     }
 
     async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
@@ -979,6 +995,21 @@ mod tests {
             }),
             MachineStatus::Failed
         );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "test-support")]
+    async fn local_operation_report_omits_the_unwired_exec_seam() {
+        let operations = LocalBackend::with_hypervisor("mock")
+            .backend_capabilities()
+            .await
+            .expect("local capabilities")
+            .operations;
+        assert!(operations.list && operations.inspect && operations.run);
+        assert!(operations.create && operations.start && operations.stop);
+        assert!(operations.remove && operations.logs && operations.reconfigure);
+        assert!(operations.set_ttl);
+        assert!(!operations.exec);
     }
 
     #[test]

--- a/crates/mvm-contract/src/protocol/capability_negotiation.rs
+++ b/crates/mvm-contract/src/protocol/capability_negotiation.rs
@@ -277,6 +277,76 @@ impl VmCapabilities {
 /// needed: an alternative depends on the pair, so a matrix without its
 /// backend cannot be negotiated against.
 ///
+/// Which facade operations a particular `MvmClient` implementation serves.
+///
+/// These are deliberately separate from [`VmCapabilities`]: two clients can
+/// target the same hypervisor while exposing different transports. The
+/// deny-all default keeps an older capability response safe when decoded by a
+/// newer consumer.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
+#[non_exhaustive]
+pub struct ClientOperationCapabilities {
+    pub list: bool,
+    pub inspect: bool,
+    pub create: bool,
+    pub run: bool,
+    pub start: bool,
+    pub stop: bool,
+    pub pause: bool,
+    pub resume: bool,
+    pub remove: bool,
+    pub logs: bool,
+    pub exec: bool,
+    pub reconfigure: bool,
+    pub set_ttl: bool,
+}
+
+impl ClientOperationCapabilities {
+    /// Start a deny-all operation declaration.
+    pub fn builder() -> ClientOperationCapabilitiesBuilder {
+        ClientOperationCapabilitiesBuilder::default()
+    }
+}
+
+/// Builder for [`ClientOperationCapabilities`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ClientOperationCapabilitiesBuilder {
+    operations: ClientOperationCapabilities,
+}
+
+macro_rules! operation_setter {
+    ($name:ident) => {
+        #[must_use]
+        pub fn $name(mut self, enabled: bool) -> Self {
+            self.operations.$name = enabled;
+            self
+        }
+    };
+}
+
+impl ClientOperationCapabilitiesBuilder {
+    operation_setter!(list);
+    operation_setter!(inspect);
+    operation_setter!(create);
+    operation_setter!(run);
+    operation_setter!(start);
+    operation_setter!(stop);
+    operation_setter!(pause);
+    operation_setter!(resume);
+    operation_setter!(remove);
+    operation_setter!(logs);
+    operation_setter!(exec);
+    operation_setter!(reconfigure);
+    operation_setter!(set_ttl);
+
+    /// Finish the declaration.
+    #[must_use]
+    pub fn build(self) -> ClientOperationCapabilities {
+        self.operations
+    }
+}
+
 /// Serializable on purpose. A remote client answers this over the wire, and
 /// [`negotiate`](Self::negotiate) then runs locally against the answer — so
 /// negotiation costs no round trip and a gateway needs no negotiation
@@ -288,11 +358,26 @@ pub struct BackendCapabilityReport {
     pub kind: BackendKind,
     /// What it advertises.
     pub capabilities: VmCapabilities,
+    /// Which facade calls the selected client transport can serve.
+    #[serde(default)]
+    pub operations: ClientOperationCapabilities,
 }
 
 impl BackendCapabilityReport {
     pub fn new(kind: BackendKind, capabilities: VmCapabilities) -> Self {
-        Self { kind, capabilities }
+        Self {
+            kind,
+            capabilities,
+            operations: ClientOperationCapabilities::default(),
+        }
+    }
+
+    /// Attach the operation surface of the client implementation returning
+    /// this report.
+    #[must_use]
+    pub fn with_operations(mut self, operations: ClientOperationCapabilities) -> Self {
+        self.operations = operations;
+        self
     }
 
     /// Check `required` against this report, naming a substitute for every
@@ -582,6 +667,44 @@ mod report_tests {
     use alloc::vec;
 
     #[test]
+    fn client_operations_default_to_deny_all() {
+        assert_eq!(
+            ClientOperationCapabilities::default(),
+            ClientOperationCapabilities::builder().build()
+        );
+        assert!(!ClientOperationCapabilities::default().exec);
+    }
+
+    #[test]
+    fn client_operations_round_trip_through_json() {
+        let operations = ClientOperationCapabilities::builder()
+            .list(true)
+            .run(true)
+            .stop(true)
+            .build();
+        let json = serde_json::to_string(&operations).expect("operations serialize");
+        let back: ClientOperationCapabilities =
+            serde_json::from_str(&json).expect("operations deserialize");
+        assert_eq!(back, operations);
+    }
+
+    #[test]
+    fn a_legacy_report_without_operations_defaults_to_deny_all() {
+        let mut legacy = serde_json::to_value(BackendCapabilityReport::new(
+            BackendKind::Mock,
+            VmCapabilities::default(),
+        ))
+        .expect("report serializes");
+        legacy
+            .as_object_mut()
+            .expect("report is an object")
+            .remove("operations");
+        let report: BackendCapabilityReport = serde_json::from_value(legacy)
+            .expect("a report written before operation discovery still decodes");
+        assert_eq!(report.operations, ClientOperationCapabilities::default());
+    }
+
+    #[test]
     fn a_report_round_trips_through_json() {
         let report = BackendCapabilityReport::new(
             BackendKind::Wasm,
@@ -590,6 +713,12 @@ mod report_tests {
                 pty_exec: false,
                 ..VmCapabilities::default()
             },
+        )
+        .with_operations(
+            ClientOperationCapabilities::builder()
+                .list(true)
+                .inspect(true)
+                .build(),
         );
         let json = serde_json::to_string(&report).expect("report serializes");
         let back: BackendCapabilityReport =

--- a/crates/mvm-core/src/client/gateway.rs
+++ b/crates/mvm-core/src/client/gateway.rs
@@ -14,7 +14,21 @@ use crate::client::dto::{
     PauseOutcome, ReconfigureRequest, ResumeOpts, ResumeOutcome,
 };
 use crate::client::error::{MvmError, Result};
-use mvm_contract::protocol::capability_negotiation::BackendCapabilityReport;
+use mvm_contract::protocol::capability_negotiation::{
+    BackendCapabilityReport, ClientOperationCapabilities,
+};
+
+fn gateway_operations() -> ClientOperationCapabilities {
+    ClientOperationCapabilities::builder()
+        .list(true)
+        .inspect(true)
+        .run(true)
+        .stop(true)
+        .remove(true)
+        .logs(true)
+        .reconfigure(true)
+        .build()
+}
 
 /// How to reach a gateway: its base URL and the bearer token to present.
 pub struct GatewayConfig {
@@ -625,9 +639,10 @@ impl MvmClient for GatewayBackend {
         if let Some(e) = status_error(resp.status(), "") {
             return Err(e);
         }
-        resp.json().await.map_err(|e| MvmError::Backend {
+        let report: BackendCapabilityReport = resp.json().await.map_err(|e| MvmError::Backend {
             reason: format!("decode capability report: {e}"),
-        })
+        })?;
+        Ok(report.with_operations(gateway_operations()))
     }
 
     async fn list_machines(&self, filter: MachineFilter) -> Result<Vec<MachineState>> {
@@ -861,6 +876,20 @@ mod tests {
     use std::net::TcpListener;
     use std::sync::{Once, mpsc};
     use std::time::Duration;
+
+    #[test]
+    fn gateway_operation_report_omits_unwired_facade_calls() {
+        let operations = gateway_operations();
+        assert!(operations.list && operations.inspect && operations.run);
+        assert!(operations.stop && operations.remove && operations.logs);
+        assert!(operations.reconfigure);
+        assert!(!operations.create);
+        assert!(!operations.start);
+        assert!(!operations.pause);
+        assert!(!operations.resume);
+        assert!(!operations.exec);
+        assert!(!operations.set_ttl);
+    }
 
     fn install_rustls_provider() {
         static INSTALL: Once = Once::new();

--- a/crates/mvm-core/src/client/mock.rs
+++ b/crates/mvm-core/src/client/mock.rs
@@ -11,10 +11,11 @@ use crate::client::dto::{
     PauseOutcome, ReconfigureRequest, ResumeOpts, ResumeOutcome,
 };
 use crate::client::error::{MvmError, Result};
-use mvm_contract::protocol::capability_negotiation::BackendCapabilityReport;
+use mvm_contract::protocol::capability_negotiation::{
+    BackendCapabilityReport, ClientOperationCapabilities,
+};
 use mvm_contract::protocol::vm_backend::{BackendKind, VmCapabilities};
 
-#[derive(Default)]
 pub struct MockBackend {
     machines: Mutex<Vec<MachineState>>,
     next: Mutex<u64>,
@@ -22,6 +23,36 @@ pub struct MockBackend {
     /// that forgets to set it sees refusals rather than a backend that
     /// silently claims to do everything.
     capabilities: Mutex<VmCapabilities>,
+    operations: Mutex<ClientOperationCapabilities>,
+}
+
+impl Default for MockBackend {
+    fn default() -> Self {
+        Self {
+            machines: Mutex::new(Vec::new()),
+            next: Mutex::new(0),
+            capabilities: Mutex::new(VmCapabilities::default()),
+            operations: Mutex::new(all_mock_operations()),
+        }
+    }
+}
+
+fn all_mock_operations() -> ClientOperationCapabilities {
+    ClientOperationCapabilities::builder()
+        .list(true)
+        .inspect(true)
+        .create(true)
+        .run(true)
+        .start(true)
+        .stop(true)
+        .pause(true)
+        .resume(true)
+        .remove(true)
+        .logs(true)
+        .exec(true)
+        .reconfigure(true)
+        .set_ttl(true)
+        .build()
 }
 
 impl MockBackend {
@@ -29,6 +60,16 @@ impl MockBackend {
     /// paths a real backend would need hardware to reach.
     pub fn with_capabilities(self, capabilities: VmCapabilities) -> Self {
         *self.capabilities.lock().unwrap() = capabilities;
+        self
+    }
+
+    /// Override the operation surface this test double advertises.
+    #[must_use]
+    pub fn with_operations(self, operations: ClientOperationCapabilities) -> Self {
+        *self
+            .operations
+            .lock()
+            .expect("mock operation capability lock poisoned") = operations;
         self
     }
 }
@@ -61,6 +102,12 @@ impl MvmClient for MockBackend {
         Ok(BackendCapabilityReport::new(
             BackendKind::Mock,
             self.capabilities.lock().unwrap().clone(),
+        )
+        .with_operations(
+            self.operations
+                .lock()
+                .expect("mock operation capability lock poisoned")
+                .clone(),
         ))
     }
 
@@ -195,6 +242,28 @@ impl MvmClient for MockBackend {
 mod tests {
     use super::*;
     use crate::client::dto::*;
+
+    #[tokio::test]
+    async fn mock_reports_every_facade_operation_it_implements() {
+        let operations = MockBackend::default()
+            .backend_capabilities()
+            .await
+            .expect("mock capabilities")
+            .operations;
+        assert!(operations.list);
+        assert!(operations.inspect);
+        assert!(operations.create);
+        assert!(operations.run);
+        assert!(operations.start);
+        assert!(operations.stop);
+        assert!(operations.pause);
+        assert!(operations.resume);
+        assert!(operations.remove);
+        assert!(operations.logs);
+        assert!(operations.exec);
+        assert!(operations.reconfigure);
+        assert!(operations.set_ttl);
+    }
 
     #[tokio::test]
     async fn run_then_list_then_stop_roundtrips() {

--- a/crates/mvm-core/src/client/mod.rs
+++ b/crates/mvm-core/src/client/mod.rs
@@ -12,7 +12,9 @@
 
 use async_trait::async_trait;
 
-pub use mvm_contract::protocol::capability_negotiation::BackendCapabilityReport;
+pub use mvm_contract::protocol::capability_negotiation::{
+    BackendCapabilityReport, ClientOperationCapabilities, ClientOperationCapabilitiesBuilder,
+};
 
 pub mod dto;
 pub mod error;

--- a/crates/mvm-mcp/Cargo.toml
+++ b/crates/mvm-mcp/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "mvm-mcp"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Bounded stdio MCP adapter over the MvmClient facade"
+
+[dependencies]
+mvm-client.workspace = true
+chrono.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["rt"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/crates/mvm-mcp/examples/stdio.rs
+++ b/crates/mvm-mcp/examples/stdio.rs
@@ -1,0 +1,19 @@
+use std::io;
+use std::sync::Arc;
+
+use mvm_client::LocalBackend;
+use mvm_mcp::{McpServer, ServerError};
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("MCP stdio example failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), ServerError> {
+    let server = McpServer::new(Arc::new(LocalBackend::new()));
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    server.serve(stdin.lock(), stdout.lock())
+}

--- a/crates/mvm-mcp/src/lib.rs
+++ b/crates/mvm-mcp/src/lib.rs
@@ -1,0 +1,924 @@
+//! A bounded, stdio-only Model Context Protocol adapter over [`MvmClient`].
+//!
+//! This crate owns JSON-RPC framing and DTO translation only. It performs no
+//! lifecycle, admission, or authorization work: every advertised machine
+//! operation delegates to the selected client facade.
+
+use std::collections::BTreeMap;
+use std::io::{self, BufRead, Write};
+use std::sync::{Arc, OnceLock};
+
+use mvm_client::dto::{
+    LogOpts, MachineFilter, MachineId, MachineSpec, MachineStatus, PauseOpts, ReconfigureRequest,
+    ResumeOpts,
+};
+use mvm_client::{
+    BackendCapabilityReport, ClientOperationCapabilities, MvmClient, validate_vm_name,
+};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+/// Current stateless MCP protocol version supported by this server.
+pub const CURRENT_PROTOCOL_VERSION: &str = "2026-07-28";
+/// Legacy handshake version retained for clients that have not moved to
+/// per-request discovery metadata yet.
+pub const LEGACY_PROTOCOL_VERSION: &str = "2025-11-25";
+
+const CATALOG_TTL_MS: u64 = 300_000;
+const DEFAULT_MAX_FRAME_BYTES: usize = 1024 * 1024;
+const DEFAULT_MAX_OUTPUT_BYTES: usize = 64 * 1024;
+
+/// Bounds applied before allocating or emitting protocol payloads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ServerLimits {
+    max_frame_bytes: usize,
+    max_output_bytes: usize,
+}
+
+impl Default for ServerLimits {
+    fn default() -> Self {
+        Self {
+            max_frame_bytes: DEFAULT_MAX_FRAME_BYTES,
+            max_output_bytes: DEFAULT_MAX_OUTPUT_BYTES,
+        }
+    }
+}
+
+impl ServerLimits {
+    /// Set the maximum request-frame size. Values below one byte are clamped
+    /// to one so the bound remains meaningful.
+    #[must_use]
+    pub fn max_frame_bytes(mut self, bytes: usize) -> Self {
+        self.max_frame_bytes = bytes.max(1);
+        self
+    }
+
+    /// Set the maximum successful tool-result payload size. Protocol errors
+    /// have a small fixed envelope and remain available when this cap trips.
+    #[must_use]
+    pub fn max_output_bytes(mut self, bytes: usize) -> Self {
+        self.max_output_bytes = bytes.max(1);
+        self
+    }
+}
+
+/// A stdio serving failure. Protocol and backend errors are encoded as JSON-RPC
+/// responses and do not terminate the loop.
+#[derive(Debug, thiserror::Error)]
+pub enum ServerError {
+    #[error("MCP stdio I/O failed: {0}")]
+    Io(#[from] io::Error),
+}
+
+/// Stateless request adapter with one process-lifetime capability snapshot.
+pub struct McpServer {
+    client: Arc<dyn MvmClient>,
+    capabilities: OnceLock<BackendCapabilityReport>,
+    limits: ServerLimits,
+}
+
+impl McpServer {
+    /// Construct a server over the selected facade implementation.
+    #[must_use]
+    pub fn new(client: Arc<dyn MvmClient>) -> Self {
+        Self::with_limits(client, ServerLimits::default())
+    }
+
+    /// Construct a server with explicit transport/output bounds.
+    #[must_use]
+    pub fn with_limits(client: Arc<dyn MvmClient>, limits: ServerLimits) -> Self {
+        Self {
+            client,
+            capabilities: OnceLock::new(),
+            limits,
+        }
+    }
+
+    /// Handle one newline-delimited JSON-RPC frame. Notifications return
+    /// `None`; all requests return exactly one serialized response.
+    pub async fn handle_json(&self, frame: &str) -> Option<String> {
+        if frame.len() > self.limits.max_frame_bytes {
+            return Some(response_error(
+                Value::Null,
+                -32700,
+                "request frame exceeds limit",
+            ));
+        }
+        let value: Value = match serde_json::from_str(frame) {
+            Ok(value) => value,
+            Err(_) => return Some(response_error(Value::Null, -32700, "invalid JSON")),
+        };
+        let request = match ParsedRequest::parse(value) {
+            Ok(request) => request,
+            Err(error) => return Some(error),
+        };
+        let id = request.id?;
+        Some(self.dispatch(id, request.method, request.params).await)
+    }
+
+    /// Serve newline-delimited MCP over the supplied streams until EOF.
+    /// stdout-equivalent output contains protocol frames only.
+    pub fn serve<R: BufRead, W: Write>(
+        &self,
+        mut reader: R,
+        mut writer: W,
+    ) -> Result<(), ServerError> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        loop {
+            match read_bounded_frame(&mut reader, self.limits.max_frame_bytes)? {
+                Frame::Eof => return Ok(()),
+                Frame::Oversized => {
+                    writeln!(
+                        writer,
+                        "{}",
+                        response_error(Value::Null, -32700, "request frame exceeds limit")
+                    )?;
+                    writer.flush()?;
+                }
+                Frame::InvalidUtf8 => {
+                    writeln!(
+                        writer,
+                        "{}",
+                        response_error(Value::Null, -32700, "request frame is not UTF-8")
+                    )?;
+                    writer.flush()?;
+                }
+                Frame::Line(line) => {
+                    if let Some(response) = runtime.block_on(self.handle_json(&line)) {
+                        writeln!(writer, "{response}")?;
+                        writer.flush()?;
+                    }
+                }
+            }
+        }
+    }
+
+    async fn capabilities(&self) -> Result<&BackendCapabilityReport, String> {
+        if let Some(report) = self.capabilities.get() {
+            return Ok(report);
+        }
+        let report = self
+            .client
+            .backend_capabilities()
+            .await
+            .map_err(|_| "client capability discovery failed".to_string())?;
+        let _ = self.capabilities.set(report);
+        self.capabilities
+            .get()
+            .ok_or_else(|| "client capability discovery did not persist".to_string())
+    }
+
+    async fn dispatch(&self, id: Value, method: String, mut params: Map<String, Value>) -> String {
+        if method == "initialize" {
+            return legacy_initialize(id, params);
+        }
+
+        let meta = params.remove("_meta");
+        if method == "server/discover" && meta.is_none() {
+            return response_error(id, -32602, "server/discover requires request metadata");
+        }
+        if let Some(meta) = meta {
+            if let Err(message) = validate_current_meta(&meta) {
+                return response_error(id, -32602, message);
+            }
+        }
+
+        match method.as_str() {
+            "server/discover" => {
+                if !params.is_empty() {
+                    return response_error(id, -32602, "unexpected discovery parameters");
+                }
+                response_result(id, discover_result())
+            }
+            "tools/list" => match parse_params::<ListParams>(params) {
+                Ok(list) if list.cursor.is_none() => match self.capabilities().await {
+                    Ok(report) => response_result(id, tools_result(&report.operations)),
+                    Err(message) => response_error(id, -32603, &message),
+                },
+                Ok(_) => response_error(id, -32602, "tool catalog has no further page"),
+                Err(message) => response_error(id, -32602, &message),
+            },
+            "tools/call" => {
+                let call = match parse_params::<CallParams>(params) {
+                    Ok(call) => call,
+                    Err(message) => return response_error(id, -32602, &message),
+                };
+                let report = match self.capabilities().await {
+                    Ok(report) => report,
+                    Err(message) => return response_error(id, -32603, &message),
+                };
+                if !tool_enabled(&call.name, &report.operations) {
+                    return response_error(id, -32602, "unknown or unavailable tool");
+                }
+                match self.call_tool(&call.name, call.arguments, report).await {
+                    Ok(value) => response_result(id, self.tool_success(value)),
+                    Err(ToolFailure::Input(message) | ToolFailure::Backend(message)) => {
+                        response_result(id, tool_error(&message))
+                    }
+                }
+            }
+            _ => response_error(id, -32601, "method not found"),
+        }
+    }
+
+    async fn call_tool(
+        &self,
+        name: &str,
+        arguments: Map<String, Value>,
+        report: &BackendCapabilityReport,
+    ) -> Result<Value, ToolFailure> {
+        match name {
+            "mvm.backend_capabilities" => {
+                parse_arguments::<EmptyArgs>(arguments)?;
+                serde_json::to_value(report).map_err(ToolFailure::serialization)
+            }
+            "mvm.machine.list" => {
+                let args = parse_arguments::<ListArgs>(arguments)?;
+                let machines = self
+                    .client
+                    .list_machines(MachineFilter {
+                        name: args.name,
+                        status: args.status,
+                    })
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                serde_json::to_value(machines).map_err(ToolFailure::serialization)
+            }
+            "mvm.machine.inspect" => {
+                let args = parse_arguments::<IdArgs>(arguments)?;
+                let state = self
+                    .client
+                    .inspect_machine(&MachineId(args.id))
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                serde_json::to_value(state).map_err(ToolFailure::serialization)
+            }
+            "mvm.machine.create" | "mvm.machine.run" => {
+                let args = parse_arguments::<LaunchArgs>(arguments)?;
+                let spec = args.into_spec()?;
+                let state = if name == "mvm.machine.create" {
+                    self.client.create_machine(spec).await
+                } else {
+                    self.client.run_machine(spec).await
+                }
+                .map_err(ToolFailure::backend)?;
+                serde_json::to_value(state).map_err(ToolFailure::serialization)
+            }
+            "mvm.machine.start" => {
+                let args = parse_arguments::<IdArgs>(arguments)?;
+                let state = self
+                    .client
+                    .start_machine(&MachineId(args.id))
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                serde_json::to_value(state).map_err(ToolFailure::serialization)
+            }
+            "mvm.machine.stop" => {
+                let args = parse_arguments::<IdArgs>(arguments)?;
+                self.client
+                    .stop_machine(&MachineId(args.id))
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                Ok(json!({"ok": true}))
+            }
+            "mvm.machine.pause" => {
+                let args = parse_arguments::<PauseArgs>(arguments)?;
+                if args.primed_timeout_secs == 0 {
+                    return Err(ToolFailure::Input(
+                        "primed_timeout_secs must be greater than zero".into(),
+                    ));
+                }
+                let outcome = self
+                    .client
+                    .pause_machine(
+                        &MachineId(args.id),
+                        PauseOpts {
+                            primed_barrier: args.primed_barrier,
+                            primed_timeout_secs: args.primed_timeout_secs,
+                        },
+                    )
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                serde_json::to_value(outcome).map_err(ToolFailure::serialization)
+            }
+            "mvm.machine.resume" => {
+                let args = parse_arguments::<ResumeArgs>(arguments)?;
+                let outcome = self
+                    .client
+                    .resume_machine(&MachineId(args.id), ResumeOpts { warm: args.warm })
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                serde_json::to_value(outcome).map_err(ToolFailure::serialization)
+            }
+            "mvm.machine.remove" => {
+                let args = parse_arguments::<IdArgs>(arguments)?;
+                self.client
+                    .remove_machine(&MachineId(args.id))
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                Ok(json!({"ok": true}))
+            }
+            "mvm.machine.logs" => {
+                let args = parse_arguments::<LogsArgs>(arguments)?;
+                let bytes = self
+                    .client
+                    .machine_logs(
+                        &MachineId(args.id),
+                        LogOpts {
+                            follow: args.follow,
+                            tail_lines: args.tail_lines,
+                        },
+                    )
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                Ok(json!({"logs": String::from_utf8_lossy(&bytes)}))
+            }
+            "mvm.machine.exec" => {
+                let args = parse_arguments::<ExecArgs>(arguments)?;
+                if args.command.is_empty() {
+                    return Err(ToolFailure::Input("command must not be empty".into()));
+                }
+                let result = self
+                    .client
+                    .exec_machine(&MachineId(args.id), args.command)
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                Ok(json!({
+                    "exit_code": result.exit_code,
+                    "stdout": String::from_utf8_lossy(&result.stdout),
+                    "stderr": String::from_utf8_lossy(&result.stderr)
+                }))
+            }
+            "mvm.machine.reconfigure" => {
+                let args = parse_arguments::<ReconfigureArgs>(arguments)?;
+                if args.cpus == Some(0) || args.memory_mib == Some(0) {
+                    return Err(ToolFailure::Input(
+                        "cpus and memory_mib must be greater than zero".into(),
+                    ));
+                }
+                let state = self
+                    .client
+                    .reconfigure_machine(
+                        &MachineId(args.id),
+                        ReconfigureRequest {
+                            net: args.net,
+                            allow_host: args.allow_host,
+                            cpus: args.cpus,
+                            memory_mib: args.memory_mib,
+                        },
+                    )
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                serde_json::to_value(state).map_err(ToolFailure::serialization)
+            }
+            "mvm.machine.set_ttl" => {
+                let args = parse_arguments::<SetTtlArgs>(arguments)?;
+                if args.expires_at.as_ref().is_some_and(|expires_at| {
+                    chrono::DateTime::parse_from_rfc3339(expires_at).is_err()
+                }) {
+                    return Err(ToolFailure::Input(
+                        "expires_at must be an RFC 3339 timestamp or null".into(),
+                    ));
+                }
+                self.client
+                    .set_ttl(&MachineId(args.id), args.expires_at)
+                    .await
+                    .map_err(ToolFailure::backend)?;
+                Ok(json!({"ok": true}))
+            }
+            _ => Err(ToolFailure::Input("unknown tool".into())),
+        }
+    }
+
+    fn tool_success(&self, value: Value) -> Value {
+        let text = match serde_json::to_string(&value) {
+            Ok(text) => text,
+            Err(_) => return tool_error("tool output could not be serialized"),
+        };
+        let result = json!({
+            "resultType": "complete",
+            "content": [{"type":"text", "text":text}],
+            "structuredContent": value,
+            "isError": false,
+            "_meta": server_meta()
+        });
+        if serde_json::to_vec(&result)
+            .is_ok_and(|bytes| bytes.len() <= self.limits.max_output_bytes)
+        {
+            result
+        } else {
+            tool_error("tool output exceeds configured limit")
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ParsedRequest {
+    id: Option<Value>,
+    method: String,
+    params: Map<String, Value>,
+}
+
+impl ParsedRequest {
+    fn parse(value: Value) -> Result<Self, String> {
+        let Some(mut object) = value.as_object().cloned() else {
+            return Err(response_error(
+                Value::Null,
+                -32600,
+                "request must be an object",
+            ));
+        };
+        let id = object.remove("id");
+        if id
+            .as_ref()
+            .is_some_and(|id| !id.is_string() && !id.is_number())
+        {
+            return Err(response_error(Value::Null, -32600, "invalid request id"));
+        }
+        if object.remove("jsonrpc") != Some(Value::String("2.0".into())) {
+            return Err(response_error(
+                id.unwrap_or(Value::Null),
+                -32600,
+                "jsonrpc must be 2.0",
+            ));
+        }
+        let Some(method) = object
+            .remove("method")
+            .and_then(|method| method.as_str().map(str::to_owned))
+        else {
+            return Err(response_error(
+                id.unwrap_or(Value::Null),
+                -32600,
+                "method must be a string",
+            ));
+        };
+        let params = match object.remove("params") {
+            None => Map::new(),
+            Some(Value::Object(params)) => params,
+            Some(_) => {
+                return Err(response_error(
+                    id.unwrap_or(Value::Null),
+                    -32602,
+                    "params must be an object",
+                ));
+            }
+        };
+        if !object.is_empty() {
+            return Err(response_error(
+                id.unwrap_or(Value::Null),
+                -32600,
+                "unexpected request fields",
+            ));
+        }
+        Ok(Self { id, method, params })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LegacyInitialize {
+    #[serde(rename = "protocolVersion")]
+    protocol_version: String,
+    capabilities: Value,
+    #[serde(rename = "clientInfo")]
+    client_info: Value,
+}
+
+fn legacy_initialize(id: Value, params: Map<String, Value>) -> String {
+    let request = match parse_params::<LegacyInitialize>(params) {
+        Ok(request) => request,
+        Err(message) => return response_error(id, -32602, &message),
+    };
+    if request.protocol_version != LEGACY_PROTOCOL_VERSION {
+        return response_error(id, -32602, "unsupported legacy protocol version");
+    }
+    if !request.capabilities.is_object() || !request.client_info.is_object() {
+        return response_error(id, -32602, "invalid initialize capabilities or clientInfo");
+    }
+    response_result(
+        id,
+        json!({
+            "protocolVersion": LEGACY_PROTOCOL_VERSION,
+            "capabilities": {"tools": {"listChanged": false}},
+            "serverInfo": {"name":"mvm", "version":env!("CARGO_PKG_VERSION")},
+            "instructions":"Drive machines through the MvmClient-backed tools."
+        }),
+    )
+}
+
+fn validate_current_meta(meta: &Value) -> Result<(), &'static str> {
+    let Some(meta) = meta.as_object() else {
+        return Err("_meta must be an object");
+    };
+    if meta
+        .get("io.modelcontextprotocol/protocolVersion")
+        .and_then(Value::as_str)
+        != Some(CURRENT_PROTOCOL_VERSION)
+    {
+        return Err("unsupported MCP protocol version");
+    }
+    if !meta
+        .get("io.modelcontextprotocol/clientCapabilities")
+        .is_some_and(Value::is_object)
+    {
+        return Err("client capabilities metadata is required");
+    }
+    Ok(())
+}
+
+fn discover_result() -> Value {
+    json!({
+        "resultType":"complete",
+        "supportedVersions":[CURRENT_PROTOCOL_VERSION, LEGACY_PROTOCOL_VERSION],
+        "capabilities":{"tools":{}},
+        "instructions":"Drive machines through the MvmClient-backed tools; unavailable facade operations are not advertised.",
+        "ttlMs":CATALOG_TTL_MS,
+        "cacheScope":"private",
+        "_meta":server_meta()
+    })
+}
+
+fn server_meta() -> Value {
+    json!({
+        "io.modelcontextprotocol/serverInfo": {
+            "name":"mvm",
+            "version":env!("CARGO_PKG_VERSION")
+        }
+    })
+}
+
+fn tools_result(operations: &ClientOperationCapabilities) -> Value {
+    let tools: Vec<Value> = tool_specs()
+        .into_iter()
+        .filter(|tool| tool_enabled(tool["name"].as_str().unwrap_or_default(), operations))
+        .collect();
+    json!({
+        "resultType":"complete",
+        "tools":tools,
+        "ttlMs":CATALOG_TTL_MS,
+        "cacheScope":"private",
+        "_meta":server_meta()
+    })
+}
+
+fn tool_enabled(name: &str, operations: &ClientOperationCapabilities) -> bool {
+    match name {
+        "mvm.backend_capabilities" => true,
+        "mvm.machine.list" => operations.list,
+        "mvm.machine.inspect" => operations.inspect,
+        "mvm.machine.create" => operations.create,
+        "mvm.machine.run" => operations.run,
+        "mvm.machine.start" => operations.start,
+        "mvm.machine.stop" => operations.stop,
+        "mvm.machine.pause" => operations.pause,
+        "mvm.machine.resume" => operations.resume,
+        "mvm.machine.remove" => operations.remove,
+        "mvm.machine.logs" => operations.logs,
+        "mvm.machine.exec" => operations.exec,
+        "mvm.machine.reconfigure" => operations.reconfigure,
+        "mvm.machine.set_ttl" => operations.set_ttl,
+        _ => false,
+    }
+}
+
+fn tool_specs() -> Vec<Value> {
+    vec![
+        tool(
+            "mvm.backend_capabilities",
+            "Describe the selected backend and client operation surface.",
+            empty_schema(),
+        ),
+        tool(
+            "mvm.machine.list",
+            "List machines visible through the selected client.",
+            object_schema(
+                json!({"name":{"type":"string"}, "status":{"type":"string","enum":["starting","running","stopped","paused","failed"]}}),
+                &[],
+            ),
+        ),
+        tool("mvm.machine.inspect", "Inspect one machine.", id_schema()),
+        tool(
+            "mvm.machine.create",
+            "Create a stopped machine through MvmClient.",
+            launch_schema(),
+        ),
+        tool(
+            "mvm.machine.run",
+            "Create and start a machine through MvmClient.",
+            launch_schema(),
+        ),
+        tool("mvm.machine.start", "Start a created machine.", id_schema()),
+        tool(
+            "mvm.machine.stop",
+            "Stop a machine idempotently.",
+            id_schema(),
+        ),
+        tool(
+            "mvm.machine.pause",
+            "Pause a running machine.",
+            object_schema(
+                json!({"id":{"type":"string"},"primed_barrier":{"type":"boolean"},"primed_timeout_secs":{"type":"integer","minimum":1}}),
+                &["id"],
+            ),
+        ),
+        tool(
+            "mvm.machine.resume",
+            "Resume a paused machine.",
+            object_schema(
+                json!({"id":{"type":"string"},"warm":{"type":"boolean"}}),
+                &["id"],
+            ),
+        ),
+        tool(
+            "mvm.machine.remove",
+            "Remove a machine idempotently.",
+            id_schema(),
+        ),
+        tool(
+            "mvm.machine.logs",
+            "Read bounded machine logs.",
+            object_schema(
+                json!({"id":{"type":"string"},"follow":{"type":"boolean"},"tail_lines":{"type":"integer","minimum":0}}),
+                &["id"],
+            ),
+        ),
+        tool(
+            "mvm.machine.exec",
+            "Run a non-interactive command when the selected client supports it.",
+            object_schema(
+                json!({"id":{"type":"string"},"command":{"type":"array","items":{"type":"string"},"minItems":1}}),
+                &["id", "command"],
+            ),
+        ),
+        tool(
+            "mvm.machine.reconfigure",
+            "Patch supported machine configuration fields.",
+            object_schema(
+                json!({"id":{"type":"string"},"net":{"type":"boolean"},"allow_host":{"type":"array","items":{"type":"string"}},"cpus":{"type":"integer","minimum":1},"memory_mib":{"type":"integer","minimum":1}}),
+                &["id"],
+            ),
+        ),
+        tool(
+            "mvm.machine.set_ttl",
+            "Set or clear a machine TTL.",
+            object_schema(
+                json!({"id":{"type":"string"},"expires_at":{"type":["string","null"]}}),
+                &["id"],
+            ),
+        ),
+    ]
+}
+
+fn tool(name: &str, description: &str, input_schema: Value) -> Value {
+    json!({"name":name, "description":description, "inputSchema":input_schema})
+}
+
+fn empty_schema() -> Value {
+    object_schema(json!({}), &[])
+}
+
+fn id_schema() -> Value {
+    object_schema(json!({"id":{"type":"string"}}), &["id"])
+}
+
+fn launch_schema() -> Value {
+    object_schema(
+        json!({
+            "name":{"type":"string"}, "image":{"type":"string"},
+            "cpus":{"type":"integer","minimum":1},
+            "memory_mib":{"type":"integer","minimum":1},
+            "env":{"type":"object","additionalProperties":{"type":"string"}}
+        }),
+        &["name", "image"],
+    )
+}
+
+fn object_schema(properties: Value, required: &[&str]) -> Value {
+    json!({
+        "type":"object",
+        "properties":properties,
+        "required":required,
+        "additionalProperties":false
+    })
+}
+
+fn response_result(id: Value, result: Value) -> String {
+    serde_json::to_string(&json!({"jsonrpc":"2.0", "id":id, "result":result}))
+        .expect("JSON-RPC result values are serializable")
+}
+
+fn response_error(id: Value, code: i64, message: &str) -> String {
+    serde_json::to_string(&json!({
+        "jsonrpc":"2.0", "id":id, "error":{"code":code, "message":message}
+    }))
+    .expect("JSON-RPC error values are serializable")
+}
+
+fn tool_error(message: &str) -> Value {
+    let message: String = message.chars().take(512).collect();
+    json!({
+        "resultType":"complete",
+        "content":[{"type":"text", "text":message}],
+        "isError":true,
+        "_meta":server_meta()
+    })
+}
+
+fn parse_params<T: for<'de> Deserialize<'de>>(params: Map<String, Value>) -> Result<T, String> {
+    serde_json::from_value(Value::Object(params))
+        .map_err(|error| format!("invalid parameters: {error}"))
+}
+
+fn parse_arguments<T: for<'de> Deserialize<'de>>(
+    arguments: Map<String, Value>,
+) -> Result<T, ToolFailure> {
+    serde_json::from_value(Value::Object(arguments))
+        .map_err(|error| ToolFailure::Input(format!("invalid tool arguments: {error}")))
+}
+
+#[derive(Debug)]
+enum ToolFailure {
+    Input(String),
+    Backend(String),
+}
+
+impl ToolFailure {
+    fn backend(error: impl std::fmt::Display) -> Self {
+        Self::Backend(format!("MvmClient operation failed: {error}"))
+    }
+
+    fn serialization(_: impl std::fmt::Display) -> Self {
+        Self::Backend("MvmClient result could not be serialized".into())
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EmptyArgs {}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ListParams {
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CallParams {
+    name: String,
+    #[serde(default)]
+    arguments: Map<String, Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ListArgs {
+    name: Option<String>,
+    status: Option<MachineStatus>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct IdArgs {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LaunchArgs {
+    name: String,
+    image: String,
+    #[serde(default = "default_cpus")]
+    cpus: u32,
+    #[serde(default = "default_memory_mib")]
+    memory_mib: u32,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+}
+
+impl LaunchArgs {
+    fn into_spec(self) -> Result<MachineSpec, ToolFailure> {
+        if self.cpus == 0 || self.memory_mib == 0 {
+            return Err(ToolFailure::Input(
+                "cpus and memory_mib must be greater than zero".into(),
+            ));
+        }
+        validate_vm_name(&self.name)
+            .map_err(|_| ToolFailure::Input("invalid machine name".into()))?;
+        let builder = MachineSpec::builder(self.name, self.image)
+            .map_err(|_| ToolFailure::Input("invalid image declaration".into()))?;
+        Ok(builder
+            .cpus(self.cpus)
+            .memory_mib(self.memory_mib)
+            .envs(self.env)
+            .build())
+    }
+}
+
+fn default_cpus() -> u32 {
+    1
+}
+
+fn default_memory_mib() -> u32 {
+    512
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PauseArgs {
+    id: String,
+    #[serde(default)]
+    primed_barrier: bool,
+    #[serde(default = "default_primed_timeout_secs")]
+    primed_timeout_secs: u64,
+}
+
+fn default_primed_timeout_secs() -> u64 {
+    120
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ResumeArgs {
+    id: String,
+    #[serde(default)]
+    warm: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LogsArgs {
+    id: String,
+    #[serde(default)]
+    follow: bool,
+    tail_lines: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExecArgs {
+    id: String,
+    command: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReconfigureArgs {
+    id: String,
+    net: Option<bool>,
+    allow_host: Option<Vec<String>>,
+    cpus: Option<u32>,
+    memory_mib: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SetTtlArgs {
+    id: String,
+    expires_at: Option<String>,
+}
+
+enum Frame {
+    Eof,
+    Oversized,
+    InvalidUtf8,
+    Line(String),
+}
+
+fn read_bounded_frame<R: BufRead>(reader: &mut R, limit: usize) -> io::Result<Frame> {
+    let mut bytes = Vec::with_capacity(limit.min(4096));
+    let mut oversized = false;
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            if bytes.is_empty() && !oversized {
+                return Ok(Frame::Eof);
+            }
+            break;
+        }
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let consumed = newline.map_or(available.len(), |position| position + 1);
+        if !oversized {
+            let content_len = newline.unwrap_or(consumed);
+            let remaining = limit.saturating_sub(bytes.len());
+            let copied = content_len.min(remaining);
+            bytes.extend_from_slice(&available[..copied]);
+            if content_len > remaining {
+                oversized = true;
+            }
+        }
+        reader.consume(consumed);
+        if newline.is_some() {
+            break;
+        }
+    }
+    if oversized {
+        return Ok(Frame::Oversized);
+    }
+    if bytes.last() == Some(&b'\r') {
+        bytes.pop();
+    }
+    Ok(String::from_utf8(bytes).map_or(Frame::InvalidUtf8, Frame::Line))
+}

--- a/crates/mvm-mcp/tests/protocol.rs
+++ b/crates/mvm-mcp/tests/protocol.rs
@@ -1,0 +1,282 @@
+use std::io::Cursor;
+use std::sync::Arc;
+
+use mvm_client::dto::{MachineFilter, MachineId, MachineStatus};
+use mvm_client::mock::MockBackend;
+use mvm_client::{ClientOperationCapabilities, MvmClient};
+use mvm_mcp::{CURRENT_PROTOCOL_VERSION, McpServer, ServerLimits};
+use serde_json::{Value, json};
+
+fn current_request(id: u64, method: &str, extra: Value) -> String {
+    let mut params = extra.as_object().cloned().expect("params object");
+    params.insert(
+        "_meta".into(),
+        json!({
+            "io.modelcontextprotocol/protocolVersion": CURRENT_PROTOCOL_VERSION,
+            "io.modelcontextprotocol/clientCapabilities": {},
+            "io.modelcontextprotocol/clientInfo": {"name": "mvm-test", "version": "1"}
+        }),
+    );
+    json!({"jsonrpc":"2.0", "id":id, "method":method, "params":params}).to_string()
+}
+
+async fn request(server: &McpServer, id: u64, method: &str, params: Value) -> Value {
+    let response = server
+        .handle_json(&current_request(id, method, params))
+        .await
+        .expect("request receives a response");
+    serde_json::from_str(&response).expect("response json")
+}
+
+async fn call(server: &McpServer, id: u64, name: &str, arguments: Value) -> Value {
+    request(
+        server,
+        id,
+        "tools/call",
+        json!({"name":name, "arguments":arguments}),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn current_discovery_is_stateless_and_private() {
+    let server = McpServer::new(Arc::new(MockBackend::default()));
+    let response = request(&server, 1, "server/discover", json!({})).await;
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(
+        response["result"]["supportedVersions"][0],
+        CURRENT_PROTOCOL_VERSION
+    );
+    assert_eq!(response["result"]["capabilities"]["tools"], json!({}));
+    assert_eq!(response["result"]["cacheScope"], "private");
+    assert!(response["result"]["ttlMs"].as_u64().is_some());
+}
+
+#[tokio::test]
+async fn tool_catalog_is_deterministic_and_derived_from_client_operations() {
+    let operations = ClientOperationCapabilities::builder()
+        .list(true)
+        .stop(true)
+        .build();
+    let server = McpServer::new(Arc::new(MockBackend::default().with_operations(operations)));
+    let response = request(&server, 2, "tools/list", json!({})).await;
+    let names: Vec<&str> = response["result"]["tools"]
+        .as_array()
+        .expect("tools")
+        .iter()
+        .map(|tool| tool["name"].as_str().expect("tool name"))
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "mvm.backend_capabilities",
+            "mvm.machine.list",
+            "mvm.machine.stop"
+        ]
+    );
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(response["result"]["cacheScope"], "private");
+}
+
+#[tokio::test]
+async fn every_mock_operation_routes_through_the_facade() {
+    let mock = Arc::new(MockBackend::default());
+    let client: Arc<dyn MvmClient> = mock.clone();
+    let server = McpServer::new(client);
+
+    let created = call(
+        &server,
+        10,
+        "mvm.machine.create",
+        json!({"name":"all-ops", "image":"alpine", "cpus":2, "memory_mib":128}),
+    )
+    .await;
+    let id = created["result"]["structuredContent"]["id"]
+        .as_str()
+        .expect("machine id")
+        .to_string();
+    for (request_id, name, arguments) in [
+        (11, "mvm.machine.inspect", json!({"id":id})),
+        (12, "mvm.machine.start", json!({"id":id})),
+        (13, "mvm.machine.pause", json!({"id":id})),
+        (14, "mvm.machine.resume", json!({"id":id, "warm":false})),
+        (15, "mvm.machine.logs", json!({"id":id, "tail_lines":10})),
+        (16, "mvm.machine.exec", json!({"id":id, "command":["true"]})),
+        (17, "mvm.machine.reconfigure", json!({"id":id, "cpus":3})),
+        (
+            18,
+            "mvm.machine.set_ttl",
+            json!({"id":id, "expires_at":"2030-01-01T00:00:00Z"}),
+        ),
+        (19, "mvm.machine.stop", json!({"id":id})),
+    ] {
+        let response = call(&server, request_id, name, arguments).await;
+        assert_eq!(response["result"]["isError"], false, "{name}: {response}");
+    }
+    let listed = call(&server, 20, "mvm.machine.list", json!({})).await;
+    assert_eq!(
+        listed["result"]["structuredContent"][0]["status"],
+        "stopped"
+    );
+    let removed = call(&server, 21, "mvm.machine.remove", json!({"id":id})).await;
+    assert_eq!(removed["result"]["isError"], false);
+    assert!(
+        mock.list_machines(MachineFilter::all())
+            .await
+            .expect("mock list")
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn backend_failure_is_a_tool_result_the_model_can_correct() {
+    let server = McpServer::new(Arc::new(MockBackend::default()));
+    let response = call(&server, 30, "mvm.machine.inspect", json!({"id":"absent"})).await;
+    assert_eq!(response["result"]["resultType"], "complete");
+    assert_eq!(response["result"]["isError"], true);
+    assert!(
+        response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("error text")
+            .contains("absent")
+    );
+}
+
+#[tokio::test]
+async fn invalid_arguments_are_strict_and_unknown_tools_are_protocol_errors() {
+    let server = McpServer::new(Arc::new(MockBackend::default()));
+    let invalid = call(&server, 40, "mvm.machine.list", json!({"unexpected":true})).await;
+    assert_eq!(invalid["result"]["isError"], true);
+
+    let unknown = call(&server, 41, "mvm.machine.nope", json!({})).await;
+    assert_eq!(unknown["error"]["code"], -32602);
+}
+
+#[tokio::test]
+async fn invalid_ttl_and_oversized_output_fail_as_tool_results() {
+    let server = McpServer::new(Arc::new(MockBackend::default()));
+    let created = call(
+        &server,
+        42,
+        "mvm.machine.create",
+        json!({"name":"ttl-check", "image":"alpine"}),
+    )
+    .await;
+    let id = created["result"]["structuredContent"]["id"]
+        .as_str()
+        .expect("machine id");
+    let invalid = call(
+        &server,
+        43,
+        "mvm.machine.set_ttl",
+        json!({"id":id, "expires_at":"tomorrow"}),
+    )
+    .await;
+    assert_eq!(invalid["result"]["isError"], true);
+
+    let bounded = McpServer::with_limits(
+        Arc::new(MockBackend::default()),
+        ServerLimits::default()
+            .max_frame_bytes(4096)
+            .max_output_bytes(512),
+    );
+    let response = call(&bounded, 44, "mvm.backend_capabilities", json!({})).await;
+    assert_eq!(response["result"]["isError"], true);
+}
+
+#[tokio::test]
+async fn notifications_receive_no_response_and_legacy_initialize_still_works() {
+    let server = McpServer::new(Arc::new(MockBackend::default()));
+    let notification = json!({
+        "jsonrpc":"2.0", "method":"notifications/initialized", "params":{}
+    })
+    .to_string();
+    assert!(server.handle_json(&notification).await.is_none());
+
+    let initialize = json!({
+        "jsonrpc":"2.0", "id":50, "method":"initialize",
+        "params":{"protocolVersion":"2025-11-25", "capabilities":{},
+                  "clientInfo":{"name":"legacy", "version":"1"}}
+    })
+    .to_string();
+    let response: Value = serde_json::from_str(
+        &server
+            .handle_json(&initialize)
+            .await
+            .expect("initialize response"),
+    )
+    .expect("initialize json");
+    assert_eq!(response["result"]["protocolVersion"], "2025-11-25");
+    assert_eq!(response["result"]["serverInfo"]["name"], "mvm");
+}
+
+#[test]
+fn stdio_frame_bound_is_recoverable_for_the_next_request() {
+    let valid = current_request(61, "server/discover", json!({}));
+    let input = format!("{}\n{valid}\n", "x".repeat(513));
+    let mut output = Vec::new();
+    McpServer::with_limits(
+        Arc::new(MockBackend::default()),
+        ServerLimits::default()
+            .max_frame_bytes(512)
+            .max_output_bytes(4096),
+    )
+    .serve(Cursor::new(input), &mut output)
+    .expect("serve recovers after oversized frame");
+    let frames: Vec<Value> = String::from_utf8(output)
+        .expect("utf8 output")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("response frame"))
+        .collect();
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0]["error"]["code"], -32700);
+    assert_eq!(frames[1]["id"], 61);
+}
+
+#[test]
+fn invalid_utf8_frame_is_recoverable_for_the_next_request() {
+    let valid = current_request(62, "server/discover", json!({}));
+    let mut input = vec![0xff, b'\n'];
+    input.extend_from_slice(valid.as_bytes());
+    input.push(b'\n');
+    let mut output = Vec::new();
+    McpServer::new(Arc::new(MockBackend::default()))
+        .serve(Cursor::new(input), &mut output)
+        .expect("serve recovers after invalid UTF-8");
+    let frames: Vec<Value> = String::from_utf8(output)
+        .expect("utf8 output")
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("response frame"))
+        .collect();
+    assert_eq!(frames.len(), 2);
+    assert_eq!(frames[0]["error"]["code"], -32700);
+    assert_eq!(frames[1]["id"], 62);
+}
+
+#[tokio::test]
+async fn list_status_filter_uses_the_wire_enum() {
+    let mock = Arc::new(MockBackend::default());
+    let server = McpServer::new(mock.clone());
+    call(
+        &server,
+        70,
+        "mvm.machine.run",
+        json!({"name":"running", "image":"alpine"}),
+    )
+    .await;
+    let response = call(&server, 71, "mvm.machine.list", json!({"status":"running"})).await;
+    assert_eq!(
+        response["result"]["structuredContent"][0]["name"],
+        "running"
+    );
+    assert_eq!(
+        mock.list_machines(MachineFilter {
+            name: None,
+            status: Some(MachineStatus::Running)
+        })
+        .await
+        .expect("mock list")[0]
+            .id,
+        MachineId("m1".into())
+    );
+}

--- a/features/suites/s0_cli/verbs.feature
+++ b/features/suites/s0_cli/verbs.feature
@@ -55,3 +55,8 @@ Feature: mvmctl top-level CLI surface
 
   Scenario: every alternative CLI help entry point obeys the one-line limit
     Then every alternative CLI help item is one line shorter than 80 columns
+
+  Scenario: the MCP consumer advertises its local stdio transport
+    When I run mvmctl with "ops mcp --help"
+    Then the command exits with code 0
+    And the help output contains "stdio"

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -25,7 +25,7 @@ verification under `trust`. Domains that already own their own subcommands
 | Daily drivers (top-level) | `machine` (`run`/`fork`/`restore`/`exec`/`console`/`logs`/`stop`/`forward`/…), `ls`, `build`, `doctor`, `init`, `bootstrap` |
 | `vm <sub>` | `pause`, `resume`, `snapshot`, `save`, `restore`, `checkpoint`, `cp`, `fs`, `proc`, `diff`, `wait`, `boot-report`, `set-ttl`, `forward`, `sandbox`, `session`, `volume` |
 | `build <sub>` | `image` (the former `build`), `compile`, `validate`, `kernel`, `runtime-overlay` |
-| `ops <sub>` | `metrics`, `bench`, `config` |
+| `ops <sub>` | `metrics`, `config`, `mcp` |
 | `env <sub>` | `bootstrap`, `cleanup`, `uninstall`, `update`, `sign` |
 | `trust <sub>` | `add`/`list`/`remove` (publishers), `attest`, `receipt`, `audit` |
 | Already-grouped top-level | `image`, `catalog`, `manifest`, `storage`, `network`, `cache`, `pool`, `secret`, `bundle`, `deps`, `artifact` |
@@ -1070,6 +1070,7 @@ running microVM.
 | `mvmctl completions <bash\|zsh>` | Print a completion script. `shell-init`'s eval block calls this; the hidden `--emit-completions` flag it used to carry is gone |
 | `mvmctl ops metrics` | Show runtime metrics (Prometheus text format) |
 | `mvmctl ops metrics --json` | Show runtime metrics as JSON |
+| `mvmctl ops mcp stdio` | Serve capability-derived `MvmClient` tools as newline-delimited MCP JSON-RPC over local stdin/stdout |
 | `mvmctl env uninstall` | Remove Firecracker, the builder microVM image, and all mvm state (confirmation required) |
 | `mvmctl env uninstall -y` | Uninstall without confirmation |
 | `mvmctl env uninstall --all` | Also remove ~/.mvm/ config dir and /usr/local/bin/mvmctl binary |

--- a/scripts/test-mcp-roundtrip.sh
+++ b/scripts/test-mcp-roundtrip.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+# Named no-boot consumer for the MCP surface. It performs discovery, catalog
+# listing, and the read-only facade capability call in one stdio process.
+mcp_bin=${MVM_MCP_BIN:-target/debug/mvmctl}
+if [ ! -x "$mcp_bin" ]; then
+  echo "MCP binary is not executable: $mcp_bin" >&2
+  exit 2
+fi
+
+output_file=$(mktemp)
+meta='{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{},"io.modelcontextprotocol/clientInfo":{"name":"mvm-roundtrip","version":"1"}}'
+input_file=$(mktemp)
+trap 'rm -f "$input_file" "$output_file"' EXIT
+{
+  printf '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":%s}}\n' "$meta"
+  printf '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{"_meta":%s}}\n' "$meta"
+  printf '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"_meta":%s,"name":"mvm.backend_capabilities","arguments":{}}}\n' "$meta"
+} >"$input_file"
+
+if [ "${MVM_MCP_DIRECT:-0}" = 1 ]; then
+  "$mcp_bin" <"$input_file" >"$output_file"
+else
+  "$mcp_bin" ops mcp stdio <"$input_file" >"$output_file"
+fi
+
+if [ "$(wc -l <"$output_file")" -ne 3 ]; then
+  echo "MCP roundtrip returned an unexpected response count" >&2
+  exit 1
+fi
+sed -n '1p' "$output_file" | grep -Fq '"supportedVersions":["2026-07-28"'
+sed -n '2p' "$output_file" | grep -Fq '"name":"mvm.backend_capabilities"'
+sed -n '3p' "$output_file" | grep -Fq '"isError":false'
+sed -n '3p' "$output_file" | grep -Fq '"kind":"'
+
+echo "MCP stdio roundtrip passed (discovery, catalog, facade capabilities)"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-18
+Last updated: 2026-08-19
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -1519,7 +1519,8 @@ for detailed scope and acceptance criteria.
   - [x] Remove branch-local multi-gigabyte Cargo target caches
   - [x] Share nested `mvm-cli` builds across feature fingerprints
   - [x] Move man-page tests onto Test's warm compile graph
-  - [x] Keep the removed MCP server and smoke lane out of CI
+  - [x] Keep a dedicated MCP smoke lane out of CI; the later restored server is
+        covered by workspace tests and a named no-boot consumer
   - [x] Complete workspace and Linux clippy verification; the first live run
         passed and measured a 19–21 minute runner wait
 

--- a/specs/adrs/002-local-mcp-server.md
+++ b/specs/adrs/002-local-mcp-server.md
@@ -2,14 +2,14 @@
 
 ## Status
 
-Withdrawn (2026-07-31). The server, its `mcp` Cargo feature, the
+Withdrawn (2026-07-31); superseded by ADR-048 (2026-08-19). The server, its `mcp` Cargo feature, the
 `mvmctl ops mcp stdio` verb, the stdio roundtrip smoke script, and the
 `mcp-server-smoke` CI lane were all deleted. It was a surface nobody
 drove: it shipped behind an opt-in feature composed only into `user`,
 had no consumer, and duplicated authority that the CLI's JSON output
 and the SDKs already expose. The record below is kept for the numbering
-and for the reasoning, should a tool-server surface ever be revisited —
-it does not describe code that exists.
+and for the reasoning. ADR-048 revisits the surface only as a capability-derived
+adapter over `MvmClient`; this record does not describe the replacement.
 
 ## Context
 

--- a/specs/adrs/048-mvm-client-mcp-server.md
+++ b/specs/adrs/048-mvm-client-mcp-server.md
@@ -1,0 +1,62 @@
+# ADR-048 — MvmClient-backed local MCP server
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Status:** Accepted
+**Date:** 2026-08-19
+**Supersedes:** ADR-002
+
+## Context
+
+ADR-002's first MCP server was withdrawn because it duplicated lifecycle and
+session authority, exposed a bespoke `run` environment abstraction, and had no
+named consumer. The later `MvmClient` facade now provides the missing single
+surface: local, remote, and test backends already express machine intent through
+one object-safe trait. Issue #2647 asks for MCP to be revived only if it adapts
+that facade rather than becoming another control plane.
+
+The current [MCP protocol](https://modelcontextprotocol.io/specification/2026-07-28)
+is the 2026-07-28 stateless model. Requests carry
+their protocol version and client capabilities in `_meta`, `server/discover`
+is mandatory, and stdio messages are newline-delimited JSON-RPC. Older clients
+still in use perform the 2025-11-25 `initialize` handshake.
+
+## Decision
+
+`mvm-mcp` is a small, hand-written JSON-RPC adapter over `Arc<dyn MvmClient>`.
+It contains no backend selection, admission, lifecycle, session, credential,
+or audit policy. Every machine tool translates strict JSON arguments into an
+existing facade DTO and invokes exactly one facade operation.
+
+The catalog is derived from `BackendCapabilityReport.operations`. Those
+operation capabilities are a serialized deny-all-by-default field, distinct
+from hypervisor capabilities because two transports can expose different
+methods against the same VMM. Local, gateway, and mock clients attach the
+methods they actually implement. An operation that is not reported is not
+advertised or callable. In particular, local and gateway clients do not
+advertise `exec` while their facade implementations return unsupported.
+
+The process transport is only `mvmctl ops mcp stdio`. There is no listener,
+HTTP transport, authentication subsystem, or orchestration service. The server
+implements current `server/discover`, `tools/list`, and `tools/call`, plus the
+legacy initialize response. Current requests are independently validated; no
+authority or capability state is inherited from a prior request.
+
+Frames are bounded before allocation, output is bounded before emission,
+unknown fields fail closed, tool-originated failures use `isError`, and
+protocol/tool-lookup failures use JSON-RPC errors. stdout is protocol-only.
+
+`scripts/test-mcp-roundtrip.sh` is the named consumer. It drives discovery,
+catalog listing, and the read-only backend-capability tool without booting a
+VM. Protocol and dispatch coverage lives in ordinary workspace tests against
+`MockBackend`; there is no dedicated CI lane to become an unowned second gate.
+
+## Consequences
+
+Agents and humans can use one long-lived structured process while local CLI,
+SDK, gateway, and MCP calls retain the same authority boundary. Adding a facade
+method does not silently add a tool: the client must report the operation and
+the adapter must define and test its strict mapping. MCP version changes remain
+an audited in-house maintenance responsibility, but add no third-party protocol
+dependency to the supply chain.

--- a/specs/plans/2026-08-19-mcp-mvm-client.md
+++ b/specs/plans/2026-08-19-mcp-mvm-client.md
@@ -28,7 +28,7 @@ prove the protocol against `MockBackend` without booting a VM.
       the sprint and refactor trackers.
 - [x] Pass formatting, workspace tests/checks, all-target clippy, and gated
       target checks.
-- [ ] Open the issue-closing pull request, enable auto-merge, and record the
+- [x] Open the issue-closing pull request, enable auto-merge, and record the
       merge-queue handoff.
 
 ## Validation evidence
@@ -48,3 +48,4 @@ prove the protocol against `MockBackend` without booting a VM.
   calls. Full Linux clippy remains delegated to CI because the shared builder's
   persistent Nix disk is reformatted on every boot and cold jobs exceed its
   fixed 30-minute execution deadline.
+- PR #2737 closes issue #2647 and is handed to the required-check merge queue.

--- a/specs/plans/2026-08-19-mcp-mvm-client.md
+++ b/specs/plans/2026-08-19-mcp-mvm-client.md
@@ -1,0 +1,49 @@
+# MvmClient-backed MCP server
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+## Goal
+
+Restore a local stdio MCP surface as a thin adapter over `dyn MvmClient`,
+derive its tool catalog from the selected client's reported operations, and
+prove the protocol against `MockBackend` without booting a VM.
+
+## Work
+
+- [x] Add a serialized, builder-constructed client-operation capability set
+      to `BackendCapabilityReport` and report it honestly from local, gateway,
+      and mock clients.
+- [x] Add the dependency-light `mvm-mcp` crate with bounded newline-delimited
+      JSON-RPC, current MCP discovery/tool methods, and legacy initialize
+      compatibility.
+- [x] Route every advertised tool directly through `dyn MvmClient`, with
+      strict inputs, bounded outputs, structured errors, and no lifecycle or
+      admission policy in the adapter.
+- [x] Prove discovery, capability projection, successful calls, invalid
+      requests, backend failures, and bounds against `MockBackend` only.
+- [x] Restore `mvmctl ops mcp stdio`, its CLI/audit coverage, and a named
+      no-boot roundtrip consumer.
+- [x] Supersede withdrawn ADR-002 with the new client-facade decision and sync
+      the sprint and refactor trackers.
+- [ ] Pass formatting, workspace tests/checks, all-target clippy, and gated
+      target checks.
+- [ ] Open the issue-closing pull request, enable auto-merge, and record the
+      merge-queue handoff.
+
+## Validation evidence
+
+- `cargo test -p mvm-mcp --all-targets`: 10 protocol tests pass and the stdio
+  example builds.
+- `just bdd`: 209 scenarios pass and one pre-existing scenario is skipped; the
+  MCP help scenario passes.
+- `just check-gated`, `cargo check --workspace`, and
+  `cargo clippy --workspace -- -D warnings` pass on the macOS host.
+- The full executable workspace test matrix passes. Its final combined rustdoc
+  invocation twice hit a transient Cargo metadata failure; the affected
+  `cargo test -p mvm-cli --doc` target passes immediately in isolation.
+- The static ARM64 Linux MCP example runs the named no-boot stdio consumer in
+  the libkrun builder and completes discovery, catalog, and facade-capability
+  calls. Full Linux clippy remains delegated to CI because the shared builder's
+  persistent Nix disk is reformatted on every boot and cold jobs exceed its
+  fixed 30-minute execution deadline.

--- a/specs/plans/2026-08-19-mcp-mvm-client.md
+++ b/specs/plans/2026-08-19-mcp-mvm-client.md
@@ -26,7 +26,7 @@ prove the protocol against `MockBackend` without booting a VM.
       no-boot roundtrip consumer.
 - [x] Supersede withdrawn ADR-002 with the new client-facade decision and sync
       the sprint and refactor trackers.
-- [ ] Pass formatting, workspace tests/checks, all-target clippy, and gated
+- [x] Pass formatting, workspace tests/checks, all-target clippy, and gated
       target checks.
 - [ ] Open the issue-closing pull request, enable auto-merge, and record the
       merge-queue handoff.
@@ -39,9 +39,10 @@ prove the protocol against `MockBackend` without booting a VM.
   MCP help scenario passes.
 - `just check-gated`, `cargo check --workspace`, and
   `cargo clippy --workspace -- -D warnings` pass on the macOS host.
-- The full executable workspace test matrix passes. Its final combined rustdoc
-  invocation twice hit a transient Cargo metadata failure; the affected
-  `cargo test -p mvm-cli --doc` target passes immediately in isolation.
+- `cargo test --workspace` passes on the rebased commit, including all
+  doctests. An earlier cold run hit a transient Cargo metadata failure during
+  the final rustdoc invocation; the affected target and the exact-commit full
+  rerun both pass.
 - The static ARM64 Linux MCP example runs the named no-boot stdio consumer in
   the libkrun builder and completes discovery, catalog, and facade-capability
   calls. Full Linux clippy remains delegated to CI because the shared builder's

--- a/specs/plans/329-run-first-cli-and-upstream-adoption.md
+++ b/specs/plans/329-run-first-cli-and-upstream-adoption.md
@@ -1,19 +1,13 @@
 # Plan 329 — Run-first CLI ergonomics and upstream-sandbox adoption
 
-**Status: COMPLETE** (2026-08-18). Every phase is landed, refused with its
-reason, or moved to the plan that owns the work — nothing is ticked to make the
-plan look finished. Two items were **refused** (the MCP server revival, and an
-install.sh bullet whose premise no longer exists); four were **moved** to the
-plans that own them (see "Where the remaining work went"); three phases turned
-out to be partly shipped already, and two were specified against verbs that had
-been removed. Those corrections are recorded in place rather than quietly
-absorbed. Two were **refused** rather than built — the MCP server
-revival in Phase 6, and Phase 8's install.sh bullet whose premise (the Docker
-backend) no longer exists — and one, the Homebrew tap, is left open as a
-maintainer decision with the evaluation written down. Three phases were found
-to be partly shipped already, and two were specified against verbs that had
-been removed; those corrections are recorded below rather than quietly
-absorbed.
+**Status: COMPLETE** (2026-08-18; amended 2026-08-19). Every phase is landed,
+refused with its reason, superseded, or moved to the plan that owns the work.
+The install.sh bullet remains deliberately refused because its Docker-backend
+premise no longer exists. The earlier MCP refusal is superseded by ADR-048,
+which permits only a capability-derived `MvmClient` adapter with a named
+consumer. Four items were moved to their owning plans, the Homebrew tap remains
+a documented maintainer decision, and the already-shipped or removed-verb
+corrections stay recorded in place.
 
 **Bound by:** [ADR-027](../adrs/027-cli-surface-consolidation.md) (amended
 2026-08-17),
@@ -147,12 +141,11 @@ against something other than what is there.
    when given no source flag. Wire the existing discovery in rather than
    adding a second config idiom.
 
-4. **Phase 6 is blocked by a standing decision this plan did not acknowledge.**
-   [ADR-002](../adrs/002-local-mcp-server.md) is **Withdrawn** — the server,
-   its `mcp` Cargo feature, the `mvmctl ops mcp stdio` verb and the CI lane
-   were deleted — and `xtask check-workflow-paths` enforces
-   `removed_mcp_server_stays_out_of_ci`. Reviving MCP means superseding an ADR
-   and deciding that gate's fate before any code is written.
+4. **Phase 6 required a decision this plan did not originally acknowledge.**
+   [ADR-002](../adrs/002-local-mcp-server.md) withdrew the bespoke server.
+   ADR-048 now supersedes it with a strict `MvmClient` adapter and a named
+   consumer. The workflow gate is retained in narrower form: no dedicated MCP
+   smoke lane is added to CI.
 
 ## Phase A — CLI truth: ADR amendment, verb visibility, docs gate
 
@@ -361,32 +354,25 @@ admission.
 
 ### Phase 6 — Agent integration (MCP / plugins)
 
-- [x] **Refused, deliberately.** [ADR-002](../adrs/002-local-mcp-server.md)
-      shipped a local MCP server and withdrew it as "a surface nobody drove …
-      duplicated authority that the CLI's JSON output and the SDKs already
-      expose". That reasoning still holds, so rebuilding it identically would
-      fail identically. ADR-002 stays withdrawn and
-      `xtask check-workflow-paths`'s `removed_mcp_server_stays_out_of_ci` stays
-      in force. The distribution problem it was reached for — getting agents to
-      use mvm — is solved below without a protocol layer.
+- [x] **Superseded by ADR-048.** ADR-002's bespoke lifecycle/session server
+      remains withdrawn. The revived surface is a strict `dyn MvmClient`
+      adapter whose catalog is derived from the selected client's declared
+      operations. `scripts/test-mcp-roundtrip.sh` is its named no-boot consumer;
+      ordinary workspace tests replace a dedicated MCP CI lane.
 - [x] Add `mvmctl plugin install <agent>` emitting the files an agent needs.
       **Claude Code only.** Emitting a config for an agent whose schema was
       guessed at produces a file that looks installed and does nothing, so only
       a format that can be verified is offered; `plugin list` names what that
       is.
-- [x] The tool set is the CLI. `mvmctl run` already covers `run_command`, and
-      `machine create/exec/ls/stop` the rest — each admitting through a signed
-      plan and auditing itself. A parallel tool surface would be a second name
-      for each.
-- [x] Covered by unit tests instead, and more sharply than a scenario would:
-      every flag and every command the emitted skill names is resolved against
-      the real clap tree, so the skill cannot tell an agent to type something
-      that does not exist. Both mutation-checked red.
+- [x] The MCP tool set is projected from the same `MvmClient` facade used by
+      local and remote consumers; it owns no parallel lifecycle or admission
+      implementation.
+- [x] Protocol behavior is covered against `MockBackend`, and the CLI grammar
+      is covered by unit, integration, and BDD help scenarios without a boot.
 
-**Acceptance:** `mvmctl plugin install claude` writes a skill that tells Claude
-Code to sandbox untrusted commands through `mvmctl run` — which is audited like
-any other run, because it *is* any other run. No `/sandbox` command and no
-server: the skill shells to the CLI.
+**Acceptance:** `mvmctl plugin install claude` still writes a skill that shells
+to the audited CLI. Separately, the named MCP consumer discovers only operations
+the selected `MvmClient` reports and adds no parallel authority path.
 
 ### Phase 7 — Observability and performance
 

--- a/specs/sprint/delivery/2647-mvm-client-mcp.md
+++ b/specs/sprint/delivery/2647-mvm-client-mcp.md
@@ -1,0 +1,10 @@
+- **Revived MCP as a facade adapter (#2647).** `mvm-mcp` now serves the current
+  stateless MCP protocol over bounded stdio, derives its deterministic tool
+  catalog from each `MvmClient` implementation's serialized operation report,
+  and routes every tool through that facade. Mock-only protocol tests cover all
+  operations, strict failures, legacy initialize compatibility, and frame
+  recovery. `mvmctl ops mcp stdio` and the named no-boot roundtrip consumer make
+  the surface usable without adding a dedicated CI lane; ADR-048 supersedes the
+  withdrawn bespoke server decision in ADR-002. Ten protocol tests, 209 passing
+  BDD scenarios, host workspace clippy, gated-target checks, and a static ARM64
+  Linux roundtrip in the libkrun builder cover the delivered surface.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -103,6 +103,7 @@ const ENV_SUB: &[(&str, AuditPosture)] = &[
 const OPS_SUB: &[(&str, AuditPosture)] = &[
     ("metrics", AuditPosture::ReadOnly),
     ("config", AuditPosture::Emits("ConfigChange")),
+    ("mcp", AuditPosture::InteractiveOrControl),
 ];
 
 // `kernel build` compiles/downloads a microVM kernel into the local

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3,6 +3,20 @@
 use assert_cmd::cargo::CommandCargoExt;
 use std::process::Command;
 
+#[test]
+fn ops_mcp_help_advertises_the_stdio_transport() {
+    let out = Command::new(env!("CARGO_BIN_EXE_mvmctl"))
+        .args(["ops", "mcp", "--help"])
+        .output()
+        .expect("run mvmctl ops mcp --help");
+    assert!(
+        out.status.success(),
+        "mcp help must succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(String::from_utf8_lossy(&out.stdout).contains("stdio"));
+}
+
 /// The README's persistent-machine form uses a positional name. Creating the
 /// spec is host-only and must succeed without booting or contacting a VM.
 #[test]

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -57,7 +57,12 @@ const BUDGETS: &[ClosureBudget] = &[
 /// 233 (was 232): `mvm-observability`, the same +1 the Linux budget took —
 /// a workspace crate holding subscriber assembly that `mvm-core` used to
 /// own, carrying no new third-party code on either target.
-const MACOS_CLOSURE_BUDGET: usize = 233;
+///
+/// 231 (was 233): ratcheted to the measured graph after adding `mvm-mcp`, the
+/// stdio-only adapter over the existing `mvm-client` facade. The adapter is one
+/// first-party crate and adds no third-party crate to mvmctl's already-linked
+/// dependency graph.
+const MACOS_CLOSURE_BUDGET: usize = 231;
 
 /// Max distinct crates allowed in `mvmctl`'s default no-dev closure on
 /// `x86_64-unknown-linux-gnu`. Baseline measured 2026-06-17 against the audited default
@@ -185,7 +190,11 @@ const MACOS_CLOSURE_BUDGET: usize = 233;
 /// the sealed guest agent `mvm-agentd` 111 -> 102 (its `tracing-subscriber`
 /// is now gated behind `addons`, since only the helper bins install one).
 /// Measured +1 here, -9 on the guest agent and the embedded musl bins.
-pub(crate) const CLOSURE_BUDGET: usize = 239;
+///
+/// 240 (was 239): `mvm-mcp`, the stdio-only adapter over the existing
+/// `mvm-client` facade. It adds one first-party crate and no third-party crate
+/// to mvmctl's already-linked dependency graph.
+pub(crate) const CLOSURE_BUDGET: usize = 240;
 
 pub fn run(workspace: &Path) -> Result<()> {
     for budget in BUDGETS {

--- a/xtask/src/check_feature_closure_budget.rs
+++ b/xtask/src/check_feature_closure_budget.rs
@@ -42,10 +42,17 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 /// Lower it freely as deps drop; raising it must be justified in the change
 /// that does.
 ///
+/// 477 (was 476): the first-party `mvm-mcp` crate. It is the +1 itself — its
+/// only dependencies are workspace crates already in this closure
+/// (`mvm-client`, `chrono`, `serde`, `serde_json`, `thiserror`, `tokio`), so it
+/// pulls in no third-party graph. That is the distinction this budget exists to
+/// police: it ratchets against *dependency* growth, and a new crate of ours that
+/// vendors nothing is not that.
+///
 /// 476 (was 475): `sigstore-tuf` enters with the sigstore-verify 0.9→0.11
 /// upgrade; it was absent from 0.9's dependency graph and is reachable only
 /// behind the `manifest-verify` optional feature.
-const FEATURE_CLOSURE_BUDGET: usize = 476;
+const FEATURE_CLOSURE_BUDGET: usize = 477;
 
 /// The two gates measure nested sets — everything in the default closure is
 /// reachable with all features on — so a feature budget at or below the default

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -771,7 +771,7 @@ mod tests {
     }
 
     #[test]
-    fn removed_mcp_server_stays_out_of_ci() {
+    fn dedicated_mcp_smoke_lane_stays_out_of_ci() {
         let workflow = ci_workflow();
         for removed in [
             "MCP server stdio roundtrip",
@@ -781,7 +781,7 @@ mod tests {
         ] {
             assert!(
                 !workflow.contains(removed),
-                "removed MCP server CI surface returned: {removed}"
+                "dedicated MCP CI surface must stay absent: {removed}"
             );
         }
     }


### PR DESCRIPTION
## Summary
- restore a bounded stdio MCP server as a thin MvmClient adapter
- derive tool availability from serialized backend operation capabilities
- restore mvmctl ops mcp stdio, protocol tests, BDD coverage, docs, and a no-boot Linux roundtrip consumer

## Validation
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- just check-gated
- just bdd
- static ARM64 Linux MCP roundtrip in the libkrun builder

Closes #2647