### PR TITLE
docs: document host-side eBPF egress telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Linux + /dev/kvm           →  Firecracker
 - **Three ways to define a workload** — an OCI image, a Nix flake (`mkGuest`), or
   a decorated function (`@mvm.app`) — all compile to the same signed, auditable
   microVM
-- **SDKs for Python, TypeScript, and Rust** — a *decorator* SDK for authoring
-  workloads and a *runtime* SDK for driving them, both thin wrappers over one
+- **SDKs for Python, TypeScript, and Rust** — a _decorator_ SDK for authoring
+  workloads and a _runtime_ SDK for driving them, both thin wrappers over one
   conformance-pinned surface
 - **Security claims, CI-enforced** — 15+ numbered claims (signed execution
   plans, chain-signed audit log, dm-verity boot, default-deny egress, run-shaped
@@ -157,7 +157,7 @@ downloads what is missing or invalid. If a Stage 0 source build is interrupted,
 the incomplete output is never installed; rerunning resumes with the persistent
 Nix store still warm.
 
-For an interactive shell you want a *workload* microVM, not the builder — use a
+For an interactive shell you want a _workload_ microVM, not the builder — use a
 transient run against a dev-tier image: `mvmctl machine run --image alpine -it -- /bin/sh`.
 
 On the first image-backed run, mvm may build and cache the workload kernel
@@ -183,17 +183,17 @@ Working example workloads live in [`examples/`](examples/) — build any of them
 with `mvmctl machine run --flake examples/<name>` (Nix) or `mvmctl build compile`
 (SDK):
 
-| Example | Kind | What it shows |
-|---|---|---|
-| [`examples/python/hello-app`](examples/python/hello-app) | Python decorator | Minimal `@mvm.app` function-entrypoint workload |
-| [`examples/python/hello-app-with-deps`](examples/python/hello-app-with-deps) | Python decorator | `@mvm.app` with a locked `python_deps` (uv) dependency → sealed deps volume |
-| [`examples/python/secret-egress`](examples/python/secret-egress) | Python decorator | Secret substitution over egress — the workload sees a placeholder, never the raw secret |
-| [`examples/typescript/hello-app`](examples/typescript/hello-app) | TS decorator | Minimal `mvm.app({...})(fn)` workload |
-| [`examples/typescript/hello-app-with-deps`](examples/typescript/hello-app-with-deps) | TS decorator | `mvm.app` with locked `node_deps` |
-| [`examples/exit_code`](examples/exit_code) | Nix flake | One-shot sealed workload (exits a chosen code) |
-| [`examples/sleeper`](examples/sleeper) | Nix flake | Long-lived sealed workload fixture |
-| [`examples/egress-probe`](examples/egress-probe) | Nix flake | One-shot workload that TCP-probes targets and exits a verdict — exercises egress policy |
-| [`examples/audit-probe`](examples/audit-probe) | Nix flake | In-guest `host.audit.v1` round-trip fixture |
+| Example                                                                              | Kind             | What it shows                                                                           |
+| ------------------------------------------------------------------------------------ | ---------------- | --------------------------------------------------------------------------------------- |
+| [`examples/python/hello-app`](examples/python/hello-app)                             | Python decorator | Minimal `@mvm.app` function-entrypoint workload                                         |
+| [`examples/python/hello-app-with-deps`](examples/python/hello-app-with-deps)         | Python decorator | `@mvm.app` with a locked `python_deps` (uv) dependency → sealed deps volume             |
+| [`examples/python/secret-egress`](examples/python/secret-egress)                     | Python decorator | Secret substitution over egress — the workload sees a placeholder, never the raw secret |
+| [`examples/typescript/hello-app`](examples/typescript/hello-app)                     | TS decorator     | Minimal `mvm.app({...})(fn)` workload                                                   |
+| [`examples/typescript/hello-app-with-deps`](examples/typescript/hello-app-with-deps) | TS decorator     | `mvm.app` with locked `node_deps`                                                       |
+| [`examples/exit_code`](examples/exit_code)                                           | Nix flake        | One-shot sealed workload (exits a chosen code)                                          |
+| [`examples/sleeper`](examples/sleeper)                                               | Nix flake        | Long-lived sealed workload fixture                                                      |
+| [`examples/egress-probe`](examples/egress-probe)                                     | Nix flake        | One-shot workload that TCP-probes targets and exits a verdict — exercises egress policy |
+| [`examples/audit-probe`](examples/audit-probe)                                       | Nix flake        | In-guest `host.audit.v1` round-trip fixture                                             |
 
 ### From a template
 
@@ -332,10 +332,9 @@ inside the microVM.
 
 ---
 
-
 ### From dev loop to attested image
 
-The three routes above are the *start* of one path: pick a base, iterate until
+The three routes above are the _start_ of one path: pick a base, iterate until
 the workload actually works, then end with a sealed, hashed, recorded artifact.
 
 What that looks like today:
@@ -374,12 +373,12 @@ the exact surface the CLI does — decorators emit the canonical `Workload` IR;
 runtime calls go through the client facade — pinned by shared conformance
 fixtures so no SDK can drift from `mvmctl`.
 
-### Decorator SDK — *authoring*
+### Decorator SDK — _authoring_
 
 Declare a workload where it lives. `@mvm.app(...)` (Python) / `mvm.app({...})`
 (TypeScript) is higher-order: it records the declaration and returns your
 function unchanged, so the same file still runs normally under `python` / `tsx`
-and is *also* read statically by `mvmctl build compile`.
+and is _also_ read statically by `mvmctl build compile`.
 
 <table>
 <tr><th>Python</th><th>TypeScript</th></tr>
@@ -422,7 +421,7 @@ the IR directly for inspection or tests with `mvm.emit_json()` /
 the canonical `ir::Workload`, and renders the flake — so adding a language means
 emitting that IR, not writing a compiler.
 
-### Runtime SDK — *control plane*
+### Runtime SDK — _control plane_
 
 Drive machines imperatively: create, exec, move files, run processes, forward
 ports, tear down. The Python/TypeScript `Sandbox` object model and the Rust
@@ -584,7 +583,13 @@ detailed sequence.
 
 Backend selection is automatic per host (`--hypervisor` overrides); all backends
 consume the same image artifacts. Egress is default-deny — where policy admits
-flows they are enforced and audited host-side.
+flows they are enforced and audited host-side. On Linux, an optional host-side
+[eBPF](https://ebpf.io/) probe attached to the egress substitution process
+observes `tcp_connect` events (destination address and port) via a ring buffer,
+with a procfs fallback when BPF loading is unavailable. The probe does not widen
+the guest attack surface: the guest still has no NIC, the probe reads no guest
+payloads, and policy enforcement remains at the existing admission and vsock
+forwarding seams.
 
 ### Vsock-only: the invariant the other guarantees rest on
 
@@ -663,7 +668,7 @@ claims), each backed by a named test or workflow gate. In summary:
     argv or env, or spawn anything, and it is refused outright without a grant
     in the signed plan.
 
-Claim 15 used to hold by *absence*: there was no host→guest byte path at all.
+Claim 15 used to hold by _absence_: there was no host→guest byte path at all.
 The workload input channel built one, so refusing input is now a policy
 decision rather than a consequence of there being nothing to refuse. ADR-001
 carries that rewording, plus a `Preview` claim 17 for the input channel with
@@ -676,7 +681,7 @@ surface yet. See
 
 The guest agent runs as an unprivileged uid under `setpriv`; `~/.mvm` and
 `~/.mvm/cache` are mode 0700. **Out of scope** (named in ADR-001): a malicious
-*host* (mvmctl trusts the host with the hypervisor and private keys),
+_host_ (mvmctl trusts the host with the hypervisor and private keys),
 multi-tenant guests (one guest = one workload), and hardware-backed key
 attestation.
 
@@ -773,7 +778,7 @@ Ground rules (enforced by CI — see [AGENTS.md](AGENTS.md) for the full set):
 - **Always `cargo fmt --all`** — without `--all`, other workspace members are
   silently skipped and CI will fail.
 - **No task is done without tests.** Types get serde round-trips; wire/protocol
-  code gets tampered-input rejection tests; security paths get positive *and*
+  code gets tampered-input rejection tests; security paths get positive _and_
   negative cases. SDK changes must keep the shared conformance fixtures
   (`tests/machine-fixtures/`) green — that is what keeps the wrappers thin.
 - **Reuse first.** Search the workspace before adding a helper — duplicated logic
@@ -788,7 +793,7 @@ Ground rules (enforced by CI — see [AGENTS.md](AGENTS.md) for the full set):
   claim→witness mapping is machine-checked.
 
 Keep PRs focused (one concern each) and write commit messages that explain
-*why*. PRs merge through the GitHub **merge queue** once CI is green. The full
+_why_. PRs merge through the GitHub **merge queue** once CI is green. The full
 live suite (workspace clippy on x86_64-linux, seccomp probes, longer fuzz runs,
 live-KVM smokes) needs real `/dev/kvm`; cloud-init scaffolding for a throwaway
 KVM box lives in [`nix/ops/hetzner/`](nix/ops/hetzner/), and the

--- a/public/src/content/docs/guides/observability-and-results.mdx
+++ b/public/src/content/docs/guides/observability-and-results.mdx
@@ -14,17 +14,52 @@ return command status and enough evidence to debug or verify the run later.
 
 ## Evidence model
 
-| Evidence | Best for | Do not store |
-| --- | --- | --- |
-| Command result | Immediate caller decision: success, failure, timeout. | Unbounded stdout/stderr or raw secrets. |
-| Receipt | Portable verification for one run. | Raw argv, env values, stdout, stderr, or host paths. |
-| Audit ID | Correlating local lifecycle and policy events. | Guest payload bytes. |
-| Logs | Operator debugging. | Unredacted secrets, full model prompts, large file contents. |
-| Boot report | Readiness and startup debugging. | Application payloads. |
-| Metrics | Dashboards, alerts, trend analysis. | Labels with argv, env values, file contents, or secret names. |
+| Evidence       | Best for                                              | Do not store                                                  |
+| -------------- | ----------------------------------------------------- | ------------------------------------------------------------- |
+| Command result | Immediate caller decision: success, failure, timeout. | Unbounded stdout/stderr or raw secrets.                       |
+| Receipt        | Portable verification for one run.                    | Raw argv, env values, stdout, stderr, or host paths.          |
+| Audit ID       | Correlating local lifecycle and policy events.        | Guest payload bytes.                                          |
+| Logs           | Operator debugging.                                   | Unredacted secrets, full model prompts, large file contents.  |
+| Boot report    | Readiness and startup debugging.                      | Application payloads.                                         |
+| Metrics        | Dashboards, alerts, trend analysis.                   | Labels with argv, env values, file contents, or secret names. |
 
 Keep identifiers everywhere. Keep payloads only where the caller explicitly
 asked for bounded output.
+
+## Host-side eBPF egress telemetry
+
+On Linux, `mvm` can attach a host-side [eBPF](https://ebpf.io/) probe to the
+per-VM egress substitution process. The probe observes outbound `tcp_connect`
+events from the host-side path that forwards guest vsock traffic to real
+endpoints, so network telemetry stays attached to the same process that enforces
+policy decisions.
+
+What the probe records:
+
+- destination IPv4 address and port for each observed `tcp_connect`;
+- events through an eBPF ring buffer, read by a dedicated worker thread;
+- a procfs fallback when the eBPF object is unavailable or the host lacks BPF
+  load permissions.
+
+What it does **not** do:
+
+- It does not give the guest a network device; the vsock-only invariant still
+  holds.
+- It does not read guest memory, payloads, or TLS cleartext.
+- It is not a data-plane enforcement point; policy decisions happen at the
+  existing admission and forwarding seams.
+
+The eBPF object is built separately with nightly Rust and `bpf-linker`:
+
+```sh
+just build-ebpf
+```
+
+The `test-ebpf-telemetry` CI lane loads and attaches the probe on every
+code-bearing merge group, so a broken object or loader surfaces before it can
+reach `main`. On macOS and on Linux builds without the `ebpf-telemetry` feature,
+the loader returns a no-op stub and telemetry continues from the audit and
+metrics surfaces above.
 
 ## CLI result workflow
 
@@ -164,16 +199,16 @@ Metrics are for aggregate behavior. Use receipts and audit IDs for drill-down.
 
 Return typed failures to callers:
 
-| Failure | Example caller action |
-| --- | --- |
-| Validation failed | Reject the model/tool request before launch. |
-| Policy denied | Ask for a reviewed policy change or remove the operation. |
-| Build failed | Inspect build logs and artifact inputs. |
-| Boot not ready | Inspect boot report, backend logs, and guest readiness. |
-| Command failed | Return bounded stderr/stdout and exit code. |
-| Timeout | Stop, snapshot, or retry intentionally. |
-| Transport failed | Retry only if the operation is idempotent. |
-| Cleanup failed | Mark retained state sensitive and ask an operator to clean up. |
+| Failure           | Example caller action                                          |
+| ----------------- | -------------------------------------------------------------- |
+| Validation failed | Reject the model/tool request before launch.                   |
+| Policy denied     | Ask for a reviewed policy change or remove the operation.      |
+| Build failed      | Inspect build logs and artifact inputs.                        |
+| Boot not ready    | Inspect boot report, backend logs, and guest readiness.        |
+| Command failed    | Return bounded stderr/stdout and exit code.                    |
+| Timeout           | Stop, snapshot, or retry intentionally.                        |
+| Transport failed  | Retry only if the operation is idempotent.                     |
+| Cleanup failed    | Mark retained state sensitive and ask an operator to clean up. |
 
 Do not collapse these into one generic runtime error. Policy denial, command
 failure, timeout, and cleanup failure all imply different next steps.


### PR DESCRIPTION
## Summary

Documents the host-side eBPF vsock egress telemetry work on the website and in the README.

## Changes

- Add a new **Host-side eBPF egress telemetry** section to the website observability guide, linking to https://ebpf.io/ and describing the Linux probe, ring buffer, procfs fallback, and security boundary.
- Add a short blurb to the README **How it works** section covering the same points.

## Security note

The docs explicitly state that the probe does not widen the guest attack surface: the guest still has no network device, the probe does not read guest memory or payloads, and policy enforcement remains at the existing admission and vsock forwarding seams.