### PR TITLE
ci: check sidecar coherence on both arches, where the boot gate reaches one

### DIFF
--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -467,6 +467,11 @@ jobs:
             "staging/default-microvm-rootfs-${ARCH}.ext4" "staged ${ARCH}"
           bash nix/packaging/release/assert-kernel-format.sh \
             "staging/default-microvm-vmlinux-${ARCH}" "${ARCH}" "staged ${ARCH} kernel"
+          # Runs on BOTH legs, unlike the boot gate below. Reading JSON needs no
+          # KVM, so the one defect class that has actually shipped through the
+          # aarch64 leg's blind spot — an incoherent sidecar — is caught on both.
+          bash nix/packaging/release/assert-sidecar-coherent.sh \
+            "staging/default-microvm-meta-${ARCH}.json" "staged ${ARCH} sidecar"
 
       # Nothing in this job ever started the image. Every gate below the build
       # is a checksum, a signature or a byte-level read, and none of those can
@@ -476,9 +481,12 @@ jobs:
       #
       # x86_64 only: the aarch64 leg runs on ubuntu-24.04-arm, which has no
       # nested KVM and cannot boot a guest at all. That leg's coverage is the
-      # static /init read above, which catches the defect class that actually
-      # shipped and is a stated compromise rather than a claim of equivalence —
-      # an aarch64-only regression that is not a shebang defect still gets past.
+      # static reads above — the /init shebang, the kernel format, and the
+      # sidecar coherence check, each catching a class that has actually shipped
+      # — and remains a stated compromise rather than a claim of equivalence: an
+      # aarch64-only regression outside those classes still gets past. Closing
+      # it needs an arm64 runner with KVM, which is infrastructure rather than
+      # anything this file can express.
       # The boot gate runs `cargo test`, which builds mvmctl, whose build.rs
       # cross-compiles the embedded host binaries as static musl and needs the
       # pinned zig. Without it the gate fails before it ever starts a guest —

--- a/nix/packaging/release/assert-sidecar-coherent.sh
+++ b/nix/packaging/release/assert-sidecar-coherent.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Assert a published image's `mvm-meta.json` describes a boot contract the
+# admission gate will accept.
+#
+# The sidecar is metadata, so every checksum and signature over it verifies
+# happily while it says something the runtime then refuses. `boot-image/v0.1.0`
+# failed on every tag push for a day because the sidecar claimed
+# `overlayAware: true` without `runtimeLean: true` — a rootfs that requires the
+# runtime overlay while also claiming a baked agent fallback. The required-
+# overlay gate refuses exactly that pair.
+#
+# It matters that this is a *static* check. The only thing that caught the
+# defect before was the boot gate, which runs on x86_64 alone: GitHub's arm64
+# runners have no nested KVM and cannot start a guest. So an aarch64 sidecar
+# defect of this class shipped unverified. Reading the JSON needs no KVM, so
+# both legs get the same check.
+#
+# Usage: assert-sidecar-coherent.sh SIDECAR_JSON [LABEL]
+set -euo pipefail
+
+sidecar="${1:-}"
+label="${2:-$sidecar}"
+if [ -z "$sidecar" ]; then
+  echo "usage: assert-sidecar-coherent.sh SIDECAR_JSON [LABEL]" >&2
+  exit 2
+fi
+if [ ! -f "$sidecar" ]; then
+  echo "assert-sidecar-coherent: $label: no sidecar at $sidecar" >&2
+  exit 1
+fi
+
+field() {
+  # Absent reads as `false`, which is exactly how the runtime treats a missing
+  # field — so a dropped key is caught here rather than inverting silently.
+  python3 -c '
+import json,sys
+with open(sys.argv[1]) as f:
+    meta = json.load(f)
+print("true" if meta.get(sys.argv[2]) is True else "false")
+' "$sidecar" "$1"
+}
+
+overlay_aware="$(field overlayAware)"
+runtime_lean="$(field runtimeLean)"
+
+if [ "$overlay_aware" != "$runtime_lean" ]; then
+  echo "assert-sidecar-coherent: $label: overlayAware=$overlay_aware but runtimeLean=$runtime_lean" >&2
+  echo "  These describe one decision — whether the rootfs omits the baked agent" >&2
+  echo "  fallback — so they must agree. A required-overlay boot refuses this pair," >&2
+  echo "  and a checksum over the sidecar cannot see it." >&2
+  echo "  Usually a field missing from default-tenant's sidecarJson inherit list." >&2
+  exit 1
+fi
+
+echo "assert-sidecar-coherent: $label: overlayAware=$overlay_aware runtimeLean=$runtime_lean (coherent)"


### PR DESCRIPTION
The second half of "the aarch64 leg publishes unverified".

## What is actually fixable here

The boot gate runs on x86_64 only, and correctly so — the aarch64 leg runs on `ubuntu-24.04-arm`, which has no nested KVM and **cannot start a guest at all**. Closing that properly needs an arm64 runner with KVM: infrastructure, not something this workflow can express. This PR does not pretend otherwise.

What *can* move is which defect classes need a boot to catch.

## The defect that proves the gap

`boot-image/v0.1.0` failed on every tag push for a day because the staged `mvm-meta.json` claimed `overlayAware: true` without `runtimeLean: true` — a rootfs that requires the runtime overlay while also claiming a baked agent fallback. The required-overlay admission gate refuses exactly that pair.

Every checksum and signature over that sidecar verified clean throughout, because the bytes were copied faithfully. They were just wrong. **Only the boot gate caught it — so only on x86_64.** The same defect on the aarch64 leg would have shipped.

## The fix

Reading JSON needs no KVM, so `assert-sidecar-coherent.sh` runs on **both** legs, beside the existing `/init` shebang and kernel-format reads.

A missing key is treated as `false` — exactly how the runtime treats it — so a dropped field is caught here rather than silently inverting its meaning, which is precisely how it shipped.

Verified both directions:

```
$ assert-sidecar-coherent.sh ok.json good
assert-sidecar-coherent: good: overlayAware=true runtimeLean=true (coherent)

$ assert-sidecar-coherent.sh bad.json "the shipped defect"
assert-sidecar-coherent: the shipped defect: overlayAware=true but runtimeLean=false
  These describe one decision — whether the rootfs omits the baked agent
  fallback — so they must agree. A required-overlay boot refuses this pair,
  and a checksum over the sidecar cannot see it.
  Usually a field missing from default-tenant's sidecarJson inherit list.
```

`shellcheck` and `actionlint` clean.

## Honesty about what remains

The scope comment above the boot gate is updated to state the aarch64 leg's static coverage as it now is — shebang, kernel format, sidecar coherence — and to keep saying plainly that an aarch64-only regression outside those classes still gets past. It remains a stated compromise, just a narrower one.