### PR TITLE
docs: establish FlowMux single-path closeout

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1597,107 +1597,33 @@ for detailed scope and acceptance criteria.
         (recon §7.7 → #2019)
 
 - [~] Plan 316 — Single flow-aware vsock networking path
-  **Phases 2-4 superseded by
-  `specs/plans/2026-08-15-flowmux-single-transport-cutover.md` (#2543): #2480 shipped the
-  FlowMux guest adapter without host identity provisioning, so guest egress is dead on
-  `main`. The cutover completes there, on one transport, folding `Wire` and `MVM_ICMP/1`
-  into FlowMux rather than leaving three protocols behind a sniff.
-  WS0-WS7 are complete: substitution rides `OpenHttp`, `ping` rides `IcmpEcho`,
-  the raw dispatcher and `EgressMode::Raw` are deleted, and launch readiness
-  waits on an endpoint-owned authenticated-session event before verifying its
-  durable marker and failing closed if no session arrives. This removes the
-  guest-agent/FlowMux authentication race without a fixed sleep. In addition,
-  `xtask check-one-guest-protocol` fails the build if a second guest->host
-  protocol returns. `EgressMode::Wire` survives for the wasm tier's host-side
-  `mvm:egress` import, which is host-internal IPC rather than a guest channel.**
-  (`specs/plans/316-single-flow-vsock-networking.md`, ADR-042, umbrella #2368)
-  Collapses the two production workload networking paths to one authenticated
-  FlowMux session on `GuestService::NetworkFlow` through one
-  `mvm-network-endpoint`. Supersedes the production-path decisions in plan 285
-  and plan 287; both are frozen, not yet deleted.
-  - [x] Phase 0 — ratify the invariant and freeze expansion (#2369): ADR-042
-        accepted; ADR-036 and ADR-037 marked superseded for production workload
-        networking; `specs/refactor/03-networking.md` corrected from "the raw
-        packet path is deleted" to the actual two-path state; ADR-001's tier
-        matrix and claim-10 section qualified; `xtask
-check-l3-expansion-freeze` added as a temporary shrink-only ratchet
-        over `L3Vsock`/`raw_ip_stack`/`NetworkControl`/`NetworkData`/
-        `spawn_netd`/`host_datapath` (29 allowlist entries); synthesis,
-        admission, and CLI preflight refuse `raw_ip_stack=true`/`L3Vsock` with
-        a migration error naming the loopback adapters and typed connectors
-  - [x] Phase 1 — pin protocol, resource, and performance baselines (#2370).
-        Closed 2026-08-13. Landed: `mvm-contract::protocol::network_flow` — the
-        v1 frame header (20 bytes, `u32` length field because 64 KiB does not
-        fit a `u16`), all 27 opcodes with their class/sender/confirmation
-        relations, state-independent cap-before-allocate decoding with golden
-        byte fixtures, and the session/stream state machine (parity-split stream
-        IDs, watermark reuse rejection rather than an unbounded set, per-stream
-        credit, declared-listener-backed ingress, fail-closed on every
-        refusal). 87 unit tests. `crates/mvm-contract/fuzz` adds
-        `fuzz_network_flow_decode` and `fuzz_network_flow_state` with 95
-        committed seeds, wired into `security.yml`. Transport-neutral signed
-        `NetworkLimits` is also implemented with default-byte compatibility,
-        validation, and one legacy/FlowMux accessor. `mvm-core::net::session`
-        extracts the authenticated session so it is shared by control RPC and
-        FlowMux, with tests for replay, tampering, wrong identity, and counter
-        exhaustion. Remaining: the perf harness + baselines.
-  - [~] Phase 2 — the one authenticated endpoint (#2371). Substantially landed,
-        **not complete**: the `EndpointSpawner` → `NetworkEndpointSpawner` rename
-        has not happened (`crates/mvm-hostd/tests/workload_stream_plane.rs` still
-        imports `EndpointSpawner`), the duplicate `EGRESS_VSOCK_PORT = 5253`
-        survives in `mvm-egress-client.rs` and `mvm-addon-dns.rs` because
-        `mvm-agentd` does not depend on `mvm-net`. The fail-closed readiness
-        assertion is now witnessed by a delayed-authentication BDD scenario,
-        endpoint subprocess coverage, and focused timeout/exit tests: launch
-        cannot reach ready until an authenticated FlowMux session has written
-        durable evidence and signaled its endpoint-owned event. Phase 3 is
-        already ahead of this, so the phase gate will not catch the remaining
-        rename and constant residue.
-        Landed: `GuestService::NetworkFlow`
-        now names the port-5253 channel; the endpoint binary, proxy, spawner, and
-        test files are renamed to `mvm-network-endpoint`/`network_endpoint_*`;
-        `mvm-hostd::supervisor::flowmux` landed the authenticated FlowMux session
-        acceptor (`FlowMuxSession::accept`, `serve`, `Hello`/`HelloAck`, `GoAway`
-        for unimplemented flows) and bounded per-stream registries
-        (`flowmux::registry`) with unit tests for parity, ceilings, state
-        transitions, and credit accounting. The acceptor is wired into the
-        `mvm-network-endpoint` binary (`EgressMode::FlowMux`,
-        `EndpointConfig::flowmux_identity`, `serve_flowmux`) and the spawner emits
-        the identity on stdin. Backend witness tests in `mvm-vmm::host::spec_map`
-        and the Firecracker/HVF/libkrun driver modules prove exactly one
-        `NetworkFlow` service and no L3 services per granted workload.
-  - [~] Phase 3 — converge egress TCP, UDP, and DNS (#2372). **The machinery
-    below is landed and unit-tested but is NOT on the production path:**
-    `RealNetworkEndpointSpawner::spawn` hard-codes `flowmux_identity: None`,
-    `EndpointSpawnRequest` has no field for it, and the only
-    `FlowMuxIdentitySpawnConfig` construction in the workspace is inside a
-    `#[cfg(test)]` function. `claim.rs` still selects the mode with
-    `let raw_egress = inputs.secrets.is_empty()`, so every admitted workload
-    speaks `Wire` or `Raw`. The last checkbox (delete `EgressMode`/`raw_egress`)
-    therefore cannot be executed as written — it would break all egress. Landed:
-    guest-initiated `OpenTcp` with typed `Opened`/`Refused` replies,
-    `OpenUdp`/`UdpSend`/`UdpRecv` associations, `Resolve`/`Resolved` DNS
-    frames, per-direction host credit accounting, UDP idle expiry, per-
-    association peer bounds, per-class connection-rate limiting, payload-
-    free audit emission for TCP/UDP allows/denies and DNS resolves/refusals,
-    and host-side integration tests for allowed/denied TCP, UDP round-trip,
-    DNS pinning, UDP idle expiry, peer bounds, half-close, reset, and rate-
-    limit overflow. Guest-side `FlowMuxClient` / `FlowMuxReconnectClient`,
-    `FlowMuxStream`, `FlowMuxUdpSocket`, async frame pump, and unit tests
-    are implemented in `crates/mvm-agentd/src/flowmux.rs`. Guest-side
-    adapters are now wired: `mvm-egress-client` uses
-    `flowmux_egress::run` with a single `FlowMuxReconnectClient`,
-    `mvm-addon-dns` optionally forwards through `FlowMuxClient::resolve`,
-    and the legacy line-prelude symbols (`HTTP_FORWARD_FRAME`,
-    `MVM_DNS/1`, `MVM_SOCKS5_UDP/1`) are removed from the guest modules.
-    Unit tests cover the new DNS and SOCKS5/HTTP parsing paths.
-    Remaining: delete the host-side raw-egress dispatcher and add endpoint
-    crash/restart integration tests.
-  - [~] Phase 4 — stream typed transformations (#2373)
-  - [ ] Phase 5 — declared ingress on FlowMux (#2374)
-  - [ ] Phase 6 — compatibility boundary (#2375)
-  - [ ] Phase 7 — delete L3 completely (#2376)
-  - [ ] Phase 8 — make "one path" mechanically enforceable (#2377)
+  (`specs/plans/316-single-flow-vsock-networking.md`, ADR-042). The active
+  remainder is issue #2751 and
+  `specs/plans/2026-08-19-flowmux-single-path-closeout.md`; the original phase
+  issues are closed historical records.
+  - [x] Protocol, authenticated endpoint, production outbound cutover, and
+        authenticated-session readiness. TCP, UDP, DNS, mediated ICMP, and
+        typed HTTP use FlowMux on `GuestService::NetworkFlow`; the raw/Wire
+        guest dispatcher is deleted and `check-one-guest-protocol` guards the
+        transport boundary.
+  - [x] Relayed-vsock host-first handshake (#2741). HVF and libkrun now open
+        the endpoint relay on guest connect, retain the route needed for a
+        host-first greeting, and reset immediately when no endpoint exists.
+  - [ ] Shared per-VM admitted limits. The endpoint still creates default
+        registry limits per session, so concurrent sessions can multiply a
+        nominal VM ceiling.
+  - [ ] FlowMux performance harness and labelled legacy/current baselines.
+  - [~] Typed HTTP uses FlowMux frames but still crosses a whole-message
+        compatibility seam; bounded end-to-end streaming and endpoint-owned
+        typed connector execution remain.
+  - [ ] Declared ingress runtime. The wire opcodes and state transitions exist;
+        endpoint listener and guest-adapter handling do not.
+  - [ ] Remove the rejected `raw_ip_stack`/`L3Vsock` public compatibility
+        surface now that the migration release condition has passed.
+  - [ ] Delete frozen L3 contract, guest, host, VMM, dependency, packaging,
+        kernel, CI, and test slices.
+  - [ ] Permanent single-path/socket-owner gates plus the final performance,
+        Firecracker, HVF, libkrun, BDD, supply-chain, and documentation matrix.
 
 - [~] Plan 285 — L3 TUN-over-vsock network mode
   (`specs/plans/285-l3-tun-over-vsock.md`, ADR-036)

--- a/specs/plans/2026-08-19-flowmux-single-path-closeout.md
+++ b/specs/plans/2026-08-19-flowmux-single-path-closeout.md
@@ -1,0 +1,194 @@
+# FlowMux single-path closeout
+
+Backing: preview
+Validation: none
+
+**Issue:** [#2751](https://github.com/tinylabscom/mvm/issues/2751)
+**Predecessors:** Plan 316, ADR-042, and the FlowMux transport cutover in
+`2026-08-15-flowmux-single-transport-cutover.md`
+
+## Status
+
+PR #2741 merged on 2026-08-19. The guest and host can now complete the
+host-first FlowMux handshake on relayed-vsock backends as well as direct-vsock
+backends. The outbound cutover is complete: guest TCP, UDP, DNS, mediated ICMP,
+and typed HTTP all use the authenticated protocol on `NetworkFlow`.
+
+That is not the final single-path architecture. Admitted `NetworkLimits` still
+stop before the endpoint's registries, typed HTTP still buffers complete
+messages at its compatibility seam, declared ingress has no runtime, the
+rejected `raw_ip_stack` configuration and frozen L3 implementation remain in
+the tree, and the permanent single-path gates and final performance/backend
+matrix do not exist. This plan owns that remainder. The closed Plan 316 phase
+issues are historical; issue #2751 is the active umbrella.
+
+## Outcome
+
+An admitted workload has either no network capability or one authenticated
+FlowMux endpoint. Every guest-visible TCP, UDP, DNS, typed HTTP/connector, and
+declared-ingress flow shares the endpoint's plan projection, per-VM resource
+budget, identity, audit sink, and lifecycle. No production L3/raw-packet
+implementation, compatibility flag, alternate socket owner, or second guest
+protocol remains.
+
+## Ordering and pull-request boundaries
+
+Workstreams run in order unless a dependency note explicitly permits overlap.
+Each implementation pull request updates this plan, its delivery record, and
+`specs/REFACTOR-STATUS.md` only after its tests are green.
+
+### W0 — Re-establish one truthful tracker
+
+- [x] Make issue #2751 the active umbrella for every remaining FlowMux item.
+- [x] Replace Plan 316's pre-cutover status with the current source inventory
+      and point its remaining phases here.
+- [x] Reconcile the sprint delivery archive and refactor rollup with the same
+      status and dependency order.
+
+### W1 — Enforce admitted limits as shared per-VM budgets
+
+- [ ] Thread signed `NetworkLimits` from the admitted plan through
+      `EndpointSpawnRequest`, `EndpointConfig`, and endpoint startup without a
+      fallback to `RegistryLimits::default()` on an admitted workload.
+- [ ] Introduce one per-VM budget owner shared by all authenticated sessions;
+      session churn or multiple guest processes must not multiply stream,
+      association, byte-credit, listener, peer, or rate ceilings.
+- [ ] Bound concurrent authenticated sessions and ensure every reservation is
+      released on refusal, cancellation, EOF, and endpoint teardown.
+- [ ] Add serde/default/validation tests, cross-session exhaustion tests,
+      reconnect tests, and endpoint subprocess coverage for malformed or
+      missing limits.
+
+### W2 — Add the performance harness before deleting the baseline path
+
+- [ ] Add `xtask network-perf` with machine-readable reports for opaque TCP,
+      UDP, DNS, and transformed HTTP latency, throughput, CPU, copies where
+      measurable, and peak RSS.
+- [ ] Record host-, backend-, storage-, build-, and sample-labelled legacy L3
+      and current FlowMux baselines under `specs/benchmarks/network/`.
+- [ ] Make comparison thresholds explicit: opaque latency at most 5% slower,
+      throughput at least 95%, RSS growth at most 10%, and transformed HTTP
+      latency at most 10% slower unless an owner-approved measured exception is
+      recorded here.
+- [ ] Keep the harness hermetic by default and isolate live KVM/HVF/libkrun
+      runners behind explicit environment checks.
+
+### W3 — Make typed transformations bounded and endpoint-owned
+
+- [ ] Replace whole-message `WireRequest`/`WireResponse` buffering with bounded
+      incremental head/body handling from `OpenHttp` through completion.
+- [ ] Preserve transformation matches across frame boundaries with a bounded
+      overlap window, enforce head/body/idle/credit ceilings, and zeroize
+      secret-bearing buffers on completion and cancellation.
+- [ ] Apply destination-bound substitution only after final DNS and redirect
+      admission; redact each response chunk before it crosses to the guest.
+- [ ] Route typed connector network execution through the endpoint. Brokers
+      retain binding authorization but do not connect, resolve, or create an
+      independent HTTP client for workload traffic.
+- [ ] Add positive, refusal, split-token, redirect, oversized-head/body,
+      timeout, cancellation, audit-leak, and long-stream tests.
+
+### W4 — Implement declared ingress on FlowMux
+
+- [ ] Replace `L3IngressMapping` with a transport-neutral signed-plan/IR type
+      carrying mapping ID, protocol, exact host bind, guest loopback target,
+      and transformation class; update Rust, Python, TypeScript, schemas, and
+      fixtures together.
+- [ ] Bind only admitted listeners before endpoint readiness. Refuse duplicate
+      or unavailable binds, undeclared wildcards, unsupported protocols, and
+      unavailable transformation material.
+- [ ] Implement TCP ingress with even stream IDs and the existing
+      `InboundOpen`/`InboundReady`/`InboundRefused` contract before relaying
+      bytes to a declared guest-loopback target.
+- [ ] Implement UDP ingress with bounded per-mapping peer tables; replies may
+      target only a peer that previously sent to that mapping.
+- [ ] Keep TLS keys and transformation material host-side, support explicitly
+      opaque TCP without transformation, and delete the unused second ingress
+      broker/handler model.
+- [ ] Add exact/wildcard bind, undeclared port, TCP/UDP delivery, guest refusal,
+      exhaustion, TLS-key non-disclosure, streaming transform, audit, and
+      teardown tests plus BDD coverage.
+
+### W5 — Remove the rejected public compatibility surface
+
+- [ ] Remove `raw_ip_stack` and `NetworkMode::L3Vsock` from the Rust IR,
+      Python and TypeScript SDKs, generated schemas, fixtures, examples, CLI
+      help, and public documentation.
+- [ ] Preserve an explicit migration error for stale serialized input at the
+      outer compatibility boundary without representing the rejected mode in
+      admitted domain types.
+- [ ] Document the supported loopback proxy, SOCKS5h/UDP, controlled DNS,
+      mediated ping, and typed connector surfaces, and the fail-closed result
+      for applications that bypass them.
+- [ ] Add schema parity, stale-input refusal, supported-adapter, typed-
+      connector, and non-cooperative direct-socket BDD tests.
+
+### W6 — Delete the superseded L3 implementation
+
+- [ ] Delete contract and policy L3 modules, L3-only channel identities,
+      leases, fuzz targets, synthesis/admission branches, and live product
+      scenarios.
+- [ ] Delete `mvm-net` and `mvm-agentd` L3 modules, `mvm-net-agent`, guest TUN
+      setup/cmdline/runtime-overlay code, and the workload-kernel TUN
+      requirement where no non-network consumer remains.
+- [ ] Delete hostd netd modules and binary, host TUN/netns/nftables and smoltcp
+      datapaths, privileged L3 tests, VMM spawn/reap/teardown hooks, and
+      control/data service sockets.
+- [ ] Remove resulting dependencies and packaging/Nix/CI/kernel residue; update
+      lockfiles and closure budgets.
+- [ ] Rewrite protocol-independent security scenarios against FlowMux and
+      delete scenarios for intentionally unsupported raw networking.
+- [ ] Run dependency, advisory, license, duplicate-major, and closure-budget
+      checks with no L3-only binary or dependency left.
+
+### W7 — Replace migration ratchets with permanent invariants
+
+- [ ] Add `check-single-network-path`: exactly one production endpoint binary
+      and spawn implementation, every networked backend binds `NetworkFlow`,
+      and forbidden packet/NIC/gateway symbols occur only in historical specs.
+- [ ] Add a socket-owner gate permitting workload outbound connects and
+      ingress listener binds only inside the endpoint, with narrow enumerated
+      exemptions for unrelated host infrastructure.
+- [ ] Test each gate with forbidden synthetic fixtures and its exact allowed
+      cases, then retire temporary L3 freeze/uniform-vsock gates that no longer
+      describe the tree.
+- [ ] Add a signed-plan projection test showing TCP, UDP, DNS, typed connectors,
+      and ingress share one policy object, budget owner, identity, and audit
+      sink.
+
+### W8 — Run the final evidence matrix and close the umbrella
+
+- [ ] Run `xtask network-perf` against the recorded baseline and record the
+      final report and any approved exception.
+- [ ] Live-witness Firecracker on Linux/KVM, HVF on macOS, and libkrun on every
+      supported host OS. Cover deny-all, TCP, UDP, DNS, typed substitution,
+      ingress, endpoint crash, no guest NIC, and no L3 services.
+- [ ] Run workspace test/check/doc-test/formatting on the macOS host; run Linux
+      all-target/all-feature Clippy, gated tests, Nix checks, and live KVM work
+      inside the project builder VM.
+- [ ] Run BDD, dependency, supply-chain, schema, product, claim, and permanent
+      networking gates.
+- [ ] Update ADR/claim witnesses, public networking docs, release notes, this
+      plan, the sprint delivery archive, and the refactor rollup; close #2751
+      only after every acceptance item is backed by recorded output.
+
+## Definition of done
+
+- [ ] The production source tree contains no L3/raw-packet workload networking
+      code, public raw-network mode, or second ingress/egress socket owner.
+- [ ] Every admitted network flow shares one endpoint, authenticated protocol,
+      signed-plan projection, per-VM budget owner, and payload-free audit sink.
+- [ ] Typed transformation and declared ingress are bounded, streaming, and
+      covered across positive, negative, cancellation, and boundary cases.
+- [ ] Permanent gates reject a second path or socket owner.
+- [ ] Performance budgets and the required cross-backend live matrix pass, and
+      all repository validation is green.
+
+## Non-goals
+
+- No guest NIC, host bridge, TAP, slirp, passt, vpnkit, or raw-packet fallback.
+- No universal TLS interception CA or attempt to bypass certificate pinning,
+  QUIC, or ECH.
+- No weakening of ptrace, seccomp, capability, Landlock, read-only-root, or
+  secret-handling boundaries for application compatibility.
+- No alternate production endpoint retained as a development escape hatch.

--- a/specs/plans/316-single-flow-vsock-networking.md
+++ b/specs/plans/316-single-flow-vsock-networking.md
@@ -2,52 +2,23 @@
 
 ## Status
 
-**Phases 2-4 are superseded by
-`specs/plans/2026-08-15-flowmux-single-transport-cutover.md` (issue #2543). Track the
-remaining work there, not here.**
+**The active remainder moved to
+`specs/plans/2026-08-19-flowmux-single-path-closeout.md` and issue #2751. Do not
+use the closed phase issues below as the current tracker.**
 
-**Phase 0 complete (#2369). Phase 1 complete (#2370). Phase 2 substantially landed but NOT complete (#2371). Phase 3 machinery landed but NOT on the production path (#2372).**
+Phase 0 froze L3 expansion and Phase 1 pinned the protocol. The transport
+cutover in `specs/plans/2026-08-15-flowmux-single-transport-cutover.md` completed
+the production outbound path: TCP, UDP, DNS, mediated ICMP, and typed HTTP use
+FlowMux, the raw/Wire dispatcher is gone, and launch waits for authenticated
+session readiness. PR #2741 then fixed the host-first handshake on the
+relayed-vsock backends.
 
-Worse than "not on the production path": #2480 shipped the guest half anyway, so
-`mvm-egress-client` is FlowMux-only while every host spawn site still serves Raw/Wire.
-Guest egress is dead on `main` — builder VM, Stage 0, and every workload. The four
-tracking issues below (#2368, #2371, #2372, #2373) are all closed despite this; do not
-read a closed issue here as landed work.
-
-**Read this before ticking another Phase 3 box.** The host-side FlowMux
-acceptor and the guest-side FlowMux client both exist and are unit-tested, and
-nothing connects them on a real launch. `RealNetworkEndpointSpawner::spawn` —
-the single production spawn — passes `flowmux_identity: None`, hard-coded;
-`EndpointSpawnRequest` has no field for it, so no caller can ask; and the only
-construction of `FlowMuxIdentitySpawnConfig` in the workspace is inside a
-`#[cfg(test)]` function. `claim.rs` still selects the mode with
-`let raw_egress = inputs.secrets.is_empty()`. Every admitted workload today
-speaks `Wire` or `Raw`.
-
-Two consequences. Phase 3's last checkbox cannot be executed as written —
-deleting `EgressMode` and `raw_egress` would remove the only modes production
-uses and break all egress. And Phase 2's remaining box and Phase 3's remaining
-box are the same work: neither "a failed FlowMux session prevents readiness"
-nor "every flow type reaches one pipeline" means anything until the production
-spawn carries a FlowMux identity. Land them together, with a live witness —
-this changes the egress path for every workload on every backend.
-
-Phase 2 previously carried a `COMPLETE` status while six of its seven
-checkboxes were unchecked below. Two are verifiably undone on `main`: the
-`EndpointSpawner` → `NetworkEndpointSpawner` rename has not happened, and the
-hand-maintained duplicate `EGRESS_VSOCK_PORT = 5253` still exists in
-`mvm-egress-client.rs` and `mvm-addon-dns.rs` because `mvm-agentd` does not
-depend on `mvm-net` and so cannot reach the typed service mapping.
-
-Phase 3 is now ahead of Phase 2. The strict ordering was the mechanism meant to
-catch Phase 2 residue, so that residue will not be caught by a later phase gate
-and must be closed deliberately — in particular the fail-closed readiness
-assertion, which is invariant 4 and the reason Phase 2 exists.
-
-ADR-042 is accepted and the raw-packet path is frozen: new
-`raw_ip_stack=true` / `NetworkMode::L3Vsock` launches are refused at synthesis,
-admission, and CLI preflight, and `xtask check-l3-expansion-freeze` holds the
-line. No FlowMux runtime exists yet.
+Phases 4–8 remain incomplete. Admitted `NetworkLimits` are not the endpoint's
+shared per-VM budgets, typed HTTP still buffers complete messages at a
+compatibility seam, declared ingress is contract-only, `raw_ip_stack` and the
+frozen L3 implementation remain in the tree, and the permanent gates,
+performance comparison, and final backend matrix have not landed. The
+successor plan splits those items into reviewable, dependency-ordered changes.
 
 ## Tracking issues
 

--- a/specs/sprint/delivery/flowmux-single-path-closeout-tracker.md
+++ b/specs/sprint/delivery/flowmux-single-path-closeout-tracker.md
@@ -1,0 +1,17 @@
+# One tracker now owns the rest of the FlowMux cutover
+
+PR #2741 removed the relayed-vsock host-first handshake deadlock. It did not
+finish the broader single-path architecture: limits are still instantiated as
+per-session defaults, typed HTTP still crosses a whole-message compatibility
+seam, declared ingress is contract-only, and the frozen L3 implementation and
+its rejected public configuration remain in the source tree.
+
+Issue #2751 and `specs/plans/2026-08-19-flowmux-single-path-closeout.md` now own
+that remainder in dependency order. The old Plan 316 phase issues remain closed
+historical records; they are not evidence that Phases 4–8 landed. The closeout
+order is shared per-VM limits, performance baselines, streaming transformations
+and endpoint-owned connectors, declared ingress, public raw-mode removal, L3
+deletion, permanent invariant gates, then the cross-backend evidence matrix.
+
+This entry changes tracking only. It does not claim that any of those runtime
+workstreams is complete.


### PR DESCRIPTION
## Summary

- establish issue #2751 and a dated closeout plan as the active owner for the remaining FlowMux single-path work
- replace Plan 316's pre-cutover status with the current source inventory
- reconcile the refactor rollup and sprint delivery record without claiming unfinished runtime work

## Validation

- `xtask check-plan-names`
- `xtask check-declared-backing`
- `xtask check-sprint-append`
- `xtask check-honesty`
- `xtask check-no-overclaim`
- `xtask check-no-spec-refs-in-comments`
- `git diff --check`

Closes the tracking-reconciliation workstream in #2751; runtime work remains open there.
