### PR TITLE
fix(stage0): find labelled disks wherever they are attached, and attach each once

### DIFF
--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -55,7 +55,6 @@ mod linux {
     /// explicit rather than a `/sys/class/block` walk — a RootDir guest never
     /// has more than a handful of disks, and a missing candidate is just a
     /// failed `File::open` (cheap, non-fatal).
-    const STAGE0_DISK_CANDIDATES: &[&str] = &["/dev/vda", "/dev/vdb", "/dev/vdc", "/dev/vdd"];
 
     const VSOCK_EGRESS_PROXY_URL: &str = mvm_core::guest_netd::DEFAULT_EGRESS_PROXY_URL;
     const VSOCK_EGRESS_NO_PROXY: &str = "127.0.0.1,localhost";
@@ -594,7 +593,12 @@ mod linux {
         // letter stays as a fallback for a store image formatted before it
         // carried a label.
         let label = mvm_build::rootfs::STAGE0_NIX_STORE_EXT4_LABEL;
-        let by_label = find_labeled_ext4_disk(STAGE0_DISK_CANDIDATES, label)
+        // Every attached virtio disk, not a fixed prefix of them. The QEMU path
+        // attaches seed, work, out, mvm-bins and the FlowMux identity ahead of
+        // the store, so a four-entry list stopped two devices short of the disk
+        // it was looking for — the lookup could never succeed there, fell back
+        // to enumeration order, and picked the 32 KiB identity image.
+        let by_label = find_labeled_ext4_disk_among(virtio_block_devices(), label)
             .map(|d| d.to_string_lossy().into_owned());
         let device: &str = match by_label.as_deref() {
             Some(dev) => {
@@ -1171,7 +1175,7 @@ mod linux {
     // `mvm_agentd::flowmux_drive`: Stage 0 mounts `/work` by label and the
     // identity drive by label, and a second copy of the superblock layout is
     // exactly the kind of duplicate that drifts.
-    use mvm_agentd::flowmux_drive::find_labeled_ext4_disk;
+    use mvm_agentd::flowmux_drive::{find_labeled_ext4_disk_among, virtio_block_devices};
 
     /// Mounts `/work` for the libkrun backend. Prefers the ext4 disk
     /// carrying [`mvm_build::rootfs::STAGE0_WORK_EXT4_LABEL`] — the host
@@ -1183,7 +1187,10 @@ mod linux {
     fn mount_libkrun_work_share() -> Result<(), String> {
         std::fs::create_dir_all("/work").map_err(|e| format!("create /work: {e}"))?;
         let label = mvm_build::rootfs::STAGE0_WORK_EXT4_LABEL;
-        match find_labeled_ext4_disk(STAGE0_DISK_CANDIDATES, label) {
+        // Same enumeration as the store lookup, for the same reason: a fixed
+        // prefix of device letters is the positional assumption the label
+        // removes, and /work is not guaranteed to land inside it either.
+        match find_labeled_ext4_disk_among(virtio_block_devices(), label) {
             Some(dev) => {
                 let dev = dev.to_string_lossy().into_owned();
                 mount_fs_ro(&dev, "/work", "ext4")?;

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -267,19 +267,15 @@ fn run_stage0_qemu(
         cmd.arg("-drive")
             .arg(format!("file={},if=virtio,format=raw", disk.display()));
     }
-    // Read-only, matching how the shell-job and build paths attach it.
+    // Read-only, matching how the shell-job and build paths attach it. Attached
+    // once: a second copy consumed another device letter and pushed the Nix
+    // store further down the enumeration, which is how the store ended up
+    // beyond where the guest looked for it.
     #[cfg(feature = "builder-vm")]
     cmd.arg("-drive").arg(format!(
         "file={},if=virtio,format=raw,readonly=on",
         identity_drive.display()
     ));
-    #[cfg(feature = "builder-vm")]
-    {
-        cmd.arg("-drive").arg(format!(
-            "file={},if=virtio,format=raw,readonly=on",
-            identity_drive.display()
-        ));
-    }
     #[cfg(feature = "builder-vm")]
     cmd.arg("-drive").arg(format!(
         "file={},if=virtio,format=raw",
@@ -1772,5 +1768,36 @@ fi
             result.vm_state_dir.join("console.log").exists(),
             "live proof must leave a console log for diagnosis"
         );
+    }
+
+    /// Each disk gets exactly one `-drive`.
+    ///
+    /// The FlowMux identity image was attached twice, which consumed a device
+    /// letter and pushed the Nix store one slot further down the enumeration —
+    /// past where the guest looked for it. The guest then fell back to
+    /// enumeration order and selected the 32 KiB identity image as its store,
+    /// failing closed on every Stage 0 kernel build.
+    #[test]
+    fn no_disk_is_attached_to_stage0_twice() {
+        let src = include_str!("qemu_builder.rs");
+        let block = src
+            .split_once("for disk in [&vda, &vdb, &vdc, &vdd]")
+            .expect("stage 0 still attaches its disks here")
+            .1
+            .split_once("\"-device\"")
+            .expect("the drive list ends before the vsock device")
+            .0;
+
+        for operand in [
+            "identity_drive.display()",
+            "nix_store_lock.path().display()",
+        ] {
+            let n = block.matches(operand).count();
+            assert_eq!(
+                n, 1,
+                "{operand} is attached {n} times; each disk takes exactly one \
+                 -drive, and a duplicate re-letters every disk behind it"
+            );
+        }
     }
 }


### PR DESCRIPTION
**Every Stage 0 kernel build on the QEMU path failed.** Found by running `machine run --image` on a real KVM box; reproduced on a fresh `MVM_HOME` every time.

```
stage0-init: no disk carries the ext4 label "mvm-nix-store";
             falling back to /dev/vde by enumeration order
stage0-init: FATAL: /dev/vde ... is 32768 bytes, below the 67108864-byte floor
             for a store disk
```

## The store was there the whole time

```
$ blkid /root/.../cache/builder-vm/nix-store-stage0-x86_64.img
  LABEL="mvm-nix-store" UUID="7532f94a-..." TYPE="ext4"      # 68 GB
$ ls -l .../flowmux-identity.ext4
  32768                                                       # the disk it picked
```

Correctly labelled, correctly sized, correctly attached. The guest never looked at it.

## Cause

```rust
const STAGE0_DISK_CANDIDATES: &[&str] = &["/dev/vda", "/dev/vdb", "/dev/vdc", "/dev/vdd"];
```

The QEMU path fills exactly those four with seed, work, out and mvm-bins, then attaches the FlowMux identity image, then the store. So the by-label lookup **stopped two devices short of the disk it was searching for** and could never succeed there.

A fixed list of device letters is precisely the positional assumption the label was introduced to remove — the code's own comment says so:

> The device letter is a function of how many block devices the backend attached ahead of this one, so adding a drive silently re-letters every disk behind it — which is how this guest came to mount a 32 KiB identity image as its Nix store.

That comment describes this bug, written while adding the label that was supposed to fix it.

Both lookups now enumerate every attached virtio disk via `virtio_block_devices()` — which `find_labeled_ext4_disk_among` already documents itself as taking. The `/work` lookup had the identical latent fault and is fixed with it.

**Second, smaller:** the identity image was attached **twice** in `qemu_builder.rs`, consuming another letter and pushing the store one slot further still. `/dev/vde` — the 32 KiB image the guest reported as its store — is that duplicate.

The fail-closed size check behaved correctly throughout. It was reporting a symptom two layers below the cause, which is why it read as a store-sizing problem rather than a lookup one.

## Verified on real KVM

Same box, same command, after the fix:

```
stage0-init: Stage 0 Nix store is /dev/vdf (label "mvm-nix-store")
```

`/dev/vdf` — two past the end of the old list. Stage 0 then proceeds into the real kernel build instead of refusing.

## Tests

`no_disk_is_attached_to_stage0_twice` asserts each disk operand appears in exactly one `-drive`, and explains why a duplicate is not merely wasteful: it re-letters every disk behind it.

`clippy --workspace --all-targets -D warnings` and `fmt --all --check` clean. The pre-commit hook caught a second live use of the constant I had missed on the first attempt, which is why the const is now gone rather than left `#[cfg(test)]`.