### PR TITLE
fix(security): pin reviewed arrayref source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,6 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,8 +172,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -571,7 +571,7 @@ trusted-apfs = ["mvm-cli/trusted-apfs", "mvm-runtime/trusted-apfs"]
 # on the reviewed 0.3.9 source at an immutable upstream revision until the
 # registry package is restored.
 [patch.crates-io]
-arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+arrayref = { path = "third_party/arrayref" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -566,6 +566,13 @@ hvf-live-validation = [
 # validation lane. The normal binary remains fail-closed without it.
 trusted-apfs = ["mvm-cli/trusted-apfs", "mvm-runtime/trusted-apfs"]
 
+# The registry owner account yanked every established arrayref release and
+# published 0.3.10 with an unresolvable `proc-macro1` dependency. Keep BLAKE3
+# on the reviewed 0.3.9 source at an immutable upstream revision until the
+# registry package is restored.
+[patch.crates-io]
+arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+
 [profile.release]
 opt-level = 3
 strip = true

--- a/crates/mvm-agentd/fuzz/Cargo.lock
+++ b/crates/mvm-agentd/fuzz/Cargo.lock
@@ -76,8 +76,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/crates/mvm-agentd/fuzz/Cargo.lock
+++ b/crates/mvm-agentd/fuzz/Cargo.lock
@@ -76,7 +76,6 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/crates/mvm-agentd/fuzz/Cargo.toml
+++ b/crates/mvm-agentd/fuzz/Cargo.toml
@@ -13,6 +13,10 @@ edition = "2024"
 # table is the documented fix.
 [workspace]
 
+# This standalone graph cannot inherit the root workspace's source patch.
+[patch.crates-io]
+arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+
 # cargo-fuzz looks for this metadata key; without it the harness refuses
 # to drive the binaries.
 [package.metadata]

--- a/crates/mvm-agentd/fuzz/Cargo.toml
+++ b/crates/mvm-agentd/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 
 # This standalone graph cannot inherit the root workspace's source patch.
 [patch.crates-io]
-arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+arrayref = { path = "../../../third_party/arrayref" }
 
 # cargo-fuzz looks for this metadata key; without it the harness refuses
 # to drive the binaries.

--- a/crates/mvm-hostd/fuzz/Cargo.lock
+++ b/crates/mvm-hostd/fuzz/Cargo.lock
@@ -76,8 +76,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/crates/mvm-hostd/fuzz/Cargo.lock
+++ b/crates/mvm-hostd/fuzz/Cargo.lock
@@ -76,7 +76,6 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/crates/mvm-hostd/fuzz/Cargo.toml
+++ b/crates/mvm-hostd/fuzz/Cargo.toml
@@ -11,6 +11,10 @@ edition = "2024"
 # self-identifies this manifest as standalone.
 [workspace]
 
+# This standalone graph cannot inherit the root workspace's source patch.
+[patch.crates-io]
+arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+
 [package.metadata]
 cargo-fuzz = true
 
@@ -18,9 +22,9 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 # rcgen (pulled in transitively via mvm-hostd's egress-CA TLS path) carries
 # a blanket `impl<T: Into<String>> From<T>` that collides with an impl
-# `time` 0.3.48 added, breaking the build with E0119. There is no committed
-# lock here (cargo-fuzz gitignores it), so the bound lives in the manifest —
-# drop it once rcgen or time resolves the coherence clash.
+# `time` 0.3.48 added, breaking the build with E0119. The committed lock is
+# checked with `--locked`, while this manifest bound keeps fresh resolution
+# safe; drop it once rcgen or time resolves the coherence clash.
 time = ">=0.3, <0.3.48"
 # The admitter's private-range list is `IpNet`, so a harness that opens one
 # has to name the type.

--- a/crates/mvm-hostd/fuzz/Cargo.toml
+++ b/crates/mvm-hostd/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 
 # This standalone graph cannot inherit the root workspace's source patch.
 [patch.crates-io]
-arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+arrayref = { path = "../../../third_party/arrayref" }
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/mvm-runtime/fuzz-backend/Cargo.lock
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.lock
@@ -76,8 +76,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/crates/mvm-runtime/fuzz-backend/Cargo.lock
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.lock
@@ -76,7 +76,6 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/crates/mvm-runtime/fuzz-backend/Cargo.toml
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2024"
 
 # This standalone graph cannot inherit the root workspace's source patch.
 [patch.crates-io]
-arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+arrayref = { path = "../../../third_party/arrayref" }
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/mvm-runtime/fuzz-backend/Cargo.toml
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2024"
 # sanitizer/linker wrapper. An empty `[workspace]` self-identifies this manifest.
 [workspace]
 
+# This standalone graph cannot inherit the root workspace's source patch.
+[patch.crates-io]
+arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+
 [package.metadata]
 cargo-fuzz = true
 

--- a/crates/mvm-sdk/fuzz/Cargo.lock
+++ b/crates/mvm-sdk/fuzz/Cargo.lock
@@ -76,8 +76,7 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/crates/mvm-sdk/fuzz/Cargo.lock
+++ b/crates/mvm-sdk/fuzz/Cargo.lock
@@ -76,7 +76,6 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 [[package]]
 name = "arrayref"
 version = "0.3.9"
-source = "git+https://github.com/droundy/arrayref?rev=f8d0299d863922db6c409d08098941e833b70d69#f8d0299d863922db6c409d08098941e833b70d69"
 
 [[package]]
 name = "arrayvec"

--- a/crates/mvm-sdk/fuzz/Cargo.toml
+++ b/crates/mvm-sdk/fuzz/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 
 # This standalone graph cannot inherit the root workspace's source patch.
 [patch.crates-io]
-arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+arrayref = { path = "../../../third_party/arrayref" }
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/mvm-sdk/fuzz/Cargo.toml
+++ b/crates/mvm-sdk/fuzz/Cargo.toml
@@ -11,6 +11,10 @@ edition = "2024"
 # self-identifies this manifest as standalone.
 [workspace]
 
+# This standalone graph cannot inherit the root workspace's source patch.
+[patch.crates-io]
+arrayref = { git = "https://github.com/droundy/arrayref", rev = "f8d0299d863922db6c409d08098941e833b70d69" }
+
 [package.metadata]
 cargo-fuzz = true
 

--- a/deny.toml
+++ b/deny.toml
@@ -157,4 +157,4 @@ deny = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+allow-git = ["https://github.com/droundy/arrayref"]

--- a/deny.toml
+++ b/deny.toml
@@ -157,4 +157,4 @@ deny = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/droundy/arrayref"]
+allow-git = []

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -331,9 +331,9 @@ for detailed scope and acceptance criteria.
 - [~] **Security lane recovery — issue #2736.** The advisory finding is fixed,
       the release-artifact bootstrap source now compiles with warnings denied,
       and pull-request CI exercises that otherwise dormant feature directly.
-      Both dependency graphs that contain `arrayref` resolve the reviewed 0.3.9
-      source from an immutable upstream revision, and the source allowlist
-      admits only that repository while the registry incident remains active.
+      Every dependency graph that contains `arrayref` resolves the reviewed
+      0.3.9 source from an immutable upstream revision, and the source
+      allowlist admits only that repository while the incident remains active.
       Closure remains gated on a clean Security workflow run from current
       `main`, including every mutation shard and both reproducibility builds.
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -331,9 +331,9 @@ for detailed scope and acceptance criteria.
 - [~] **Security lane recovery — issue #2736.** The advisory finding is fixed,
       the release-artifact bootstrap source now compiles with warnings denied,
       and pull-request CI exercises that otherwise dormant feature directly.
-      Every dependency graph that contains `arrayref` resolves the reviewed
-      0.3.9 source from an immutable upstream revision, and the source
-      allowlist admits only that repository while the incident remains active.
+      Every dependency graph that contains `arrayref` resolves a byte-for-byte
+      vendored copy of the reviewed 0.3.9 upstream revision. Pinned file hashes
+      guard the vendored source, and Git dependencies remain denied.
       Closure remains gated on a clean Security workflow run from current
       `main`, including every mutation shard and both reproducibility builds.
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -331,6 +331,9 @@ for detailed scope and acceptance criteria.
 - [~] **Security lane recovery — issue #2736.** The advisory finding is fixed,
       the release-artifact bootstrap source now compiles with warnings denied,
       and pull-request CI exercises that otherwise dormant feature directly.
+      Both dependency graphs that contain `arrayref` resolve the reviewed 0.3.9
+      source from an immutable upstream revision, and the source allowlist
+      admits only that repository while the registry incident remains active.
       Closure remains gated on a clean Security workflow run from current
       `main`, including every mutation shard and both reproducibility builds.
 

--- a/specs/sprint/delivery/2736-security-release-feature.md
+++ b/specs/sprint/delivery/2736-security-release-feature.md
@@ -5,10 +5,10 @@
       The merge-queue fuzz compile gate also consumes refreshed committed
       lockfiles with `--locked`, so newly published registry versions cannot
       replace the reviewed graph while the invariant job is running.
-      The root graph and standalone `mvm-hostd` fuzz graph pin `arrayref` to
-      the immutable upstream revision for the reviewed 0.3.9 source; a
-      regression test proves both manifests and lockfiles agree, while the
-      source policy admits only that upstream repository.
+      The root graph and every affected standalone fuzz graph pin `arrayref`
+      to the immutable upstream revision for the reviewed 0.3.9 source; a
+      discovery-based regression test proves each manifest and lockfile agree,
+      while the source policy admits only that upstream repository.
       The exact feature check fails on the prior source and passes after the
       fix; every fuzz manifest compiles from its lockfile, and workspace
       all-target Clippy, workflow syntax, formatting, and the workspace suite

--- a/specs/sprint/delivery/2736-security-release-feature.md
+++ b/specs/sprint/delivery/2736-security-release-feature.md
@@ -6,9 +6,9 @@
       lockfiles with `--locked`, so newly published registry versions cannot
       replace the reviewed graph while the invariant job is running.
       The root graph and every affected standalone fuzz graph pin `arrayref`
-      to the immutable upstream revision for the reviewed 0.3.9 source; a
-      discovery-based regression test proves each manifest and lockfile agree,
-      while the source policy admits only that upstream repository.
+      to a byte-for-byte vendored copy of the reviewed 0.3.9 upstream revision.
+      A discovery-based regression test proves each manifest and lockfile use
+      it, verifies the vendored file hashes, and keeps Git sources denied.
       The exact feature check fails on the prior source and passes after the
       fix; every fuzz manifest compiles from its lockfile, and workspace
       all-target Clippy, workflow syntax, formatting, and the workspace suite

--- a/specs/sprint/delivery/2736-security-release-feature.md
+++ b/specs/sprint/delivery/2736-security-release-feature.md
@@ -5,6 +5,10 @@
       The merge-queue fuzz compile gate also consumes refreshed committed
       lockfiles with `--locked`, so newly published registry versions cannot
       replace the reviewed graph while the invariant job is running.
+      The root graph and standalone `mvm-hostd` fuzz graph pin `arrayref` to
+      the immutable upstream revision for the reviewed 0.3.9 source; a
+      regression test proves both manifests and lockfiles agree, while the
+      source policy admits only that upstream repository.
       The exact feature check fails on the prior source and passes after the
       fix; every fuzz manifest compiles from its lockfile, and workspace
       all-target Clippy, workflow syntax, formatting, and the workspace suite

--- a/tests/supply_chain_dependency_pin.rs
+++ b/tests/supply_chain_dependency_pin.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+
+const ARRAYREF_REVISION: &str = "f8d0299d863922db6c409d08098941e833b70d69";
+const ARRAYREF_REPOSITORY: &str = "https://github.com/droundy/arrayref";
+
+fn read(path: &Path) -> String {
+    std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+fn assert_arrayref_patch(manifest_path: &Path) {
+    let manifest: toml::Value =
+        toml::from_str(&read(manifest_path)).expect("Cargo.toml must parse");
+    let patch = &manifest["patch"]["crates-io"]["arrayref"];
+
+    assert_eq!(patch["git"].as_str(), Some(ARRAYREF_REPOSITORY));
+    assert_eq!(patch["rev"].as_str(), Some(ARRAYREF_REVISION));
+}
+
+fn assert_arrayref_lock(lockfile_path: &Path) {
+    let expected_source =
+        format!("git+{ARRAYREF_REPOSITORY}?rev={ARRAYREF_REVISION}#{ARRAYREF_REVISION}");
+    assert!(
+        read(lockfile_path).contains(&expected_source),
+        "{} must resolve arrayref from the reviewed revision",
+        lockfile_path.display()
+    );
+}
+
+#[test]
+fn every_arrayref_graph_uses_the_reviewed_upstream_revision() {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let graphs = [
+        (workspace.join("Cargo.toml"), workspace.join("Cargo.lock")),
+        (
+            workspace.join("crates/mvm-hostd/fuzz/Cargo.toml"),
+            workspace.join("crates/mvm-hostd/fuzz/Cargo.lock"),
+        ),
+    ];
+
+    for (manifest, lockfile) in graphs {
+        assert_arrayref_patch(&manifest);
+        assert_arrayref_lock(&lockfile);
+    }
+}
+
+#[test]
+fn deny_policy_allows_only_the_pinned_repository() {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let policy: toml::Value =
+        toml::from_str(&read(&workspace.join("deny.toml"))).expect("deny.toml must parse");
+    let allowed = policy["sources"]["allow-git"]
+        .as_array()
+        .expect("sources.allow-git must be an array");
+
+    assert_eq!(allowed.len(), 1);
+    assert_eq!(allowed[0].as_str(), Some(ARRAYREF_REPOSITORY));
+}

--- a/tests/supply_chain_dependency_pin.rs
+++ b/tests/supply_chain_dependency_pin.rs
@@ -1,33 +1,78 @@
-use std::path::Path;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
 
 const ARRAYREF_REVISION: &str = "f8d0299d863922db6c409d08098941e833b70d69";
 const ARRAYREF_REPOSITORY: &str = "https://github.com/droundy/arrayref";
+const CARGO_TOML_SHA256: &str = "122da2bce2d1aea793e4dc4d38a98966c67f3339a4db2f8fc740bd74ce97e668";
+const LICENSE_SHA256: &str = "1bc7e6f475b3ec99b7e2643411950ae2368c250dd4c5c325f80f9811362a94a1";
+const LIB_SHA256: &str = "b74872c9bb2b836132817e024a3f9205f83a6864de1a9bfb46acc1bfbbc1873a";
 
 fn read(path: &Path) -> String {
     std::fs::read_to_string(path)
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
 }
 
-fn assert_arrayref_patch(manifest_path: &Path) {
-    let manifest: toml::Value =
-        toml::from_str(&read(manifest_path)).expect("Cargo.toml must parse");
-    let patch = &manifest["patch"]["crates-io"]["arrayref"];
+fn parse_toml(path: &Path) -> toml::Value {
+    toml::from_str(&read(path))
+        .unwrap_or_else(|error| panic!("failed to parse {}: {error}", path.display()))
+}
 
-    assert_eq!(patch["git"].as_str(), Some(ARRAYREF_REPOSITORY));
-    assert_eq!(patch["rev"].as_str(), Some(ARRAYREF_REVISION));
+fn assert_arrayref_patch(manifest_path: &Path, vendored: &Path) {
+    let manifest = parse_toml(manifest_path);
+    let patch = &manifest["patch"]["crates-io"]["arrayref"];
+    let relative = patch["path"]
+        .as_str()
+        .unwrap_or_else(|| panic!("{} must use a path patch", manifest_path.display()));
+    let resolved = manifest_path
+        .parent()
+        .expect("a manifest has a containing directory")
+        .join(relative)
+        .canonicalize()
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to resolve arrayref patch from {}: {error}",
+                manifest_path.display()
+            )
+        });
+
+    assert_eq!(resolved, vendored);
+    assert!(patch.get("git").is_none());
+    assert!(patch.get("rev").is_none());
+}
+
+fn arrayref_package(lockfile_path: &Path) -> toml::Value {
+    let lock = parse_toml(lockfile_path);
+    let matches: Vec<_> = lock["package"]
+        .as_array()
+        .expect("Cargo.lock package must be an array")
+        .iter()
+        .filter(|package| package["name"].as_str() == Some("arrayref"))
+        .cloned()
+        .collect();
+
+    assert_eq!(
+        matches.len(),
+        1,
+        "{} must resolve exactly one arrayref package",
+        lockfile_path.display()
+    );
+    matches.into_iter().next().expect("one package was found")
 }
 
 fn assert_arrayref_lock(lockfile_path: &Path) {
-    let expected_source =
-        format!("git+{ARRAYREF_REPOSITORY}?rev={ARRAYREF_REVISION}#{ARRAYREF_REVISION}");
+    let package = arrayref_package(lockfile_path);
+    assert_eq!(package["version"].as_str(), Some("0.3.9"));
     assert!(
-        read(lockfile_path).contains(&expected_source),
-        "{} must resolve arrayref from the reviewed revision",
+        package.get("source").is_none(),
+        "{} must resolve arrayref from the vendored path",
         lockfile_path.display()
     );
+    assert!(package.get("checksum").is_none());
 }
 
-fn collect_lockfiles(directory: &Path, lockfiles: &mut Vec<std::path::PathBuf>) {
+fn collect_lockfiles(directory: &Path, lockfiles: &mut Vec<PathBuf>) {
     let entries = std::fs::read_dir(directory)
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", directory.display()));
     for entry in entries {
@@ -44,9 +89,23 @@ fn collect_lockfiles(directory: &Path, lockfiles: &mut Vec<std::path::PathBuf>) 
     }
 }
 
+fn sha256(path: &Path) -> String {
+    let bytes = std::fs::read(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    let mut encoded = String::with_capacity(64);
+    for byte in Sha256::digest(bytes) {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
 #[test]
-fn every_arrayref_graph_uses_the_reviewed_upstream_revision() {
+fn every_arrayref_graph_uses_the_vendored_reviewed_source() {
     let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let vendored = workspace
+        .join("third_party/arrayref")
+        .canonicalize()
+        .expect("vendored arrayref directory must exist");
     let mut lockfiles = vec![workspace.join("Cargo.lock")];
     collect_lockfiles(&workspace.join("crates"), &mut lockfiles);
     let affected: Vec<_> = lockfiles
@@ -60,20 +119,36 @@ fn every_arrayref_graph_uses_the_reviewed_upstream_revision() {
             .parent()
             .expect("a lockfile has a containing directory")
             .join("Cargo.toml");
-        assert_arrayref_patch(&manifest);
+        assert_arrayref_patch(&manifest, &vendored);
         assert_arrayref_lock(&lockfile);
     }
 }
 
 #[test]
-fn deny_policy_allows_only_the_pinned_repository() {
+fn vendored_arrayref_matches_the_reviewed_upstream_revision() {
+    let vendored = Path::new(env!("CARGO_MANIFEST_DIR")).join("third_party/arrayref");
+    let origin = parse_toml(&vendored.join("ORIGIN.toml"));
+
+    assert_eq!(origin["repository"].as_str(), Some(ARRAYREF_REPOSITORY));
+    assert_eq!(origin["revision"].as_str(), Some(ARRAYREF_REVISION));
+    assert_eq!(
+        origin["cargo_toml_sha256"].as_str(),
+        Some(CARGO_TOML_SHA256)
+    );
+    assert_eq!(origin["license_sha256"].as_str(), Some(LICENSE_SHA256));
+    assert_eq!(origin["lib_sha256"].as_str(), Some(LIB_SHA256));
+    assert_eq!(sha256(&vendored.join("Cargo.toml")), CARGO_TOML_SHA256);
+    assert_eq!(sha256(&vendored.join("LICENSE")), LICENSE_SHA256);
+    assert_eq!(sha256(&vendored.join("src/lib.rs")), LIB_SHA256);
+}
+
+#[test]
+fn deny_policy_rejects_git_sources() {
     let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let policy: toml::Value =
-        toml::from_str(&read(&workspace.join("deny.toml"))).expect("deny.toml must parse");
+    let policy = parse_toml(&workspace.join("deny.toml"));
     let allowed = policy["sources"]["allow-git"]
         .as_array()
         .expect("sources.allow-git must be an array");
 
-    assert_eq!(allowed.len(), 1);
-    assert_eq!(allowed[0].as_str(), Some(ARRAYREF_REPOSITORY));
+    assert!(allowed.is_empty());
 }

--- a/tests/supply_chain_dependency_pin.rs
+++ b/tests/supply_chain_dependency_pin.rs
@@ -27,18 +27,39 @@ fn assert_arrayref_lock(lockfile_path: &Path) {
     );
 }
 
+fn collect_lockfiles(directory: &Path, lockfiles: &mut Vec<std::path::PathBuf>) {
+    let entries = std::fs::read_dir(directory)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", directory.display()));
+    for entry in entries {
+        let entry = entry.expect("directory entry must be readable");
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .unwrap_or_else(|error| panic!("failed to inspect {}: {error}", path.display()));
+        if file_type.is_dir() {
+            collect_lockfiles(&path, lockfiles);
+        } else if path.file_name().is_some_and(|name| name == "Cargo.lock") {
+            lockfiles.push(path);
+        }
+    }
+}
+
 #[test]
 fn every_arrayref_graph_uses_the_reviewed_upstream_revision() {
     let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let graphs = [
-        (workspace.join("Cargo.toml"), workspace.join("Cargo.lock")),
-        (
-            workspace.join("crates/mvm-hostd/fuzz/Cargo.toml"),
-            workspace.join("crates/mvm-hostd/fuzz/Cargo.lock"),
-        ),
-    ];
+    let mut lockfiles = vec![workspace.join("Cargo.lock")];
+    collect_lockfiles(&workspace.join("crates"), &mut lockfiles);
+    let affected: Vec<_> = lockfiles
+        .into_iter()
+        .filter(|lockfile| read(lockfile).contains("name = \"arrayref\""))
+        .collect();
 
-    for (manifest, lockfile) in graphs {
+    assert!(!affected.is_empty(), "the workspace must contain arrayref");
+    for lockfile in affected {
+        let manifest = lockfile
+            .parent()
+            .expect("a lockfile has a containing directory")
+            .join("Cargo.toml");
         assert_arrayref_patch(&manifest);
         assert_arrayref_lock(&lockfile);
     }

--- a/third_party/arrayref/Cargo.toml
+++ b/third_party/arrayref/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "arrayref"
+version = "0.3.9"
+authors = ["David Roundy <roundyd@physics.oregonstate.edu>"]
+description = "Macros to take array references of slices"
+license = "BSD-2-Clause"
+repository = "https://github.com/droundy/arrayref"
+documentation = "https://docs.rs/arrayref"
+
+[dev-dependencies]
+quickcheck = "1.0"

--- a/third_party/arrayref/LICENSE
+++ b/third_party/arrayref/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2015 David Roundy <roundyd@physics.oregonstate.edu>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/arrayref/ORIGIN.toml
+++ b/third_party/arrayref/ORIGIN.toml
@@ -1,0 +1,5 @@
+repository = "https://github.com/droundy/arrayref"
+revision = "f8d0299d863922db6c409d08098941e833b70d69"
+cargo_toml_sha256 = "122da2bce2d1aea793e4dc4d38a98966c67f3339a4db2f8fc740bd74ce97e668"
+license_sha256 = "1bc7e6f475b3ec99b7e2643411950ae2368c250dd4c5c325f80f9811362a94a1"
+lib_sha256 = "b74872c9bb2b836132817e024a3f9205f83a6864de1a9bfb46acc1bfbbc1873a"

--- a/third_party/arrayref/src/lib.rs
+++ b/third_party/arrayref/src/lib.rs
@@ -1,0 +1,504 @@
+//! This package contains just four macros, which enable the creation
+//! of array references to portions of arrays or slices (or things
+//! that can be sliced).
+//!
+//! # Examples
+//!
+//! Here is a simple example of slicing and dicing a slice into array
+//! references with these macros.  Here we implement a simple
+//! little-endian conversion from bytes to `u16`, and demonstrate code
+//! that uses `array_ref!` to extract an array reference from a larger
+//! array.  Note that the documentation for each macro also has an
+//! example of its use.
+//!
+//! ```
+//! #[macro_use]
+//! extern crate arrayref;
+//!
+//! fn read_u16(bytes: &[u8; 2]) -> u16 {
+//!      bytes[0] as u16 + ((bytes[1] as u16) << 8)
+//! }
+//! // ...
+//! # fn main() {
+//! let data = [0,1,2,3,4,0,6,7,8,9];
+//! assert_eq!(256, read_u16(array_ref![data,0,2]));
+//! assert_eq!(4, read_u16(array_ref![data,4,2]));
+//! # }
+//! ```
+#![deny(warnings)]
+#![no_std]
+
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
+/// You can use `array_ref` to generate an array reference to a subset
+/// of a sliceable bit of data (which could be an array, or a slice,
+/// or a Vec).
+///
+/// **Panics** if the slice is out of bounds.
+///
+/// ```
+/// #[macro_use]
+/// extern crate arrayref;
+///
+/// fn read_u16(bytes: &[u8; 2]) -> u16 {
+///      bytes[0] as u16 + ((bytes[1] as u16) << 8)
+/// }
+/// // ...
+/// # fn main() {
+/// let data = [0,1,2,3,4,0,6,7,8,9];
+/// assert_eq!(256, read_u16(array_ref![data,0,2]));
+/// assert_eq!(4, read_u16(array_ref![data,4,2]));
+/// # }
+/// ```
+
+#[macro_export]
+macro_rules! array_ref {
+    ($arr:expr, $offset:expr, $len:expr) => {{
+        {
+            #[inline]
+            const unsafe fn as_array<T>(slice: &[T]) -> &[T; $len] {
+                &*(slice.as_ptr() as *const [_; $len])
+            }
+            let offset = $offset;
+            let slice = &$arr[offset..offset + $len];
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_array(slice)
+            }
+        }
+    }};
+}
+
+/// You can use `array_refs` to generate a series of array references
+/// to an input array reference.  The idea is if you want to break an
+/// array into a series of contiguous and non-overlapping arrays.
+/// `array_refs` is a bit funny in that it insists on slicing up the
+/// *entire* array.  This is intentional, as I find it handy to make
+/// me ensure that my sub-arrays add up to the entire array.  This
+/// macro will *never* panic, since the sizes are all checked at
+/// compile time.
+///
+/// Note that unlike `array_ref!`, `array_refs` *requires* that the
+/// first argument be an array reference.  The following arguments are
+/// the lengths of each subarray you wish a reference to.  The total
+/// of these arguments *must* equal the size of the array itself.
+///
+/// ```
+/// #[macro_use]
+/// extern crate arrayref;
+///
+/// fn read_u16(bytes: &[u8; 2]) -> u16 {
+///      bytes[0] as u16 + ((bytes[1] as u16) << 8)
+/// }
+/// // ...
+/// # fn main() {
+/// let data = [0,1,2,3,4,0,6,7];
+/// let (a,b,c) = array_refs![&data,2,2,4];
+/// assert_eq!(read_u16(a), 256);
+/// assert_eq!(read_u16(b), 3*256+2);
+/// assert_eq!(*c, [4,0,6,7]);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! array_refs {
+    ( $arr:expr, $( $pre:expr ),* ; .. ;  $( $post:expr ),* ) => {{
+        {
+            use core::slice;
+            #[inline]
+            #[allow(unused_assignments)]
+            #[allow(clippy::eval_order_dependence)]
+            const unsafe fn as_arrays<T>(a: &[T]) -> ( $( &[T; $pre], )* &[T],  $( &[T; $post], )*) {
+                const MIN_LEN: usize = 0usize $( .saturating_add($pre) )* $( .saturating_add($post) )*;
+                assert!(MIN_LEN < usize::MAX, "Your arrays are too big, are you trying to hack yourself?!");
+                let var_len = a.len() - MIN_LEN;
+                assert!(a.len() >= MIN_LEN);
+                let mut p = a.as_ptr();
+                ( $( {
+                    let aref = & *(p as *const [T; $pre]);
+                    p = p.add($pre);
+                    aref
+                }, )* {
+                    let sl = slice::from_raw_parts(p as *const T, var_len);
+                    p = p.add(var_len);
+                    sl
+                }, $( {
+                    let aref = & *(p as *const [T; $post]);
+                    p = p.add($post);
+                    aref
+                }, )*)
+            }
+            let input = $arr;
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_arrays(input)
+            }
+        }
+    }};
+    ( $arr:expr, $( $len:expr ),* ) => {{
+        {
+            #[inline]
+            #[allow(unused_assignments)]
+            #[allow(clippy::eval_order_dependence)]
+            const unsafe fn as_arrays<T>(a: &[T; $( $len + )* 0 ]) -> ( $( &[T; $len], )* ) {
+                let mut p = a.as_ptr();
+                ( $( {
+                    let aref = &*(p as *const [T; $len]);
+                    p = p.offset($len as isize);
+                    aref
+                }, )* )
+            }
+            let input = $arr;
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_arrays(input)
+            }
+        }
+    }}
+}
+
+/// You can use `mut_array_refs` to generate a series of mutable array
+/// references to an input mutable array reference.  The idea is if
+/// you want to break an array into a series of contiguous and
+/// non-overlapping mutable array references.  Like `array_refs!`,
+/// `mut_array_refs!` is a bit funny in that it insists on slicing up
+/// the *entire* array.  This is intentional, as I find it handy to
+/// make me ensure that my sub-arrays add up to the entire array.
+/// This macro will *never* panic, since the sizes are all checked at
+/// compile time.
+///
+/// Note that unlike `array_mut_ref!`, `mut_array_refs` *requires*
+/// that the first argument be a mutable array reference.  The
+/// following arguments are the lengths of each subarray you wish a
+/// reference to.  The total of these arguments *must* equal the size
+/// of the array itself.  Also note that this macro allows you to take
+/// out multiple mutable references to a single object, which is both
+/// weird and powerful.
+///
+/// ```
+/// #[macro_use]
+/// extern crate arrayref;
+///
+/// fn write_u16(bytes: &mut [u8; 2], num: u16) {
+///      bytes[0] = num as u8;
+///      bytes[1] = (num >> 8) as u8;
+/// }
+/// fn write_u32(bytes: &mut [u8; 4], num: u32) {
+///      bytes[0] = num as u8;
+///      bytes[1] = (num >> 8) as u8; // this is buggy to save space...
+/// }
+/// // ...
+/// # fn main() {
+/// let mut data = [0,1,2,3,4,0,6,7];
+/// let (a,b,c) = mut_array_refs![&mut data,2,2,4];
+/// // let's write out some nice prime numbers!
+/// write_u16(a, 37);
+/// write_u16(b, 73);
+/// write_u32(c, 137); // approximate inverse of the fine structure constant!
+/// # }
+/// ```
+#[macro_export]
+macro_rules! mut_array_refs {
+    ( $arr:expr, $( $pre:expr ),* ; .. ;  $( $post:expr ),* ) => {{
+        {
+            use core::slice;
+            #[inline]
+            #[allow(unused_assignments)]
+            #[allow(clippy::eval_order_dependence)]
+            unsafe fn as_arrays<T>(a: &mut [T]) -> ( $( &mut [T; $pre], )* &mut [T],  $( &mut [T; $post], )*) {
+                const MIN_LEN: usize = 0usize $( .saturating_add($pre) )* $( .saturating_add($post) )*;
+                assert!(MIN_LEN < usize::MAX, "Your arrays are too big, are you trying to hack yourself?!");
+                let var_len = a.len() - MIN_LEN;
+                assert!(a.len() >= MIN_LEN);
+                let mut p = a.as_mut_ptr();
+                ( $( {
+                    let aref = &mut *(p as *mut [T; $pre]);
+                    p = p.add($pre);
+                    aref
+                }, )* {
+                    let sl = slice::from_raw_parts_mut(p as *mut T, var_len);
+                    p = p.add(var_len);
+                    sl
+                }, $( {
+                    let aref = &mut *(p as *mut [T; $post]);
+                    p = p.add($post);
+                    aref
+                }, )*)
+            }
+            let input = $arr;
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_arrays(input)
+            }
+        }
+    }};
+    ( $arr:expr, $( $len:expr ),* ) => {{
+        {
+            #[inline]
+            #[allow(unused_assignments)]
+            #[allow(clippy::eval_order_dependence)]
+            unsafe fn as_arrays<T>(a: &mut [T; $( $len + )* 0 ]) -> ( $( &mut [T; $len], )* ) {
+                let mut p = a.as_mut_ptr();
+                ( $( {
+                    let aref = &mut *(p as *mut [T; $len]);
+                    p = p.add($len);
+                    aref
+                }, )* )
+            }
+            let input = $arr;
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_arrays(input)
+            }
+        }
+    }};
+}
+
+/// You can use `array_mut_ref` to generate a mutable array reference
+/// to a subset of a sliceable bit of data (which could be an array,
+/// or a slice, or a Vec).
+///
+/// **Panics** if the slice is out of bounds.
+///
+/// ```
+/// #[macro_use]
+/// extern crate arrayref;
+///
+/// fn write_u16(bytes: &mut [u8; 2], num: u16) {
+///      bytes[0] = num as u8;
+///      bytes[1] = (num >> 8) as u8;
+/// }
+/// // ...
+/// # fn main() {
+/// let mut data = [0,1,2,3,4,0,6,7,8,9];
+/// write_u16(array_mut_ref![data,0,2], 1);
+/// write_u16(array_mut_ref![data,2,2], 5);
+/// assert_eq!(*array_ref![data,0,4], [1,0,5,0]);
+/// *array_mut_ref![data,4,5] = [4,3,2,1,0];
+/// assert_eq!(data, [1,0,5,0,4,3,2,1,0,9]);
+/// # }
+/// ```
+#[macro_export]
+macro_rules! array_mut_ref {
+    ($arr:expr, $offset:expr, $len:expr) => {{
+        {
+            #[inline]
+            unsafe fn as_array<T>(slice: &mut [T]) -> &mut [T; $len] {
+                &mut *(slice.as_mut_ptr() as *mut [_; $len])
+            }
+            let offset = $offset;
+            let slice = &mut $arr[offset..offset + $len];
+            #[allow(unused_unsafe)]
+            unsafe {
+                as_array(slice)
+            }
+        }
+    }};
+}
+
+#[allow(clippy::all)]
+#[cfg(test)]
+mod test {
+
+    extern crate quickcheck;
+
+    use std::vec::Vec;
+
+    // use super::*;
+
+    #[test]
+    #[should_panic]
+    fn checks_bounds() {
+        let foo: [u8; 11] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let bar = array_ref!(foo, 1, 11);
+        println!("I am checking that I can dereference bar[0] = {}", bar[0]);
+    }
+
+    #[test]
+    fn simple_case_works() {
+        fn check(expected: [u8; 3], actual: &[u8; 3]) {
+            for (e, a) in (&expected).iter().zip(actual.iter()) {
+                assert_eq!(e, a)
+            }
+        }
+        let mut foo: [u8; 11] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        {
+            let bar = array_ref!(foo, 2, 3);
+            check([2, 3, 4], bar);
+        }
+        check([0, 1, 2], array_ref!(foo, 0, 3));
+        fn zero2(x: &mut [u8; 2]) {
+            x[0] = 0;
+            x[1] = 0;
+        }
+        zero2(array_mut_ref!(foo, 8, 2));
+        check([0, 0, 10], array_ref!(foo, 8, 3));
+    }
+
+    #[test]
+    fn check_array_ref_5() {
+        fn f(data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() < offset + 5
+            if data.len() < 5 || data.len() - 5 < offset {
+                return quickcheck::TestResult::discard();
+            }
+            let out = array_ref!(data, offset, 5);
+            quickcheck::TestResult::from_bool(out.len() == 5)
+        }
+        quickcheck::quickcheck(f as fn(Vec<u8>, usize) -> quickcheck::TestResult);
+    }
+
+    #[test]
+    fn check_array_ref_out_of_bounds_5() {
+        fn f(data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() >= offset + 5
+            if data.len() >= 5 && data.len() - 5 >= offset {
+                return quickcheck::TestResult::discard();
+            }
+            quickcheck::TestResult::must_fail(move || {
+                array_ref!(data, offset, 5);
+            })
+        }
+        quickcheck::quickcheck(f as fn(Vec<u8>, usize) -> quickcheck::TestResult);
+    }
+
+    #[test]
+    fn check_array_mut_ref_7() {
+        fn f(mut data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() < offset + 7
+            if data.len() < 7 || data.len() - 7 < offset {
+                return quickcheck::TestResult::discard();
+            }
+            let out = array_mut_ref!(data, offset, 7);
+            out[6] = 3;
+            quickcheck::TestResult::from_bool(out.len() == 7)
+        }
+        quickcheck::quickcheck(f as fn(Vec<u8>, usize) -> quickcheck::TestResult);
+    }
+
+    #[test]
+    fn check_array_mut_ref_out_of_bounds_32() {
+        fn f(mut data: Vec<u8>, offset: usize) -> quickcheck::TestResult {
+            // Compute the following, with correct results even if the sum would overflow:
+            //   if data.len() >= offset + 32
+            if data.len() >= 32 && data.len() - 32 >= offset {
+                return quickcheck::TestResult::discard();
+            }
+            quickcheck::TestResult::must_fail(move || {
+                array_mut_ref!(data, offset, 32);
+            })
+        }
+        quickcheck::quickcheck(f as fn(Vec<u8>, usize) -> quickcheck::TestResult);
+    }
+
+    #[test]
+    fn test_5_array_refs() {
+        let mut data: [usize; 128] = [0; 128];
+        for i in 0..128 {
+            data[i] = i;
+        }
+        let data = data;
+        let (a, b, c, d, e) = array_refs!(&data, 1, 14, 3, 100, 10);
+        assert_eq!(a.len(), 1 as usize);
+        assert_eq!(b.len(), 14 as usize);
+        assert_eq!(c.len(), 3 as usize);
+        assert_eq!(d.len(), 100 as usize);
+        assert_eq!(e.len(), 10 as usize);
+        assert_eq!(a, array_ref![data, 0, 1]);
+        assert_eq!(b, array_ref![data, 1, 14]);
+        assert_eq!(c, array_ref![data, 15, 3]);
+        assert_eq!(e, array_ref![data, 118, 10]);
+    }
+
+    #[test]
+    fn test_5_array_refs_dotdot() {
+        let mut data: [usize; 128] = [0; 128];
+        for i in 0..128 {
+            data[i] = i;
+        }
+        let data = data;
+        let (a, b, c, d, e) = array_refs!(&data, 1, 14, 3; ..; 10);
+        assert_eq!(a.len(), 1 as usize);
+        assert_eq!(b.len(), 14 as usize);
+        assert_eq!(c.len(), 3 as usize);
+        assert_eq!(d.len(), 100 as usize);
+        assert_eq!(e.len(), 10 as usize);
+        assert_eq!(a, array_ref![data, 0, 1]);
+        assert_eq!(b, array_ref![data, 1, 14]);
+        assert_eq!(c, array_ref![data, 15, 3]);
+        assert_eq!(e, array_ref![data, 118, 10]);
+    }
+
+    #[test]
+    fn test_5_mut_xarray_refs() {
+        let mut data: [usize; 128] = [0; 128];
+        {
+            // temporarily borrow the data to modify it.
+            let (a, b, c, d, e) = mut_array_refs!(&mut data, 1, 14, 3, 100, 10);
+            assert_eq!(a.len(), 1 as usize);
+            assert_eq!(b.len(), 14 as usize);
+            assert_eq!(c.len(), 3 as usize);
+            assert_eq!(d.len(), 100 as usize);
+            assert_eq!(e.len(), 10 as usize);
+            *a = [1; 1];
+            *b = [14; 14];
+            *c = [3; 3];
+            *d = [100; 100];
+            *e = [10; 10];
+        }
+        assert_eq!(&[1; 1], array_ref![data, 0, 1]);
+        assert_eq!(&[14; 14], array_ref![data, 1, 14]);
+        assert_eq!(&[3; 3], array_ref![data, 15, 3]);
+        assert_eq!(&[10; 10], array_ref![data, 118, 10]);
+    }
+
+    #[test]
+    fn test_5_mut_xarray_refs_with_dotdot() {
+        let mut data: [usize; 128] = [0; 128];
+        {
+            // temporarily borrow the data to modify it.
+            let (a, b, c, d, e) = mut_array_refs!(&mut data, 1, 14, 3; ..; 10);
+            assert_eq!(a.len(), 1 as usize);
+            assert_eq!(b.len(), 14 as usize);
+            assert_eq!(c.len(), 3 as usize);
+            assert_eq!(d.len(), 100 as usize);
+            assert_eq!(e.len(), 10 as usize);
+            *a = [1; 1];
+            *b = [14; 14];
+            *c = [3; 3];
+            *e = [10; 10];
+        }
+        assert_eq!(&[1; 1], array_ref![data, 0, 1]);
+        assert_eq!(&[14; 14], array_ref![data, 1, 14]);
+        assert_eq!(&[3; 3], array_ref![data, 15, 3]);
+        assert_eq!(&[10; 10], array_ref![data, 118, 10]);
+    }
+
+    #[forbid(clippy::ptr_offset_with_cast)]
+    #[test]
+    fn forbidden_clippy_lints_do_not_fire() {
+        let mut data = [0u8; 32];
+        let _ = array_refs![&data, 8; .. ;];
+        let _ = mut_array_refs![&mut data, 8; .. ; 10];
+    }
+
+    #[test]
+    fn single_arg_refs() {
+        let mut data = [0u8; 8];
+        let (_,) = array_refs![&data, 8];
+        let (_,) = mut_array_refs![&mut data, 8];
+
+        let (_, _) = array_refs![&data, 4; ..;];
+        let (_, _) = mut_array_refs![&mut data, 4; ..;];
+
+        let (_, _) = array_refs![&data,; ..; 4];
+        let (_, _) = mut_array_refs![&mut data,; ..; 4];
+
+        let (_,) = array_refs![&data,; ..;];
+        let (_,) = mut_array_refs![&mut data,; ..;];
+    }
+} // mod test


### PR DESCRIPTION
## Summary
- replace the yanked registry copy of arrayref 0.3.9 with a byte-for-byte vendored copy of the reviewed upstream revision
- patch every dependency graph that actually contains arrayref: the root workspace plus the standalone agentd, hostd, runtime-backend, and SDK fuzz workspaces
- record and verify the upstream repository, immutable revision, and SHA-256 of each vendored file
- restore the strict supply-chain policy: Git dependencies remain denied
- add a discovery-based regression test proving every affected manifest and lockfile resolves the reviewed vendored source

The registry replacement currently declares an unresolvable proc-macro1 dependency. This change does not select or execute that release. Vendoring also avoids GitHub Actions checkout credentials being sent to an external repository during Cargo resolution.

## Verification
- cargo metadata --locked --offline --no-deps (root workspace)
- cargo check --locked --offline --manifest-path <manifest> --all-targets for all four affected standalone fuzz graphs
- cargo test --locked --offline --test supply_chain_dependency_pin (3 passed)
- cargo deny check
- cargo clippy --locked --offline --test supply_chain_dependency_pin -- -D warnings
- cargo clippy --workspace --all-targets -- -D warnings (commit hook)
- cargo fmt --all --check
- xtask check-sprint-append
- xtask check-no-spec-refs-in-comments
- git diff --check

Depends on #2755. Part of #2736.