### PR TITLE
fix(ci): activate the staged sealed boot image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1012,7 +1012,7 @@ jobs:
       # nobody had published. Boot images get their own tags precisely so
       # this pin stops moving with the CLI's version — keep it in step with
       # `DEFAULT_BOOT_IMAGE_TAG` in mvm-core's config.
-      IMAGE_TAG: boot-image/v0.1.0
+      IMAGE_TAG: boot-image/v0.1.3
       # Must track `crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT`. The
       # launch path passes `--enable-pci`, which older Firecracker rejects
       # outright: it exits before creating its API socket, and the only symptom

--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -567,8 +567,13 @@ jobs:
           SYSTEM="${ARCH}-linux"
           INITRAMFS_PATH=$(nix build "./nix/images/initramfs#packages.${SYSTEM}.default" \
             --no-link --print-out-paths | head -1)
-          mkdir -p initramfs-staging
-          cp -L "$INITRAMFS_PATH/initramfs.cpio.gz" initramfs-staging/initramfs.cpio.gz
+          # The runtime identifies the universal initramfs by its location in
+          # the mvm cache. Keep the staged witness on that production path so
+          # WorkloadRunner sends ActivateEnvironment instead of treating this
+          # as a legacy per-rootfs initramfs.
+          mkdir -p "$HOME/.mvm/cache/initramfs"
+          cp -L "$INITRAMFS_PATH/initramfs.cpio.gz" \
+            "$HOME/.mvm/cache/initramfs/initramfs.cpio.gz"
 
       - name: Boot the staged image before it becomes a release asset
         if: matrix.arch == 'x86_64'
@@ -600,7 +605,7 @@ jobs:
           cp "staging/default-microvm-meta-${ARCH}.json" staging/mvm-meta.json
           cargo test --test runtime_boot_bench \
             prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
-          MVM_RUNTIME_BOOT_INITRD=initramfs-staging/initramfs.cpio.gz \
+          MVM_RUNTIME_BOOT_INITRD="$HOME/.mvm/cache/initramfs/initramfs.cpio.gz" \
           MVM_RUNTIME_BOOT_ROOTFS_VERITY="staging/default-microvm-rootfs-${ARCH}.verity" \
           MVM_RUNTIME_BOOT_ROOTFS_ROOTHASH="$(tr -d '[:space:]' < "staging/default-microvm-rootfs-${ARCH}.roothash")" \
             cargo test --test runtime_boot_bench \

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -14,15 +14,13 @@ pub const FC_VERSION_DEFAULT: &str = match option_env!("MVM_FC_VERSION") {
 /// rather than a bare version, because it is spliced straight into a release
 /// download URL: `https://github.com/<repo>/releases/download/<tag>/<asset>`.
 ///
-/// **Nothing reads this yet.** `download_default_microvm_image` and the
-/// workload kernel fetch still build their URLs from the CLI's own version and
-/// must keep doing so until a `boot-image/v0.1.0` release actually exists —
-/// repointing them at a tag nobody has published turns every fresh install's
-/// first boot into a 404. Publishing that tag is the condition that unblocks
-/// the switch.
+/// Downloaders and the merge-queue boot witnesses must stay on this same
+/// published tag. Advancing the constant before the release exists turns every
+/// fresh install's first boot into a 404; advancing only one consumer makes CI
+/// validate a different image from the one users receive.
 pub const DEFAULT_BOOT_IMAGE_TAG: &str = match option_env!("MVM_BOOT_IMAGE_TAG") {
     Some(t) => t,
-    None => "boot-image/v0.1.0",
+    None => "boot-image/v0.1.3",
 };
 
 /// Host CPU architecture for arch-tagged downloads (the Firecracker release

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -37,6 +37,12 @@ fn boot_image_workflow() -> String {
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
 }
 
+fn ci_workflow() -> String {
+    let path = Path::new(".github/workflows/ci.yml");
+    fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
 fn pages_workflow() -> String {
     let path = Path::new(".github/workflows/pages.yml");
     fs::read_to_string(path)
@@ -352,6 +358,10 @@ fn the_staged_microvm_boot_gate_covers_plain_and_sealed_boots() {
             "the sealed boot invocation must set {variable}"
         );
     }
+    assert!(
+        step.contains("MVM_RUNTIME_BOOT_INITRD=\"$HOME/.mvm/cache/initramfs/initramfs.cpio.gz\""),
+        "the staged universal initramfs must use the production cache path so activation runs"
+    );
 }
 
 /// The four jobs that build a boot image. They move as a set: splitting them
@@ -576,6 +586,15 @@ fn the_boot_image_tag_composes_the_url_the_workflow_uploads_to() {
             "the workflow must stage {staged:?}, or {url} 404s"
         );
     }
+}
+
+#[test]
+fn the_ci_boot_witness_pins_the_compiled_boot_image_tag() {
+    let tag = mvmctl::core::config::DEFAULT_BOOT_IMAGE_TAG;
+    assert!(
+        ci_workflow().contains(&format!("IMAGE_TAG: {tag}")),
+        "the merge-queue boot witness must validate the compiled default boot image tag {tag}"
+    );
 }
 
 #[test]

--- a/xtask/src/check_single_home.rs
+++ b/xtask/src/check_single_home.rs
@@ -127,6 +127,12 @@ const EXEMPTIONS: &[(&str, &[Rule], &str)] = &[
         ".mvm-shaped test fixtures asserting host paths are redacted from normalized event detail; \
          it derives no mvm path",
     ),
+    (
+        "tests/release_assets.rs",
+        &[Rule::HomeLiteral],
+        "structural release tests inspect the boot workflow's shell command and pin its canonical \
+         production cache path; the test derives no host path",
+    ),
 ];
 
 pub fn run(workspace: &Path) -> Result<()> {


### PR DESCRIPTION
## Summary

- stage the universal initramfs under the production cache path so the workload runner sends ActivateEnvironment during the sealed release witness
- pin runtime downloads and merge-queue boot witnesses to additive boot-image/v0.1.3
- assert CI and the compiled default use the same published tag and that the sealed witness uses the activation-managed initramfs path

## Failure reproduced

boot-image/v0.1.2 proved the plain FlowMux image boots, then failed closed on the sealed boot with NotActivated because the witness copied the universal initramfs outside the cache path used to identify it.

## Verification

- cargo test --test release_assets (24 passed)
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- pre-commit full workspace/all-target Clippy and actionlint

The boot-image/v0.1.3 release workflow is running from this exact commit; publication remains fail-closed on both architectures and the staged plain+sealed boot gate.