### PR TITLE
Fix builder hook loop mounts in AArch64 witness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1611,6 +1611,11 @@ jobs:
       # flake so `mvmctl` treats this as an installed binary and downloads the
       # published image instead.
       - name: Build mvmctl
+        env:
+          # This witness boots embedded builder-guest code. A restored Cargo
+          # cache may contain binaries built from an older source tree, which
+          # would make the live gate validate stale mvm-host-vm-init behavior.
+          MVM_EMBED_NO_CACHE: 1
         run: cargo build --release -p mvmctl --features release-artifact-bootstrap,release-channel
 
       - name: Use published builder VM bootstrap path

--- a/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
@@ -23,6 +23,12 @@ const HOOK_PATH: &str = "/etc/mvm/hooks/before_build.sh";
 /// does not depend on any host share.
 const MOUNT_POINT: &str = "/tmp/mvm-before-build-rootfs";
 
+/// Absolute path populated by the builder image from util-linux.
+///
+/// `/bin/mount` is the BusyBox applet. It does not allocate a loop device for
+/// `-o loop`; it forwards `loop` to ext4 as a filesystem option instead.
+const UTIL_LINUX_MOUNT: &str = "/sbin/mount";
+
 /// Grace period for the before_build hook. Build-time setup (DB
 /// migrations, cache warming) should complete promptly; if it hangs we
 /// fail the build rather than leaving a builder VM wedged.
@@ -151,7 +157,7 @@ fn mount_rootfs(rootfs_path: &Path) -> Result<(), BuilderHookError> {
     // util-linux mount -o loop allocates a loop device for the
     // file-backed ext4 image. The nix mount(2) syscall wrapper
     // lacks LOOP_SET_FD, so shell out.
-    let status = std::process::Command::new("mount")
+    let status = std::process::Command::new(UTIL_LINUX_MOUNT)
         .arg("-o")
         .arg("loop")
         .arg(rootfs_path)
@@ -263,6 +269,7 @@ mod tests {
         // the Nix factory. If they change, the wiring sites must update.
         assert_eq!(HOOK_PATH, "/etc/mvm/hooks/before_build.sh");
         assert_eq!(MOUNT_POINT, "/tmp/mvm-before-build-rootfs");
+        assert_eq!(UTIL_LINUX_MOUNT, "/sbin/mount");
         assert_eq!(
             CHROOT_PATH,
             "/usr/local/sbin:/usr/local/bin:/sbin:/usr/sbin:/bin:/usr/bin"

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2721,3 +2721,14 @@ wrong UDS alternative. Recovery and transport alternatives now match every
 `BackendKind` exhaustively, and a focused WebLinux negotiation witness requires
 the browser-channel route. A missing backend arm is therefore a compile error,
 while the behavior-specific test catches a wrong explicit alternative.
+
+## 2026-08-22 AArch64 before-build loop mount repair
+
+The merge-group AArch64 QEMU witness completed its workload build but failed
+the before-build lifecycle hook because bare `mount` resolved to BusyBox.
+BusyBox forwarded `loop` to ext4 instead of allocating a loop device, so the
+guest powered down without returning `rootfs.ext4`. The hook runner now calls
+the builder image's explicit util-linux `/sbin/mount`, with a focused constant
+regression pinning that executable contract. The live lane forces a refresh of
+embedded host binaries so the guest always carries the checkout under test,
+even when Cargo caches are restored.

--- a/specs/sprint/delivery/aarch64-vsock-and-actionlint-retry.md
+++ b/specs/sprint/delivery/aarch64-vsock-and-actionlint-retry.md
@@ -19,3 +19,14 @@ backend capability negotiation. Its mutation shard could delete the WebLinux
 transport arm because the wildcard silently substituted the UDS route. Both
 backend matches are now exhaustive, so a new or missing backend is a compile
 failure, and a focused WebLinux test pins the browser-channel alternative.
+
+The merge-group AArch64 witness then reached the before-build lifecycle hook
+and exposed an image-path mismatch: the hook runner invoked bare `mount`, so
+the inherited PATH selected BusyBox instead of the installed util-linux
+binary. BusyBox passed `loop` through as an ext4 option, the hook failed after
+the expensive build, and no `rootfs.ext4` was returned. The runner now invokes
+the image contract's explicit `/sbin/mount`; a focused constant regression
+pins that selection so PATH ordering cannot silently restore the broken path.
+The AArch64 live lane also opts out of the embedded-host-binary cache while it
+builds `mvmctl`, ensuring source changes to the builder guest are cross-compiled
+and injected rather than hidden by a restored stale binary.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -1425,6 +1425,30 @@ fn mk_guest_uses_the_static_custom_privilege_helper() {
     );
 }
 
+#[test]
+fn builder_hook_uses_the_installed_util_linux_mount() {
+    let builder_flake_path = nix_dir().join("images/builder-vm/flake.nix");
+    let builder_flake = fs::read_to_string(&builder_flake_path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", builder_flake_path.display()));
+    assert!(
+        builder_flake.contains("        util-linux"),
+        "the builder image must retain util-linux for file-backed loop mounts"
+    );
+
+    let hook_path = repo_dir().join("crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs");
+    let hook = fs::read_to_string(&hook_path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", hook_path.display()));
+    assert!(
+        hook.contains("const UTIL_LINUX_MOUNT: &str = \"/sbin/mount\";")
+            && hook.contains("Command::new(UTIL_LINUX_MOUNT)"),
+        "the hook runner must bypass BusyBox and invoke the installed util-linux mount"
+    );
+    assert!(
+        !hook.contains("Command::new(\"mount\")"),
+        "a PATH-resolved mount can select BusyBox, which cannot allocate the loop device"
+    );
+}
+
 /// Every recipe whose `src` is the whole workspace must normalize it before the
 /// generic unpacker runs: a `path:` input evaluated from the `nix/` subflake can
 /// retain a trailing `nix/..` shape and the unpacker then fails with

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -795,6 +795,19 @@ mod tests {
             smoke.find(grant) < smoke.find("Build and boot the sealed exit_code workload"),
             "vhost-vsock access must be granted before QEMU starts"
         );
+        let current_embedded_bins = concat!(
+            "      - name: Build mvmctl\n",
+            "        env:\n",
+            "          # This witness boots embedded builder-guest code. A restored Cargo\n",
+            "          # cache may contain binaries built from an older source tree, which\n",
+            "          # would make the live gate validate stale mvm-host-vm-init behavior.\n",
+            "          MVM_EMBED_NO_CACHE: 1\n",
+            "        run: cargo build --release -p mvmctl",
+        );
+        assert!(
+            smoke.contains(current_embedded_bins),
+            "the live AArch64 gate must rebuild embedded host binaries from its checkout"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The merge-group AArch64 witness reached the before-build lifecycle hook but bare mount resolved to BusyBox, which forwarded loop to ext4 instead of allocating a loop device. Invoke the builder image's installed util-linux mount by absolute path and force this live lane to rebuild embedded host binaries from the checked-out source. Adds structural regression coverage and updates delivery evidence.\n\nValidated locally with full workspace tests, workspace all-target Clippy with warnings denied, workspace check, Linux-gated cross-compilation, focused structure and workflow-policy tests, formatting, and repository policy checks.