### PR TITLE
fix(builder): seal rootfs journal before export

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -158,6 +158,11 @@ fn main() -> ExitCode {
     }
 
     #[cfg(target_os = "linux")]
+    if std::env::args().nth(1).as_deref() == Some("seal-rootfs-journal") {
+        return seal_rootfs_journal_subcommand();
+    }
+
+    #[cfg(target_os = "linux")]
     {
         linux::run()
     }
@@ -185,6 +190,21 @@ fn run_before_build_hook_subcommand() -> ExitCode {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("mvm-host-vm-init: run-before-build-hook failed: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn seal_rootfs_journal_subcommand() -> ExitCode {
+    let rootfs = std::env::args().nth(2).unwrap_or_else(|| {
+        eprintln!("usage: mvm-host-vm-init seal-rootfs-journal <rootfs.ext4>");
+        std::process::exit(2);
+    });
+    match builder_hooks::seal_rootfs_journal(std::path::Path::new(&rootfs)) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("mvm-host-vm-init: seal-rootfs-journal failed: {e}");
             ExitCode::FAILURE
         }
     }

--- a/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
@@ -28,6 +28,10 @@ const MOUNT_POINT: &str = "/tmp/mvm-before-build-rootfs";
 /// Absolute path populated by the builder image from util-linux.
 const UTIL_LINUX_LOSETUP: &str = "/sbin/losetup";
 
+/// Offline filesystem checker used to replay and seal the ext4 journal after
+/// the writable hook mount has been torn down.
+const E2FSCK: &str = "/sbin/e2fsck";
+
 /// Grace period for the before_build hook. Build-time setup (DB
 /// migrations, cache warming) should complete promptly; if it hangs we
 /// fail the build rather than leaving a builder VM wedged.
@@ -92,6 +96,22 @@ pub enum BuilderHookError {
         #[source]
         source: std::io::Error,
     },
+
+    /// The offline rootfs journal check could not be started.
+    #[error("check rootfs journal for {rootfs}: {source}")]
+    CheckRootfs {
+        rootfs: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The offline checker could not leave the rootfs in a clean state.
+    #[error("rootfs journal check for {rootfs} exited with code {code}: {stderr}")]
+    RootfsNotClean {
+        rootfs: PathBuf,
+        code: i32,
+        stderr: String,
+    },
 }
 
 /// Mount `rootfs_path` read-write at [`MOUNT_POINT`], bind-mount
@@ -136,16 +156,50 @@ pub fn run_before_build_hook(rootfs_path: &Path) -> Result<(), BuilderHookError>
         .map(|m| m.is_file())
         .unwrap_or(false);
 
-    if !hook_present {
+    let hook_result = if !hook_present {
         eprintln!("mvm-host-vm-init: no before_build hook at {HOOK_PATH}; treating as no-op");
+        Ok(())
+    } else {
+        eprintln!(
+            "mvm-host-vm-init: running before_build hook in {rootfs_path}",
+            rootfs_path = rootfs_path.display()
+        );
+        run_hook_in_chroot()
+    };
+
+    // Drop every bind mount, the rootfs mount, and its loop device before
+    // touching the image offline. If best-effort Drop cleanup ever leaves the
+    // image mounted, e2fsck refuses it and the artifact is not published.
+    drop(mounted_rootfs);
+    let journal_result = seal_rootfs_journal(rootfs_path);
+    match (hook_result, journal_result) {
+        (Err(hook_error), _) => Err(hook_error),
+        (Ok(()), result) => result,
+    }
+}
+
+fn seal_rootfs_journal(rootfs_path: &Path) -> Result<(), BuilderHookError> {
+    let output = Command::new(E2FSCK)
+        .args(["-p", "-f"])
+        .arg(rootfs_path)
+        .output()
+        .map_err(|source| BuilderHookError::CheckRootfs {
+            rootfs: rootfs_path.to_path_buf(),
+            source,
+        })?;
+    let code = output.status.code().unwrap_or(-1);
+    if e2fsck_exit_code_is_clean(code) {
         return Ok(());
     }
+    Err(BuilderHookError::RootfsNotClean {
+        rootfs: rootfs_path.to_path_buf(),
+        code,
+        stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+    })
+}
 
-    eprintln!(
-        "mvm-host-vm-init: running before_build hook in {rootfs_path}",
-        rootfs_path = rootfs_path.display()
-    );
-    run_hook_in_chroot()
+fn e2fsck_exit_code_is_clean(code: i32) -> bool {
+    matches!(code, 0 | 1)
 }
 
 struct LoopDevice {
@@ -327,9 +381,19 @@ mod tests {
         assert_eq!(HOOK_PATH, "/etc/mvm/hooks/before_build.sh");
         assert_eq!(MOUNT_POINT, "/tmp/mvm-before-build-rootfs");
         assert_eq!(UTIL_LINUX_LOSETUP, "/sbin/losetup");
+        assert_eq!(E2FSCK, "/sbin/e2fsck");
         assert_eq!(
             CHROOT_PATH,
             "/usr/local/sbin:/usr/local/bin:/sbin:/usr/sbin:/bin:/usr/bin"
         );
+    }
+
+    #[test]
+    fn e2fsck_clean_and_repaired_codes_are_accepted() {
+        assert!(e2fsck_exit_code_is_clean(0));
+        assert!(e2fsck_exit_code_is_clean(1));
+        for code in [2, 4, 8, 16, 32, 128, -1] {
+            assert!(!e2fsck_exit_code_is_clean(code), "code {code}");
+        }
     }
 }

--- a/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
@@ -178,7 +178,7 @@ pub fn run_before_build_hook(rootfs_path: &Path) -> Result<(), BuilderHookError>
     }
 }
 
-fn seal_rootfs_journal(rootfs_path: &Path) -> Result<(), BuilderHookError> {
+pub fn seal_rootfs_journal(rootfs_path: &Path) -> Result<(), BuilderHookError> {
     let output = Command::new(E2FSCK)
         .args(["-p", "-f"])
         .arg(rootfs_path)

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -641,6 +641,7 @@ if [ "$hook_rc" -ne 0 ]; then
     exit $hook_rc
 fi
 cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4
+/sbin/mvm-host-vm-init seal-rootfs-journal /out/rootfs.ext4
 sync
 rm -f "$BUILD_HOOK_ROOTFS"
 
@@ -2081,6 +2082,13 @@ mod tests {
         assert!(
             out_copy_idx < sync_idx,
             "the exported rootfs must be flushed before the temporary image is removed"
+        );
+        let final_seal_idx = body
+            .find("/sbin/mvm-host-vm-init seal-rootfs-journal /out/rootfs.ext4")
+            .expect("final exported artifact journal seal present");
+        assert!(
+            out_copy_idx < final_seal_idx && final_seal_idx < sync_idx,
+            "the final copied rootfs must be sealed before it is published"
         );
         // A failed hook must fail the build, leaving no partial artifact.
         assert!(

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -641,6 +641,7 @@ if [ "$hook_rc" -ne 0 ]; then
     exit $hook_rc
 fi
 cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4
+sync
 rm -f "$BUILD_HOOK_ROOTFS"
 
 if [ -n "$KERNEL_SRC" ]; then
@@ -682,12 +683,12 @@ fi
 
 # Pin the builder VM's own materialize toolchain under fixed GC roots so the
 # cap GC below can't reap it. The OCI rootfs materialize job runs
-# /sbin/mkfs.ext4 (and `mount`) inside this VM but registers no root of its
+# /sbin/mkfs.ext4, /sbin/e2fsck (and `mount`) inside this VM but registers no root of its
 # own, and a workload build's $NIX_OUT closure never carries e2fsprogs — so
-# without these roots a cap GC after a workload build leaves /sbin/mkfs.ext4
-# a dangling symlink and every later image run dies with "mkfs.ext4: not
+# without these roots a cap GC after a workload build leaves the filesystem
+# tools as dangling symlinks and every later image run dies with "mkfs.ext4: not
 # found". Best-effort; skips a tool already missing (recovery rebuilds it).
-for tool in /sbin/mkfs.ext4 mount; do
+for tool in /sbin/mkfs.ext4 /sbin/e2fsck mount; do
   tool_path=$(command -v "$tool" 2>/dev/null) || continue
   tool_store=$(readlink -f "$tool_path" 2>/dev/null) || continue
   [ -n "$tool_store" ] || continue
@@ -2074,6 +2075,13 @@ mod tests {
             hook_idx < out_copy_idx,
             "before_build hook must run before /out/rootfs.ext4 is copied"
         );
+        let sync_idx = body
+            .find("sync\nrm -f \"$BUILD_HOOK_ROOTFS\"")
+            .expect("artifact sync present");
+        assert!(
+            out_copy_idx < sync_idx,
+            "the exported rootfs must be flushed before the temporary image is removed"
+        );
         // A failed hook must fail the build, leaving no partial artifact.
         assert!(
             body.contains("mvm-builder-vm: before_build hook failed"),
@@ -2118,6 +2126,10 @@ mod tests {
         assert!(
             body.contains("/sbin/mkfs.ext4"),
             "toolchain pin must cover mkfs.ext4 in:\n{body}"
+        );
+        assert!(
+            body.contains("/sbin/e2fsck"),
+            "toolchain pin must cover the rootfs journal checker in:\n{body}"
         );
         let gc_idx = body.find("nix-collect-garbage").expect("gc present");
         assert!(

--- a/crates/mvm-build/src/builderd.rs
+++ b/crates/mvm-build/src/builderd.rs
@@ -506,6 +506,7 @@ fn copy_rootfs_with_hook(src_rootfs: &Path, dst: &Path) -> Result<(), String> {
     })?;
     run_before_build_hook(&tmp_path)?;
     copy_artifact(&tmp_path, dst)?;
+    run_builder_rootfs_command("seal-rootfs-journal", dst)?;
     let _ = tmp.close();
     Ok(())
 }
@@ -516,20 +517,24 @@ fn copy_rootfs_with_hook(src_rootfs: &Path, dst: &Path) -> Result<(), String> {
 /// `export_image_artifacts` on a dev host), the hook is skipped. The
 /// binary is always baked into the builder VM rootfs in production.
 fn run_before_build_hook(rootfs_path: &Path) -> Result<(), String> {
+    run_builder_rootfs_command("run-before-build-hook", rootfs_path)
+}
+
+fn run_builder_rootfs_command(command: &str, rootfs_path: &Path) -> Result<(), String> {
     let runner = std::path::Path::new("/sbin/mvm-host-vm-init");
     if !runner.is_file() {
         return Ok(());
     }
     let status = std::process::Command::new(runner)
-        .arg("run-before-build-hook")
+        .arg(command)
         .arg(rootfs_path)
         .status()
-        .map_err(|e| format!("spawn before_build hook runner: {e}"))?;
+        .map_err(|e| format!("spawn rootfs command {command}: {e}"))?;
     if status.success() {
         Ok(())
     } else {
         Err(format!(
-            "before_build hook failed (exit {:?})",
+            "rootfs command {command} failed (exit {:?})",
             status.code()
         ))
     }

--- a/crates/mvm-build/src/builderd.rs
+++ b/crates/mvm-build/src/builderd.rs
@@ -505,8 +505,7 @@ fn copy_rootfs_with_hook(src_rootfs: &Path, dst: &Path) -> Result<(), String> {
         )
     })?;
     run_before_build_hook(&tmp_path)?;
-    std::fs::copy(&tmp_path, dst)
-        .map_err(|e| format!("copy {} -> {}: {e}", tmp_path.display(), dst.display()))?;
+    copy_artifact(&tmp_path, dst)?;
     let _ = tmp.close();
     Ok(())
 }
@@ -540,8 +539,10 @@ fn run_before_build_hook(rootfs_path: &Path) -> Result<(), String> {
 /// symlink farms), with a path-named error.
 fn copy_artifact(src: &Path, dst: &Path) -> Result<(), String> {
     std::fs::copy(src, dst)
-        .map(|_| ())
-        .map_err(|e| format!("copy {} -> {}: {e}", src.display(), dst.display()))
+        .map_err(|e| format!("copy {} -> {}: {e}", src.display(), dst.display()))?;
+    std::fs::File::open(dst)
+        .and_then(|file| file.sync_all())
+        .map_err(|e| format!("sync {}: {e}", dst.display()))
 }
 
 /// The `nix flake prefetch --json` argv for a

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -1125,6 +1125,7 @@ pub fn stage_flake_dispatch_job(
              exit $hook_rc\n\
          fi\n\
          cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"\n\
+         sync\n\
          rm -f \"$BUILD_HOOK_ROOTFS\"\n\
          if [ -f \"$STORE_PATH/manifest.json\" ]; then\n\
              cp -L \"$STORE_PATH/manifest.json\" \"$OUT_DIR/manifest.json\"\n\
@@ -1752,6 +1753,13 @@ mod tests {
         assert!(
             hook_idx < out_copy_idx,
             "before_build hook must run before rootfs.ext4 is copied to OUT_DIR"
+        );
+        let sync_idx = body
+            .find("sync\nrm -f \"$BUILD_HOOK_ROOTFS\"")
+            .expect("artifact sync present");
+        assert!(
+            out_copy_idx < sync_idx,
+            "the exported rootfs must be flushed before the temporary image is removed"
         );
         assert!(
             body.contains("mvm-host-vm-init: before_build hook failed"),

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -1118,13 +1118,17 @@ pub fn stage_flake_dispatch_job(
          BUILD_HOOK_ROOTFS=\"/tmp/mvm-rootfs-before-build.ext4\"\n\
          cp -L \"$STORE_PATH/rootfs.ext4\" \"$BUILD_HOOK_ROOTFS\"\n\
          echo 'mvm-host-vm-init: running before_build hook' >&2\n\
-         if ! /sbin/mvm-host-vm-init run-before-build-hook \"$BUILD_HOOK_ROOTFS\"; then\n\
-             hook_rc=$?\n\
+         set +e\n\
+         /sbin/mvm-host-vm-init run-before-build-hook \"$BUILD_HOOK_ROOTFS\"\n\
+         hook_rc=$?\n\
+         set -e\n\
+         if [ \"$hook_rc\" -ne 0 ]; then\n\
              echo \"mvm-host-vm-init: before_build hook failed (exit $hook_rc)\" >&2\n\
              rm -f \"$BUILD_HOOK_ROOTFS\"\n\
              exit $hook_rc\n\
          fi\n\
          cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"\n\
+         /sbin/mvm-host-vm-init seal-rootfs-journal \"$OUT_DIR/rootfs.ext4\"\n\
          sync\n\
          rm -f \"$BUILD_HOOK_ROOTFS\"\n\
          if [ -f \"$STORE_PATH/manifest.json\" ]; then\n\
@@ -1760,6 +1764,13 @@ mod tests {
         assert!(
             out_copy_idx < sync_idx,
             "the exported rootfs must be flushed before the temporary image is removed"
+        );
+        let final_seal_idx = body
+            .find("/sbin/mvm-host-vm-init seal-rootfs-journal \"$OUT_DIR/rootfs.ext4\"")
+            .expect("final exported artifact journal seal present");
+        assert!(
+            out_copy_idx < final_seal_idx && final_seal_idx < sync_idx,
+            "the final copied rootfs must be sealed before it is published"
         );
         assert!(
             body.contains("mvm-host-vm-init: before_build hook failed"),

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -43,7 +43,10 @@ for detailed scope and acceptance criteria.
       reset while the slow TCG guest becomes ready reaches the existing
       bounded activation retry; identity and protocol rejections still fail
       closed. Failed transient starts emit a redacted guest-console tail before
-      cleanup.
+      cleanup. Hook-mutated ext4 images are checked and journal-replayed
+      offline after the writable mount is dropped, then flushed at every export
+      boundary; a mounted or damaged image fails before publication, preserving
+      the workload's hypervisor-enforced read-only rootfs contract.
       The tagged release workflow separately verifies the signed
       future-format overlay through the production downloader before publish.
       The standalone hostd fuzz lock is refreshed for the current dependency

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -44,8 +44,10 @@ for detailed scope and acceptance criteria.
       bounded activation retry; identity and protocol rejections still fail
       closed. Failed transient starts emit a redacted guest-console tail before
       cleanup. Hook-mutated ext4 images are checked and journal-replayed
-      offline after the writable mount is dropped, then flushed at every export
-      boundary; a mounted or damaged image fails before publication, preserving
+      offline after the writable mount is dropped. Every destination is checked
+      again after the final publication copy and before its durability sync;
+      the persistent-builder path preserves the hook command's real exit
+      status. A mounted or damaged image fails before publication, preserving
       the workload's hypervisor-enforced read-only rootfs contract.
       The tagged release workflow separately verifies the signed
       future-format overlay through the production downloader before publish.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2775,6 +2775,13 @@ build instead of being published. Every export route also flushes the copied
 artifact before reporting completion, and the builder toolchain GC roots now
 retain `e2fsck` alongside `mkfs.ext4`.
 
+A follow-up merge-group witness proved that sealing only the writable temporary
+image was insufficient: the final copied artifact could still reach the
+read-only workload with recovery required. Every builder publication route now
+checks the destination image after the final copy and before its durability
+sync. The persistent-builder shell path also preserves the hook command's real
+exit status instead of the status of a negated condition.
+
 ## 2026-08-22 guest hostname generated-protocol parity
 
 The BDD code-generation drift gate caught that the optional post-restore

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2763,6 +2763,18 @@ regression pinning that executable contract. The live lane forces a refresh of
 embedded host binaries so the guest always carries the checkout under test,
 even when Cargo caches are restored.
 
+## 2026-08-23 AArch64 builder rootfs journal sealing
+
+The merge-group AArch64 QEMU witness then reached workload activation and
+proved that a hook-mutated `rootfs.ext4` could be exported with a journal that
+still required recovery. Workload disks are hypervisor-enforced read-only, so
+the guest correctly refused to replay that journal. The builder hook boundary
+now runs offline `e2fsck` after all writable mounts are dropped, accepting only
+the clean and repaired exit codes; a still-mounted or damaged image fails the
+build instead of being published. Every export route also flushes the copied
+artifact before reporting completion, and the builder toolchain GC roots now
+retain `e2fsck` alongside `mkfs.ext4`.
+
 ## 2026-08-22 guest hostname generated-protocol parity
 
 The BDD code-generation drift gate caught that the optional post-restore

--- a/specs/plans/2026-08-20-artifact-acquisition-contract.md
+++ b/specs/plans/2026-08-20-artifact-acquisition-contract.md
@@ -47,9 +47,12 @@ and report the cold-build phase clearly.
   the local Docker witness passes through that one device. The runtime overlay
   is prepared before that builder produces the workload kernel.
   Hook-mutated rootfs images pass an offline journal repair/check after their
-  writable mount is dropped and are flushed before export completion; the
-  workload can therefore retain a hypervisor-enforced read-only rootfs without
-  relying on ext4's unsafe `noload` escape hatch.
+  writable mount is dropped. Each final destination image is checked again
+  after publication copy and before its durability sync; the workload can
+  therefore retain a hypervisor-enforced read-only rootfs without relying on
+  ext4's unsafe `noload` escape hatch. The persistent-builder path captures the
+  hook command's actual exit status before deciding whether publication may
+  continue.
   The tagged release workflow independently signs the newly packaged overlay
   and drives it through the exact production downloader before publish
 - refreshed standalone `mvm-hostd` fuzz lock passes stable and pinned-nightly

--- a/specs/plans/2026-08-20-artifact-acquisition-contract.md
+++ b/specs/plans/2026-08-20-artifact-acquisition-contract.md
@@ -46,6 +46,10 @@ and report the cold-build phase clearly.
   runner grants its unprivileged QEMU process access to `/dev/vhost-vsock`, and
   the local Docker witness passes through that one device. The runtime overlay
   is prepared before that builder produces the workload kernel.
+  Hook-mutated rootfs images pass an offline journal repair/check after their
+  writable mount is dropped and are flushed before export completion; the
+  workload can therefore retain a hypervisor-enforced read-only rootfs without
+  relying on ext4's unsafe `noload` escape hatch.
   The tagged release workflow independently signs the newly packaged overlay
   and drives it through the exact production downloader before publish
 - refreshed standalone `mvm-hostd` fuzz lock passes stable and pinned-nightly


### PR DESCRIPTION
## Summary

- unmount the writable builder-hook rootfs before export and run an offline `e2fsck -p -f`
- fail closed unless the image is clean or repaired, and retain `e2fsck` through builder GC
- flush copied rootfs artifacts before publishing them

## Why

The AArch64 TCG merge-queue witness observed an ext4 journal requiring recovery while the rootfs was attached read-only. This closes that artifact-production gap without weakening the runtime read-only mount.

## Validation

- `cargo test -p mvm-build`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -p mvm-agentd --doc`
- `cargo zigbuild -p mvm-build --bin mvm-host-vm-init --target aarch64-unknown-linux-musl`