### PR TITLE
fix(nix): retain vendored dependency sources

### DIFF
--- a/crates/mvm-build/src/pipeline/build_cache.rs
+++ b/crates/mvm-build/src/pipeline/build_cache.rs
@@ -91,6 +91,7 @@ const INCLUDED_TOP_LEVEL: &[&str] = &[
     "crates",
     "xtask",
     "tests",
+    "third_party",
     "schema",
     "nix",
 ];

--- a/nix/lib/workspace-filter.nix
+++ b/nix/lib/workspace-filter.nix
@@ -29,6 +29,7 @@
 #   tests/                   root package integration targets; the source-built
 #                            mvmctl derivation leaves doCheck at its default, so
 #                            `cargo test --package mvmctl` compiles these
+#   third_party/             vendored path dependencies referenced by Cargo.toml
 #   schema/                  wire schemas; kept because they never churn, so
 #                            excluding them would buy nothing
 #   nix/                     the flakes themselves, nix/lib, nix/packages, and
@@ -71,6 +72,7 @@ let
     "crates"
     "xtask"
     "tests"
+    "third_party"
     "schema"
     "nix"
   ];

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -336,7 +336,8 @@ for detailed scope and acceptance criteria.
       projection, and endpoint identity configuration.
       Every dependency graph that contains `arrayref` resolves a byte-for-byte
       vendored copy of the reviewed 0.3.9 upstream revision. Pinned file hashes
-      guard the vendored source, and Git dependencies remain denied.
+      guard the vendored source, Git dependencies remain denied, and Nix image
+      sources plus the host build fingerprint retain that path dependency.
       Closure remains gated on a clean Security workflow run from current
       `main`, including every mutation shard and both reproducibility builds.
 

--- a/specs/sprint/delivery/2736-security-release-feature.md
+++ b/specs/sprint/delivery/2736-security-release-feature.md
@@ -13,6 +13,9 @@
       to a byte-for-byte vendored copy of the reviewed 0.3.9 upstream revision.
       A discovery-based regression test proves each manifest and lockfile use
       it, verifies the vendored file hashes, and keeps Git sources denied.
+      Nix image-source filtering and the mirrored host build fingerprint retain
+      the vendored dependency directory, with a regression test covering the
+      omission that previously broke offline runtime-overlay builds.
       The exact feature check fails on the prior source and passes after the
       fix; every fuzz manifest compiles from its lockfile, and workspace
       all-target Clippy, workflow syntax, formatting, and the workspace suite

--- a/tests/supply_chain_dependency_pin.rs
+++ b/tests/supply_chain_dependency_pin.rs
@@ -99,6 +99,25 @@ fn sha256(path: &Path) -> String {
     encoded
 }
 
+fn nix_filter_list(name: &str) -> Vec<String> {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let path = workspace.join("nix/lib/workspace-filter.nix");
+    let body = read(&path);
+    let start = body
+        .find(&format!("{name} = ["))
+        .unwrap_or_else(|| panic!("{name} list not found in {}", path.display()));
+    let rest = &body[start..];
+    let end = rest
+        .find(']')
+        .unwrap_or_else(|| panic!("{name} list is unterminated in {}", path.display()));
+    rest[..end]
+        .split('"')
+        .skip(1)
+        .step_by(2)
+        .map(str::to_string)
+        .collect()
+}
+
 #[test]
 fn every_arrayref_graph_uses_the_vendored_reviewed_source() {
     let workspace = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -140,6 +159,16 @@ fn vendored_arrayref_matches_the_reviewed_upstream_revision() {
     assert_eq!(sha256(&vendored.join("Cargo.toml")), CARGO_TOML_SHA256);
     assert_eq!(sha256(&vendored.join("LICENSE")), LICENSE_SHA256);
     assert_eq!(sha256(&vendored.join("src/lib.rs")), LIB_SHA256);
+}
+
+#[test]
+fn nix_workspace_filter_includes_the_vendored_arrayref_source() {
+    let included = nix_filter_list("includedTopLevel");
+
+    assert!(
+        included.iter().any(|entry| entry == "third_party"),
+        "Nix image builds must include the top-level directory containing the vendored arrayref path dependency"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- include the top-level vendored dependency directory in filtered Nix workspace sources
- mirror that source boundary in the host build-cache fingerprint
- add a regression test proving the path dependency survives Nix filtering

## Why

The combined security-recovery branch vendors the reviewed `arrayref` source after the trusted crates.io releases were yanked. The Nix workspace allowlist omitted `third_party/`, so the sealed-rootfs and verified-boot Security jobs could not read the path dependency.

## Validation

- `cargo test --workspace`
- `cargo test --test supply_chain_dependency_pin`
- `cargo test -p mvm-build pipeline::build_cache::tests`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`

Supports #2736; closure remains gated on a clean Security workflow from current `main`.