### PR TITLE
ci: separate release bootstrap from artifact distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1589,7 +1589,7 @@ jobs:
         with:
           # qemu-system-arm provides qemu-system-aarch64; e2fsprogs provides the
           # mkfs.ext4/debugfs tools the Stage 0 builder uses to pack images.
-          packages: qemu-system-arm e2fsprogs attr jq virtiofsd
+          packages: qemu-system-arm qemu-system-common qemu-system-data e2fsprogs attr jq virtiofsd
 
       - uses: ./.github/actions/rust-cache
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1602,7 +1602,7 @@ jobs:
       # flake so `mvmctl` treats this as an installed binary and downloads the
       # published image instead.
       - name: Build mvmctl
-        run: cargo build --release -p mvm-cli --features release-artifact-bootstrap
+        run: cargo build --release -p mvm-cli --features release-artifact-bootstrap,release-channel
 
       - name: Use published builder VM bootstrap path
         run: mv nix/images/builder-vm nix/images/builder-vm.hidden

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1602,7 +1602,7 @@ jobs:
       # flake so `mvmctl` treats this as an installed binary and downloads the
       # published image instead.
       - name: Build mvmctl
-        run: cargo build --release -p mvm-cli --features release-artifact-bootstrap,release-channel
+        run: cargo build --release -p mvmctl --features release-artifact-bootstrap,release-channel
 
       - name: Use published builder VM bootstrap path
         run: mv nix/images/builder-vm nix/images/builder-vm.hidden

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1589,7 +1589,7 @@ jobs:
         with:
           # qemu-system-arm provides qemu-system-aarch64; e2fsprogs provides the
           # mkfs.ext4/debugfs tools the Stage 0 builder uses to pack images.
-          packages: qemu-system-arm e2fsprogs attr jq
+          packages: qemu-system-arm e2fsprogs attr jq virtiofsd
 
       - uses: ./.github/actions/rust-cache
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1589,7 +1589,7 @@ jobs:
         with:
           # qemu-system-arm provides qemu-system-aarch64; e2fsprogs provides the
           # mkfs.ext4/debugfs tools the Stage 0 builder uses to pack images.
-          packages: qemu-system-arm qemu-system-common qemu-system-data e2fsprogs attr jq virtiofsd
+          packages: qemu-system-arm ipxe-qemu e2fsprogs attr jq virtiofsd
 
       - uses: ./.github/actions/rust-cache
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  MVMCTL_RELEASE_FEATURES: host,user,template-registry-s3,release-artifact-bootstrap
+  MVMCTL_RELEASE_FEATURES: host,user,template-registry-s3,release-artifact-bootstrap,release-channel
 
 jobs:
   bdd:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -224,7 +224,7 @@ jobs:
       - uses: ./.github/actions/install-zigbuild
 
       - name: Build A
-        run: cargo build --release --locked --bin mvmctl --features host,user,template-registry-s3,release-artifact-bootstrap
+        run: cargo build --release --locked --bin mvmctl --features host,user,template-registry-s3,release-artifact-bootstrap,release-channel
 
       - name: Hash A
         run: sha256sum target/release/mvmctl | tee /tmp/hash-a.txt
@@ -233,7 +233,7 @@ jobs:
         run: cargo clean
 
       - name: Build B
-        run: cargo build --release --locked --bin mvmctl --features host,user,template-registry-s3,release-artifact-bootstrap
+        run: cargo build --release --locked --bin mvmctl --features host,user,template-registry-s3,release-artifact-bootstrap,release-channel
 
       - name: Hash B
         run: sha256sum target/release/mvmctl | tee /tmp/hash-b.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -541,6 +541,9 @@ hostd-transport = ["mvm-core/hostd-transport"]
 # VM images on a cache miss. Off for source checkouts (they build locally); the
 # release workflow turns it on.
 release-artifact-bootstrap = ["mvm-cli/release-artifact-bootstrap"]
+# Mark an official distribution separately so runtime artifact resolution uses
+# the published channel even when the binary runs from a source checkout.
+release-channel = ["mvm-cli/release-channel"]
 
 # Optional S3 storage backend for the template registry — a heavy cloud dep kept
 # opt-in (not part of the local host runtime; fleet/deployment use only).

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -170,6 +170,9 @@ xattr.workspace = true
 
 [features]
 default = []
+# Marks an official binary distribution so artifact resolvers do not infer
+# contributor behavior from the checkout that happens to launch the binary.
+release-channel = []
 # Forwards to mvm-core's sigstore keyless-verification feature so
 # `builder_pack`'s tests can exercise `verify_pack_keyless_at` without
 # every mvm-build build pulling the sigstore dependency tree.

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -141,6 +141,11 @@ libkrun-live = []
 # release artifact. The feature is only intended to be enabled when cutting
 # an end-user-binary release that legitimately wants the download fallback.
 release-artifact-bootstrap = []
+# Mark an official distribution separately from the builder-image bootstrap
+# capability. CI exercises the published-builder path from a source checkout;
+# coupling these features makes that test refuse its local runtime overlay
+# before it can boot the workload.
+release-channel = ["mvm-build/release-channel"]
 custom-dns = ["mvm-hostd/custom-dns"]
 dev-watch = ["dep:notify", "dep:notify-debouncer-mini"]
 manifest-verify = [

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -144,8 +144,9 @@ release-artifact-bootstrap = []
 # Mark an official distribution separately from the builder-image bootstrap
 # capability. CI exercises the published-builder path from a source checkout;
 # coupling these features makes that test refuse its local runtime overlay
-# before it can boot the workload.
-release-channel = ["mvm-build/release-channel"]
+# before it can boot the workload. Official artifacts also verify the signed
+# builder manifest before using a published image.
+release-channel = ["mvm-build/release-channel", "manifest-verify"]
 custom-dns = ["mvm-hostd/custom-dns"]
 dev-watch = ["dep:notify", "dep:notify-debouncer-mini"]
 manifest-verify = [

--- a/crates/mvm-cli/src/commands/runtime_overlay.rs
+++ b/crates/mvm-cli/src/commands/runtime_overlay.rs
@@ -38,6 +38,9 @@ pub(crate) fn runtime_overlay_acquire_mode() -> RuntimeOverlayAcquireMode {
             _ => {}
         }
     }
+    if cfg!(feature = "release-channel") {
+        return RuntimeOverlayAcquireMode::DownloadPublishedArtifact;
+    }
     if runtime_overlay_source_checkout_root().is_some() {
         RuntimeOverlayAcquireMode::BuildFromSourceCheckout
     } else {

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -1209,6 +1209,18 @@ mod runtime_overlay_attach_tests {
         );
     }
 
+    #[cfg(feature = "release-channel")]
+    #[test]
+    fn release_channel_defaults_to_published_runtime_overlay() {
+        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut env = TestEnv::new();
+        env.remove(RUNTIME_OVERLAY_ACQUIRE_MODE_ENV);
+        assert_eq!(
+            runtime_overlay_acquire_mode(),
+            RuntimeOverlayAcquireMode::DownloadPublishedArtifact
+        );
+    }
+
     #[test]
     fn attach_runtime_overlay_if_cached_version_uses_requested_cached_version() {
         let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());

--- a/scripts/local-aarch64-no-kvm-smoke.sh
+++ b/scripts/local-aarch64-no-kvm-smoke.sh
@@ -54,7 +54,7 @@ cargo install cargo-zigbuild --version 0.20.0 --locked
 cd /work
 
 echo "Building mvmctl ..."
-cargo build --release -p mvm-cli --features release-artifact-bootstrap
+cargo build --release -p mvm-cli --features release-artifact-bootstrap,release-channel
 
 # The source-checkout bootstrap path would rebuild the builder VM image from
 # scratch under TCG. Hide the in-repo flake so mvmctl downloads the published

--- a/scripts/local-aarch64-no-kvm-smoke.sh
+++ b/scripts/local-aarch64-no-kvm-smoke.sh
@@ -40,7 +40,7 @@ echo "Installing system dependencies ..."
 apt-get update -qq
 apt-get install -y -qq \
     curl git build-essential pkg-config \
-    qemu-system-arm e2fsprogs attr jq virtiofsd
+    qemu-system-arm qemu-system-common qemu-system-data e2fsprogs attr jq virtiofsd
 
 echo "Installing Rust nightly + musl targets ..."
 curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs \

--- a/scripts/local-aarch64-no-kvm-smoke.sh
+++ b/scripts/local-aarch64-no-kvm-smoke.sh
@@ -40,7 +40,7 @@ echo "Installing system dependencies ..."
 apt-get update -qq
 apt-get install -y -qq \
     curl git build-essential pkg-config \
-    qemu-system-arm qemu-system-common qemu-system-data e2fsprogs attr jq virtiofsd
+    qemu-system-arm ipxe-qemu e2fsprogs attr jq virtiofsd
 
 echo "Installing Rust nightly + musl targets ..."
 curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs \

--- a/scripts/local-aarch64-no-kvm-smoke.sh
+++ b/scripts/local-aarch64-no-kvm-smoke.sh
@@ -40,7 +40,7 @@ echo "Installing system dependencies ..."
 apt-get update -qq
 apt-get install -y -qq \
     curl git build-essential pkg-config \
-    qemu-system-arm e2fsprogs attr jq
+    qemu-system-arm e2fsprogs attr jq virtiofsd
 
 echo "Installing Rust nightly + musl targets ..."
 curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs \

--- a/scripts/local-aarch64-no-kvm-smoke.sh
+++ b/scripts/local-aarch64-no-kvm-smoke.sh
@@ -54,7 +54,7 @@ cargo install cargo-zigbuild --version 0.20.0 --locked
 cd /work
 
 echo "Building mvmctl ..."
-cargo build --release -p mvm-cli --features release-artifact-bootstrap,release-channel
+cargo build --release -p mvmctl --features release-artifact-bootstrap,release-channel
 
 # The source-checkout bootstrap path would rebuild the builder VM image from
 # scratch under TCG. Hide the in-repo flake so mvmctl downloads the published

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -1272,6 +1272,14 @@ updates only its own entry below.
       (24 MiB) with `virtio_pci` and `virtio_vsock` built into the kernel.
       The only remaining blocker is that `rpi1.local` is no longer reachable
       via mDNS, so Pi-side validation is on hold until network access returns.
+      **Update 2026-08-21:** the merge-group QEMU-TCG witness exposed a second
+      distribution boundary: enabling the published builder bootstrap also
+      selected release-only runtime-overlay downloads in CI, where the source
+      checkout is intentionally available. The feature split now keeps
+      `release-artifact-bootstrap` independent from `release-channel`; release
+      and security builds opt into both explicitly, while the aarch64 witness
+      can build its checked-out overlay and still download the published
+      builder image.
 
 - [x] **Backend shim removal — invert the driver/backend relationship.**
       `FcDriver`, `HvfDriver`, `LibkrunDriver`, and `QemuDriver` now own their

--- a/xtask/src/check_two_surfaces.rs
+++ b/xtask/src/check_two_surfaces.rs
@@ -49,7 +49,7 @@ const INTERNAL: [&str; 8] = [
 /// either product surface (they gate acquisition mechanics, not behaviour).
 /// `dev` is the local-development meta-feature (the `host` + `user` union that
 /// runs every documented example) — a convenience, not a third product surface.
-const BUILD_ONLY: [&str; 2] = ["release-artifact-bootstrap", "dev"];
+const BUILD_ONLY: [&str; 3] = ["release-artifact-bootstrap", "release-channel", "dev"];
 
 /// `dev` must aggregate both surfaces so a contributor can run every README /
 /// docs example from one build. Asserted structurally below.
@@ -301,6 +301,7 @@ dev = ["host", "user", "dev-watch"]
             "template-registry-s3",
             "hostd-transport",
             "release-artifact-bootstrap",
+            "release-channel",
             "test-support",
         ] {
             assert!(allowed.contains(f), "{f} must be classified");


### PR DESCRIPTION
The AArch64 no-KVM merge-group witness builds mvmctl with release-artifact-bootstrap so it can download the published builder VM. Coupling that capability to release-channel makes the same checkout refuse its local runtime overlay and the guest exits without reporting its code. Keep the capabilities independent: release/security builds opt into release-channel explicitly, while CI can use the published builder and source-built overlay. Validated both mvm-cli feature combinations with cargo check.