### PR TITLE
Session CLI and chain records: mvmctl agent-session, and evidence for park/resume

### DIFF
--- a/crates/mvm-cli/src/commands/agent_session.rs
+++ b/crates/mvm-cli/src/commands/agent_session.rs
@@ -1,0 +1,340 @@
+//! `mvmctl agent-session` — the operator surface for durable agent sessions.
+//!
+//! A durable agent session outlives the sandbox that runs it: it parks
+//! (releasing its sandbox) and resumes later as a fresh admission. The records
+//! behind that live in `mvm_runtime::agent_session`; until this verb existed
+//! nothing outside the library could see or move one.
+//!
+//! Deliberately **not** called `session`: `mvmctl machine session` already
+//! means machine-session residency — a warm VM kept alive across calls, with
+//! idle timeouts and attach — which is a different concept over a different
+//! store. The types settled the collision first by taking the `AgentSession`
+//! prefix; the verb follows them.
+
+use anyhow::{Context, Result};
+use clap::{Args as ClapArgs, Subcommand};
+
+use mvm_contract::protocol::agent_session::AgentSessionId;
+use mvm_core::user_config::MvmConfig;
+use mvm_runtime::agent_session::{
+    AgentSessionRecord, AgentSessionStore, ParkReason, SandboxResidency, StorageTier,
+};
+
+use super::Cli;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub action: AgentSessionAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum AgentSessionAction {
+    /// List every durable agent session recorded on this host
+    #[command(alias = "list")]
+    Ls(LsArgs),
+    /// Print one session's recorded state in full
+    Show(ShowArgs),
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct LsArgs {
+    /// Emit the records as JSON instead of one summary line each
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct ShowArgs {
+    /// Session id, as `agent-session ls` prints it
+    pub session_id: String,
+    /// Emit the record as JSON instead of a field-per-line summary
+    #[arg(long)]
+    pub json: bool,
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    match args.action {
+        AgentSessionAction::Ls(a) => ls(&AgentSessionStore::open(), a.json),
+        AgentSessionAction::Show(a) => show(&AgentSessionStore::open(), &a.session_id, a.json),
+    }
+}
+
+/// Parse an operator-supplied session id at the boundary, so a malformed one
+/// is refused before it is ever joined into a store path.
+fn parse_session_id(raw: &str) -> Result<AgentSessionId> {
+    AgentSessionId::parse(raw).map_err(|e| anyhow::anyhow!("invalid session id '{raw}': {e}"))
+}
+
+fn ls(store: &AgentSessionStore, json: bool) -> Result<()> {
+    let records = store.list()?;
+    if json {
+        return crate::json_out::emit_json(&records);
+    }
+    if records.is_empty() {
+        println!("(no agent sessions)");
+        return Ok(());
+    }
+    println!("{:<32} {:<5} RESIDENCY", "SESSION", "GEN");
+    for record in &records {
+        println!("{}", summary_line(record));
+    }
+    Ok(())
+}
+
+fn show(store: &AgentSessionStore, raw_id: &str, json: bool) -> Result<()> {
+    let id = parse_session_id(raw_id)?;
+    // An absent session is an error naming the id rather than an empty
+    // success: "no such session" and "a session with nothing in it" are
+    // different answers and an operator acts differently on each.
+    let record = store
+        .load(&id)
+        .with_context(|| format!("no agent session '{raw_id}' on this host"))?;
+    if json {
+        return crate::json_out::emit_json(&record);
+    }
+    for line in detail_lines(&record) {
+        println!("{line}");
+    }
+    Ok(())
+}
+
+/// The `ls` row for one session.
+///
+/// A parked session's reason and tier ride on the same line because they are
+/// what an operator triages on: the reason says why it is waiting, and the
+/// tier says what the wait costs.
+fn summary_line(record: &AgentSessionRecord) -> String {
+    let mut line = format!(
+        "{:<32} {:<5} {}",
+        record.session_id.as_str(),
+        record.generation,
+        residency_name(record.state)
+    );
+    if let Some(reason) = record.park_reason {
+        line.push_str("  reason=");
+        line.push_str(park_reason_name(reason));
+    }
+    if let Some(tier) = record.storage_tier {
+        line.push_str("  tier=");
+        line.push_str(storage_tier_name(tier));
+    }
+    line
+}
+
+/// Every recorded field of one session, one per line.
+fn detail_lines(record: &AgentSessionRecord) -> Vec<String> {
+    let mut lines = vec![
+        format!("session:        {}", record.session_id.as_str()),
+        format!("residency:      {}", residency_name(record.state)),
+        format!("generation:     {}", record.generation),
+        format!(
+            "park reason:    {}",
+            record
+                .park_reason
+                .map_or("-", |reason| park_reason_name(reason))
+        ),
+        format!(
+            "storage tier:   {}",
+            record.storage_tier.map_or("-", storage_tier_name)
+        ),
+        format!("journal cursor: {}", record.journal_cursor),
+        format!(
+            "resume point:   {}",
+            record
+                .parent_checkpoint
+                .as_ref()
+                .map_or_else(|| "-".to_string(), ToString::to_string)
+        ),
+    ];
+    // The head is a digest, not a secret, so it is printed as recorded. Its
+    // *absence* is the reportable fact: the store's resume fence has nothing
+    // to compare against for a session parked without one, so that session
+    // resumes unfenced and an operator should be able to see it.
+    lines.push(match record.approval_head.as_ref() {
+        Some(head) => format!("approval head:  {head}"),
+        None => "approval head:  (none recorded — this session resumes unfenced)".to_string(),
+    });
+    lines.push(format!(
+        "members:        {}",
+        if record.members.is_empty() {
+            "-".to_string()
+        } else {
+            record.members.join(", ")
+        }
+    ));
+    lines.push(format!("created (unix): {}", record.created_unix));
+    lines.push(format!("updated (unix): {}", record.updated_unix));
+    lines
+}
+
+fn residency_name(state: SandboxResidency) -> &'static str {
+    match state {
+        SandboxResidency::Active => "active",
+        SandboxResidency::Hibernated => "hibernated",
+        SandboxResidency::Closed => "closed",
+    }
+}
+
+/// The operator-facing spelling of a park reason. Shared by the renderer and
+/// by `--reason` parsing, so what an operator reads back is exactly what they
+/// may type.
+fn park_reason_name(reason: ParkReason) -> &'static str {
+    match reason {
+        ParkReason::ApprovalWait => "approval-wait",
+        ParkReason::Idle => "idle",
+        ParkReason::HostShutdown => "host-shutdown",
+        ParkReason::Operator => "operator",
+        ParkReason::RetentionDemotion => "retention-demotion",
+    }
+}
+
+fn storage_tier_name(tier: StorageTier) -> &'static str {
+    match tier {
+        StorageTier::Resident => "resident",
+        StorageTier::Parked => "parked",
+        StorageTier::Cold => "cold",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_core::checkpoint::{ApprovalHead, CheckpointDigest};
+    use mvm_runtime::agent_session::ParkInput;
+
+    fn active(id: &str) -> AgentSessionRecord {
+        AgentSessionRecord {
+            session_id: AgentSessionId::parse(id).unwrap(),
+            generation: 1,
+            state: SandboxResidency::Active,
+            members: vec!["vm-alpha".to_string()],
+            parent_checkpoint: Some(
+                CheckpointDigest::parse(format!("sha256:{}", "1a".repeat(32))).unwrap(),
+            ),
+            created_unix: 1_755_000_000,
+            updated_unix: 1_755_000_000,
+            journal_cursor: 7,
+            approval_head: None,
+            storage_tier: None,
+            park_reason: None,
+        }
+    }
+
+    /// Park through the real transition rather than writing `Hibernated` into
+    /// a literal, so the fixture cannot describe a state the state machine
+    /// would never produce.
+    fn parked(id: &str, reason: ParkReason) -> AgentSessionRecord {
+        active(id)
+            .park(
+                &ParkInput {
+                    reason,
+                    journal_cursor: 7,
+                    approval_head: Some(
+                        ApprovalHead::parse(format!("sha256:{}", "ab".repeat(32))).unwrap(),
+                    ),
+                },
+                1_755_000_100,
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn an_active_session_renders_its_residency_and_nothing_about_a_park() {
+        let line = summary_line(&active("sess-alpha"));
+        assert!(line.contains("sess-alpha"), "{line}");
+        assert!(line.contains("active"), "{line}");
+        assert!(!line.contains("reason="), "{line}");
+        assert!(!line.contains("tier="), "{line}");
+    }
+
+    #[test]
+    fn a_parked_session_renders_its_reason_and_tier() {
+        // The tier is not decoration: approval-wait selects `parked`, so the
+        // rendered row is also how an operator sees what the wait costs.
+        let line = summary_line(&parked("sess-beta", ParkReason::ApprovalWait));
+        assert!(line.contains("hibernated"), "{line}");
+        assert!(line.contains("reason=approval-wait"), "{line}");
+        assert!(line.contains("tier=parked"), "{line}");
+    }
+
+    #[test]
+    fn an_idle_park_renders_the_resident_tier_it_actually_selects() {
+        let line = summary_line(&parked("sess-gamma", ParkReason::Idle));
+        assert!(line.contains("reason=idle"), "{line}");
+        assert!(line.contains("tier=resident"), "{line}");
+    }
+
+    #[test]
+    fn a_closed_session_renders_as_closed() {
+        let mut record = active("sess-delta");
+        record.state = SandboxResidency::Closed;
+        assert!(summary_line(&record).contains("closed"));
+    }
+
+    #[test]
+    fn detail_says_when_no_approval_head_was_recorded() {
+        let lines = detail_lines(&active("sess-alpha")).join("\n");
+        assert!(
+            lines.contains("approval head:  (none recorded"),
+            "an unfenced session must say so: {lines}"
+        );
+    }
+
+    #[test]
+    fn detail_prints_a_recorded_approval_head_as_the_digest_it_is() {
+        let record = parked("sess-alpha", ParkReason::Operator);
+        let lines = detail_lines(&record).join("\n");
+        assert!(
+            lines.contains(&format!("sha256:{}", "ab".repeat(32))),
+            "the head is a digest, not a secret: {lines}"
+        );
+    }
+
+    #[test]
+    fn detail_carries_every_recorded_field() {
+        let record = parked("sess-alpha", ParkReason::ApprovalWait);
+        let lines = detail_lines(&record).join("\n");
+        for expected in [
+            "session:        sess-alpha",
+            "residency:      hibernated",
+            "generation:     1",
+            "park reason:    approval-wait",
+            "storage tier:   parked",
+            "journal cursor: 7",
+            "members:        vm-alpha",
+        ] {
+            assert!(lines.contains(expected), "missing `{expected}`:\n{lines}");
+        }
+        assert!(
+            lines.contains(&format!("resume point:   sha256:{}", "1a".repeat(32))),
+            "{lines}"
+        );
+    }
+
+    #[test]
+    fn an_absent_session_is_an_error_naming_the_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let err = show(&store, "sess-nope", false).expect_err("an absent session must refuse");
+        assert!(
+            format!("{err}").contains("sess-nope"),
+            "the refusal must name the id: {err}"
+        );
+    }
+
+    #[test]
+    fn a_malformed_session_id_is_refused_before_it_reaches_the_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let err = show(&store, "../escape", false).expect_err("a path-escaping id must refuse");
+        assert!(format!("{err}").contains("invalid session id"), "{err}");
+    }
+
+    #[test]
+    fn ls_on_an_empty_store_is_a_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path().join("not-created-yet"));
+        ls(&store, false).expect("an empty host has no sessions, which is not an error");
+    }
+}

--- a/crates/mvm-cli/src/commands/agent_session.rs
+++ b/crates/mvm-cli/src/commands/agent_session.rs
@@ -15,7 +15,7 @@ use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 
 use mvm_contract::protocol::agent_session::AgentSessionId;
-use mvm_core::checkpoint::ApprovalHead;
+use mvm_core::checkpoint::{ApprovalHead, CheckpointDigest};
 use mvm_core::plan::PlanId;
 use mvm_core::user_config::MvmConfig;
 use mvm_hostd::plan_admission::{InMemoryNonceLedger, SystemClock};
@@ -37,6 +37,8 @@ pub(in crate::commands) struct Args {
 
 #[derive(Subcommand, Debug, Clone)]
 pub(in crate::commands) enum AgentSessionAction {
+    /// Record a new durable agent session, resident from the start
+    Open(OpenArgs),
     /// List every durable agent session recorded on this host
     #[command(alias = "list")]
     Ls(LsArgs),
@@ -46,6 +48,27 @@ pub(in crate::commands) enum AgentSessionAction {
     Park(ParkArgs),
     /// Re-admit a parked session under a freshly signed plan
     Resume(ResumeArgs),
+}
+
+/// What it takes to bring a session into existence.
+///
+/// Every other subcommand needs a record that already exists, so without this
+/// one the verb had no reachable production input at all: `ls` printed nothing
+/// forever and `park` and `resume` could only ever refuse.
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct OpenArgs {
+    /// Session id to create. Refused if a record already exists under it.
+    pub session_id: String,
+    /// Checkpoint the session may later resume from, as `sha256:<64-hex>`.
+    /// Optional: a session with no resume point is legal, and `resume` will
+    /// refuse it later saying so.
+    #[arg(long)]
+    pub resume_point: Option<String>,
+    /// Sandbox lineage belonging to the session. Repeatable. The first one
+    /// supplies the admitted plan a `park` entry is chained under, so a
+    /// session opened with none cannot record its park in the audit chain.
+    #[arg(long = "member")]
+    pub members: Vec<String>,
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -127,6 +150,7 @@ pub(in crate::commands) struct ResumeArgs {
 
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
     match args.action {
+        AgentSessionAction::Open(a) => open(&AgentSessionStore::open(), &a),
         AgentSessionAction::Ls(a) => ls(&AgentSessionStore::open(), a.json),
         AgentSessionAction::Show(a) => show(&AgentSessionStore::open(), &a.session_id, a.json),
         AgentSessionAction::Park(a) => park(&AgentSessionStore::open(), &a),
@@ -140,6 +164,65 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
 /// is refused before it is ever joined into a store path.
 fn parse_session_id(raw: &str) -> Result<AgentSessionId> {
     AgentSessionId::parse(raw).map_err(|e| anyhow::anyhow!("invalid session id '{raw}': {e}"))
+}
+
+/// Create a session record and report the state it starts in.
+fn open(store: &AgentSessionStore, args: &OpenArgs) -> Result<()> {
+    let record = open_record(store, args)?;
+    println!("{}", summary_line(&record));
+    if record.members.is_empty() {
+        // Said at open time rather than discovered at park time: the park is
+        // what fails to chain, and by then the operator has already moved on.
+        crate::ui::warn(
+            "this session records no member sandbox, so a later park has no admitted \
+             plan to bind to and will not reach the audit chain",
+        );
+    }
+    Ok(())
+}
+
+/// Write the initial record, refusing to displace an existing one.
+///
+/// Split from the printing half for the same reason `park_record` is: the
+/// transition is then testable without a terminal.
+fn open_record(store: &AgentSessionStore, args: &OpenArgs) -> Result<AgentSessionRecord> {
+    let id = parse_session_id(&args.session_id)?;
+    let parent_checkpoint = args
+        .resume_point
+        .as_deref()
+        .map(CheckpointDigest::parse)
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("invalid --resume-point: {e}"))?;
+    // Refuse rather than replace. An overwrite would reset a live session to
+    // generation 1 and drop its resume point, which is the one piece of state
+    // a parked session cannot be recovered without. `exists` rather than a
+    // successful `load` so a record that is present but corrupt also refuses.
+    anyhow::ensure!(
+        !store.exists(&id),
+        "agent session '{}' already exists on this host",
+        args.session_id
+    );
+    let now = mvm_core::util::time::now_unix_secs();
+    let record = AgentSessionRecord {
+        session_id: id,
+        // Generation 1, not 0: a generation counts periods of sandbox
+        // residency and this record opens the first one.
+        generation: 1,
+        state: SandboxResidency::Active,
+        members: args.members.clone(),
+        parent_checkpoint,
+        created_unix: now,
+        updated_unix: now,
+        journal_cursor: 0,
+        // Both are the park transition's to write. An active session has not
+        // parked, so it has no tier, no reason, and no head it was parked
+        // under.
+        approval_head: None,
+        storage_tier: None,
+        park_reason: None,
+    };
+    store.write(&record)?;
+    Ok(record)
 }
 
 fn ls(store: &AgentSessionStore, json: bool) -> Result<()> {
@@ -653,17 +736,55 @@ mod tests {
         assert!(format!("{err}").contains("invalid session id"), "{err}");
     }
 
+    /// The signed labels a resume plan actually carries, read out of the
+    /// synthesis the resume path runs.
+    ///
+    /// Derived rather than listed. A hardcoded denylist of `session_id` and
+    /// `session_generation` would miss `session_parent_checkpoint` and
+    /// `session_approval_head`, which that synthesis also emits, and would go
+    /// on missing whatever is added next.
+    fn resume_plan_label_keys(record: &AgentSessionRecord) -> Vec<String> {
+        let material = ResumePlanMaterial {
+            backend_name: "hvf".to_string(),
+            image_name: "demo".to_string(),
+            image_sha256: "ab".repeat(32),
+            kernel_sha256: None,
+            cpus: 1,
+            mem_mib: 256,
+        };
+        let synthesis = mvm_hostd::session_resume::synthesis_for_resume(record, &material);
+        synthesis.audit_labels.keys().cloned().collect()
+    }
+
+    /// Assert an emitter's extras cannot shadow any signed plan label.
+    fn assert_extras_are_disjoint_from_the_plan_labels(
+        record: &AgentSessionRecord,
+        extras: &[(String, String)],
+    ) {
+        let labels = resume_plan_label_keys(record);
+        // Guard the guard: an empty label set would make the disjointness
+        // below hold for a reason that has nothing to do with the code.
+        assert!(
+            labels.contains(&"session_id".to_string()),
+            "the label set is not the one the resume plan carries: {labels:?}"
+        );
+        let keys: Vec<&str> = extras.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(!keys.is_empty(), "the entry must carry something");
+        for label in &labels {
+            assert!(
+                !keys.contains(&label.as_str()),
+                "extra `{label}` would overwrite the signed plan label of the same name \
+                 (extras: {keys:?}, plan labels: {labels:?})"
+            );
+        }
+    }
+
     #[test]
     fn the_park_entry_keys_do_not_collide_with_the_plan_labels() {
         // `for_plan` extends the plan's labels with the per-event extras, so
         // an extra sharing a key silently replaces the signed plan's value.
-        // The resume plan carries `session_id` and `session_generation` as
-        // signed labels; a park entry must not shadow either.
-        let extras = park_audit_extras(&parked("sess-alpha", ParkReason::ApprovalWait));
-        let keys: Vec<&str> = extras.iter().map(|(k, _)| k.as_str()).collect();
-        assert!(!keys.contains(&"session_id"), "{keys:?}");
-        assert!(!keys.contains(&"session_generation"), "{keys:?}");
-        assert!(!keys.is_empty(), "the entry must carry something");
+        let record = parked("sess-alpha", ParkReason::ApprovalWait);
+        assert_extras_are_disjoint_from_the_plan_labels(&record, &park_audit_extras(&record));
     }
 
     #[test]
@@ -824,16 +945,30 @@ mod tests {
 
     #[test]
     fn the_resume_entry_keys_do_not_collide_with_the_plan_labels() {
-        // Same hazard as the park entry: extras are merged over the signed
-        // plan's labels, and the resume plan carries `session_id` and
-        // `session_generation` as signed labels of its own.
-        let mut record = active("sess-alpha");
-        record.generation = 2;
+        // Same hazard as the park entry, and here it is live rather than
+        // theoretical: this entry rides on the resume plan itself.
+        let record = parked("sess-alpha", ParkReason::ApprovalWait);
         let extras = resume_audit_extras(&record, &PlanId("plan-abc".to_string()));
-        let keys: Vec<&str> = extras.iter().map(|(k, _)| k.as_str()).collect();
-        assert!(!keys.contains(&"session_id"), "{keys:?}");
-        assert!(!keys.contains(&"session_generation"), "{keys:?}");
-        assert!(!keys.is_empty(), "the entry must carry something");
+        assert_extras_are_disjoint_from_the_plan_labels(&record, &extras);
+    }
+
+    #[test]
+    fn the_derived_label_set_covers_more_than_the_two_obvious_names() {
+        // The reason the guard is derived: a record carrying a resume point
+        // and an approval head makes the synthesis emit four labels, and a
+        // hardcoded pair would have watched only half of them.
+        let labels = resume_plan_label_keys(&parked("sess-alpha", ParkReason::ApprovalWait));
+        for expected in [
+            "session_id",
+            "session_generation",
+            "session_parent_checkpoint",
+            "session_approval_head",
+        ] {
+            assert!(
+                labels.contains(&expected.to_string()),
+                "missing `{expected}`: {labels:?}"
+            );
+        }
     }
 
     #[test]
@@ -853,6 +988,152 @@ mod tests {
         // residency behind.
         assert_eq!(got("resumed_at_generation"), Some("2"));
         assert_eq!(got("resumed_plan_id"), Some("plan-abc"));
+    }
+
+    fn open_args(session_id: &str) -> OpenArgs {
+        OpenArgs {
+            session_id: session_id.to_string(),
+            resume_point: None,
+            members: vec!["vm-alpha".to_string()],
+        }
+    }
+
+    #[test]
+    fn open_creates_a_resident_record_at_generation_one() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let record = open_record(&store, &open_args("sess-alpha")).expect("a new session opens");
+
+        assert_eq!(record.generation, 1);
+        assert_eq!(record.state, SandboxResidency::Active);
+        assert_eq!(record.members, vec!["vm-alpha".to_string()]);
+        // A session that has not parked carries none of the park transition's
+        // fields; a tier written here would name a cost nothing is paying.
+        assert_eq!(record.park_reason, None);
+        assert_eq!(record.storage_tier, None);
+        assert_eq!(record.approval_head, None);
+        assert_eq!(
+            store.load(&record.session_id).unwrap(),
+            record,
+            "the record must be readable back through the store"
+        );
+    }
+
+    #[test]
+    fn open_records_a_resume_point_when_one_is_supplied() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let digest = format!("sha256:{}", "1a".repeat(32));
+        let record = open_record(
+            &store,
+            &OpenArgs {
+                resume_point: Some(digest.clone()),
+                ..open_args("sess-alpha")
+            },
+        )
+        .expect("a resume point is legal at open");
+        assert_eq!(
+            record.parent_checkpoint.as_ref().map(ToString::to_string),
+            Some(digest)
+        );
+    }
+
+    #[test]
+    fn opening_an_existing_session_is_refused_and_leaves_it_byte_identical() {
+        // The failure this prevents: an overwrite resets a live session to
+        // generation 1 and drops the resume point it would be brought back
+        // from, so the session becomes unrecoverable rather than merely stale.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let record = parked("sess-alpha", ParkReason::ApprovalWait);
+        store.write(&record).unwrap();
+        let on_disk = tmp.path().join("sess-alpha").join("session.json");
+        let before = std::fs::read(&on_disk).unwrap();
+
+        let err = open_record(&store, &open_args("sess-alpha"))
+            .expect_err("an existing session must not be displaced");
+        assert!(format!("{err:#}").contains("already exists"), "{err:#}");
+        assert_eq!(
+            std::fs::read(&on_disk).unwrap(),
+            before,
+            "a refused open must not rewrite a byte"
+        );
+    }
+
+    #[test]
+    fn open_refuses_a_malformed_session_id_before_it_reaches_the_store() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let err = open_record(&store, &open_args("../escape"))
+            .expect_err("a path-escaping id must refuse");
+        assert!(format!("{err:#}").contains("invalid session id"), "{err:#}");
+    }
+
+    #[test]
+    fn open_refuses_a_malformed_resume_point_and_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let err = open_record(
+            &store,
+            &OpenArgs {
+                resume_point: Some("not-a-digest".to_string()),
+                ..open_args("sess-alpha")
+            },
+        )
+        .expect_err("a malformed digest must be refused at the boundary");
+        assert!(
+            format!("{err:#}").contains("invalid --resume-point"),
+            "{err:#}"
+        );
+        assert!(
+            store.list().unwrap().is_empty(),
+            "a refused open must leave no record behind"
+        );
+    }
+
+    #[test]
+    fn open_then_park_then_show_walks_one_session_end_to_end() {
+        // The four subcommands are only useful as a sequence, and until
+        // `open` existed no sequence was reachable: `park` needed a record
+        // nothing produced. This walks the real code paths in order.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+
+        let opened = open_record(&store, &open_args("sess-alpha")).expect("open");
+        assert_eq!(opened.state, SandboxResidency::Active);
+        assert_eq!(
+            store.list().unwrap().len(),
+            1,
+            "`ls` must now see the session `open` created"
+        );
+
+        let parked = park_record(
+            &store,
+            &ParkArgs {
+                session_id: "sess-alpha".to_string(),
+                reason: "approval-wait".to_string(),
+                journal_cursor: 9,
+                approval_head: None,
+            },
+        )
+        .expect("the session opened active, so it parks");
+
+        // What `show` renders, read off the same record `show` would load.
+        let rendered = detail_lines(&store.load(&parked.session_id).unwrap()).join("\n");
+        assert!(
+            rendered.contains("residency:      hibernated"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("park reason:    approval-wait"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("storage tier:   parked"), "{rendered}");
+        assert!(rendered.contains("journal cursor: 9"), "{rendered}");
+        assert!(
+            rendered.contains("approval head:  (none recorded"),
+            "the park carried no head, and `show` must say so: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/agent_session.rs
+++ b/crates/mvm-cli/src/commands/agent_session.rs
@@ -15,9 +15,10 @@ use anyhow::{Context, Result};
 use clap::{Args as ClapArgs, Subcommand};
 
 use mvm_contract::protocol::agent_session::AgentSessionId;
+use mvm_core::checkpoint::ApprovalHead;
 use mvm_core::user_config::MvmConfig;
 use mvm_runtime::agent_session::{
-    AgentSessionRecord, AgentSessionStore, ParkReason, SandboxResidency, StorageTier,
+    AgentSessionRecord, AgentSessionStore, ParkInput, ParkReason, SandboxResidency, StorageTier,
 };
 
 use super::Cli;
@@ -35,6 +36,8 @@ pub(in crate::commands) enum AgentSessionAction {
     Ls(LsArgs),
     /// Print one session's recorded state in full
     Show(ShowArgs),
+    /// Release an active session's sandbox, recording why
+    Park(ParkArgs),
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -53,10 +56,30 @@ pub(in crate::commands) struct ShowArgs {
     pub json: bool,
 }
 
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct ParkArgs {
+    /// Session id, as `agent-session ls` prints it
+    pub session_id: String,
+    /// Why the session is parking. One of approval-wait, idle,
+    /// host-shutdown, operator, retention-demotion. The reason selects the
+    /// storage tier, so it is not decoration.
+    #[arg(long)]
+    pub reason: String,
+    /// Session-journal position the park is consistent with. A later resume
+    /// that replayed from an earlier cursor would re-run committed work.
+    #[arg(long, default_value_t = 0)]
+    pub journal_cursor: u64,
+    /// Approval-ledger head the session was last admitted under, as
+    /// `sha256:<64-hex>`. A session parked without one resumes unfenced.
+    #[arg(long)]
+    pub approval_head: Option<String>,
+}
+
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
     match args.action {
         AgentSessionAction::Ls(a) => ls(&AgentSessionStore::open(), a.json),
         AgentSessionAction::Show(a) => show(&AgentSessionStore::open(), &a.session_id, a.json),
+        AgentSessionAction::Park(a) => park(&AgentSessionStore::open(), &a),
     }
 }
 
@@ -97,6 +120,137 @@ fn show(store: &AgentSessionStore, raw_id: &str, json: bool) -> Result<()> {
         println!("{line}");
     }
     Ok(())
+}
+
+/// Park a session, then bind the park into the chain-signed audit log.
+fn park(store: &AgentSessionStore, args: &ParkArgs) -> Result<()> {
+    let record = park_record(store, args)?;
+    println!("{}", summary_line(&record));
+    // The record is already durable at this point. A chain entry that cannot
+    // be written is reported rather than raised: failing here would tell an
+    // operator the park did not happen when it did, and a park with no entry
+    // is the lesser of those two wrongs.
+    if let Err(error) = record_park_in_chain(&record) {
+        crate::ui::warn(&format!(
+            "session {} parked, but the park was not recorded in the audit chain: {error:#}",
+            record.session_id.as_str()
+        ));
+    }
+    Ok(())
+}
+
+/// Apply the park to the store and return the record it wrote.
+///
+/// Split from the audit half so the transition is testable without a signer
+/// or an audit directory.
+fn park_record(store: &AgentSessionStore, args: &ParkArgs) -> Result<AgentSessionRecord> {
+    let id = parse_session_id(&args.session_id)?;
+    let reason = parse_park_reason(&args.reason)?;
+    let approval_head = args
+        .approval_head
+        .as_deref()
+        .map(ApprovalHead::parse)
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("invalid --approval-head: {e}"))?;
+    let current = store
+        .load(&id)
+        .with_context(|| format!("no agent session '{}' on this host", args.session_id))?;
+    // The store's fence refuses a caller working from a record some other
+    // transition has superseded. This command loaded the record a moment ago
+    // and is the caller, so it passes what it just read; the fence is doing
+    // nothing for it. What the fence cannot do either way is serialize two
+    // concurrent parks of one session — that needs file locking the store
+    // does not have.
+    store.park(
+        &id,
+        current.generation,
+        ParkInput {
+            reason,
+            journal_cursor: args.journal_cursor,
+            approval_head,
+        },
+        mvm_core::util::time::now_unix_secs(),
+    )
+}
+
+/// Map the `--reason` spelling onto the typed reason.
+///
+/// An explicit match rather than a permissive lookup: an unrecognised reason
+/// is refused naming the accepted set, because falling through to a default
+/// would pick a storage tier the operator never asked for.
+fn parse_park_reason(raw: &str) -> Result<ParkReason> {
+    match raw {
+        "approval-wait" => Ok(ParkReason::ApprovalWait),
+        "idle" => Ok(ParkReason::Idle),
+        "host-shutdown" => Ok(ParkReason::HostShutdown),
+        "operator" => Ok(ParkReason::Operator),
+        "retention-demotion" => Ok(ParkReason::RetentionDemotion),
+        other => anyhow::bail!(
+            "unknown park reason '{other}'; accepted: approval-wait, idle, \
+             host-shutdown, operator, retention-demotion"
+        ),
+    }
+}
+
+/// The extra labels a `session.parked` entry carries.
+///
+/// The keys are deliberately not `session_id` / `session_generation`. An
+/// entry's extras are merged *over* the signed plan's audit labels, and a
+/// resume plan carries both of those names as signed labels; an extra reusing
+/// one would replace what was admitted with what this command believed, so the
+/// entry would attribute the park to the emitter's belief rather than to the
+/// admission. The `parked_`/`park_` prefixes keep both readable side by side.
+fn park_audit_extras(record: &AgentSessionRecord) -> Vec<(String, String)> {
+    let mut extras = vec![
+        (
+            "parked_session".to_string(),
+            record.session_id.as_str().to_string(),
+        ),
+        (
+            "parked_at_generation".to_string(),
+            record.generation.to_string(),
+        ),
+    ];
+    // Both are written by the park transition, so both are present on a record
+    // this function is called with. They are still emitted conditionally
+    // rather than defaulted: a blank tier would read in the chain as a tier
+    // that was checked and found empty.
+    if let Some(reason) = record.park_reason {
+        extras.push((
+            "park_reason".to_string(),
+            park_reason_name(reason).to_string(),
+        ));
+    }
+    if let Some(tier) = record.storage_tier {
+        extras.push((
+            "park_storage_tier".to_string(),
+            storage_tier_name(tier).to_string(),
+        ));
+    }
+    extras
+}
+
+/// Bind a completed park into the chain-signed audit log.
+///
+/// The entry rides on the plan the parked residency was admitted under: the
+/// session record holds no plan of its own, and the member sandbox's persisted
+/// plan is the authority the residency actually ran with. A session with no
+/// member, or a member with no persisted plan, has nothing to bind to and is
+/// reported rather than recorded under a plan it never ran.
+fn record_park_in_chain(record: &AgentSessionRecord) -> Result<()> {
+    let member = record.members.first().ok_or_else(|| {
+        anyhow::anyhow!(
+            "session {} records no member sandbox, so there is no admitted plan to bind to",
+            record.session_id.as_str()
+        )
+    })?;
+    let plan = mvm_hostd::audit::plan_persist::read_plan(member)
+        .with_context(|| format!("reading the admitted plan of member sandbox '{member}'"))?;
+    let signer = super::vm::host_signer::load_or_init()
+        .context("loading the host signer to sign the park entry")?;
+    let emitter = super::vm::audit_chain::AuditEmitter::new(signer.signing)
+        .context("opening the audit chain to record the park")?;
+    emitter.emit_session_parked(&plan, park_audit_extras(record))
 }
 
 /// The `ls` row for one session.
@@ -329,6 +483,130 @@ mod tests {
         let store = AgentSessionStore::at(tmp.path());
         let err = show(&store, "../escape", false).expect_err("a path-escaping id must refuse");
         assert!(format!("{err}").contains("invalid session id"), "{err}");
+    }
+
+    #[test]
+    fn the_park_entry_keys_do_not_collide_with_the_plan_labels() {
+        // `for_plan` extends the plan's labels with the per-event extras, so
+        // an extra sharing a key silently replaces the signed plan's value.
+        // The resume plan carries `session_id` and `session_generation` as
+        // signed labels; a park entry must not shadow either.
+        let extras = park_audit_extras(&parked("sess-alpha", ParkReason::ApprovalWait));
+        let keys: Vec<&str> = extras.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(!keys.contains(&"session_id"), "{keys:?}");
+        assert!(!keys.contains(&"session_generation"), "{keys:?}");
+        assert!(!keys.is_empty(), "the entry must carry something");
+    }
+
+    #[test]
+    fn park_extras_carry_what_the_store_actually_wrote() {
+        let record = parked("sess-alpha", ParkReason::ApprovalWait);
+        let extras = park_audit_extras(&record);
+        let got = |key: &str| {
+            extras
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(got("parked_session"), Some("sess-alpha"));
+        // The generation is unchanged by a park — it identifies one period of
+        // residency, which a park suspends rather than ends.
+        assert_eq!(got("parked_at_generation"), Some("1"));
+        assert_eq!(got("park_reason"), Some("approval-wait"));
+        assert_eq!(got("park_storage_tier"), Some("parked"));
+    }
+
+    #[test]
+    fn an_unknown_park_reason_is_refused_and_names_the_accepted_set() {
+        let err = parse_park_reason("whenever").expect_err("an unknown reason must refuse");
+        let text = format!("{err}");
+        assert!(text.contains("whenever"), "{text}");
+        for accepted in ["approval-wait", "idle", "host-shutdown", "operator"] {
+            assert!(
+                text.contains(accepted),
+                "the error must list `{accepted}`: {text}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_park_reason_round_trips_through_its_operator_spelling() {
+        // What `ls` prints back is exactly what `--reason` accepts. A reason
+        // added later that renders one way and parses another would leave an
+        // operator retyping a value the tool just showed them.
+        for reason in [
+            ParkReason::ApprovalWait,
+            ParkReason::Idle,
+            ParkReason::HostShutdown,
+            ParkReason::Operator,
+            ParkReason::RetentionDemotion,
+        ] {
+            assert_eq!(parse_park_reason(park_reason_name(reason)).unwrap(), reason);
+        }
+    }
+
+    #[test]
+    fn parking_an_already_parked_session_refuses_and_leaves_the_record_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let record = parked("sess-alpha", ParkReason::Idle);
+        store.write(&record).unwrap();
+        park_record(
+            &store,
+            &ParkArgs {
+                session_id: "sess-alpha".to_string(),
+                reason: "operator".to_string(),
+                journal_cursor: 0,
+                approval_head: None,
+            },
+        )
+        .expect_err("a hibernated session is not active, so it cannot be parked");
+        assert_eq!(store.load(&record.session_id).unwrap(), record);
+    }
+
+    #[test]
+    fn a_park_writes_the_reason_and_the_tier_it_selects() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        store.write(&active("sess-alpha")).unwrap();
+        let parked = park_record(
+            &store,
+            &ParkArgs {
+                session_id: "sess-alpha".to_string(),
+                reason: "approval-wait".to_string(),
+                journal_cursor: 11,
+                approval_head: None,
+            },
+        )
+        .expect("an active session parks");
+        assert_eq!(parked.state, SandboxResidency::Hibernated);
+        assert_eq!(parked.park_reason, Some(ParkReason::ApprovalWait));
+        assert_eq!(parked.storage_tier, Some(StorageTier::Parked));
+        assert_eq!(parked.journal_cursor, 11);
+        assert_eq!(store.load(&parked.session_id).unwrap(), parked);
+    }
+
+    #[test]
+    fn a_malformed_approval_head_is_refused_before_the_record_moves() {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let record = active("sess-alpha");
+        store.write(&record).unwrap();
+        park_record(
+            &store,
+            &ParkArgs {
+                session_id: "sess-alpha".to_string(),
+                reason: "operator".to_string(),
+                journal_cursor: 0,
+                approval_head: Some("not-a-digest".to_string()),
+            },
+        )
+        .expect_err("a malformed head must be refused at the boundary");
+        assert_eq!(
+            store.load(&record.session_id).unwrap(),
+            record,
+            "a refused park must not touch the record"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/agent_session.rs
+++ b/crates/mvm-cli/src/commands/agent_session.rs
@@ -16,10 +16,16 @@ use clap::{Args as ClapArgs, Subcommand};
 
 use mvm_contract::protocol::agent_session::AgentSessionId;
 use mvm_core::checkpoint::ApprovalHead;
+use mvm_core::plan::PlanId;
 use mvm_core::user_config::MvmConfig;
+use mvm_hostd::plan_admission::{InMemoryNonceLedger, SystemClock};
+use mvm_hostd::session_resume::{
+    ResumePlanMaterial, ResumeRequest, ResumedSession, resume_session,
+};
 use mvm_runtime::agent_session::{
     AgentSessionRecord, AgentSessionStore, ParkInput, ParkReason, SandboxResidency, StorageTier,
 };
+use mvm_runtime::checkpoint::CheckpointStore;
 
 use super::Cli;
 
@@ -38,6 +44,8 @@ pub(in crate::commands) enum AgentSessionAction {
     Show(ShowArgs),
     /// Release an active session's sandbox, recording why
     Park(ParkArgs),
+    /// Re-admit a parked session under a freshly signed plan
+    Resume(ResumeArgs),
 }
 
 #[derive(ClapArgs, Debug, Clone)]
@@ -75,11 +83,56 @@ pub(in crate::commands) struct ParkArgs {
     pub approval_head: Option<String>,
 }
 
+/// The workload half of a resume, taken as flags.
+///
+/// The session record deliberately holds none of this: an image, a kernel and
+/// a size change on their own schedule, and recording them in the record would
+/// make it a second copy of the plan that has to be kept in step with one.
+/// Somebody therefore has to supply them, and for now that is the operator.
+/// Deriving them from the resume point's supervisor config is a later step;
+/// taking them as flags keeps the seam visible instead of guessing.
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct ResumeArgs {
+    /// Session id, as `agent-session ls` prints it
+    pub session_id: String,
+    /// Runtime profile the resumed sandbox is admitted for (hvf, libkrun, …).
+    /// Not in the session record — supply it here.
+    #[arg(long)]
+    pub backend: String,
+    /// Image reference to record in the signed plan. Not in the session
+    /// record — supply it here.
+    #[arg(long)]
+    pub image: String,
+    /// Lowercase-hex SHA-256 of the rootfs the resume boots. Not in the
+    /// session record — supply it here.
+    #[arg(long)]
+    pub image_sha256: String,
+    /// Lowercase-hex SHA-256 of the kernel. Omit for a backend that carries
+    /// its own.
+    #[arg(long)]
+    pub kernel_sha256: Option<String>,
+    /// vCPUs the resumed sandbox is admitted for
+    #[arg(long)]
+    pub cpus: u32,
+    /// Memory the resumed sandbox is admitted for, in MiB
+    #[arg(long)]
+    pub mem_mib: u64,
+    /// The approval ledger's head right now, as `sha256:<64-hex>`. The store
+    /// refuses when it differs from the head recorded at park time, so a
+    /// resume cannot silently run under grants the session was never admitted
+    /// for. Omit only for a session parked without one.
+    #[arg(long)]
+    pub approval_head: Option<String>,
+}
+
 pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
     match args.action {
         AgentSessionAction::Ls(a) => ls(&AgentSessionStore::open(), a.json),
         AgentSessionAction::Show(a) => show(&AgentSessionStore::open(), &a.session_id, a.json),
         AgentSessionAction::Park(a) => park(&AgentSessionStore::open(), &a),
+        AgentSessionAction::Resume(a) => {
+            resume(&AgentSessionStore::open(), &CheckpointStore::open(), &a)
+        }
     }
 }
 
@@ -251,6 +304,121 @@ fn record_park_in_chain(record: &AgentSessionRecord) -> Result<()> {
     let emitter = super::vm::audit_chain::AuditEmitter::new(signer.signing)
         .context("opening the audit chain to record the park")?;
     emitter.emit_session_parked(&plan, park_audit_extras(record))
+}
+
+/// Re-admit a parked session, then bind the resume into the audit chain.
+fn resume(
+    sessions: &AgentSessionStore,
+    checkpoints: &CheckpointStore,
+    args: &ResumeArgs,
+) -> Result<()> {
+    let resumed = resume_record(sessions, checkpoints, args)?;
+    println!("{}", summary_line(&resumed.record));
+    println!("admitted plan:  {}", resumed.admitted.plan_id().0);
+    // Said plainly rather than implied by silence: a resume re-admits the
+    // session under a fresh signed plan and stops there. Restoring the memory
+    // image and starting a sandbox from it is not wired.
+    println!("(no sandbox was booted — a resume re-admits the session, nothing more)");
+    if let Err(error) = record_resume_in_chain(&resumed) {
+        crate::ui::warn(&format!(
+            "session {} resumed, but the resume was not recorded in the audit chain: {error:#}",
+            resumed.record.session_id.as_str()
+        ));
+    }
+    Ok(())
+}
+
+/// Drive the resume through the host's admission path.
+///
+/// This is the first production caller of `resume_session`. It stops at an
+/// admitted plan, exactly as that function does.
+fn resume_record(
+    sessions: &AgentSessionStore,
+    checkpoints: &CheckpointStore,
+    args: &ResumeArgs,
+) -> Result<ResumedSession> {
+    let id = parse_session_id(&args.session_id)?;
+    let approval_head = args
+        .approval_head
+        .as_deref()
+        .map(ApprovalHead::parse)
+        .transpose()
+        .map_err(|e| anyhow::anyhow!("invalid --approval-head: {e}"))?;
+    let current = sessions
+        .load(&id)
+        .with_context(|| format!("no agent session '{}' on this host", args.session_id))?;
+    let material = ResumePlanMaterial {
+        backend_name: args.backend.clone(),
+        image_name: args.image.clone(),
+        image_sha256: args.image_sha256.clone(),
+        kernel_sha256: args.kernel_sha256.clone(),
+        cpus: args.cpus,
+        mem_mib: args.mem_mib,
+    };
+    // The generation is what this command just read, for the same reason the
+    // park path passes what it read: the store's fence refuses a caller
+    // working from a superseded record, and this caller cannot be holding one.
+    let request = ResumeRequest {
+        session_id: &id,
+        expected_generation: current.generation,
+        // The operator's assertion of where the ledger is now, not the head
+        // the record was parked under. Passing the record's own head back
+        // would compare it against itself and check nothing.
+        current_approval_head: approval_head.as_ref(),
+        material: &material,
+        host_signer_keys_dir: None,
+        now_unix: mvm_core::util::time::now_unix_secs(),
+    };
+    // The nonce ledger is per-invocation, so it refuses a replay within one
+    // command and not across two. That is the same posture every other CLI
+    // admission path runs under.
+    resume_session(
+        sessions,
+        checkpoints,
+        &request,
+        &SystemClock,
+        &InMemoryNonceLedger::new(),
+    )
+}
+
+/// The extra labels a `session.resumed` entry carries.
+///
+/// Non-colliding for the same reason the park entry's are, and here the hazard
+/// is live rather than theoretical: this entry rides on the resume plan
+/// itself, which carries `session_id` and `session_generation` as signed
+/// labels. An extra reusing either name would overwrite a value that was
+/// signed with one this command merely believed.
+fn resume_audit_extras(record: &AgentSessionRecord, plan_id: &PlanId) -> Vec<(String, String)> {
+    vec![
+        (
+            "resumed_session".to_string(),
+            record.session_id.as_str().to_string(),
+        ),
+        // The generation the transition wrote — the residency this resume
+        // opened, not the parked one it came from.
+        (
+            "resumed_at_generation".to_string(),
+            record.generation.to_string(),
+        ),
+        // Restates the entry's own plan_id field, so a reader looking only at
+        // labels can still say which admission authorized this residency.
+        ("resumed_plan_id".to_string(), plan_id.0.clone()),
+    ]
+}
+
+/// Bind a completed resume into the chain-signed audit log.
+///
+/// Unlike the park entry, this one needs no plan lookup: the resume produced
+/// the plan it is recorded under.
+fn record_resume_in_chain(resumed: &ResumedSession) -> Result<()> {
+    let signer = super::vm::host_signer::load_or_init()
+        .context("loading the host signer to sign the resume entry")?;
+    let emitter = super::vm::audit_chain::AuditEmitter::new(signer.signing)
+        .context("opening the audit chain to record the resume")?;
+    emitter.emit_session_resumed(
+        resumed.admitted.plan(),
+        resume_audit_extras(&resumed.record, resumed.admitted.plan_id()),
+    )
 }
 
 /// The `ls` row for one session.
@@ -607,6 +775,84 @@ mod tests {
             record,
             "a refused park must not touch the record"
         );
+    }
+
+    fn resume_args(session_id: &str) -> ResumeArgs {
+        ResumeArgs {
+            session_id: session_id.to_string(),
+            backend: "hvf".to_string(),
+            image: "demo".to_string(),
+            image_sha256: "ab".repeat(32),
+            kernel_sha256: Some("cd".repeat(32)),
+            cpus: 2,
+            mem_mib: 512,
+            approval_head: None,
+        }
+    }
+
+    #[test]
+    fn resume_refuses_a_session_that_is_not_parked() {
+        // An active session must be refused on its residency alone, before any
+        // checkpoint is resolved or any plan is signed: a resume of something
+        // already resident would open a second residency for one session.
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions = AgentSessionStore::at(tmp.path().join("sessions"));
+        let checkpoints = CheckpointStore::at(tmp.path().join("checkpoints"));
+        let record = active("sess-alpha");
+        sessions.write(&record).unwrap();
+
+        let err = resume_record(&sessions, &checkpoints, &resume_args("sess-alpha"))
+            .expect_err("an active session must not resume");
+        let text = format!("{err:#}");
+        assert!(text.contains("not parked"), "{text}");
+        assert_eq!(
+            sessions.load(&record.session_id).unwrap(),
+            record,
+            "a refused resume must not touch the record"
+        );
+    }
+
+    #[test]
+    fn resume_refuses_an_unknown_session_naming_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sessions = AgentSessionStore::at(tmp.path().join("sessions"));
+        let checkpoints = CheckpointStore::at(tmp.path().join("checkpoints"));
+        let err = resume_record(&sessions, &checkpoints, &resume_args("sess-nope"))
+            .expect_err("an absent session must refuse");
+        assert!(format!("{err:#}").contains("sess-nope"), "{err:#}");
+    }
+
+    #[test]
+    fn the_resume_entry_keys_do_not_collide_with_the_plan_labels() {
+        // Same hazard as the park entry: extras are merged over the signed
+        // plan's labels, and the resume plan carries `session_id` and
+        // `session_generation` as signed labels of its own.
+        let mut record = active("sess-alpha");
+        record.generation = 2;
+        let extras = resume_audit_extras(&record, &PlanId("plan-abc".to_string()));
+        let keys: Vec<&str> = extras.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(!keys.contains(&"session_id"), "{keys:?}");
+        assert!(!keys.contains(&"session_generation"), "{keys:?}");
+        assert!(!keys.is_empty(), "the entry must carry something");
+    }
+
+    #[test]
+    fn resume_extras_name_the_residency_the_resume_opened() {
+        let mut record = active("sess-alpha");
+        record.generation = 2;
+        let extras = resume_audit_extras(&record, &PlanId("plan-abc".to_string()));
+        let got = |key: &str| {
+            extras
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.as_str())
+        };
+        assert_eq!(got("resumed_session"), Some("sess-alpha"));
+        // The generation the transition wrote, not the parked one it came
+        // from: an entry naming the parent would put the whole chain one
+        // residency behind.
+        assert_eq!(got("resumed_at_generation"), Some("2"));
+        assert_eq!(got("resumed_plan_id"), Some("plan-abc"));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -245,6 +245,7 @@ impl Commands {
             // `trust <sub>` delegates: attest/receipt/audit keep their own
             // verbs, publisher add/list/remove keep `trust`.
             Commands::Trust(a) => a.action.verb_name(),
+            Commands::AgentSession(_) => "agent-session",
             Commands::Deps(_) => "deps",
             Commands::Artifact(_) => "artifact",
             Commands::SeccompAudit(_) => "seccomp-audit",

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -52,6 +52,7 @@ impl TopLevelCommand for Commands {
             Commands::Secret(a) => ops::secret::run(cli, a, cfg),
             Commands::Bundle(a) => bundle::run(cli, a, cfg),
             Commands::Trust(a) => trust::run(cli, a, cfg),
+            Commands::AgentSession(a) => agent_session::run(cli, a, cfg),
             Commands::Deps(a) => deps::run(cli, a, cfg),
             Commands::Artifact(a) => vm::artifact::run(cli, a, cfg),
             Commands::SeccompAudit(a) => seccomp_audit::run(cli, a),

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod agent_session;
 mod bench;
 mod bootstrap;
 mod build;
@@ -239,6 +240,9 @@ pub(in crate::commands) enum Commands {
     /// Manage trusted bundle publishers
     #[command(display_order = 13)]
     Trust(trust::Args),
+    /// Inspect, park, and resume durable agent sessions
+    #[command(name = "agent-session", display_order = 12)]
+    AgentSession(agent_session::Args),
     /// Inspect cached application dependencies
     #[command(display_order = 14)]
     Deps(deps::Args),

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -88,6 +88,7 @@ fn collect_help_width_violations(
 
 // Group module aliases — give tests short names (`cleanup`, `up`, etc.) that
 // follow the dispatcher's naming, regardless of which group they live in.
+use super::agent_session;
 use super::build::build;
 use super::build::compile;
 use super::build::group as build_group;
@@ -1925,6 +1926,47 @@ fn agent_session_verb_is_not_named_session() {
     // `mvmctl machine session` already means machine-session residency.
     // A bare `session` verb would collide with it in the operator's head.
     assert!(Cli::try_parse_from(["mvmctl", "session", "ls"]).is_err());
+}
+
+#[test]
+fn agent_session_park_requires_a_reason() {
+    assert!(Cli::try_parse_from(["mvmctl", "agent-session", "park", "sess-a"]).is_err());
+    assert!(
+        Cli::try_parse_from([
+            "mvmctl",
+            "agent-session",
+            "park",
+            "sess-a",
+            "--reason",
+            "approval-wait",
+        ])
+        .is_ok()
+    );
+}
+
+#[test]
+fn agent_session_park_takes_a_journal_cursor_and_an_approval_head() {
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "agent-session",
+        "park",
+        "sess-a",
+        "--reason",
+        "idle",
+        "--journal-cursor",
+        "42",
+        "--approval-head",
+        "sha256:abababababababababababababababababababababababababababababababab",
+    ])
+    .unwrap();
+    let Commands::AgentSession(args) = cli.command else {
+        panic!("expected the agent-session command")
+    };
+    let agent_session::AgentSessionAction::Park(park) = args.action else {
+        panic!("expected the park subcommand")
+    };
+    assert_eq!(park.journal_cursor, 42);
+    assert!(park.approval_head.is_some());
 }
 
 #[test]

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1916,6 +1916,50 @@ fn agent_session_ls_parses() {
 }
 
 #[test]
+fn agent_session_open_requires_an_id_and_takes_repeatable_members() {
+    assert!(Cli::try_parse_from(["mvmctl", "agent-session", "open"]).is_err());
+
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "agent-session",
+        "open",
+        "sess-a",
+        "--member",
+        "vm-one",
+        "--member",
+        "vm-two",
+        "--resume-point",
+        "sha256:abababababababababababababababababababababababababababababababab",
+    ])
+    .unwrap();
+    let Commands::AgentSession(args) = cli.command else {
+        panic!("expected the agent-session command")
+    };
+    let agent_session::AgentSessionAction::Open(open) = args.action else {
+        panic!("expected the open subcommand")
+    };
+    assert_eq!(open.session_id, "sess-a");
+    assert_eq!(open.members, vec!["vm-one", "vm-two"]);
+    assert!(open.resume_point.is_some());
+}
+
+#[test]
+fn agent_session_open_needs_neither_a_member_nor_a_resume_point() {
+    // Both are legal to omit: a session with no resume point is refused at
+    // resume time, not at open time, and one with no member simply cannot
+    // chain its park.
+    let cli = Cli::try_parse_from(["mvmctl", "agent-session", "open", "sess-a"]).unwrap();
+    let Commands::AgentSession(args) = cli.command else {
+        panic!("expected the agent-session command")
+    };
+    let agent_session::AgentSessionAction::Open(open) = args.action else {
+        panic!("expected the open subcommand")
+    };
+    assert!(open.members.is_empty());
+    assert!(open.resume_point.is_none());
+}
+
+#[test]
 fn agent_session_show_requires_an_id() {
     assert!(Cli::try_parse_from(["mvmctl", "agent-session", "show"]).is_err());
     assert!(Cli::try_parse_from(["mvmctl", "agent-session", "show", "sess-alpha"]).is_ok());

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1945,6 +1945,46 @@ fn agent_session_park_requires_a_reason() {
 }
 
 #[test]
+fn agent_session_resume_requires_the_workload_material() {
+    // The session record deliberately carries no image, kernel or size, so
+    // the operator supplies them. A resume that could be typed without them
+    // would have to guess, which is the thing the flags exist to prevent.
+    assert!(Cli::try_parse_from(["mvmctl", "agent-session", "resume", "sess-a"]).is_err());
+
+    let cli = Cli::try_parse_from([
+        "mvmctl",
+        "agent-session",
+        "resume",
+        "sess-a",
+        "--backend",
+        "hvf",
+        "--image",
+        "demo",
+        "--image-sha256",
+        "abababababababababababababababababababababababababababababababab",
+        "--cpus",
+        "2",
+        "--mem-mib",
+        "512",
+    ])
+    .unwrap();
+    let Commands::AgentSession(args) = cli.command else {
+        panic!("expected the agent-session command")
+    };
+    let agent_session::AgentSessionAction::Resume(resume) = args.action else {
+        panic!("expected the resume subcommand")
+    };
+    assert_eq!(resume.backend, "hvf");
+    assert_eq!(resume.image, "demo");
+    assert_eq!(resume.cpus, 2);
+    assert_eq!(resume.mem_mib, 512);
+    assert!(
+        resume.kernel_sha256.is_none(),
+        "a backend that carries its own kernel supplies no sha"
+    );
+}
+
+#[test]
 fn agent_session_park_takes_a_journal_cursor_and_an_approval_head() {
     let cli = Cli::try_parse_from([
         "mvmctl",

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1906,6 +1906,27 @@ fn top_level_listing_verbs_are_unrecognized() {
     assert!(Cli::try_parse_from(["mvmctl", "ps"]).is_err());
 }
 
+// --- `agent-session`: the durable-agent-session operator surface ---
+
+#[test]
+fn agent_session_ls_parses() {
+    let cli = Cli::try_parse_from(["mvmctl", "agent-session", "ls"]).unwrap();
+    assert!(matches!(cli.command, Commands::AgentSession(_)));
+}
+
+#[test]
+fn agent_session_show_requires_an_id() {
+    assert!(Cli::try_parse_from(["mvmctl", "agent-session", "show"]).is_err());
+    assert!(Cli::try_parse_from(["mvmctl", "agent-session", "show", "sess-alpha"]).is_ok());
+}
+
+#[test]
+fn agent_session_verb_is_not_named_session() {
+    // `mvmctl machine session` already means machine-session residency.
+    // A bare `session` verb would collide with it in the operator's head.
+    assert!(Cli::try_parse_from(["mvmctl", "session", "ls"]).is_err());
+}
+
 #[test]
 fn test_start_verb_is_unrecognized() {
     let result = Cli::try_parse_from(["mvmctl", "start", "--flake", "."]);

--- a/crates/mvm-client/src/audit/event.rs
+++ b/crates/mvm-client/src/audit/event.rs
@@ -365,6 +365,7 @@ pub(crate) fn classify_lifecycle_event(event: &str) -> AuditEventKind {
 fn classify_lifecycle_prefix(event: &str) -> AuditEventKind {
     if event.starts_with("lifecycle.")
         || event.starts_with("checkpoint.")
+        || event.starts_with("session.")
         || event.starts_with("cmd.")
     {
         AuditEventKind::Lifecycle
@@ -601,6 +602,8 @@ mod tests {
             ("plan.exited", Lifecycle),
             ("lifecycle.tenant.destroyed", Lifecycle),
             ("checkpoint.forked", Lifecycle),
+            ("session.parked", Lifecycle),
+            ("session.resumed", Lifecycle),
             ("cmd.up.completed", Lifecycle),
             ("readiness.probe", Readiness),
             ("volume.sealed", Volume),

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -817,6 +817,21 @@ impl AuditEmitter {
         self.emit(plan, "plan.oci_provenance", labels)
     }
 
+    /// Emit `session.parked` — a durable agent session released its sandbox.
+    ///
+    /// Bound to the plan the parked residency was admitted under, so the chain
+    /// records which authorization the session was running with when it
+    /// stopped. The caller supplies the labels; they name the session, the
+    /// generation, the reason and the storage tier, and carry nothing the
+    /// session was working on.
+    pub fn emit_session_parked(
+        &self,
+        plan: &ExecutionPlan,
+        labels: Vec<(String, String)>,
+    ) -> Result<()> {
+        self.emit(plan, "session.parked", labels)
+    }
+
     /// Emit `stream.subscribed` — a follower attached to `vm_name`'s output
     /// stream at `from_seq`.
     ///
@@ -1822,6 +1837,49 @@ mod tests {
         assert!(content.contains("docker.io"));
         assert!(content.contains("oci_resolved_digest"));
         assert!(content.contains("oci_layer_digests"));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn session_parked_event_is_chain_signed_and_keeps_the_plan_labels() {
+        // The park entry's extras must add to the plan's session labels, not
+        // replace them: `for_plan` merges extras over the plan's own labels,
+        // so a key collision would overwrite what was signed.
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::rng().fill_bytes(&mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let mut plan = fixture_plan("local", "plan-SESSION");
+        plan.audit_labels
+            .insert("session_id".to_string(), "sess-alpha".to_string());
+        plan.audit_labels
+            .insert("session_generation".to_string(), "3".to_string());
+
+        emitter
+            .emit_session_parked(
+                &plan,
+                vec![
+                    ("parked_session".to_string(), "sess-alpha".to_string()),
+                    ("parked_at_generation".to_string(), "3".to_string()),
+                    ("park_reason".to_string(), "approval-wait".to_string()),
+                    ("park_storage_tier".to_string(), "parked".to_string()),
+                ],
+            )
+            .unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).expect("audit file exists");
+        assert!(content.contains("session.parked"));
+        assert!(content.contains("park_reason"));
+        assert!(content.contains("approval-wait"));
+        assert!(
+            content.contains("session_generation"),
+            "the plan's own session labels must survive the merge: {content}"
+        );
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
     }
 

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -832,6 +832,20 @@ impl AuditEmitter {
         self.emit(plan, "session.parked", labels)
     }
 
+    /// Emit `session.resumed` — a parked durable agent session was
+    /// re-admitted into a new residency.
+    ///
+    /// Bound to the freshly signed plan the resume admitted, which is the
+    /// authority the new residency runs under. Nothing of the previous
+    /// residency's authority carries over, and neither does its plan.
+    pub fn emit_session_resumed(
+        &self,
+        plan: &ExecutionPlan,
+        labels: Vec<(String, String)>,
+    ) -> Result<()> {
+        self.emit(plan, "session.resumed", labels)
+    }
+
     /// Emit `stream.subscribed` — a follower attached to `vm_name`'s output
     /// stream at `from_seq`.
     ///
@@ -1876,6 +1890,44 @@ mod tests {
         assert!(content.contains("session.parked"));
         assert!(content.contains("park_reason"));
         assert!(content.contains("approval-wait"));
+        assert!(
+            content.contains("session_generation"),
+            "the plan's own session labels must survive the merge: {content}"
+        );
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn session_resumed_event_is_chain_signed_and_keeps_the_plan_labels() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::rng().fill_bytes(&mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let mut plan = fixture_plan("local", "plan-RESUME");
+        plan.audit_labels
+            .insert("session_id".to_string(), "sess-alpha".to_string());
+        plan.audit_labels
+            .insert("session_generation".to_string(), "4".to_string());
+
+        emitter
+            .emit_session_resumed(
+                &plan,
+                vec![
+                    ("resumed_session".to_string(), "sess-alpha".to_string()),
+                    ("resumed_at_generation".to_string(), "4".to_string()),
+                    ("resumed_plan_id".to_string(), "plan-RESUME".to_string()),
+                ],
+            )
+            .unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).expect("audit file exists");
+        assert!(content.contains("session.resumed"));
+        assert!(content.contains("resumed_at_generation"));
         assert!(
             content.contains("session_generation"),
             "the plan's own session labels must survive the merge: {content}"

--- a/crates/mvm-runtime/src/agent_session/mod.rs
+++ b/crates/mvm-runtime/src/agent_session/mod.rs
@@ -233,6 +233,17 @@ impl AgentSessionStore {
         self.root.join(id.as_str()).join(RECORD_FILE)
     }
 
+    /// Whether a record file is present for `id`.
+    ///
+    /// Deliberately not `load(id).is_ok()`: a record that is on disk but
+    /// unparseable must still read as present. A caller that probes before
+    /// creating a session would otherwise treat a corrupt record as an absent
+    /// one and overwrite it, and the record is the only thing a parked
+    /// session's resume point can be recovered from.
+    pub fn exists(&self, id: &AgentSessionId) -> bool {
+        self.record_path(id).is_file()
+    }
+
     /// Write a record, replacing any prior one for the same session.
     ///
     /// Goes through the workspace's shared `mvm_core::atomic_io::atomic_write`
@@ -415,6 +426,33 @@ mod tests {
             journal_cursor: 0,
             approval_head: None,
         }
+    }
+
+    #[test]
+    fn exists_reports_a_present_record_even_when_it_will_not_parse() {
+        // The distinction the method exists for: a caller creating a session
+        // probes `exists` and must be told "present" for a corrupt record, or
+        // it would overwrite the only copy of a parked session's resume point.
+        let tmp = tempfile::tempdir().unwrap();
+        let store = AgentSessionStore::at(tmp.path());
+        let rec = record("sess-alpha");
+        assert!(!store.exists(&rec.session_id));
+        store.write(&rec).unwrap();
+        assert!(store.exists(&rec.session_id));
+
+        std::fs::write(
+            tmp.path().join("sess-alpha").join(RECORD_FILE),
+            b"{ not json",
+        )
+        .unwrap();
+        assert!(
+            store.load(&rec.session_id).is_err(),
+            "the record no longer parses"
+        );
+        assert!(
+            store.exists(&rec.session_id),
+            "an unparseable record is still a record"
+        );
     }
 
     #[test]

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -843,6 +843,50 @@ silently selecting a weaker tier.
 
 Checkpoint blobs are stored under the configured checkpoint store (`MVM_HOME` / `~/.mvm` via the core path helpers). The audit chain records `checkpoint.created`, `checkpoint.restored`, and `checkpoint.forked` entries with content hashes; restore and fork refuse tampered checkpoint content before booting.
 
+## Durable Agent Sessions
+
+`mvmctl agent-session` is the operator surface for durable agent sessions: an
+agent session outlives the sandbox that runs it, parking (releasing its
+sandbox) and resuming later as a fresh admission. It is deliberately not
+spelled `session` — `mvmctl machine session` already means machine-session
+residency, a warm VM kept alive across `invoke` calls, which is a different
+concept over a different store.
+
+| Command | Description |
+|---------|-------------|
+| `mvmctl agent-session open <id> [--resume-point <sha256:...>] [--member <name>]...` | Record a new session, resident from the start, at generation 1. Refuses if a record already exists under that id. `--member` is repeatable. |
+| `mvmctl agent-session ls [--json]` | List every session recorded on this host, one summary line each: id, generation, residency, and — when parked — reason and storage tier. |
+| `mvmctl agent-session show <id> [--json]` | Print one session's recorded state in full: residency, generation, storage tier, park reason, journal cursor, resume point, approval head, members, timestamps. An absent session is an error naming the id. |
+| `mvmctl agent-session park <id> --reason <reason> [--journal-cursor <n>] [--approval-head <sha256:...>]` | Release an active session's sandbox. `--reason` is one of `approval-wait`, `idle`, `host-shutdown`, `operator`, `retention-demotion`, and selects the storage tier. Emits a `session.parked` chain entry. |
+| `mvmctl agent-session resume <id> --backend <name> --image <ref> --image-sha256 <hex> --cpus <n> --mem-mib <n> [--kernel-sha256 <hex>] [--approval-head <sha256:...>]` | Re-admit a parked session under a freshly signed `ExecutionPlan`. Emits a `session.resumed` chain entry. |
+
+`open` is what gives the other four subcommands something to act on: `park` and
+`resume` both need a record that already exists, and nothing else on the host
+writes one.
+
+`resume` takes the workload material — backend, image reference, rootfs and
+kernel SHA-256, vCPUs, memory — as flags because the session record
+deliberately does not carry it. An image, a kernel and a sandbox size each
+change on their own schedule, and recording them in the record would make it a
+second copy of the plan that has to be kept in step with one. Deriving them
+from the resume point's supervisor config instead is a later step; taking them
+as flags keeps the seam visible rather than guessing.
+
+A resume stops at an admitted plan. It does not restore a memory image and does
+not boot a sandbox — the command says so on completion.
+
+`--approval-head` on `resume` is the operator's assertion of where the approval
+ledger is *now*. The store refuses when it differs from the head recorded at
+park time, so a session cannot silently resume under grants it was never
+admitted for. A session parked without a head resumes unfenced, and
+`agent-session show` says so in as many words.
+
+Both chain entries are best-effort: if the entry cannot be written the
+transition is still reported as done, with a warning, because the store write
+already succeeded and failing afterwards would tell an operator a park did not
+happen when it did. A caller that needs the entry must verify the chain
+separately.
+
 ## File Copy
 
 | Command | Description |

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-18
+Last updated: 2026-08-19
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -382,14 +382,29 @@ resume` takes a `current_head` and refuses when it differs from the
       carries — `resume_session` included, which reads its caller-supplied
       `current_approval_head` straight off the record; there is no tier
       selection, no `PostRestore` fabric re-registration, no credential
-      minting at the substitution endpoint, and no chain entry (WS7). The
+      minting at the substitution endpoint. The
       synthesized plan carries `grants: None`, so a resumed session re-arms
-      neither a wall-clock bound nor a CPU share. `resume_session` has no
-      caller anywhere in the workspace outside its own tests — it is wired
-      to no CLI verb or other host code path. A session parked with
-      `approval_head: None` resumes with no ledger fence at all. WS5
-      retention ladder + GC, WS6 CLI, WS7 chain records, WS8 BDD remain
-      untouched.
+      neither a wall-clock bound nor a CPU share. A session parked with
+      `approval_head: None` resumes with no ledger fence at all.
+
+      WS6 is DONE and WS7 is PARTIAL, both via
+      `specs/plans/2026-08-19-session-cli-and-audit.md`
+      (`crates/mvm-cli/src/commands/agent_session.rs`). `mvmctl agent-session`
+      carries `open`, `ls`, `show`, `park` and `resume`. `open` is the
+      producer the verb was missing: before it, no code path anywhere created
+      an `AgentSessionRecord`, so `ls` listed nothing forever and `park` and
+      `resume` could only refuse. With it in place `resume` is a caller of
+      `resume_session` that is both correctly constructed and exercisable, so
+      that function is no longer reachable only from its own tests. WS7 stops
+      short of a tick: `session.parked` and `session.resumed` are emitted, but
+      nothing verifies a session's chain as a unit, there is no
+      `session.closed` entry because no `close()` transition exists, and a
+      failed chain write downgrades to a warning with exit 0, so a scripted
+      operator cannot detect a missing entry. The design spec's
+      `sandbox.parked` / `sandbox.resumed` names were changed to match the
+      code's `session.` prefix rather than the reverse — these are session
+      transitions, and `SandboxResidency` is a field of a session record, not
+      the subject. WS5 retention ladder + GC and WS8 BDD remain untouched here.
 
 - [~] **Admission-bound AI assurance sessions** —
       `specs/plans/2026-08-17-admission-bound-ai-assurance-sessions.md`. W1–W4,

--- a/specs/plans/2026-08-18-durable-agent-sessions.md
+++ b/specs/plans/2026-08-18-durable-agent-sessions.md
@@ -435,17 +435,51 @@ Numbering was reconciled before these documents landed on main (PR #2691):
       it directly today by reading it off the record; there is no tier
       selection, no `PostRestore` fabric re-registration, no credential
       minting at the substitution endpoint, and no chain entry (WS7).
-      `resume_session` itself has no caller anywhere in the workspace outside
-      its own tests — nothing in `mvmctl` or elsewhere invokes it, so none of
-      the above runs on a real resume yet. A session parked with
+      `resume_session` now has one production caller, `mvmctl agent-session
+      resume` (WS6), so the steps above that it does implement do run on a
+      real resume; the steps it does not implement — tier selection,
+      `PostRestore`, credential minting — still do not. A session parked with
       `approval_head: None` resumes with no ledger fence at all.
 - [ ] **WS5 — Retention ladder + GC.** Retention classes, one-way demotion,
       first GC over `checkpoints_dir()` with parent-reachability refusal.
-- [ ] **WS6 — CLI.** `mvmctl session {open,ls,show,park,resume,approve,close}`.
-- [ ] **WS7 — Chain records.** `session.opened`, `sandbox.admitted`,
-      `sandbox.parked`, `approval.requested`, `approval.granted`,
-      `sandbox.resumed`, `session.hibernated`, `session.closed`, wired through
-      the existing `AgentApprovalEvent::audit_action` projection.
+- [x] **WS6 — CLI.** Delivered as `mvmctl agent-session
+      {open,ls,show,park,resume}`
+      (`crates/mvm-cli/src/commands/agent_session.rs`,
+      `specs/plans/2026-08-19-session-cli-and-audit.md`). Named
+      `agent-session`, not `session`: `mvmctl machine session` already means
+      machine-session residency — a warm VM held across `invoke` calls — over
+      a different store.
+      `open` writes the initial record (Active, generation 1) and is what
+      makes the other four reachable at all; before it existed no code path
+      anywhere created an `AgentSessionRecord`, so `ls` printed nothing
+      forever and `park`/`resume` could only refuse. `resume` is the first
+      production caller of `mvm_hostd::session_resume::resume_session` — a
+      caller that is both correctly constructed and, with `open` in place,
+      exercisable end to end.
+      `approve` and `close` are **not** delivered: there is no `close()`
+      transition on the record and no approval-grant surface for a CLI to
+      drive.
+- [ ] **WS7 — Chain records.** Partial. `session.parked` and
+      `session.resumed` are emitted by the CLI's park and resume paths
+      (`AuditEmitter::emit_session_parked` / `emit_session_resumed`), each
+      carrying non-colliding extras so a per-event label cannot overwrite a
+      signed plan label of the same name. Still open: nothing verifies a
+      session's chain as a unit the way `verify_audit_chain` walks a tenant's;
+      there is no `session.closed` entry because no `close()` transition
+      exists to emit one; and a chain-entry write failure downgrades to a
+      warning with exit 0 (the precedent `bind_checkpoint_created` set), so a
+      scripted operator cannot detect a missing entry from the exit status.
+      `session.opened`, `sandbox.admitted`, `approval.requested`,
+      `approval.granted` and `session.hibernated` are unwritten, and nothing
+      yet routes through the `AgentApprovalEvent::audit_action` projection.
+
+      **Event naming.** The two entries that exist are spelled `session.parked`
+      and `session.resumed`, not the `sandbox.parked` / `sandbox.resumed` this
+      spec first proposed. The code's spelling is the better one and the spec
+      follows it: parking and resuming are transitions of a *session*, and
+      `SandboxResidency` is a field of the session record rather than the
+      subject of the event. A `sandbox.` prefix would also read as a sibling of
+      `sandbox.admitted`, which is genuinely about one sandbox.
 - [ ] **WS8 — Tests + BDD** per the Testing section.
 
 ## Out of scope

--- a/specs/plans/2026-08-19-session-cli-and-audit.md
+++ b/specs/plans/2026-08-19-session-cli-and-audit.md
@@ -1,0 +1,377 @@
+# Session CLI and Chain Records Implementation Plan
+
+Backing: preview
+Validation: none
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give durable agent sessions an operator surface, and make park and
+resume leave chain-signed evidence. This is WS6 and WS7 together, because the
+chain entry belongs in the same code path the CLI drives — doing them apart
+would touch park and resume twice.
+
+**Architecture:** A new top-level `mvmctl agent-session` verb with `ls`, `show`,
+`park`, and `resume`. It is **not** called `session`: `mvmctl machine session`
+already exists for machine sessions — warm-VM residency, idle timeouts, attach —
+which is a different concept, and the types already settled this collision by
+taking the `AgentSession*` prefix. `resume` gives
+`mvm_hostd::session_resume::resume_session` its first production caller, which
+is the largest disclosed gap in the work so far.
+
+**Tech Stack:** Rust, `clap`, `anyhow`, `tempfile`, `cargo nextest`.
+
+**Spec:** `specs/plans/2026-08-18-durable-agent-sessions.md` WS6 and WS7.
+
+## Global Constraints
+
+- **In every shell, including the one you commit from, put
+  `export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target`
+  in the SAME command as the cargo or git invocation.** The Bash tool does not
+  persist exports. Do not point it elsewhere — the shared default is corrupted
+  by other concurrent sessions. The machine is near-full on disk; an ENOSPC is a
+  host condition from other worktrees, so wait and retry rather than deleting
+  anything outside this worktree.
+- Use `~/.cargo/bin/cargo`, never Homebrew's rustc.
+- `#[allow(clippy::too_many_arguments)]` is banned; use a params struct.
+- No plan, PR, or ADR references in code comments — CI-gated.
+- Let the pre-commit hook run (~1 min workspace clippy); a guard blocks skipping.
+- Gate before each commit: `cargo fmt --all -- --check`, then
+  `cargo nextest run -p mvm-runtime -p mvm-hostd -p mvm-cli`, then
+  `cargo clippy --workspace --all-targets -- -D warnings`.
+
+## The label-override hazard, which Task 3 must not trip
+
+`mvm_hostd::supervisor::audit::for_plan` does `labels.extend(extras)`
+(`crates/mvm-hostd/src/supervisor/audit.rs:41`), so a per-event extra
+**overrides** a plan label of the same key. The resume plan already carries
+`session_id` and `session_generation` as signed plan labels. If an emitter
+passes either as an extra, the signed plan's value is silently replaced by
+whatever the emitter believed — and the entry would then attribute the action to
+the emitter's guess rather than to what was admitted. Emitters here must use
+distinct extra keys and let the plan labels stand.
+
+## A search discipline this work has violated four times
+
+Before writing that something does not exist, verify **exhaustively** — `| wc -l`
+first, or read the whole result. Do NOT truncate a search establishing absence
+through `head`. Four false "nothing does X" claims have reached committed
+documents on this line of work that way. Cite the command behind each absence
+claim in your report.
+
+## Interfaces produced by this plan
+
+```rust
+// mvm_cli::commands::agent_session
+pub struct Args { /* clap: ls | show | park | resume */ }
+pub fn run(cli: &Cli, args: Args, cfg: &Config) -> anyhow::Result<()>;
+```
+
+---
+
+### Task 1: `agent-session ls` and `show`
+
+Read-only. Introduces the verb, its module, and its dispatch wiring.
+
+**Files:**
+- Create: `crates/mvm-cli/src/commands/agent_session.rs`
+- Modify: `crates/mvm-cli/src/commands/mod.rs` (a `Commands` variant, placed by
+  the file's existing convention — read it before inserting)
+- Modify: `crates/mvm-cli/src/commands/dispatch.rs` (the match arm)
+- Test: `crates/mvm-cli/src/commands/tests.rs` for argument parsing, plus inline
+  tests in the new module for the rendering helpers
+
+**Interfaces:**
+- Consumes: `mvm_runtime::agent_session::{AgentSessionStore, AgentSessionRecord}`.
+- Produces: the `agent-session` verb.
+
+**Mirror, do not invent:** read `crates/mvm-cli/src/commands/trust.rs` (a
+sibling top-level verb with subcommands) for module shape, and
+`crates/mvm-cli/src/commands/pool.rs` for how a verb reaches a store. Follow
+the repo's existing output conventions — check whether sibling verbs support
+`--json` and match that choice rather than inventing a format.
+
+- [ ] **Step 1: Write the failing tests**
+
+Argument parsing, in `commands/tests.rs` alongside the existing verb-parsing
+tests (read a few first and match their style):
+
+```rust
+    #[test]
+    fn agent_session_ls_parses() {
+        let cli = Cli::try_parse_from(["mvmctl", "agent-session", "ls"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::AgentSession(_))));
+    }
+
+    #[test]
+    fn agent_session_show_requires_an_id() {
+        assert!(Cli::try_parse_from(["mvmctl", "agent-session", "show"]).is_err());
+        assert!(Cli::try_parse_from(["mvmctl", "agent-session", "show", "sess-alpha"]).is_ok());
+    }
+
+    #[test]
+    fn agent_session_verb_is_not_named_session() {
+        // `mvmctl machine session` already means machine-session residency.
+        // A bare `session` verb would collide with it in the operator's head.
+        assert!(Cli::try_parse_from(["mvmctl", "session", "ls"]).is_err());
+    }
+```
+
+And a rendering test in the new module: given a record in each residency state,
+the summary line names the state and, when parked, the reason and tier. Assert
+on the rendered string so a format change is visible.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+`export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target && ~/.cargo/bin/cargo nextest run -p mvm-cli agent_session`
+
+Expected: FAIL to compile — no `Commands::AgentSession`.
+
+- [ ] **Step 3: Write the implementation**
+
+`ls` lists every record from `AgentSessionStore::open()`, sorted as the store
+returns them. `show <id>` prints one record's full state: residency, generation,
+storage tier, park reason, journal cursor, resume point, and whether an approval
+head is recorded. An absent session is an error naming the id, not an empty
+success.
+
+Do not print the approval head's value as if it were a secret — it is a digest
+and safe to show — but do say when it is absent, because a session parked
+without one resumes unfenced and an operator should be able to see that.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target
+~/.cargo/bin/cargo fmt --all
+git add crates/mvm-cli/src/commands/agent_session.rs crates/mvm-cli/src/commands/mod.rs crates/mvm-cli/src/commands/dispatch.rs crates/mvm-cli/src/commands/tests.rs
+git commit -m "feat(cli): add agent-session ls and show"
+```
+
+---
+
+### Task 2: `agent-session park`, with a `session.parked` chain entry
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/agent_session.rs`
+- Test: inline
+
+**Interfaces:**
+- Consumes: `AgentSessionStore::park`, `ParkInput`, `ParkReason`;
+  `mvm_hostd::audit::emitter::AuditEmitter`.
+- Produces: the `park` subcommand.
+
+**Read first:** `crates/mvm-cli/src/commands/pool.rs:471` for how a CLI verb
+builds an `AuditEmitter` from a resolved signer. Follow it; do not invent a
+second way to get a signer.
+
+**The entry:** emit `session.parked` after the park succeeds, carrying the
+session id, the generation it parked at, the reason, and the tier — as **extras
+whose keys do not collide with the resume plan's `session_id` /
+`session_generation` labels**. Use distinct keys and say in a comment why they
+are distinct. Emit only after the store write succeeds: an entry for a park that
+did not happen is worse than a missing one.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    #[test]
+    fn park_requires_a_reason() {
+        assert!(Cli::try_parse_from(["mvmctl", "agent-session", "park", "sess-a"]).is_err());
+        assert!(Cli::try_parse_from(
+            ["mvmctl", "agent-session", "park", "sess-a", "--reason", "approval-wait"]
+        ).is_ok());
+    }
+
+    #[test]
+    fn the_park_entry_keys_do_not_collide_with_the_plan_labels() {
+        // for_plan extends plan labels with extras, so an extra sharing a key
+        // silently replaces the signed plan's value. The resume plan carries
+        // session_id and session_generation; a park entry must not shadow them.
+        let extras = park_audit_extras(/* build from a parked record */);
+        let keys: Vec<&str> = extras.iter().map(|(k, _)| k.as_str()).collect();
+        assert!(!keys.contains(&"session_id"));
+        assert!(!keys.contains(&"session_generation"));
+        assert!(!keys.is_empty(), "the entry must carry something");
+    }
+```
+
+Factor the extras into a small pure function (`park_audit_extras`) so this is
+testable without a signer or a filesystem. That factoring is the point of the
+test, not incidental to it.
+
+Also test that an unparseable `--reason` is refused rather than defaulting.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Write the implementation**
+
+Map `--reason` onto `ParkReason` with an explicit match — no
+stringly-typed fallthrough, and an unknown value is an error naming the accepted
+set. The `--journal-cursor` flag defaults to 0; `--approval-head` is optional
+and parsed through `ApprovalHead::parse` so a malformed value is refused at the
+boundary.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Verify the no-collision guard is not vacuous**
+
+Temporarily rename one extras key to `session_id`, confirm the collision test
+goes RED, restore. Report that RED with command and output. If it does not go
+red, say so and stop rather than reporting one you did not observe.
+
+- [ ] **Step 6: Commit**
+
+```bash
+export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target
+~/.cargo/bin/cargo fmt --all
+git add crates/mvm-cli/src/commands/agent_session.rs
+git commit -m "feat(cli): add agent-session park with a chain-signed entry"
+```
+
+---
+
+### Task 3: `agent-session resume`, with a `session.resumed` chain entry
+
+This is the one that matters: `resume_session` has had no production caller.
+
+**Files:**
+- Modify: `crates/mvm-cli/src/commands/agent_session.rs`
+- Test: inline
+
+**Interfaces:**
+- Consumes: `mvm_hostd::session_resume::{resume_session, ResumeRequest,
+  ResumePlanMaterial}`, `AgentSessionStore`, `CheckpointStore`, `AuditEmitter`.
+- Produces: the `resume` subcommand.
+
+**The material problem, stated honestly:** `resume_session` needs a
+`ResumePlanMaterial` — backend, image name and sha, kernel sha, cpus, mem —
+which the session record deliberately does not carry. The CLI must get them
+from somewhere. For this slice, take them as flags. That is clunky for an
+operator and it is the right first step anyway: it makes the seam visible rather
+than guessing, and a later slice can derive them from the resume point's
+supervisor config. Say so in the flag help text.
+
+- [ ] **Step 1: Write the failing tests**
+
+Parsing tests for the required flags, plus:
+
+```rust
+    #[test]
+    fn resume_refuses_a_session_that_is_not_parked() {
+        // Drive the real code path against a temp store: an Active session
+        // must be refused before any checkpoint or signer work.
+    }
+
+    #[test]
+    fn the_resume_entry_keys_do_not_collide_with_the_plan_labels() {
+        // Same hazard as the park entry, same shape of assertion, against
+        // resume_audit_extras.
+    }
+```
+
+The refusal test needs a temp `AgentSessionStore` and `CheckpointStore`; read
+the tests in `crates/mvm-hostd/src/session_resume.rs` for the fixture shape and
+reuse the approach rather than inventing one. If those fixtures are
+`#[cfg(test)]` and unreachable across the crate boundary, say so in your report
+and build the smallest local equivalent.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Write the implementation**
+
+Wire the subcommand to `resume_session`. Emit `session.resumed` **only after**
+it returns `Ok`, carrying the session id, the generation the resume opened, and
+the admitted plan's id — again as non-colliding extras.
+
+A refused resume must not emit a success entry. Whether it emits a refusal entry
+is a real question: this plan does **not** add one, because
+`admit_for_run` emits nothing itself and a refusal entry from the CLI would be
+the only record of a refusal that a non-CLI caller would never produce.
+Record that as a limit rather than half-building it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Run the full gate**
+
+```bash
+export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target
+~/.cargo/bin/cargo fmt --all -- --check
+~/.cargo/bin/cargo nextest run -p mvm-runtime -p mvm-hostd -p mvm-cli
+~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mvm-cli/src/commands/agent_session.rs
+git commit -m "feat(cli): add agent-session resume, the first caller of resume_session"
+```
+
+---
+
+### Task 4: Docs, CLI reference, and delivery record
+
+**Files:**
+- Modify: `specs/plans/2026-08-18-durable-agent-sessions.md` (WS6, WS7 state)
+- Modify: `specs/REFACTOR-STATUS.md`
+- Modify: `public/src/content/docs/reference/cli-commands.md`
+- Create: `specs/sprint/delivery/session-cli-and-audit.md`
+- Modify: this plan's checkboxes
+
+- [ ] **Step 1: Document the verb in the CLI reference**
+
+`public/src/content/docs/reference/cli-commands.md` is described in CLAUDE.md as
+the complete CLI reference. Add `agent-session` and its four subcommands,
+matching the file's existing entry format. Say plainly that `resume` requires
+the workload material as flags and why.
+
+- [ ] **Step 2: Update WS6 and WS7 state**
+
+WS6 is delivered for `ls`/`show`/`park`/`resume`. WS7 is **partial**: park and
+resume emit entries, but nothing verifies a session's chain as a unit and there
+is no `session.closed` entry because nothing can close a session — no `close()`
+transition exists. Be accurate; do not tick WS7.
+
+- [ ] **Step 3: Update `specs/REFACTOR-STATUS.md`** and its "Last updated".
+
+- [ ] **Step 4: Write `specs/sprint/delivery/session-cli-and-audit.md`**,
+style-matching that directory. Do NOT append to `specs/SPRINT.md` —
+`xtask check-sprint-append` fails if its delivery section grows.
+
+- [ ] **Step 5: Tick this plan's checkboxes and run the doc gates**
+
+```bash
+export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target
+~/.cargo/bin/cargo run -p xtask -- check-plan-names
+~/.cargo/bin/cargo run -p xtask -- check-declared-backing
+~/.cargo/bin/cargo run -p xtask -- check-sprint-append
+~/.cargo/bin/cargo run -p xtask -- check-no-spec-refs-in-comments
+```
+
+These spec files carry `Backing: preview`, which bars a short list of assertive
+verbs matched as whole words — quoting one in prose trips the gate. The gate
+names the word it found.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add specs/ public/
+git commit -m "docs: record the session CLI and chain-record slice"
+```
+
+---
+
+## Deferred to later plans
+
+- **A `close()` transition.** `SandboxResidency::Closed` still has no producer,
+  so `session.closed` cannot be emitted and a session's resume point is never
+  released by the retention pin.
+- **Verifying a session's chain as a unit.** Entries are emitted; nothing walks
+  a session's entries end to end the way `verify_audit_chain` walks a tenant's.
+- **Refusal entries.** A refused resume emits nothing.
+- **Deriving `ResumePlanMaterial` from the resume point** rather than taking it
+  as operator flags.
+- **Booting a resumed session** — tier selection, memory-image restore,
+  `PostRestore`, credential minting.

--- a/specs/plans/2026-08-19-session-cli-and-audit.md
+++ b/specs/plans/2026-08-19-session-cli-and-audit.md
@@ -10,8 +10,11 @@ resume leave chain-signed evidence. This is WS6 and WS7 together, because the
 chain entry belongs in the same code path the CLI drives — doing them apart
 would touch park and resume twice.
 
-**Architecture:** A new top-level `mvmctl agent-session` verb with `ls`, `show`,
-`park`, and `resume`. It is **not** called `session`: `mvmctl machine session`
+**Architecture:** A new top-level `mvmctl agent-session` verb with `open`, `ls`,
+`show`, `park`, and `resume`. (`open` was not in this plan as written; review of
+Tasks 1-3 found the verb had no reachable production input without it — nothing
+in the workspace created an `AgentSessionRecord` — so it landed alongside Task
+4.) It is **not** called `session`: `mvmctl machine session`
 already exists for machine sessions — warm-VM residency, idle timeouts, attach —
 which is a different concept, and the types already settled this collision by
 taking the `AgentSession*` prefix. `resume` gives
@@ -90,7 +93,7 @@ sibling top-level verb with subcommands) for module shape, and
 the repo's existing output conventions — check whether sibling verbs support
 `--json` and match that choice rather than inventing a format.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Argument parsing, in `commands/tests.rs` alongside the existing verb-parsing
 tests (read a few first and match their style):
@@ -120,13 +123,13 @@ And a rendering test in the new module: given a record in each residency state,
 the summary line names the state and, when parked, the reason and tier. Assert
 on the rendered string so a format change is visible.
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
 `export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target && ~/.cargo/bin/cargo nextest run -p mvm-cli agent_session`
 
 Expected: FAIL to compile — no `Commands::AgentSession`.
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 `ls` lists every record from `AgentSessionStore::open()`, sorted as the store
 returns them. `show <id>` prints one record's full state: residency, generation,
@@ -138,9 +141,9 @@ Do not print the approval head's value as if it were a secret — it is a digest
 and safe to show — but do say when it is absent, because a session parked
 without one resumes unfenced and an operator should be able to see that.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target
@@ -173,7 +176,7 @@ whose keys do not collide with the resume plan's `session_id` /
 are distinct. Emit only after the store write succeeds: an entry for a park that
 did not happen is worse than a missing one.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```rust
     #[test]
@@ -203,9 +206,9 @@ test, not incidental to it.
 
 Also test that an unparseable `--reason` is refused rather than defaulting.
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 Map `--reason` onto `ParkReason` with an explicit match — no
 stringly-typed fallthrough, and an unknown value is an error naming the accepted
@@ -213,15 +216,15 @@ set. The `--journal-cursor` flag defaults to 0; `--approval-head` is optional
 and parsed through `ApprovalHead::parse` so a malformed value is refused at the
 boundary.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
-- [ ] **Step 5: Verify the no-collision guard is not vacuous**
+- [x] **Step 5: Verify the no-collision guard is not vacuous**
 
 Temporarily rename one extras key to `session_id`, confirm the collision test
 goes RED, restore. Report that RED with command and output. If it does not go
 red, say so and stop rather than reporting one you did not observe.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target
@@ -253,7 +256,7 @@ operator and it is the right first step anyway: it makes the seam visible rather
 than guessing, and a later slice can derive them from the resume point's
 supervisor config. Say so in the flag help text.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Parsing tests for the required flags, plus:
 
@@ -277,9 +280,9 @@ reuse the approach rather than inventing one. If those fixtures are
 `#[cfg(test)]` and unreachable across the crate boundary, say so in your report
 and build the smallest local equivalent.
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x] **Step 2: Run tests to verify they fail**
 
-- [ ] **Step 3: Write the implementation**
+- [x] **Step 3: Write the implementation**
 
 Wire the subcommand to `resume_session`. Emit `session.resumed` **only after**
 it returns `Ok`, carrying the session id, the generation the resume opened, and
@@ -291,9 +294,9 @@ is a real question: this plan does **not** add one, because
 the only record of a refusal that a non-CLI caller would never produce.
 Record that as a limit rather than half-building it.
 
-- [ ] **Step 4: Run tests to verify they pass**
+- [x] **Step 4: Run tests to verify they pass**
 
-- [ ] **Step 5: Run the full gate**
+- [x] **Step 5: Run the full gate**
 
 ```bash
 export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target
@@ -302,7 +305,7 @@ export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-
 ~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings
 ```
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add crates/mvm-cli/src/commands/agent_session.rs
@@ -320,27 +323,38 @@ git commit -m "feat(cli): add agent-session resume, the first caller of resume_s
 - Create: `specs/sprint/delivery/session-cli-and-audit.md`
 - Modify: this plan's checkboxes
 
-- [ ] **Step 1: Document the verb in the CLI reference**
+- [x] **Step 1: Document the verb in the CLI reference**
 
 `public/src/content/docs/reference/cli-commands.md` is described in CLAUDE.md as
-the complete CLI reference. Add `agent-session` and its four subcommands,
+the complete CLI reference. Add `agent-session` and its five subcommands,
 matching the file's existing entry format. Say plainly that `resume` requires
-the workload material as flags and why.
+the workload material as flags and why. `xtask check-cli-help-matches-docs`
+requires a row for every non-hidden top-level verb, so this gate is red until
+the section lands.
 
-- [ ] **Step 2: Update WS6 and WS7 state**
+- [x] **Step 2: Update WS6 and WS7 state**
 
-WS6 is delivered for `ls`/`show`/`park`/`resume`. WS7 is **partial**: park and
-resume emit entries, but nothing verifies a session's chain as a unit and there
-is no `session.closed` entry because nothing can close a session — no `close()`
-transition exists. Be accurate; do not tick WS7.
+WS6 is delivered for `open`/`ls`/`show`/`park`/`resume`, and `resume_session`
+now has a caller that is both correctly constructed *and* exercisable — the
+second half of which was not true before `open`. WS7 is **partial**: park and
+resume emit entries, but nothing verifies a session's chain as a unit, there is
+no `session.closed` entry because nothing can close a session (no `close()`
+transition exists), and a chain-entry failure downgrades to a warning with exit
+0, so a scripted operator cannot detect a missing entry. Be accurate; do not
+tick WS7.
 
-- [ ] **Step 3: Update `specs/REFACTOR-STATUS.md`** and its "Last updated".
+The design spec spells the events `sandbox.parked` / `sandbox.resumed`; the code
+emits `session.parked` / `session.resumed`. Update the spec to match the code —
+these are session transitions, and `SandboxResidency` is a field of a session
+record rather than the subject of the event.
 
-- [ ] **Step 4: Write `specs/sprint/delivery/session-cli-and-audit.md`**,
+- [x] **Step 3: Update `specs/REFACTOR-STATUS.md`** and its "Last updated".
+
+- [x] **Step 4: Write `specs/sprint/delivery/session-cli-and-audit.md`**,
 style-matching that directory. Do NOT append to `specs/SPRINT.md` —
 `xtask check-sprint-append` fails if its delivery section grows.
 
-- [ ] **Step 5: Tick this plan's checkboxes and run the doc gates**
+- [x] **Step 5: Tick this plan's checkboxes and run the doc gates**
 
 ```bash
 export CARGO_TARGET_DIR=/Users/auser/work/tinylabs/mvmco/.worktrees/mvm-durable-sessions/target
@@ -354,7 +368,7 @@ These spec files carry `Backing: preview`, which bars a short list of assertive
 verbs matched as whole words — quoting one in prose trips the gate. The gate
 names the word it found.
 
-- [ ] **Step 6: Commit**
+- [x] **Step 6: Commit**
 
 ```bash
 git add specs/ public/
@@ -367,9 +381,23 @@ git commit -m "docs: record the session CLI and chain-record slice"
 
 - **A `close()` transition.** `SandboxResidency::Closed` still has no producer,
   so `session.closed` cannot be emitted and a session's resume point is never
-  released by the retention pin.
+  released by the retention pin. This is also why WS6's `close` subcommand is
+  not delivered: there is nothing for it to call. `open` landed as part of this
+  plan after review found the verb had no reachable production input at all —
+  no code path anywhere created an `AgentSessionRecord`, so every other
+  subcommand could only refuse.
+- **A live source for `--approval-head` on `resume`.** Nothing in the workspace
+  calls `ApprovalLedger::head()`, so an operator's only source for the value is
+  `agent-session show` — which prints the head recorded on the record itself.
+  Passing that back compares it against itself and fences nothing. The flag and
+  the store's fence are both correct; what is missing is a reading of the
+  ledger's current state to compare the recorded head against.
 - **Verifying a session's chain as a unit.** Entries are emitted; nothing walks
   a session's entries end to end the way `verify_audit_chain` walks a tenant's.
+- **A chain-entry failure is observable only as a warning.** Both park and
+  resume exit 0 when the entry cannot be written, following
+  `bind_checkpoint_created`'s precedent, so a scripted operator cannot detect a
+  missing entry from the exit status.
 - **Refusal entries.** A refused resume emits nothing.
 - **Deriving `ResumePlanMaterial` from the resume point** rather than taking it
   as operator flags.

--- a/specs/sprint/delivery/session-cli-and-audit.md
+++ b/specs/sprint/delivery/session-cli-and-audit.md
@@ -1,0 +1,135 @@
+# Session CLI and chain records: the operator surface for durable agent sessions
+
+`specs/plans/2026-08-18-durable-agent-sessions.md` WS6 and WS7, delivered
+together because the chain entry belongs in the same code path the CLI drives —
+doing them apart would have touched park and resume twice. Implementation plan:
+`specs/plans/2026-08-19-session-cli-and-audit.md`.
+
+Everything before this branch was library: a record type, a store, park and
+resume transitions, and `resume_session`. None of it was reachable from a
+terminal, and one piece of it was not reachable at all.
+
+## Delivered
+
+- **`mvmctl agent-session`** (`crates/mvm-cli/src/commands/agent_session.rs`),
+  a new top-level verb with five subcommands. Named `agent-session` and not
+  `session` because `mvmctl machine session` already means machine-session
+  residency — a warm VM held across `invoke` calls, over a different store —
+  and the types settled the collision first by taking the `AgentSession`
+  prefix.
+- **`open <id> [--resume-point <sha256:...>] [--member <name>]...`** — writes
+  the initial record: `SandboxResidency::Active`, generation 1, no park fields.
+  This is the piece nothing else supplied. Before it, `agent_sessions_dir` had
+  six references workspace-wide (its definition, its test, two doc comments and
+  `AgentSessionStore::open`) and the only production writers of the store were
+  `park` and `resume`, both of which need a record that already exists. On a
+  real host `ls` therefore printed `(no agent sessions)` forever, `park` and
+  `resume` always errored, and both chain emitters were unreachable.
+  - The id is parsed through `AgentSessionId::parse` at the boundary, so a
+    malformed one is refused before it can be joined into a store path.
+  - An existing session refuses rather than being overwritten. An overwrite
+    would reset a live session to generation 1 and drop its `parent_checkpoint`
+    — the one thing a parked session cannot be brought back without.
+  - `--resume-point` goes through `CheckpointDigest::parse`, so a malformed
+    digest refuses before any write. A session with no resume point is legal;
+    `resume` refuses it later, which is the right place for that refusal.
+  - `--member` is repeatable and matters: the park entry chains under
+    `members[0]`'s persisted plan, so a session opened with none takes the
+    warn-instead-of-record path. `open` says so at open time rather than
+    letting the operator discover it at park time.
+- **`ls [--json]` / `show <id> [--json]`** — the read-only half. `show` on an
+  absent session is an error naming the id, not an empty success, and it says
+  in as many words when no approval head was recorded, because such a session
+  resumes unfenced.
+- **`park <id> --reason <reason> [--journal-cursor] [--approval-head]`** —
+  drives `AgentSessionStore::park` and then emits a `session.parked`
+  chain-signed entry under the member sandbox's admitted plan. `--reason` maps
+  onto `ParkReason` through an explicit match; an unknown value refuses naming
+  the accepted set, because falling through to a default would pick a storage
+  tier nobody asked for.
+- **`resume <id> --backend --image --image-sha256 --cpus --mem-mib [...]`** —
+  the first production caller of
+  `mvm_hostd::session_resume::resume_session`, emitting `session.resumed` on
+  success. With `open` in place that caller is not only correctly constructed
+  but exercisable: a session can be opened, parked and resumed in one sitting,
+  which was not true of any earlier arrangement of this code.
+- **`AgentSessionStore::exists`** (`crates/mvm-runtime/src/agent_session/`) —
+  a presence probe deliberately distinct from `load().is_ok()`. A record that
+  is on disk but unparseable reads as present, so the create path treats a
+  corrupt record as a reason to refuse rather than a reason to overwrite.
+- **`session.` audit events classify as `Lifecycle`**
+  (`crates/mvm-client/src/audit/event.rs`), alongside `checkpoint.`, instead
+  of falling through to `AuditEventKind::Other`. Classification only —
+  `sync_policy_for` already defaulted to `Barrier`, so durability was never
+  affected.
+- **The CLI reference** gains a `## Durable Agent Sessions` section
+  (`public/src/content/docs/reference/cli-commands.md`) with a row per
+  subcommand. `xtask check-cli-help-matches-docs` requires a row for every
+  non-hidden top-level verb and was red on this branch until it landed.
+
+## The label-override hazard, and a guard that watches all of it
+
+`mvm_hostd::supervisor::audit::for_plan` does `labels.extend(extras)`, so a
+per-event extra **overrides** a plan label of the same key. The resume plan
+carries `session_id` and `session_generation` as signed labels, so an emitter
+reusing either name would replace what was admitted with what the emitter
+believed, and the entry would then attribute the action to a guess.
+
+Both emitters use distinct keys (`parked_session`, `parked_at_generation`,
+`park_reason`, `park_storage_tier`; `resumed_session`,
+`resumed_at_generation`, `resumed_plan_id`). The test that holds them there no
+longer compares against a copied list of two names — it derives the forbidden
+set from `synthesis_for_resume(record, material).audit_labels`, the labels the
+resume path actually builds. The copied list was watching half the surface:
+that synthesis also emits `session_parent_checkpoint` and
+`session_approval_head`, and an extra named either would have collided
+uncaught. Verified non-vacuous by renaming one park extra to
+`session_parent_checkpoint` and one resume extra to `session_approval_head`
+and confirming both tests go red, naming the colliding key, before restoring.
+
+## Deliberately not covered
+
+- **A `close()` transition.** `SandboxResidency::Closed` still has no
+  producer, so no `session.closed` entry can be emitted and a session's resume
+  point is never released by the retention pin. `open`'s counterpart is
+  missing, which is why WS6's `close` subcommand is not delivered either.
+- **Verifying a session's chain as a unit.** Entries are written; nothing
+  walks a session's entries end to end the way `verify_audit_chain` walks a
+  tenant's.
+- **A chain-entry failure is a warning, not a failure.** Both park and resume
+  report the transition as done with exit 0 when the entry cannot be written,
+  following `bind_checkpoint_created`'s precedent: the store write already
+  succeeded, and failing afterwards would tell an operator the park did not
+  happen when it did. The cost is that a scripted operator cannot detect a
+  missing entry from the exit status.
+- **Refusal entries.** A refused resume emits nothing. `admit_for_run` emits
+  nothing itself, and a refusal entry written only by the CLI would record
+  something no non-CLI caller would ever produce.
+- **`--approval-head` on `resume` has no production source.** Nothing in the
+  workspace calls `ApprovalLedger::head()`, so an operator's only source for
+  the value is `agent-session show` — which prints the record's own recorded
+  head, and passing that back compares it against itself and fences nothing.
+  The flag is correct and the fence works; what is missing is a live reading
+  of the ledger to compare against.
+- **`ResumePlanMaterial` is taken as operator flags** — backend, image, rootfs
+  and kernel sha, cpus, memory. The session record deliberately holds none of
+  it: an image, a kernel and a sandbox size each change on their own schedule,
+  and recording them would make the record a second copy of the plan. Deriving
+  them from the resume point's supervisor config is a later step; flags keep
+  the seam visible rather than guessing.
+- **Booting a resumed session.** A resume stops at an admitted plan. Tier
+  selection, memory-image restore, `PostRestore` fabric re-registration and
+  credential minting are all absent, and the command says so on completion
+  rather than letting silence imply a boot.
+
+## Tests
+
+28 tests in `commands::agent_session::tests` and 2 more in
+`commands::tests` for `open`'s argument parsing, plus one in
+`mvm_runtime::agent_session` for `exists` and two classification cases in
+`mvm_client::audit::event`. The one that matters most is
+`open_then_park_then_show_walks_one_session_end_to_end`: it opens a session,
+asserts `ls` now sees it, parks it through the real transition, and asserts
+what `show` renders off the record the store holds afterwards — so the verb is
+witnessed as a usable whole rather than as five independent subcommands that
+each happen to compile.


### PR DESCRIPTION
## Summary

WS6 and WS7: an operator surface for durable agent sessions, and chain-signed evidence for park and resume.

**Stacked on #2734** → #2729 → `main`. Review those first; this needs retargeting as they land.

## The verb

`mvmctl agent-session` with `open`, `ls`, `show`, `park`, `resume`.

Not `session`: `mvmctl machine session` already means machine-session residency — warm VM, idle timeouts, attach — which is a different concept. The types settled that collision earlier by taking the `AgentSession*` prefix, and the CLI follows. A test pins that a bare `session` verb does not parse.

`resume` is the point: `mvm_hostd::session_resume::resume_session` had no production caller before this.

## `open` exists because the review found the verb was decorative

The first pass shipped `ls`/`show`/`park`/`resume` and the review caught that **nothing in the workspace creates an `AgentSessionRecord`**. On a real host `ls` would print "(no agent sessions)" forever, `park` and `resume` would always error, and both new chain emitters were unreachable. `resume_session` had a correctly-constructed caller that could never be exercised.

`open` is the missing producer. It refuses an id that already exists rather than overwriting — an overwrite would destroy a live session's resume point — and takes `--resume-point` and repeatable `--member`. A lifecycle test now walks open → park → show, so the verb is witnessed as a usable whole rather than five independent subcommands.

## Chain records, and the hazard they had to avoid

`supervisor::audit::for_plan` does `labels.extend(extras)`, so a per-event extra **overrides** a signed plan label of the same key. The resume plan carries `session_id` and `session_generation` as signed labels; an emitter passing either as an extra would silently replace the admitted value with the emitter's belief, and the entry would then attribute the action to a guess.

Both emitters use distinct keys, and the guard is derived from the real label set — the test asserts extras keys are disjoint from `synthesis_for_resume(...).audit_labels`, rather than from a copied denylist that would miss `session_parent_checkpoint` and `session_approval_head`. Four independent mutation REDs back it.

## Known limits, recorded in the specs

- **WS7 is partial.** Nothing verifies a session's chain as a unit the way `verify_audit_chain` walks a tenant's, and there is no `session.closed` entry because no `close()` transition exists.
- A chain-entry failure downgrades to a warning with exit 0, matching `bind_checkpoint_created`'s precedent — the right trade against failing after a durable write, but a scripted operator cannot detect a missing entry.
- `open` is an operator verb. Nothing on the `machine run` path opens a session or validates `--member`, so a wrong member chains the park entry under another workload's plan.
- `--approval-head` on resume has no production source: nothing calls `ApprovalLedger::head()`, so an operator's only source is `agent-session show` — the record's own head, which would compare against itself.
- `resume` takes the workload material as flags, because the session record deliberately does not carry image/kernel/cpu facts. Deriving them from the resume point's supervisor config is a later slice.

## Validation

- `cargo nextest run -p mvm-runtime -p mvm-hostd -p mvm-cli` — 4873 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `check-cli-help-matches-docs`, `check-plan-names`, `check-declared-backing`, `check-sprint-append`, `check-no-spec-refs-in-comments`, `check-no-overclaim` — pass

The CLI-reference gate was proved red on the pre-change doc before being fixed, so its row is witnessed rather than assumed.
