### PR TITLE
fix(update): fetch published images from the boot image tag, not the CLI version

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -29,11 +29,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Install system build dependencies
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
-          sudo apt-get update
-          sudo apt-get install -y libcap-ng-dev lld
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: libcap-ng-dev lld
 
       - uses: ./.github/actions/install-zigbuild
 

--- a/crates/mvm-build/src/release_signature.rs
+++ b/crates/mvm-build/src/release_signature.rs
@@ -57,6 +57,26 @@ pub struct ReleaseSignatureRequest<'a> {
     /// Version whose signing identity is accepted. The release identity is
     /// tag-bound, so this pins *which* release may have signed the archive.
     pub version: &'a str,
+    /// Which release train published the asset, and therefore which workflow
+    /// identity may have signed it.
+    pub train: ReleaseTrain,
+}
+
+/// The release train an asset was published on.
+///
+/// The two trains sign different artifact classes under different refs, and
+/// `mvm_core::release_trust` keeps their identity sets deliberately disjoint so
+/// a signature minted over a boot image cannot validate a CLI tarball or the
+/// reverse. Making the caller name its train keeps that separation a decision
+/// at the fetch site rather than an accident of which helper it reached for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ReleaseTrain {
+    /// `release.yml`, signing CLI tarballs under `refs/tags/v<version>`.
+    #[default]
+    Cli,
+    /// `release-boot-image.yml`, signing images under
+    /// `refs/tags/boot-image/v<version>`.
+    BootImage,
 }
 
 /// Verify `request`'s archive against the release workflow's keyless signing
@@ -106,11 +126,17 @@ fn verify_against_release_identities(
     bundle: &[u8],
     request: &ReleaseSignatureRequest<'_>,
 ) -> Result<(), RuntimeOverlayError> {
+    let identities = match request.train {
+        ReleaseTrain::Cli => mvm_core::release_trust::accepted_release_identities(request.version),
+        ReleaseTrain::BootImage => {
+            mvm_core::release_trust::accepted_boot_image_identities(request.version)
+        }
+    };
     verify_release_archive_bytes(
         archive,
         bundle,
         request.asset,
-        &mvm_core::release_trust::accepted_release_identities(request.version),
+        &identities,
         mvm_core::release_trust::RELEASE_OIDC_ISSUER,
     )
 }
@@ -196,6 +222,7 @@ mod tests {
             asset: ASSET,
             archive_path: &path,
             version: FIXTURE_VERSION,
+            train: ReleaseTrain::Cli,
         })
         .map_err(|e| e.to_string())
     }

--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -935,6 +935,10 @@ pub fn download_runtime_overlay(
             asset: &names.archive,
             archive_path: &archive_local,
             version,
+            // Unchanged: this path still resolves its base URL from the CLI
+            // version, so its signature train must stay the CLI one. Splitting
+            // its download tag from its cache key is a separate change.
+            train: crate::release_signature::ReleaseTrain::Cli,
         },
     )?;
     extract_release_archive(&archive_local, stage, &OVERLAY_ARCHIVE_MEMBERS)?;

--- a/crates/mvm-build/src/sdk_sidecar.rs
+++ b/crates/mvm-build/src/sdk_sidecar.rs
@@ -148,6 +148,9 @@ pub fn download_sdk_sidecar(
             asset: &names.archive,
             archive_path: &archive_local,
             version,
+            // Unchanged for the same reason as the runtime overlay: the base
+            // URL is still CLI-version-derived, so the train must match it.
+            train: crate::release_signature::ReleaseTrain::Cli,
         },
     )?;
 

--- a/crates/mvm-cli/src/commands/env/artifact_verify.rs
+++ b/crates/mvm-cli/src/commands/env/artifact_verify.rs
@@ -65,6 +65,9 @@ pub(crate) struct ChecksumManifest<'a> {
     pub asset: &'a str,
     /// Release version whose signing identity is accepted for this manifest.
     pub version: &'a str,
+    /// Which release train published the manifest, and therefore which
+    /// workflow identity may have signed it.
+    pub train: mvm_build::release_signature::ReleaseTrain,
 }
 
 impl ChecksumManifest<'_> {
@@ -150,6 +153,7 @@ pub(super) fn verify_manifest_signature(
             asset: manifest.asset,
             archive_path: staged,
             version: manifest.version,
+            train: manifest.train,
         },
     )
     .map_err(|error| {
@@ -391,6 +395,7 @@ mod tests {
             base_url,
             asset: MANIFEST_ASSET,
             version: MANIFEST_VERSION,
+            train: mvm_build::release_signature::ReleaseTrain::Cli,
         }
     }
 

--- a/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
@@ -556,8 +556,11 @@ fn download_default_microvm_image(
     kernel_path: &str,
     rootfs_path: &str,
 ) -> Result<(String, String)> {
-    let version = env!("CARGO_PKG_VERSION");
-    let base_url = format!("https://github.com/tinylabscom/mvm/releases/download/v{version}");
+    // The default microVM ships on the boot image counter, not the CLI's. See
+    // `update::boot_image_release` for why deriving this from CARGO_PKG_VERSION
+    // 404s for most of a release cycle.
+    let (tag, image_version) = crate::update::boot_image_release()?;
+    let base_url = format!("https://github.com/tinylabscom/mvm/releases/download/{tag}");
     let arch = if cfg!(target_arch = "aarch64") {
         "aarch64"
     } else {
@@ -567,16 +570,15 @@ fn download_default_microvm_image(
     let assets = default_microvm_assets(cache_dir, arch);
     let checksums_name = format!("default-microvm-{arch}-checksums-sha256.txt");
 
-    ui::info(&format!(
-        "Downloading default microVM image (v{version})..."
-    ));
+    ui::info(&format!("Downloading default microVM image ({tag})..."));
 
     let asset_names: Vec<&str> = assets.iter().map(|(n, _)| n.as_str()).collect();
     let expected = fetch_expected_hashes(
         &ChecksumManifest {
             base_url: &base_url,
             asset: &checksums_name,
-            version,
+            version: &image_version,
+            train: mvm_build::release_signature::ReleaseTrain::BootImage,
         },
         &asset_names,
     )?;

--- a/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
@@ -895,7 +895,9 @@ pub(super) fn promote_builder_vm_stage0_cache(
 pub(super) fn download_builder_vm_image(arch: &str, cache_dir: &str) -> Result<()> {
     let version = env!("CARGO_PKG_VERSION");
     let names = builder_vm_artifact_names(arch);
-    let base_url = format!("https://github.com/tinylabscom/mvm/releases/download/v{version}");
+    // Builder-VM images ship on the boot image counter, not the CLI's.
+    let (tag, image_version) = crate::update::boot_image_release()?;
+    let base_url = format!("https://github.com/tinylabscom/mvm/releases/download/{tag}");
     let kernel_url = format!("{base_url}/{}", names.kernel);
     let rootfs_url = format!("{base_url}/{}", names.rootfs);
     let cmdline_url = format!("{base_url}/{}", names.cmdline);
@@ -908,7 +910,8 @@ pub(super) fn download_builder_vm_image(arch: &str, cache_dir: &str) -> Result<(
         &ChecksumManifest {
             base_url: &base_url,
             asset: &names.checksums,
-            version,
+            version: &image_version,
+            train: mvm_build::release_signature::ReleaseTrain::BootImage,
         },
         &[
             &names.kernel,

--- a/crates/mvm-cli/src/commands/image/boot/update.rs
+++ b/crates/mvm-cli/src/commands/image/boot/update.rs
@@ -95,17 +95,15 @@ fn fetch_into(dir: &Path, tag: &str) -> Result<()> {
     let checksums = format!("default-microvm-{arch}-checksums-sha256.txt");
     let names: Vec<&str> = assets.iter().map(|(name, _)| name.as_str()).collect();
 
-    // The manifest's signing identity is tag-bound. The boot-image release
-    // train has not published its first tag yet, so the identity this resolves
-    // to is the binary train's; when the image train ships, its own identity
-    // belongs here. Until then this rung fails closed rather than admitting
-    // unverified bytes, which is the safe direction to be wrong in.
+    // The manifest's signing identity is tag-bound, and the image train has now
+    // published, so its own identity is what belongs here.
     let version = tag.strip_prefix("boot-image/v").unwrap_or(tag);
     let expected = fetch_expected_hashes(
         &ChecksumManifest {
             base_url: &base_url,
             asset: &checksums,
             version,
+            train: mvm_build::release_signature::ReleaseTrain::BootImage,
         },
         &names,
     )?;

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -107,7 +107,56 @@ fn strip_v_prefix(tag: &str) -> &str {
 /// serve one picks the artifact; TLS says nothing about who wrote it. Refuses
 /// on a missing, unparseable, or foreign-signed bundle — the shared release
 /// verifier does the deciding.
-fn fetch_signed_checksum_manifest(base_url: &str, asset: &str, version: &str) -> Result<String> {
+/// The boot image release every published guest artifact is fetched from, as
+/// `(tag, bare-semver)`.
+///
+/// Deliberately *not* the CLI's own version. Those are separate counters: the
+/// CLI ships from `v<crate version>` and the images from `boot-image/vN`, so a
+/// kernel fix does not wait for a CLI release. Deriving the image URL from
+/// `CARGO_PKG_VERSION` meant every build between two CLI releases pointed at a
+/// tag nobody had published — a 404 on the first boot of a fresh install, for
+/// most of the CLI's life rather than at its edges.
+///
+/// The bare semver is what `release_trust`'s boot image identity template
+/// interpolates, so it is derived here rather than re-split at each call site.
+pub(crate) fn boot_image_release() -> Result<(String, String)> {
+    let tag = mvm_core::config::DEFAULT_BOOT_IMAGE_TAG;
+    let version = tag.rsplit_once("/v").map(|(_, v)| v).with_context(|| {
+        format!("boot image tag {tag:?} is not of the form `boot-image/v<semver>`")
+    })?;
+    Ok((tag.to_string(), version.to_string()))
+}
+
+/// Asset and checksum-manifest names for a kernel variant on the boot image
+/// release.
+///
+/// The two release trains name the same bytes differently: `kernel-build.yml`
+/// publishes `vmlinux-<arch>-<variant>`, while `release-boot-image.yml`
+/// publishes the kernel *inside* the image it belongs to. The workload kernel
+/// is `nix/images/default-tenant`'s, whose flake states it is "the single
+/// shared definition in `nix/images/kernel/`, identical to the one builder-vm
+/// builds" — so the mapping is a rename, not a substitution.
+fn boot_image_kernel_assets(arch: &str, variant: &str) -> Result<(String, String)> {
+    let image = match variant {
+        "workload" => "default-microvm",
+        "builder" => "builder-vm",
+        other => anyhow::bail!(
+            "unknown kernel variant {other:?}: the boot image publishes only the \
+             workload (default-microvm) and builder (builder-vm) kernels"
+        ),
+    };
+    Ok((
+        format!("{image}-vmlinux-{arch}"),
+        format!("{image}-{arch}-checksums-sha256.txt"),
+    ))
+}
+
+fn fetch_signed_checksum_manifest(
+    base_url: &str,
+    asset: &str,
+    version: &str,
+    train: mvm_build::release_signature::ReleaseTrain,
+) -> Result<String> {
     let staged = tempfile::NamedTempFile::new()
         .with_context(|| format!("creating staging file for {asset}"))?;
     http::download_file(&format!("{base_url}/{asset}"), staged.path())
@@ -118,6 +167,7 @@ fn fetch_signed_checksum_manifest(base_url: &str, asset: &str, version: &str) ->
             asset,
             archive_path: staged.path(),
             version,
+            train,
         },
     )
     .with_context(|| format!("refusing to parse an unauthenticated checksum manifest ({asset})"))?;
@@ -290,9 +340,8 @@ fn kernel_fetch_hint(tag: &str, asset: &str, release_exists: bool) -> String {
 /// locally, so downloading the release-matched kernel is their supported
 /// acquisition path.
 pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<()> {
-    let tag = format!("v{}", current_version());
-    let asset = format!("vmlinux-{arch}-{variant}");
-    let checksums = format!("kernel-{arch}-checksums-sha256.txt");
+    let (tag, image_version) = boot_image_release()?;
+    let (asset, checksums) = boot_image_kernel_assets(arch, variant)?;
     let base = github_download_base();
 
     if let Some(parent) = dest.parent() {
@@ -322,7 +371,12 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
     // waives comparing the digest, not the question of who published the
     // manifest the digest comes from. Waiving the publisher takes the separate
     // MVM_SKIP_COSIGN_VERIFY.
-    let manifest = fetch_signed_checksum_manifest(&release_base, &checksums, current_version())?;
+    let manifest = fetch_signed_checksum_manifest(
+        &release_base,
+        &checksums,
+        &image_version,
+        mvm_build::release_signature::ReleaseTrain::BootImage,
+    )?;
 
     if std::env::var("MVM_SKIP_HASH_VERIFY").is_ok() {
         ui::warn("MVM_SKIP_HASH_VERIFY set — skipping kernel checksum verification (never in CI).");
@@ -903,6 +957,64 @@ pub fn update(check_only: bool, force: bool, skip_verify: bool) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    /// The image counter and the CLI counter are different numbers, and the
+    /// fetch URL has to follow the image one.
+    #[test]
+    fn the_boot_image_release_is_not_the_cli_version() {
+        let (tag, version) = boot_image_release().expect("a well-formed pinned tag");
+        assert!(
+            tag.starts_with("boot-image/v"),
+            "images ship on their own counter: {tag}"
+        );
+        assert_eq!(tag, format!("boot-image/v{version}"));
+        assert_ne!(
+            tag,
+            format!("v{}", current_version()),
+            "deriving the image tag from the CLI version is the bug this fixes"
+        );
+    }
+
+    /// The bare semver is what the boot image identity template interpolates,
+    /// so a tag that does not split cleanly would silently accept no identity.
+    #[test]
+    fn the_image_version_matches_the_signing_identity_template() {
+        let (_tag, version) = boot_image_release().expect("tag");
+        let identities = mvm_core::release_trust::accepted_boot_image_identities(&version);
+        assert!(
+            identities
+                .iter()
+                .any(|i| i.ends_with(&format!("refs/tags/boot-image/v{version}"))),
+            "identity must bind the published tag: {identities:?}"
+        );
+    }
+
+    /// The two release trains name the same kernel differently; this is the
+    /// rename, and getting it wrong would fetch the *other* kernel.
+    #[test]
+    fn kernel_variants_map_to_their_published_image_assets() {
+        assert_eq!(
+            boot_image_kernel_assets("aarch64", "workload").unwrap(),
+            (
+                "default-microvm-vmlinux-aarch64".to_string(),
+                "default-microvm-aarch64-checksums-sha256.txt".to_string()
+            )
+        );
+        assert_eq!(
+            boot_image_kernel_assets("x86_64", "builder").unwrap(),
+            (
+                "builder-vm-vmlinux-x86_64".to_string(),
+                "builder-vm-x86_64-checksums-sha256.txt".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn an_unknown_kernel_variant_is_refused_rather_than_guessed() {
+        let err = boot_image_kernel_assets("aarch64", "initramfs")
+            .expect_err("only workload and builder kernels are published");
+        assert!(format!("{err}").contains("unknown kernel variant"), "{err}");
+    }
+
     use super::*;
     use sha2::{Digest, Sha256};
     use std::io::Write;

--- a/crates/mvm-cli/src/update.rs
+++ b/crates/mvm-cli/src/update.rs
@@ -107,6 +107,21 @@ fn strip_v_prefix(tag: &str) -> &str {
 /// serve one picks the artifact; TLS says nothing about who wrote it. Refuses
 /// on a missing, unparseable, or foreign-signed bundle — the shared release
 /// verifier does the deciding.
+/// Download a GitHub release asset.
+///
+/// Release asset URLs always answer `302` and redirect to blob storage, and
+/// `mvm_http` deliberately does not follow redirects ("no HTTP/2, no redirect
+/// following ..." — every one of its other callers has already disabled them).
+/// So a release fetch routed through it fails on the redirect no matter how
+/// correct the URL is. Reuses the curl downloader the working release paths
+/// already use, whose `-fSL` follows the redirect and fails on HTTP error.
+fn download_release_asset(url: &str, dest: &Path) -> Result<()> {
+    let dest_str = dest
+        .to_str()
+        .with_context(|| format!("release asset destination is not UTF-8: {}", dest.display()))?;
+    crate::commands::env::artifact_verify::download_file(url, dest_str)
+}
+
 /// The boot image release every published guest artifact is fetched from, as
 /// `(tag, bare-semver)`.
 ///
@@ -159,7 +174,7 @@ fn fetch_signed_checksum_manifest(
 ) -> Result<String> {
     let staged = tempfile::NamedTempFile::new()
         .with_context(|| format!("creating staging file for {asset}"))?;
-    http::download_file(&format!("{base_url}/{asset}"), staged.path())
+    download_release_asset(&format!("{base_url}/{asset}"), staged.path())
         .with_context(|| format!("downloading {asset} — cannot verify integrity"))?;
     mvm_build::release_signature::verify_release_archive_signature(
         &mvm_build::release_signature::ReleaseSignatureRequest {
@@ -263,7 +278,7 @@ fn download_release(version: &str, target: &str, tmp_dir: &Path) -> Result<()> {
 
     let sp = ui::spinner(&format!("Downloading {}...", download_url));
 
-    http::download_file(&download_url, &dest).with_context(|| {
+    download_release_asset(&download_url, &dest).with_context(|| {
         format!(
             "Download failed. Check that {} has a release for {}.",
             version, target
@@ -363,7 +378,7 @@ pub(crate) fn download_kernel(arch: &str, variant: &str, dest: &Path) -> Result<
         })?
         .into_temp_path();
     let sp = ui::spinner(&format!("Downloading {asset} ({tag})..."));
-    let dl = http::download_file(&asset_url, &download);
+    let dl = download_release_asset(&asset_url, &download);
     sp.finish_and_clear();
     dl.with_context(|| kernel_fetch_hint(&tag, &asset, release_exists(&tag)))?;
 
@@ -770,7 +785,7 @@ fn verify_signature(version: &str, archive_name: &str, archive_path: &Path) -> R
         .join(&bundle_name);
 
     ui::info("Downloading signature bundle...");
-    http::download_file(&bundle_url, &bundle_path)
+    download_release_asset(&bundle_url, &bundle_path)
         .context("Failed to download cosign bundle — cannot verify signature")?;
 
     let output = std::process::Command::new(&cosign)

--- a/specs/sprint/delivery/bdd-bounded-apt.md
+++ b/specs/sprint/delivery/bdd-bounded-apt.md
@@ -1,0 +1,29 @@
+# BDD setup uses the bounded apt path
+
+**Status:** COMPLETE
+
+## Failure reproduced
+
+Three independent BDD jobs exhausted their 30-minute job budget in `apt-get
+update` without reaching the suite. The shared `.github/actions/apt-deps`
+action already replaces the hosted runner's unreliable Azure mirrorlist and
+bounds each update/install attempt, but `.github/workflows/bdd.yml` bypassed it
+with raw `apt-get` commands.
+
+## Delivered
+
+- The canonical reusable BDD workflow now installs `libcap-ng-dev` and `lld`
+  through `.github/actions/apt-deps`.
+- A workflow-structure regression test refuses any return to raw `sudo
+  apt-get` in that workflow and requires the shared action.
+
+This changes setup behavior only. The BDD command, cache policy, SDK suites,
+and 30-minute job ceiling are unchanged.
+
+## Validation
+
+- The exact new test was run before the workflow edit and failed on the
+  missing shared action.
+- `cargo test --test github_actions_bdd_gate
+  canonical_bdd_workflow_uses_bounded_apt_action -- --exact`: 1 passed.
+- `cargo test --test github_actions_bdd_gate`: 6 passed.

--- a/tests/github_actions_bdd_gate.rs
+++ b/tests/github_actions_bdd_gate.rs
@@ -64,6 +64,19 @@ fn canonical_bdd_workflow_runs_the_full_suite() {
 }
 
 #[test]
+fn canonical_bdd_workflow_uses_bounded_apt_action() {
+    let contents = workflow("bdd.yml");
+    assert!(
+        contents.contains("uses: ./.github/actions/apt-deps"),
+        "BDD setup must inherit the shared mirror replacement, timeouts, and retries"
+    );
+    assert!(
+        !contents.contains("sudo apt-get"),
+        "BDD setup must not bypass the bounded apt action"
+    );
+}
+
+#[test]
 fn runtime_release_publication_needs_bdd() {
     assert_reuses_bdd_gate("release.yml");
     assert_job_needs_bdd("release.yml", "release");

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -1574,3 +1574,41 @@ fn default_tenant_exports_and_ci_counts_the_rootfs_closure() {
         "the footprint CI gate must consume the exported closure inventory"
     );
 }
+
+/// No published-image fetch may build its release URL from the CLI's own
+/// version.
+///
+/// The CLI ships from `v<crate version>`; the guest images ship from
+/// `boot-image/vN`, on a counter that moves independently so a kernel fix does
+/// not wait for a CLI release. Deriving an image URL from `CARGO_PKG_VERSION`
+/// therefore points at a tag nobody has published for most of a release cycle —
+/// a 404 on the first boot of a fresh install, which is exactly how it shipped.
+///
+/// `runtime_overlay.rs` and `sdk_sidecar.rs` are deliberately excluded: their
+/// version is also the on-disk cache key, so splitting their download tag from
+/// their cache identity is a separate change, not a rename.
+#[test]
+fn image_fetches_do_not_derive_their_release_url_from_the_cli_version() {
+    let cli = repo_dir().join("crates/mvm-cli/src");
+    let offenders: Vec<String> = [
+        "commands/env/builder_vm/default_microvm.rs",
+        "commands/env/builder_vm/stage0_cache.rs",
+        "commands/image/boot/update.rs",
+        "update.rs",
+    ]
+    .iter()
+    .filter(|rel| {
+        fs::read_to_string(cli.join(rel))
+            .unwrap_or_default()
+            .contains("releases/download/v{version}")
+    })
+    .map(|rel| (*rel).to_string())
+    .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "these build an image release URL from the CLI version, which 404s \
+         whenever the crate version is ahead of the last CLI tag: {offenders:?}. \
+         Use `update::boot_image_release()`."
+    );
+}


### PR DESCRIPTION
Closes #2675 — which was **closed as completed on 2026-08-18 with the code unchanged**. `download_kernel` still built its URL from `CARGO_PKG_VERSION`, so the bug is live.

## The bug, still reproducible

The CLI ships from `v<crate version>`; the guest images ship from `boot-image/vN`, on a counter that moves independently so a kernel fix does not wait for a CLI release. Deriving an image URL from the crate version points at a tag nobody has published for most of a release cycle:

| | |
|---|---|
| workspace version | `0.18.0` |
| `v0.18.0` release | **does not exist** |
| newest release with kernel assets | `v0.16.0` |

So a lean client — the one that *cannot* compile kernels, whose "supported acquisition path" this is — 404s.

## The switch was scaffolded and waiting

Three separate places in the tree pre-marked this, each naming the same unblock condition:

- `DEFAULT_BOOT_IMAGE_TAG`: *"**Nothing reads this yet.** ... Publishing that tag is the condition that unblocks the switch."*
- `boot/update.rs`: *"the boot-image release train has not published its first tag yet ... **when the image train ships, its own identity belongs here.**"*
- `release_trust`'s boot image identity templates: **no caller outside their own tests.**

`boot-image/v0.1.0` published on 2026-08-19 with 42 assets. The condition is met.

## What moves

Four fetch paths: the kernel, the default microVM image, the Stage 0 builder image, and `image boot update`.

Each now also declares **which release train** signed what it fetched. The two trains sign different artifact classes under different refs, and `release_trust` keeps their identity sets deliberately disjoint so a boot image signature cannot validate a CLI tarball or the reverse. A `ReleaseTrain` on the request makes that a decision at the fetch site rather than an accident of which helper the caller reached for.

## The kernel is a rename, not a substitution

The trains publish the same bytes under different names. `default-tenant`'s flake settles it:

> Workload kernel — the single shared definition in `nix/images/kernel/`, **identical to the one builder-vm builds**.

| variant | boot image asset | checksums |
|---|---|---|
| workload | `default-microvm-vmlinux-<arch>` | `default-microvm-<arch>-checksums-sha256.txt` |
| builder | `builder-vm-vmlinux-<arch>` | `builder-vm-<arch>-checksums-sha256.txt` |

Verified against the published manifests — both arches, both variants, each checksum file containing its kernel.

## Deliberately not moved

- **`runtime_overlay.rs` / `sdk_sidecar.rs`** — same root cause, but their version is *also* the on-disk cache key, so splitting download tag from cache identity is a separate change. They keep `ReleaseTrain::Cli` explicitly, so the choice is recorded rather than defaulted.
- **`bootstrap.rs`** — fetches `*.pack-manifest.json`, which the release job's `nullglob` silently dropped. Repointing it trades one 404 for another.

## Guard

Over the class, not the instance: no image fetch may contain `releases/download/v{version}`. Mutation-tested — restoring it in Stage 0 fails with the file named:

```
these build an image release URL from the CLI version, which 404s whenever the
crate version is ahead of the last CLI tag: ["commands/env/builder_vm/stage0_cache.rs"].
Use `update::boot_image_release()`.
```

Plus unit tests that the image tag is not the CLI version, that the bare semver matches what the signing-identity template interpolates, that each variant maps to its published asset, and that an unknown variant is refused rather than guessed.

## Verification

`cargo nextest run --workspace` — 12,456 passed. Three failures were attributed, not waved through:

- `check-l3-expansion-freeze` and `check-no-gateway-names` fail **identically on unmodified main** in this checkout: two worktrees are nested at `.claude/worktrees/`, and the workspace-scanning gates walk into them and count duplicated source. Environmental; CI checks out clean.
- `run_detached_spawns_redirects_console_and_reports_exit` passes in isolation; it failed only while two suites ran concurrently.

`clippy --workspace --all-targets -D warnings`, `fmt --all --check`, and `actionlint` clean.

## Not claimed

That a fresh install now boots end to end. That needs a real download against a live release with cosign, which no local run can stand in for.