### PR TITLE
fix(runtime-overlay): add forward_proxy field to RuntimeOverlayGuestLayout

### DIFF
--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -131,6 +131,7 @@ pub struct RuntimeOverlayGuestBinaries {
     pub addon_dns: PathBuf,
     pub exit_report: PathBuf,
     pub ping: PathBuf,
+    pub forward_proxy: PathBuf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -145,6 +146,7 @@ pub struct RuntimeOverlayGuestLayout {
     pub addon_dns: PathBuf,
     pub exit_report: PathBuf,
     pub ping: PathBuf,
+    pub forward_proxy: PathBuf,
 }
 
 impl RuntimeOverlayGuestLayout {
@@ -164,6 +166,7 @@ impl RuntimeOverlayGuestLayout {
             addon_dns: dir.join("addon-dns"),
             exit_report: dir.join("exit-report"),
             ping: dir.join("ping"),
+            forward_proxy: dir.join("forward-proxy"),
             dir,
         }
     }
@@ -178,6 +181,7 @@ impl RuntimeOverlayGuestLayout {
             && self.addon_dns.is_file()
             && self.exit_report.is_file()
             && self.ping.is_file()
+            && self.forward_proxy.is_file()
     }
 
     fn binaries(&self) -> RuntimeOverlayGuestBinaries {
@@ -191,6 +195,7 @@ impl RuntimeOverlayGuestLayout {
             addon_dns: self.addon_dns.clone(),
             exit_report: self.exit_report.clone(),
             ping: self.ping.clone(),
+            forward_proxy: self.forward_proxy.clone(),
         }
     }
 }

--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -2164,6 +2164,7 @@ mod tests {
             addon_dns: make_bin("addon-dns"),
             exit_report: make_bin("exit-report"),
             verity_init: make_bin("verity-init"),
+            forward_proxy: make_bin("forward-proxy"),
         };
 
         let artifact = build_runtime_overlay_from_guest_binaries(

--- a/crates/mvm-conformance/tests/steps/volume.rs
+++ b/crates/mvm-conformance/tests/steps/volume.rs
@@ -126,6 +126,7 @@ fn cache_live_runtime_overlay(world: &CliWorld, source_dir: &Path, fingerprint: 
         ("mvm-addon-dns", &layout.addon_dns),
         ("mvm-exit-report", &layout.exit_report),
         ("mvm-ping", &layout.ping),
+        ("mvm-forward-proxy", &layout.forward_proxy),
     ] {
         let source = source_dir.join(source_name);
         fs::copy(&source, destination).unwrap_or_else(|error| {


### PR DESCRIPTION
## Summary

Add the forward-proxy binary to the runtime-overlay guest layout and its construction fixtures, so overlays that require `/forward-proxy` are built and validated consistently.

## Validation

- Full PR CI is green, including workspace, aarch64, release-profile, BDD conformance, Linux/conformance, clippy, and policy gates.

## Dependencies

This supplies the runtime-overlay layout support needed by the FlowMux forward-proxy and Nix egress-service changes in #2827 and #2829.