### PR TITLE
fix(ci): restore extended witnesses

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -147,8 +147,9 @@ jobs:
         # `vmlinux`, `rootfs.ext4`, `cmdline.txt`, `manifest.json`.
         #
         # Plan 115 / ADR-065: the flake reads `MVM_HOST_BIN_DIR`
-        # under `--impure` to inject mvm-host-vm-init + mvm-egress-proxy
-        # via extraFiles. mvmctl normally extracts its embedded copy
+        # under `--impure` to inject every binary declared by
+        # nix/lib/mvm-host-binaries.nix via extraFiles. mvmctl normally
+        # extracts its embedded copy
         # before invoking nix; CI uses placeholder files so the flake
         # evaluates + builds (the rootfs will contain placeholder
         # bytes at the binary install paths, which is fine for an
@@ -160,6 +161,7 @@ jobs:
           # at the names the manifest declares.
           : > "$HOST_BIN_DIR/mvm-host-vm-init"
           : > "$HOST_BIN_DIR/mvm-egress-proxy"
+          : > "$HOST_BIN_DIR/mvm-builderd"
           chmod 0755 "$HOST_BIN_DIR"/mvm-*
           MVM_HOST_BIN_DIR="$HOST_BIN_DIR" \
             nix build "./nix/images/builder-vm#packages.x86_64-linux.default" \
@@ -217,6 +219,12 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install libkrun
+        run: |
+          brew tap slp/krun
+          brew trust slp/krun
+          brew install slp/krun/libkrun
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -286,7 +294,8 @@ jobs:
         # probes for.
         run: |
           brew tap slp/krun
-          brew install libkrun
+          brew trust slp/krun
+          brew install slp/krun/libkrun
 
       - name: Cache cargo
         if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,12 +17,6 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
-- [x] **Issue #2830 — Extended CI lanes restored.** Both macOS lanes trust
-      the `slp/krun` Homebrew tap and install libkrun before compiling its
-      consumers. The Linux builder-image smoke supplies all three binaries in
-      the host-binary manifest, including `mvm-builderd`. Structural tests pin
-      the two workflow contracts.
-
 - [x] **Retained-state log diagnostics.** When a machine state directory
       survives but every output capture is absent, `machine logs` now names
       the retained state, each missing source, and the likely interrupted-boot
@@ -121,6 +115,12 @@ for detailed scope and acceptance criteria.
       A failed, cancelled, timed-out, or still-running nightly is therefore
       reported even if GitHub omits the event-driven watcher's `workflow_run`
       delivery; pull-request and dispatch runs cannot mask the evidence.
+
+- [x] **Issue #2830 — Extended CI lanes restored.** Both macOS lanes trust
+      the `slp/krun` Homebrew tap and install libkrun before compiling its
+      consumers. The Linux builder-image smoke supplies all three binaries in
+      the host-binary manifest, including `mvm-builderd`. Structural tests pin
+      the two workflow contracts.
 
 - [x] **Issue #2789 — guest hostname follows the machine name.** The shared
       workload cmdline carries one validated `mvm.hostname=` token for cold

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,6 +17,12 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
+- [x] **Issue #2830 — Extended CI lanes restored.** Both macOS lanes trust
+      the `slp/krun` Homebrew tap and install libkrun before compiling its
+      consumers. The Linux builder-image smoke supplies all three binaries in
+      the host-binary manifest, including `mvm-builderd`. Structural tests pin
+      the two workflow contracts.
+
 - [x] **Retained-state log diagnostics.** When a machine state directory
       survives but every output capture is absent, `machine logs` now names
       the retained state, each missing source, and the likely interrupted-boot
@@ -70,7 +76,6 @@ for detailed scope and acceptance criteria.
       behavior while equivalent/performance-only misses stay documented. The
       broker's teaching-refusal ceiling is also mutation-pinned at its exact
       transition.
-
 - [x] **Artifact acquisition is explicit across source and release builds.**
       Official binaries download verified launch artifacts even when invoked
       from an mvm checkout; contributor binaries may build source-matched

--- a/specs/plans/2026-08-24-extended-ci-lane-repair.md
+++ b/specs/plans/2026-08-24-extended-ci-lane-repair.md
@@ -1,0 +1,27 @@
+# Extended CI lane repair
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+## Outcome
+
+Restore the scheduled Extended CI witnesses reported by issue #2830 without
+weakening or skipping their build coverage.
+
+## Work
+
+- [x] Trust the `slp/krun` Homebrew tap before installing libkrun in every
+      macOS Extended CI lane that compiles libkrun consumers.
+- [x] Install libkrun in the release-only Apple workspace lane before its
+      all-target build.
+- [x] Supply the builder-image smoke with a placeholder for every binary in
+      `nix/lib/mvm-host-binaries.nix`, including `mvm-builderd`.
+- [x] Add structural regression tests for the trusted Homebrew install and
+      builder binary set.
+- [x] Run focused tests, formatting, workflow-path validation, workspace
+      check, and workspace Clippy with warnings denied.
+
+## Acceptance
+
+The repair lands through a merged PR that closes #2830, and the next Extended
+CI run completes its macOS libkrun, Apple, and Linux builder-image lanes.

--- a/specs/sprint/delivery/2830-extended-ci-lane-repair.md
+++ b/specs/sprint/delivery/2830-extended-ci-lane-repair.md
@@ -1,0 +1,11 @@
+# Issue #2830 — Extended CI lane repair
+
+- [x] Both macOS lanes trust the third-party Homebrew tap before installing
+      `slp/krun/libkrun`; the general Apple lane now installs the library it
+      needs before compiling all workspace targets.
+- [x] The Linux builder-image lane supplies `mvm-builderd` alongside the other
+      manifest-declared host binaries, so Nix evaluation no longer fails on a
+      missing impure input.
+- [x] Structural tests pin both contracts in `ci-full.yml`.
+
+Owning plan: `specs/plans/2026-08-24-extended-ci-lane-repair.md`.

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -1129,6 +1129,37 @@ mod tests {
         }
     }
 
+    #[test]
+    fn extended_ci_macos_builds_install_libkrun_from_a_trusted_tap() {
+        let extended = workflow("ci-full.yml");
+        for job in ["apple", "libkrun-macos"] {
+            let body = job_body(&extended, job).expect("extended CI job must exist");
+            for command in [
+                "brew tap slp/krun",
+                "brew trust slp/krun",
+                "brew install slp/krun/libkrun",
+            ] {
+                assert!(
+                    body.contains(command),
+                    "{job} must run `{command}` before compiling libkrun consumers"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn extended_ci_builder_image_stubs_every_manifest_binary() {
+        let extended = workflow("ci-full.yml");
+        let body =
+            job_body(&extended, "builder-vm-image-linux").expect("builder VM image job must exist");
+        for binary in ["mvm-host-vm-init", "mvm-egress-proxy", "mvm-builderd"] {
+            assert!(
+                body.contains(&format!("$HOST_BIN_DIR/{binary}")),
+                "builder VM image smoke must provide the manifest binary {binary}"
+            );
+        }
+    }
+
     /// Only one workflow may publish a required check's name.
     ///
     /// Both of these build kernels from the same script, and both once


### PR DESCRIPTION
## Summary

- trust the `slp/krun` Homebrew tap and install libkrun in both macOS Extended CI lanes
- supply `mvm-builderd` with the other manifest-declared host binaries in the Linux builder-image smoke
- pin both workflow contracts with structural regression tests

## Validation

- `cargo test -p xtask check_workflow_paths::tests`
- `cargo run -p xtask -- check-workflow-paths`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- pre-commit all-target Clippy and actionlint
- `cargo run -p xtask -- check-sprint-append`
- `cargo run -p xtask -- check-plan-names`

Fixes #2830