### PR TITLE
fix(guest): serve ping from the process that holds the FlowMux identity

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-egress-client.rs
+++ b/crates/mvm-agentd/src/bin/mvm-egress-client.rs
@@ -166,6 +166,25 @@ fn run(addr: std::net::SocketAddr, host_port: u32) -> ExitCode {
         }
     };
 
+    // The ICMP mediator serves `ping` for the unprivileged workload, which
+    // cannot read the signing key this process just loaded. Its own blocking
+    // thread rather than a task on this runtime: it opens a blocking FlowMux
+    // session per client, and `block_on` inside the runtime would panic. Bound
+    // here rather than on the thread, because the guest init waits only for the
+    // proxy port and a workload can already be running by the time a lazily
+    // bound listener is scheduled. A bind failure is not fatal — every other
+    // kind of egress still works without `ping`.
+    match mvm_agentd::icmp_mediator::bind_icmp_mediator() {
+        Ok(listener) => {
+            std::thread::spawn(move || {
+                if let Err(e) = mvm_agentd::icmp_mediator::serve_icmp_mediator(&listener) {
+                    eprintln!("mvm-egress-client: ICMP mediator stopped: {e:#}");
+                }
+            });
+        }
+        Err(e) => eprintln!("mvm-egress-client: ICMP mediator not serving: {e:#}"),
+    }
+
     match rt.block_on(mvm_agentd::flowmux_egress::run(addr, client)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {

--- a/crates/mvm-agentd/src/bin/mvm-ping.rs
+++ b/crates/mvm-agentd/src/bin/mvm-ping.rs
@@ -3,7 +3,10 @@
 //! Installed ahead of busybox on `PATH`, so `ping example.com` inside a workload
 //! resolves to this rather than to a binary that will fail at `socket()`. A
 //! NIC-less guest has no route and no raw socket; the host echoes on its behalf
-//! over vsock, gated by the same allow-list every other egress verb uses.
+//! over vsock, gated by the same allow-list every other egress verb uses. The
+//! workload cannot open that vsock session itself — the guest identity is
+//! root-only — so this asks the guest's loopback mediator, the same way a
+//! workload's HTTP reaches the host through the loopback proxy.
 //!
 //! Output is ping-shaped on purpose — the familiar lines are the point of
 //! shadowing `ping` at all — with one addition: each reply reports the host's own
@@ -23,8 +26,9 @@ const DEFAULT_TIMEOUT_MS: u32 = 4_000;
 /// Default echo count. Unlike `ping`, this terminates: a workload's `ping` with
 /// no bound is a hang in a place nobody is watching.
 const DEFAULT_COUNT: u16 = 4;
-/// How long to wait for the host egress port.
-const CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Slack over the per-echo wait before giving up on the mediator, which is
+/// waiting on the host in turn.
+const HOST_WAIT_SLACK_SECS: u64 = 10;
 
 fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().skip(1).collect();
@@ -41,17 +45,26 @@ fn main() -> ExitCode {
         }
     };
 
-    match mvm_agentd::icmp_client::echo(&parsed, CONNECT_TIMEOUT_SECS) {
+    match mvm_agentd::icmp_client::echo(&parsed, HOST_WAIT_SLACK_SECS) {
         Ok(outcomes) => report(&parsed, &outcomes),
         Err(error) => {
-            // A refusal is the common case here and it is a policy answer, not a
-            // crash: say what the host said and point at the flag that fixes it.
+            // A refusal is the common case here and it is a policy answer, not
+            // a crash: say what the host said and point at the flag that fixes
+            // it. Only for a refusal, though — printing the flag hint after a
+            // transport failure sends the reader to re-check a flag they
+            // already passed, which is the one place the message must not
+            // point.
             eprintln!("mvm-ping: {error:#}");
-            eprintln!(
-                "mvm-ping: a host must be admitted to be pinged — \
-                 pass `--allow-host {}` to the run",
-                parsed.host
-            );
+            if error
+                .downcast_ref::<mvm_agentd::icmp_client::Refused>()
+                .is_some()
+            {
+                eprintln!(
+                    "mvm-ping: a host must be admitted to be pinged — \
+                     pass `--allow-host {}` to the run",
+                    parsed.host
+                );
+            }
             ExitCode::from(2)
         }
     }

--- a/crates/mvm-agentd/src/flowmux_sync.rs
+++ b/crates/mvm-agentd/src/flowmux_sync.rs
@@ -1,11 +1,17 @@
 //! Blocking one-shot FlowMux client for the guest's non-async callers.
 //!
 //! `mvm-egress-client` owns a long-lived async session and multiplexes the
-//! loopback proxy over it. The forward proxy and `ping` cannot use it: they run
-//! inside `mvm-guest-agent`, whose closure is deliberately tokio-free — that is
-//! what the `addons` feature gates, and the sealed agent stays on the near side
-//! of it. So they get this instead: open a connection, do one authenticated
-//! exchange on it, close.
+//! loopback proxy over it. Its other callers cannot reach that session: the
+//! forward proxy runs inside `mvm-guest-agent`, whose closure is deliberately
+//! tokio-free — that is what the `addons` feature gates, and the sealed agent
+//! stays on the near side of it — and the ICMP mediator runs on a blocking
+//! thread beside the runtime rather than on it. So they get this instead: open
+//! a connection, do one authenticated exchange on it, close.
+//!
+//! Every caller here holds the guest signing key, which is root-only by
+//! construction. A process that runs as the workload cannot open a session at
+//! all, which is why `ping` asks [`crate::icmp_mediator`] rather than dialling
+//! the host itself.
 //!
 //! It is the same protocol on the same port, not a second one. The host accepts
 //! any number of concurrent sessions per VM, all pinned to the same guest key,

--- a/crates/mvm-agentd/src/icmp_client.rs
+++ b/crates/mvm-agentd/src/icmp_client.rs
@@ -2,22 +2,46 @@
 //!
 //! A NIC-less guest cannot originate ICMP: there is no route and no raw socket,
 //! so `ping` fails at `socket()` before a packet exists. This asks the host to
-//! echo on the guest's behalf, as one `IcmpEcho` flow on the same authenticated
-//! FlowMux session every other byte between this guest and its host crosses.
+//! echo on the guest's behalf, through the guest's own loopback mediator
+//! ([`crate::icmp_mediator`]) — the same shape as every other thing a workload
+//! sends outward, which reaches the host through the loopback SOCKS proxy or
+//! the loopback DNS stub rather than dialling it directly. The workload runs
+//! unprivileged and the FlowMux identity is root-only, so the mediator is what
+//! makes the echo reachable at all.
 //!
 //! The round trip this measures is the *guest's*, not the host's. The timer
-//! starts before the vsock write and stops when the reply line lands, so it
-//! covers the vsock hop and the host's mediation as well as the network — which
-//! is the whole path any request from this workload takes. The host also reports
-//! its own leg, so the two can be compared rather than conflated.
+//! starts before the request goes to the mediator and stops when the reply line
+//! lands, so it covers the loopback hop, the vsock hop and the host's mediation
+//! as well as the network — which is the whole path any request from this
+//! workload takes. The host also reports its own leg, so the two can be
+//! compared rather than conflated. The mediator's session is established before
+//! the first timer starts, so what is timed is the echo and not the handshake.
 
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpStream;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
-use mvm_contract::protocol::network_flow::Opcode;
+use mvm_core::guest_netd::ICMP_MEDIATOR_LISTEN;
 use mvm_core::icmp_wire::{IcmpEchoReply, IcmpEchoRequest};
 
-use crate::flowmux_sync::SyncFlowMux;
+use crate::icmp_mediator::MediatorHello;
+
+/// The host refused the echo. A policy answer, not a failure to reach it.
+///
+/// Distinguished from every other error so a caller can say which one happened:
+/// pointing at `--allow-host` when the mediator itself was unreachable sends
+/// the user to fix a flag that was never the problem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Refused(pub String);
+
+impl std::fmt::Display for Refused {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for Refused {}
 
 /// One echo's outcome as the guest saw it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -28,8 +52,8 @@ pub enum EchoOutcome {
         seq: u16,
         /// The address the host echoed.
         ip: String,
-        /// Guest end-to-end round trip: vsock out, host mediation, network,
-        /// and back. This is what the workload experiences.
+        /// Guest end-to-end round trip: loopback out, vsock, host mediation,
+        /// network, and back. This is what the workload experiences.
         rtt: Duration,
         /// The host's own leg, for comparison against `rtt`.
         host_leg: Duration,
@@ -45,114 +69,226 @@ pub enum EchoOutcome {
 
 /// Ask the host to echo `request`, returning one outcome per sequence.
 ///
-/// Each echo is its own request on its own connection, because that is the only
-/// way its round trip is real. Batching them onto one connection and timing the
-/// reply lines as they are read measures the reader's buffer, not the network:
-/// later lines are already in memory and clock in at ~0 ms. `ping` times each
-/// packet separately and so does this.
+/// Each echo is sent and awaited on its own, because that is the only way its
+/// round trip is real. Writing them all and then timing the reply lines as they
+/// are read measures the reader's buffer, not the network: later lines are
+/// already in memory and clock in at ~0 ms. `ping` times each packet separately
+/// and so does this.
 ///
 /// A refusal is an error rather than an outcome: it is terminal and applies to
 /// the whole request, so the caller should print the reason rather than report
 /// loss.
-pub fn echo(request: &IcmpEchoRequest, connect_timeout_secs: u64) -> Result<Vec<EchoOutcome>> {
+pub fn echo(request: &IcmpEchoRequest, host_wait_slack_secs: u64) -> Result<Vec<EchoOutcome>> {
     request
         .validate()
         .map_err(|bounds| anyhow::anyhow!("{bounds}"))?;
 
+    // Outlast the host's own wait, or the guest reports a failure for a reply
+    // the host is still legitimately waiting on.
+    let budget = Duration::from_millis(u64::from(request.timeout_ms))
+        .saturating_add(Duration::from_secs(host_wait_slack_secs));
+    let mut mediator = Mediator::connect(budget)?;
+
     let mut outcomes = Vec::with_capacity(usize::from(request.count));
     for seq in 0..request.count {
-        outcomes.push(echo_once(request, seq, connect_timeout_secs)?);
+        outcomes.push(mediator.echo_once(request, seq)?);
     }
     Ok(outcomes)
 }
 
-/// One echo, timed guest-side across the whole path: vsock out, host mediation,
-/// network, and back.
-fn echo_once(
-    request: &IcmpEchoRequest,
-    seq: u16,
-    connect_timeout_secs: u64,
-) -> Result<EchoOutcome> {
-    // One echo per flow; the sequence the guest reports is its own.
-    let single = IcmpEchoRequest {
-        host: request.host.clone(),
-        count: 1,
-        payload_len: request.payload_len,
-        timeout_ms: request.timeout_ms,
-    };
-    let encoded = serde_json::to_vec(&single).context("encode the echo request")?;
+/// An open conversation with the guest's ICMP mediator.
+struct Mediator {
+    writer: TcpStream,
+    reader: BufReader<TcpStream>,
+}
 
-    let mut flowmux = SyncFlowMux::connect().context("open a FlowMux session for the echo")?;
-    // Outlast the host's own wait, or the guest reports a timeout for a reply
-    // the host is still legitimately waiting on.
-    let budget = Duration::from_millis(u64::from(request.timeout_ms))
-        .saturating_add(Duration::from_secs(connect_timeout_secs));
-    flowmux.set_read_timeout(budget)?;
+impl Mediator {
+    /// Dial the mediator and wait for it to announce a session.
+    ///
+    /// The hello is read here rather than folded into the first echo so that
+    /// session setup lands outside every timer.
+    fn connect(budget: Duration) -> Result<Self> {
+        let stream = TcpStream::connect(ICMP_MEDIATOR_LISTEN).with_context(|| {
+            format!(
+                "connect to the guest ICMP mediator on {ICMP_MEDIATOR_LISTEN} \
+                 (served by the egress client, which a run with no admitted egress \
+                 does not start)"
+            )
+        })?;
+        stream
+            .set_read_timeout(Some(budget))
+            .context("set the mediator read timeout")?;
+        // Nagle would hold a short request back waiting for more, which on a
+        // request/reply exchange is added latency inside the number being
+        // reported.
+        stream.set_nodelay(true).ok();
 
-    let stream_id = flowmux.next_stream_id();
-    // The timer spans exactly the request: the session is already up, so what
-    // it measures is the echo, not the dial.
-    let started = Instant::now();
-    flowmux.send(Opcode::IcmpEcho, stream_id, &encoded)?;
-    let (opcode, _stream_id, payload) = flowmux.recv()?;
-    let rtt = started.elapsed();
-
-    let reply: IcmpEchoReply = match opcode {
-        Opcode::IcmpReply | Opcode::IcmpRefused => {
-            serde_json::from_slice(&payload).context("decode the echo reply")?
+        let mut mediator = Self {
+            writer: stream.try_clone().context("clone the mediator socket")?,
+            reader: BufReader::new(stream),
+        };
+        match mediator.read_line().context("read the mediator hello")? {
+            Some(line) => match serde_json::from_str::<MediatorHello>(&line)
+                .context("decode the mediator hello")?
+            {
+                MediatorHello::Ready => Ok(mediator),
+                MediatorHello::Unavailable { message } => bail!("{message}"),
+            },
+            None => bail!("the ICMP mediator closed the connection without a hello"),
         }
-        other => bail!("expected an echo reply, got {other:?}"),
-    };
+    }
 
-    match reply {
-        IcmpEchoReply::Reply {
-            ip,
-            host_leg_us,
-            payload_len,
-            ..
-        } => Ok(EchoOutcome::Reply {
-            seq,
-            ip,
-            rtt,
-            host_leg: Duration::from_micros(host_leg_us),
-            payload_len,
-        }),
-        IcmpEchoReply::Timeout { .. } => Ok(EchoOutcome::Timeout { seq }),
-        IcmpEchoReply::Refused { message } => bail!("{message}"),
+    /// One echo, timed guest-side across the whole path.
+    fn echo_once(&mut self, request: &IcmpEchoRequest, seq: u16) -> Result<EchoOutcome> {
+        // One echo per request; the sequence the guest reports is its own.
+        let single = IcmpEchoRequest {
+            host: request.host.clone(),
+            count: 1,
+            payload_len: request.payload_len,
+            timeout_ms: request.timeout_ms,
+        };
+        let mut encoded = serde_json::to_vec(&single).context("encode the echo request")?;
+        encoded.push(b'\n');
+
+        let started = Instant::now();
+        self.writer
+            .write_all(&encoded)
+            .context("send the echo request to the mediator")?;
+        self.writer.flush().context("flush the echo request")?;
+        let line = self
+            .read_line()
+            .context("read the echo reply")?
+            .ok_or_else(|| anyhow::anyhow!("the ICMP mediator closed before answering"))?;
+        let rtt = started.elapsed();
+
+        match serde_json::from_str::<IcmpEchoReply>(&line).context("decode the echo reply")? {
+            IcmpEchoReply::Reply {
+                ip,
+                host_leg_us,
+                payload_len,
+                ..
+            } => Ok(EchoOutcome::Reply {
+                seq,
+                ip,
+                rtt,
+                host_leg: Duration::from_micros(host_leg_us),
+                payload_len,
+            }),
+            IcmpEchoReply::Timeout { .. } => Ok(EchoOutcome::Timeout { seq }),
+            IcmpEchoReply::Refused { message } => Err(Refused(message).into()),
+        }
+    }
+
+    /// Read one line, `None` at a clean end of stream.
+    fn read_line(&mut self) -> Result<Option<String>> {
+        let mut line = String::new();
+        if self.reader.read_line(&mut line)? == 0 {
+            return Ok(None);
+        }
+        Ok(Some(line.trim().to_string()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{SocketAddr, TcpListener};
+
+    /// Stand in for the mediator: announce `hello`, then answer each request
+    /// line with the next canned reply.
+    fn fake_mediator(hello: MediatorHello, replies: Vec<IcmpEchoReply>) -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let conn = listener.incoming().next().unwrap().unwrap();
+            let mut writer = conn.try_clone().unwrap();
+            let mut reader = BufReader::new(conn);
+            writeln!(writer, "{}", serde_json::to_string(&hello).unwrap()).unwrap();
+            for reply in replies {
+                let mut line = String::new();
+                if reader.read_line(&mut line).unwrap() == 0 {
+                    return;
+                }
+                writeln!(writer, "{}", serde_json::to_string(&reply).unwrap()).unwrap();
+            }
+        });
+        addr
+    }
+
+    /// Drive the client against `addr` rather than the fixed mediator address,
+    /// so the tests need no VM and no fixed port.
+    fn echo_against(addr: SocketAddr, request: &IcmpEchoRequest) -> Result<Vec<EchoOutcome>> {
+        let stream = TcpStream::connect(addr)?;
+        stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+        let mut mediator = Mediator {
+            writer: stream.try_clone()?,
+            reader: BufReader::new(stream),
+        };
+        let hello = mediator.read_line()?.expect("the mediator sends a hello");
+        match serde_json::from_str::<MediatorHello>(&hello)? {
+            MediatorHello::Ready => {}
+            MediatorHello::Unavailable { message } => bail!("{message}"),
+        }
+        (0..request.count)
+            .map(|seq| mediator.echo_once(request, seq))
+            .collect()
+    }
+
+    fn request(count: u16) -> IcmpEchoRequest {
+        IcmpEchoRequest {
+            host: "example.com".into(),
+            count,
+            payload_len: 56,
+            timeout_ms: 1000,
+        }
+    }
 
     /// The request the guest puts on the wire carries exactly one echo, whatever
     /// the caller asked for in total: batching is what made the round trips
     /// meaningless.
     #[test]
     fn each_wire_request_carries_a_single_echo() {
-        let asked = IcmpEchoRequest {
-            host: "example.com".into(),
-            count: 4,
-            payload_len: 56,
-            timeout_ms: 1000,
-        };
-        // Mirrors what `echo_once` builds.
-        let single = IcmpEchoRequest {
-            host: asked.host.clone(),
-            count: 1,
-            payload_len: asked.payload_len,
-            timeout_ms: asked.timeout_ms,
-        };
-        assert_eq!(single.count, 1);
-        assert_eq!(single.payload_len, asked.payload_len);
-        assert_eq!(single.timeout_ms, asked.timeout_ms);
-        assert_eq!(single.host, asked.host);
-        assert_eq!(single.validate(), Ok(()));
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let asked = request(3);
+        let seen = std::thread::spawn(move || {
+            let conn = listener.incoming().next().unwrap().unwrap();
+            let mut writer = conn.try_clone().unwrap();
+            let mut reader = BufReader::new(conn);
+            writeln!(
+                writer,
+                "{}",
+                serde_json::to_string(&MediatorHello::Ready).unwrap()
+            )
+            .unwrap();
+            let mut requests = Vec::new();
+            for _ in 0..3 {
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                requests.push(serde_json::from_str::<IcmpEchoRequest>(line.trim()).unwrap());
+                writeln!(
+                    writer,
+                    "{}",
+                    serde_json::to_string(&IcmpEchoReply::Timeout { seq: 0 }).unwrap()
+                )
+                .unwrap();
+            }
+            requests
+        });
+
+        echo_against(addr, &asked).unwrap();
+        let requests = seen.join().unwrap();
+        assert_eq!(requests.len(), 3, "one request per echo, not one batch");
+        for sent in requests {
+            assert_eq!(sent.count, 1);
+            assert_eq!(sent.host, asked.host);
+            assert_eq!(sent.payload_len, asked.payload_len);
+            assert_eq!(sent.timeout_ms, asked.timeout_ms);
+        }
     }
 
-    /// An out-of-bounds request is refused before any connection is attempted,
-    /// so a bad `-c` costs nothing.
+    /// An out-of-bounds request is refused before anything is dialled, so a bad
+    /// `-c` costs nothing.
     #[test]
     fn an_invalid_request_is_refused_before_dialling() {
         let bad = IcmpEchoRequest {
@@ -162,5 +298,64 @@ mod tests {
             timeout_ms: 1,
         };
         assert!(echo(&bad, 1).is_err());
+    }
+
+    /// The reply's own fields reach the caller, including the host's leg — the
+    /// number that makes mediation cost visible rather than folding it into the
+    /// round trip.
+    #[test]
+    fn a_reply_carries_the_address_and_the_host_leg() {
+        let addr = fake_mediator(
+            MediatorHello::Ready,
+            vec![IcmpEchoReply::Reply {
+                seq: 0,
+                ip: "93.184.216.34".into(),
+                host_leg_us: 12_500,
+                payload_len: 56,
+            }],
+        );
+        let outcomes = echo_against(addr, &request(1)).unwrap();
+        match &outcomes[0] {
+            EchoOutcome::Reply {
+                ip,
+                host_leg,
+                payload_len,
+                ..
+            } => {
+                assert_eq!(ip, "93.184.216.34");
+                assert_eq!(*host_leg, Duration::from_micros(12_500));
+                assert_eq!(*payload_len, 56);
+            }
+            other => panic!("expected a reply, got {other:?}"),
+        }
+    }
+
+    /// A refusal is typed, so the caller can point at `--allow-host` for a
+    /// policy answer and stay quiet about it for anything else.
+    #[test]
+    fn a_refusal_is_distinguishable_from_a_transport_failure() {
+        let refused = fake_mediator(
+            MediatorHello::Ready,
+            vec![IcmpEchoReply::Refused {
+                message: "host not admitted by policy".into(),
+            }],
+        );
+        let error = echo_against(refused, &request(1)).unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<Refused>(),
+            Some(&Refused("host not admitted by policy".into()))
+        );
+
+        let unavailable = fake_mediator(
+            MediatorHello::Unavailable {
+                message: "no FlowMux session".into(),
+            },
+            Vec::new(),
+        );
+        let error = echo_against(unavailable, &request(1)).unwrap_err();
+        assert!(
+            error.downcast_ref::<Refused>().is_none(),
+            "an unreachable mediator is not a policy refusal"
+        );
     }
 }

--- a/crates/mvm-agentd/src/icmp_mediator.rs
+++ b/crates/mvm-agentd/src/icmp_mediator.rs
@@ -1,0 +1,507 @@
+//! Guest-local ICMP mediator, served by the process that holds the FlowMux
+//! identity.
+//!
+//! The guest's signing key is root-only by construction (`/run/mvm`, mode
+//! 0400): the workload runs as uid 901 and must not be able to authenticate as
+//! its own guest. `mvm-ping` runs *as* the workload, so it cannot open a
+//! FlowMux session of its own — the same reason an ordinary workload reaches
+//! the network through the loopback SOCKS proxy and the loopback DNS stub
+//! rather than dialling the host itself.
+//!
+//! So ICMP gets the third loopback mediator, beside those two and in the same
+//! root process: the workload speaks to [`ICMP_MEDIATOR_LISTEN`], and the
+//! mediator performs the echo over the one authenticated session. Nothing new
+//! crosses the guest→host boundary — this is the guest's own loopback, and the
+//! request and reply on it are the same [`IcmpEchoRequest`] / [`IcmpEchoReply`]
+//! the FlowMux flow carries.
+//!
+//! The connection opens with a [`MediatorHello`] because the round trip
+//! `mvm-ping` reports has to be the echo and not the handshake. The mediator
+//! establishes its session first and says so; the client starts timing after
+//! that, exactly as it did when it owned the session itself.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{TcpListener, TcpStream};
+
+use anyhow::{Context, Result};
+use mvm_contract::protocol::network_flow::Opcode;
+use mvm_core::guest_netd::ICMP_MEDIATOR_LISTEN;
+use mvm_core::icmp_wire::{IcmpEchoReply, IcmpEchoRequest};
+
+use crate::flowmux_sync::SyncFlowMux;
+
+/// The mediator's first line: whether it has a session to echo over.
+///
+/// A failure to reach the host is reported here rather than as a closed
+/// socket, so the workload sees the host's own words instead of `EOF`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum MediatorHello {
+    /// The session is up; send echo requests.
+    Ready,
+    /// No session could be opened. Terminal for this connection.
+    Unavailable {
+        /// Why, in terms the workload can act on.
+        message: String,
+    },
+}
+
+/// Bind the mediator's loopback port.
+///
+/// Separate from [`serve`] so the caller can bind before it spawns: the guest
+/// init only waits for the proxy port, so a workload can be running by the time
+/// a thread that binds lazily gets scheduled, and `ping` would fail with
+/// connection-refused for the first moments of a boot.
+pub fn bind_icmp_mediator() -> Result<TcpListener> {
+    TcpListener::bind(ICMP_MEDIATOR_LISTEN)
+        .with_context(|| format!("binding the ICMP mediator on {ICMP_MEDIATOR_LISTEN}"))
+}
+
+/// Serve echoes on `listener` until it fails. Blocking; the egress client runs
+/// it on its own thread.
+pub fn serve_icmp_mediator(listener: &TcpListener) -> Result<()> {
+    serve(listener, SyncFlowMux::connect)
+}
+
+/// How long a connected client may go without sending before it is dropped.
+///
+/// A client owns a FlowMux session for as long as it stays connected, so one
+/// that connects and then stops talking — a workload killed mid-`ping`, say —
+/// would otherwise hold a session for the life of the guest.
+const CLIENT_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// Ceiling on one request line. An `IcmpEchoRequest` is a couple of hundred
+/// bytes; without a ceiling a client that never sends a newline grows this
+/// process's heap without bound, and the process holding the guest identity is
+/// the wrong one to let a workload exhaust.
+const MAX_REQUEST_LINE: u64 = 8 * 1024;
+
+/// Slack over the caller's own per-echo wait before the mediator gives up on
+/// the host. Outlasts it, so a reply the host is still legitimately waiting on
+/// is not cut off here — but it is bounded, or a host that never answers pins
+/// this thread and its session for the life of the guest.
+const HOST_REPLY_SLACK: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Accept loop, with the session opener injected so a test can drive a real
+/// exchange without a host.
+///
+/// A thread per client, because a client holds its connection across all of its
+/// echoes: served inline, one `ping -c 4 -W 4000` would make every other caller
+/// in the guest wait up to sixteen seconds on a listener that looked live. One
+/// client's error never ends the loop either.
+pub fn serve<F>(listener: &TcpListener, open_session: F) -> Result<()>
+where
+    F: Fn() -> Result<SyncFlowMux> + Clone + Send + 'static,
+{
+    for conn in listener.incoming() {
+        let stream = conn.context("accept on the ICMP mediator listener")?;
+        let open_session = open_session.clone();
+        std::thread::spawn(move || {
+            if let Err(error) = handle_connection(stream, &open_session) {
+                eprintln!("mvm-icmp-mediator: {error:#}");
+            }
+        });
+    }
+    Ok(())
+}
+
+/// One client: announce a session, then echo for as long as it keeps asking.
+fn handle_connection<F>(stream: TcpStream, open_session: &F) -> Result<()>
+where
+    F: Fn() -> Result<SyncFlowMux>,
+{
+    stream
+        .set_read_timeout(Some(CLIENT_IDLE_TIMEOUT))
+        .context("set the mediator idle timeout")?;
+    let mut writer = stream
+        .try_clone()
+        .context("clone the mediator connection")?;
+    let mut reader = BufReader::new(stream);
+
+    let mut flowmux = match open_session() {
+        Ok(flowmux) => {
+            write_line(&mut writer, &MediatorHello::Ready)?;
+            flowmux
+        }
+        Err(error) => {
+            // The client is owed the reason: it cannot see the host endpoint,
+            // the identity drive, or this process's stderr.
+            write_line(
+                &mut writer,
+                &MediatorHello::Unavailable {
+                    message: format!("{error:#}"),
+                },
+            )?;
+            return Ok(());
+        }
+    };
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = (&mut reader)
+            .take(MAX_REQUEST_LINE)
+            .read_line(&mut line)
+            .context("read an echo request from the workload")?;
+        if read == 0 {
+            return Ok(());
+        }
+        if !line.ends_with('\n') {
+            anyhow::bail!("an echo request exceeded {MAX_REQUEST_LINE} bytes");
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        let request: IcmpEchoRequest =
+            serde_json::from_str(line.trim()).context("decode the workload's echo request")?;
+        let reply = echo_over_flowmux(&mut flowmux, &request)?;
+        write_line(&mut writer, &reply)?;
+    }
+}
+
+/// Perform one echo on an open session.
+///
+/// The bounds check is the wire contract's own, applied here because the
+/// mediator forwards on the workload's behalf and an out-of-range request must
+/// be refused locally rather than spent on the session.
+pub fn echo_over_flowmux(
+    flowmux: &mut SyncFlowMux,
+    request: &IcmpEchoRequest,
+) -> Result<IcmpEchoReply> {
+    if let Err(bounds) = request.validate() {
+        return Ok(IcmpEchoReply::Refused {
+            message: bounds.to_string(),
+        });
+    }
+    flowmux.set_read_timeout(
+        std::time::Duration::from_millis(u64::from(request.timeout_ms))
+            .saturating_add(HOST_REPLY_SLACK),
+    )?;
+    let encoded = serde_json::to_vec(request).context("encode the echo request")?;
+    let stream_id = flowmux.next_stream_id();
+    flowmux.send(Opcode::IcmpEcho, stream_id, &encoded)?;
+    let (opcode, _stream_id, payload) = flowmux.recv()?;
+    match opcode {
+        Opcode::IcmpReply | Opcode::IcmpRefused => {
+            serde_json::from_slice(&payload).context("decode the echo reply")
+        }
+        other => anyhow::bail!("expected an echo reply, got {other:?}"),
+    }
+}
+
+/// Write one JSON line and flush it: the peer is reading line by line and a
+/// buffered reply is indistinguishable from a hung host.
+fn write_line<T: serde::Serialize>(writer: &mut impl Write, value: &T) -> Result<()> {
+    let mut encoded = serde_json::to_vec(value).context("encode a mediator line")?;
+    encoded.push(b'\n');
+    writer
+        .write_all(&encoded)
+        .context("write a mediator line")?;
+    writer.flush().context("flush a mediator line")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_hello_round_trips_both_arms() {
+        for hello in [
+            MediatorHello::Ready,
+            MediatorHello::Unavailable {
+                message: "no identity".into(),
+            },
+        ] {
+            let encoded = serde_json::to_string(&hello).unwrap();
+            assert_eq!(
+                serde_json::from_str::<MediatorHello>(&encoded).unwrap(),
+                hello
+            );
+        }
+    }
+
+    /// An unknown field is a different protocol, not a newer one: the guest and
+    /// the workload ship in the same binary, so there is no version skew to
+    /// tolerate and a typo should be loud.
+    #[test]
+    fn an_unknown_hello_field_is_refused() {
+        assert!(serde_json::from_str::<MediatorHello>(r#"{"ready":{"extra":1}}"#).is_err());
+    }
+
+    /// One echo end to end: an unprivileged client on the loopback, the
+    /// mediator holding the only identity, and a host speaking the real sealed
+    /// protocol on the other side.
+    ///
+    /// The client here does nothing but read and write lines — no key, no
+    /// anchor, no vsock — which is exactly the position `mvm-ping` is in.
+    #[test]
+    fn an_echo_crosses_the_loopback_and_comes_back_off_the_session() {
+        use ed25519_dalek::SigningKey;
+        use mvm_contract::protocol::network_flow::hello::Handshake;
+        use mvm_contract::protocol::network_flow::{MAX_FRAME_LEN, decode, encode_into};
+        use mvm_core::net::session::{Session, read_sealed_frame, write_sealed_frame};
+        use std::os::unix::net::UnixStream;
+
+        let (guest_side, host_side) = UnixStream::pair().unwrap();
+        let guest_key = SigningKey::from_bytes(&[5u8; 32]);
+        let host_key = SigningKey::from_bytes(&[11u8; 32]);
+        let host_anchor = host_key.verifying_key();
+
+        let host = std::thread::spawn(move || {
+            let mut stream = host_side;
+            let (mut session, _peer) = Session::host(&mut stream, "icmp-test", host_key).unwrap();
+            let recv = |session: &mut Session, stream: &mut UnixStream| {
+                let sealed = read_sealed_frame(stream, MAX_FRAME_LEN + 512).unwrap();
+                let plain = session.open(&sealed).unwrap();
+                let parsed = decode(&plain).unwrap();
+                (parsed.header.opcode, parsed.payload.to_vec())
+            };
+            let send = |session: &mut Session,
+                        stream: &mut UnixStream,
+                        opcode: Opcode,
+                        stream_id: u32,
+                        payload: &[u8]| {
+                let mut wire = Vec::new();
+                encode_into(&mut wire, opcode, stream_id, payload).unwrap();
+                let sealed = session.seal(&wire).unwrap();
+                write_sealed_frame(stream, &sealed).unwrap();
+            };
+
+            let (opcode, _) = recv(&mut session, &mut stream);
+            assert_eq!(opcode, Opcode::Hello);
+            send(
+                &mut session,
+                &mut stream,
+                Opcode::HelloAck,
+                0,
+                &Handshake::local("test-host").encode(),
+            );
+
+            let (opcode, payload) = recv(&mut session, &mut stream);
+            assert_eq!(opcode, Opcode::IcmpEcho);
+            let asked: IcmpEchoRequest = serde_json::from_slice(&payload).unwrap();
+            assert_eq!(asked.host, "example.com");
+            let reply = IcmpEchoReply::Reply {
+                seq: 0,
+                ip: "93.184.216.34".into(),
+                host_leg_us: 4_200,
+                payload_len: asked.payload_len,
+            };
+            send(
+                &mut session,
+                &mut stream,
+                Opcode::IcmpReply,
+                1,
+                &serde_json::to_vec(&reply).unwrap(),
+            );
+        });
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let opened = std::sync::Mutex::new(Some(guest_side));
+        let mediator = std::thread::spawn(move || {
+            let conn = listener.incoming().next().unwrap().unwrap();
+            handle_connection(conn, &|| {
+                let stream = opened.lock().unwrap().take().expect("one session");
+                SyncFlowMux::handshake(stream, guest_key.clone(), &host_anchor)
+            })
+            .unwrap();
+        });
+
+        let client = TcpStream::connect(addr).unwrap();
+        let mut writer = client.try_clone().unwrap();
+        let mut reader = BufReader::new(client);
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        assert_eq!(
+            serde_json::from_str::<MediatorHello>(line.trim()).unwrap(),
+            MediatorHello::Ready
+        );
+
+        let request = IcmpEchoRequest {
+            host: "example.com".into(),
+            count: 1,
+            payload_len: 56,
+            timeout_ms: 1000,
+        };
+        writeln!(writer, "{}", serde_json::to_string(&request).unwrap()).unwrap();
+        line.clear();
+        reader.read_line(&mut line).unwrap();
+        match serde_json::from_str::<IcmpEchoReply>(line.trim()).unwrap() {
+            IcmpEchoReply::Reply {
+                ip,
+                host_leg_us,
+                payload_len,
+                ..
+            } => {
+                assert_eq!(ip, "93.184.216.34");
+                assert_eq!(host_leg_us, 4_200);
+                assert_eq!(payload_len, 56);
+            }
+            other => panic!("expected a reply, got {other:?}"),
+        }
+
+        drop(writer);
+        drop(reader);
+        mediator.join().unwrap();
+        host.join().unwrap();
+    }
+
+    /// An out-of-range request is answered locally rather than spent on the
+    /// session: the bounds are the wire contract's and the mediator forwards on
+    /// the workload's behalf, so it owes the refusal itself. The host asserts
+    /// the negative — no frame reached it — because "refused" and "refused by
+    /// the host" print the same to the workload.
+    #[test]
+    fn an_out_of_bounds_request_is_refused_without_reaching_the_host() {
+        use ed25519_dalek::SigningKey;
+        use mvm_contract::protocol::network_flow::hello::Handshake;
+        use mvm_contract::protocol::network_flow::{MAX_FRAME_LEN, decode, encode_into};
+        use mvm_core::net::session::{Session, read_sealed_frame, write_sealed_frame};
+        use std::os::unix::net::UnixStream;
+
+        let (guest_side, host_side) = UnixStream::pair().unwrap();
+        let guest_key = SigningKey::from_bytes(&[5u8; 32]);
+        let host_key = SigningKey::from_bytes(&[11u8; 32]);
+        let host_anchor = host_key.verifying_key();
+
+        let host = std::thread::spawn(move || {
+            let mut stream = host_side;
+            let (mut session, _peer) = Session::host(&mut stream, "bounds-test", host_key).unwrap();
+            let sealed = read_sealed_frame(&mut stream, MAX_FRAME_LEN + 512).unwrap();
+            let plain = session.open(&sealed).unwrap();
+            assert_eq!(decode(&plain).unwrap().header.opcode, Opcode::Hello);
+            let mut wire = Vec::new();
+            encode_into(
+                &mut wire,
+                Opcode::HelloAck,
+                0,
+                &Handshake::local("h").encode(),
+            )
+            .unwrap();
+            let sealed = session.seal(&wire).unwrap();
+            write_sealed_frame(&mut stream, &sealed).unwrap();
+            // Anything after the handshake is an echo the mediator should have
+            // refused itself.
+            read_sealed_frame(&mut stream, MAX_FRAME_LEN + 512).is_ok()
+        });
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let opened = std::sync::Mutex::new(Some(guest_side));
+        let mediator = std::thread::spawn(move || {
+            let conn = listener.incoming().next().unwrap().unwrap();
+            handle_connection(conn, &|| {
+                let stream = opened.lock().unwrap().take().expect("one session");
+                SyncFlowMux::handshake(stream, guest_key.clone(), &host_anchor)
+            })
+            .unwrap();
+        });
+
+        let client = TcpStream::connect(addr).unwrap();
+        let mut writer = client.try_clone().unwrap();
+        let mut reader = BufReader::new(client);
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+
+        let bad = IcmpEchoRequest {
+            host: String::new(),
+            count: 1,
+            payload_len: 0,
+            timeout_ms: 1,
+        };
+        writeln!(writer, "{}", serde_json::to_string(&bad).unwrap()).unwrap();
+        line.clear();
+        reader.read_line(&mut line).unwrap();
+        match serde_json::from_str::<IcmpEchoReply>(line.trim()).unwrap() {
+            IcmpEchoReply::Refused { message } => assert!(!message.is_empty()),
+            other => panic!("expected a refusal, got {other:?}"),
+        }
+
+        drop(writer);
+        drop(reader);
+        mediator.join().unwrap();
+        assert!(
+            !host.join().unwrap(),
+            "an out-of-bounds request must not be spent on the session"
+        );
+    }
+
+    /// A slow client does not hold the mediator: served in the accept loop, the
+    /// second caller waits out the first, and `ping` in a guest running two
+    /// things at once looks hung.
+    #[test]
+    fn a_second_client_is_served_while_the_first_is_still_holding_its_session() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{Arc, Barrier};
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // The first client's session never finishes opening; the second's fails
+        // at once. Serial accept would leave the second with no hello at all.
+        let held = Arc::new(Barrier::new(2));
+        let opener_held = Arc::clone(&held);
+        let seen = Arc::new(AtomicUsize::new(0));
+        std::thread::spawn(move || {
+            serve(&listener, move || {
+                if seen.fetch_add(1, Ordering::SeqCst) == 0 {
+                    opener_held.wait();
+                }
+                anyhow::bail!("no session")
+            })
+        });
+
+        let first = TcpStream::connect(addr).unwrap();
+        // Give the first client's thread time to reach the blocked opener, so a
+        // pass cannot come from the second simply winning the race.
+        first
+            .set_read_timeout(Some(std::time::Duration::from_millis(250)))
+            .unwrap();
+        let mut discard = String::new();
+        assert!(
+            BufReader::new(&first).read_line(&mut discard).is_err(),
+            "the first client must still be waiting on its session"
+        );
+
+        let second = TcpStream::connect(addr).unwrap();
+        second
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .unwrap();
+        let mut line = String::new();
+        BufReader::new(second)
+            .read_line(&mut line)
+            .expect("the second client is served while the first is blocked");
+        assert!(matches!(
+            serde_json::from_str::<MediatorHello>(line.trim()).unwrap(),
+            MediatorHello::Unavailable { .. }
+        ));
+
+        held.wait();
+    }
+
+    /// The whole point of the mediator: a client that cannot read the signing
+    /// key still gets an answer, because the session is opened over here.
+    #[test]
+    fn a_client_that_cannot_open_a_session_is_told_why_rather_than_dropped() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            let conn = listener.incoming().next().unwrap().unwrap();
+            handle_connection(conn, &|| {
+                anyhow::bail!("reading the guest signing key: EACCES")
+            })
+            .unwrap();
+        });
+
+        let client = TcpStream::connect(addr).unwrap();
+        let mut line = String::new();
+        BufReader::new(client).read_line(&mut line).unwrap();
+        let hello: MediatorHello = serde_json::from_str(line.trim()).unwrap();
+        match hello {
+            MediatorHello::Unavailable { message } => {
+                assert!(message.contains("EACCES"), "{message}")
+            }
+            MediatorHello::Ready => panic!("a failed session must not announce Ready"),
+        }
+    }
+}

--- a/crates/mvm-agentd/src/lib.rs
+++ b/crates/mvm-agentd/src/lib.rs
@@ -83,6 +83,7 @@ pub mod host_cost;
 /// broker transport.
 pub mod host_time;
 pub mod icmp_client;
+pub mod icmp_mediator;
 pub mod integrations;
 pub mod lifecycle_hooks;
 /// Guest-side network defense. The `mvm-guest-netinit`

--- a/crates/mvm-core/src/guest_netd.rs
+++ b/crates/mvm-core/src/guest_netd.rs
@@ -31,6 +31,14 @@ pub const EGRESS_PROXY_READY_TIMEOUT: std::time::Duration = std::time::Duration:
 pub const DEFAULT_EGRESS_PROXY_URL: &str = "socks5h://127.0.0.1:1080";
 /// Loopback listen address of the in-guest DNS stub.
 pub const DEFAULT_DNS_STUB_LISTEN: &str = "127.0.0.1:53";
+/// Loopback listen address of the in-guest ICMP mediator.
+///
+/// A workload cannot open a FlowMux session of its own — the guest signing key
+/// is root-only — so `ping` asks this instead, and the process holding the
+/// identity performs the echo. Declared beside the proxy and the DNS stub
+/// because the three are one allocation decision: a guest loopback port that
+/// two of them want is a collision nobody sees until a boot.
+pub const ICMP_MEDIATOR_LISTEN: &str = "127.0.0.1:1081";
 /// First-line marker selecting DNS on the shared host egress stream.
 pub const DNS_FRAME_LINE: &str = "MVM_DNS/1";
 /// First-line marker selecting ICMP echo on the shared host egress stream.

--- a/specs/sprint/delivery/2821-guest-ping-mediator.md
+++ b/specs/sprint/delivery/2821-guest-ping-mediator.md
@@ -1,0 +1,83 @@
+# `ping` works again: a loopback ICMP mediator in the process that holds the identity
+
+Issue [#2821](https://github.com/tinylabscom/mvm/issues/2821).
+
+## What was broken
+
+```
+$ mvmctl machine run --image alpine --allow-host github.com -- sh -c "ping github.com"
+mvm-ping: open a FlowMux session for the echo: reading the guest signing key from
+          /run/mvm/flowmux-guest-signing-key: Permission denied (os error 13)
+mvm-ping: a host must be admitted to be pinged — pass `--allow-host github.com` to the run
+```
+
+`mvm-ping` is bind-mounted over the image's `/bin/ping` and runs as the workload, uid 901. The
+identity drive's signing key lands in `/run/mvm` root-owned at mode 0400, and the workload's
+capability bounding set is `CAP_KILL|CAP_SYS_TIME` — no `CAP_DAC_OVERRIDE`. So the read cannot
+succeed, and `SyncFlowMux::connect` does that read first.
+
+Before the one-transport cutover, `icmp_client` dialled the egress port directly and needed no
+key at all; the cutover put it on an authenticated session without noticing that its one caller
+runs as the one uid that cannot authenticate. `ping` has been dead in every guest since.
+
+## The key being unreadable is not the bug
+
+It is the point. The whole reason the identity rides a drive rather than the kernel cmdline is
+that the cmdline is readable by uid 901, and the drive copy's mode is what keeps the property
+after the copy. A workload that can read the key can authenticate as its own guest. So the fix
+is not to widen the mode — it is for `ping` to stop trying, the way every other outbound thing a
+workload does already works: through a loopback service in the process that legitimately holds
+the identity.
+
+`mvm-egress-client` runs as root and is already that process for two of them — the SOCKS/HTTP
+proxy on `127.0.0.1:1080` and the DNS stub on `127.0.0.1:53`. ICMP is now the third, on
+`127.0.0.1:1081`.
+
+## What the mediator is
+
+`mvm_agentd::icmp_mediator`. Per connection: open one blocking FlowMux session, announce it,
+then answer echo requests until the client hangs up. The request and reply lines are the same
+`IcmpEchoRequest` / `IcmpEchoReply` the `IcmpEcho` flow already carries, so nothing new was
+invented and the host side is untouched — `icmp_handler::serve_request` still makes every
+decision.
+
+Nothing new crosses the guest→host boundary either. This is the guest's own loopback;
+`check-one-guest-protocol` still sees one dialer per file and one protocol on the wire.
+
+The connection opens with a `MediatorHello` for one reason: the round trip `ping` prints has to
+be the echo and not the handshake. The mediator establishes its session and says so, and the
+client starts timing after that — the same property the old code had by opening its own session
+before starting the timer, kept rather than quietly lost.
+
+A session that cannot be opened comes back as `Unavailable { message }` rather than a closed
+socket, because the workload cannot see the host endpoint, the identity drive, or the egress
+client's stderr, and `EOF` would be all it had to go on.
+
+## The second line of that output
+
+The `--allow-host` hint was printed for every error, including this one — advising the reader to
+pass a flag they had just passed. A refusal is now typed (`icmp_client::Refused`) and the hint is
+printed only for one, which is the only case where it is true.
+
+## Tests
+
+- `an_echo_crosses_the_loopback_and_comes_back_off_the_session` — an unprivileged line-speaking
+  client, the mediator holding the only key, and a host running the real sealed session on the
+  other side.
+- `an_out_of_bounds_request_is_refused_without_reaching_the_host` — the host asserts the
+  negative, because "refused" and "refused by the host" print the same to the workload. Confirmed
+  red with the bounds check removed: the frame reaches the host.
+- `a_client_that_cannot_open_a_session_is_told_why_rather_than_dropped`.
+- `a_refusal_is_distinguishable_from_a_transport_failure` — confirmed red with the refusal
+  untyped back to a bare `bail!`.
+- `each_wire_request_carries_a_single_echo` — still one request per echo, now asserted against
+  what the mediator actually received rather than against a locally rebuilt copy of it.
+
+## Not fixed here: the same defect in the forward proxy
+
+[#2822](https://github.com/tinylabscom/mvm/issues/2822). `mvm-guest-agent` also runs as uid 901
+and also relays through `SyncFlowMux::connect`, so every request to its forward proxy on 18080
+fails the same read and returns a `502` with nothing logged — the egress-substitution path is
+dead for the same reason. The fix is the same shape, but it has two decisions this one did not
+(the egress client is started only under `mvm.vsock_egress=1`, and the container tier reaches the
+endpoint over a bind-mounted socket), so it is filed rather than folded in.


### PR DESCRIPTION
Closes #2821.

```
$ mvmctl machine run --image alpine --allow-host github.com -- sh -c "ping github.com"
mvm-ping: open a FlowMux session for the echo: reading the guest signing key from
          /run/mvm/flowmux-guest-signing-key: Permission denied (os error 13)
mvm-ping: a host must be admitted to be pinged — pass `--allow-host github.com` to the run
```

## Root cause

`mvm-ping` is bind-mounted over the image's `/bin/ping` and runs as the workload, uid 901. The identity drive's signing key is copied into `/run/mvm` root-owned at mode 0400, and the workload's capability bounding set is `CAP_KILL|CAP_SYS_TIME` — no `CAP_DAC_OVERRIDE`. `SyncFlowMux::connect` reads that key before anything else, so the read cannot succeed. Confirmed in a live guest:

```
uid=901(mvm-worker) gid=901(mvm-worker)
-r--------  1 0  0  32 flowmux-guest-signing-key
head: /run/mvm/flowmux-guest-signing-key: Permission denied
```

Before the one-transport cutover `icmp_client` dialled the egress port directly and needed no key. The cutover moved it onto an authenticated session without noticing that its one caller is the one uid that cannot authenticate, so `ping` has been dead in every guest since.

## Why not widen the mode

The unreadable key is the point. The whole reason the identity rides a drive rather than the kernel cmdline is that the cmdline is readable by uid 901; the copy's mode is what keeps that property afterwards. A workload that can read the key can authenticate as its own guest.

So `ping` stops trying and does what every other outbound thing a workload does: it asks a loopback service in the process that legitimately holds the identity. `mvm-egress-client` runs as root and is already that process for the SOCKS/HTTP proxy on 1080 and the DNS stub on 53. ICMP is the third, on 1081.

## The mediator

`mvm_agentd::icmp_mediator`. Per connection: open one blocking FlowMux session, announce it, then answer echo requests until the client hangs up. The lines it speaks are the same `IcmpEchoRequest` / `IcmpEchoReply` the `IcmpEcho` flow already carries, so the host side is untouched — `icmp_handler::serve_request` still makes every decision. Nothing new crosses the guest→host boundary; `check-one-guest-protocol` still sees one protocol and one dialer per file.

The hello exists because the round trip `ping` prints has to be the echo and not the handshake: the mediator establishes its session and says so, and the client starts timing after that — the property the old code had by opening its own session first, kept rather than quietly lost. A session that cannot be opened comes back as `Unavailable { message }`, because the workload can see neither the endpoint nor the egress client's stderr.

A thread per client, because a client holds its connection across all of its echoes; served inline, one `ping -c 4 -W 4000` would make every other caller in the guest wait sixteen seconds on a listener that looked live. The request line and the wait on the host are both bounded — the process holding the guest identity is the wrong one to let a workload pin.

## The second line of that output

The `--allow-host` hint was printed for every error, telling the reader to re-check a flag they had just passed. A refusal is now typed (`icmp_client::Refused`) and the hint is printed only for one.

## Verification

Live, macOS/HVF, the reported command:

```
PING github.com (56 bytes) via host
56 bytes from 140.82.114.3: seq=0 time=77.8 ms (host leg 68.6 ms)
56 bytes from 140.82.114.3: seq=1 time=77.3 ms (host leg 71.6 ms)
56 bytes from 140.82.114.3: seq=2 time=74.3 ms (host leg 67.6 ms)
56 bytes from 140.82.114.3: seq=3 time=79.1 ms (host leg 71.8 ms)
--- github.com statistics ---
4 sent, 4 received, 0% packet loss
```

Refusal path, live:

```
mvm-ping: example.com is not admitted; allowed: github.com
mvm-ping: a host must be admitted to be pinged — pass `--allow-host example.com` to the run
```

No admitted egress at all, live — accurate, and no hint:

```
mvm-ping: connect to the guest ICMP mediator on 127.0.0.1:1081 (served by the egress
client, which a run with no admitted egress does not start): Connection refused
```

Gates: `xtask check-all` 61 clean, plus `check-claim-witness-freshness`, `check-declared-backing`, `check-nextest-groups`, `check-single-workload-env`; workspace clippy `-D warnings`; nightly `cargo fmt --all --check`; `just check-gated`; workspace doctests.

`cargo nextest run --workspace` — 12333 tests, 14 failing, all `CARGO_BIN_EXE_mvmctl is unset` in the root package's CLI integration tests. Pre-existing and environmental: the same tests fail at `4de8f88` with this branch stashed and in an untouched `main` checkout.

## Same defect, not fixed here

#2822: the guest agent runs as uid 901 too and relays its forward proxy through the same `SyncFlowMux::connect`, so every substituted request 502s for exactly this reason, with nothing logged. The fix is the same shape but has two decisions this one did not (the egress client is only started under `mvm.vsock_egress=1`, and the container tier reaches the endpoint over a bind-mounted socket), so it is filed rather than folded in.