### PR TITLE
fix(machine): builder VMs are not user machines

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -4576,7 +4576,10 @@ impl LibkrunPersistentHostVm {
         let job_dir = builder_vm_cache_dir().join("jobs").join(&session_id);
         stage_persistent_job_dir(&job_dir)?;
 
-        let vm_name = format!("mvm-persistent-builder-vm-{session_id}");
+        let vm_name = mvm_core::naming::persistent_builder_vm_name(
+            mvm_core::naming::BuilderVmSlot::Libkrun,
+            &session_id,
+        );
         let vm_state_dir = builder_vm_cache_dir().join("vms").join(&vm_name);
         std::fs::create_dir_all(&vm_state_dir).map_err(|e| {
             BuilderVmError::ExtractionFailed(format!(

--- a/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
@@ -245,6 +245,62 @@ mod reap_orphans_tests {
         assert!(vm.join("config").exists(), "persistent state untouched");
     }
 
+    /// The HVF builder stages each shell job under the *workload* root, so a
+    /// finished build leaves a dir there. Blanket workload treatment kept it
+    /// forever; now that the inventory no longer surfaces builder VMs, nothing
+    /// else would have shown the accumulation either.
+    #[test]
+    fn a_finished_builder_job_under_the_workload_root_is_pruned() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        let vm = vms_root.join(mvm_core::naming::builder_shell_vm_name("4242-9999"));
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        std::fs::write(vm.join("hvf.pid"), "2147483646\n").expect("write pid");
+        std::fs::write(vm.join("payload"), vec![0u8; 2048]).expect("write payload");
+
+        let out = reap_orphaned_vm_helpers_at(&vms_root, WORKLOAD_SIDECARS, true, true, false)
+            .expect("reap workload root");
+        assert_eq!(out.removed_dirs, 1, "a dead per-job builder dir is garbage");
+        assert!(!vm.exists(), "the job dir should be gone");
+        assert!(out.freed_bytes >= 2048);
+    }
+
+    /// The persistent builder's dir is its warm Nix store. Reaping it would
+    /// throw away the cache the builder exists to hold, so it stays managed
+    /// even though it is equally "builder-owned".
+    #[test]
+    fn the_persistent_builder_dir_is_never_pruned() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        let vm = vms_root.join(mvm_core::naming::persistent_builder_vm_name(
+            mvm_core::naming::BuilderVmSlot::Hvf,
+            "session",
+        ));
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        std::fs::write(vm.join("hvf.pid"), "2147483646\n").expect("write pid");
+
+        let out = reap_orphaned_vm_helpers_at(&vms_root, WORKLOAD_SIDECARS, true, true, false)
+            .expect("reap workload root");
+        assert_eq!(out.removed_dirs, 0);
+        assert!(vm.exists(), "the warm store must survive a prune");
+    }
+
+    /// The prune authority granted above must not spill onto real machines:
+    /// a stopped machine's state dir is restartable state, not garbage.
+    #[test]
+    fn granting_builder_prune_does_not_reach_a_stopped_machine() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let vms_root = dir.path().join("vms");
+        let vm = vms_root.join("web");
+        std::fs::create_dir_all(&vm).expect("mkdir");
+        std::fs::write(vm.join("libkrun.pid"), "2147483646\n").expect("write pid");
+
+        let out = reap_orphaned_vm_helpers_at(&vms_root, WORKLOAD_SIDECARS, true, true, false)
+            .expect("reap workload root");
+        assert_eq!(out.removed_dirs, 0);
+        assert!(vm.exists(), "a stopped machine keeps its state dir");
+    }
+
     #[test]
     fn dry_run_does_not_mutate() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/vm_helpers.rs
@@ -126,9 +126,6 @@ pub(super) const BUILDER_SIDECARS: &[&str] = &["builder.pid", "stage0.pid"];
 /// so the reaper would SIGTERM the helpers of a guest that is still running.
 pub(super) const WORKLOAD_SIDECARS: &[&str] = mvm_vmm::host::process_liveness::PID_FILE_NAMES;
 
-/// Dir-name prefix of the persistent dev builder VM.
-const PERSISTENT_BUILDER_DIR_PREFIX: &str = "mvm-persistent-builder-";
-
 fn reap_orphaned_vm_helpers_both_roots(
     remove_builder_dirs: bool,
     dry_run: bool,
@@ -146,10 +143,14 @@ fn reap_orphaned_vm_helpers_both_roots(
         dry_run,
         &snapshot,
     )?;
+    // `remove_builder_dirs` rather than a flat `false`: everything under the
+    // workload root is managed except a per-job builder dir, so this grants
+    // exactly the authority to prune finished builds that stage there, and
+    // the kill-only startup sweep (which passes `false`) still removes nothing.
     let workload = reap_orphaned_vm_helpers_at_with_snapshot(
         &workload_root,
         WORKLOAD_SIDECARS,
-        false,
+        remove_builder_dirs,
         true,
         dry_run,
         &snapshot,
@@ -245,7 +246,14 @@ pub(super) fn reap_orphaned_vm_helpers_at_with_snapshot(
         let Some(dir_basename) = dir.file_name().and_then(|s| s.to_str()) else {
             continue;
         };
-        let managed = all_dirs_managed || dir_basename.starts_with(PERSISTENT_BUILDER_DIR_PREFIX);
+        // A per-job builder dir is ephemeral wherever it sits. The HVF
+        // builder family stages its jobs under the workload root, so without
+        // this the blanket `all_dirs_managed` there would treat a finished
+        // build's leftovers as restartable machine state and keep them
+        // forever — and now that the inventory no longer lists builder VMs,
+        // nothing would show they had accumulated.
+        let managed = !mvm_core::naming::is_ephemeral_builder_vm_name(dir_basename)
+            && (all_dirs_managed || mvm_core::naming::is_builder_owned_vm_name(dir_basename));
 
         let mut dir_has_live_owner = false;
         let mut killed_in_dir = 0u64;

--- a/crates/mvm-cli/src/commands/machine/lifecycle.rs
+++ b/crates/mvm-cli/src/commands/machine/lifecycle.rs
@@ -296,8 +296,41 @@ pub(super) fn start_machine(args: MachineStartArgs) -> Result<()> {
     Ok(())
 }
 
+/// Gate `machine shell` / `machine exec` on the machine existing at all,
+/// rather than on it having a persisted spec.
+///
+/// Both verbs reach the guest over the per-VM vsock socket under
+/// `~/.mvm/vms/<name>/` and never read the spec they used to load — it was a
+/// bare existence check. But `machine run` boots a transient VM that has a
+/// live console and no spec, so that check refused, with "does not exist", a
+/// machine `machine ls` was listing as running.
+///
+/// A builder VM is refused by name. It is headless by construction — no guest
+/// agent, no PTY — so admitting it would trade one wrong error for a worse
+/// one, and the build system is not a machine the user drives.
+pub(super) fn require_console_target(name: &str) -> Result<()> {
+    // Before the name reaches `vm_state_dir`: the gate is the first thing
+    // either verb does, and `console::run`'s own validation is downstream of
+    // it.
+    validate_machine_name(name)?;
+    if mvm_core::naming::is_builder_owned_vm_name(name) {
+        bail!(
+            "{name:?} is an internal builder VM, not a machine. \
+             The builder VM is headless — it has no shell and no console. \
+             Its logs are the way in; `mvmctl doctor` reports its state."
+        );
+    }
+    if load_machine_spec(name).is_ok() || config::vm_state_dir(name).exists() {
+        return Ok(());
+    }
+    bail!(
+        "machine {name:?} does not exist. Run `mvmctl machine ls` to list machines, \
+         or `mvmctl machine create {name} --image <ref>` to create one."
+    )
+}
+
 pub(super) fn exec_machine(cli: &Cli, args: MachineExecArgs, cfg: &MvmConfig) -> Result<()> {
-    let _ = load_machine_spec(&args.name)?;
+    require_console_target(&args.name)?;
     let command = if args.argv.is_empty() {
         None
     } else {
@@ -328,7 +361,7 @@ pub(super) fn exec_machine(cli: &Cli, args: MachineExecArgs, cfg: &MvmConfig) ->
 }
 
 pub(super) fn shell_machine(cli: &Cli, args: MachineShellArgs, cfg: &MvmConfig) -> Result<()> {
-    let _ = load_machine_spec(&args.name)?;
+    require_console_target(&args.name)?;
     console::run(
         cli,
         console::Args {

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -2316,8 +2316,11 @@ fn resolve_remove_targets_dedupes_named_and_enumerates_all() {
     assert_eq!(all, vec!["alpha", "zeta"]);
 }
 
+/// Named for what it drives: `load_machine_spec` itself. The `shell`/`exec`
+/// wrappers no longer go through it — they gate on `require_console_target`,
+/// which admits a transient with no spec.
 #[test]
-fn running_vm_wrappers_require_a_persisted_machine_spec() {
+fn loading_a_missing_machine_spec_names_the_recovery_verbs() {
     let _state = IsolatedMachineState::new();
     let err = load_machine_spec("web").expect_err("missing spec rejected");
     let msg = format!("{err:#}");
@@ -2325,6 +2328,55 @@ fn running_vm_wrappers_require_a_persisted_machine_spec() {
     assert!(msg.contains("machine \"web\" does not exist"), "msg: {msg}");
     assert!(msg.contains("machine ls"), "msg: {msg}");
     assert!(msg.contains("machine create"), "msg: {msg}");
+}
+
+/// `machine shell`/`exec` used to gate on a persisted spec, which a
+/// transient VM from `machine run` never has — so the console was refused for
+/// a machine `machine ls` was listing as running. The gate is existence now,
+/// and a transient's existence is its runtime state dir.
+#[test]
+fn console_target_accepts_a_transient_vm_with_no_spec() {
+    let _state = IsolatedMachineState::new();
+    std::fs::create_dir_all(config::vm_state_dir("adhoc")).expect("seed runtime state");
+    lifecycle::require_console_target("adhoc").expect("a live transient is a console target");
+}
+
+#[test]
+fn console_target_accepts_a_created_machine_that_has_never_booted() {
+    let _state = IsolatedMachineState::new();
+    seed_machine_spec("web");
+    lifecycle::require_console_target("web").expect("a created machine is a console target");
+}
+
+#[test]
+fn console_target_rejects_a_name_with_neither_spec_nor_state() {
+    let _state = IsolatedMachineState::new();
+    let msg = format!(
+        "{:#}",
+        lifecycle::require_console_target("ghost").expect_err("unknown name rejected")
+    );
+    assert!(
+        msg.contains("machine \"ghost\" does not exist"),
+        "msg: {msg}"
+    );
+    assert!(msg.contains("machine ls"), "msg: {msg}");
+}
+
+/// Relaxing the gate to "has a runtime state dir" must not open the builder
+/// VM, which stages its state in the same directory and is headless: it
+/// serves no agent and no PTY, so admitting it would swap a wrong error for a
+/// hang.
+#[test]
+fn console_target_rejects_an_internal_builder_vm_by_name() {
+    let _state = IsolatedMachineState::new();
+    let job = mvm_core::naming::builder_shell_vm_name("92326-1787337475138993000");
+    std::fs::create_dir_all(config::vm_state_dir(&job)).expect("seed builder state");
+    let msg = format!(
+        "{:#}",
+        lifecycle::require_console_target(&job).expect_err("builder VM is not a console target")
+    );
+    assert!(msg.contains("internal builder VM"), "msg: {msg}");
+    assert!(msg.contains("headless"), "msg: {msg}");
 }
 
 #[test]

--- a/crates/mvm-client/src/inventory.rs
+++ b/crates/mvm-client/src/inventory.rs
@@ -87,6 +87,14 @@ pub fn summarize_volume_spec(raw: &str) -> VolumeAttachment {
 /// the listing is stable and the two kinds read as groups. `posture`
 /// resolves the dev/prod posture per record — pass
 /// [`resolve_workload_posture`] on a live host, or a stub in tests.
+///
+/// Builder VMs are dropped from the spec-less remainder. The HVF builder
+/// family writes its runtime state into `~/.mvm/vms/` alongside workload
+/// machines, so the live scan finds a running `nix build` and, having no spec
+/// to join it to, was presenting it as a transient machine the user owned —
+/// with every spec-derived column blank and every spec-requiring verb
+/// (`shell`, `inspect`, `rm`) refusing the name it had just printed. A spec
+/// with a builder-shaped name is still listed: that one the user did create.
 pub fn join_inventory(
     specs: Vec<PersistedMachineSpec>,
     live: Vec<MachineState>,
@@ -105,10 +113,13 @@ pub fn join_inventory(
     persistent.sort_by(|a, b| a.name.cmp(&b.name));
 
     // Whatever the spec registry did not claim is running without a spec.
-    let transient = by_name.into_values().map(|state| {
-        let posture = posture(None, &state.name);
-        transient_record(state, posture)
-    });
+    let transient = by_name
+        .into_values()
+        .filter(|state| !mvm_core::naming::is_builder_owned_vm_name(&state.name))
+        .map(|state| {
+            let posture = posture(None, &state.name);
+            transient_record(state, posture)
+        });
 
     persistent.into_iter().chain(transient).collect()
 }
@@ -420,6 +431,49 @@ mod tests {
         assert_eq!(r.backend.as_deref(), Some("hvf"));
         assert_eq!(r.tags.get("env").map(String::as_str), Some("prod"));
         assert_eq!(r.expires_at.as_deref(), Some("2099-01-01T00:00:00Z"));
+    }
+
+    /// The reported bug: an HVF builder shell job stages its runtime state in
+    /// `~/.mvm/vms/` like a workload, so the live scan found it and the join,
+    /// having no spec for it, rendered it as a transient machine — which
+    /// `machine shell`/`rm` then said did not exist.
+    #[test]
+    fn a_live_builder_vm_without_a_spec_is_not_a_machine() {
+        let job = mvm_core::naming::builder_shell_vm_name("92326-1787337475138993000");
+        let persistent = mvm_core::naming::persistent_builder_vm_name(
+            mvm_core::naming::BuilderVmSlot::Hvf,
+            "session",
+        );
+        let records = join_inventory(
+            vec![spec("web")],
+            vec![
+                live(&job, MachineStatus::Running),
+                live(&persistent, MachineStatus::Running),
+                live("adhoc", MachineStatus::Running),
+            ],
+            stub_posture,
+        );
+        let names: Vec<&str> = records.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["web", "adhoc"],
+            "builder VMs are the build system's, not the user's"
+        );
+    }
+
+    /// The filter keys on "live and spec-less", not on the name alone: a
+    /// machine the user created is theirs whatever they called it.
+    #[test]
+    fn a_user_spec_with_a_builder_shaped_name_is_still_listed() {
+        let name = mvm_core::naming::builder_shell_vm_name("mine");
+        let records = join_inventory(
+            vec![spec(&name)],
+            vec![live(&name, MachineStatus::Running)],
+            stub_posture,
+        );
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].name, name);
+        assert_eq!(records[0].kind, MachineKind::Persistent);
     }
 
     #[test]

--- a/crates/mvm-core/src/naming.rs
+++ b/crates/mvm-core/src/naming.rs
@@ -71,6 +71,63 @@ pub fn validate_id(id: &str, kind: &str) -> Result<()> {
     Ok(())
 }
 
+/// Which persistent builder VM a name belongs to. The token is the on-disk
+/// state-dir infix, so the variants are the storage format and not a display
+/// nicety — renaming one strands every existing builder state dir.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuilderVmSlot {
+    /// The libkrun builder, `mvm-persistent-builder-vm-*`.
+    Libkrun,
+    /// The HVF builder, `mvm-persistent-builder-hvf-*`.
+    Hvf,
+}
+
+impl BuilderVmSlot {
+    fn token(self) -> &'static str {
+        match self {
+            Self::Libkrun => "vm",
+            Self::Hvf => "hvf",
+        }
+    }
+}
+
+/// Shared prefix of every long-lived builder VM name.
+const PERSISTENT_BUILDER_PREFIX: &str = "mvm-persistent-builder-";
+
+/// Shared prefix of every ephemeral per-job builder shell VM name.
+const BUILDER_SHELL_JOB_PREFIX: &str = "mvm-hvf-builder-shell-";
+
+/// Name of the long-lived builder VM for `session_id` in `slot`.
+pub fn persistent_builder_vm_name(slot: BuilderVmSlot, session_id: &str) -> String {
+    format!("{PERSISTENT_BUILDER_PREFIX}{}-{session_id}", slot.token())
+}
+
+/// Name of the ephemeral builder VM that runs one shell job and exits.
+pub fn builder_shell_vm_name(job_id: &str) -> String {
+    format!("{BUILDER_SHELL_JOB_PREFIX}{job_id}")
+}
+
+/// True when `name` is a VM the build system owns rather than one the user
+/// asked for.
+///
+/// These VMs write their runtime state into the same `~/.mvm/vms/` namespace
+/// as workload machines, so every surface that presents "the user's machines"
+/// has to exclude them by name — there is no other discriminator on disk. The
+/// predicate lives beside the two minting functions above so a change to the
+/// name format cannot silently stop matching.
+pub fn is_builder_owned_vm_name(name: &str) -> bool {
+    name.starts_with(PERSISTENT_BUILDER_PREFIX) || is_ephemeral_builder_vm_name(name)
+}
+
+/// True when `name` is a per-job builder VM: state that exists only for the
+/// duration of one build and is safe to remove once nothing owns it.
+///
+/// The persistent builder is deliberately excluded — its dir is its warm Nix
+/// store, and reaping it would throw away the cache it exists to hold.
+pub fn is_ephemeral_builder_vm_name(name: &str) -> bool {
+    name.starts_with(BUILDER_SHELL_JOB_PREFIX)
+}
+
 /// Generate a random instance ID: "i-" followed by 8 hex chars.
 pub fn generate_instance_id() -> String {
     let bytes: [u8; 4] = rand_bytes();
@@ -148,6 +205,52 @@ pub fn parse_instance_path(path: &str) -> Result<(&str, &str, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The whole point of the predicate is that it recognises what the
+    /// minting functions produce; asserting against a hand-written literal
+    /// would let the two drift apart and still pass.
+    #[test]
+    fn builder_vm_names_are_recognised_as_builder_owned() {
+        for slot in [BuilderVmSlot::Libkrun, BuilderVmSlot::Hvf] {
+            let name = persistent_builder_vm_name(slot, "abc123");
+            assert!(
+                is_builder_owned_vm_name(&name),
+                "{name:?} must read as builder-owned"
+            );
+            assert!(
+                !is_ephemeral_builder_vm_name(&name),
+                "{name:?} is the warm store and must never read as ephemeral"
+            );
+        }
+        let job = builder_shell_vm_name("92326-1787337475138993000");
+        assert!(is_builder_owned_vm_name(&job));
+        assert!(is_ephemeral_builder_vm_name(&job));
+    }
+
+    /// The slot tokens are the on-disk state-dir infixes documented in
+    /// CLAUDE.md; changing one strands existing builder state.
+    #[test]
+    fn builder_slot_tokens_are_the_documented_on_disk_names() {
+        assert_eq!(
+            persistent_builder_vm_name(BuilderVmSlot::Libkrun, "s"),
+            "mvm-persistent-builder-vm-s"
+        );
+        assert_eq!(
+            persistent_builder_vm_name(BuilderVmSlot::Hvf, "s"),
+            "mvm-persistent-builder-hvf-s"
+        );
+        assert_eq!(builder_shell_vm_name("j"), "mvm-hvf-builder-shell-j");
+    }
+
+    #[test]
+    fn a_user_machine_name_is_not_builder_owned() {
+        for name in ["web", "builder", "mvm-builder", "my-persistent-builder-vm"] {
+            assert!(
+                !is_builder_owned_vm_name(name),
+                "{name:?} is a user machine"
+            );
+        }
+    }
 
     #[test]
     fn test_validate_id_valid() {

--- a/crates/mvm-runtime/src/builder_runner/hvf_builder.rs
+++ b/crates/mvm-runtime/src/builder_runner/hvf_builder.rs
@@ -105,7 +105,7 @@ impl HvfBuilderVm {
             ))
         })?;
 
-        let name = format!("mvm-hvf-builder-shell-{job_id}");
+        let name = mvm_core::naming::builder_shell_vm_name(&job_id);
         let runtime_overlay = require_runtime_overlay_ext4()?;
         let outcome = BuilderRunner::new(HvfDriver::new())
             .build(&BuilderBuild {

--- a/crates/mvm-runtime/src/builder_runner/hvf_persistent.rs
+++ b/crates/mvm-runtime/src/builder_runner/hvf_persistent.rs
@@ -134,7 +134,10 @@ impl HvfPersistentHostVm {
         .map_err(|e: BuilderVmError| anyhow::anyhow!(e))
         .context("materializing the nix-store image for the persistent builder")?;
 
-        let vm_name = format!("mvm-persistent-builder-hvf-{session_id}");
+        let vm_name = mvm_core::naming::persistent_builder_vm_name(
+            mvm_core::naming::BuilderVmSlot::Hvf,
+            session_id,
+        );
         let state_dir = vm_state_dir(&vm_name);
         std::fs::create_dir_all(&state_dir)
             .with_context(|| format!("creating builder state dir {}", state_dir.display()))?;

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -555,7 +555,7 @@ guest, on any tier.
 | `mvmctl machine exec <name> -- <cmd>...` | Run a command in an already-started named machine |
 | `mvmctl machine exec <name> -it -- <cmd>...` | Run a command in an already-started named machine attached to a PTY |
 | `mvmctl machine exec <name>` | Omit the command to drop into an interactive shell (same as `machine shell`) |
-| `mvmctl machine shell <name>` | Attach an interactive shell/console to an already-started named machine |
+| `mvmctl machine shell <name>` | Attach an interactive shell/console to an already-started named machine — persistent or transient (a `machine run --name <name>` VM is reachable while it runs) |
 | `mvmctl machine stop <name>...` | Stop one or more already-started named machines (prompts for confirmation; pass `--yes` to skip) |
 | `mvmctl machine reconfigure <name> [flags]` | Patch a persistent machine's config and relaunch it. Only the flags you pass are changed; everything else (image, volumes, profile) is preserved. When the machine is running, it is stopped and restarted automatically; when stopped, the change is staged for the next `machine start`. |
 | `mvmctl machine reconfigure <name> --net` / `--no-net` | Enable or disable the dev-tier outbound network preset |

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-20
+Last updated: 2026-08-21
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -341,6 +341,15 @@ for detailed scope and acceptance criteria.
       zero; the later workload boot stopped at a separate readiness timeout.
 
 ## In-flight plans
+
+- [ ] **HVF builder state out of the workload VM namespace**
+      (`specs/plans/2026-08-21-hvf-builder-state-out-of-the-workload-namespace.md`).
+      The HVF builder family stages VM state under `~/.mvm/vms/` rather than
+      the builder cache root libkrun uses, so `machine ls` listed a running
+      `nix build` as a user machine and the orphan reaper never pruned a
+      finished build's dir. Both reading ends are fixed by name via
+      `mvm_core::naming::is_builder_owned_vm_name`; separating the two state
+      roots so the filter stops being the mechanism is open.
 
 - [~] **Plan 338 — WebLinux browser backend, builder, workbench, and `mvmd`
       deployment client**

--- a/specs/plans/2026-08-21-hvf-builder-state-out-of-the-workload-namespace.md
+++ b/specs/plans/2026-08-21-hvf-builder-state-out-of-the-workload-namespace.md
@@ -1,0 +1,57 @@
+# HVF builder state out of the workload VM namespace
+
+Backing: shipped-source
+Validation: none
+
+**Status:** OPEN
+**Date:** 2026-08-21
+**Owner:** mvm
+
+## Why
+
+The libkrun builder stages its VM state under `~/.mvm/cache/builder-vm/vms/`.
+The HVF builder family stages its state under `~/.mvm/vms/` — the workload
+machine namespace — because `BuilderRunner::build`
+(`crates/mvm-runtime/src/builder_runner/runner.rs:90`) and
+`HvfPersistentBuilder` (`.../hvf_persistent.rs:138`) both call
+`mvm_core::config::vm_state_dir`.
+
+Two surfaces read that directory as "the user's machines" and got the builder
+back:
+
+- `machine ls` listed a running `nix build` as a transient machine the user
+  owned, whose every spec-derived column was blank and whose name every
+  spec-requiring verb then refused.
+- The orphan reaper treats everything under the workload root as managed
+  restartable state, so a finished build's dir was never pruned.
+
+Both were fixed at the reading end, by name
+(`mvm_core::naming::is_builder_owned_vm_name`). That is a correct filter and a
+fragile boundary: it holds only as long as every builder VM name keeps a
+recognisable prefix, and it does nothing about the namespace collision itself —
+a machine and a builder job can still claim the same directory.
+
+## What
+
+Give the HVF builder its own state root, so the two namespaces stop
+overlapping and the name filter becomes belt-and-braces rather than the
+mechanism.
+
+- [ ] Thread a state root through `BuilderRunner`/`BuilderBuild` instead of
+      reaching for `vm_state_dir` directly; default it to
+      `builder_vm_cache_dir().join("vms")`, matching libkrun.
+- [ ] Move `HvfPersistentBuilder`'s `vm_state_dir` call to the same root.
+- [ ] Follow the vsock socket paths: `vm_hvf_vsock_port_socket_at` and
+      `vm_vsock_port_socket_at` are resolved from the state dir, so anything
+      that reconnects to a builder by name has to move with it.
+- [ ] Migration: an existing `~/.mvm/vms/mvm-*builder*` dir must not strand a
+      warm Nix store. Either move it on first use or accept the one-time
+      rebuild and prune it.
+- [ ] Once the roots are disjoint, `mvmctl doctor`'s builder line and
+      `cache prune` can drop their workload-root special cases.
+
+## Not doing
+
+Renaming the on-disk name prefixes. `mvm-persistent-builder-vm-*` /
+`mvm-persistent-builder-hvf-*` are documented in CLAUDE.md and are load-bearing
+for existing state dirs; `mvm_core::naming::BuilderVmSlot` pins them.

--- a/specs/sprint/delivery/builder-vms-are-not-user-machines.md
+++ b/specs/sprint/delivery/builder-vms-are-not-user-machines.md
@@ -1,0 +1,72 @@
+# Builder VMs are not user machines
+
+Delivered 2026-08-21.
+
+## What was wrong
+
+`mvmctl machine ls` listed a running `nix build` as a machine:
+
+```
+NAME                                             KIND       STATUS   HEALTH  BACKEND  PORTS  SOURCE  AGE
+mvm-hvf-builder-shell-92326-1787337475138993000  transient  running  -       hvf      -      -       -
+```
+
+and then every spec-requiring verb refused the name it had just printed:
+
+```
+$ mvmctl machine shell mvm-hvf-builder-shell-92326-1787337475138993000
+Error: machine "mvm-hvf-builder-shell-…" does not exist.
+```
+
+PID 92326 was an `mvmctl __builder-shell-job` running in a different worktree
+against a shared `MVM_HOME`.
+
+Two independent defects met there.
+
+**The builder is in the workload namespace.** libkrun's builder stages VM state
+under `~/.mvm/cache/builder-vm/vms/`; the HVF builder family stages it under
+`~/.mvm/vms/`, because `BuilderRunner::build` and `HvfPersistentBuilder` both
+call `mvm_core::config::vm_state_dir`. The inventory join
+(`mvm_client::inventory::join_inventory`) is specs × live-backend-scan, and
+anything live the spec registry does not claim becomes a transient record — so
+the builder job arrived as a machine with every spec-derived column blank.
+
+**`shell`/`exec` gated on the wrong thing.** Both did `let _ =
+load_machine_spec(&args.name)?;` and discarded the result: a bare existence
+check against the *spec* store. But they reach the guest over the per-VM vsock
+socket under `~/.mvm/vms/<name>/` and never read a spec. A transient VM from
+`machine run` has that socket and no spec, so the console was refused for a
+machine `machine ls` was correctly listing as running. The builder job hit the
+same gate, which is why it produced a misleading error rather than the right
+one.
+
+## What changed
+
+`mvm_core::naming` now owns builder VM names — both the minting
+(`persistent_builder_vm_name`, `builder_shell_vm_name`, and the
+`BuilderVmSlot` enum pinning the documented `-vm-` / `-hvf-` on-disk tokens)
+and the predicates that recognise them. The three `format!` sites in
+`hvf_builder`, `hvf_persistent` and `libkrun_builder` call it, so the format
+and the predicate cannot drift apart — a test asserts the predicate against
+what the minting functions return, not against a literal.
+
+- `join_inventory` drops builder-owned VMs from the spec-less remainder. A
+  *spec* with a builder-shaped name is still listed: that one the user created.
+- `machine shell` / `machine exec` gate on `require_console_target`: a
+  persisted spec **or** a runtime state dir admits, so transients work; a
+  builder-owned name is refused by name with the reason (headless, no agent,
+  no PTY) rather than "does not exist".
+- The orphan reaper now treats a per-job builder dir as ephemeral wherever it
+  sits, and the workload root is swept under the same `remove_builder_dirs`
+  authority the builder root already had. Without this, hiding builder VMs
+  from `machine ls` would have converted a visible leak into an invisible one:
+  everything under the workload root was `all_dirs_managed`, so a finished
+  build's dir was never pruned. The kill-only startup sweep passes `false` and
+  still removes nothing.
+
+## Not fixed
+
+The namespace collision itself. The filter is by name, which holds only while
+builder VM names keep a recognisable prefix. Moving HVF builder state out of
+`~/.mvm/vms/` is
+`specs/plans/2026-08-21-hvf-builder-state-out-of-the-workload-namespace.md`.


### PR DESCRIPTION
## The report

`mvmctl machine ls` listed a running `nix build` as a machine, and then every
spec-requiring verb refused the name it had just printed:

```
NAME                                             KIND       STATUS   HEALTH  BACKEND  PORTS  SOURCE  AGE
mvm-hvf-builder-shell-92326-1787337475138993000  transient  running  -       hvf      -      -       -

$ mvmctl machine shell mvm-hvf-builder-shell-92326-1787337475138993000
Error: machine "mvm-hvf-builder-shell-…" does not exist.
```

PID 92326 was an `mvmctl __builder-shell-job` from another worktree sharing the
same `MVM_HOME`. Two independent defects met on that row.

## Defect 1 — the builder lives in the workload namespace

The libkrun builder stages VM state under `~/.mvm/cache/builder-vm/vms/`. The
HVF builder family stages it under `~/.mvm/vms/` — the workload machine
namespace — because `BuilderRunner::build` and `HvfPersistentBuilder` both call
`mvm_core::config::vm_state_dir`.

`join_inventory` is specs × live-backend-scan, and anything live the spec
registry does not claim becomes a transient record. So the builder job arrived
as a machine whose every spec-derived column (AGE, SOURCE, PORTS) was blank.

## Defect 2 — `shell`/`exec` gated on the wrong store

Both did `let _ = load_machine_spec(&args.name)?;` and discarded the result: a
bare existence check against the *spec* store. They reach the guest over the
per-VM vsock socket under `~/.mvm/vms/<name>/` and never read a spec, so a
transient VM from `machine run --name` — which has that socket and no spec —
was refused for a machine `machine ls` was correctly listing as running.

## The fix

`mvm_core::naming` now owns builder VM names: the minting
(`persistent_builder_vm_name`, `builder_shell_vm_name`, and a `BuilderVmSlot`
enum pinning the documented `-vm-` / `-hvf-` on-disk tokens) **and** the
predicates that recognise them. The three `format!` sites call it, and the test
asserts the predicate against what the minting functions return rather than
against a literal, so the format and the filter cannot drift apart.

- `join_inventory` drops builder-owned VMs from the spec-less remainder. A
  *spec* with a builder-shaped name is still listed — that one the user created.
- `require_console_target` admits a persisted spec **or** a runtime state dir,
  so transients work, and refuses a builder VM by name with the actual reason
  (headless, no agent, no PTY) instead of "does not exist". It validates the
  name before that name reaches a path.
- The orphan reaper treats a per-job builder dir as ephemeral wherever it sits,
  and the workload root is swept under the same `remove_builder_dirs` authority
  the builder root already had. Without this, hiding builder VMs from
  `machine ls` would have converted a visible leak into an invisible one:
  everything under the workload root was `all_dirs_managed`, so a finished
  build's dir was never pruned. The kill-only startup sweep passes `false` and
  still removes nothing.

## Not fixed

The namespace collision itself. Both fixes are name filters, which hold only
while builder VM names keep a recognisable prefix. Moving HVF builder state out
of `~/.mvm/vms/` means threading a state root through `BuilderRunner`, moving
the vsock socket paths with it, and migrating existing warm Nix stores — too
large to bolt onto a bug fix. Written up in
`specs/plans/2026-08-21-hvf-builder-state-out-of-the-workload-namespace.md` and
registered in `specs/REFACTOR-STATUS.md`.

## Tests

12 new tests. The inventory one reproduces the reported output exactly —
mutating the filter out yields:

```
left:  ["web", "adhoc", "mvm-hvf-builder-shell-92326-1787337475138993000", "mvm-persistent-builder-hvf-session"]
right: ["web", "adhoc"]
```

Verified: nightly `cargo fmt --all --check`; `clippy --all-targets -D warnings`
and `clippy -p mvm-conformance --features bdd` clean; `just check-gated`; all 62
xtask gates plus `check-no-orchestration-server.sh`; `cargo nextest run -p mvm-cli`
2009/2009; `cargo test -p mvmctl --tests` 262/262; workspace doctests 7/7.

One caveat worth recording: `cargo nextest run --workspace` on this host fails
216 tests with `CARGO_BIN_EXE_* is unset`, in the root package's integration
tests and `mvm-hostd`'s provider tests. Every one of those passes under
`cargo test`, which sets the variable itself. It is a local nextest environment
problem, not a change in this branch, but it does mean the nextest workspace
lane could not be used as the verification here.
