### PR TITLE
fix(ci): bound apt setup in the BDD gate

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -29,11 +29,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
-      - name: Install system build dependencies
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
-          sudo apt-get update
-          sudo apt-get install -y libcap-ng-dev lld
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: libcap-ng-dev lld
 
       - uses: ./.github/actions/install-zigbuild
 

--- a/specs/sprint/delivery/bdd-bounded-apt.md
+++ b/specs/sprint/delivery/bdd-bounded-apt.md
@@ -1,0 +1,29 @@
+# BDD setup uses the bounded apt path
+
+**Status:** COMPLETE
+
+## Failure reproduced
+
+Three independent BDD jobs exhausted their 30-minute job budget in `apt-get
+update` without reaching the suite. The shared `.github/actions/apt-deps`
+action already replaces the hosted runner's unreliable Azure mirrorlist and
+bounds each update/install attempt, but `.github/workflows/bdd.yml` bypassed it
+with raw `apt-get` commands.
+
+## Delivered
+
+- The canonical reusable BDD workflow now installs `libcap-ng-dev` and `lld`
+  through `.github/actions/apt-deps`.
+- A workflow-structure regression test refuses any return to raw `sudo
+  apt-get` in that workflow and requires the shared action.
+
+This changes setup behavior only. The BDD command, cache policy, SDK suites,
+and 30-minute job ceiling are unchanged.
+
+## Validation
+
+- The exact new test was run before the workflow edit and failed on the
+  missing shared action.
+- `cargo test --test github_actions_bdd_gate
+  canonical_bdd_workflow_uses_bounded_apt_action -- --exact`: 1 passed.
+- `cargo test --test github_actions_bdd_gate`: 6 passed.

--- a/tests/github_actions_bdd_gate.rs
+++ b/tests/github_actions_bdd_gate.rs
@@ -64,6 +64,19 @@ fn canonical_bdd_workflow_runs_the_full_suite() {
 }
 
 #[test]
+fn canonical_bdd_workflow_uses_bounded_apt_action() {
+    let contents = workflow("bdd.yml");
+    assert!(
+        contents.contains("uses: ./.github/actions/apt-deps"),
+        "BDD setup must inherit the shared mirror replacement, timeouts, and retries"
+    );
+    assert!(
+        !contents.contains("sudo apt-get"),
+        "BDD setup must not bypass the bounded apt action"
+    );
+}
+
+#[test]
 fn runtime_release_publication_needs_bdd() {
     assert_reuses_bdd_gate("release.yml");
     assert_job_needs_bdd("release.yml", "release");


### PR DESCRIPTION
## Summary

- route the reusable BDD workflow through the shared bounded apt action
- inherit mirror replacement plus update/install retries and timeouts
- add a workflow regression test that forbids raw apt setup in the BDD gate

Three independent BDD jobs exhausted their 30-minute budget in raw apt setup without reaching the suite, including the #2737 merge-group run. The shared action already contains the bounded behavior; this closes the one workflow that bypassed it.

## Validation

- regression test was confirmed failing before the workflow edit
- `cargo test --test github_actions_bdd_gate canonical_bdd_workflow_uses_bounded_apt_action -- --exact`
- `cargo test --test github_actions_bdd_gate`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- workflow path, sprint append, backing, and no-overclaim checks
- pre-commit actionlint