### PR TITLE
fix(site): strengthen architecture proof points

### DIFF
--- a/public/src/components/architecture/Architecture.astro
+++ b/public/src/components/architecture/Architecture.astro
@@ -17,10 +17,10 @@ import { Footer } from "../landing/Footer";
     <p class="lede">MVM runs any workload — an AI agent, a customer's code, a build job — inside a <strong>sealed, immutable, hardware-isolated microVM</strong>, on the laptop and in the fleet, with the security posture <strong>enforced by CI, not promised in a slide</strong>.</p>
 
     <div class="proof">
-      <div><b>15 + 3</b><span>security claims, CI-enforced</span></div>
-      <div><b>~4,350</b><span>tests on every merge</span></div>
-      <div><b>3 + 1</b><span>hypervisors + Wasm, one CLI</span></div>
-      <div><b>0</b><span>containers, SSH daemons, guest NICs</span></div>
+      <div><b>18</b><span>claims with live machine witnesses</span></div>
+      <div><b>3</b><span>production microVM backends, one signed plan</span></div>
+      <div><b>2</b><span>independent plan verifiers, one shared corpus</span></div>
+      <div><b>0</b><span>guest NICs, SSH daemons, container fallbacks</span></div>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary

- remove the inaccurate claim that the full test suite runs on every merge
- replace the proof strip with durable, repository-backed architecture guarantees
- highlight 18 claims with live witnesses, 3 production microVM backends, 2 independent plan verifiers, and zero guest NICs, SSH daemons, or container fallbacks

## Validation

- pnpm --dir public check