### PR TITLE
fix(egress): stop leaking https requests in cleartext, and unblock pool-less backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,9 +1958,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/crates/mvm-agentd/src/egress_client.rs
+++ b/crates/mvm-agentd/src/egress_client.rs
@@ -271,9 +271,25 @@ where
     stream.flush().await
 }
 
+/// Where an absolute-form HTTP forward request wants to go, and whether the
+/// origin expects TLS there.
+///
+/// The scheme is carried out rather than folded into the port because the two
+/// answers have opposite consequences. A `http://` request is forwarded
+/// verbatim, which is what a forward proxy is for. A `https://` one cannot be:
+/// this proxy relays bytes and never originates TLS, so forwarding the head
+/// would put a cleartext request on port 443.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HttpForwardTarget {
+    /// `host:port`, defaulted per scheme when the authority names no port.
+    pub(crate) target: String,
+    /// The absolute-form URI named `https`.
+    pub(crate) tls: bool,
+}
+
 /// Extract the TCP target (`host:port`) from an absolute-form HTTP forward
 /// request head. HTTP targets use port 80 by default; HTTPS targets use 443.
-pub(crate) fn http_forward_target(head: &[u8]) -> std::io::Result<String> {
+pub(crate) fn http_forward_target(head: &[u8]) -> std::io::Result<HttpForwardTarget> {
     let text = std::str::from_utf8(head).map_err(|_| invalid_http("HTTP proxy head not UTF-8"))?;
     let request_line = text
         .split_once('\n')
@@ -308,12 +324,12 @@ pub(crate) fn http_forward_target(head: &[u8]) -> std::io::Result<String> {
         .map(|(_, rest)| rest)
         .unwrap_or(target);
     let authority = authority.split(['/', '?']).next().unwrap_or(authority);
-    let default_port = if target.len() >= 8 && target[..8].eq_ignore_ascii_case("https://") {
-        443
-    } else {
-        80
-    };
-    parse_authority_target(authority, default_port)
+    let tls = target.len() >= 8 && target[..8].eq_ignore_ascii_case("https://");
+    let default_port = if tls { 443 } else { 80 };
+    Ok(HttpForwardTarget {
+        target: parse_authority_target(authority, default_port)?,
+        tls,
+    })
 }
 
 fn parse_authority_target(authority: &str, default_port: u16) -> std::io::Result<String> {
@@ -542,32 +558,43 @@ mod tests {
             route.head().unwrap(),
             b"GET https://example.com/path?q=1 HTTP/1.1\r\nHost: example.com\r\n\r\n"
         );
-        assert_eq!(
-            http_forward_target(route.head().unwrap()).unwrap(),
-            "example.com:443"
-        );
+        let forward = http_forward_target(route.head().unwrap()).unwrap();
+        assert_eq!(forward.target, "example.com:443");
+        assert!(forward.tls, "the scheme has to survive the parse");
     }
 
     #[test]
     fn http_forward_target_uses_port_80_for_http() {
-        assert_eq!(
-            http_forward_target(b"GET http://example.com/ HTTP/1.1\r\n\r\n").unwrap(),
-            "example.com:80"
-        );
+        let forward = http_forward_target(b"GET http://example.com/ HTTP/1.1\r\n\r\n").unwrap();
+        assert_eq!(forward.target, "example.com:80");
+        assert!(!forward.tls, "a http:// request is forwardable as-is");
     }
 
+    /// The port is right and the scheme is reported, which is what stops the
+    /// head being forwarded in cleartext to a port that expects TLS.
     #[test]
-    fn http_forward_target_uses_port_443_for_https() {
-        assert_eq!(
-            http_forward_target(b"GET https://example.com/ HTTP/1.1\r\n\r\n").unwrap(),
-            "example.com:443"
-        );
+    fn http_forward_target_uses_port_443_for_https_and_reports_tls() {
+        let forward = http_forward_target(b"GET https://example.com/ HTTP/1.1\r\n\r\n").unwrap();
+        assert_eq!(forward.target, "example.com:443");
+        assert!(forward.tls);
+    }
+
+    /// An explicit port does not change what the scheme means: `https://` on
+    /// any port still expects TLS the proxy cannot originate.
+    #[test]
+    fn an_explicit_port_does_not_hide_the_https_scheme() {
+        let forward =
+            http_forward_target(b"GET https://example.com:8080/ HTTP/1.1\r\n\r\n").unwrap();
+        assert_eq!(forward.target, "example.com:8080");
+        assert!(forward.tls);
     }
 
     #[test]
     fn http_forward_target_honours_explicit_port() {
         assert_eq!(
-            http_forward_target(b"GET https://example.com:8080/ HTTP/1.1\r\n\r\n").unwrap(),
+            http_forward_target(b"GET http://example.com:8080/ HTTP/1.1\r\n\r\n")
+                .unwrap()
+                .target,
             "example.com:8080"
         );
     }

--- a/crates/mvm-agentd/src/flowmux_egress.rs
+++ b/crates/mvm-agentd/src/flowmux_egress.rs
@@ -143,12 +143,49 @@ async fn serve_http_connect(
     }
 }
 
+/// What a client asking this proxy to fetch an `https://` URL is told.
+///
+/// The reason travels in the status line because that is the only part of the
+/// refusal most clients surface: BusyBox `wget` prints the whole line, so an
+/// operator sees what to do instead of a bare code.
+const TLS_ABSOLUTE_URI_STATUS: &str =
+    "501 Not Implemented (https absolute-URI needs CONNECT or SOCKS)";
+
+/// Refuse an absolute-form `https://` request rather than forwarding it.
+///
+/// A forward proxy asked for `GET https://host/…` is being asked to speak TLS
+/// on the client's behalf. This proxy never originates TLS — it relays bytes
+/// so the host can authorize and log every connection — so forwarding the head
+/// would write a cleartext request to a port that expects TLS: the origin
+/// answers with an error or hangs up, and the request line, `Host` and every
+/// header have already crossed the network in the clear. Refusing keeps that
+/// from happening and names the two transports that do work.
+async fn refuse_tls_absolute_uri(mut client: TcpStream, target: &str) -> io::Result<()> {
+    warn!(
+        %target,
+        "refusing an https absolute-URI proxy request: this proxy tunnels TLS \
+         (CONNECT or SOCKS5) and never originates it, so forwarding the head \
+         would send it in cleartext"
+    );
+    write_http_response(&mut client, TLS_ABSOLUTE_URI_STATUS)
+        .await
+        .ok();
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "https absolute-URI proxy request",
+    ))
+}
+
 async fn serve_http_forward(
     client: TcpStream,
     head: &[u8],
     flowmux: FlowMuxReconnectClient,
 ) -> io::Result<()> {
-    let target = http_forward_target(head)?;
+    let forward = http_forward_target(head)?;
+    if forward.tls {
+        return refuse_tls_absolute_uri(client, &forward.target).await;
+    }
+    let target = forward.target;
     match flowmux.open_tcp(&target).await {
         Ok(mut upstream) => {
             upstream.write_all(head).await?;
@@ -547,5 +584,206 @@ pub mod dns_stub {
             task.abort();
             host.await.unwrap();
         }
+    }
+}
+
+#[cfg(test)]
+mod http_forward_tests {
+    use super::*;
+    use ed25519_dalek::{SigningKey, VerifyingKey};
+    use mvm_contract::protocol::network_flow::hello::Handshake;
+    use mvm_contract::protocol::network_flow::{Opcode, encode_into};
+    use tokio::io::{AsyncRead, AsyncWrite};
+
+    fn keypair() -> (SigningKey, VerifyingKey) {
+        let bytes: [u8; 32] = rand::random();
+        let signing = SigningKey::from_bytes(&bytes);
+        let verifying = signing.verifying_key();
+        (signing, verifying)
+    }
+
+    async fn send_frame<S>(
+        stream: &mut S,
+        session: &mut mvm_core::net::session::Session,
+        opcode: Opcode,
+        stream_id: u32,
+        payload: &[u8],
+    ) where
+        S: AsyncWrite + Unpin,
+    {
+        let mut wire = Vec::new();
+        encode_into(&mut wire, opcode, stream_id, payload).unwrap();
+        let sealed = session.seal(&wire).unwrap();
+        let mut sealed_bytes = Vec::new();
+        sealed.encode(&mut sealed_bytes).unwrap();
+        let len = u32::try_from(sealed_bytes.len()).unwrap();
+        stream.write_all(&len.to_be_bytes()).await.unwrap();
+        stream.write_all(&sealed_bytes).await.unwrap();
+        stream.flush().await.unwrap();
+    }
+
+    async fn read_frame<S>(
+        stream: &mut S,
+        session: &mut mvm_core::net::session::Session,
+    ) -> Option<(Opcode, u32, u32, Vec<u8>)>
+    where
+        S: AsyncRead + Unpin,
+    {
+        crate::flowmux::read_sealed_frame_from(stream, session)
+            .await
+            .unwrap()
+    }
+
+    /// The regression this exists for: BusyBox `wget` asks a plain HTTP proxy
+    /// for `GET https://host/ HTTP/1.1`. The proxy used to resolve that to
+    /// `host:443`, open a TCP flow and write the head — a cleartext request to
+    /// a port that expects TLS. The origin answered with an error or hung up,
+    /// which read as "mvm egress is broken", and the request line and every
+    /// header had already crossed the network in the clear.
+    ///
+    /// Nothing may reach the host, and the client must be told which
+    /// transports do work.
+    #[tokio::test]
+    async fn an_https_absolute_uri_is_refused_without_opening_a_flow() {
+        let (guest_stream, host_stream) = tokio::io::duplex(4096);
+        let (guest_key, _guest_anchor) = keypair();
+        let (host_key, host_anchor) = keypair();
+
+        let host = tokio::spawn(async move {
+            let handle = tokio::runtime::Handle::try_current().unwrap();
+            let (mut host_stream, mut host_session) = tokio::task::spawn_blocking(move || {
+                let mut adapter = crate::flowmux::AsyncStreamSyncAdapter::new(host_stream, handle);
+                let result =
+                    mvm_core::net::session::Session::host(&mut adapter, "test-session", host_key);
+                let stream = adapter.into_inner();
+                result.map(|(session, _peer)| (stream, session))
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+            let _hello = read_frame(&mut host_stream, &mut host_session)
+                .await
+                .unwrap();
+            send_frame(
+                &mut host_stream,
+                &mut host_session,
+                Opcode::HelloAck,
+                0,
+                &Handshake::local("test-host").encode(),
+            )
+            .await;
+
+            // Whatever the proxy decides, it decides without us: anything that
+            // arrives after the handshake is a flow it should never have opened.
+            tokio::time::timeout(
+                std::time::Duration::from_millis(500),
+                read_frame(&mut host_stream, &mut host_session),
+            )
+            .await
+            .ok()
+            .flatten()
+            .map(|(opcode, _, _, _)| opcode)
+        });
+
+        let client = crate::flowmux::FlowMuxClient::connect(guest_stream, guest_key, host_anchor)
+            .await
+            .unwrap();
+        let (tx, rx) = watch::channel(Some(Arc::new(client)));
+        let _tx = tx;
+        let flowmux = crate::flowmux::FlowMuxReconnectClient::from_receiver(rx);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut caller = TcpStream::connect(addr).await.unwrap();
+        let (served, _) = listener.accept().await.unwrap();
+
+        let head = b"GET https://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let err = serve_http_forward(served, head, flowmux)
+            .await
+            .expect_err("an https absolute-URI must be refused");
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+
+        let mut reply = String::new();
+        caller.read_to_string(&mut reply).await.unwrap();
+        assert!(
+            reply.starts_with("HTTP/1.1 501 Not Implemented"),
+            "unexpected reply: {reply}"
+        );
+        assert!(
+            reply.contains("CONNECT"),
+            "the refusal must name the way through: {reply}"
+        );
+
+        assert_eq!(
+            host.await.unwrap(),
+            None,
+            "no frame may reach the host for a request that is never forwarded"
+        );
+    }
+
+    /// The path that still works, and must keep working: a `http://` absolute
+    /// URI is forwarded, so the guest opens a flow for it.
+    #[tokio::test]
+    async fn a_plain_http_absolute_uri_still_opens_a_flow() {
+        let (guest_stream, host_stream) = tokio::io::duplex(4096);
+        let (guest_key, _guest_anchor) = keypair();
+        let (host_key, host_anchor) = keypair();
+
+        let host = tokio::spawn(async move {
+            let handle = tokio::runtime::Handle::try_current().unwrap();
+            let (mut host_stream, mut host_session) = tokio::task::spawn_blocking(move || {
+                let mut adapter = crate::flowmux::AsyncStreamSyncAdapter::new(host_stream, handle);
+                let result =
+                    mvm_core::net::session::Session::host(&mut adapter, "test-session", host_key);
+                let stream = adapter.into_inner();
+                result.map(|(session, _peer)| (stream, session))
+            })
+            .await
+            .unwrap()
+            .unwrap();
+
+            let _hello = read_frame(&mut host_stream, &mut host_session)
+                .await
+                .unwrap();
+            send_frame(
+                &mut host_stream,
+                &mut host_session,
+                Opcode::HelloAck,
+                0,
+                &Handshake::local("test-host").encode(),
+            )
+            .await;
+
+            let (opcode, _sid, _len, payload) = read_frame(&mut host_stream, &mut host_session)
+                .await
+                .unwrap();
+            (opcode, String::from_utf8_lossy(&payload).to_string())
+        });
+
+        let client = crate::flowmux::FlowMuxClient::connect(guest_stream, guest_key, host_anchor)
+            .await
+            .unwrap();
+        let (tx, rx) = watch::channel(Some(Arc::new(client)));
+        let _tx = tx;
+        let flowmux = crate::flowmux::FlowMuxReconnectClient::from_receiver(rx);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let _caller = TcpStream::connect(addr).await.unwrap();
+        let (served, _) = listener.accept().await.unwrap();
+
+        let head = b"GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let forward = tokio::spawn(async move {
+            let _ = serve_http_forward(served, head, flowmux).await;
+        });
+
+        let (opcode, target) = host.await.unwrap();
+        assert_eq!(opcode, Opcode::OpenTcp);
+        assert!(
+            target.contains("example.com:80"),
+            "unexpected open target: {target}"
+        );
+        forward.abort();
     }
 }

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -523,6 +523,30 @@ fn discard_preloaded_child(backend: &AnyBackend, handle: &StandbyHandle) {
     }
 }
 
+/// Whether a standby pool this backend cannot serve should fail the launch.
+///
+/// The warm target is not always something anyone asked for. On the HVF
+/// default tier the host residency policy resolves to always-warm on its own,
+/// and a run that names a pool-less backend — `--hypervisor libkrun`, wasm —
+/// inherits that default without ever opting into it. Refusing there makes
+/// those backends unusable on this host for a pool nobody configured, which is
+/// what `machine run --hypervisor libkrun` reported: "claiming *configured*
+/// warm standby", naming a configuration that did not exist.
+///
+/// An operator who set `MVM_RESIDENCY` did ask, and a request this backend
+/// cannot serve is worth saying out loud rather than quietly cold-booting.
+///
+/// Pure over the source so both answers are testable without mutating process
+/// env, which no test can do safely while others run beside it.
+fn unsupported_standby_pool_is_fatal(source: mvm_core::residency::ResidencySource) -> bool {
+    matches!(source, mvm_core::residency::ResidencySource::EnvOverride)
+}
+
+/// How this launch came by its warm target.
+fn residency_source() -> mvm_core::residency::ResidencySource {
+    mvm_core::residency::resolve_residency().1
+}
+
 pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Result<WarmResult> {
     if p.target == 0 {
         return Ok(WarmResult {
@@ -531,6 +555,12 @@ pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Resul
         });
     }
     if !p.backend.capabilities().standby_pool {
+        if !unsupported_standby_pool_is_fatal(residency_source()) {
+            return Ok(WarmResult {
+                spawned: 0,
+                failed: 0,
+            });
+        }
         return Err(anyhow::Error::new(StandbyError::Unsupported {
             backend: p.backend.name().to_string(),
         })
@@ -743,6 +773,9 @@ where
                 },
             ));
         }
+        if !unsupported_standby_pool_is_fatal(residency_source()) {
+            return Ok(LaunchDecision::ColdBoot);
+        }
         return Err(anyhow::Error::new(StandbyError::Unsupported {
             backend: backend.name().to_string(),
         })
@@ -942,6 +975,9 @@ pub fn try_warm_claim(
         return Ok(None);
     };
     if !backend.capabilities().standby_pool {
+        if !unsupported_standby_pool_is_fatal(residency_source()) {
+            return Ok(None);
+        }
         return Err(anyhow::Error::new(StandbyError::Unsupported {
             backend: backend.name().to_string(),
         })
@@ -1271,11 +1307,18 @@ mod tests {
         );
     }
 
+    /// A pool the operator named is still worth refusing over: silently
+    /// cold-booting would hide that the backend they also chose cannot serve
+    /// the residency they asked for.
+    ///
+    /// qemu is the dev/test substrate and is never wired for the standby pool,
+    /// so it stays "unsupported" regardless of which workload backend grows a
+    /// live warm path next.
     #[test]
-    fn try_warm_claim_refuses_unsupported_backend_instead_of_cold_booting() {
-        // qemu is the dev/test substrate and is never wired for the standby
-        // pool, so it stays "unsupported" regardless of which workload backend
-        // grows a live warm path next.
+    fn try_warm_claim_refuses_an_operator_configured_pool_on_an_unsupported_backend() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_RESIDENCY", "warm");
+
         let backend = AnyBackend::from_hypervisor("qemu");
         let err = try_warm_claim(&backend, &eligible_cfg(), false)
             .expect_err("configured warm pool must not silently cold-boot");
@@ -1287,6 +1330,22 @@ mod tests {
         assert!(
             message.contains("requested standby-pool recovery"),
             "{message}"
+        );
+    }
+
+    /// The other half, and the regression: with no `MVM_RESIDENCY` the warm
+    /// target is the host tier's own default, which a run naming a pool-less
+    /// backend never opted into. It cold-boots instead of failing the launch.
+    #[test]
+    fn try_warm_claim_cold_boots_a_host_default_pool_on_an_unsupported_backend() {
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.remove("MVM_RESIDENCY");
+
+        let backend = AnyBackend::from_hypervisor("qemu");
+        assert_eq!(
+            try_warm_claim(&backend, &eligible_cfg(), false).unwrap(),
+            None,
+            "a default nobody configured must not fail the launch"
         );
     }
 
@@ -1385,6 +1444,29 @@ mod tests {
             warm_claim_plan_json(libkrun.as_vm_backend(), &cfg),
             Some("{\"signed\":\"plan\"}".into())
         );
+    }
+
+    /// The regression: on the HVF default tier the residency policy resolves to
+    /// always-warm with nobody configuring anything, and every pool-less
+    /// backend inherited it. `machine run --hypervisor libkrun` then died on
+    /// "claiming configured warm standby / standby pool is not supported by
+    /// this backend" before it could boot, naming a configuration that did not
+    /// exist. A host default is a preference, so it yields to the backend.
+    #[test]
+    fn a_host_default_warm_target_yields_to_a_backend_with_no_pool() {
+        assert!(!unsupported_standby_pool_is_fatal(
+            mvm_core::residency::ResidencySource::AutoDetect
+        ));
+    }
+
+    /// An operator who set `MVM_RESIDENCY` asked for warm by name. Silently
+    /// cold-booting there would hide that the backend they also chose cannot
+    /// do it, so that one still refuses.
+    #[test]
+    fn an_operator_set_residency_still_refuses_a_backend_with_no_pool() {
+        assert!(unsupported_standby_pool_is_fatal(
+            mvm_core::residency::ResidencySource::EnvOverride
+        ));
     }
 
     #[test]

--- a/specs/sprint/delivery/egress-https-absolute-uri-refusal.md
+++ b/specs/sprint/delivery/egress-https-absolute-uri-refusal.md
@@ -1,0 +1,46 @@
+# The proxy stops sending https requests in cleartext
+
+`wget https://example.com/` inside a guest reported `error getting response`,
+or a `400 Bad Request` the origin server had written. Both read as "mvm egress
+is broken". Egress was fine: `http://` fetched through the same proxy, and a
+raw `CONNECT` returned `200 Connection established`.
+
+BusyBox `wget` does not issue `CONNECT` for an `https://` URL behind an HTTP
+proxy. It sends the absolute form:
+
+```
+GET https://example.com/ HTTP/1.1
+Host: example.com
+```
+
+`http_forward_target` resolved that to `example.com:443` — the right port — and
+`serve_http_forward` then wrote the head to it. Nothing on either side speaks
+TLS on that path: the in-guest proxy relays bytes so the host can authorize and
+log every connection, and the host relays them onward untouched. So a plaintext
+HTTP request went to a port expecting TLS. The origin answered with an error or
+hung up, which is the symptom; the request line, the `Host` header and every
+other header had already crossed the network in the clear, which is the part
+that mattered.
+
+The proxy now refuses instead, with the reason in the status line because that
+is the only part most clients print:
+
+```
+HTTP/1.1 501 Not Implemented (https absolute-URI needs CONNECT or SOCKS)
+```
+
+Both transports that do work are unchanged: `CONNECT` (curl, and anything else
+that tunnels) and SOCKS5. `http://` absolute-form requests are still forwarded,
+which is what a forward proxy is for.
+
+`http_forward_target` returns `HttpForwardTarget { target, tls }` rather than a
+bare string. The scheme decided the port and was then thrown away, which is how
+the two cases became indistinguishable one line later.
+
+Witnesses: `an_https_absolute_uri_is_refused_without_opening_a_flow` (the host
+end of a live FlowMux session receives no frame at all, so nothing was opened
+and nothing was written — red against the old forward),
+`a_plain_http_absolute_uri_still_opens_a_flow`,
+`http_forward_target_uses_port_443_for_https_and_reports_tls`, and
+`an_explicit_port_does_not_hide_the_https_scheme`. Confirmed live on HVF: the
+refusal reaches `wget` verbatim and a raw `CONNECT` still returns 200.

--- a/specs/sprint/delivery/warm-residency-default-yields-to-backend.md
+++ b/specs/sprint/delivery/warm-residency-default-yields-to-backend.md
@@ -1,0 +1,42 @@
+# A residency nobody configured stops failing launches
+
+`machine run --hypervisor libkrun` could not boot on a macOS 26 host:
+
+```
+Error: claiming configured warm standby
+Caused by:
+    0: requested standby-pool recovery
+    1: libkrun: standby pool is not supported by this backend
+```
+
+Nothing was configured. On the HVF default tier `resolve_residency` returns
+`always_warm` on its own, so `effective_warm_pool_size(None)` hands every
+transient run a warm target of 1 — including runs that name a backend with no
+standby pool. Three capability gates then turned that inherited default into a
+hard error. The message said "configured", and the code comment beside it said
+only an explicitly configured pool should refuse; the path that produced it
+had no explicit configuration anywhere, because `MachineRunMode::warm_pool_size`
+is called with `None` and nothing else reaches `try_warm_claim` outside tests.
+
+The three gates now ask where the target came from.
+`unsupported_standby_pool_is_fatal` is pure over `ResidencySource`: an
+`EnvOverride` is an operator asking for warm by name and still refuses, so
+choosing a backend that cannot serve it is not hidden; an `AutoDetect` default
+yields and the launch cold-boots.
+
+`MVM_HVF_WARM_REQUIRE_CLAIM=1` is unaffected — `claim_with_mode` answers that
+with its existing `BackendUnsupported` refusal before this decision is reached.
+
+Left alone deliberately: `machine/runtime.rs` still zeroes the warm target for
+`--hypervisor wasm` by name. That carve-out is the same bug fixed for one
+backend by string comparison, and it is now redundant, but removing it changes
+what `warm_pool_size` is on the wasm path for every downstream reader of the
+value — worth doing on its own, not folded into this.
+
+Witnesses: `try_warm_claim_cold_boots_a_host_default_pool_on_an_unsupported_backend`,
+`try_warm_claim_refuses_an_operator_configured_pool_on_an_unsupported_backend`,
+`a_host_default_warm_target_yields_to_a_backend_with_no_pool`, and
+`an_operator_set_residency_still_refuses_a_backend_with_no_pool`. Confirmed
+live: `machine run --hypervisor libkrun --allow-host example.com:80` boots,
+authenticates FlowMux and fetches the page with no `MVM_RESIDENCY` set, and the
+HVF default path is unchanged.


### PR DESCRIPTION
Two follow-ups from #2741. With the vsock relay fixed, `--allow-host` reached
the point where the *rest* of the egress path could be exercised, and it turned
up one leak and one launch blocker. Independent of #2741 and of each other — no
file overlap.

## 1. The guest proxy sent https requests in cleartext

`wget https://example.com/` in a guest reported `error getting response`, or a
`400 Bad Request` the origin had written. Both read as broken egress. Egress
was fine — `http://` fetched through the same proxy, and a raw `CONNECT`
returned `200 Connection established`:

```
$ printf 'CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n' | nc 127.0.0.1 1080
HTTP/1.1 200 Connection established
```

BusyBox `wget` does not issue CONNECT for an https URL behind an HTTP proxy. It
sends the absolute form — captured off the wire inside the guest:

```
GET https://example.com/ HTTP/1.1
Host: example.com
```

`http_forward_target` resolved that to `example.com:443` (the right port) and
`serve_http_forward` wrote the head to it. Nothing on that path speaks TLS: the
in-guest proxy relays bytes so the host can authorize and log every connection,
and the host relays them onward untouched. So a plaintext request went to a port
expecting TLS. The origin erroring or hanging up is the symptom. **The request
line and every header having already crossed the network in the clear is the
part that mattered.**

Now refused, with the reason in the status line because that is the only part
most clients print:

```
$ wget -O- https://example.com/
wget: server returned error: HTTP/1.1 501 Not Implemented (https absolute-URI needs CONNECT or SOCKS)
```

CONNECT and SOCKS5 are unchanged, and `http://` absolute-form requests are still
forwarded. `http_forward_target` now returns the scheme alongside the target —
it decided the port and was then discarded, which is how the two cases became
indistinguishable one line later.

## 2. A residency nobody configured failed libkrun launches

```
$ mvmctl machine run --image alpine --hypervisor libkrun --allow-host example.com:80 -- ...
Error: claiming configured warm standby
Caused by:
    0: requested standby-pool recovery
    1: libkrun: standby pool is not supported by this backend
```

Nothing was configured. On the HVF default tier `resolve_residency` returns
always-warm on its own, so `effective_warm_pool_size(None)` hands every
transient run a warm target of 1 — including runs naming a backend with no
standby pool. Three capability gates turned that inherited default into a hard
error. The message said "configured"; the comment beside it said only an
explicitly configured pool should refuse; and nothing outside tests reaches
`try_warm_claim` with an explicit request, because `MachineRunMode::warm_pool_size`
is called with `None`.

The gates now ask where the target came from.
`unsupported_standby_pool_is_fatal` is pure over `ResidencySource`: an
`EnvOverride` is an operator asking for warm by name and still refuses;
an `AutoDetect` default yields and the launch cold-boots.
`MVM_HVF_WARM_REQUIRE_CLAIM=1` is unaffected — `claim_with_mode` answers that
with its existing `BackendUnsupported` refusal first.

Deliberately not folded in: `machine/runtime.rs` still zeroes the warm target
for `--hypervisor wasm` by name. That is the same bug fixed for one backend by
string comparison and is now redundant, but removing it changes what
`warm_pool_size` is on the wasm path for every downstream reader.

## Verification

Live on macOS 26 / HVF, both backends, no workaround:

```
$ mvmctl machine run --image alpine --hypervisor libkrun --allow-host example.com:80 \
    -- sh -c 'wget -O- http://example.com/'
<!doctype html><html lang="en"><head><title>Example Domain</title>…
$ mvmctl machine run --image alpine --allow-host example.com:80 \
    -- sh -c 'wget -O- http://example.com/'
<!doctype html><html lang="en"><head><title>Example Domain</title>…
```

New witnesses, each confirmed red against the old behaviour:

- `an_https_absolute_uri_is_refused_without_opening_a_flow` — the host end of a
  live FlowMux session receives no frame at all, so nothing was opened and
  nothing was written
- `a_plain_http_absolute_uri_still_opens_a_flow`
- `http_forward_target_uses_port_443_for_https_and_reports_tls`,
  `an_explicit_port_does_not_hide_the_https_scheme`
- `try_warm_claim_cold_boots_a_host_default_pool_on_an_unsupported_backend`,
  `try_warm_claim_refuses_an_operator_configured_pool_on_an_unsupported_backend`
- `a_host_default_warm_target_yields_to_a_backend_with_no_pool`,
  `an_operator_set_residency_still_refuses_a_backend_with_no_pool`

`try_warm_claim_refuses_unsupported_backend_instead_of_cold_booting` is renamed
and now sets `MVM_RESIDENCY` so it tests the case its name claims.

Gates: `cargo nextest run --workspace` (12460 passed), `cargo test --workspace
--doc`, `cargo clippy --workspace --all-targets -D warnings`, nightly `cargo fmt
--all --check`, `just check-gated`, and every `xtask check-*` gate named in the
workflows.
