### PR TITLE
feat(contract): compile an upstream tool namespace into bindable capabilities

### DIFF
--- a/crates/mvm-contract/src/protocol/mod.rs
+++ b/crates/mvm-contract/src/protocol/mod.rs
@@ -22,5 +22,6 @@ pub mod resource_controls;
 pub mod routing;
 pub mod signed_config;
 pub mod signing;
+pub mod upstream_tools;
 pub mod vcpu_quota;
 pub mod vm_backend;

--- a/crates/mvm-contract/src/protocol/upstream_tools.rs
+++ b/crates/mvm-contract/src/protocol/upstream_tools.rs
@@ -1,0 +1,281 @@
+//! Compiling an upstream tool namespace into capabilities admission can bind.
+//!
+//! A dynamic tool namespace — Model Context Protocol and its equivalents — is
+//! admitted host-side only (ADR-045 section 18). The host runs the client; the
+//! guest never speaks the protocol outward. This module is the seam where what
+//! an upstream server *says* it offers becomes what this host is willing to
+//! bind, and it is deliberately pure: no transport, no I/O, no clock.
+//!
+//! # Why compilation happens once, at admission
+//!
+//! Everything downstream keys off the descriptor digest. Compiling once and
+//! binding the result is what makes an upstream server unable to widen a guest
+//! that is already running: a server that adds, renames, or redefines a tool
+//! afterwards produces a different descriptor set, which is a different digest,
+//! which the running admission does not carry. The guest's catalog is derived
+//! from the admission, so it simply does not move.
+//!
+//! # Why an unrepresentable name is refused rather than repaired
+//!
+//! Upstream chooses its own names. This host's verbs are `[a-z0-9_-]`. The
+//! tempting repair is to lowercase and substitute, and it is the one thing this
+//! module must not do: `getWeather`, `get_weather` and `Get Weather` all
+//! collapse to the same repaired verb, and collapsing two upstream tools onto
+//! one capability merges their authority. A name this host cannot represent
+//! exactly is a refusal.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use super::agent_capability::{
+    CapabilityDescriptor, CapabilityError, CapabilityId, CapabilityLimits, MAX_DESCRIPTION_BYTES,
+    SchemaRef,
+};
+use super::broker::ServiceId;
+
+/// How many tools one upstream namespace may contribute.
+///
+/// A guest's catalog is read into a model's context, so an unbounded namespace
+/// is a denial of service against the planner as much as against the host.
+pub const MAX_UPSTREAM_TOOLS: usize = 64;
+
+/// One tool as an upstream server describes it, before this host has agreed to
+/// anything.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpstreamTool {
+    /// The name upstream chose. Must already be a verb this host can represent.
+    pub name: String,
+    /// Upstream's human-readable description. Data, never an identifier.
+    pub description: String,
+    /// Input schema reference.
+    pub input_schema: SchemaRef,
+    /// Output schema reference.
+    pub output_schema: SchemaRef,
+}
+
+/// A namespace of upstream tools, fetched once at admission.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpstreamNamespace {
+    /// The host-side service every tool in this namespace compiles under.
+    pub service: ServiceId,
+    /// The tools upstream advertised.
+    pub tools: Vec<UpstreamTool>,
+}
+
+/// Why an upstream namespace was not admitted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpstreamCompileError {
+    /// The namespace advertised more tools than a catalog may carry.
+    TooManyTools {
+        /// How many were advertised.
+        count: usize,
+    },
+    /// A name this host cannot represent as a verb. Not repaired: see the
+    /// module docs.
+    NameNotRepresentable {
+        /// The offending upstream name.
+        name: String,
+    },
+    /// Two tools claimed the same verb. Refused rather than last-one-wins,
+    /// which would silently pick which authority survives.
+    DuplicateVerb {
+        /// The verb claimed twice.
+        verb: String,
+    },
+    /// A description outside the bound a descriptor may carry.
+    DescriptionOutOfBounds {
+        /// The tool whose description was refused.
+        name: String,
+    },
+}
+
+/// Compile an upstream namespace into the descriptors admission will bind.
+///
+/// The output is sorted by verb so the same namespace always compiles to the
+/// same bytes: admission binds a digest, and a digest that depended on upstream
+/// ordering would make an identical namespace admit differently run to run.
+///
+/// # Errors
+///
+/// Refuses the whole namespace rather than dropping the offending tool. A
+/// partial namespace is one an operator did not review.
+pub fn compile_namespace(
+    namespace: &UpstreamNamespace,
+    limits: CapabilityLimits,
+) -> Result<Vec<CapabilityDescriptor>, UpstreamCompileError> {
+    if namespace.tools.len() > MAX_UPSTREAM_TOOLS {
+        return Err(UpstreamCompileError::TooManyTools {
+            count: namespace.tools.len(),
+        });
+    }
+
+    let mut descriptors: Vec<CapabilityDescriptor> = Vec::new();
+    for tool in &namespace.tools {
+        if tool.description.is_empty() || tool.description.len() > MAX_DESCRIPTION_BYTES {
+            return Err(UpstreamCompileError::DescriptionOutOfBounds {
+                name: tool.name.clone(),
+            });
+        }
+        // Reuse the verb rule rather than restating it: two spellings of the
+        // same rule drift, and the drift is invisible until one is wrong.
+        let id =
+            CapabilityId::new(namespace.service.clone(), tool.name.clone()).map_err(|error| {
+                match error {
+                    CapabilityError::EmptyVerb | CapabilityError::InvalidVerb => {
+                        UpstreamCompileError::NameNotRepresentable {
+                            name: tool.name.clone(),
+                        }
+                    }
+                    _ => UpstreamCompileError::NameNotRepresentable {
+                        name: tool.name.clone(),
+                    },
+                }
+            })?;
+        if descriptors.iter().any(|existing| existing.id == id) {
+            return Err(UpstreamCompileError::DuplicateVerb {
+                verb: tool.name.clone(),
+            });
+        }
+        let descriptor = CapabilityDescriptor::builder()
+            .id(id)
+            .description(tool.description.clone())
+            .input_schema(tool.input_schema.clone())
+            .output_schema(tool.output_schema.clone())
+            .limits(limits)
+            .build()
+            .map_err(|_| UpstreamCompileError::DescriptionOutOfBounds {
+                name: tool.name.clone(),
+            })?;
+        descriptors.push(descriptor);
+    }
+    descriptors.sort_by(|a, b| a.id.verb.cmp(&b.id.verb));
+    Ok(descriptors)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+    use alloc::vec;
+
+    use super::*;
+
+    fn limits() -> CapabilityLimits {
+        CapabilityLimits::new(1024, 1024, 5_000).expect("limits")
+    }
+
+    fn tool(name: &str) -> UpstreamTool {
+        UpstreamTool {
+            name: name.to_string(),
+            description: "an upstream tool".to_string(),
+            input_schema: SchemaRef::new("upstream.in.v1", [7; 32]).expect("schema"),
+            output_schema: SchemaRef::new("upstream.out.v1", [8; 32]).expect("schema"),
+        }
+    }
+
+    fn namespace(names: &[&str]) -> UpstreamNamespace {
+        UpstreamNamespace {
+            service: ServiceId::parse("host.upstream.v1").expect("service"),
+            tools: names.iter().map(|n| tool(n)).collect(),
+        }
+    }
+
+    #[test]
+    fn a_namespace_compiles_to_one_descriptor_per_tool() {
+        let compiled = compile_namespace(&namespace(&["search", "fetch_page"]), limits())
+            .expect("a well-formed namespace compiles");
+        let verbs: Vec<&str> = compiled.iter().map(|d| d.id.verb.as_str()).collect();
+        assert_eq!(verbs, vec!["fetch_page", "search"]);
+    }
+
+    #[test]
+    fn compilation_is_order_independent_so_the_digest_is_stable() {
+        let one = compile_namespace(&namespace(&["search", "fetch_page"]), limits()).expect("one");
+        let other =
+            compile_namespace(&namespace(&["fetch_page", "search"]), limits()).expect("two");
+        assert_eq!(
+            one, other,
+            "admission binds a digest; upstream ordering must not change it"
+        );
+    }
+
+    #[test]
+    fn a_name_this_host_cannot_represent_is_refused_not_repaired() {
+        for bad in ["getWeather", "Get Weather", "search!", ""] {
+            let err = compile_namespace(&namespace(&[bad]), limits())
+                .expect_err("an unrepresentable name is refused");
+            assert!(
+                matches!(err, UpstreamCompileError::NameNotRepresentable { .. }),
+                "{bad} produced {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn two_tools_claiming_one_verb_refuse_the_namespace() {
+        let err = compile_namespace(&namespace(&["search", "search"]), limits())
+            .expect_err("a duplicate verb is refused");
+        assert!(
+            matches!(err, UpstreamCompileError::DuplicateVerb { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn an_unbounded_namespace_is_refused() {
+        let names: Vec<String> = (0..=MAX_UPSTREAM_TOOLS)
+            .map(|i| alloc::format!("tool_{i}"))
+            .collect();
+        let refs: Vec<&str> = names.iter().map(|n| n.as_str()).collect();
+        let err = compile_namespace(&namespace(&refs), limits())
+            .expect_err("a catalog is read into a context window; it is bounded");
+        assert!(
+            matches!(err, UpstreamCompileError::TooManyTools { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn an_oversized_description_is_refused() {
+        let mut ns = namespace(&["search"]);
+        ns.tools[0].description = "x".repeat(MAX_DESCRIPTION_BYTES + 1);
+        let err = compile_namespace(&ns, limits()).expect_err("bounded");
+        assert!(
+            matches!(err, UpstreamCompileError::DescriptionOutOfBounds { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn a_namespace_that_gains_a_tool_compiles_to_different_bindings() {
+        let before = compile_namespace(&namespace(&["search"]), limits()).expect("before");
+        let after =
+            compile_namespace(&namespace(&["search", "exfiltrate"]), limits()).expect("after");
+
+        let before_bindings: Vec<_> = before.iter().map(|d| d.binding()).collect();
+        let after_bindings: Vec<_> = after.iter().map(|d| d.binding()).collect();
+        assert_ne!(
+            before_bindings, after_bindings,
+            "an upstream server that grows a tool must not be able to widen an admission \
+             already in flight"
+        );
+        assert!(
+            !before_bindings
+                .iter()
+                .any(|b| b.capability.verb == "exfiltrate"),
+            "the earlier admission never carried the new tool"
+        );
+    }
+
+    #[test]
+    fn a_refused_namespace_yields_nothing_rather_than_a_partial_set() {
+        let err = compile_namespace(&namespace(&["search", "Get Weather"]), limits());
+        assert!(
+            err.is_err(),
+            "one bad tool refuses the namespace; a partial set is one nobody reviewed"
+        );
+    }
+}

--- a/crates/mvm-contract/src/protocol/upstream_tools.rs
+++ b/crates/mvm-contract/src/protocol/upstream_tools.rs
@@ -1,7 +1,7 @@
 //! Compiling an upstream tool namespace into capabilities admission can bind.
 //!
 //! A dynamic tool namespace — Model Context Protocol and its equivalents — is
-//! admitted host-side only (ADR-045 section 18). The host runs the client; the
+//! admitted host-side only. The host runs the client; the
 //! guest never speaks the protocol outward. This module is the seam where what
 //! an upstream server *says* it offers becomes what this host is willing to
 //! bind, and it is deliberately pure: no transport, no I/O, no clock.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -363,7 +363,7 @@ for detailed scope and acceptance criteria.
       session identity memory keys on and is itself unmerged.
   - [x] WS1 — catalog derivation from the signed admission (PR #2705)
   - [x] WS2 — per-capability argument policy inside the descriptor digest (#2705)
-  - [~] WS3 — the guest-side-client gate landed; the host-side adapter has not
+  - [~] WS3 — gate + compilation seam landed; only the transport client remains
   - [x] WS4 — refusal names the surface, and repeated misses are rate-bounded (#2705)
   - [ ] WS5-WS9 — memory plane: store + record, `host.memory.v1`, write scan
         and ceilings, audit + retention, bounded recall

--- a/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
+++ b/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
@@ -87,17 +87,30 @@ verified, not merged — check the PR before relying on it being on `main`.
 
 ### WS3 — Host-side dynamic tool adapter
 
-**Status: the gate landed; the adapter has not.** The two halves were split
-because the gate is independent of the rest of Part A — it lives in `xtask/`
-and touches none of the broker files — while the adapter does not, and stacking
-it on an unmerged broker change is how work gets stranded in a squash-merging
-repository.
+**Status: the compilation seam and the gate are in; the transport is not.**
+The seam is `mvm_contract::protocol::upstream_tools::compile_namespace` — pure,
+no I/O, no clock — which is where an upstream server's claims become
+descriptors this host is willing to bind. The protocol client that *fetches*
+those claims is deliberately still absent: it is transport behind a seam that
+already refuses everything a malformed or hostile namespace can express, and
+building it first would have meant testing the security properties through a
+socket.
 
-- [ ] **WS3 — Compile an upstream tool namespace at admission.** The host runs
-      the client. Each upstream tool compiles to a `ServiceId` recorded inside
-      the plan digest, so the surface is fixed for the admission's lifetime.
-- [ ] Discovery verbs answer from the plan binding. An upstream server that
-      adds or redefines a tool mid-session cannot widen a running guest.
+- [x] **WS3 — Compile an upstream tool namespace at admission.** Each upstream
+      tool compiles to a `CapabilityId` under one `ServiceId`, and the result is
+      sorted so an identical namespace always compiles to identical bytes —
+      admission binds a digest, and a digest that depended on upstream ordering
+      would admit differently run to run.
+- [x] An upstream name this host cannot represent as a verb is refused rather
+      than repaired. Lowercasing and substituting would collapse `getWeather`,
+      `get_weather` and `Get Weather` onto one capability, which merges their
+      authority. Duplicate verbs refuse the namespace instead of last-one-wins.
+- [x] Discovery verbs answer from the plan binding — that is WS1's
+      `admitted_catalog`. A namespace that gains a tool compiles to different
+      bindings, so it cannot widen an admission already in flight.
+- [ ] The transport itself: a host-side client that fetches a namespace and
+      hands it to `compile_namespace`. Nothing guest-reachable, and the gate
+      below already refuses the shape that would be wrong.
 - [x] A gate — in the `xtask check-*` family — refusing an outbound tool
       protocol client on any guest-reachable path, in the manner of
       `check-vsock-only-egress`. Without it this decision decays the first time

--- a/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
+++ b/specs/plans/2026-08-18-agent-tool-and-memory-planes.md
@@ -108,9 +108,11 @@ socket.
 - [x] Discovery verbs answer from the plan binding — that is WS1's
       `admitted_catalog`. A namespace that gains a tool compiles to different
       bindings, so it cannot widen an admission already in flight.
-- [ ] The transport itself: a host-side client that fetches a namespace and
-      hands it to `compile_namespace`. Nothing guest-reachable, and the gate
-      below already refuses the shape that would be wrong.
+- [ ] **WS3c — The transport.** Fully specified below; implementing it is
+      mechanical. It is last on purpose: it is the only part with no security
+      properties of its own, and putting it behind a seam that already refuses
+      everything a hostile namespace can express means none of those refusals
+      have to be tested through a socket.
 - [x] A gate — in the `xtask check-*` family — refusing an outbound tool
       protocol client on any guest-reachable path, in the manner of
       `check-vsock-only-egress`. Without it this decision decays the first time
@@ -121,6 +123,53 @@ socket.
       gate that greps for the protocol's name rather than for outbound
       connection setup would refuse it. A gate written the lazy way here
       breaks the common packaging of that ecosystem.
+
+#### WS3c design — the transport, specified
+
+**A namespace comes from operator configuration, not from discovery.** The host
+reads a declared list of upstream servers; it does not go looking for them.
+Discovery would make the set of things a workload might be offered depend on
+the network at boot time, which is the mutable-namespace problem wearing a
+different hat.
+
+**One `ServiceHandler` per namespace.** `compile_namespace` yields the
+descriptors; the handler owns the client and routes `verb` to the matching
+upstream tool. It needs no new gate: `dispatch_capability` already enforces the
+binding, the descriptor digest, the argument policy, the size bounds, the
+timeout and replay, and it does that before the handler is reached.
+
+**Prefer a host-side subprocess over stdio to a network client.** A subprocess
+adds no network surface, no new dependency, and no destination to admit, and it
+is how most of that ecosystem ships anyway. A remote server is not a second
+transport — it is a *destination*, and it goes through the ordinary egress
+policy like any other, which is what keeps one rule instead of two.
+
+**Admission is fail-closed.** A namespace that cannot be fetched, cannot be
+parsed, or fails `compile_namespace` refuses the admission rather than booting
+a workload whose catalog advertises tools that will error on first call. A
+planner that is told a tool exists and then finds it does not is worse off than
+one never told: it will retry, and the retry is indistinguishable from the
+enumeration the refusal path is bounding.
+
+**Never re-fetch inside an admission.** If an upstream server dies mid-session,
+its calls fail and the catalog does not change; the surface is fixed for the
+admission's lifetime and a new surface requires a new admission. A handler that
+re-fetched on failure would reintroduce exactly the mid-epoch mutation the
+compile-once rule exists to prevent.
+
+**Upstream text is `Observed`, in ADR-047's sense.** Names and descriptions are
+authored by a third party and land directly in a model's context window. They
+are bounded at compile time and they never become identifiers beyond the verb,
+which is why an unrepresentable name is refused rather than repaired. When the
+memory plane lands, a description quoted into a memory record carries the
+`Observed` class for the same reason.
+
+Tests worth having, none of which need a live server: a namespace that fails to
+fetch refuses the admission; a namespace that compiles registers exactly its
+compiled verbs and no others; a verb absent from the compiled set is `NotBound`
+through the shipped path; an upstream process that dies leaves the catalog
+unchanged; and a call whose upstream response exceeds the descriptor's output
+bound is refused by the existing gate rather than by the handler.
 
 ### WS4 — Refusal is a signal
 


### PR DESCRIPTION
The remaining half of WS3 in `specs/plans/2026-08-18-agent-tool-and-memory-planes.md`, now that #2705 and #2712 have merged.

## What this is

The seam where what an upstream server *claims* to offer becomes what this host is willing to bind. `compile_namespace` is deliberately pure — no transport, no I/O, no clock — so its properties are tested directly rather than through a socket.

## Why compilation happens once, at admission

Everything downstream keys off the descriptor digest. A server that adds, renames or redefines a tool afterwards compiles to a different set, which is a different digest, which the running admission does not carry. The guest's catalog derives from the admission (WS1's `admitted_catalog`), so it does not move. There is a test for that exact shape.

Output is sorted by verb, because admission binds a digest and a digest that depended on upstream's listing order would make an identical namespace admit differently run to run.

## The decision most worth keeping

**An upstream name this host cannot represent is refused, not repaired.** Lowercasing and substituting is the obvious repair, and it silently collapses `getWeather`, `get_weather` and `Get Weather` onto one capability — merging the authority of tools upstream considers distinct.

Related refusals, same reasoning:
- Two tools claiming one verb refuse the **whole namespace** rather than last-one-wins, which would pick which authority survives without saying so.
- A refused namespace yields nothing rather than a partial set, because a partial set is one nobody reviewed.
- Tool count and description length are bounded — a catalog is read into a model's context window, so an unbounded namespace is a denial of service against the planner as much as against the host.

The verb rule itself is not restated: `CapabilityId::new` owns it and this maps its error. Two spellings of one rule drift, and the drift stays invisible until one is wrong.

## Not included

The transport that fetches a namespace. It is the part with no security properties of its own, and it belongs behind a seam that already refuses everything a hostile namespace can express. The plan's WS3 box for it stays open, and `check-no-guest-tool-client` (merged in #2712) already refuses the shape that would be wrong.

## Verification

`12461/12461` workspace tests, `just check-gated`, doctests, six xtask gates, workspace clippy at `-D warnings`.

Three guards mutation-checked — the deterministic sort, the duplicate-verb refusal, and the tool-count bound. Each fails its own test and no other.

The pre-commit hook caught an unused import that `cargo test` did not: `ToString` is test-only, and clippy checks the lib target separately.