### PR TITLE
site: show measured launch latency against its budget on the homepage

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,10 +1,16 @@
 name: Website
 
-# check:tokens and check:samples were developer conventions with no CI gate:
-# a hardcoded hex value or a drifted code sample could land on main and only
-# ever get caught by someone remembering to run pnpm check locally. This is
-# the gate. It's scoped to public/** so it doesn't run (and can't be required)
-# on PRs that never touch the site.
+# check:tokens, check:samples and check:perf were developer conventions with
+# no CI gate: a hardcoded hex value, a drifted code sample, or a homepage
+# percentile that no longer matches the performance page could land on main
+# and only ever get caught by someone remembering to run pnpm check locally.
+# This is the gate. It's scoped to public/** so it doesn't run (and can't be
+# required) on PRs that never touch the site.
+#
+# Steps are listed individually rather than via `pnpm check` so a failure
+# names the gate that failed. Adding a check:* script therefore needs a step
+# here too, or it runs nowhere. The job `name:` is deliberately left alone
+# when steps are added — it is the check name branch protection matches on.
 on:
   pull_request:
     paths:
@@ -68,6 +74,10 @@ jobs:
       - name: Check sample provenance
         working-directory: public
         run: pnpm check:samples
+
+      - name: Check perf provenance
+        working-directory: public
+        run: pnpm check:perf
 
       - name: Build
         working-directory: public

--- a/public/package.json
+++ b/public/package.json
@@ -11,7 +11,8 @@
     "astro": "astro",
     "check:tokens": "node scripts/check-no-hardcoded-hex.mjs",
     "check:samples": "node scripts/check-sample-provenance.mjs",
-    "check": "pnpm check:tokens && pnpm check:samples && pnpm build"
+    "check:perf": "node scripts/check-perf-provenance.mjs",
+    "check": "pnpm check:tokens && pnpm check:samples && pnpm check:perf && pnpm build"
   },
   "dependencies": {
     "@astrojs/react": "^4.4.2",

--- a/public/scripts/check-perf-provenance.mjs
+++ b/public/scripts/check-perf-provenance.mjs
@@ -1,0 +1,125 @@
+// Every launch number on the homepage must still be the number the published
+// performance page states. A landing page that quotes a stale percentile is
+// worse than one that quotes none: the perf page's whole contract is that a
+// number travels with the host that produced it, and a drifted copy breaks
+// that silently while still looking authoritative.
+//
+// This parses the two tables on that page separately and on purpose. The
+// budget table is generated from the Rust accessor CI gates against; the
+// seeded table is an observation with a fingerprint. Conflating them is the
+// specific failure the page is built to prevent, so the gate that guards the
+// homepage copy refuses to conflate them either.
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dirname, "..", "..");
+const perfPath = join(import.meta.dirname, "..", "src/components/landing/perf.ts");
+const { PERCENTILES, MEASUREMENT, PERF_SOURCE, PERF_LANE } = await import(perfPath);
+
+const failures = [];
+const fail = (m) => failures.push(m);
+
+let page;
+try {
+  page = readFileSync(join(repoRoot, PERF_SOURCE), "utf8");
+} catch {
+  console.error(`Perf provenance failures:\n  source not found: ${PERF_SOURCE}`);
+  process.exit(1);
+}
+
+// Backticks are markdown, not data: the page writes `prepared_cold` and
+// (`ROTA=1`) as code spans, and the homepage renders them as plain text.
+const cells = (row) => row.split("|").slice(1, -1).map((c) => c.replaceAll("`", "").trim());
+const rows = page.split("\n").filter((l) => l.trimStart().startsWith("|"));
+const ms = (cell) => {
+  const m = /^([0-9]+(?:\.[0-9]+)?) ms$/.exec(cell);
+  return m ? Number(m[1]) : null;
+};
+
+// --- Budget table: the ceilings CI enforces -------------------------------
+// Read only from inside the generated region, so a hand-written example
+// table elsewhere on the page can never be mistaken for the contract.
+const genStart = page.indexOf("<!-- generated:launch-budgets:begin -->");
+const genEnd = page.indexOf("<!-- generated:launch-budgets:end -->");
+if (genStart === -1 || genEnd === -1 || genEnd < genStart) {
+  fail("generated launch-budget markers not found on the performance page");
+}
+const generated = genStart === -1 ? "" : page.slice(genStart, genEnd);
+const budgetRow = generated
+  .split("\n")
+  .filter((l) => l.trimStart().startsWith("|"))
+  .map(cells)
+  .find((c) => c[0] === PERF_LANE);
+
+if (!budgetRow) {
+  fail(`no generated budget row for lane \`${PERF_LANE}\``);
+} else {
+  // Columns: lane | what it measures | p50 | p95 | p99 | every boot
+  const budgets = { p50: ms(budgetRow[2]), p95: ms(budgetRow[3]), p99: ms(budgetRow[4]) };
+  for (const p of PERCENTILES) {
+    const want = budgets[p.label];
+    if (want === null || want === undefined) {
+      fail(`budget table has no parseable ${p.label} for \`${PERF_LANE}\``);
+    } else if (want !== p.budgetMs) {
+      fail(`${p.label} budget drifted: perf.ts says ${p.budgetMs} ms, page says ${want} ms`);
+    }
+  }
+}
+
+// --- Seeded table: one observation, with its fingerprint ------------------
+// Columns: date | lane | host | backend | storage | samples | p50 | p95 | p99
+const seededRow = rows
+  .map(cells)
+  .find((c) => c.length === 9 && c[1] === PERF_LANE && c[0] === MEASUREMENT.date);
+
+if (!seededRow) {
+  fail(
+    `no seeded measurement row for lane \`${PERF_LANE}\` dated ${MEASUREMENT.date} ` +
+      `— if the seeded row was replaced, update perf.ts to the new row rather than keeping the old numbers`,
+  );
+} else {
+  const provenance = [
+    ["host", MEASUREMENT.host, seededRow[2]],
+    ["backend", MEASUREMENT.backend, seededRow[3]],
+    ["storage", MEASUREMENT.storage, seededRow[4]],
+    ["samples", MEASUREMENT.samples, seededRow[5]],
+  ];
+  for (const [field, ours, theirs] of provenance) {
+    if (ours !== theirs) {
+      fail(`${field} drifted: perf.ts says "${ours}", page says "${theirs}"`);
+    }
+  }
+
+  const measured = { p50: ms(seededRow[6]), p95: ms(seededRow[7]), p99: ms(seededRow[8]) };
+  for (const p of PERCENTILES) {
+    const want = measured[p.label];
+    if (want === null || want === undefined) {
+      fail(`seeded table has no parseable ${p.label} measurement`);
+    } else if (want !== p.measuredMs) {
+      fail(`${p.label} measurement drifted: perf.ts says ${p.measuredMs} ms, page says ${want} ms`);
+    }
+  }
+}
+
+// --- The gauge's own precondition -----------------------------------------
+// The arc spans zero to the budget, so a measurement above its ceiling would
+// render as a full sweep and read as "exactly at budget" — the one way this
+// section could show a passing picture of a failing number.
+for (const p of PERCENTILES) {
+  if (p.measuredMs > p.budgetMs) {
+    fail(
+      `${p.label} measurement ${p.measuredMs} ms exceeds its ${p.budgetMs} ms ceiling; ` +
+        `the gauge cannot render this honestly and the homepage must not claim it`,
+    );
+  }
+}
+
+if (PERCENTILES.length === 0) {
+  fail("PERCENTILES is empty — the homepage section would render no readings");
+}
+
+if (failures.length) {
+  console.error("Perf provenance failures:\n  " + failures.join("\n  "));
+  process.exit(1);
+}
+console.log(`perf provenance OK (${PERCENTILES.length} percentiles against ${PERF_SOURCE})`);

--- a/public/src/components/landing/Landing.tsx
+++ b/public/src/components/landing/Landing.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Backends } from "./Backends";
 import { ExecutionContract } from "./ExecutionContract";
 import { Hero } from "./Hero";
+import { LaunchPerf } from "./LaunchPerf";
 import { Quickstart } from "./Quickstart";
 import { DemoTeaser } from "./DemoTeaser";
 import { DeploymentTiers } from "./DeploymentTiers";
@@ -40,11 +41,20 @@ import { Footer } from "./Footer";
 //                         just seen how you *use* mvm, so this is where
 //                         "here's what you're actually getting" lands
 //                         hardest.
-//   6a. Deployment tiers — "one contract, four places to run it": the
+//   6a. Launch performance — the objection Why-a-microVM provokes, answered
+//                         where it forms: a reader who has just been told
+//                         every workload boots its own kernel under a real
+//                         hypervisor is at that moment thinking "that must
+//                         be slow". Budget-vs-measurement is drawn, not
+//                         narrated — the arc is the ceiling CI enforces and
+//                         the fill is what one fingerprinted host did.
+//                         Numbers live in perf.ts and are gated against the
+//                         performance page by check-perf-provenance.mjs.
+//   6b. Deployment tiers — "one contract, four places to run it": the
 //                         product-site tier grid (local / hosted / edge /
 //                         confidential), after the case for the boundary
 //                         is made.
-//   6b. Backends          — "the backend is an implementation detail": the
+//   6c. Backends          — "the backend is an implementation detail": the
 //                         product-site backend/attestation grid, standing in
 //                         where the Boundary panel used to make the
 //                         backend-agnostic point.
@@ -75,6 +85,7 @@ export function Landing() {
           entry to the section-order comment above. */}
       {/* <Positioning /> */}
       <WhyMicrovm />
+      <LaunchPerf />
       <DeploymentTiers />
       <Backends />
       <FAQ />

--- a/public/src/components/landing/LaunchPerf.tsx
+++ b/public/src/components/landing/LaunchPerf.tsx
@@ -1,0 +1,161 @@
+import { Eyebrow } from "./primitives/Eyebrow";
+import { Reveal } from "./primitives/Reveal";
+import { Section } from "./primitives/Section";
+import { MEASUREMENT, PERCENTILES, PERF_LANE, type Percentile } from "./perf";
+
+// The arc spans zero to the *budget*, so a full sweep is the ceiling and the
+// fill is how much of it the measured launch actually spent. That mapping is
+// chosen so the picture cannot make the claim the performance page warns
+// about: there is no scale on which a measurement can be mistaken for the
+// ceiling, because the ceiling is the arc itself.
+//
+// `pathLength={100}` renormalizes the arc so stroke-dasharray is read in
+// percent — no arc-length arithmetic to drift when the radius changes.
+const ARC = "M 8 60 A 52 52 0 0 1 112 60";
+
+function Gauge({ p }: { p: Percentile }) {
+  // Rounded before it reaches the attribute: an unrounded ratio serializes
+  // as 70.39999999999999 in the markup, which reads as spurious precision
+  // on a page whose argument is that its numbers are exact.
+  const pct = Math.round((p.measuredMs / p.budgetMs) * 1000) / 10;
+  // A reading this close to its ceiling is a warning, not a pass. The
+  // threshold is deliberately blunt: the point is that the colour is
+  // derived from the numbers, so it cannot flatter a regression.
+  const nearCeiling = pct >= 90;
+
+  return (
+    <div className="h-full rounded-xl border border-glass-border/60 bg-raised p-5">
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="font-mono text-[11px] font-semibold tracking-[0.14em] uppercase text-label">
+          {p.label}
+        </p>
+        <span className="shrink-0 font-mono text-[10px] uppercase tracking-widest text-label">
+          {Math.round(pct)}% of ceiling
+        </span>
+      </div>
+
+      <svg
+        viewBox="0 0 120 68"
+        className="mt-4 w-full"
+        role="img"
+        aria-label={`${p.label} dispatch ${p.measuredMs} milliseconds, against a ${p.budgetMs} millisecond ceiling`}
+      >
+        <path
+          d={ARC}
+          fill="none"
+          stroke="var(--color-edge)"
+          strokeWidth="8"
+          strokeLinecap="round"
+        />
+        <path
+          d={ARC}
+          fill="none"
+          stroke={nearCeiling ? "var(--color-amber)" : "var(--color-accent)"}
+          strokeWidth="8"
+          strokeLinecap="round"
+          pathLength={100}
+          strokeDasharray={`${pct} 100`}
+        />
+      </svg>
+
+      <p className="-mt-4 text-center font-display text-3xl font-bold leading-none text-title">
+        {p.measuredMs.toFixed(1)}
+        <span className="ml-1 text-base font-normal text-label">ms</span>
+      </p>
+      <p className="mt-2 text-center font-mono text-[11px] text-label">
+        ceiling {p.budgetMs} ms
+      </p>
+    </div>
+  );
+}
+
+export function LaunchPerf() {
+  const rawBase = import.meta.env.BASE_URL;
+  const base = rawBase.endsWith("/") ? rawBase : `${rawBase}/`;
+
+  return (
+    <Section id="launch-performance" rule>
+      <Reveal>
+        <Eyebrow>Performance</Eyebrow>
+        <h2 className="lowercase font-display text-2xl font-bold leading-tight text-title sm:text-3xl">
+          measured, not asserted.
+        </h2>
+        <p
+          className="max-w-2xl text-sm leading-relaxed text-body"
+          style={{ marginTop: "1rem" }}
+        >
+          The dispatch window — an admitted execution plan to the guest command
+          running. The arc is the budget CI enforces on every launch; the fill
+          is what one named host actually did, revalidated sample by sample
+          before it was allowed onto the page.
+        </p>
+      </Reveal>
+
+      <div
+        className="grid gap-3 sm:grid-cols-3"
+        style={{ marginTop: "3rem" }}
+      >
+        {PERCENTILES.map((p, i) => (
+          <Reveal key={p.label} delay={i * 80}>
+            <Gauge p={p} />
+          </Reveal>
+        ))}
+      </div>
+
+      {/* Provenance is not a footnote here. The performance page refuses a
+          number whose host fingerprint it does not know, so reprinting the
+          number without the fingerprint would launder exactly the context
+          that makes it checkable.
+
+          Inline margin, not mt-*: Starlight's unlayered stylesheet beats
+          layered utilities on this page (see Positioning.tsx) — a margin
+          utility here collapses to zero and runs this list into the cards. */}
+      <dl
+        className="grid gap-x-6 gap-y-2 font-mono text-xs leading-relaxed text-label sm:grid-cols-2"
+        style={{ marginTop: "2rem" }}
+      >
+        <div>
+          <dt className="inline text-dim">lane </dt>
+          <dd className="inline">{PERF_LANE}</dd>
+        </div>
+        <div>
+          <dt className="inline text-dim">backend </dt>
+          <dd className="inline">{MEASUREMENT.backend}</dd>
+        </div>
+        <div>
+          <dt className="inline text-dim">host </dt>
+          <dd className="inline">{MEASUREMENT.host}</dd>
+        </div>
+        <div>
+          <dt className="inline text-dim">storage </dt>
+          <dd className="inline">{MEASUREMENT.storage}</dd>
+        </div>
+        <div>
+          <dt className="inline text-dim">samples </dt>
+          <dd className="inline">{MEASUREMENT.samples}</dd>
+        </div>
+        <div>
+          <dt className="inline text-dim">date </dt>
+          <dd className="inline">{MEASUREMENT.date}</dd>
+        </div>
+      </dl>
+
+      <p
+        className="max-w-2xl font-mono text-xs leading-relaxed text-label"
+        style={{ marginTop: "1.75rem" }}
+      >
+        Measured on spinning media, where a large fixed fraction of the window
+        is <code>fsync</code> cost that disappears on NVMe — so this is a
+        pessimistic reading, not a favourable one. Budgets, disqualification
+        rules, and the raw report digest are on the{" "}
+        <a
+          href={`${base}reference/performance/`}
+          className="text-accent underline underline-offset-2 hover:text-accent/80"
+        >
+          launch performance
+        </a>{" "}
+        page.
+      </p>
+    </Section>
+  );
+}

--- a/public/src/components/landing/perf.ts
+++ b/public/src/components/landing/perf.ts
@@ -1,0 +1,41 @@
+// Launch numbers shown on the homepage, mirrored from the published
+// performance page. `scripts/check-perf-provenance.mjs` re-parses that page
+// and fails if any value here drifts, so this file is a cache of the source
+// of truth rather than a second copy of it.
+//
+// The budget/measurement split is the whole point and must survive any edit
+// here: a budget is a ceiling CI enforces, a measurement is something a
+// named host actually did. The performance page keeps them in separate
+// tables precisely so a ceiling is never read as a result — this section
+// keeps them in separate *roles*, ceiling as the arc's full sweep and
+// measurement as the fill, which is the same distinction drawn visually.
+
+/** Page the provenance gate parses. Repo-root-relative. */
+export const PERF_SOURCE = "public/src/content/docs/reference/performance.md";
+
+/** The lane both tables on that page describe. */
+export const PERF_LANE = "prepared_cold";
+
+export type Percentile = {
+  /** Column heading in both source tables. */
+  label: "p50" | "p95" | "p99";
+  /** Ceiling from the generated budget table. */
+  budgetMs: number;
+  /** Observation from the seeded measurements table. */
+  measuredMs: number;
+};
+
+export const PERCENTILES: Percentile[] = [
+  { label: "p50", budgetMs: 200, measuredMs: 171.5 },
+  { label: "p95", budgetMs: 250, measuredMs: 176.0 },
+  { label: "p99", budgetMs: 300, measuredMs: 178.0 },
+];
+
+/** The seeded row's provenance columns, verbatim from the page. */
+export const MEASUREMENT = {
+  date: "2026-08-19",
+  host: "Linux 6.8.0-137 x86_64, Intel i7-7700",
+  backend: "Firecracker v1.14.1",
+  storage: "rotational md-RAID (ROTA=1)",
+  samples: "20 (+2 warm-ups)",
+} as const;


### PR DESCRIPTION
The landing page argues for a full guest kernel under a real hypervisor and
then says nothing about what that costs, leaving the obvious objection — that
a VM must be slow to start — unanswered at the moment a reader forms it. This
adds a gauge row directly after Why-a-microVM.

## The budget/measurement split is drawn, not narrated

`performance.md` keeps ceilings and observations in separate tables because
"a ceiling printed in the same column as an observation gets read as an
observation." This section preserves that distinction structurally: the arc
is the budget CI enforces, the fill is what one fingerprinted host actually
did. There is no scale on which the two can be confused, because the ceiling
*is* the arc.

Current readings, all from the seeded `prepared_cold` row:

| | measured | ceiling | |
| --- | ---: | ---: | ---: |
| p50 | 171.5 ms | 200 ms | 86% |
| p95 | 176.0 ms | 250 ms | 70% |
| p99 | 178.0 ms | 300 ms | 59% |

Provenance (lane, host, backend, storage, samples, date) renders alongside
them rather than as a footnote — the perf page refuses a number whose host
fingerprint it doesn't know, so reprinting one without the fingerprint would
launder exactly the context that makes it checkable.

## Numbers are gated, not typed

`perf.ts` caches the values; `scripts/check-perf-provenance.mjs` re-parses the
performance page and fails on drift. It reads the generated budget region and
the seeded measurement row separately — conflating them is the failure that
page is built to prevent, so the gate doesn't either.

Each arm was confirmed to go red rather than assumed:

- budget drift — `p50 budget drifted: perf.ts says 180 ms, page says 200 ms`
- measurement drift — `p50 measurement drifted: perf.ts says 149.5 ms, page says 171.5 ms`
- fingerprint drift — `host drifted: ... says "Apple M3 Max", page says "Intel i7-7700"`

It also refuses a measurement above its ceiling, which the arc would otherwise
clamp to a full sweep and render as a pass.

## CI

`website.yml` runs each `check:*` as its own step rather than via `pnpm check`,
so a new script is gated nowhere by default. Added the step, and a comment
saying so.

The job's `name:` is deliberately unchanged — it is the check name branch
protection matches on. Worth renaming to include "perf" alongside a protection
rule update, not before.

## Cost

SVG, no WebGL. Landing island 167 KB → 172 KB. The section is server-rendered
and static, so there is no animation to gate on reduced motion, and it renders
without JS.

## Verification

- `pnpm check` green — tokens, samples, perf, build
- `actionlint` clean
- screenshotted in both themes; tokens flip correctly, no hardcoded hex

## Notes

- The homepage now depends on the single seeded `2026-08-19` row existing. If
  it is replaced, the gate fails and names the fix rather than silently
  keeping stale numbers.
- `Landing.tsx`'s ordering comment defers to `reshape-brief.md` and
  `layout-match-report.md`; neither is in the repo. Numbering kept consistent,
  but flagging that those docs aren't checked in.
