### PR TITLE
feat(assurance): carry the admitted session on the signed registration

### DIFF
--- a/crates/mvm-contract/src/assurance/mod.rs
+++ b/crates/mvm-contract/src/assurance/mod.rs
@@ -27,6 +27,7 @@ pub mod ids;
 pub mod input;
 pub mod outcome;
 pub mod probe;
+pub mod session;
 pub mod wire;
 
 #[cfg(test)]
@@ -53,6 +54,7 @@ pub use probe::{
     PROBE_OBSERVATION_SCHEMA, PROBE_REQUEST_SCHEMA, ProbeInvocation, ProbeObservation,
     ProbeRefusal, ProbeRequest,
 };
+pub use session::{AdmittedAssuranceSession, DeclaredEdge, PlanIdentity};
 pub use wire::{
     AuthorityWire, DeliveredSession, DeliveredSessionError, MvmBindingWire, TrialResultDocument,
     TrialResultIdentity, TrialResultSession,

--- a/crates/mvm-contract/src/assurance/session.rs
+++ b/crates/mvm-contract/src/assurance/session.rs
@@ -1,0 +1,75 @@
+//! The admitted session as it crosses to the process that serves probes.
+//!
+//! These types live here, rather than beside the ledger in `mvm-hostd`,
+//! because the carrier does. `RegisterVm` is declared in this crate and its
+//! production constructor sits in `mvm-vmm`, which is *below* `mvm-hostd` —
+//! so a session type defined up there could not be named at either end of the
+//! hop it has to make.
+//!
+//! Everything here is a decision already taken. The supervisor holds the plan:
+//! it verifies it, mints the binding, intersects the authority, and resolves
+//! the operator's declared destinations. What travels is the result, so the
+//! receiving process gains no new judgement — the same shape as
+//! `services_bindings`, which is also decided elsewhere and merely enforced.
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+use super::authority::EffectiveAuthority;
+use super::binding::MvmBinding;
+use super::ids::AssuranceId;
+use crate::plan::types::{PlanId, TenantId};
+use crate::policy::network_policy::NetworkPolicy;
+
+/// The only part of an admitted plan an assurance record quotes.
+///
+/// Exactly the fields a `PlanAuditEntry` carries, so a record written on
+/// either side of the process boundary is identical — without the receiving
+/// process ever being handed a plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct PlanIdentity {
+    pub tenant: TenantId,
+    pub plan_id: PlanId,
+    pub plan_version: u32,
+    pub image_name: String,
+    pub image_sha256: String,
+    /// Labels the plan asks to be copied onto every entry it generates.
+    #[serde(default)]
+    pub audit_labels: BTreeMap<String, String>,
+}
+
+/// A destination an operator declared for one campaign, already resolved.
+///
+/// The workload only ever names the label. What it resolves to is settled
+/// host-side before this crosses, so the probe path has nothing to look up and
+/// nothing to be steered by.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct DeclaredEdge {
+    pub label: AssuranceId,
+    pub host: String,
+    pub port: u16,
+}
+
+/// An assurance session the supervisor already admitted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+pub struct AdmittedAssuranceSession {
+    /// The workload session id the supervisor will report in the call context.
+    pub workload_session_id: String,
+    pub binding: MvmBinding,
+    /// Authority after every intersection. The receiver narrows nothing.
+    pub authority: EffectiveAuthority,
+    pub trial_id: AssuranceId,
+    pub identity: PlanIdentity,
+    /// The workload's admitted egress policy, which the probe consults.
+    pub policy: NetworkPolicy,
+    pub destinations: Vec<DeclaredEdge>,
+}

--- a/crates/mvm-contract/src/plan/types.rs
+++ b/crates/mvm-contract/src/plan/types.rs
@@ -459,10 +459,12 @@ pub struct BuildProvenance {
 /// reference this id verbatim.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct PlanId(pub String);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct TenantId(pub String);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/crates/mvm-contract/src/policy/network_policy.rs
+++ b/crates/mvm-contract/src/policy/network_policy.rs
@@ -44,6 +44,7 @@ pub enum NetworkPolicyParseError {
 
 /// A host:port pair for network allowlist rules.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct HostPort {
     pub host: String,
     pub port: u16,
@@ -95,6 +96,7 @@ pub fn is_banned_ssh_port(port: u16) -> bool {
 /// Built-in network presets for common workloads.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum NetworkPreset {
     /// Full internet access (no filtering). Default for backward compatibility.
     Unrestricted,
@@ -178,6 +180,7 @@ impl fmt::Display for NetworkPreset {
 /// the policy resolves to a non-empty allowlist.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum EgressMode {
     /// No filtering — guest gets full outbound. Implied by an
     /// unrestricted policy.
@@ -236,6 +239,7 @@ impl fmt::Display for EgressMode {
 /// consumer to re-thread a separate parameter.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub enum NetworkPolicy {
     /// Use a built-in preset.
     Preset {

--- a/crates/mvm-contract/src/protocol/broker_control.rs
+++ b/crates/mvm-contract/src/protocol/broker_control.rs
@@ -81,6 +81,20 @@ pub struct RegisterVm {
     /// existed. Omitting the empty case keeps them byte-identical.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub capability_bindings: Vec<CapabilityBinding>,
+    /// An assurance campaign session the supervisor admitted for this VM.
+    ///
+    /// The daemon opens it against the handler it registers, because that is
+    /// the process a probe reaches. Absent on every ordinary workload.
+    ///
+    /// Skip-serialized when absent for the same reason `capability_bindings`
+    /// is when empty: `ControlRequest` is signed over its JCS canonical bytes,
+    /// so a field that serialized as `null` on every registration would move
+    /// those bytes and invalidate signatures produced before it existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Boxed: the session is much larger than the rest of the registration,
+    /// and `ControlRequest` is an enum whose other variants are small — an
+    /// inline copy would size every control message by the rarest one.
+    pub assurance: Option<alloc::boxed::Box<crate::assurance::AdmittedAssuranceSession>>,
 }
 
 /// Deregister a VM at teardown: the daemon unbinds + drops its listen socket
@@ -135,6 +149,28 @@ pub enum ControlResponse {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn an_absent_campaign_leaves_the_signed_bytes_alone() {
+        // `ControlRequest` is signed over its JCS canonical bytes, so a field
+        // that serialized on every registration would invalidate signatures
+        // produced before it existed — the same reason `capability_bindings`
+        // is skip-serialized when empty.
+        let req = sample_register();
+        let json = serde_json::to_string(&req).expect("serialize");
+        assert!(!json.contains("assurance"), "{json}");
+    }
+
+    #[test]
+    fn a_registration_without_the_field_still_parses() {
+        // Older signed registrations predate the field and must keep working.
+        let json = serde_json::to_string(&sample_register()).expect("serialize");
+        let back: ControlRequest = serde_json::from_str(&json).expect("parse");
+        match back {
+            ControlRequest::Register(vm) => assert!(vm.assurance.is_none()),
+            other => panic!("expected a Register, got {other:?}"),
+        }
+    }
     use alloc::vec;
 
     use super::*;
@@ -150,6 +186,7 @@ mod tests {
             audit_signer_uds_path: Some("/run/state/vm-1/audit-signer.sock".into()),
             services_bindings: vec![ServiceId::parse("host.time.v1").unwrap()],
             capability_bindings: vec![],
+            assurance: None,
         })
     }
 

--- a/crates/mvm-core/src/protocol/broker_control.rs
+++ b/crates/mvm-core/src/protocol/broker_control.rs
@@ -101,6 +101,7 @@ mod tests {
                 mvm_contract::protocol::broker::ServiceId::parse("host.time.v1").unwrap(),
             ],
             capability_bindings: vec![],
+            assurance: None,
         })
     }
 

--- a/crates/mvm-hostd/src/assurance_session.rs
+++ b/crates/mvm-hostd/src/assurance_session.rs
@@ -32,7 +32,7 @@ use mvm_core::protocol::broker::ServiceId;
 use sha2::{Digest, Sha256};
 
 use crate::audit::assurance::{
-    AssuranceAuditSink, AssuranceLedger, PlanIdentity, SessionIdentity, cite,
+    AssuranceAuditSink, AssuranceLedger, SessionIdentity, cite, identity_of,
 };
 use crate::audit::emitter::AuditEmitter;
 use crate::broker::handlers::host_assurance_v1::{
@@ -282,7 +282,7 @@ pub fn open_on(
         trial_id: request.declaration.trial_id.clone(),
         source_digest: request.declaration.source_digest.clone(),
     };
-    let plan_identity = PlanIdentity::from(plan);
+    let plan_identity = identity_of(plan);
     let ledger = AssuranceLedger::new(request.emitter.as_ref(), &plan_identity);
     let refs = ledger
         .open_session(&identity)
@@ -325,7 +325,7 @@ pub fn open_on(
                 port: edge.port,
             })
             .collect(),
-        identity: PlanIdentity::from(plan),
+        identity: identity_of(plan),
         sink: Some(Arc::clone(request.emitter) as Arc<dyn AssuranceAuditSink + Send + Sync>),
     });
     Ok(binding)
@@ -376,7 +376,7 @@ pub fn close_on(
     verdict: &TrialVerdict,
 ) -> Result<()> {
     let _ = plane;
-    AssuranceLedger::new(emitter, &PlanIdentity::from(admitted.plan()))
+    AssuranceLedger::new(emitter, &identity_of(admitted.plan()))
         .complete_trial(identity, verdict)
         .context("recording the trial outcome")?;
     Ok(())

--- a/crates/mvm-hostd/src/audit/assurance.rs
+++ b/crates/mvm-hostd/src/audit/assurance.rs
@@ -116,63 +116,46 @@ impl LedgerRefs {
     }
 }
 
-/// The only part of an admitted plan an assurance record quotes.
-///
-/// The broker records campaign probes but is deliberately never given the
-/// plan — it receives derived bindings, the way `services_bindings` and
-/// `capability_bindings` already travel. These six fields are exactly what a
-/// `PlanAuditEntry` carries, so passing them keeps the records identical on
-/// both routes without widening what the broker is trusted with.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct PlanIdentity {
-    pub tenant: mvm_core::plan::TenantId,
-    pub plan_id: mvm_core::plan::PlanId,
-    pub plan_version: u32,
-    pub image_name: String,
-    pub image_sha256: String,
-    /// Labels the plan asks to be copied onto every entry it generates.
-    #[serde(default)]
-    pub audit_labels: std::collections::BTreeMap<String, String>,
-}
+/// Re-exported: the wire type now lives in `mvm-contract`, because the
+/// carrier (`RegisterVm`) is declared there and its producer sits below this
+/// crate.
+pub use mvm_contract::assurance::PlanIdentity;
 
-impl From<&ExecutionPlan> for PlanIdentity {
-    fn from(plan: &ExecutionPlan) -> Self {
-        Self {
-            tenant: plan.tenant.clone(),
-            plan_id: plan.plan_id.clone(),
-            plan_version: plan.plan_version,
-            image_name: plan.image.name.clone(),
-            image_sha256: plan.image.sha256.to_ascii_lowercase(),
-            audit_labels: plan.audit_labels.clone(),
-        }
+/// Build the entry `identity` would produce for `event`.
+///
+/// Mirrors `supervisor::for_plan` field for field; it exists separately
+/// because that one needs a whole plan and this route has none.
+fn entry_for(
+    identity: &PlanIdentity,
+    event: &str,
+    extras: impl IntoIterator<Item = (String, String)>,
+) -> PlanAuditEntry {
+    let mut labels = identity.audit_labels.clone();
+    labels.extend(extras);
+    PlanAuditEntry {
+        timestamp: chrono::Utc::now(),
+        tenant: identity.tenant.clone(),
+        plan_id: identity.plan_id.clone(),
+        plan_version: identity.plan_version,
+        bundle_id: None,
+        bundle_version: None,
+        image_name: identity.image_name.clone(),
+        image_sha256: identity.image_sha256.clone(),
+        event: event.to_string(),
+        labels,
     }
 }
 
-impl PlanIdentity {
-    /// Build the entry this identity would produce for `event`.
-    ///
-    /// Mirrors `supervisor::for_plan` field for field; it exists separately
-    /// because that one needs a whole plan and this route has none.
-    fn entry(
-        &self,
-        event: &str,
-        extras: impl IntoIterator<Item = (String, String)>,
-    ) -> PlanAuditEntry {
-        let mut labels = self.audit_labels.clone();
-        labels.extend(extras);
-        PlanAuditEntry {
-            timestamp: chrono::Utc::now(),
-            tenant: self.tenant.clone(),
-            plan_id: self.plan_id.clone(),
-            plan_version: self.plan_version,
-            bundle_id: None,
-            bundle_version: None,
-            image_name: self.image_name.clone(),
-            image_sha256: self.image_sha256.clone(),
-            event: event.to_string(),
-            labels,
-        }
+/// Derive the identity an admitted plan presents to the ledger.
+#[must_use]
+pub fn identity_of(plan: &ExecutionPlan) -> PlanIdentity {
+    PlanIdentity {
+        tenant: plan.tenant.clone(),
+        plan_id: plan.plan_id.clone(),
+        plan_version: plan.plan_version,
+        image_name: plan.image.name.clone(),
+        image_sha256: plan.image.sha256.to_ascii_lowercase(),
+        audit_labels: plan.audit_labels.clone(),
     }
 }
 
@@ -309,7 +292,7 @@ impl<'a> AssuranceLedger<'a> {
     where
         I: IntoIterator<Item = (String, String)>,
     {
-        let entry = self.identity.entry(event, labels);
+        let entry = entry_for(self.identity, event, labels);
         let emitted = self
             .sink
             .record(&entry, receipt)

--- a/crates/mvm-hostd/src/broker/daemon.rs
+++ b/crates/mvm-hostd/src/broker/daemon.rs
@@ -194,6 +194,70 @@ impl RegistrationJournal {
     }
 }
 
+/// Open the assurance session the supervisor admitted for this VM.
+///
+/// This daemon is the process a probe reaches, so it is the only place a
+/// session can usefully exist. The registration is host-signed, so what
+/// arrives here has already been decided: the binding names a plan the
+/// supervisor verified, the authority is post-intersection, and the declared
+/// destinations are resolved. Nothing is judged again.
+///
+/// Both refusals below open nothing rather than opening something partial. A
+/// session whose service is not bound and a session with no audit route are
+/// each a registration that does not describe a run this daemon should serve,
+/// and the probe verb answers `NotBound` or `AuditUnavailable` either way.
+fn open_admitted_assurance_session(bound: &super::handlers::BoundHandlers, r: &RegisterVm) {
+    let Some(session) = &r.assurance else { return };
+    let Some(handler) = &bound.assurance else {
+        tracing::warn!(
+            vm_id = %r.vm_id,
+            "an assurance session was registered but host.assurance.v1 is not bound; \
+             opening nothing"
+        );
+        return;
+    };
+    let Some(path) = &r.audit_signer_uds_path else {
+        tracing::warn!(
+            vm_id = %r.vm_id,
+            "an assurance session was registered with no audit route; its probes could \
+             not be recorded, so the session is not opened"
+        );
+        return;
+    };
+
+    let sink = crate::audit::assurance::SignerSink::new(
+        super::audit_client::AuditClient::new(path.clone()),
+        r.workload_id.clone().unwrap_or_else(|| r.vm_id.clone()),
+        r.tenant_id.clone(),
+        session.workload_session_id.clone(),
+    );
+    handler.open_session(super::handlers::host_assurance_v1::AssuranceSessionSpec {
+        workload_session_id: session.workload_session_id.clone(),
+        binding: session.binding.clone(),
+        authority: session.authority.clone(),
+        trial_id: session.trial_id.clone(),
+        policy: session.policy.clone(),
+        destinations: session
+            .destinations
+            .iter()
+            .map(
+                |edge| super::handlers::host_assurance_v1::DeclaredDestination {
+                    label: edge.label.clone(),
+                    host: edge.host.clone(),
+                    port: edge.port,
+                },
+            )
+            .collect(),
+        identity: session.identity.clone(),
+        sink: Some(std::sync::Arc::new(sink)),
+    });
+    tracing::info!(
+        vm_id = %r.vm_id,
+        workload_session_id = %session.workload_session_id,
+        "assurance session opened for the admitted campaign"
+    );
+}
+
 impl HostAgentDaemon {
     /// New daemon for `tenant_id`, verifying control messages against
     /// `verifying_key` (the host signer's public key). `max_frame_bytes` caps
@@ -371,7 +435,8 @@ impl HostAgentDaemon {
         registry
             .admit_capabilities(r.capability_bindings.clone())
             .context("load host-signed capability bindings")?;
-        let _bound = register_bound_handlers(&mut registry, &r.services_bindings);
+        let bound = register_bound_handlers(&mut registry, &r.services_bindings);
+        open_admitted_assurance_session(&bound, r);
         let host_audit = mvm_core::protocol::broker::ServiceId::parse("host.audit.v1")
             .expect("host.audit.v1 is a valid ServiceId");
         if r.services_bindings.contains(&host_audit)
@@ -719,6 +784,7 @@ mod tests {
             audit_signer_uds_path: signer.map(|p| p.to_string_lossy().into_owned()),
             services_bindings: vec![],
             capability_bindings: vec![],
+            assurance: None,
         }
     }
 

--- a/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_assurance_v1.rs
@@ -431,6 +431,7 @@ impl ServiceHandler for HostAssuranceV1Handler {
 mod tests {
     use super::*;
 
+    use crate::audit::assurance::identity_of;
     use crate::audit::assurance::{audit_citations_resolve, resolve_audit_ref};
     use crate::audit::emitter::AuditEmitter;
     use mvm_contract::assurance::{
@@ -551,7 +552,7 @@ mod tests {
                 host: "attacker.example.com".to_string(),
                 port: 443,
             }],
-            identity: PlanIdentity::from(&PlanFixture::new().build()),
+            identity: identity_of(&PlanFixture::new().build()),
             sink: None,
         }
     }
@@ -978,7 +979,7 @@ mod tests {
             .expect("emitter")
             .with_receipts();
         let plan = PlanFixture::new().build();
-        let identity = PlanIdentity::from(&plan);
+        let identity = identity_of(&plan);
         let ledger = AssuranceLedger::new(&emitter, &identity);
         let identity = crate::audit::assurance::SessionIdentity {
             session_id: id(SESSION),
@@ -1023,7 +1024,7 @@ mod tests {
             .expect("emitter")
             .with_receipts();
         let plan = PlanFixture::new().build();
-        let identity = PlanIdentity::from(&plan);
+        let identity = identity_of(&plan);
         let ledger = AssuranceLedger::new(&emitter, &identity);
         let refs = ledger
             .open_session(&SessionIdentity {

--- a/crates/mvm-hostd/tests/host_agent_restart.rs
+++ b/crates/mvm-hostd/tests/host_agent_restart.rs
@@ -93,6 +93,7 @@ impl HostAgentFixture {
             audit_signer_uds_path: None,
             services_bindings: vec![ServiceId::parse("host.audit.v1").expect("service id")],
             capability_bindings: vec![],
+            assurance: None,
         };
         register_vm(&control_socket, &key_bytes, reg).expect("register vm");
 

--- a/crates/mvm-hostd/tests/per_tenant_isolation.rs
+++ b/crates/mvm-hostd/tests/per_tenant_isolation.rs
@@ -166,6 +166,7 @@ async fn start_tenant(id: &str) -> TenantHandle {
         audit_signer_uds_path: None,
         services_bindings: vec![ServiceId::parse("host.audit.v1").expect("service id")],
         capability_bindings: vec![],
+        assurance: None,
     };
     register_vm(&control_socket, &key_bytes, reg).expect("register vm");
 

--- a/crates/mvm-vmm/src/host/host_agent_spawn.rs
+++ b/crates/mvm-vmm/src/host/host_agent_spawn.rs
@@ -399,6 +399,7 @@ pub fn register_host_agent_services_if_admitted(
             audit_signer_uds_path: None,
             services_bindings: services.to_vec(),
             capability_bindings: vec![],
+            assurance: None,
         },
     )?;
     warm_claim_debug("register_vm_done");
@@ -697,6 +698,7 @@ mod tests {
             ),
             services_bindings: vec![],
             capability_bindings: vec![],
+            assurance: None,
         }
     }
 

--- a/specs/plans/2026-08-19-assurance-remaining-workstreams.md
+++ b/specs/plans/2026-08-19-assurance-remaining-workstreams.md
@@ -1,0 +1,131 @@
+# Assurance: the remaining workstreams
+
+Backing: preview
+Validation: none
+
+A pick-up-cold checklist for the three workstreams left in
+`specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. That plan is
+the source of truth for what landed and why; this one is the task list.
+
+Status: **W9b one hop from done. W5b open. W8 blocked outside this repo.**
+
+## What already holds
+
+Worth knowing before touching any of it, because each of these was learned the
+expensive way.
+
+- **A session may only be opened by the process that hosts the broker
+  registry.** `install_host_assurance_plane` is called only by
+  `register_bound_handlers`, which only `mvm-host-agent` and `mvm-broker` call.
+  Anything else gets `SessionRefusal::NoPlane`.
+- **`RegisterVm` is the carrier**, not `broker::config::SubprocessConfig`.
+  Nothing in production constructs the latter, and it is unsigned where
+  `RegisterVm` is host-signed.
+- **`ControlRequest` is signed over its JCS canonical bytes.** Any new field
+  must be skip-serialized when absent or every pre-existing signature breaks.
+- **The broker never receives a plan.** `PlanIdentity` carries the six fields
+  `supervisor::for_plan` reads, and nothing more.
+- **A record the host cannot write means the probe does not happen.**
+  `AuditUnavailable` is a refusal, not a warning.
+
+## W9b — populate `RegisterVm.assurance`
+
+Everything downstream is done: the field exists, `daemon::register` opens the
+session, and the sink records through the audit-signer. What is missing is a
+producer.
+
+- [ ] Decide the carrier from the supervisor to `mvm-vmm`. Two candidates, and
+      the choice is not obvious:
+      - `HostAgentServicesParams` — where `services` already travels, so it is
+        the matching precedent. **Cross-repo**: mvmd constructs this struct, and
+        its main is already broken on a related mismatch, so adding a field
+        without a default will break their build again.
+      - `VmStartConfig` — already carries `PlanBinding { plan_json, audit_dir,
+        signing_key_path }` into `mvm-vmm` via
+        `spec_map::workload_plan_binding`, so the admitted plan is *already*
+        there. Check whether mvmd constructs `VmStartConfig` too before
+        assuming this avoids the cross-repo break.
+- [ ] Mint the session at admission: build the `MvmBinding`, intersect the
+      authority, resolve the operator's declared destinations, and derive the
+      `PlanIdentity`. `assurance_session::open`'s body is the reference — it
+      already does all four for the in-process path.
+- [ ] Attach it to the chosen carrier and set `RegisterVm.assurance` in
+      `host_agent_spawn.rs`.
+- [ ] Test: a registration carrying a session opens one on the daemon's
+      handler, and a probe dispatched against that session is recorded.
+- [ ] Test: a registration without one changes nothing (the signed-bytes test
+      already exists; extend it to the daemon path).
+- [ ] Delete the now-dead in-process open in `admit_and_start` if it turns out to be
+      unreachable, or document why the library path keeps it.
+
+## W5b — a guest-side observer
+
+`observer_verified` currently means "MVM recorded a probe and an effect was
+attempted". That is honest evidence the trial ran; it is not an independent
+observer of what happened *inside* the guest, which is what the assurance
+contract means. Until this lands, every live trial is `INCONCLUSIVE` for
+`ObserverMissing` — and
+`evidence_from_a_real_session_still_evaluates_inconclusive_today` pins that.
+
+- [ ] Decide what the guest can report that the host cannot already see.
+      The host owns the egress decision and the audit chain; the guest owns
+      whether the effect *took hold* — a process started, a file appeared, a
+      connection was attempted from inside.
+- [ ] Decide the transport. The guest agent already speaks the broker channel
+      (`mvm_agentd::assurance`), so a report verb there is the cheap route.
+      **The guest is untrusted**: whatever it says must be corroborated, not
+      believed. Design the corroboration before the transport.
+- [ ] Extend `HostObservation` with the corroborated guest signal, keeping the
+      existing rule that a candidate contradicting the observer is
+      `INCONCLUSIVE` rather than silently overridden.
+- [ ] Populate `observer_verified` from that corroboration, and update its
+      doc comment, which currently states the limit plainly.
+- [ ] Update the pinning test. When it changes, that should be the *only*
+      thing that starts certifying.
+
+## W8 — the framed-stdio provider
+
+**Blocked outside this repo**, and not by a little. `mvm-security assurance
+plan` reports seven brokers it cannot reach (`immutable_snapshot`,
+`builder_microvm`, `subject_microvm`, `guest_observer`, `host_observer`,
+`execution_receipts`, `artifact_sealing`), and the counterparty's own
+broker-backed execution milestone (M3) is unstarted. No amount of MVM-side work
+produces a certifying campaign until that moves.
+
+- [ ] Confirm with the assurance side whether M3 is being picked up, and which
+      brokers they expect MVM to serve versus stub.
+- [ ] Ship an MVM-side binary speaking `mvm.security.campaign-request/v1` over
+      framed stdio, returning `mvm.security.provider-response/v1`.
+      `apps/mvm-security/src/broker.rs` in the counterparty is the reader; the
+      exact key sets are already asserted by
+      `the_emitted_record_matches_the_counterparty_field_set`.
+- [ ] Map a campaign request onto an admitted run: build the workload, open the
+      session, run the declared probes, assemble the evidence, emit
+      `mvm.security.trial-evidence/v1`.
+- [ ] Keep the outcome honest. The provider reports evidence; it does not
+      decide. `PREVENTED`/`CONTAINED` stay derived, and missing evidence stays
+      `INCONCLUSIVE`.
+
+## Verification, for any of the above
+
+The full set, because two of these lanes have caught real bugs that
+`--all-targets` did not:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace -j 6
+cargo test --workspace --doc
+# the feature lane `--all-targets` cannot see
+cargo nextest run --features test-support --lib \
+  -p mvm-backends -p mvm-runtime -p mvm-client -p mvm-cli -p mvm-vmm
+cargo nextest run -p mvmctl --features test-support --test audit_emissions_live
+cargo check -p mvm-cli --features test-support --example verification_loop
+# every gate CI runs
+grep -rho 'xtask -- [a-z0-9-]*' .github/workflows/*.yml | sed 's/xtask -- //' | sort -u
+```
+
+Two standing traps: run the xtask gate loop **separately** from `nextest` (they
+share `MVM_HOME` and racing them fails unrelated `mvm-core` tests), and move any
+`graft/` index aside first (`check_no_gateway_names` and
+`check_l3_expansion_freeze` scan without honouring `.gitignore`).

--- a/specs/sprint/delivery/assurance-registervm-session.md
+++ b/specs/sprint/delivery/assurance-registervm-session.md
@@ -1,0 +1,67 @@
+# The assurance session reaches the process that serves probes
+
+Plan: `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md` (W9b)
+
+## What landed
+
+An admitted assurance session now travels on `RegisterVm` and is opened by
+`daemon::register` against the handler it has just built. That closes the
+topology gap: the plane is installed when the registry is built, so the daemon
+is the only process where a session can usefully exist, and it is now the
+process that opens one.
+
+## Why `RegisterVm` and not `SubprocessConfig`
+
+An earlier attempt put the session on `SubprocessConfig` and had `mvm-broker`
+open it. Two things were wrong, and both were found by tracing the destination
+rather than reasoning outward from the ledger:
+
+- **It is not the live path.** Nothing in production constructs a
+  `broker::config::SubprocessConfig`; the `mvm-broker` subprocess is not
+  spawned. Registration goes through the `mvm-host-agent` daemon.
+- **It is the wrong trust envelope.** `SubprocessConfig`'s own docs record that
+  it is unsigned and that a compromised supervisor could redirect the audit
+  back-channel. `RegisterVm` is host-signed.
+
+Adding a security-relevant field to an unsigned envelope on a dead path is
+worse than adding none, so that work was reverted rather than landed.
+
+## Signature stability is the constraint that shaped the field
+
+`ControlRequest` is signed over its JCS canonical bytes. A field that
+serialized on every registration would move those bytes and invalidate every
+signature produced before it existed — which is exactly why
+`capability_bindings` is skip-serialized when empty. The assurance field
+follows that precedent, and two tests hold it: an absent campaign leaves the
+serialized bytes free of the key, and a registration written without the field
+still parses.
+
+## Where the types live, and why it is not arbitrary
+
+`PlanIdentity`, `DeclaredEdge` and `AdmittedAssuranceSession` are in
+`mvm-contract`. The carrier decides: `RegisterVm` is declared there, and its
+production constructor is in `mvm-vmm`, which sits *below* `mvm-hostd`. A
+session type defined beside the ledger could not be named at either end of the
+hop it has to make.
+
+`PlanIdentity` carries the six fields `supervisor::for_plan` reads and nothing
+else, so the receiving process still never holds a plan.
+
+## Nothing is judged twice
+
+Every field that crosses is a decision already taken: the binding names a plan
+the supervisor verified, the authority is post-intersection, the destinations
+are resolved. The daemon narrows nothing and resolves nothing — the same shape
+as `services_bindings`, which is also decided elsewhere and merely enforced.
+
+Both refusals open nothing rather than something partial. A session whose
+service is not bound, and a session with no audit route, each describe a
+registration this daemon should not serve; the probe verb answers `NotBound` or
+`AuditUnavailable` either way.
+
+## What this still does not do
+
+Nothing populates `RegisterVm.assurance` yet. The supervisor must mint the
+session at admission and pass it through `HostAgentServicesParams`, which is a
+cross-repo change: mvmd constructs that struct too. That is the last hop, and
+it is now a parameter-threading job rather than a design question.


### PR DESCRIPTION
Lands W9b's carrier hop, and adds
`specs/plans/2026-08-19-assurance-remaining-workstreams.md` — a pick-up-cold
checklist for W9b's last hop, W5b and W8.

## What this does

The admitted session travels on `RegisterVm`, and `daemon::register` opens it
against the handler it has just built. That closes the topology gap: the plane
is installed when the registry is built, so the daemon is the only process where
a session can usefully exist — and it is now the one that opens it.

## Why `RegisterVm`

An earlier attempt used `SubprocessConfig` and was reverted. Two reasons:

- **Live path.** Nothing in production constructs a
  `broker::config::SubprocessConfig`; the `mvm-broker` subprocess is not
  spawned. Registration goes through the `mvm-host-agent` daemon.
- **Trust envelope.** `SubprocessConfig` is unsigned by its own documentation.
  `RegisterVm` is host-signed.

## Signature stability shaped the field

`ControlRequest` is signed over its JCS canonical bytes, so a field present on
every registration would invalidate every signature written before it existed —
the same reason `capability_bindings` is skip-serialized when empty. Two tests
hold it: an absent campaign leaves the bytes free of the key, and a registration
written without the field still parses.

The session is boxed: `ControlRequest`'s other variants are small, and an inline
copy would size every control message by the rarest one. (clippy's
`large_enum_variant` caught that, correctly.)

## Where the types live

`PlanIdentity`, `DeclaredEdge` and `AdmittedAssuranceSession` moved to
`mvm-contract` because the carrier is there: `RegisterVm` is declared in that
crate and its producer is in `mvm-vmm`, *below* `mvm-hostd`. A session type
defined beside the ledger could not be named at either end of the hop.

`PlanIdentity` still carries only the six fields `supervisor::for_plan` reads,
so the daemon never receives a plan.

## Scope

Nothing populates `RegisterVm.assurance` yet — that is the last hop, and the new
plan spells out the two candidate carriers from the supervisor along with the
cross-repo risk in each.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo nextest run --workspace` — 12,453 of 12,455; the two failures are
  `mvm-agentd` guest-agent process-spawn tests timing out under build load, and
  both pass isolated in 0.6s against a 10s bound
- the `test-support` feature lane — 3,669 passed
- `check-declared-backing` and `check-plan-names` — clean on the new plan
