### PR TITLE
fix(test): resolve the provider binary at compile time so nextest can find it

### DIFF
--- a/crates/mvm-hostd/tests/extension_provider_process.rs
+++ b/crates/mvm-hostd/tests/extension_provider_process.rs
@@ -96,23 +96,31 @@ fn frame(kind: ExtensionMessageKind, sequence: u64, payload: &[u8]) -> Vec<u8> {
     .expect("fixture frame encodes")
 }
 
+/// Path to the provider binary under test.
+///
+/// `CARGO_BIN_EXE_<name>` is a **compile-time** variable cargo provides to
+/// `env!`. `cargo test` also happens to export it into the test process, so
+/// reading it at runtime worked there and failed under `cargo nextest`, which
+/// runs the test binary directly — and nextest is the named gate. Resolving it
+/// at compile time works under both.
+fn provider_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_mvm-extension-provider")
+}
+
 #[test]
 fn provider_process_injects_configured_runner_and_fails_closed_without_admitted_boot() {
     let state = tempfile::tempdir().expect("provider state");
     write_boot_config(state.path());
-    let mut child = Command::new(
-        std::env::var("CARGO_BIN_EXE_mvm-extension-provider")
-            .expect("cargo supplies the provider binary path"),
-    )
-    .arg("--state-root")
-    .arg(state.path())
-    .env_clear()
-    .env("MVM_HOME", state.path())
-    .stdin(Stdio::piped())
-    .stdout(Stdio::piped())
-    .stderr(Stdio::piped())
-    .spawn()
-    .expect("start provider process");
+    let mut child = Command::new(provider_bin())
+        .arg("--state-root")
+        .arg(state.path())
+        .env_clear()
+        .env("MVM_HOME", state.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start provider process");
 
     let bundle = include_bytes!("../../mvm-contract/fixtures/operator-session-bundle-v1.json");
     let request = include_bytes!("../../mvm-contract/fixtures/campaign-provider-request-v1.json");
@@ -205,15 +213,12 @@ fn provider_process_injects_configured_runner_and_fails_closed_without_admitted_
 #[test]
 fn provider_process_never_uses_ambient_home_or_mvm_state() {
     let ambient = tempfile::tempdir().expect("ambient trap");
-    let output = Command::new(
-        std::env::var("CARGO_BIN_EXE_mvm-extension-provider")
-            .expect("cargo supplies the provider binary path"),
-    )
-    .env_clear()
-    .env("HOME", ambient.path())
-    .env("MVM_HOME", ambient.path())
-    .output()
-    .expect("run provider without explicit state");
+    let output = Command::new(provider_bin())
+        .env_clear()
+        .env("HOME", ambient.path())
+        .env("MVM_HOME", ambient.path())
+        .output()
+        .expect("run provider without explicit state");
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("--state-root is required"));
     assert!(
@@ -229,15 +234,12 @@ fn provider_process_never_uses_ambient_home_or_mvm_state() {
 fn provider_refuses_boot_config_without_an_explicit_matching_global_mvm_home() {
     let state = tempfile::tempdir().expect("provider state");
     write_boot_config(state.path());
-    let output = Command::new(
-        std::env::var("CARGO_BIN_EXE_mvm-extension-provider")
-            .expect("cargo supplies the provider binary path"),
-    )
-    .arg("--state-root")
-    .arg(state.path())
-    .env_clear()
-    .output()
-    .expect("run provider without global MVM home");
+    let output = Command::new(provider_bin())
+        .arg("--state-root")
+        .arg(state.path())
+        .env_clear()
+        .output()
+        .expect("run provider without global MVM home");
     assert!(!output.status.success());
     assert!(
         String::from_utf8_lossy(&output.stderr)


### PR DESCRIPTION
Closes #2783.

Three tests in `extension_provider_process.rs` resolve the provider binary at **runtime**:

```rust
std::env::var("CARGO_BIN_EXE_mvm-extension-provider")
    .expect("cargo supplies the provider binary path")
```

`CARGO_BIN_EXE_<name>` is a **compile-time** variable that cargo provides to `env!`. Whether it is *also* exported into the test process at runtime depends on the runner.

## What I verified, and what I got wrong twice

Verified locally, `cargo-nextest 0.9.122`:

| runner | result |
|---|---|
| `cargo test` | 3 passed |
| `cargo nextest run --workspace` | **3 failed** — `NotPresent` |
| `cargo nextest run … --all-targets` | **3 failed** — `NotPresent` |
| same, with the provider binary pre-built in the target dir | **3 failed** — `NotPresent` |

CI is green. Its `Test workspace` job runs the same `cargo nextest run --workspace --all-targets`, but installs nextest through `taiki-e/install-action` unpinned, so it gets a newer release than the 0.9.122 I have locally — and that one evidently does export the variable. I have not reproduced CI's version locally, so that last step is inference from CI being green, not something I ran.

Two earlier revisions of this description were wrong and are corrected above:

1. First I claimed `main` was red in CI. It was not, and is not.
2. Then I claimed the failure depended on whether the provider binary already existed in the target directory, with a red/green table to match. It does not — the table above replaces it. That claim came from a mis-run experiment where the branch under test was not the one I thought was checked out.

## Why the fix is still right

`env!` resolves at compile time, so it does not depend on the runner exporting anything, and it declares the binary as a build dependency of the test so cargo builds it regardless of flags. That holds on every nextest version, old or new — which is the property these tests should have had in the first place, rather than one that varies with the tooling.

One `provider_bin()` helper instead of repeating `env!` at three call sites.

## Verification

With this branch, `cargo-nextest 0.9.122`: `cargo nextest run -p mvm-hostd --test extension_provider_process` → **3 passed**, where `main` gives 3 failed on the same runner.

Whole workspace on this branch: **12875 tests run, 12875 passed, 0 failed, 26 skipped**.

Also gated: nightly `cargo fmt --all --check`, `clippy --workspace --all-targets -D warnings`, and all 63 `xtask` gates referenced by the workflows.

Found while gating #2784.
