### PR TITLE
fix(vsock): dial the per-VM endpoint when the guest connects, not on its first byte

### DIFF
--- a/crates/mvm-vmm/src/vmm/vsock.rs
+++ b/crates/mvm-vmm/src/vmm/vsock.rs
@@ -1268,6 +1268,99 @@ mod tests {
         assert!(d.transport.pending_rx.iter().any(|(h, _)| h.op == OP_RST));
     }
 
+    /// The regression a FlowMux launch died on: the session handshake opens
+    /// with the *host's* `SessionHello`, so the guest connects and reads. A
+    /// bridge that dials the endpoint only on the first guest payload leaves
+    /// the endpoint with no socket to greet on, and both halves wait — which
+    /// surfaced as "no guest authenticated" with a guest that had connected.
+    #[test]
+    fn egress_port_delivers_a_host_first_greeting_after_only_a_connect() {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+        let server = std::thread::spawn(move || {
+            let (mut c, _) = listener.accept().unwrap();
+            c.write_all(b"HELLO").unwrap();
+            // The real endpoint holds the session open waiting for the guest's
+            // reply; dropping here would close the socket before the drain.
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        });
+
+        let mut d = dev();
+        d.set_network_endpoint(&sock);
+
+        let request = VsockHdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 1600,
+            dst_port: mvm_agentd::vsock::EGRESS_PORT,
+            len: 0,
+            op: OP_REQUEST,
+            typ: TYPE_STREAM,
+            buf_alloc: HOST_BUF_ALLOC,
+            ..Default::default()
+        };
+        d.handle_packet(request, &[]);
+        assert!(
+            d.transport
+                .pending_rx
+                .iter()
+                .any(|(h, _)| h.op == OP_RESPONSE),
+            "the connect itself must still be accepted"
+        );
+
+        let mut greeting = None;
+        for _ in 0..200 {
+            let _ = d.service_host_io();
+            if let Some((h, payload)) = d
+                .transport
+                .pending_rx
+                .iter()
+                .find(|(h, _)| h.op == OP_RW && h.dst_port == 1600)
+            {
+                greeting = Some((*h, payload.clone()));
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        let (h, payload) =
+            greeting.expect("the endpoint's greeting reaches a guest that has only connected");
+        assert_eq!(h.src_port, mvm_agentd::vsock::EGRESS_PORT);
+        assert_eq!(payload, b"HELLO");
+        server.join().unwrap();
+    }
+
+    /// With nothing bound the refusal now lands on the connect rather than on
+    /// the first payload, so a guest waiting to be greeted learns immediately
+    /// instead of blocking until its own timeout.
+    #[test]
+    fn egress_port_resets_a_connect_without_endpoint() {
+        let mut d = dev();
+        let request = VsockHdr {
+            src_cid: GUEST_CID,
+            dst_cid: HOST_CID,
+            src_port: 2100,
+            dst_port: mvm_agentd::vsock::EGRESS_PORT,
+            len: 0,
+            op: OP_REQUEST,
+            typ: TYPE_STREAM,
+            ..Default::default()
+        };
+        d.handle_packet(request, &[]);
+        assert!(d.transport.pending_rx.iter().any(|(h, _)| h.op == OP_RST));
+        assert!(
+            !d.transport
+                .pending_rx
+                .iter()
+                .any(|(h, _)| h.op == OP_RESPONSE),
+            "a connect with no endpoint must not read as accepted"
+        );
+    }
+
     #[test]
     fn teardown_cancellation_clears_vsock_state() {
         let mut d = dev();

--- a/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
@@ -461,7 +461,22 @@ impl GuestPortHandler for StreamRelayHandler {
 
     fn on_packet(&mut self, ctx: &mut VsockHandlerContext<'_>, hdr: VsockHdr, payload: &[u8]) {
         match hdr.op {
-            OP_REQUEST => ctx.queue_reply(&hdr, OP_RESPONSE, &[]),
+            // Open the endpoint side now, not on the guest's first payload.
+            // The endpoint speaks first here — a FlowMux session opens with the
+            // host's `SessionHello` — so a guest that connects goes straight
+            // into a read. Dialing lazily leaves nothing on the host end to
+            // send it, and both sides wait forever. Remembering the header is
+            // the other half: `drain` can only push endpoint bytes at a
+            // connection it has a header for.
+            OP_REQUEST => {
+                if self.bridge.open_connection(hdr.src_port) {
+                    self.headers.insert(hdr.src_port, hdr);
+                    ctx.queue_reply(&hdr, OP_RESPONSE, &[]);
+                } else {
+                    self.headers.remove(&hdr.src_port);
+                    ctx.queue_reply(&hdr, OP_RST, &[]);
+                }
+            }
             OP_RW => {
                 let n = (hdr.len as usize).min(payload.len());
                 if !ctx.try_add_recv(&hdr, n as u32) {

--- a/crates/mvm-vmm/src/vsock_egress_bridge/substitution_bridge.rs
+++ b/crates/mvm-vmm/src/vsock_egress_bridge/substitution_bridge.rs
@@ -236,9 +236,22 @@ fn refill_tokens(state: &mut EgressBudgetState, rate: u64, now: Instant) {
 /// stream abstraction and the per-VM UDS endpoint. Policy, HTTP parsing, TLS, and
 /// host client behavior stay above this seam.
 pub(crate) trait GuestEndpointRelay {
-    /// Relay guest→host bytes for `conn_id`. The first payload may open the
-    /// endpoint connection. Implementations fail closed on missing endpoints or
-    /// connect failures.
+    /// Open the endpoint side of `conn_id` before any guest bytes arrive.
+    ///
+    /// Needed because the endpoint speaks first on this channel: the FlowMux
+    /// session handshake opens with the host's `SessionHello`, so a guest that
+    /// has connected sits in a read. Deferring the endpoint dial to the first
+    /// guest payload deadlocks that exchange — each side waits for the other.
+    ///
+    /// Returns `false` when the connection cannot be opened, which is the same
+    /// fail-closed set [`Self::relay_guest_bytes`] refuses on: no endpoint
+    /// bound, the per-guest connection cap, an exhausted stream budget, or a
+    /// failed dial.
+    fn open_connection(&mut self, conn_id: u32) -> bool;
+
+    /// Relay guest→host bytes for `conn_id`, opening the endpoint connection if
+    /// [`Self::open_connection`] has not already. Implementations fail closed on
+    /// missing endpoints or connect failures.
     fn relay_guest_bytes(&mut self, conn_id: u32, payload: &[u8]) -> EndpointRelayAction;
 
     /// Drain host→guest endpoint bytes once from every active connection.
@@ -362,46 +375,54 @@ impl SubstitutionBridge {
 }
 
 impl GuestEndpointRelay for SubstitutionBridge {
-    fn relay_guest_bytes(&mut self, conn_id: u32, payload: &[u8]) -> EndpointRelayAction {
-        if let Some(conn) = self.conns.get_mut(&conn_id) {
-            if !self.budget.consume_waiting(payload.len()) {
-                return EndpointRelayAction::Refused;
-            }
-            write_nonblocking(&mut conn.stream, payload);
-            conn.last_activity = Instant::now();
-            return EndpointRelayAction::Relayed;
+    fn open_connection(&mut self, conn_id: u32) -> bool {
+        if self.conns.contains_key(&conn_id) {
+            return true;
         }
         if self.conns.len() >= MAX_CONNECTIONS {
-            return EndpointRelayAction::Refused;
+            return false;
         }
         if !self.budget.try_reserve_stream() {
-            return EndpointRelayAction::Refused;
+            return false;
         }
         let Some(path) = self.endpoint.clone() else {
             self.budget.release_stream();
-            return EndpointRelayAction::Refused;
+            return false;
         };
         match UnixStream::connect(&path) {
             Ok(stream) => {
                 let _ = stream.set_nonblocking(true);
-                if !self.budget.consume_waiting(payload.len()) {
-                    self.budget.release_stream();
-                    return EndpointRelayAction::Refused;
-                }
-                let conn = self.conns.entry(conn_id).or_insert(EndpointConn {
-                    stream,
-                    last_activity: Instant::now(),
-                });
-                write_nonblocking(&mut conn.stream, payload);
-                conn.last_activity = Instant::now();
+                self.conns.insert(
+                    conn_id,
+                    EndpointConn {
+                        stream,
+                        last_activity: Instant::now(),
+                    },
+                );
                 self.bump(1);
-                EndpointRelayAction::Relayed
+                true
             }
             Err(_) => {
                 self.budget.release_stream();
-                EndpointRelayAction::Refused
+                false
             }
         }
+    }
+
+    fn relay_guest_bytes(&mut self, conn_id: u32, payload: &[u8]) -> EndpointRelayAction {
+        if !self.open_connection(conn_id) {
+            return EndpointRelayAction::Refused;
+        }
+        if !self.budget.consume_waiting(payload.len()) {
+            return EndpointRelayAction::Refused;
+        }
+        let conn = self
+            .conns
+            .get_mut(&conn_id)
+            .expect("open_connection returned true, so the connection is present");
+        write_nonblocking(&mut conn.stream, payload);
+        conn.last_activity = Instant::now();
+        EndpointRelayAction::Relayed
     }
 
     fn drain_endpoint_bytes(&mut self) -> EndpointRelayDrain {
@@ -502,6 +523,61 @@ mod tests {
             EndpointRelayAction::Refused
         );
         assert!(!b.is_active());
+    }
+
+    /// Opening ahead of any guest bytes is what lets a host-first protocol
+    /// greet the guest. It must still fail closed with nothing bound, and must
+    /// hand the stream reservation back when it does — otherwise a guest that
+    /// retries its connect burns the budget down and the endpoint that finally
+    /// arrives can never be dialed.
+    #[test]
+    fn open_connection_fails_closed_without_an_endpoint_and_returns_the_reservation() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+
+        let mut b = SubstitutionBridge::new();
+        for conn_id in 0..MAX_EGRESS_STREAMS as u32 + 1 {
+            assert!(!b.open_connection(conn_id), "nothing is bound yet");
+        }
+        assert!(!b.is_active());
+
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+        let server = std::thread::spawn(move || listener.accept().map(|(c, _)| c));
+        b.set_endpoint(&sock);
+        assert!(
+            b.open_connection(0),
+            "every refused open returned its reservation, so the budget has room"
+        );
+        drop(server.join().unwrap());
+    }
+
+    /// An opened connection is live before a single guest byte, and closing it
+    /// gives the stream slot back.
+    #[test]
+    fn open_connection_is_active_before_any_guest_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("subst.sock");
+        let Some(listener) = bind_unix_listener(&sock) else {
+            return;
+        };
+        let server = std::thread::spawn(move || listener.accept().map(|(c, _)| c));
+
+        let mut b = SubstitutionBridge::new();
+        b.set_endpoint(&sock);
+        assert!(b.open_connection(9));
+        assert!(
+            b.is_active(),
+            "the endpoint side is open with no guest bytes"
+        );
+        // Idempotent: a second open on the same id reuses the connection.
+        assert!(b.open_connection(9));
+        assert_eq!(b.conns.len(), 1);
+
+        b.close_connection(9);
+        assert!(!b.is_active());
+        drop(server.join().unwrap());
     }
 
     #[test]

--- a/specs/sprint/delivery/flowmux-host-first-handshake.md
+++ b/specs/sprint/delivery/flowmux-host-first-handshake.md
@@ -1,0 +1,44 @@
+# The endpoint speaks first, so the relay has to dial first
+
+`machine run --allow-host …` failed on HVF every time with "the network
+endpoint is running but no guest authenticated within 5s — check that the
+guest found its FlowMux identity drive". The guest had found its drive, and
+had connected. The message named the one thing that was fine.
+
+The FlowMux session handshake is host-first: `Session::guest` opens with a
+read and waits for the endpoint's `SessionHello`. The in-house VMM's vsock
+relay was guest-first — `SubstitutionBridge` dialed the per-VM endpoint UDS
+lazily, on the first guest payload, which is the right shape for the
+substitution protocol it was written for and the wrong one for this. So the
+guest connected and blocked on a read, the endpoint had no accepted socket to
+greet it on, and both halves waited until the launcher's five-second deadline
+tore the VM down. A trace of the vsock device showed one packet on port 5253
+for the whole run: `OP_REQUEST`, then nothing.
+
+The relay now opens the endpoint connection on the guest's connect, and
+answers `OP_RST` rather than `OP_RESPONSE` when it cannot — a guest with
+nothing bound learns at connect instead of blocking until its own retry budget
+runs out. Recording the connect header there is the other half of the same
+bug: `drain` can only push endpoint bytes at a connection it holds a header
+for, and the header was only recorded after a successful *guest→host* relay,
+so even an eagerly opened connection had no way back to a guest that had not
+spoken.
+
+Firecracker and QEMU were never affected. Their transports accept on the
+endpoint's own listener, so a guest connect and the host-side accept are the
+same event; only the relayed-UDS path could defer one behind the other.
+
+Two accounting details stayed put. The stream reservation is taken at connect
+and released by `close_connection`, which the refusal arms already call, so
+the budget stays balanced when a first payload is rate-limited on a
+connection that is now already open. And the connection cap is checked before
+the reservation, as before.
+
+Witnesses: `egress_port_delivers_a_host_first_greeting_after_only_a_connect`
+(an endpoint that writes on accept and never reads reaches a guest that has
+only connected — red against the lazy dial),
+`egress_port_resets_a_connect_without_endpoint`,
+`open_connection_fails_closed_without_an_endpoint_and_returns_the_reservation`, and
+`open_connection_is_active_before_any_guest_bytes`. Confirmed live: the
+reported command boots, runs, and returns 0 on HVF, and the endpoint logs
+`FlowMux handshake complete` followed by `FlowMux sending Opened`.


### PR DESCRIPTION
## The bug

`mvmctl machine run --image alpine --allow-host github.com …` never started on
HVF. Every run died with:

```
Error: VM <name>: the network endpoint is running but no guest authenticated
within 5s — the workload has no network. Check that the guest found its
FlowMux identity drive.
```

The guest had found its drive, and had connected. The message named the one
thing that was fine.

## Root cause

The FlowMux session handshake is **host-first**: `Session::guest` opens with a
read and waits for the endpoint's `SessionHello`.

The in-house VMM's vsock relay is **guest-first**: `SubstitutionBridge` dialed
the per-VM endpoint UDS lazily, on the first guest payload — the right shape
for the substitution protocol it was written for, the wrong one for this. So
the guest connected and blocked on a read, the endpoint had no accepted socket
to greet it on, and both halves waited until the launcher's five-second
deadline tore the VM down.

Instrumenting the vsock device made it unambiguous — one packet on port 5253
for an entire run:

```
[vsock-trace] guest_port hit dst=5253 src=486287850 op=1 len=0   # OP_REQUEST
```

…and then nothing. The endpoint log showed `bound` and `serving`, never
`FlowMux handshake complete`.

## The fix

- Open the endpoint connection on the guest's **connect**, not on its first
  byte (`GuestEndpointRelay::open_connection`).
- Answer `OP_RST` instead of `OP_RESPONSE` when it cannot be opened, so a
  guest with nothing bound learns at connect rather than blocking until its
  own retry budget expires.
- Record the connect header there too. That is the other half of the same
  bug: `drain` can only push endpoint bytes at a connection it holds a header
  for, and the header was only recorded after a successful *guest→host* relay
  — so even an eagerly-opened connection had no way back to a guest that had
  not spoken.

Stream-budget accounting is unchanged in effect: the reservation is taken at
connect and returned by `close_connection`, which the refusal arms already
call.

Firecracker and QEMU were never affected — their transports accept on the
endpoint's own listener, so a guest connect and the host-side accept are the
same event.

## Verification

Live on HVF, the reported command now boots, runs and returns 0:

```
$ mvmctl machine run --image alpine --env NAME=ari --allow-host github.com \
    --mount $PWD:/work -- sh -c 'echo hello from a microVM && echo Hi from $NAME'
hello from a microVM
Hi from ari
```

and the endpoint logs `FlowMux handshake complete` followed by
`FlowMux sending Opened`.

New witnesses, each confirmed red against the lazy dial:

- `egress_port_delivers_a_host_first_greeting_after_only_a_connect`
- `egress_port_resets_a_connect_without_endpoint`
- `open_connection_fails_closed_without_an_endpoint_and_returns_the_reservation`
- `open_connection_is_active_before_any_guest_bytes`

Gates: `cargo nextest run --workspace` (12457 passed), `cargo test --workspace
--doc`, `cargo clippy --workspace --all-targets -D warnings`, nightly `cargo
fmt --all --check`, `just check-gated`, and every `xtask check-*` gate named
in the workflows.
