### PR TITLE
test(security): kill endpoint readiness mutants

### DIFF
--- a/crates/mvm-vmm/src/host/network_endpoint_spawn.rs
+++ b/crates/mvm-vmm/src/host/network_endpoint_spawn.rs
@@ -1215,16 +1215,17 @@ mod tests {
         let endpoint = std::thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
             std::fs::write(marker, b"1").unwrap();
-            stream.write_all(&[1]).unwrap();
+            let _ = stream.write_all(&[1]);
         });
 
-        wait_for_endpoint_session_with_timeout(
+        let result = wait_for_endpoint_session_with_timeout(
             "vm-1",
             dir.path(),
             std::time::Duration::from_secs(1),
-        )
-        .expect("the authenticated-session event admits the launch");
+        );
+        let _ = std::os::unix::net::UnixStream::connect(&ready_socket);
         endpoint.join().unwrap();
+        result.expect("the authenticated-session event admits the launch");
     }
 
     #[test]
@@ -1241,12 +1242,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join(SUBST_PID_FILE), "2147483646").unwrap();
 
-        let err = wait_for_endpoint_session_with_timeout(
-            "vm-1",
-            dir.path(),
-            std::time::Duration::from_secs(1),
-        )
-        .unwrap_err();
+        let err = wait_for_endpoint_session("vm-1", dir.path()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("exited before any guest authenticated"),
@@ -1274,6 +1270,74 @@ mod tests {
         .unwrap_err();
         assert!(
             err.to_string().contains("no guest authenticated within"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn a_launch_rejects_an_invalid_session_signal_even_when_a_marker_exists() {
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(SUBST_PID_FILE),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+        let ready_socket = dir.path().join(SUBST_SESSION_READY_SOCKET);
+        let listener = std::os::unix::net::UnixListener::bind(&ready_socket).unwrap();
+        let marker = dir.path().join(SUBST_SESSION_FILE);
+        let endpoint = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            std::fs::write(marker, b"1").unwrap();
+            let _ = stream.write_all(&[2]);
+        });
+
+        let result = wait_for_endpoint_session_with_timeout(
+            "vm-1",
+            dir.path(),
+            std::time::Duration::from_secs(1),
+        );
+        if result.is_ok() {
+            let _ = std::os::unix::net::UnixStream::connect(&ready_socket);
+        }
+        endpoint.join().unwrap();
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("invalid authenticated-session signal"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn a_launch_reports_a_broken_readiness_channel_from_a_live_endpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(SUBST_PID_FILE),
+            std::process::id().to_string(),
+        )
+        .unwrap();
+        let ready_socket = dir.path().join(SUBST_SESSION_READY_SOCKET);
+        let listener = std::os::unix::net::UnixListener::bind(&ready_socket).unwrap();
+        let endpoint = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            drop(stream);
+        });
+
+        let result = wait_for_endpoint_session_with_timeout(
+            "vm-1",
+            dir.path(),
+            std::time::Duration::from_secs(1),
+        );
+        if result.is_ok() {
+            let _ = std::os::unix::net::UnixStream::connect(&ready_socket);
+        }
+        endpoint.join().unwrap();
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("waiting for the network endpoint's authenticated session"),
             "unexpected: {err}"
         );
     }
@@ -1314,6 +1378,93 @@ mod tests {
         params.session_marker = Some(marker.clone());
         let cfg = build_endpoint_config_json(&params);
         assert_eq!(cfg["session_marker"], serde_json::json!(marker));
+    }
+
+    #[test]
+    fn tls_delivery_debug_redacts_the_private_key() {
+        let delivery = EgressTlsDelivery {
+            guest_cert: DriveFile {
+                name: EGRESS_CERT_DRIVE_NAME.to_string(),
+                content: "guest certificate".to_string(),
+                mode: 0o444,
+            },
+            endpoint_cert_pem: "endpoint certificate".to_string(),
+            endpoint_key_pem: "never-print-this-private-key".to_string(),
+        };
+
+        let rendered = format!("{delivery:?}");
+        assert!(rendered.contains(EGRESS_CERT_DRIVE_NAME));
+        assert!(rendered.contains("<intermediate cert>"));
+        assert!(rendered.contains("<redacted>"));
+        assert!(!rendered.contains("never-print-this-private-key"));
+    }
+
+    #[test]
+    fn substitution_spawn_builder_preserves_every_optional_endpoint_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let redaction = mvm_core::policy::RedactionPolicy::default();
+        let network_policy = mvm_core::policy::network_policy::NetworkPolicy::default();
+        let limits = mvm_core::plan::NetworkLimits::default();
+        let terminator: SocketAddr = "127.0.0.1:18080".parse().unwrap();
+        let tls = ("certificate".to_string(), "private-key".to_string());
+        let resolver = RemoteResolverSpawnConfig {
+            uds_path: dir.path(),
+            timeout_secs: 9,
+        };
+        let identity = FlowMuxIdentitySpawnConfig {
+            session_id: "session-builder".to_string(),
+            host_signing_key_base64: "host-key".to_string(),
+            guest_verifying_key_base64: "guest-key".to_string(),
+        };
+        let proxy = EgressProxySpawnConfig {
+            https: Some("http://proxy.example:8443".to_string()),
+            http: Some("http://proxy.example:8080".to_string()),
+            no_proxy: Some("localhost".to_string()),
+        };
+
+        let params = SubstitutionSpawnParams::builder()
+            .vm_name("vm-builder")
+            .state_dir(dir.path())
+            .tenant("tenant-builder")
+            .secrets(&[])
+            .redaction(&redaction)
+            .transport(EndpointTransport::Uds {
+                path: dir.path().join("endpoint.sock"),
+            })
+            .network_limits(limits)
+            .terminator_listen(terminator)
+            .tls_intermediate(tls.clone())
+            .network_policy(&network_policy)
+            .resolver_remote(resolver)
+            .binding_store_dir(dir.path())
+            .flowmux_identity(identity.clone())
+            .egress_proxy(proxy.clone())
+            .build()
+            .expect("every named builder input is retained");
+
+        assert_eq!(params.terminator_listen, Some(terminator));
+        assert_eq!(params.tls_intermediate, Some(tls));
+        assert_eq!(params.network_policy, Some(&network_policy));
+        assert_eq!(params.resolver_remote, Some(resolver));
+        assert_eq!(params.binding_store_dir, Some(dir.path()));
+        assert_eq!(params.flowmux_identity, Some(identity));
+        assert_eq!(params.egress_proxy, Some(proxy));
+    }
+
+    #[test]
+    fn endpoint_config_for_identity_selects_flowmux_and_carries_the_anchor() {
+        let identity = FlowMuxIdentitySpawnConfig {
+            session_id: "session-config".to_string(),
+            host_signing_key_base64: "host-signing-key".to_string(),
+            guest_verifying_key_base64: "guest-verifying-key".to_string(),
+        };
+
+        let config = endpoint_config_for_identity(Some(identity));
+        assert_eq!(config["egress_mode"], "flow_mux");
+        assert_eq!(
+            config["flowmux_identity"]["guest_verifying_key_base64"],
+            "guest-verifying-key"
+        );
     }
     use super::*;
     use mvm_contract::stream::secret_fingerprint::SecretCategory;

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -331,6 +331,9 @@ for detailed scope and acceptance criteria.
 - [~] **Security lane recovery — issue #2736.** The advisory finding is fixed,
       the release-artifact bootstrap source now compiles with warnings denied,
       and pull-request CI exercises that otherwise dormant feature directly.
+      Focused mutation witnesses cover authenticated-session signal validity,
+      live/dead endpoint readiness branches, redacted TLS material, builder
+      projection, and endpoint identity configuration.
       Closure remains gated on a clean Security workflow run from current
       `main`, including every mutation shard and both reproducibility builds.
 

--- a/specs/sprint/delivery/2736-security-release-feature.md
+++ b/specs/sprint/delivery/2736-security-release-feature.md
@@ -5,6 +5,10 @@
       The merge-queue fuzz compile gate also consumes refreshed committed
       lockfiles with `--locked`, so newly published registry versions cannot
       replace the reviewed graph while the invariant job is running.
+      Readiness witnesses now reject invalid authentication signals, broken
+      live-endpoint channels, and endpoint death through the public launch
+      boundary; direct tests also pin secret-redacted debug output, optional
+      spawn-builder projection, and FlowMux identity configuration.
       The exact feature check fails on the prior source and passes after the
       fix; every fuzz manifest compiles from its lockfile, and workspace
       all-target Clippy, workflow syntax, formatting, and the workspace suite


### PR DESCRIPTION
## Summary
- reject invalid authenticated-session signals and broken live endpoint channels in focused readiness witnesses
- exercise endpoint death through the public launch boundary
- pin TLS debug redaction, optional spawn-builder projection, and FlowMux identity configuration
- make helper-thread cleanup bounded even when the readiness function is fully short-circuited

## Verification
- cargo test -p mvm-vmm network_endpoint_spawn -- --test-threads=1 (48 passed)
- cargo clippy -p mvm-vmm --all-targets -- -D warnings
- cargo mutants --package mvm-vmm --file crates/mvm-vmm/src/host/network_endpoint_spawn.rs --re wait_for_endpoint_session_with_timeout --jobs 2 --timeout 90 (8 tested, 8 caught)
- cargo fmt --all --check
- xtask check-sprint-append
- xtask check-no-spec-refs-in-comments

Depends on #2755. Part of #2736.