### PR TITLE
fix(site): clarify architecture proof points

### DIFF
--- a/public/src/components/architecture/Architecture.astro
+++ b/public/src/components/architecture/Architecture.astro
@@ -17,9 +17,9 @@ import { Footer } from "../landing/Footer";
     <p class="lede">MVM runs any workload — an AI agent, a customer's code, a build job — inside a <strong>sealed, immutable, hardware-isolated microVM</strong>, on the laptop and in the fleet, with the security posture <strong>enforced by CI, not promised in a slide</strong>.</p>
 
     <div class="proof">
-      <div><b>18</b><span>claims with live machine witnesses</span></div>
-      <div><b>3</b><span>production microVM backends, one signed plan</span></div>
-      <div><b>2</b><span>independent plan verifiers, one shared corpus</span></div>
+      <div><b>18</b><span>security claims — 15 enforced, 3 preview</span></div>
+      <div><b>4</b><span>runtime backends, one CLI</span></div>
+      <div><b>3</b><span>workload sources, one signed contract</span></div>
       <div><b>0</b><span>guest NICs, SSH daemons, container fallbacks</span></div>
     </div>
   </header>


### PR DESCRIPTION
## Summary

- correct the architecture page to show all 4 runtime backends
- replace internal verifier terminology with the clearer 3 workload sources, one signed contract proof point
- clarify the 18-claim total as 15 enforced claims plus 3 preview claims

## Validation

- pnpm --dir public check