### PR TITLE
ci: run the boot-latency ceiling in the merge queue, not on every PR push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -992,8 +992,23 @@ jobs:
   # to catch drift will flake here and get switched off.
   boot-latency:
     name: Boot latency ceiling
+    # Merge queue and manual dispatch, not every PR push. This lane needs a KVM
+    # runner and takes ~11 minutes, and at the 20-concurrent-job cap six of them
+    # were queued at once across open PRs — it was a material share of the wait
+    # before any PR's own jobs could start.
+    #
+    # Safe to move because of what this lane is: it pins a *published* image on
+    # purpose, as a control variable, so a regression it catches is in host-side
+    # code and is caught in the queue before anything reaches main. The budget is
+    # a ceiling with roughly 3x headroom over the observed median, not a
+    # tolerance — it exists to catch multiple-x regressions, and one merge-queue
+    # run catches those exactly as well as one run per push.
+    #
+    # `nix-flake-check` below makes the same trade for the same reason.
     needs: [scope]
-    if: needs.scope.outputs.code == 'true'
+    if: >-
+      needs.scope.outputs.code == 'true'
+      && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:


### PR DESCRIPTION
CI is at the **20-concurrent-job cap**: 20 running against **53 queued**. A new
PR's jobs wait behind roughly fifty others before its own 28-minute critical
path even starts. That queueing, not job duration, is what makes merges take
hours.

Six `Boot latency ceiling` jobs were queued simultaneously across open PRs, each
~11 minutes, each holding a KVM-capable runner.

## It was never gating anything

The required contexts on `main` are exactly six:

```
Build kernels (aarch64)      Invariant
Build kernels (x86_64)       Lint (fmt + clippy + policy)
Nix flake check (Linux eval) Test
```

`Boot latency ceiling` is not among them. It has been spending a scarce runner
on every push while blocking no merge — and every red it showed on a PR (the
`boot-image/v0.1.0` 404s, most of today) was cosmetic.

## Safe on the merits, not just because it is unrequired

The lane pins a **published** image on purpose, as a control variable — that is
why it is not affected by the PR's own image. What it can catch is a regression
in *host-side* code, and it catches that in the merge queue, before anything
reaches main.

Its budget is a ceiling with roughly 3× headroom over the observed median, not a
tolerance. It exists to catch multiple-x regressions, and one merge-queue run
catches those exactly as well as one run per push does.

## Precedent, and the proof it works

`Nix flake check (Linux eval)` already runs merge-queue-and-dispatch only, for
the same stated reason — *"Nix eval/build is heavy; run it in the merge queue
and on manual dispatch, not on every PR update"* — **and it is required**. That
is the proof the pattern holds: a check reporting only in the queue still
satisfies the requirement there.

## What this does not fix

The dominant constraint is capacity, not this lane: 73 jobs in flight against 20
slots, from ~12 jobs per PR run plus ~14 per merge-queue run. Raising the
concurrency limit is the larger lever and is a settings change rather than a
code one. This removes one 11-minute KVM job per PR push, which is the biggest
cut available without weakening a gate that actually gates.

`actionlint` clean, `check-workflow-paths` clean, YAML parses.