### PR TITLE
site: add architecture one-pager and link it from the landing nav

### DIFF
--- a/public/public/architecture.html
+++ b/public/public/architecture.html
@@ -1,0 +1,527 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MVM — Architecture at a Glance</title>
+<meta name="description" content="How MVM runs untrusted code — AI agents, customer workloads, build jobs — inside sealed, immutable, hardware-isolated microVMs, and where it sits inside a company's systems.">
+<link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<meta property="og:title" content="MVM — Architecture at a Glance">
+<meta property="og:description" content="A secure execution layer for the code you can't fully trust: the MVM stack top to bottom, and where it sits inside a company.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://gomicrovm.com/architecture.html">
+<style>
+  :root {
+    --bg: #F4F6F8;
+    --surface: #FDFEFF;
+    --ink: #1C2530;
+    --muted: #5C6B7A;
+    --line: #C9D2DA;
+    --line-soft: #DEE5EA;
+    --accent: #B8430F;          /* ember — the security plane */
+    --accent-soft: #F6E3D8;
+    --steel: #34627E;           /* steel blue — data & flow */
+    --steel-soft: #DDE9F0;
+    --guest: #3E7355;           /* sealed-guest green */
+    --guest-soft: #DCEAE2;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #141B22;
+      --surface: #1B242D;
+      --ink: #E4EAEF;
+      --muted: #93A3B1;
+      --line: #33414D;
+      --line-soft: #28343F;
+      --accent: #E8794A;
+      --accent-soft: #3A2417;
+      --steel: #7FB0D3;
+      --steel-soft: #1E3241;
+      --guest: #7BB897;
+      --guest-soft: #1E3229;
+    }
+  }
+
+  * { box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  @media (prefers-reduced-motion: reduce) {
+    html { scroll-behavior: auto; }
+  }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: 'Charter', 'Iowan Old Style', 'Georgia', serif;
+    font-size: 17px;
+    line-height: 1.55;
+  }
+  .wrap { max-width: 980px; margin: 0 auto; padding: 20px 28px 96px; }
+
+  /* top bar */
+  .bar {
+    display: flex; align-items: baseline; gap: 22px; flex-wrap: wrap;
+    padding: 14px 0 12px;
+    border-bottom: 1px solid var(--line);
+    font-family: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
+    margin-bottom: 44px;
+  }
+  .bar .brand {
+    font-weight: 700; font-size: 17px; letter-spacing: 0.02em;
+    color: var(--ink); text-decoration: none;
+  }
+  .bar nav { display: flex; gap: 18px; margin-left: auto; flex-wrap: wrap; }
+  .bar nav a {
+    font-size: 13px; font-weight: 600; letter-spacing: 0.04em;
+    color: var(--muted); text-decoration: none;
+  }
+  .bar nav a:hover { color: var(--accent); }
+
+  a:focus-visible, svg a:focus-visible rect { outline: 2px solid var(--steel); outline-offset: 2px; }
+
+  .eyebrow {
+    font-family: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
+    font-size: 12px; font-weight: 600; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--accent); margin: 0 0 10px;
+  }
+  h1 {
+    font-family: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
+    font-weight: 600; font-size: clamp(30px, 4.5vw, 44px);
+    line-height: 1.12; letter-spacing: -0.01em; margin: 0 0 14px;
+    text-wrap: balance;
+  }
+  .lede { max-width: 62ch; font-size: 19px; color: var(--muted); margin: 0 0 8px; }
+  .lede strong { color: var(--ink); font-weight: 600; }
+
+  .proof {
+    display: flex; flex-wrap: wrap; gap: 10px 28px;
+    margin: 28px 0 0; padding: 16px 0;
+    border-top: 1px solid var(--line); border-bottom: 1px solid var(--line);
+    font-family: 'Avenir Next', 'Segoe UI', sans-serif;
+  }
+  .proof div { display: flex; flex-direction: column; gap: 1px; }
+  .proof b { font-size: 19px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .proof span { font-size: 12px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--muted); }
+
+  section { margin-top: 64px; scroll-margin-top: 24px; }
+  h2 {
+    font-family: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
+    font-weight: 600; font-size: 26px; letter-spacing: -0.005em;
+    margin: 0 0 6px; text-wrap: balance;
+  }
+  .kicker {
+    font-family: 'Avenir Next', 'Segoe UI', sans-serif;
+    font-size: 12px; font-weight: 600; letter-spacing: 0.16em;
+    text-transform: uppercase; color: var(--muted); margin: 0 0 4px;
+  }
+  h2 + p { max-width: 66ch; color: var(--muted); margin: 6px 0 24px; }
+  h2 + p strong, .notes strong { color: var(--ink); }
+
+  figure { margin: 0; }
+  .fig-scroll {
+    overflow-x: auto;
+    background: var(--surface);
+    border: 1px solid var(--line-soft);
+    border-radius: 6px;
+    padding: 26px 20px;
+  }
+  .fig-scroll svg { display: block; min-width: 720px; max-width: 100%; height: auto; margin: 0 auto; }
+  figcaption {
+    font-family: 'Avenir Next', 'Segoe UI', sans-serif;
+    font-size: 13px; color: var(--muted); margin-top: 10px; max-width: 74ch;
+  }
+  figcaption .hint { color: var(--steel); font-weight: 600; }
+
+  /* clickable diagram regions */
+  svg a { cursor: pointer; }
+  svg a rect { transition: stroke-width 0.12s ease; }
+  svg a:hover > rect:first-of-type { stroke-width: 2.5; }
+
+  .notes { margin: 30px 0 0; padding: 0; list-style: none; display: grid; gap: 10px; }
+  .notes li {
+    display: grid; grid-template-columns: 34px 1fr; gap: 14px; align-items: start;
+    max-width: 74ch;
+    padding: 8px 12px; margin-left: -12px;
+    border-radius: 6px;
+    scroll-margin-top: 90px;
+  }
+  .notes li:target { background: var(--steel-soft); }
+  .notes li.sec:target { background: var(--accent-soft); }
+  .notes .tick {
+    font-family: 'Avenir Next', 'Segoe UI', sans-serif;
+    font-weight: 600; font-size: 13px; line-height: 24px;
+    width: 26px; height: 26px; text-align: center;
+    border: 1.5px solid var(--line); border-radius: 50%;
+    color: var(--muted); margin-top: 2px;
+  }
+  .notes li.sec .tick { border-color: var(--accent); color: var(--accent); }
+  .notes h3 {
+    font-family: 'Avenir Next', 'Segoe UI', sans-serif;
+    font-size: 16px; font-weight: 600; margin: 0 0 3px;
+  }
+  .notes p { margin: 0; color: var(--muted); font-size: 16px; }
+
+  .pull {
+    margin: 40px 0 0; padding: 22px 26px;
+    border-left: 3px solid var(--accent);
+    background: var(--surface);
+    border-radius: 0 6px 6px 0;
+    max-width: 72ch;
+  }
+  .pull p { margin: 0; font-size: 18px; }
+  .pull p + p { margin-top: 10px; color: var(--muted); font-size: 16px; }
+
+  footer {
+    margin-top: 72px; padding-top: 18px; border-top: 1px solid var(--line);
+    font-family: 'Avenir Next', 'Segoe UI', sans-serif;
+    font-size: 13px; color: var(--muted);
+  }
+  footer a { color: var(--steel); text-decoration: none; }
+  footer a:hover { text-decoration: underline; }
+
+  /* SVG text roles */
+  svg { color: var(--ink); }
+  svg text {
+    font-family: 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
+  }
+  .sv-title { font-size: 14px; font-weight: 600; fill: currentColor; }
+  .sv-body  { font-size: 11.5px; fill: var(--muted); }
+  .sv-label { font-size: 10.5px; font-weight: 600; letter-spacing: 0.08em; fill: var(--muted); }
+  .sv-flow  { font-size: 11px; font-weight: 600; fill: var(--steel); }
+  .sv-sec   { font-size: 11px; font-weight: 600; fill: var(--accent); }
+  .sv-guest { font-size: 11px; font-weight: 600; fill: var(--guest); }
+  .box      { fill: var(--surface); stroke: var(--line); stroke-width: 1.25; }
+  .box-soft { fill: var(--bg); stroke: var(--line-soft); stroke-width: 1; }
+
+  @media print {
+    body { background: #FFFFFF; }
+    .wrap { max-width: none; padding: 0 8px; }
+    .bar { display: none; }
+    figure, .pull, .notes li, .proof { break-inside: avoid; }
+    section { margin-top: 40px; }
+    .fig-scroll { overflow: visible; padding: 16px 8px; }
+    .fig-scroll svg { min-width: 0; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="bar">
+    <a class="brand" href="/">mvm</a>
+    <nav>
+      <a href="#stack">The stack</a>
+      <a href="#company">Inside a company</a>
+      <a href="/docs">Docs</a>
+      <a href="https://github.com/tinylabscom/mvm">GitHub</a>
+    </nav>
+  </div>
+
+  <header>
+    <p class="eyebrow">Architecture</p>
+    <h1>A secure execution layer for the code you can't fully trust</h1>
+    <p class="lede">MVM runs any workload — an AI agent, a customer's code, a build job — inside a <strong>sealed, immutable, hardware-isolated microVM</strong>, on the laptop and in the fleet, with the security posture <strong>enforced by CI, not promised in a slide</strong>.</p>
+
+    <div class="proof">
+      <div><b>15 + 3</b><span>security claims, CI-enforced</span></div>
+      <div><b>~4,350</b><span>tests on every merge</span></div>
+      <div><b>3 + 1</b><span>hypervisors + Wasm, one CLI</span></div>
+      <div><b>0</b><span>containers, SSH daemons, guest NICs</span></div>
+    </div>
+  </header>
+
+  <!-- ============ VIEW 1: THE STACK ============ -->
+  <section id="stack">
+    <p class="kicker">View 1 · Zoom in</p>
+    <h2>The MVM stack, top to bottom</h2>
+    <p>Everything on the left runs on the host and is trusted. Everything on the right runs in the guest and is not. The only wire between them is <strong>vsock</strong> — the guest has no network card at all, so every byte that leaves it passes through host-side policy.</p>
+
+    <figure>
+      <div class="fig-scroll">
+      <svg viewBox="0 0 960 560" role="img" aria-label="MVM layered architecture: developer surface, signed admission, runtime, and an interchangeable backend seam (Firecracker, libkrun, HVF, and a lightweight Wasm tier) on the trusted host; a sealed immutable no-NIC microVM guest connected only by vsock, with all egress passing through a default-deny gate on the host.">
+        <defs>
+          <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+          </marker>
+          <marker id="arr-steel" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="var(--steel)"/>
+          </marker>
+          <marker id="arr-sec" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="var(--accent)"/>
+          </marker>
+        </defs>
+
+        <!-- zone labels -->
+        <text x="330" y="26" text-anchor="middle" class="sv-label">TRUSTED HOST · macOS / LINUX</text>
+        <text x="790" y="26" text-anchor="middle" class="sv-guest" style="letter-spacing:0.08em; font-size:10.5px;">UNTRUSTED GUEST</text>
+        <line x1="618" y1="14" x2="618" y2="546" stroke="var(--line)" stroke-width="1" stroke-dasharray="3 5"/>
+
+        <!-- audit rail -->
+        <line x1="52" y1="118" x2="52" y2="452" stroke="var(--accent)" stroke-width="2.5"/>
+        <circle cx="52" cy="146" r="3.5" fill="var(--accent)"/>
+        <circle cx="52" cy="226" r="3.5" fill="var(--accent)"/>
+        <circle cx="52" cy="452" r="3.5" fill="var(--accent)"/>
+        <text transform="rotate(-90 38 285)" x="38" y="285" text-anchor="middle" class="sv-sec" style="letter-spacing:0.08em; font-size:10px;">CHAIN-SIGNED AUDIT LOG</text>
+
+        <!-- L1: developer surface -->
+        <a href="#note-surface" aria-label="Jump to: Developer surface">
+          <rect x="84" y="40" width="492" height="58" rx="4" class="box"/>
+          <text x="100" y="64" class="sv-title">1 · Developer surface</text>
+          <text x="100" y="84" class="sv-body">mvmctl CLI · language SDKs — code in, workload spec out</text>
+        </a>
+
+        <!-- arrow down -->
+        <line x1="330" y1="98" x2="330" y2="118" stroke="currentColor" stroke-width="1.25" marker-end="url(#arr)"/>
+
+        <!-- L2: admission (accent) -->
+        <a href="#note-admission" aria-label="Jump to: Signed admission">
+          <rect x="84" y="120" width="492" height="66" rx="4" fill="var(--accent-soft)" stroke="var(--accent)" stroke-width="1.5"/>
+          <text x="100" y="145" class="sv-title">2 · Signed admission</text>
+          <text x="100" y="165" class="sv-body">Every run becomes a signed ExecutionPlan — verified, policy-checked,</text>
+          <text x="100" y="180" class="sv-body">replay-proof — before anything boots</text>
+        </a>
+
+        <line x1="330" y1="186" x2="330" y2="206" stroke="currentColor" stroke-width="1.25" marker-end="url(#arr)"/>
+
+        <!-- L3: runtime -->
+        <a href="#note-runtime" aria-label="Jump to: Runtime orchestration">
+          <rect x="84" y="208" width="492" height="58" rx="4" class="box"/>
+          <text x="100" y="232" class="sv-title">3 · Runtime orchestration</text>
+          <text x="100" y="252" class="sv-body">VM lifecycle · templates · checkpoints · one funnel every workload boots through</text>
+        </a>
+
+        <line x1="330" y1="266" x2="330" y2="286" stroke="currentColor" stroke-width="1.25" marker-end="url(#arr)"/>
+
+        <!-- L4: backend seam -->
+        <a href="#note-backends" aria-label="Jump to: Backend seam">
+          <rect x="84" y="288" width="492" height="104" rx="4" class="box"/>
+          <text x="100" y="312" class="sv-title">4 · Backend seam — one interface, interchangeable engines</text>
+          <rect x="100" y="326" width="106" height="50" rx="3" class="box-soft"/>
+          <text x="153" y="347" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">Firecracker</text>
+          <text x="153" y="364" text-anchor="middle" class="sv-body">Linux · KVM</text>
+          <rect x="218" y="326" width="106" height="50" rx="3" class="box-soft"/>
+          <text x="271" y="347" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">libkrun</text>
+          <text x="271" y="364" text-anchor="middle" class="sv-body">macOS 13–25</text>
+          <rect x="336" y="326" width="106" height="50" rx="3" class="box-soft"/>
+          <text x="389" y="347" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">HVF</text>
+          <text x="389" y="364" text-anchor="middle" class="sv-body">macOS 26+</text>
+          <rect x="454" y="326" width="106" height="50" rx="3" class="box-soft" stroke-dasharray="4 3"/>
+          <text x="507" y="347" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">Wasm</text>
+          <text x="507" y="364" text-anchor="middle" class="sv-body">lightweight tier</text>
+        </a>
+
+        <!-- L5: host OS -->
+        <rect x="84" y="412" width="492" height="44" rx="4" class="box-soft"/>
+        <text x="330" y="439" text-anchor="middle" class="sv-body">Host OS — Apple Silicon Mac or Linux/KVM · no Docker, no host Nix required</text>
+
+        <line x1="330" y1="392" x2="330" y2="412" stroke="currentColor" stroke-width="1.25" marker-end="url(#arr)"/>
+
+        <!-- Guest: sealed microVM -->
+        <a href="#note-guest" aria-label="Jump to: The sealed guest">
+          <rect x="660" y="60" width="262" height="270" rx="6" fill="var(--guest-soft)" stroke="var(--guest)" stroke-width="1.5"/>
+          <text x="676" y="88" class="sv-title">Sealed microVM</text>
+          <rect x="676" y="104" width="230" height="46" rx="3" class="box"/>
+          <text x="691" y="123" class="sv-body" style="font-weight:600; fill:currentColor;">Your workload</text>
+          <text x="691" y="140" class="sv-body">agent code · builds · customer jobs</text>
+          <rect x="676" y="160" width="230" height="40" rx="3" class="box"/>
+          <text x="691" y="178" class="sv-body" style="font-weight:600; fill:currentColor;">Guest agent</text>
+          <text x="691" y="193" class="sv-body">speaks only vsock, runs unprivileged</text>
+          <text x="676" y="228" class="sv-guest">✕ no network card</text>
+          <text x="676" y="248" class="sv-guest">✕ no SSH, no shell in production</text>
+          <text x="676" y="268" class="sv-guest">✕ no raw secrets in memory</text>
+          <text x="676" y="288" class="sv-guest">✓ immutable, tamper-proof rootfs</text>
+          <text x="676" y="308" class="sv-guest">✓ CPU / memory / wall-clock bounded</text>
+        </a>
+
+        <!-- vsock link -->
+        <line x1="576" y1="340" x2="656" y2="340" stroke="var(--steel)" stroke-width="2" marker-end="url(#arr-steel)" marker-start="url(#arr-steel)"/>
+        <text x="616" y="330" text-anchor="middle" class="sv-flow">vsock only</text>
+
+        <!-- egress path -->
+        <a href="#note-guest" aria-label="Jump to: The sealed guest — egress gate">
+          <rect x="660" y="400" width="262" height="56" rx="4" fill="var(--accent-soft)" stroke="var(--accent)" stroke-width="1.5"/>
+          <text x="676" y="423" class="sv-title" style="font-size:13px;">Egress gate · default-deny</text>
+          <text x="676" y="441" class="sv-body">host opens every connection, signs secrets in</text>
+        </a>
+        <path d="M 791 330 L 791 396" stroke="var(--accent)" stroke-width="1.5" fill="none" marker-end="url(#arr-sec)"/>
+        <text x="800" y="368" class="sv-sec">outbound request</text>
+        <text x="800" y="382" class="sv-sec">over vsock</text>
+        <line x1="791" y1="456" x2="791" y2="500" stroke="var(--accent)" stroke-width="1.5" marker-end="url(#arr-sec)"/>
+        <text x="800" y="483" class="sv-sec">policy-admitted only</text>
+        <text x="791" y="522" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">Internet / approved endpoints</text>
+      </svg>
+      </div>
+      <figcaption>Fig. 1 — The MVM stack today. The guest boots with no network device; its only channel is vsock to the host, so authorization, secret substitution, and audit all happen at one enforced chokepoint. <span class="hint">Click a layer to jump to its explanation.</span></figcaption>
+    </figure>
+
+    <ol class="notes">
+      <li id="note-surface"><span class="tick">1</span><div>
+        <h3>Developer surface</h3>
+        <p>One CLI (<strong>mvmctl</strong>) and language SDKs. A developer points MVM at code, a flake, or an OCI image and gets a running microVM — same commands on a MacBook and a Linux server. No Docker anywhere in the path.</p>
+      </div></li>
+      <li class="sec" id="note-admission"><span class="tick">2</span><div>
+        <h3>Signed admission — the security plane starts here</h3>
+        <p>Nothing boots ad-hoc. Every run is compiled into a <strong>cryptographically signed ExecutionPlan</strong>, verified, checked against policy, and recorded in a <strong>chain-signed audit log</strong> — tamper with the log and verification breaks. Image provenance, dependency scans (SBOM + CVE), and secret bindings all attach at this step.</p>
+      </div></li>
+      <li id="note-runtime"><span class="tick">3</span><div>
+        <h3>Runtime orchestration</h3>
+        <p>Lifecycle, reusable templates, and checkpoints. Critically, there is <strong>one funnel every workload boots through</strong> — a backend can't grow a side door, and CI has lint gates that fail the build if one appears.</p>
+      </div></li>
+      <li id="note-backends"><span class="tick">4</span><div>
+        <h3>Backend seam — the portability story</h3>
+        <p>Interchangeable engines behind one interface: <strong>Firecracker</strong> (the AWS Lambda hypervisor) on Linux, <strong>libkrun</strong> on older Macs, our <strong>in-house Hypervisor.framework VMM</strong> on modern Apple Silicon — byte-identical artifacts across all three, with automatic fallback — plus an emerging <strong>Wasm tier</strong> for workloads that don't need a full VM. This is why "works on the laptop, ships to the fleet" is real, and why new isolation technologies slot in without rewriting the product.</p>
+      </div></li>
+      <li class="sec" id="note-guest"><span class="tick">G</span><div>
+        <h3>The sealed guest — immutable by construction</h3>
+        <p>The workload runs in a hardware-isolated VM booted from an <strong>immutable, cryptographically verified image</strong> — flip a single block on disk and it refuses to boot, so there is no drift and no snowflake state; a new run is always a fresh, identical VM. No network card, no SSH, resource ceilings enforced at admission. Secrets never enter the guest — the host substitutes short-lived signed credentials into outbound requests at the egress gate, so a fully compromised workload still can't exfiltrate a raw key.</p>
+      </div></li>
+    </ol>
+
+    <div class="pull">
+      <p>The differentiator isn't any one layer — it's that <strong>every security claim is wired to an automated check</strong>. Fifteen numbered claims (plus three in preview) each point to a specific test or CI gate that proves it still holds; delete that test and the build fails.</p>
+      <p>In most products a security guarantee can quietly rot after a refactor. Here, the rot shows up as a red build — the posture can't silently drift from the pitch.</p>
+    </div>
+  </section>
+
+  <!-- ============ VIEW 2: THE COMPANY ============ -->
+  <section id="company">
+    <p class="kicker">View 2 · Zoom out</p>
+    <h2>Where MVM sits inside a company</h2>
+    <p>MVM slots in as the <strong>execution layer</strong> between the systems a company trusts and the code it doesn't. Work arrives from developers, CI, and AI agents; trusted systems plug into the host side; only policy-admitted traffic ever leaves.</p>
+
+    <figure>
+      <div class="fig-scroll">
+      <svg viewBox="0 0 960 540" role="img" aria-label="MVM as the execution layer inside a company: developers, CI, and AI agent platforms submit work as signed plans; the image registry and secrets manager connect on the trusted host side; sealed microVMs run inside; audit events flow to compliance systems and only policy-admitted egress reaches external services.">
+        <defs>
+          <marker id="arr2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="var(--steel)"/>
+          </marker>
+          <marker id="arr2-sec" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="var(--accent)"/>
+          </marker>
+        </defs>
+
+        <!-- Sources (left) -->
+        <a href="#note-wedge" aria-label="Jump to: The wedge — where work comes from">
+          <text x="118" y="78" text-anchor="middle" class="sv-label">WHERE WORK COMES FROM</text>
+          <rect x="40" y="94" width="156" height="52" rx="4" class="box"/>
+          <text x="118" y="115" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">Developers</text>
+          <text x="118" y="132" text-anchor="middle" class="sv-body">laptops · mvmctl · SDKs</text>
+          <rect x="40" y="162" width="156" height="52" rx="4" class="box"/>
+          <text x="118" y="183" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">CI / CD</text>
+          <text x="118" y="200" text-anchor="middle" class="sv-body">build &amp; test jobs</text>
+          <rect x="40" y="230" width="156" height="52" rx="4" class="box"/>
+          <text x="118" y="251" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">AI agent platforms</text>
+          <text x="118" y="268" text-anchor="middle" class="sv-body">autonomous code, sandboxed</text>
+        </a>
+
+        <!-- arrows in -->
+        <line x1="196" y1="120" x2="286" y2="168" stroke="var(--steel)" stroke-width="1.5" marker-end="url(#arr2)"/>
+        <line x1="196" y1="188" x2="286" y2="192" stroke="var(--steel)" stroke-width="1.5" marker-end="url(#arr2)"/>
+        <line x1="196" y1="256" x2="286" y2="216" stroke="var(--steel)" stroke-width="1.5" marker-end="url(#arr2)"/>
+        <text x="241" y="152" text-anchor="middle" class="sv-flow">signed plans</text>
+
+        <!-- Trusted inputs (top) -->
+        <a href="#note-plugs" aria-label="Jump to: Plugs into what exists">
+          <text x="475" y="40" text-anchor="middle" class="sv-label">TRUSTED COMPANY SYSTEMS</text>
+          <rect x="316" y="54" width="150" height="46" rx="4" class="box"/>
+          <text x="391" y="73" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">Image registry</text>
+          <text x="391" y="90" text-anchor="middle" class="sv-body">digest-pinned OCI</text>
+          <rect x="484" y="54" width="150" height="46" rx="4" class="box"/>
+          <text x="559" y="73" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">Secrets manager</text>
+          <text x="559" y="90" text-anchor="middle" class="sv-body">keys stay host-side</text>
+        </a>
+        <line x1="391" y1="100" x2="391" y2="140" stroke="var(--steel)" stroke-width="1.5" marker-end="url(#arr2)"/>
+        <text x="399" y="126" class="sv-flow">verified pulls</text>
+        <line x1="559" y1="100" x2="559" y2="140" stroke="var(--accent)" stroke-width="1.5" marker-end="url(#arr2-sec)"/>
+        <text x="567" y="126" class="sv-sec">brokered, never raw</text>
+
+        <!-- MVM core -->
+        <rect x="290" y="144" width="380" height="266" rx="6" fill="var(--steel-soft)" stroke="var(--steel)" stroke-width="1.5"/>
+        <text x="310" y="174" class="sv-title" style="font-size:16px;">MVM · execution layer</text>
+        <text x="310" y="193" class="sv-body">admission → policy → sealed microVMs</text>
+
+        <rect x="310" y="210" width="106" height="62" rx="3" class="box"/>
+        <rect x="426" y="210" width="106" height="62" rx="3" class="box"/>
+        <rect x="542" y="210" width="106" height="62" rx="3" class="box"/>
+        <rect x="310" y="282" width="106" height="62" rx="3" class="box"/>
+        <rect x="426" y="282" width="106" height="62" rx="3" class="box"/>
+        <rect x="542" y="282" width="106" height="62" rx="3" class="box-soft" stroke-dasharray="4 3"/>
+        <text x="363" y="238" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">agent run</text>
+        <text x="363" y="255" text-anchor="middle" class="sv-guest">sealed VM</text>
+        <text x="479" y="238" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">customer job</text>
+        <text x="479" y="255" text-anchor="middle" class="sv-guest">sealed VM</text>
+        <text x="595" y="238" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">build</text>
+        <text x="595" y="255" text-anchor="middle" class="sv-guest">sealed VM</text>
+        <text x="363" y="310" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">eval suite</text>
+        <text x="363" y="327" text-anchor="middle" class="sv-guest">sealed VM</text>
+        <text x="479" y="310" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">untrusted PR</text>
+        <text x="479" y="327" text-anchor="middle" class="sv-guest">sealed VM</text>
+        <text x="595" y="314" text-anchor="middle" class="sv-body">…per-workload,</text>
+        <text x="595" y="330" text-anchor="middle" class="sv-body">hardware-isolated</text>
+
+        <text x="480" y="380" text-anchor="middle" class="sv-body">One VM = one workload · no shared kernel</text>
+        <text x="480" y="396" text-anchor="middle" class="sv-body">admission-bounded resources</text>
+
+        <!-- substrate -->
+        <a href="#note-fleet" aria-label="Jump to: Laptop to fleet is one product">
+          <rect x="290" y="428" width="380" height="46" rx="4" class="box-soft"/>
+          <text x="480" y="447" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">Runs on what the company already owns</text>
+          <text x="480" y="464" text-anchor="middle" class="sv-body">developer Macs · CI runners · Linux servers (fleet via mvmd)</text>
+        </a>
+        <line x1="480" y1="410" x2="480" y2="428" stroke="currentColor" stroke-width="1" stroke-dasharray="2 3"/>
+
+        <!-- Outputs (right) -->
+        <text x="836" y="128" text-anchor="middle" class="sv-label">WHAT COMES OUT</text>
+        <a href="#note-plugs" aria-label="Jump to: Plugs into what exists — audit and compliance">
+          <rect x="758" y="144" width="162" height="60" rx="4" fill="var(--accent-soft)" stroke="var(--accent)" stroke-width="1.5"/>
+          <text x="839" y="167" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">Audit &amp; compliance</text>
+          <text x="839" y="184" text-anchor="middle" class="sv-body">SIEM · tamper-evident</text>
+          <text x="839" y="198" text-anchor="middle" class="sv-body">chain-signed trail</text>
+        </a>
+        <line x1="670" y1="182" x2="754" y2="176" stroke="var(--accent)" stroke-width="1.5" marker-end="url(#arr2-sec)"/>
+        <text x="712" y="166" text-anchor="middle" class="sv-sec">every event</text>
+
+        <rect x="758" y="256" width="162" height="60" rx="4" class="box"/>
+        <text x="839" y="279" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">External services</text>
+        <text x="839" y="296" text-anchor="middle" class="sv-body">APIs · model providers</text>
+        <text x="839" y="310" text-anchor="middle" class="sv-body">package registries</text>
+        <line x1="670" y1="286" x2="754" y2="286" stroke="var(--accent)" stroke-width="1.5" marker-end="url(#arr2-sec)"/>
+        <text x="712" y="276" text-anchor="middle" class="sv-sec">default-deny</text>
+        <text x="712" y="302" text-anchor="middle" class="sv-sec" style="font-size:10px;">policy-admitted only</text>
+
+        <rect x="758" y="368" width="162" height="60" rx="4" class="box"/>
+        <text x="839" y="391" text-anchor="middle" class="sv-body" style="font-weight:600; fill:currentColor;">Results &amp; artifacts</text>
+        <text x="839" y="408" text-anchor="middle" class="sv-body">outputs, checkpoints,</text>
+        <text x="839" y="422" text-anchor="middle" class="sv-body">reusable templates</text>
+        <line x1="670" y1="392" x2="754" y2="396" stroke="var(--steel)" stroke-width="1.5" marker-end="url(#arr2)"/>
+      </svg>
+      </div>
+      <figcaption>Fig. 2 — MVM as company infrastructure. Trusted systems (registry, secrets) attach on the host side of the boundary; untrusted code runs inside it; the only outbound paths are the audited egress gate and the results themselves. <span class="hint">Click a group to jump to its explanation.</span></figcaption>
+    </figure>
+
+    <ol class="notes">
+      <li id="note-wedge"><span class="tick">A</span><div>
+        <h3>The wedge: AI agents made this urgent</h3>
+        <p>Companies are handing autonomous agents the ability to write and execute code. Containers share the host kernel; a microVM doesn't. MVM gives each agent run a disposable hardware boundary <strong>with an audit trail</strong> — the thing a CISO asks for before agents touch production-adjacent systems.</p>
+      </div></li>
+      <li id="note-plugs"><span class="tick">B</span><div>
+        <h3>Plugs into what exists</h3>
+        <p>MVM doesn't replace the registry, the secrets manager, or the SIEM — it <strong>connects them on the trusted side of the boundary</strong>. Images are digest-pinned and signature-verified on pull; secrets are brokered per-request; audit events are ready for compliance tooling.</p>
+      </div></li>
+      <li id="note-fleet"><span class="tick">C</span><div>
+        <h3>Laptop to fleet is one product</h3>
+        <p>The same CLI and the same artifacts run on a developer's Mac and on Linux servers. The companion <strong>mvmd</strong> project extends this into multi-tenant fleet orchestration — pools, tenants, coordinators — which is the expansion path from single-developer tool to platform contract.</p>
+      </div></li>
+    </ol>
+
+    <div class="pull">
+      <p><strong>The one-sentence version:</strong> MVM is the layer where a company runs code it can't fully trust — AI agents, customer workloads, third-party dependencies — with hardware isolation, immutable execution, cryptographic admission, and a tamper-evident audit trail, from a single laptop to a fleet.</p>
+    </div>
+  </section>
+
+  <footer>
+    Every security property on this page is backed by a named test or CI gate in the <a href="https://github.com/tinylabscom/mvm">mvm repository</a>. Fleet orchestration is the companion <a href="https://github.com/tinylabscom/mvmd">mvmd</a> project. · <a href="/docs">Read the docs</a>
+  </footer>
+</div>
+</body>
+</html>

--- a/public/src/overrides/Header.astro
+++ b/public/src/overrides/Header.astro
@@ -11,6 +11,7 @@ const base = import.meta.env.BASE_URL;
 const b = base.endsWith("/") ? base : `${base}/`;
 const navLinks = [
   { label: "Docs", href: `${b}getting-started/installation/` },
+  { label: "Architecture", href: `${b}architecture.html` },
   { label: "Pricing", href: `${b}pricing/` },
   { label: "Request access", href: `${b}#request-access` },
 ];


### PR DESCRIPTION
## Summary

- Adds a self-contained static page at `/architecture.html` (served from `public/public/`, no build wiring) with two hand-drawn SVG diagrams: the MVM stack top to bottom (host layers, backend seam, sealed guest, vsock-only egress path) and MVM as the execution layer inside a company's systems.
- Diagram regions are clickable — each layer/group anchor-links to its explanation, which highlights via `:target`. Pure HTML/CSS, no JavaScript.
- Light and dark themes via `prefers-color-scheme`, print styles, OpenGraph tags.
- Adds an "Architecture" entry to the landing header's shared `navLinks` array in `src/overrides/Header.astro`, so the link appears in both the desktop and mobile menus.

## Notes for review

- Content is additive only — no existing landing copy or docs changed.
- "Architecture" now appears twice on the site with different destinations: this new top-nav one-pager and the existing footer link to `/architecture/overview/` (docs). Flagging in case you want the nav label renamed (e.g. "How it works").
- The Wasm backend is drawn as a dashed "lightweight tier" box and described as "emerging" — it exists behind the backend seam but is not on the secured workload funnel, so the page deliberately doesn't claim the sealed-VM guarantees for it.

## Test plan

- Verified the page renders standalone in headless Chrome (both figures, both themes' token sets, no text overflowing its containers).
- Booted `astro dev` and confirmed the homepage renders the "Architecture" link in the desktop nav and mobile hamburger menu, pointing at `/architecture.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)