### PR TITLE
fix(kernel): bump Linux pins to 6.12.105

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -48,10 +48,10 @@ let
   # kernel — lets both of mvm's kernels track the latest point release exactly
   # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
   # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
-  kernelVersion = "6.12.104";
+  kernelVersion = "6.12.105";
   kernelSrc = pkgs.fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
-    hash = "sha256-lJ0WahJjvQzwxaq0TutXhpYVCZ58SL+I0OStt3N5uZk=";
+    hash = "sha256-6zaAHhGVKbE1E8NFncIOKjL3BTYp86q7Y+pQGk2I9j0=";
   };
   # The builder's overlay filesystem triggers a GNU tar directory-metadata
   # race while unpacking this archive. Materialize the source with bsdtar once

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.104.tar.xz";
-    hash = "sha256-lJ0WahJjvQzwxaq0TutXhpYVCZ58SL+I0OStt3N5uZk=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.105.tar.xz";
+    hash = "sha256-6zaAHhGVKbE1E8NFncIOKjL3BTYp86q7Y+pQGk2I9j0=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.104' \
+      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.105' \
       --replace-fail 'curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)' 'ln -s ${kernelSrc} $(KERNEL_TARBALL)'
     substituteInPlace patches/0008-virtio-vsock-support-dgrams.patch \
       --replace-fail 'virtio_transport_alloc_skb(&info, dgram_len, false,' \

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,6 +17,11 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
+- [x] **Issue #2831 — Linux 6.12.105 kernel pin refresh.** The libkrunfw
+      firmware build and custom workload/builder kernels consume the same
+      kernel.org-verified source archive and SRI hash. Structural parity and
+      freshness checks report both pins synchronized and current.
+
 - [x] **Retained-state log diagnostics.** When a machine state directory
       survives but every output capture is absent, `machine logs` now names
       the retained state, each missing source, and the likely interrupted-boot
@@ -70,7 +75,6 @@ for detailed scope and acceptance criteria.
       behavior while equivalent/performance-only misses stay documented. The
       broker's teaching-refusal ceiling is also mutation-pinned at its exact
       transition.
-
 - [x] **Artifact acquisition is explicit across source and release builds.**
       Official binaries download verified launch artifacts even when invoked
       from an mvm checkout; contributor binaries may build source-matched

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,11 +17,6 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
-- [x] **Issue #2831 — Linux 6.12.105 kernel pin refresh.** The libkrunfw
-      firmware build and custom workload/builder kernels consume the same
-      kernel.org-verified source archive and SRI hash. Structural parity and
-      freshness checks report both pins synchronized and current.
-
 - [x] **Retained-state log diagnostics.** When a machine state directory
       survives but every output capture is absent, `machine logs` now names
       the retained state, each missing source, and the likely interrupted-boot
@@ -140,6 +135,11 @@ for detailed scope and acceptance criteria.
       sequence.
 
 - [x] **Issue #2756 — Linux 6.12.104 kernel pin refresh.** The libkrunfw
+      firmware build and custom workload/builder kernels consume the same
+      kernel.org-verified source archive and SRI hash. Structural parity and
+      freshness checks report both pins synchronized and current.
+
+- [x] **Issue #2831 — Linux 6.12.105 kernel pin refresh.** The libkrunfw
       firmware build and custom workload/builder kernels consume the same
       kernel.org-verified source archive and SRI hash. Structural parity and
       freshness checks report both pins synchronized and current.

--- a/specs/plans/2026-08-24-kernel-6-12-105.md
+++ b/specs/plans/2026-08-24-kernel-6-12-105.md
@@ -1,0 +1,29 @@
+# Linux 6.12.105 kernel pin refresh
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#2831](https://github.com/tinylabscom/mvm/issues/2831)
+
+## Outcome
+
+The custom workload/builder kernel and libkrunfw firmware build consume the
+same verified Linux 6.12.105 LTS source archive. Structural coverage keeps the
+version and source hash synchronized.
+
+## Delivery checklist
+
+- [x] Verify the upstream `linux-6.12.105.tar.xz` SHA-256 against kernel.org's
+      signed checksum manifest.
+- [x] Update the custom workload/builder kernel source pin and SRI hash.
+- [x] Update the libkrunfw kernel source pin, substitution, and SRI hash.
+- [x] Pass the focused synchronization test and kernel freshness check.
+- [x] Pass formatting, workspace check, and zero-warning Clippy.
+- [ ] Merge the tested pull request and close #2831 through its linkage.
+
+## Source verification
+
+The upstream archive SHA-256 is
+`eb36801e119529b13513c3459dc20e2a32f7053629f3aabb63ea501a4d88f63d`,
+which converts to the Nix SRI hash
+`sha256-6zaAHhGVKbE1E8NFncIOKjL3BTYp86q7Y+pQGk2I9j0=`.

--- a/specs/sprint/delivery/2831-kernel-pin-6-12-105.md
+++ b/specs/sprint/delivery/2831-kernel-pin-6-12-105.md
@@ -1,0 +1,10 @@
+# Linux 6.12.105 kernel pin refresh
+
+- [x] Updated the libkrunfw firmware build and custom workload/builder kernels
+      from Linux 6.12.104 to 6.12.105.
+- [x] Verified the archive digest against kernel.org's signed SHA-256 manifest
+      and converted it to the Nix SRI hash used by both consumers.
+- [x] Updated structural parity coverage so both kernel consumers must remain
+      synchronized.
+
+Owning plan: `specs/plans/2026-08-24-kernel-6-12-105.md`.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -240,8 +240,8 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         );
     }
 
-    const KERNEL_VERSION: &str = "6.12.104";
-    const KERNEL_HASH: &str = "sha256-lJ0WahJjvQzwxaq0TutXhpYVCZ58SL+I0OStt3N5uZk=";
+    const KERNEL_VERSION: &str = "6.12.105";
+    const KERNEL_HASH: &str = "sha256-6zaAHhGVKbE1E8NFncIOKjL3BTYp86q7Y+pQGk2I9j0=";
     assert!(
         libkrunfw.contains(&format!("linux-{KERNEL_VERSION}.tar.xz"))
             && libkrunfw.contains(&format!("hash = \"{KERNEL_HASH}\""))


### PR DESCRIPTION
## Summary
- update both custom workload/builder kernels and libkrunfw to Linux 6.12.105
- keep both consumers pinned to the same kernel.org-verified source archive
- extend structural parity coverage and record the delivery plan

## Verification
- upstream SHA-256: eb36801e119529b13513c3459dc20e2a32f7053629f3aabb63ea501a4d88f63d
- cargo test --test nix_flake_structure
- cargo run -p xtask -- check-kernel-pin-freshness
- cargo check --workspace
- cargo clippy --workspace -- -D warnings
- cargo run -p xtask -- check-sprint-append
- cargo run -p xtask -- check-plan-names

Fixes #2831