### PR TITLE
fix(vsock): stop stdout over ~25 KB from desyncing the control session

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/socket.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/socket.rs
@@ -78,7 +78,14 @@ pub(crate) fn write_response(file: &mut (impl Write + ?Sized), resp: &GuestRespo
     if let Err(error) = write_frame(file, selected) {
         // Do not append a fallback after an I/O error: the original frame may
         // already be partially written, so another prefix would corrupt it.
-        eprintln!("failed to write vsock response: {error}");
+        //
+        // Nothing is retried and the caller is not told, because there is
+        // nothing useful either could do: the sealed frame already spent its
+        // sequence number, so `AuthenticatedSession::write` has poisoned the
+        // session and no later frame on this connection can reach the host.
+        // The host learns of it as a closed connection, and this line is the
+        // only place the cause is recorded.
+        eprintln!("mvm-guest-agent: control response dropped, connection is finished: {error}");
     }
 }
 

--- a/crates/mvm-agentd/src/flowmux.rs
+++ b/crates/mvm-agentd/src/flowmux.rs
@@ -1100,6 +1100,26 @@ where
             .session
             .seal(&frame)
             .map_err(|e| FlowMuxError::Frame(e.to_string()))?;
+        // The sequence is spent from here on, whether or not the bytes land, so
+        // anything that fails below ends the session rather than leaving the
+        // peer permanently one frame behind. A partial `write_all` is worse
+        // still: the stream itself is then mid-frame.
+        let sequence = sealed.sequence;
+        match self.write_sealed(&sealed).await {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.session.poison_send(sequence, error.to_string());
+                Err(error)
+            }
+        }
+    }
+
+    /// Encode and write one already-sealed frame. Split out so every way this
+    /// can fail funnels through the one poison in [`Self::write_frame`].
+    async fn write_sealed(
+        &mut self,
+        sealed: &mvm_core::net::session::SealedFrame,
+    ) -> Result<(), FlowMuxError> {
         let mut sealed_bytes = Vec::new();
         sealed
             .encode(&mut sealed_bytes)

--- a/crates/mvm-agentd/src/flowmux_sync.rs
+++ b/crates/mvm-agentd/src/flowmux_sync.rs
@@ -133,8 +133,15 @@ impl SyncFlowMux {
             .session
             .seal(&wire)
             .map_err(|e| anyhow::anyhow!("sealing {opcode:?}: {e}"))?;
-        write_sealed_frame(&mut self.stream, &sealed)
-            .map_err(|e| anyhow::anyhow!("writing {opcode:?}: {e}"))
+        // The seal already spent this sequence. A write that fails now cannot
+        // be retried under it — the AES-GCM nonce derives from the sequence —
+        // so the session ends here instead of running on one frame ahead of
+        // the peer.
+        let sequence = sealed.sequence;
+        write_sealed_frame(&mut self.stream, &sealed).map_err(|e| {
+            self.session.poison_send(sequence, e.to_string());
+            anyhow::anyhow!("writing {opcode:?}: {e}")
+        })
     }
 
     /// Read and open the next frame.
@@ -406,6 +413,54 @@ mod tests {
     /// `mvm-secret-abc`; every frame it emits is captured and checked to
     /// confirm the real value never appears in one. That is claim 13 on this
     /// transport, checked on the bytes rather than assumed from the design.
+    /// A FlowMux write that dies after the seal must end the session rather
+    /// than run on one frame ahead of the host. Same defect as the control
+    /// channel's: `seal` spends the sequence before the transport sees the
+    /// frame, and the AES-GCM nonce derives from that sequence, so it cannot
+    /// be reissued.
+    #[test]
+    fn a_send_that_never_reaches_the_host_ends_the_session() {
+        use mvm_core::net::session::Session;
+
+        let (mut guest_side, host_side) = UnixStream::pair().unwrap();
+        let guest_key = SigningKey::from_bytes(&[3u8; 32]);
+        let host_key = SigningKey::from_bytes(&[9u8; 32]);
+        let host_anchor = host_key.verifying_key();
+
+        let host = std::thread::spawn(move || {
+            let mut stream = host_side;
+            let (session, _peer) = Session::host(&mut stream, "poison-test", host_key).unwrap();
+            (stream, session)
+        });
+        let (session, _session_id) =
+            Session::guest(&mut guest_side, guest_key, &host_anchor).expect("guest handshake");
+        let _host = host.join().unwrap();
+
+        let mut mux = SyncFlowMux {
+            stream: guest_side,
+            session,
+            next_stream_id: 1,
+        };
+        // Closing our own write half makes every later write fail at the
+        // syscall, which is the shape a host that went away produces.
+        mux.stream.shutdown(std::net::Shutdown::Write).unwrap();
+
+        mux.send(Opcode::Hello, 0, b"first")
+            .expect_err("the write half is closed");
+
+        assert!(
+            mux.session.is_poisoned(),
+            "a spent sequence that never reached the host must end the session"
+        );
+        let err = mux
+            .send(Opcode::Hello, 0, b"second")
+            .expect_err("a poisoned session must refuse further sends");
+        assert!(
+            err.to_string().contains("session poisoned"),
+            "the refusal must name the cause, got {err}"
+        );
+    }
+
     #[test]
     fn a_placeholder_bearing_request_round_trips_and_the_guest_never_sees_the_credential() {
         use mvm_core::net::session::Session;

--- a/crates/mvm-agentd/src/vsock/framing.rs
+++ b/crates/mvm-agentd/src/vsock/framing.rs
@@ -368,12 +368,19 @@ impl AuthenticatedSession {
     }
 
     /// Write one encrypted, signed control frame.
+    ///
+    /// A write that fails after the frame is sealed ends the session: the
+    /// sequence number is already spent, so continuing would put every later
+    /// frame one ahead of what the peer expects and surface as an
+    /// unexplained sequence mismatch instead of the write failure that
+    /// actually happened.
     pub fn write<T: Serialize>(&mut self, stream: &mut impl Write, value: &T) -> Result<()> {
         let plaintext = serde_json::to_vec(value).with_context(|| "serialize control payload")?;
         let sealed = self
             .inner
             .seal(&plaintext)
             .map_err(|error| anyhow::anyhow!("control frame seal failed: {error}"))?;
+        let sequence = sealed.sequence;
         let frame = AuthenticatedFrame {
             version: sealed.version,
             sig_alg: sealed.sig_alg,
@@ -386,8 +393,9 @@ impl AuthenticatedSession {
                 signer_id: sealed.signer_id,
             },
         };
-        write_frame(stream, &frame)?;
-        Ok(())
+        write_frame(stream, &frame).inspect_err(|error| {
+            self.inner.poison_send(sequence, error.to_string());
+        })
     }
 
     /// Read, authenticate, decrypt, and deserialize one control frame.
@@ -736,6 +744,144 @@ mod tests {
             read_authenticated_frame(&mut host_stream, &guest_vk, session_id, 0).unwrap();
         assert!(matches!(resp, GuestResponse::Pong));
         assert_eq!(seq, 1);
+    }
+
+    /// Build a host/guest session pair over a socketpair, as a completed
+    /// handshake would leave them.
+    fn confidential_pair() -> (
+        (UnixStream, AuthenticatedSession),
+        (UnixStream, AuthenticatedSession),
+    ) {
+        let (mut host_stream, mut guest_stream) = UnixStream::pair().unwrap();
+        host_stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        guest_stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let host_key = test_keypair();
+        let guest_key = test_keypair();
+        let host_anchor = host_key.verifying_key();
+
+        let guest_thread = std::thread::spawn(move || {
+            let session =
+                AuthenticatedSession::guest(&mut guest_stream, guest_key, &host_anchor).unwrap();
+            (guest_stream, session)
+        });
+        let host_session =
+            AuthenticatedSession::host(&mut host_stream, "chunk-cap-test", host_key).unwrap();
+        let guest = guest_thread.join().unwrap();
+        ((host_stream, host_session), guest)
+    }
+
+    /// The witness the chunk cap was missing: a full-size chunk of the most
+    /// expensive bytes there are must still fit the frame cap *after* both JSON
+    /// encodings — the response body and the sealed envelope's ciphertext.
+    ///
+    /// Checking the cap against the response body alone is what let a 48 KiB
+    /// chunk pass the handler and then fail on the wire.
+    #[test]
+    fn sealed_worst_case_chunk_fits_the_frame_cap() {
+        let (_host, (guest_stream, mut guest_session)) = confidential_pair();
+        drop(guest_stream);
+
+        // 0xFF is the worst case: every byte serializes as the four characters
+        // `255,` in both the response body and the sealed ciphertext.
+        let response = GuestResponse::ExecEvent(ExecEvent::Stdout {
+            chunk: vec![0xFF; MAX_DATA_CHUNK_SIZE],
+        });
+
+        let mut wire = Vec::new();
+        guest_session
+            .write(&mut wire, &response)
+            .expect("a full-size chunk must fit the wire");
+
+        let body = wire.len() - 4;
+        assert!(
+            body <= MAX_FRAME_SIZE,
+            "a {MAX_DATA_CHUNK_SIZE}-byte chunk sealed to {body} bytes, over the \
+             {MAX_FRAME_SIZE}-byte cap"
+        );
+
+        let mut host_session = _host.1;
+        let decoded: GuestResponse = host_session
+            .read(&mut std::io::Cursor::new(wire))
+            .expect("the frame must round-trip");
+        assert!(matches!(
+            decoded,
+            GuestResponse::ExecEvent(ExecEvent::Stdout { .. })
+        ));
+    }
+
+    /// A chunk the old cap allowed is still too big for the wire. Pins the
+    /// boundary so a future edit that raises `MAX_DATA_CHUNK_SIZE` back toward
+    /// 48 KiB has to confront this.
+    #[test]
+    fn a_chunk_above_the_cap_fails_the_write_and_poisons_the_session() {
+        let (_host, (_guest_stream, mut guest_session)) = confidential_pair();
+
+        let oversize = GuestResponse::ExecEvent(ExecEvent::Stdout {
+            chunk: vec![0xFF; 48 * 1024],
+        });
+        let mut wire = Vec::new();
+        let err = guest_session
+            .write(&mut wire, &oversize)
+            .expect_err("48 KiB of worst-case bytes must not fit the sealed envelope");
+        assert!(
+            err.to_string().contains("Frame too large"),
+            "expected the frame cap to reject it, got {err}"
+        );
+        assert!(wire.is_empty(), "nothing may reach the wire on a rejection");
+
+        // The sequence that frame consumed cannot be reissued, so the session
+        // must be finished rather than silently one ahead of the peer.
+        let next = guest_session.write(&mut wire, &GuestResponse::Pong);
+        let err = next.expect_err("a poisoned session must refuse further writes");
+        assert!(
+            err.to_string().contains("session poisoned"),
+            "expected the poison to name itself, got {err}"
+        );
+    }
+
+    /// The user-visible failure this fixes: a write that dies after the seal
+    /// used to leave the peer permanently one frame behind, reported several
+    /// frames later as a sequence mismatch with no mention of the write.
+    #[test]
+    fn a_transport_failure_after_the_seal_does_not_desync_the_peer() {
+        struct DeadTransport;
+        impl Write for DeadTransport {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "peer went away",
+                ))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let ((mut host_stream, mut host_session), (mut guest_stream, mut guest_session)) =
+            confidential_pair();
+
+        host_session
+            .write(&mut DeadTransport, &GuestRequest::Ping)
+            .expect_err("the transport is dead");
+
+        // Without the poison this write would succeed and land as sequence 2
+        // against a peer still expecting 1.
+        let err = host_session
+            .write(&mut host_stream, &GuestRequest::Ping)
+            .expect_err("the session must be finished, not one frame ahead");
+        assert!(err.to_string().contains("session poisoned"), "got {err}");
+
+        // And the peer sees nothing rather than a frame it must reject.
+        drop(host_stream);
+        assert!(
+            guest_session
+                .read::<GuestRequest>(&mut guest_stream)
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/mvm-agentd/src/vsock/mod.rs
+++ b/crates/mvm-agentd/src/vsock/mod.rs
@@ -184,12 +184,47 @@ pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 2;
 /// Maximum response frame size (256 KiB).
 pub const MAX_FRAME_SIZE: usize = 256 * 1024;
 
+/// Worst-case bytes one payload byte costs once `serde_json` has written it as
+/// a decimal element of a `Vec<u8>` array: `255,`.
+const JSON_BYTE_ARRAY_WORST_CASE: usize = 4;
+
+/// How far a payload byte expands between the handler and the wire.
+///
+/// Content crosses *two* nested `Vec<u8>` JSON encodings, not one. First the
+/// `GuestRequest` / `GuestResponse` body is serialized, inflating each content
+/// byte. That whole JSON document is then sealed, and the resulting ciphertext
+/// is itself a `Vec<u8>` — `SignedPayload::payload` — which
+/// `AuthenticatedSession::write` serializes as a second integer array. Neither
+/// hop is base64, so the expansions multiply.
+///
+/// Sizing the chunk cap against a single encoding is what let a stdout chunk
+/// pass the handler's own [`MAX_FRAME_SIZE`] check and then fail the identical
+/// check on the sealed envelope, spending a sequence number on a frame that
+/// never reached the wire.
+const SEALED_ENVELOPE_EXPANSION: usize = JSON_BYTE_ARRAY_WORST_CASE * JSON_BYTE_ARRAY_WORST_CASE;
+
+/// Room reserved for everything in the two envelopes that is not content: the
+/// variant tags and field names, the session id, timestamp, signer id and
+/// signature, and the GCM tag. Generous on purpose — the cost of over-reserving
+/// is a slightly smaller chunk, and the cost of under-reserving is a dead
+/// session.
+const SEALED_ENVELOPE_OVERHEAD: usize = 8 * 1024;
+
 /// Maximum raw user-content bytes placed in one JSON data-plane frame.
 ///
-/// `Vec<u8>` serializes as a JSON integer array, whose worst case is four
-/// bytes per input byte (`255,`). Forty-eight KiB leaves room for the request
-/// or response envelope while remaining below [`MAX_FRAME_SIZE`].
-pub const MAX_DATA_CHUNK_SIZE: usize = 48 * 1024;
+/// Derived from what the wire can actually carry rather than picked: a chunk
+/// this size is guaranteed to fit under [`MAX_FRAME_SIZE`] after both JSON
+/// encodings. `sealed_worst_case_chunk_fits_the_frame_cap` proves it against
+/// the real envelope.
+pub const MAX_DATA_CHUNK_SIZE: usize =
+    (MAX_FRAME_SIZE - SEALED_ENVELOPE_OVERHEAD) / SEALED_ENVELOPE_EXPANSION;
+
+// A chunk must survive both encodings with the envelope still inside the cap.
+// Stated as a build-time assertion so a future edit to either constant cannot
+// silently reintroduce a chunk size the wire will not carry.
+const _: () = assert!(
+    MAX_DATA_CHUNK_SIZE * SEALED_ENVELOPE_EXPANSION + SEALED_ENVELOPE_OVERHEAD <= MAX_FRAME_SIZE
+);
 
 /// Number of transport reconnect attempts before giving up.
 const CONNECT_RETRIES: u32 = 4;

--- a/crates/mvm-core/src/net/session.rs
+++ b/crates/mvm-core/src/net/session.rs
@@ -67,6 +67,18 @@ pub enum SessionError {
     /// The send or receive sequence counter overflowed `u64`.
     #[error("sequence counter exhausted")]
     SequenceExhausted,
+    /// A sealed frame was spent without reaching the peer, so the session can
+    /// no longer be used in either direction.
+    #[error(
+        "session poisoned: frame {sequence} was sealed but never reached the peer ({reason}); \
+         the sequence is spent and cannot be reissued"
+    )]
+    Poisoned {
+        /// The sequence number the unsent frame consumed.
+        sequence: u64,
+        /// Why the frame did not reach the peer.
+        reason: String,
+    },
     /// A handshake message was malformed or inconsistent.
     #[error("invalid handshake: {0}")]
     InvalidHandshake(String),
@@ -203,6 +215,21 @@ pub struct Session {
     role: SessionRole,
     next_send_sequence: u64,
     next_receive_sequence: u64,
+    poison: Option<Poison>,
+}
+
+/// A sealed frame that was spent without reaching the peer.
+///
+/// Recorded rather than rolled back: the AES-GCM nonce derives from
+/// `(session_id, role, sequence)`, so re-sealing different plaintext under a
+/// spent sequence would reuse a nonce. A session that kept going instead would
+/// leave the peer one frame behind for the rest of its life, surfacing as an
+/// unexplained sequence mismatch several frames later rather than as the write
+/// failure that actually happened.
+#[derive(Debug, Clone)]
+struct Poison {
+    sequence: u64,
+    reason: String,
 }
 
 impl fmt::Debug for Session {
@@ -212,6 +239,7 @@ impl fmt::Debug for Session {
             .field("role", &self.role)
             .field("next_send_sequence", &self.next_send_sequence)
             .field("next_receive_sequence", &self.next_receive_sequence)
+            .field("poison", &self.poison)
             .finish_non_exhaustive()
     }
 }
@@ -265,6 +293,44 @@ impl Session {
             role,
             next_send_sequence: 1,
             next_receive_sequence: 1,
+            poison: None,
+        }
+    }
+
+    /// Record that `sequence` was sealed but never reached the peer, ending
+    /// this session.
+    ///
+    /// Callers that own the transport must call this when writing a sealed
+    /// frame fails. The sequence is spent either way — [`seal`](Self::seal)
+    /// advances the counter before the frame can be handed to a transport, and
+    /// it cannot be rewound without reusing an AES-GCM nonce. Every later
+    /// [`seal`](Self::seal) and [`open`](Self::open) then refuses and names
+    /// this cause, so the failure is reported where it happened instead of as
+    /// a sequence mismatch on the peer.
+    ///
+    /// The first poison wins; a later one does not overwrite the original
+    /// cause.
+    pub fn poison_send(&mut self, sequence: u64, reason: impl Into<String>) {
+        if self.poison.is_none() {
+            self.poison = Some(Poison {
+                sequence,
+                reason: reason.into(),
+            });
+        }
+    }
+
+    /// Whether an unsent sealed frame has ended this session.
+    pub fn is_poisoned(&self) -> bool {
+        self.poison.is_some()
+    }
+
+    fn check_poison(&self) -> Result<(), SessionError> {
+        match &self.poison {
+            Some(poison) => Err(SessionError::Poisoned {
+                sequence: poison.sequence,
+                reason: poison.reason.clone(),
+            }),
+            None => Ok(()),
         }
     }
 
@@ -287,7 +353,13 @@ impl Session {
     ///
     /// Advances the outbound sequence counter. The returned [`SealedFrame`]
     /// is owned; the caller frames it for transport.
+    ///
+    /// The sequence is spent the moment this returns, whether or not the frame
+    /// reaches the peer, so a caller whose transport write fails must call
+    /// [`poison_send`](Self::poison_send) with the frame's sequence. Dropping
+    /// the frame silently leaves the peer permanently one frame behind.
     pub fn seal(&mut self, plaintext: &[u8]) -> Result<SealedFrame, SessionError> {
+        self.check_poison()?;
         let sequence = self.next_send_sequence;
         let timestamp = chrono::Utc::now().to_rfc3339();
         let context = frame_context(
@@ -328,6 +400,7 @@ impl Session {
     /// Rejects replay, wrong session, wrong signer, bad signature, and
     /// tampered ciphertext. Advances the inbound sequence counter on success.
     pub fn open(&mut self, frame: &SealedFrame) -> Result<Vec<u8>, SessionError> {
+        self.check_poison()?;
         if frame.version != PROTOCOL_VERSION_AUTHENTICATED || frame.sig_alg != SIG_ALG_ED25519 {
             return Err(SessionError::UnsupportedVersion {
                 got: frame.version,
@@ -930,6 +1003,68 @@ mod tests {
             assert_eq!(received_session_id, session_id);
             assert_eq!(session.peer_verifying_key(), &host_verify);
         });
+    }
+
+    #[test]
+    fn poisoning_ends_the_session_in_both_directions() {
+        let (mut host, mut guest) = paired_sessions();
+
+        // A frame the transport accepted, to prove the poison is what stops
+        // the session rather than it never having worked.
+        let good = host.seal(b"first").unwrap();
+        assert_eq!(guest.open(&good).unwrap(), b"first");
+
+        // Sequence 2 is now spent on a frame the peer will never see.
+        let spent = host.seal(b"lost to the transport").unwrap();
+        assert_eq!(spent.sequence, 2);
+        host.poison_send(spent.sequence, "Frame too large: 700000 bytes (max 262144)");
+
+        assert!(host.is_poisoned());
+        let err = host.seal(b"third").unwrap_err();
+        let SessionError::Poisoned { sequence, reason } = err else {
+            panic!("expected Poisoned, got {err}");
+        };
+        assert_eq!(sequence, 2);
+        assert!(
+            reason.contains("Frame too large"),
+            "the poison must carry the original cause, got {reason}"
+        );
+
+        // Inbound too: a poisoned session is finished, not half usable.
+        let from_guest = guest.seal(b"reply").unwrap();
+        assert!(matches!(
+            host.open(&from_guest),
+            Err(SessionError::Poisoned { .. })
+        ));
+    }
+
+    #[test]
+    fn the_first_poison_cause_survives_a_later_one() {
+        let (mut host, _guest) = paired_sessions();
+        host.poison_send(1, "original cause");
+        host.poison_send(2, "downstream noise");
+        let SessionError::Poisoned { sequence, reason } = host.seal(b"x").unwrap_err() else {
+            panic!("expected Poisoned");
+        };
+        assert_eq!(sequence, 1);
+        assert_eq!(reason, "original cause");
+    }
+
+    /// The failure this replaces: without the poison the session kept sealing,
+    /// so the peer's very next `open` rejected a sequence gap it could not
+    /// explain. Pinned so a regression reads as the confusing error again.
+    #[test]
+    fn without_poisoning_a_dropped_frame_would_desync_the_peer() {
+        let (mut host, mut guest) = paired_sessions();
+        let _dropped = host.seal(b"never written").unwrap();
+        let next = host.seal(b"written").unwrap();
+        assert!(matches!(
+            guest.open(&next),
+            Err(SessionError::SequenceMismatch {
+                got: 2,
+                expected: 1
+            })
+        ));
     }
 
     #[test]

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -72,8 +72,14 @@ readiness, lifecycle, and cancellation requests. A saturated transfer cannot
 consume all control capacity.
 
 Every encoded request and response is capped symmetrically at 256 KiB before
-any bytes are written. User-content chunks are at most 48 KiB, leaving enough
-headroom for worst-case JSON encoding and the response envelope. The split is
+any bytes are written. User-content chunks are at most 15.5 KiB, leaving enough
+headroom for worst-case JSON encoding and the response envelope.
+
+That chunk size is derived from the 256 KiB cap rather than chosen. Content is
+encoded twice on its way to the wire: once as a `Vec<u8>` in the request or
+response body, and again as the sealed envelope's ciphertext, which is itself a
+`Vec<u8>`. Neither hop is base64, so the worst case — four characters per byte,
+`255,` — applies twice and the expansions multiply. The split is
 orthogonal to the agent profile gate: `Exec` is dev-only and data-plane;
 `Ping` is always available and control-plane.
 
@@ -105,10 +111,10 @@ share the 48-request data admission budget.
 
 | Verb | Flow | Frame cap | Chunk size | Terminal | Backpressure | Payload in audit? |
 |---|---|---|---|---|---|---|
-| `RunEntrypoint` | Request → `EntrypointEvent` stream | 256 KiB per event | 48 KiB stdout/stderr | `Exit` / `Killed` / `TimedOut` / `Error` | Bounded process buffers. | No. |
-| `ProcWait` | Request → `ProcWaitEvent` stream | 256 KiB per event | 48 KiB stdout/stderr | `Exit` / `Killed` / `TimedOut` / `Error` | Typed non-terminal backpressure events. | No. |
-| `ProcSendInput` | Bounded request → ack | 256 KiB | At most 48 KiB per protocol frame | `InputAccepted` | Caller retries subsequent chunks. | No; byte count only. |
-| `FsRead` / `FsWrite` | Repeated offset requests → bounded responses | 256 KiB | 48 KiB | Each chunk response | Caller advances the offset; the first write truncates and later chunks do not. | No; offsets, sizes, and counts only. |
+| `RunEntrypoint` | Request → `EntrypointEvent` stream | 256 KiB per event | 15.5 KiB stdout/stderr | `Exit` / `Killed` / `TimedOut` / `Error` | Bounded process buffers. | No. |
+| `ProcWait` | Request → `ProcWaitEvent` stream | 256 KiB per event | 15.5 KiB stdout/stderr | `Exit` / `Killed` / `TimedOut` / `Error` | Typed non-terminal backpressure events. | No. |
+| `ProcSendInput` | Bounded request → ack | 256 KiB | At most 15.5 KiB per protocol frame | `InputAccepted` | Caller retries subsequent chunks. | No; byte count only. |
+| `FsRead` / `FsWrite` | Repeated offset requests → bounded responses | 256 KiB | 15.5 KiB | Each chunk response | Caller advances the offset; the first write truncates and later chunks do not. | No; offsets, sizes, and counts only. |
 | `FsList` / `FsDiff` | Request → bounded metadata response | 256 KiB | Protocol-bounded result | Response itself | Result caps and frame cap fail closed. | No file contents. |
 | `Exec` / `ExecBatch` / `RunCode` (dev-only) | One-shot request and capture | 256 KiB | Protocol-bounded result | Response itself | Oversized encoded responses fail closed. | No. |
 | Console PTY traffic | Raw bytes on a dedicated vsock port | Raw transport | TTY-shaped reads | Close or PTY exit | Kernel/socket backpressure; only the host CID may connect. | No. |

--- a/specs/adrs/019-guest-protocol-versioning-and-readiness.md
+++ b/specs/adrs/019-guest-protocol-versioning-and-readiness.md
@@ -72,8 +72,13 @@ protocol, not a claim that every verb has a dedicated socket. The agent
 classifies every verb exhaustively, caps every encoded request and response at
 256 KiB, admits at most 64 concurrent sessions, and reserves 16 of those slots
 for control-plane work by limiting data-plane requests to 48. Filesystem
-payloads and process output use 48 KiB chunks so JSON encoding cannot consume
-the frame headroom. Dedicated raw transports, such as console and port-forward
+payloads and process output use 15.5 KiB chunks so JSON encoding cannot consume
+the frame headroom. That figure is derived, not chosen: content crosses two
+nested `Vec<u8>` JSON encodings before it reaches the wire — the request or
+response body, and then the sealed envelope's ciphertext — and the worst-case
+four-bytes-per-byte expansions multiply. Sizing the chunk against a single
+encoding is what previously let a chunk pass the handler's own frame check and
+fail the identical check on the sealed envelope. Dedicated raw transports, such as console and port-forward
 sockets, remain separate and accept only the host vsock CID.
 
 ### Backpressure is typed, non-terminal product state

--- a/specs/sprint/delivery/2780-vsock-sealed-frame-desync.md
+++ b/specs/sprint/delivery/2780-vsock-sealed-frame-desync.md
@@ -1,0 +1,75 @@
+# 2780 — stdout over ~25 KB killed the control session
+
+`mvmctl machine run --image rust -- sh -c "ls -l /usr/bin"` failed with
+
+```
+Error: control frame open failed: sequence mismatch: got 2, expected 1
+```
+
+Nothing about that message is about stdout, which is what it was about. Any
+command whose output exceeded roughly 25 KB in one burst hit it; `echo hi` did
+not. Bisected on HVF/macOS 26 aarch64: 24000 bytes passed, 28000 failed.
+
+## Two defects, one visible
+
+**The chunk cap was sized against one JSON encoding, not two.** Content crosses
+two nested `Vec<u8>` encodings before it reaches the wire — first the
+`GuestResponse` body, then the sealed envelope's ciphertext, which is itself a
+`Vec<u8>` in `SignedPayload::payload`. Neither hop is base64, so the worst case
+of four characters per byte (`255,`) applies twice and the expansions multiply
+to roughly 10x in practice. `MAX_DATA_CHUNK_SIZE` was 48 KiB against a 256 KiB
+frame cap; the wire could carry about 25 KB.
+
+The old constant's own doc comment states the single-encoding reasoning
+verbatim — "whose worst case is four bytes per input byte (`255,`). Forty-eight
+KiB leaves room for the request or response envelope" — so the miss was in the
+derivation, not in an edit that drifted from it. `MAX_DATA_CHUNK_SIZE` is now
+computed from `MAX_FRAME_SIZE` and a named expansion factor, with a
+`const` assertion so neither constant can move without confronting the other.
+
+**A frame that failed to send left the session permanently desynchronized.**
+`Session::seal` advances the send counter before the frame can be handed to a
+transport, so a `write_frame` failure spent a sequence number on bytes that
+never left the guest. `write_response` logged it and carried on. The next chunk
+went out as sequence 2 against a host still expecting 1.
+
+The counter cannot be rewound: the AES-GCM nonce derives from
+`(session_id, role, sequence)`, so re-sealing different plaintext under a spent
+sequence would be nonce reuse. The session therefore fails closed —
+`Session::poison_send` records the spent sequence and the original cause, and
+every later `seal` and `open` refuses and names it.
+
+This half is not specific to oversize frames. *Any* transport failure on this
+path produced the same misleading `sequence mismatch`, several frames later,
+with no context — `send_exec_streaming` propagates it bare, so the CLI printed a
+one-line error with no hint of what had actually gone wrong.
+
+## What the tests are worth
+
+`oversized_write_is_rejected_before_writing_any_bytes` already existed and
+passed throughout. It exercises `write_frame` in isolation, so it proved no
+bytes were written and could not see that the session had been left unusable —
+the gap was between the two, which is where the bug lived.
+
+The new witnesses were confirmed red before they were green. Reverting the
+poison alone fails `a_transport_failure_after_the_seal_does_not_desync_the_peer`
+and `a_chunk_above_the_cap_fails_the_write_and_poisons_the_session`;
+`without_poisoning_a_dropped_frame_would_desync_the_peer` pins the old
+behaviour so a regression reads as the confusing error again;
+`sealed_worst_case_chunk_fits_the_frame_cap` seals a full-size chunk of `0xFF`
+— the most expensive byte there is under both encodings — through a real
+session and asserts the encoded envelope fits.
+
+## Not done here
+
+`AuthenticatedSession::write` JSON-wraps the sealed frame even though
+`SealedFrame::encode` already defines a compact binary layout for exactly this.
+Using it would remove the ~4x envelope expansion and let chunks go back to
+48 KiB. It changes the host↔guest wire format and needs a guest-agent and OCI
+rootfs cache rebuild, so it is its own change; recorded on the issue.
+
+`write_response` still returns `()` and still swallows the write error. With the
+session poisoned that swallow is now inert by construction rather than by luck —
+no wrong-sequence frame can reach the wire afterwards — so threading a `Result`
+through its four guest-agent call sites buys nothing but churn. The console
+message now names the consequence instead of just the error.


### PR DESCRIPTION
Closes #2780.

`mvmctl machine run -- <cmd>` failed with `control frame open failed: sequence mismatch: got 2, expected 1` whenever the command wrote more than roughly 25 KB to stdout in one burst. Nothing in that message is about stdout, which is what it was about. `--env` and `--mount` were red herrings; output volume was the only variable.

## The chunk cap was sized against one JSON encoding, not two

Content crosses two nested `Vec<u8>` encodings before it reaches the wire — the `GuestResponse` body, and then the sealed envelope's ciphertext, which is itself a `Vec<u8>` in `SignedPayload::payload`. Neither hop is base64, so the worst case of four characters per byte (`255,`) applies twice and the expansions multiply. `MAX_DATA_CHUNK_SIZE` was 48 KiB against a 256 KiB frame cap; the wire could carry about 25 KB.

`write_response` checked the cap against the response body and passed; `write_frame` checked the identical cap against the sealed envelope and bailed.

The old constant's own doc comment states the single-encoding reasoning verbatim, so the miss was in the derivation rather than in an edit that drifted from it. The cap is now computed from `MAX_FRAME_SIZE` and a named expansion factor, with a `const` assertion so neither constant can move without confronting the other.

## A frame that failed to send desynced the session permanently

`Session::seal` advances the send counter before the frame can be handed to a transport, so a `write_frame` failure spent a sequence number on bytes that never left the guest. The next chunk went out as sequence 2 against a host still expecting 1.

The counter cannot be rewound — the AES-GCM nonce derives from `(session_id, role, sequence)`, so re-sealing different plaintext under a spent sequence would be nonce reuse. The session therefore fails closed: `Session::poison_send` records the spent sequence and the original cause, and every later `seal` and `open` refuses and names it.

Wired at **all three** seal-then-write sites — the control channel and both FlowMux paths — not only the one this bug arrived through. FlowMux is the worse case of the two: a partial async `write_all` leaves the stream itself mid-frame on top of the spent sequence.

This half is not specific to oversize frames. *Any* transport failure on these paths produced the same misleading `sequence mismatch`, several frames later, with no context.

## Tests

`oversized_write_is_rejected_before_writing_any_bytes` already existed and passed throughout. It exercises `write_frame` in isolation, so it could prove no bytes were written but not that the session had been left unusable — the gap was between the two, which is where the bug lived.

Every new witness was confirmed red before it was green:

| Test | Goes red without |
|---|---|
| `sealed_worst_case_chunk_fits_the_frame_cap` | the derived cap |
| `a_chunk_above_the_cap_fails_the_write_and_poisons_the_session` | either half |
| `a_transport_failure_after_the_seal_does_not_desync_the_peer` | the poison |
| `a_send_that_never_reaches_the_host_ends_the_session` (FlowMux) | the poison |
| `poisoning_ends_the_session_in_both_directions` | the poison |
| `without_poisoning_a_dropped_frame_would_desync_the_peer` | pins the old behaviour so a regression reads as the confusing error again |

`sealed_worst_case_chunk_fits_the_frame_cap` seals a full-size chunk of `0xFF` — the most expensive byte under both encodings — through a real session and asserts the encoded envelope fits.

## Verification

Gates: nightly `cargo fmt --all --check`, `clippy --workspace --all-targets -D warnings`, `nextest run --workspace`, `test --workspace --doc`, `check-gated` (zigbuild `x86_64-unknown-linux-gnu --all-targets` + `mvm-conformance --features bdd`), and all 63 `xtask` gates referenced by the workflows.

End-to-end on HVF / macOS 26 aarch64, with a rebuilt guest agent:

| single-burst stdout | before | after |
|---|---|---|
| 24000 B | ok | ok |
| 28000 B | `sequence mismatch` | byte-exact |
| 100000 B | `sequence mismatch` | byte-exact |
| 900000 B | `sequence mismatch` | byte-exact |

The reported command now works, `--env` and `--mount` included.

## Two things left out deliberately

`AuthenticatedSession::write` JSON-wraps the sealed frame even though `SealedFrame::encode` already defines a compact binary layout for exactly this. Using it would remove the ~4x envelope expansion and let chunks return to 48 KiB. It changes the host↔guest wire format and needs a guest-agent and OCI rootfs cache rebuild, so it is its own change; recorded on #2780.

`write_response` still returns `()` and still swallows the write error. With the session poisoned, that swallow is now inert by construction rather than by luck — no wrong-sequence frame can reach the wire afterwards — so threading a `Result` through its four guest-agent call sites buys churn and no behaviour. Its console message now names the consequence instead of just the error.

## Unrelated, found while gating

Three `mvm-hostd::extension_provider_process` tests are red on `main` under `nextest` (the named gate) and green under `cargo test`: they read `CARGO_BIN_EXE_*` at runtime instead of via `env!`. Filed as #2783 rather than fixed here.
