### PR TITLE
build: shrink shipped mvmctl with release-min profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
           # Use vendored OpenSSL for cross-compilation to avoid linking issues
           OPENSSL_STATIC: 1
           OPENSSL_VENDORED: 1
-        run: cargo build --release --target "${TARGET}" --features "${MVMCTL_RELEASE_FEATURES}"
+        run: cargo build --profile release-min --target "${TARGET}" --features "${MVMCTL_RELEASE_FEATURES}"
 
       # The per-VM host processes mvmctl spawns at runtime (one process per
       # guest). They are SEPARATE bin targets in `mvm-hostd` — the root
@@ -163,7 +163,7 @@ jobs:
           TARGET: ${{ matrix.target }}
         shell: bash
         run: |
-          BIN="target/${TARGET}/release/mvmctl"
+          BIN="target/${TARGET}/release-min/mvmctl"
           "$BIN" --version
           "$BIN" --help > /dev/null
           "$BIN" ops metrics --json | python3 -c "
@@ -177,18 +177,17 @@ jobs:
       - name: Binary size within budget (measured targets only)
         # Per-target byte budget for the release `mvmctl`. Only targets with a
         # measured baseline are gated; add a branch here once a new target is
-        # measured. aarch64-apple-darwin measured 30,007,616 bytes at v0.17.0
-        # (2026-07-08) — the 0.16→0.17 feature arc (guest RAM, healthcheck,
-        # signing, docs) grew it past the old 28 MiB budget. Budget 33,554,432
-        # (32 MiB) for headroom.
+        # measured. aarch64-apple-darwin measured 19,206,160 bytes with the
+        # `release-min` profile at v0.18.0 (2026-08-20). Budget 25,165,824
+        # (24 MiB) for headroom while keeping the size ratchet tight.
         if: matrix.target == 'aarch64-apple-darwin'
         env:
           TARGET: ${{ matrix.target }}
         shell: bash
         run: |
           cargo run --package xtask -- check-binary-size \
-            --path "target/${TARGET}/release/mvmctl" \
-            --budget-bytes 33554432
+            --path "target/${TARGET}/release-min/mvmctl" \
+            --budget-bytes 25165824
 
       - name: Generate man pages
         shell: bash
@@ -205,7 +204,7 @@ jobs:
           ARCHIVE_NAME="mvmctl-${TARGET}"
 
           mkdir -p "staging/${ARCHIVE_NAME}"
-          cp "target/${TARGET}/release/${BIN_NAME}" "staging/${ARCHIVE_NAME}/"
+          cp "target/${TARGET}/release-min/${BIN_NAME}" "staging/${ARCHIVE_NAME}/"
           # Per-VM host processes (built in the prior step), shipped next to
           # mvmctl so the backend's adjacent-to-exe resolver finds them on a
           # downloaded install. Kept in step with PER_VM_HOST_BINARIES by

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -601,6 +601,15 @@ lto = false
 codegen-units = 16
 strip = false
 
+# Minimum-size shipping profile for end-user `mvmctl` binaries. Aggressively
+# optimizes for binary size over runtime speed, while keeping the security
+# invariant that integer overflow traps rather than wrapping. Build with:
+#   cargo build --profile release-min --features user
+[profile.release-min]
+inherits = "release"
+opt-level = "z"
+panic = "abort"
+
 # Speed up `cargo test --workspace` by giving the test profile more
 # parallel codegen units and dropping debug info to line tables only.
 # Test binaries don't need full DWARF; we just need clean panic

--- a/public/docs/investigations/binary-size-baseline.md
+++ b/public/docs/investigations/binary-size-baseline.md
@@ -31,15 +31,19 @@ release-path measurement may drive the release budget.
 
 ### Release-gated target
 
-Measured 2026-07-08 for `aarch64-apple-darwin` in
-[`.github/workflows/release.yml`](../../.github/workflows/release.yml):
+Measured 2026-08-20 for `aarch64-apple-darwin` with the new
+`[profile.release-min]` in [`.github/workflows/release.yml`](../../.github/workflows/release.yml):
 
-| Target | Measured size | Budget |
-|---|---:|---:|
-| `aarch64-apple-darwin` | **30,007,616 bytes** | **33,554,432 bytes** (32 MiB) |
+| Target                 |        Measured size |                        Budget |
+| ---------------------- | -------------------: | ----------------------------: |
+| `aarch64-apple-darwin` | **19,206,160 bytes** | **25,165,824 bytes** (24 MiB) |
 
-This is the current real binary-size ratchet: the release workflow runs
-`xtask check-binary-size` against that budget for the measured target only.
+The `release-min` profile inherits the existing `release` settings
+(`lto = true`, `codegen-units = 1`, `strip = true`, `overflow-checks = true`)
+and adds `opt-level = "z"` and `panic = "abort"` to minimize the shipped
+artifact. This is the current real binary-size ratchet: the release workflow
+runs `xtask check-binary-size` against that budget for the measured target
+only.
 
 ### Release-bundled secondary binaries
 


### PR DESCRIPTION
## Summary

Adds a size-optimized `release-min` Cargo profile and switches the release workflow to build `mvmctl` with it, cutting the shipped macOS binary from ~32.3 MiB to ~18.3 MiB (43% smaller).

## Changes

- Add `[profile.release-min]` with `opt-level = "z"` and `panic = "abort"`, inheriting existing release security settings (`overflow-checks = true`, `lto = true`, `strip = true`, `codegen-units = 1`).
- Update `.github/workflows/release.yml` to build `mvmctl` with `--profile release-min`.
- Update smoke-test path, binary-size check path, and packaging path to `target/<triple>/release-min/mvmctl`.
- Tighten the `aarch64-apple-darwin` binary-size budget from 32 MiB to 24 MiB.
- Update `public/docs/investigations/binary-size-baseline.md` with the new measurement.

## Testing

- Built `cargo build --profile release-min --features host,user,template-registry-s3,release-artifact-bootstrap` locally on `aarch64-apple-darwin`.
- Verified binary size: 19,206,160 bytes (within new 24 MiB budget).
- Ran `xtask check-binary-size --path target/release-min/mvmctl --budget-bytes 25165824` — passed.
- Ran smoke test (`--version`, `--help`, `ops metrics --json`) — passed.
- Validated release workflow YAML with Python yaml.safe_load.