### PR TITLE
fix(site): restore architecture header spacing

### DIFF
--- a/public/src/components/architecture/Architecture.astro
+++ b/public/src/components/architecture/Architecture.astro
@@ -358,6 +358,10 @@ import { Footer } from "../landing/Footer";
     .arch { padding-inline: 2rem; }
   }
 
+  @media (min-width: 64rem) {
+    .arch { padding-block-start: 6rem; }
+  }
+
   .arch a:focus-visible,
   .arch svg a:focus-visible rect {
     outline: 2px solid var(--steel);


### PR DESCRIPTION
## Summary

- restore the large-screen top-padding step on the architecture page
- match the landing-page spacing below the fixed header
- increase the measured header-to-content gap from about 4px to about 15px

## Validation

- pnpm --dir public check
- browser layout assertion at 1280px viewport
- no horizontal overflow or browser console errors