### PR TITLE
fix(xtask): skip nested .claude/worktrees in source policy scans

### DIFF
--- a/xtask/src/check_l3_expansion_freeze.rs
+++ b/xtask/src/check_l3_expansion_freeze.rs
@@ -97,6 +97,7 @@ const EXEMPT: &[&str] = &[
 
 const SKIP_DIRS: &[&str] = &[
     ".git",
+    ".claude",
     ".mvm-test",
     ".mvm-verify",
     "target",
@@ -346,6 +347,36 @@ mod tests {
             unique.len(),
             ALLOWLIST.len(),
             "duplicate allowlist entries hide a stale one"
+        );
+    }
+
+    /// Claude worktrees nested inside the main checkout carry independent
+    /// branch states and must not be scanned as if they were part of the
+    /// source tree.
+    #[test]
+    fn claude_worktrees_are_not_scanned() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nested = tmp
+            .path()
+            .join(".claude")
+            .join("worktrees")
+            .join("old-branch");
+        std::fs::create_dir_all(&nested).expect("create nested worktree");
+        std::fs::write(
+            nested.join("legacy.rs"),
+            "let mode = NetworkMode::L3Vsock;\n",
+        )
+        .expect("write legacy source");
+        std::fs::write(tmp.path().join("source.rs"), "// clean\n").expect("write source file");
+
+        let found = walk(tmp.path()).expect("walk temp tree");
+        assert!(
+            found.iter().all(|p| !p.ends_with("legacy.rs")),
+            "walker descended into .claude/worktrees: {found:?}"
+        );
+        assert!(
+            found.iter().any(|p| p.ends_with("source.rs")),
+            "walker skipped the real source file: {found:?}"
         );
     }
 }

--- a/xtask/src/check_no_gateway_names.rs
+++ b/xtask/src/check_no_gateway_names.rs
@@ -62,6 +62,7 @@ const EXEMPT: &[&str] = &[
 /// would fail the gate on prose that has already been corrected at the source.
 const SKIP_DIRS: &[&str] = &[
     ".git",
+    ".claude",
     ".mvm-test",
     ".mvm-verify",
     "target",
@@ -238,6 +239,24 @@ mod tests {
         std::fs::write(tmp.path().join("source.txt"), "clean\n").expect("source file");
 
         run(tmp.path()).expect("generated mvm state must not enter source policy scans");
+    }
+
+    /// Nested Claude worktrees inside the main checkout carry independent branch
+    /// states and must not be treated as source tree content.
+    #[test]
+    fn claude_worktrees_are_not_scanned() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nested = tmp
+            .path()
+            .join(".claude")
+            .join("worktrees")
+            .join("old-branch");
+        std::fs::create_dir_all(&nested).expect("create nested worktree");
+        std::fs::write(nested.join("legacy.txt"), "spawn gvproxy for the guest\n")
+            .expect("write legacy file");
+        std::fs::write(tmp.path().join("source.txt"), "clean\n").expect("write source file");
+
+        run(tmp.path()).expect("nested claude worktrees must not pollute source scans");
     }
 
     /// `passthru` is a Nix attribute used throughout the builder pipeline and


### PR DESCRIPTION
Nested Claude worktrees inside the main checkout (e.g. `.claude/worktrees/`) carry independent branch states. The policy walkers were descending into them and reporting legacy symbols/gateway names from those branches as if they were part of the source tree, making `check-l3-expansion-freeze` and `check-no-gateway-names` fail on an otherwise clean `main`.

Changes:
- Add `.claude` to `SKIP_DIRS` in both gates.
- Add focused tests proving `.claude/worktrees/...` is skipped.

Verification:
- `cargo run -p xtask -- check-l3-expansion-freeze` passes.
- `cargo run -p xtask -- check-no-gateway-names` passes.
- `cargo test -p xtask claude_worktrees_are_not_scanned` passes.
- `cargo clippy -p xtask --all-targets -- -D warnings` is clean.