### PR TITLE
fix(kernel): refresh synchronized pins to 6.12.104

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -48,10 +48,10 @@ let
   # kernel — lets both of mvm's kernels track the latest point release exactly
   # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
   # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
-  kernelVersion = "6.12.103";
+  kernelVersion = "6.12.104";
   kernelSrc = pkgs.fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
-    hash = "sha256-8UOqreiHe6VhbniLRIJXbbKEgbz1V+9Tf0/MOTj8MXY=";
+    hash = "sha256-lJ0WahJjvQzwxaq0TutXhpYVCZ58SL+I0OStt3N5uZk=";
   };
   # The builder's overlay filesystem triggers a GNU tar directory-metadata
   # race while unpacking this archive. Materialize the source with bsdtar once

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.103.tar.xz";
-    hash = "sha256-8UOqreiHe6VhbniLRIJXbbKEgbz1V+9Tf0/MOTj8MXY=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.104.tar.xz";
+    hash = "sha256-lJ0WahJjvQzwxaq0TutXhpYVCZ58SL+I0OStt3N5uZk=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.103' \
+      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.104' \
       --replace-fail 'curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)' 'ln -s ${kernelSrc} $(KERNEL_TARBALL)'
     substituteInPlace patches/0008-virtio-vsock-support-dgrams.patch \
       --replace-fail 'virtio_transport_alloc_skb(&info, dgram_len, false,' \

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -7,6 +7,11 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
+- [x] **Issue #2756 — Linux 6.12.104 kernel pin refresh.** The libkrunfw
+      firmware build and custom workload/builder kernels consume the same
+      kernel.org-verified source archive and SRI hash. Structural parity and
+      freshness checks report both pins synchronized and current.
+
 - [x] **Faster Rust compilation — nightly Cranelift development path.** The
       dated nightly compiler, eight frontend threads, and Cranelift cut a cold
       representative build from 172.14s to 66.48s (61.4%). Tests and release

--- a/specs/plans/2026-08-19-kernel-6-12-104.md
+++ b/specs/plans/2026-08-19-kernel-6-12-104.md
@@ -20,7 +20,7 @@ version and source hash synchronized.
 - [x] Pass the focused synchronization test, kernel freshness check, builder-VM
       flake evaluation, and workload config materialization.
 - [x] Pass formatting, workspace tests/check, and zero-warning Clippy.
-- [ ] Publish the tested topic branch as a pull request.
+- [x] Publish the tested topic branch as pull request #2759.
 
 ## Source verification
 

--- a/specs/plans/2026-08-19-kernel-6-12-104.md
+++ b/specs/plans/2026-08-19-kernel-6-12-104.md
@@ -1,0 +1,30 @@
+# Linux 6.12.104 kernel pin refresh
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#2756](https://github.com/tinylabscom/mvm/issues/2756)
+
+## Outcome
+
+The custom workload/builder kernel and libkrunfw firmware build consume the
+same verified Linux 6.12.104 LTS source archive. Structural coverage keeps the
+version and source hash synchronized.
+
+## Delivery checklist
+
+- [x] Verify the upstream `linux-6.12.104.tar.xz` SHA-256 against kernel.org's
+      signed checksum manifest.
+- [x] Update the custom workload/builder kernel source pin and SRI hash.
+- [x] Update the libkrunfw kernel source pin, substitution, and SRI hash.
+- [x] Pass the focused synchronization test, kernel freshness check, builder-VM
+      flake evaluation, and workload config materialization.
+- [x] Pass formatting, workspace tests/check, and zero-warning Clippy.
+- [ ] Publish the tested topic branch as a pull request.
+
+## Source verification
+
+The upstream archive SHA-256 is
+`949d166a1263bd0cf0c5aab44eeb57869615099e7c48bf88d0e4adb77379b999`,
+which converts to the Nix SRI hash
+`sha256-lJ0WahJjvQzwxaq0TutXhpYVCZ58SL+I0OStt3N5uZk=`.

--- a/specs/sprint/delivery/2756-kernel-pin-6-12-104.md
+++ b/specs/sprint/delivery/2756-kernel-pin-6-12-104.md
@@ -1,0 +1,16 @@
+# Linux 6.12.104 kernel pin refresh
+
+- [x] Updated the libkrunfw firmware build and custom workload/builder kernels
+      from Linux 6.12.103 to 6.12.104.
+- [x] Verified the archive digest against kernel.org's signed checksum
+      manifest and converted it to the Nix SRI hash used by both consumers.
+- [x] Updated structural parity coverage and confirmed the online freshness
+      watcher reports both pins current.
+- [x] Evaluated the kernel flake and materialized `workload-configfile` inside
+      the project libkrun builder VM against the new archive.
+- [x] Passed workspace formatting and check, all executable tests, the isolated
+      mvm-cli doctest, and workspace all-target Clippy with warnings denied.
+
+The combined workspace test invocation hit the known nested-Cargo doctest
+artifact collision after every executable target passed. The affected mvm-cli
+doctest passed immediately in isolation.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -240,8 +240,8 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         );
     }
 
-    const KERNEL_VERSION: &str = "6.12.103";
-    const KERNEL_HASH: &str = "sha256-8UOqreiHe6VhbniLRIJXbbKEgbz1V+9Tf0/MOTj8MXY=";
+    const KERNEL_VERSION: &str = "6.12.104";
+    const KERNEL_HASH: &str = "sha256-lJ0WahJjvQzwxaq0TutXhpYVCZ58SL+I0OStt3N5uZk=";
     assert!(
         libkrunfw.contains(&format!("linux-{KERNEL_VERSION}.tar.xz"))
             && libkrunfw.contains(&format!("hash = \"{KERNEL_HASH}\""))


### PR DESCRIPTION
Closes #2756.

## Summary

- update the custom workload/builder kernel and libkrunfw firmware build to Linux 6.12.104
- pin both consumers to the kernel.org-verified archive digest and matching Nix SRI hash
- update structural parity coverage, the owning plan, sprint delivery record, and refactor rollup

## Verification

- kernel.org signed checksum manifest: `949d166a1263bd0cf0c5aab44eeb57869615099e7c48bf88d0e4adb77379b999`
- focused pin synchronization test (red before implementation, green after)
- `cargo run -p xtask -- check-kernel-pin-freshness` (both pins up to date)
- builder VM: kernel flake evaluation and `workload-configfile` materialization
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- all workspace executable tests passed; the known nested-Cargo doctest artifact collision was followed by a clean isolated `cargo test -p mvm-cli --doc`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo run -p xtask -- check-sprint-append`
- `cargo run -p xtask -- check-plan-names`