### PR TITLE
fix(security): declare xtask license

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.0.0"
 edition.workspace = true
+license.workspace = true
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Declare the workspace license for the non-published xtask package so cargo-deny license checks do not reject the current main dependency graph.