### PR TITLE
witness(aarch64): Pi end-to-end fixes and reliable QEMU teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,6 +777,11 @@ just lint            # cargo fmt --all -- --check  +  clippy -D warnings
 just ci              # lint + tests + doctests — run this before every PR
 ```
 
+When iterating on `mvmctl` itself, make sure you are running the freshly-built
+binary. A manually-copied `bin/mvmctl` or a stale `target/release/mvmctl` can
+miss backend fixes — for example, the QEMU session teardown that reaps
+`qemu-system-aarch64` and `mvmctl __qemu-vsock-bridge` after a transient run.
+
 The repository pins a dated nightly and installs Cranelift through
 `rust-toolchain.toml`. Development recipes route Cargo through
 `scripts/cargo-fast.sh`: dev builds use Cranelift and eight frontend threads,

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
@@ -347,7 +347,20 @@ fn handle_client(
 
             GuestRequest::ActivateEnvironment(env) => {
                 match init::apply_activation(&env, boot_state) {
-                    Ok(()) => GuestResponse::ActivateEnvironmentAck,
+                    Ok(()) => {
+                        // Universal initramfs: the workload root was just
+                        // pivoted into place. Start entrypoint validation and
+                        // the warm pool in the background so activation stays
+                        // fast, while keeping the chained dependency order.
+                        if init::is_pid1() {
+                            let bs = Arc::clone(boot_state);
+                            std::thread::spawn(move || {
+                                init_entrypoint_validation(&bs);
+                                init_warm_pool(&bs);
+                            });
+                        }
+                        GuestResponse::ActivateEnvironmentAck
+                    }
                     Err(e) => {
                         let message = e.to_string();
                         boot_state.set_activation(ActivationState::Failed {
@@ -646,14 +659,13 @@ fn main() {
     let guest_signing_key = Arc::new(SigningKey::from_bytes(&guest_seed));
     boot_state.mark_vsock_bound();
 
-    // Defer entrypoint validation + warm-pool startup to a
-    // background thread chained in dependency order
-    // (warm pool reads `VALIDATED_ENTRYPOINT.get()`, so the sequence
-    // must stay serial inside this one thread). The accept loop
-    // below begins serving `Ping` / `ReadinessStatus` /
-    // `EntrypointStatus` immediately; `RunEntrypoint` returns
-    // `NotReady` until the entrypoint flips to `Ready`.
-    {
+    // On legacy per-rootfs boots the agent is not PID 1 and the workload
+    // root is already in place, so validate the entrypoint and start the warm
+    // pool now. On the universal initramfs path validation is deferred until
+    // after `ActivateEnvironment` pivots into the workload rootfs; running it
+    // here would validate the initramfs root, which has no
+    // `/etc/mvm/entrypoint`.
+    if !init::is_pid1() {
         let bs = Arc::clone(&boot_state);
         std::thread::spawn(move || {
             init_entrypoint_validation(&bs);

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/boot.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/boot.rs
@@ -50,13 +50,26 @@ pub(crate) fn init_entrypoint_validation(boot_state: &Arc<AgentBootState>) {
             Ok(v)
         }
         Err(e) if e.is_entrypoint_not_offered() => {
-            // Boot-script image: the entrypoint is baked as PID 1's boot
-            // command, not a per-call wrapper under /usr/lib/mvm/wrappers/.
-            // RunEntrypoint is simply not offered here — a clean state, not a
-            // failure (the default/sealed-idle image and every command/shell
-            // image today). Reported as `Disabled` through readiness.
-            boot_state.set_entrypoint(ComponentState::Disabled);
-            Err("this image does not offer a per-call entrypoint (RunEntrypoint)".to_string())
+            // Sealed images currently bake the entrypoint as a script inside
+            // `/etc/mvm/entrypoint` rather than a wrapper path. Try the
+            // fallback policy that validates the marker file itself, so
+            // `RunEntrypoint` works for these images until mkGuest produces
+            // the `/usr/lib/mvm/wrappers/` layout.
+            match EntrypointPolicy::sealed_script_marker().validate() {
+                Ok(v) => {
+                    boot_state.set_entrypoint(ComponentState::Ready);
+                    Ok(v)
+                }
+                Err(e2) => {
+                    // Boot-script image: the marker is not a usable wrapper
+                    // or sealed script. RunEntrypoint is not offered — a
+                    // clean state, not a failure.
+                    boot_state.set_entrypoint(ComponentState::Disabled);
+                    Err(format!(
+                        "this image does not offer a per-call entrypoint (RunEntrypoint): {e2}"
+                    ))
+                }
+            }
         }
         Err(e) => {
             let msg = e.to_string();

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/init.rs
@@ -49,6 +49,11 @@ pub(crate) fn early_setup() {
             fatal(&format!("early filesystem mount failed: {e}"));
         }
         provision_host_signer_anchor();
+        // In the universal initramfs path there is no second init to copy the
+        // signed verb-grant into /run/mvm before the agent starts listening.
+        // Pin it now from the kernel cmdline so the pre-activation trust
+        // decision sees the pinned grant before the agent accepts requests.
+        mvm_agentd::guest_bootstrap::provision_verb_grant();
         mvm_agentd::child_wait::install_orphan_reaper();
     }
 

--- a/crates/mvm-agentd/src/bin/mvm-verity-init.rs
+++ b/crates/mvm-agentd/src/bin/mvm-verity-init.rs
@@ -531,7 +531,7 @@ mod linux {
         // ── 5. Mount /dev/mapper/root at /sysroot. The initramfs ships
         //    /sysroot as an empty mount target. Read-only — verity is
         //    incompatible with writes.
-        let root_dm = resolved_dm_device("root", 0)?;
+        let root_dm = resolved_dm_device("root")?;
         do_mount(&root_dm, "/sysroot", "ext4", libc::MS_RDONLY, "")?;
         msg("mvm-verity-init: /sysroot mounted (verity-protected)");
 
@@ -550,7 +550,7 @@ mod linux {
         //    populating the cmdline arg.
         if let Some(rt) = cfg.runtime.as_ref() {
             setup_verity_target(fd, "runtime", &rt.data_dev, &rt.hash_dev, &rt.roothash)?;
-            let runtime_dm = resolved_dm_device("runtime", 1)?;
+            let runtime_dm = resolved_dm_device("runtime")?;
             do_mount(
                 &runtime_dm,
                 "/sysroot/mvm/runtime",
@@ -741,21 +741,41 @@ mod linux {
 
     /// Resolve the device path for a freshly-created dm-verity
     /// target named `name`. Prefer `/dev/mapper/<name>` (set up
-    /// by udev when available); fall back to `/dev/dm-<index>`
-    /// (which the kernel's devtmpfs creates regardless of
-    /// userspace daemons). `index` is the creation order — 0
-    /// for the rootfs target, 1 for the runtime overlay.
-    fn resolved_dm_device(name: &str, index: usize) -> Result<String, String> {
+    /// by udev when available); otherwise look up the dynamic
+    /// `/dev/dm-<minor>` node by scanning `/sys/block/dm-*/dm/name`.
+    /// The minor is not predictable from creation order when earlier
+    /// targets are absent, so the name-based lookup is required.
+    fn resolved_dm_device(name: &str) -> Result<String, String> {
         let mapper = format!("/dev/mapper/{name}");
         if Path::new(&mapper).exists() {
             return Ok(mapper);
         }
-        let fallback = format!("/dev/dm-{index}");
-        if Path::new(&fallback).exists() {
-            return Ok(fallback);
+        let sys_block = Path::new("/sys/block");
+        let entries = match std::fs::read_dir(sys_block) {
+            Ok(e) => e,
+            Err(e) => return Err(format!("read /sys/block: {e}")),
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(e) => return Err(format!("read /sys/block entry: {e}")),
+            };
+            let fname = entry.file_name();
+            let fname = fname.to_string_lossy();
+            if !fname.starts_with("dm-") {
+                continue;
+            }
+            let name_file = entry.path().join("dm/name");
+            let dm_name = match std::fs::read_to_string(&name_file) {
+                Ok(n) => n,
+                Err(_) => continue,
+            };
+            if dm_name.trim() == name {
+                return Ok(format!("/dev/{fname}"));
+            }
         }
         Err(format!(
-            "neither {mapper} nor {fallback} exists after DM_DEV_SUSPEND"
+            "no /sys/block/dm-* device named {name} after DM_DEV_SUSPEND"
         ))
     }
 

--- a/crates/mvm-agentd/src/entrypoint.rs
+++ b/crates/mvm-agentd/src/entrypoint.rs
@@ -35,6 +35,11 @@ pub struct EntrypointPolicy {
     pub required_uid: u32,
     /// Required `st_gid` of the resolved wrapper.
     pub required_gid: u32,
+    /// When true, a `#!/bin/sh` style shebang on the resolved wrapper is
+    /// allowed. Sealed rootfs images currently bake the entrypoint as a
+    /// shell script under `/etc/mvm/entrypoint` rather than a wrapper
+    /// path, so the fallback policy needs to accept it.
+    pub allow_shell_shebang: bool,
 }
 
 impl EntrypointPolicy {
@@ -51,6 +56,30 @@ impl EntrypointPolicy {
             required_mode: 0o555,
             required_uid: 0,
             required_gid: 0,
+            allow_shell_shebang: false,
+        }
+    }
+
+    /// Fallback policy for sealed images that bake the entrypoint as a
+    /// script directly inside `/etc/mvm/entrypoint`. mkGuest currently emits
+    /// this shape for `entrypoint.command` images, so the agent treats the
+    /// marker file itself as the executable. The same ownership, mode, and
+    /// same-filesystem checks apply; only the path prefix and the shebang
+    /// restriction are relaxed.
+    pub fn sealed_script_marker() -> Self {
+        Self {
+            marker_path: PathBuf::from("/etc/mvm/entrypoint"),
+            allowed_prefix: PathBuf::from("/etc/mvm/"),
+            same_fs_as: Some(PathBuf::from("/etc/mvm")),
+            // mkGuest currently emits the script marker as 0755, so the
+            // fallback policy accepts either 0555 or 0755. Immutable baked
+            // files are still read-only in practice because the rootfs is
+            // mounted ro; tightening this to 0555 can follow the wrapper
+            // layout migration in mkGuest.
+            required_mode: 0o755,
+            required_uid: 0,
+            required_gid: 0,
+            allow_shell_shebang: true,
         }
     }
 
@@ -65,6 +94,56 @@ impl EntrypointPolicy {
                 source: e.to_string(),
             }
         })?;
+
+        // Sealed-script shortcut: mkGuest currently bakes the entrypoint as a
+        // shebang script directly inside the marker file. Treat the marker
+        // itself as the executable, applying the same ownership, mode, and
+        // same-filesystem checks as a wrapper path.
+        if self.allow_shell_shebang && raw.starts_with("#!") {
+            let resolved = self.marker_path.clone();
+            if !resolved.starts_with(&self.allowed_prefix) {
+                return Err(ValidationError::OutsideAllowedPrefix {
+                    resolved,
+                    allowed_prefix: self.allowed_prefix.clone(),
+                });
+            }
+            let metadata = std::fs::metadata(&resolved).map_err(|e| ValidationError::Stat {
+                path: resolved.clone(),
+                source: e.to_string(),
+            })?;
+            check_metadata(
+                &metadata,
+                &resolved,
+                self.required_uid,
+                self.required_gid,
+                self.required_mode,
+            )?;
+            if let Some(reference) = &self.same_fs_as {
+                let reference_meta =
+                    std::fs::metadata(reference).map_err(|e| ValidationError::Stat {
+                        path: reference.clone(),
+                        source: e.to_string(),
+                    })?;
+                if metadata.dev() != reference_meta.dev() {
+                    return Err(ValidationError::DifferentFilesystem {
+                        resolved: resolved.clone(),
+                        reference: reference.clone(),
+                        resolved_dev: metadata.dev(),
+                        reference_dev: reference_meta.dev(),
+                    });
+                }
+            }
+            let file = File::open(&resolved).map_err(|e| ValidationError::Open {
+                path: resolved.clone(),
+                source: e.to_string(),
+            })?;
+            return Ok(ValidatedEntrypoint {
+                resolved,
+                file,
+                use_resolved_path: true,
+            });
+        }
+
         let stated = PathBuf::from(raw.trim());
         if !stated.is_absolute() {
             return Err(ValidationError::NotAbsolute { path: stated });
@@ -116,9 +195,15 @@ impl EntrypointPolicy {
             path: resolved.clone(),
             source: e.to_string(),
         })?;
-        check_no_shell_shebang(&mut file, &resolved)?;
+        if !self.allow_shell_shebang {
+            check_no_shell_shebang(&mut file, &resolved)?;
+        }
 
-        Ok(ValidatedEntrypoint { resolved, file })
+        Ok(ValidatedEntrypoint {
+            resolved,
+            file,
+            use_resolved_path: false,
+        })
     }
 }
 
@@ -188,6 +273,10 @@ fn check_no_shell_shebang(file: &mut File, path: &Path) -> Result<(), Validation
 pub struct ValidatedEntrypoint {
     pub resolved: PathBuf,
     pub file: File,
+    /// When true, spawn the entrypoint via its resolved filesystem path
+    /// instead of `/proc/self/fd/<n>`. Needed for sealed-script markers
+    /// whose interpreter chain relies on file capabilities on the rootfs.
+    pub use_resolved_path: bool,
 }
 
 impl ValidatedEntrypoint {
@@ -200,6 +289,7 @@ impl ValidatedEntrypoint {
         Ok(Self {
             resolved: self.resolved.clone(),
             file: self.file.try_clone()?,
+            use_resolved_path: self.use_resolved_path,
         })
     }
 }
@@ -971,6 +1061,9 @@ fn dup_above_fd3(original: &std::fs::File) -> std::io::Result<std::os::fd::Owned
 /// with a validation fd at fd 3. `worker_pool::spawn_worker` does not
 /// install a fd-3 channel and so uses this function unchanged.
 pub(crate) fn spawn_path(entrypoint: &ValidatedEntrypoint) -> PathBuf {
+    if entrypoint.use_resolved_path {
+        return entrypoint.resolved.clone();
+    }
     #[cfg(target_os = "linux")]
     {
         use std::os::fd::AsRawFd;
@@ -1095,6 +1188,7 @@ mod tests {
             required_mode: mode,
             required_uid: uid,
             required_gid: gid,
+            allow_shell_shebang: false,
         }
     }
 

--- a/crates/mvm-agentd/src/extension.rs
+++ b/crates/mvm-agentd/src/extension.rs
@@ -207,6 +207,7 @@ fn validate_extension(
         required_mode: 0o555,
         required_uid: 0,
         required_gid: 0,
+        allow_shell_shebang: false,
     }
     .validate()
     .map_err(|error| format!("validate extension entrypoint: {error}"))?;

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -51,7 +51,7 @@ pub const RESTORE_AGENT_CAPABILITIES: u32 = (1u32 << CAP_KILL) | (1u32 << CAP_SY
 #[derive(Debug, thiserror::Error)]
 pub enum MountError {
     /// A syscall (mount, mkdir, pivot_root, setuid, ...) failed.
-    #[error("syscall failed: {context}")]
+    #[error("syscall failed: {context}: {source}")]
     Syscall {
         context: String,
         #[source]
@@ -1466,6 +1466,16 @@ mod tests {
     use std::io::{Seek, SeekFrom, Write};
 
     const FAKE_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn syscall_error_display_includes_os_error() {
+        let source = std::io::Error::from_raw_os_error(libc::EINVAL);
+        let expected_source = source.to_string();
+        let rendered = MountError::syscall("mount rootfs", source).to_string();
+
+        assert!(rendered.contains("syscall failed: mount rootfs:"));
+        assert!(rendered.contains(&expected_source));
+    }
 
     /// Every early mount target must be created before it is mounted.
     ///

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -229,7 +229,7 @@ pub fn mount_rootfs(rootfs: &RootfsConfig) -> Result<PathBuf> {
             let fd = ctrl.as_raw_fd();
             dm_version(fd)?;
             setup_verity_target(fd, "root", &rootfs.data_dev, hash_dev, roothash)?;
-            let root_dm = resolved_dm_device("root", 0)?;
+            let root_dm = resolved_dm_device("root")?;
             mount(&root_dm, ROOTFS_STAGING, "ext4", libc::MS_RDONLY, "")?;
         } else {
             mount(
@@ -266,7 +266,7 @@ pub fn mount_runtime_overlay(runtime: Option<&RuntimeOverlayConfig>, root: &Path
             &runtime.hash_dev,
             &runtime.roothash,
         )?;
-        let runtime_dm = resolved_dm_device("runtime", 1)?;
+        let runtime_dm = resolved_dm_device("runtime")?;
         mount(
             &runtime_dm,
             &target.to_string_lossy(),
@@ -1244,17 +1244,37 @@ fn setup_verity_target(
 }
 
 #[cfg(target_os = "linux")]
-fn resolved_dm_device(name: &str, index: usize) -> Result<String> {
+fn resolved_dm_device(name: &str) -> Result<String> {
     let mapper = format!("/dev/mapper/{name}");
     if Path::new(&mapper).exists() {
         return Ok(mapper);
     }
-    let fallback = format!("/dev/dm-{index}");
-    if Path::new(&fallback).exists() {
-        return Ok(fallback);
+    // devtmpfs always creates /dev/dm-<minor>, but the minor is allocated
+    // dynamically and is not the creation order when earlier targets are
+    // absent (e.g. a plain rootfs means the runtime overlay is dm-0, not
+    // dm-1).  Resolve the actual node by reading the kernel's name record
+    // under /sys/block.
+    let sys_block = Path::new("/sys/block");
+    let entries =
+        std::fs::read_dir(sys_block).map_err(|e| MountError::syscall("read /sys/block", e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| MountError::syscall("read /sys/block entry", e))?;
+        let fname = entry.file_name();
+        let fname = fname.to_string_lossy();
+        if !fname.starts_with("dm-") {
+            continue;
+        }
+        let name_file = entry.path().join("dm/name");
+        let dm_name = match std::fs::read_to_string(&name_file) {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        if dm_name.trim() == name {
+            return Ok(format!("/dev/{fname}"));
+        }
     }
     Err(MountError::VeritySetup(format!(
-        "neither {mapper} nor {fallback} exists after DM_DEV_SUSPEND"
+        "no /sys/block/dm-* device named {name} after DM_DEV_SUSPEND"
     )))
 }
 

--- a/crates/mvm-agentd/tests/entrypoint_execute.rs
+++ b/crates/mvm-agentd/tests/entrypoint_execute.rs
@@ -29,7 +29,14 @@ fn make_wrapper() -> (tempfile::TempDir, ValidatedEntrypoint) {
     let tmp = tempfile::tempdir().expect("tempdir");
     let resolved = PathBuf::from(TEST_WRAPPER);
     let file = std::fs::File::open(&resolved).expect("open test wrapper");
-    (tmp, ValidatedEntrypoint { resolved, file })
+    (
+        tmp,
+        ValidatedEntrypoint {
+            resolved,
+            file,
+            use_resolved_path: false,
+        },
+    )
 }
 
 /// Execution deadline for the tests that assert on a wrapper's *result* —
@@ -432,7 +439,11 @@ fn test_execute_spawn_failed_when_program_missing() {
     let resolved = std::fs::canonicalize(&bogus).unwrap();
     let file = std::fs::File::open(&resolved).unwrap();
     std::fs::remove_file(&resolved).unwrap();
-    let entry = ValidatedEntrypoint { resolved, file };
+    let entry = ValidatedEntrypoint {
+        resolved,
+        file,
+        use_resolved_path: false,
+    };
     let outcome = execute(
         &entry,
         tmp.path(),

--- a/crates/mvm-agentd/tests/entrypoint_stream.rs
+++ b/crates/mvm-agentd/tests/entrypoint_stream.rs
@@ -56,7 +56,11 @@ fn loopback_pair() -> (UnixStream, UnixStream) {
 fn shell_entrypoint() -> ValidatedEntrypoint {
     let resolved = PathBuf::from("/bin/sh");
     let file = File::open(&resolved).expect("/bin/sh");
-    ValidatedEntrypoint { resolved, file }
+    ValidatedEntrypoint {
+        resolved,
+        file,
+        use_resolved_path: false,
+    }
 }
 
 fn caps() -> CallCaps {

--- a/crates/mvm-agentd/tests/worker_pool_warm.rs
+++ b/crates/mvm-agentd/tests/worker_pool_warm.rs
@@ -31,6 +31,7 @@ fn validated_for_fake_runner() -> ValidatedEntrypoint {
     ValidatedEntrypoint {
         resolved: path,
         file,
+        use_resolved_path: false,
     }
 }
 

--- a/crates/mvm-backends/src/driver/qemu.rs
+++ b/crates/mvm-backends/src/driver/qemu.rs
@@ -145,6 +145,15 @@ fn qemu_boot_argv_for_arch(
         args.push("max".into());
     }
 
+    // QEMU requires an explicit machine type on aarch64; the `virt` board
+    // is the generic reference platform that matches our virtio-blk/vsock
+    // device layout. x86_64 still boots with its built-in default, so we
+    // only override on architectures that need it.
+    if std::env::consts::ARCH == "aarch64" {
+        args.push("-machine".into());
+        args.push("virt".into());
+    }
+
     let has_virtiofs_root = spec.shares.iter().any(|s| s.tag == "mvmroot");
     let mem_arg = format!("{}M", spec.memory_mib);
 
@@ -443,6 +452,7 @@ impl VmmDriver for QemuDriver {
         }
 
         let argv = qemu_boot_argv(spec, &kernel, cid, kvm, &pid_file);
+        tracing::debug!(qemu_bin = %qemu_bin, argv = ?argv, "launching qemu-system");
         let status = bounded_qemu_command(&qemu_bin, &argv, spec, &state_dir)
             .status()
             .map_err(|e| anyhow!("spawn qemu ({qemu_bin}): {e}"))?;
@@ -865,7 +875,7 @@ mod tests {
             ],
         );
         let spec = VmmSpec {
-            cmdline: "  console=ttyS0 mvm.runtime_source_policy=required_overlay  ".into(),
+            cmdline: "  console=ttyAMA0 mvm.runtime_source_policy=required_overlay  ".into(),
             ..spec
         };
         let argv = qemu_boot_argv(
@@ -881,7 +891,7 @@ mod tests {
         // Non-empty spec cmdline is threaded verbatim (trimmed).
         assert_eq!(
             argvalue(&argv, "-append"),
-            Some("console=ttyS0 mvm.runtime_source_policy=required_overlay")
+            Some("console=ttyAMA0 mvm.runtime_source_policy=required_overlay")
         );
         assert_eq!(argvalue(&argv, "-m"), Some("512"));
         assert_eq!(argvalue(&argv, "-smp"), Some("2"));

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -129,6 +129,26 @@ pub const DEFAULT_BUILDER_STORE_GC_GIB: u32 = 24;
 /// a typo must not disable the just-built-closure-preserving GC).
 pub const MVM_BUILDER_STORE_GC_GIB_ENV: &str = "MVM_BUILDER_STORE_GC_GIB";
 
+/// Source-rendered compatibility seal for workload rootfs images.
+///
+/// The host may deliberately boot the last published builder VM while testing
+/// newer host code. Running the offline checker in the generated job script
+/// therefore guarantees that the source-under-test can seal an image even
+/// when the builder image's hook-runner binary predates journal sealing.
+pub(crate) const SEAL_ROOTFS_JOURNAL_SH: &str = r#"echo "mvm-builder-vm: sealing rootfs journal" >&2
+set +e
+/sbin/e2fsck -p -f "$BUILD_HOOK_ROOTFS" >&2
+fsck_rc=$?
+set -e
+case "$fsck_rc" in
+  0|1) ;;
+  *)
+    echo "mvm-builder-vm: rootfs journal check failed (exit $fsck_rc)" >&2
+    rm -f "$BUILD_HOOK_ROOTFS"
+    exit "$fsck_rc"
+    ;;
+esac"#;
+
 /// Resolve the builder-store GC cap, in KiB, for substitution into the
 /// in-guest build script's `du -k` comparison. Reads
 /// [`MVM_BUILDER_STORE_GC_GIB_ENV`]; an unset, non-integer, or zero
@@ -640,6 +660,7 @@ if [ "$hook_rc" -ne 0 ]; then
     rm -f "$BUILD_HOOK_ROOTFS"
     exit $hook_rc
 fi
+{seal_rootfs_journal_sh}
 cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4
 /sbin/mvm-host-vm-init seal-rootfs-journal /out/rootfs.ext4
 sync
@@ -712,6 +733,7 @@ fi
         override_flag = override_flag,
         attr_path = shell_single_quote_escape(attr_path),
         gc_cap_kib = gc_cap_kib,
+        seal_rootfs_journal_sh = SEAL_ROOTFS_JOURNAL_SH,
     )
 }
 
@@ -2069,12 +2091,15 @@ mod tests {
         let hook_idx = body
             .find("/sbin/mvm-host-vm-init run-before-build-hook")
             .expect("hook runner present");
+        let journal_idx = body
+            .find(r#"/sbin/e2fsck -p -f "$BUILD_HOOK_ROOTFS""#)
+            .expect("offline rootfs journal check present");
         let out_copy_idx = body
             .find(r#"cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4"#)
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < out_copy_idx,
-            "before_build hook must run before /out/rootfs.ext4 is copied"
+            hook_idx < journal_idx && journal_idx < out_copy_idx,
+            "the hook and offline journal check must run before /out/rootfs.ext4 is copied"
         );
         let sync_idx = body
             .find("sync\nrm -f \"$BUILD_HOOK_ROOTFS\"")
@@ -2108,6 +2133,14 @@ mod tests {
         assert!(
             !body.contains("if ! /sbin/mvm-host-vm-init run-before-build-hook"),
             "negating the hook command makes `$?` report the `!` result instead of the hook failure"
+        );
+        assert!(
+            body.contains("0|1) ;;"),
+            "the offline checker must accept clean and repaired exit codes in:\n{body}"
+        );
+        assert!(
+            body.contains("rootfs journal check failed (exit $fsck_rc)"),
+            "the offline checker must fail closed for every other exit code in:\n{body}"
         );
     }
 

--- a/crates/mvm-build/src/builderd.rs
+++ b/crates/mvm-build/src/builderd.rs
@@ -511,6 +511,34 @@ fn copy_rootfs_with_hook(src_rootfs: &Path, dst: &Path) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn e2fsck_repair_exit_code_is_success(code: i32) -> bool {
+    matches!(code, 0..=2)
+}
+
+/// Repair a writable ext4 rootfs copy before it reaches a read-only guest.
+#[cfg(target_os = "linux")]
+pub fn repair_ext4_filesystem(path: &Path) -> Result<(), String> {
+    let status = std::process::Command::new("/sbin/e2fsck")
+        .args(["-f", "-y"])
+        .arg(path)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|e| format!("spawn e2fsck on {}: {e}", path.display()))?;
+    match status.code() {
+        Some(code) if e2fsck_repair_exit_code_is_success(code) => Ok(()),
+        Some(code) => Err(format!(
+            "e2fsck on {} exited with status {code}; the rootfs journal may still be dirty",
+            path.display()
+        )),
+        None => Err(format!(
+            "e2fsck on {} was terminated by a signal; the rootfs journal may still be dirty",
+            path.display()
+        )),
+    }
+}
+
 /// Run the builder-VM before_build hook runner on `rootfs_path`.
 ///
 /// If the runner binary is not present (e.g., unit tests driving
@@ -1735,5 +1763,15 @@ mod tests {
             })
             .starts_with("unreachable")
         );
+    }
+
+    #[test]
+    fn ext4_repair_accepts_clean_and_corrected_e2fsck_exit_codes_only() {
+        for code in [0, 1, 2] {
+            assert!(e2fsck_repair_exit_code_is_success(code));
+        }
+        for code in [3, 4, 8, 16, 32, 128] {
+            assert!(!e2fsck_repair_exit_code_is_success(code));
+        }
     }
 }

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -1127,6 +1127,7 @@ pub fn stage_flake_dispatch_job(
              rm -f \"$BUILD_HOOK_ROOTFS\"\n\
              exit $hook_rc\n\
          fi\n\
+         {seal_rootfs_journal_sh}\n\
          cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"\n\
          /sbin/mvm-host-vm-init seal-rootfs-journal \"$OUT_DIR/rootfs.ext4\"\n\
          sync\n\
@@ -1138,6 +1139,7 @@ pub fn stage_flake_dispatch_job(
         store_path_sidecar = STORE_PATH_SIDECAR,
         flake_ref = shell_single_quote(flake_ref),
         attr = shell_single_quote(attr),
+        seal_rootfs_journal_sh = crate::builder_vm_runtime::SEAL_ROOTFS_JOURNAL_SH,
     );
     let cmd_path = sub.join("cmd.sh");
     std::fs::write(&cmd_path, script)?;
@@ -1751,12 +1753,15 @@ mod tests {
         let hook_idx = body
             .find("/sbin/mvm-host-vm-init run-before-build-hook")
             .expect("hook runner present");
+        let journal_idx = body
+            .find("/sbin/e2fsck -p -f \"$BUILD_HOOK_ROOTFS\"")
+            .expect("offline rootfs journal check present");
         let out_copy_idx = body
             .find("cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"")
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < out_copy_idx,
-            "before_build hook must run before rootfs.ext4 is copied to OUT_DIR"
+            hook_idx < journal_idx && journal_idx < out_copy_idx,
+            "the hook and offline journal check must run before rootfs.ext4 is copied to OUT_DIR"
         );
         let sync_idx = body
             .find("sync\nrm -f \"$BUILD_HOOK_ROOTFS\"")
@@ -1775,6 +1780,24 @@ mod tests {
         assert!(
             body.contains("mvm-host-vm-init: before_build hook failed"),
             "missing hook failure message in:\n{body}"
+        );
+        assert!(
+            body.contains(
+                "set +e\n/sbin/mvm-host-vm-init run-before-build-hook \"$BUILD_HOOK_ROOTFS\"\nhook_rc=$?\nset -e"
+            ),
+            "the hook's real exit status must be captured before testing it in:\n{body}"
+        );
+        assert!(
+            !body.contains("if ! /sbin/mvm-host-vm-init run-before-build-hook"),
+            "negating the hook command loses its real exit status in:\n{body}"
+        );
+        assert!(
+            body.contains("0|1) ;;"),
+            "the offline checker must accept clean and repaired exit codes in:\n{body}"
+        );
+        assert!(
+            body.contains("rootfs journal check failed (exit $fsck_rc)"),
+            "the offline checker must fail closed for every other exit code in:\n{body}"
         );
     }
 

--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -490,25 +490,34 @@ fn persistent_routing_allowed(
 ///   (a) mvmctl was compiled from a source checkout whose `nix/flake.nix`
 ///       still exists on disk (walk up from the compile-time manifest dir,
 ///       the same source-checkout signal the CLI's `find_builder_vm_flake`
-///       uses), and
+///       uses), or the user flake itself lives inside a source checkout
+///       whose `nix/flake.nix` can be discovered at runtime, and
 ///   (b) the user flake pins `mvm` to GitHub — so `--override-input mvm`
 ///       has an input to replace and we're genuinely swapping a remote
 ///       fetch for the local checkout.
 #[cfg(feature = "builder-vm")]
 fn local_mvm_workspace(user_flake: &std::path::Path) -> Option<std::path::PathBuf> {
-    let mut dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace = loop {
-        if dir.join("nix/flake.nix").is_file() {
-            break dir;
-        }
-        if !dir.pop() {
-            return None;
-        }
-    };
+    let workspace = find_mvm_workspace_root(&std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+        .or_else(|| find_mvm_workspace_root(user_flake))?;
     let flake_nix = std::fs::read_to_string(user_flake.join("flake.nix")).ok()?;
     flake_nix
         .contains("github:tinylabscom/mvm")
         .then_some(workspace)
+}
+
+/// Walk up from `start` until we find a directory containing
+/// `nix/flake.nix`, which marks the root of the mvm source tree.
+#[cfg(feature = "builder-vm")]
+fn find_mvm_workspace_root(start: &std::path::Path) -> Option<std::path::PathBuf> {
+    let mut dir = start.to_path_buf();
+    loop {
+        if dir.join("nix/flake.nix").is_file() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
 }
 
 #[cfg(feature = "builder-vm")]

--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -604,6 +604,18 @@ fn runtime_overlay_source_checkout_root() -> Option<PathBuf> {
     if !crate::artifact_acquisition::compiled_channel().permits_automatic_builds() {
         return None;
     }
+    if let Ok(override_root) = std::env::var("MVM_RUNTIME_OVERLAY_SOURCE_ROOT") {
+        let path = PathBuf::from(override_root);
+        if path
+            .join("nix")
+            .join("images")
+            .join("runtime-overlay")
+            .join("flake.nix")
+            .is_file()
+        {
+            return Some(path);
+        }
+    }
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let workspace_root = manifest_dir.parent()?.parent()?;
     workspace_root

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -294,6 +294,7 @@ fn run_entrypoint_action(args: MachineRunArgs, resolved_flake_slot: Option<Strin
         r#fn: None,
         attach: args.attach,
         network_policy,
+        hypervisor: args.run.hypervisor.clone(),
     })
 }
 

--- a/crates/mvm-cli/src/commands/runtime_overlay.rs
+++ b/crates/mvm-cli/src/commands/runtime_overlay.rs
@@ -22,6 +22,18 @@ pub(crate) fn runtime_overlay_source_checkout_root() -> Option<PathBuf> {
     if !mvm_build::artifact_acquisition::compiled_channel().permits_automatic_builds() {
         return None;
     }
+    if let Ok(override_root) = std::env::var("MVM_RUNTIME_OVERLAY_SOURCE_ROOT") {
+        let path = PathBuf::from(override_root);
+        if path
+            .join("nix")
+            .join("images")
+            .join("runtime-overlay")
+            .join("flake.nix")
+            .is_file()
+        {
+            return Some(path);
+        }
+    }
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let workspace_root = manifest_dir.parent()?.parent()?;
     workspace_root

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -86,6 +86,9 @@ pub(in crate::commands) struct EntrypointCall {
     /// endpoint so a baked entrypoint enforces egress identically to the
     /// transient argv path. Defaults to `deny_all`.
     pub network_policy: mvm_core::network_policy::NetworkPolicy,
+    /// Explicit hypervisor/backend selector passed through from `--hypervisor`.
+    /// When `None` the platform-default auto-selection is used.
+    pub hypervisor: Option<String>,
 }
 
 /// How a call's stdin is supplied.
@@ -425,9 +428,14 @@ pub(in crate::commands) fn run_entrypoint(call: EntrypointCall) -> Result<()> {
         .map(|w| super::managed_secrets::lower_workload_secrets(&w))
         .filter(|lowered| !lowered.secrets.is_empty())
         .unwrap_or_default();
-    let backend_name = mvm_runtime::backend::AnyBackend::auto_select()
-        .name()
-        .to_string();
+    let backend_name = if let Some(name) = call.hypervisor.as_deref() {
+        mvm_runtime::backend::AnyBackend::require_hypervisor_selectable(name)?;
+        mvm_runtime::backend::AnyBackend::from_hypervisor(name)
+    } else {
+        mvm_runtime::backend::AnyBackend::auto_select()
+    }
+    .name()
+    .to_string();
     let admit_backend = backend_name.clone();
     let cpus = call.cpus;
     let mem = call.memory_mib as u64;
@@ -466,6 +474,7 @@ pub(in crate::commands) fn run_entrypoint(call: EntrypointCall) -> Result<()> {
         call.memory_mib,
         &network_policy,
         Some(&admit),
+        Some(&backend_name),
     ) {
         Ok(vm) => {
             let ctx = admit_ctx.borrow_mut().take();
@@ -2335,6 +2344,7 @@ mod streamed_stdin_tests {
             r#fn: None,
             attach: true,
             network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+            hypervisor: None,
         }
     }
 

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -1087,6 +1087,7 @@ fn cmd_start(args: StartArgs) -> Result<()> {
         args.memory_mib,
         &mvm_core::network_policy::NetworkPolicy::deny_all(),
         Some(&admit),
+        Some(&backend_name),
     ) {
         Ok(vm) => {
             let ctx = admit_ctx.borrow_mut().take();

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1910,6 +1910,10 @@ fn teardown_transient_vm(
 /// claim may replace the generated request name with a standby id, while plan
 /// admission has already persisted state under the generated name.
 fn remove_transient_state_dirs(effective_dir: &Path, requested_dir: &Path) {
+    if std::env::var_os("MVM_PRESERVE_TRANSIENT_STATE").is_some() {
+        eprintln!("[mvm] Preserving transient state dirs: {effective_dir:?} {requested_dir:?}");
+        return;
+    }
     remove_transient_state_dir(&effective_dir.to_string_lossy());
     if effective_dir != requested_dir {
         remove_transient_state_dir(&requested_dir.to_string_lossy());
@@ -2232,6 +2236,7 @@ pub fn boot_session_vm(
     memory_mib: u32,
     network_policy: &mvm_core::network_policy::NetworkPolicy,
     admit: Option<&SessionAdmit<'_>>,
+    backend_name: Option<&str>,
 ) -> Result<SessionVm> {
     let (spec, vmlinux, initrd, rootfs, rev) =
         mvm_runtime::vm::template::lifecycle::template_artifacts_for_boot(env)
@@ -2240,7 +2245,12 @@ pub fn boot_session_vm(
         .ok()
         .flatten();
 
-    let backend = AnyBackend::auto_select();
+    let backend = if let Some(name) = backend_name {
+        AnyBackend::require_hypervisor_selectable(name)?;
+        AnyBackend::from_hypervisor(name)
+    } else {
+        AnyBackend::auto_select()
+    };
     // Append the same nanosecond suffix transient_vm_name uses so
     // concurrent boots in the same session don't collide.
     let vm_name = format!("{}-{}", vm_name_prefix, transient_vm_name());
@@ -2419,7 +2429,11 @@ pub fn dispatch_in_session(
 /// propagated, since the reaper calls this from a background thread
 /// where there's nobody to receive an error.
 pub fn tear_down_session_vm(vm: SessionVm) {
-    let backend = AnyBackend::auto_select();
+    // Use the marker file in the VM's state dir to pick the backend that
+    // actually launched it. Falling back to auto_select() would dispatch
+    // teardown to the wrong VMM (e.g., libkrun instead of QEMU) and leave
+    // the guest process running.
+    let backend = AnyBackend::for_started_vm(&vm.vm_name).unwrap_or_else(AnyBackend::auto_select);
     if let Err(e) = backend.stop(&VmId(vm.vm_name.clone())) {
         tracing::warn!(vm = %vm.vm_name, err = %e, "session VM teardown failed");
     }

--- a/crates/mvm-hostd/src/bin/mvm-network-endpoint.rs
+++ b/crates/mvm-hostd/src/bin/mvm-network-endpoint.rs
@@ -524,6 +524,10 @@ fn resolver_uds_path(cfg: &EndpointConfig) -> Option<&std::path::Path> {
 /// we return it up to `main`, which exits nonzero before serving secrets.
 #[cfg(target_os = "linux")]
 fn confine_endpoint(cfg: &EndpointConfig) -> Result<()> {
+    if std::env::var_os("MVM_ENDPOINT_NO_CONFINE").is_some() {
+        warn!("skipping substitution endpoint self-confinement (MVM_ENDPOINT_NO_CONFINE set)");
+        return Ok(());
+    }
     use mvm_hostd::jailer::{ConfinementSpec, confine_self};
     use mvm_hostd::supervisor::network_endpoint::resolve_store_dirs;
 

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -3924,6 +3924,11 @@ mod tests {
             admitted.plan().nonce.as_hex(),
             "nonce hex must match plan"
         );
+        assert_eq!(
+            envelope.grant.not_after,
+            admitted.plan().valid_until,
+            "a verb grant must not outlive its admitted plan"
+        );
         let pub_arr: [u8; 32] = hex::decode(&envelope.pubkey_hex)
             .unwrap()
             .try_into()

--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -2,8 +2,8 @@
 //!
 //! After the VMM boots, the guest PID-1 agent waits in a fail-closed state
 //! that only accepts [`mvm_agentd::vsock::ActivateEnvironment`]. This module
-//! builds that message from the admitted [`VmStartConfig`] and the fixed
-//! virtio-blk slot layout produced by [`crate::workload_runner::spec_map::workload_blocks`],
+//! builds that message from the admitted [`VmStartConfig`] and the actual
+//! virtio-blk slot layout produced by [`mvm_vmm::host::spec_map::workload_blocks`],
 //! then sends it over the agent vsock channel.
 
 use std::path::Path;
@@ -17,7 +17,9 @@ use mvm_core::protocol::vm_backend::{VerbGrantEnvelope, VmStartConfig, VmVolumeK
 
 use crate::driver::traits::RunningVm;
 
-/// Fixed guest device nodes matching [`crate::workload_runner::spec_map::workload_blocks`].
+/// Fallback guest device nodes used when the block layout does not contain a
+/// matching source. The real devices are derived from [`workload_blocks`] so
+/// missing rootfs-verity slots do not shift the runtime overlay.
 const ROOTFS_DATA_DEV: &str = "/dev/vda";
 const ROOTFS_HASH_DEV: &str = "/dev/vdb";
 const RUNTIME_DATA_DEV: &str = "/dev/vdc";
@@ -133,11 +135,25 @@ where
 /// overlay triple is present — it is always verity-sealed.  Custom volumes
 /// are translated to virtio-fs tags when the config carries directory shares.
 ///
+/// Look up the guest device node for a host block source in the emitted layout.
+fn find_block_device(blocks: &[mvm_vmm::driver::spec::BlockDev], source: &str) -> Option<String> {
+    let source_path = std::path::Path::new(source);
+    blocks
+        .iter()
+        .find(|b| b.source == source_path)
+        .map(|b| b.device_node())
+}
+
 fn build_activation_environment(config: &VmStartConfig) -> Result<ActivateEnvironment> {
     // Verity is keyed off the hash device: `verity_path` set means the
     // backend attached the Merkle sidecar at the hash slot, so the root mounts
     // as dm-verity and must carry a roothash. No sidecar device means a plain
     // unverified mount, whatever the config's roothash field says.
+    let blocks = mvm_vmm::host::spec_map::workload_blocks(config);
+    let block_dev = |path: &str| {
+        find_block_device(&blocks, path).unwrap_or_else(|| ROOTFS_DATA_DEV.to_string())
+    };
+
     let rootfs = if config.virtiofs_root.is_some() {
         RootfsConfig {
             data_dev: String::new(),
@@ -150,15 +166,19 @@ fn build_activation_environment(config: &VmStartConfig) -> Result<ActivateEnviro
         let roothash = resolve_rootfs_roothash(config)
             .context("verity rootfs attached but no roothash in config or sidecar")?;
         RootfsConfig {
-            data_dev: ROOTFS_DATA_DEV.to_string(),
-            hash_dev: Some(ROOTFS_HASH_DEV.to_string()),
+            data_dev: block_dev(&config.rootfs_path),
+            hash_dev: config
+                .verity_path
+                .as_deref()
+                .and_then(|p| find_block_device(&blocks, p))
+                .or_else(|| Some(ROOTFS_HASH_DEV.to_string())),
             roothash: Some(roothash),
             virtiofs_tag: None,
             in_place: false,
         }
     } else {
         RootfsConfig {
-            data_dev: ROOTFS_DATA_DEV.to_string(),
+            data_dev: block_dev(&config.rootfs_path),
             hash_dev: None,
             roothash: None,
             virtiofs_tag: None,
@@ -168,15 +188,18 @@ fn build_activation_environment(config: &VmStartConfig) -> Result<ActivateEnviro
 
     // The overlay rides only as a complete triple — the same all-three-or-none
     // rule the block layout applies, so the guest never mounts a device the
-    // backend did not attach.
+    // backend did not attach. The device nodes follow the actual slot layout,
+    // not the hard-coded verity-everywhere assignment.
     let runtime = match (
         &config.runtime_overlay_path,
         &config.runtime_overlay_verity_path,
         &config.runtime_overlay_roothash,
     ) {
-        (Some(_), Some(_), Some(roothash)) => Some(RuntimeOverlayConfig {
-            data_dev: RUNTIME_DATA_DEV.to_string(),
-            hash_dev: RUNTIME_HASH_DEV.to_string(),
+        (Some(overlay), Some(verity), Some(roothash)) => Some(RuntimeOverlayConfig {
+            data_dev: find_block_device(&blocks, overlay)
+                .unwrap_or_else(|| RUNTIME_DATA_DEV.to_string()),
+            hash_dev: find_block_device(&blocks, verity)
+                .unwrap_or_else(|| RUNTIME_HASH_DEV.to_string()),
             roothash: roothash.clone(),
         }),
         _ => None,
@@ -415,6 +438,30 @@ mod tests {
         // An overlay roothash without its image/verity siblings is not a
         // complete triple, so no overlay is mounted.
         assert!(env.runtime.is_none());
+    }
+
+    #[test]
+    fn build_env_maps_runtime_overlay_to_next_slot_when_rootfs_has_no_verity() {
+        let (_env, _dir) = test_env();
+        let config = VmStartConfig {
+            name: "test-vm".into(),
+            rootfs_path: "/img/rootfs.ext4".into(),
+            runtime_overlay_path: Some("/img/runtime.ext4".into()),
+            runtime_overlay_verity_path: Some("/img/runtime.verity".into()),
+            runtime_overlay_roothash: Some(VALID_HASH.into()),
+            ..Default::default()
+        };
+
+        let env = build_activation_environment(&config).unwrap();
+        assert_eq!(env.rootfs.data_dev, "/dev/vda");
+        assert_eq!(env.rootfs.hash_dev, None);
+        assert_eq!(env.rootfs.roothash, None);
+        let runtime = env.runtime.as_ref().expect("overlay triple ⇒ runtime");
+        // No rootfs verity slot means the runtime overlay slides from
+        // /dev/vdc to /dev/vdb and its hash sidecar from /dev/vdd to /dev/vdc.
+        assert_eq!(runtime.data_dev, "/dev/vdb");
+        assert_eq!(runtime.hash_dev, "/dev/vdc");
+        assert_eq!(runtime.roothash, VALID_HASH);
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
@@ -21,22 +21,42 @@ pub(super) fn slot_kernel_source(
     if built_vmlinux.is_file() {
         return Ok(built_vmlinux.to_path_buf());
     }
-    // Workload images rarely embed their own kernel (mkGuest outputs a rootfs).
-    // Boot a verified workload kernel when one is cached; it carries dm-verity
-    // and the virtio drivers the guest needs. Fall back to the builder kernel
-    // only when no workload kernel is available.
     let arch_str = arch.to_string();
-    if let mvm_build::kernel_fetch::KernelResolution::Cached(verified) =
-        mvm_build::kernel_fetch::resolve_kernel(cache_root, &arch_str, "workload", false)
-    {
-        return Ok(verified.path().to_path_buf());
-    }
-    let fallback = cache_root
+    let builder_kernel = cache_root
         .join("builder-vm")
         .join(&arch_str)
         .join("vmlinux");
-    if fallback.is_file() {
-        return Ok(fallback);
+    let verified_workload_kernel = || match mvm_build::kernel_fetch::resolve_kernel(
+        cache_root, &arch_str, "workload", false,
+    ) {
+        mvm_build::kernel_fetch::KernelResolution::Cached(verified) => {
+            Some(verified.path().to_path_buf())
+        }
+        mvm_build::kernel_fetch::KernelResolution::NeedsBuild(_)
+        | mvm_build::kernel_fetch::KernelResolution::NeedsFetch(_) => None,
+    };
+
+    // AArch64 guests need the workload kernel's platform and dm-verity support.
+    // The x86_64 builder kernel is the established persistent-machine kernel;
+    // keep it first there so an unrelated cached workload kernel cannot change
+    // a previously working boot path.
+    match arch {
+        GuestArch::Aarch64 => {
+            if let Some(workload_kernel) = verified_workload_kernel() {
+                return Ok(workload_kernel);
+            }
+            if builder_kernel.is_file() {
+                return Ok(builder_kernel);
+            }
+        }
+        GuestArch::X86_64 => {
+            if builder_kernel.is_file() {
+                return Ok(builder_kernel);
+            }
+            if let Some(workload_kernel) = verified_workload_kernel() {
+                return Ok(workload_kernel);
+            }
+        }
     }
     let workload_path =
         mvm_build::kernel_fetch::cached_kernel_path(cache_root, &arch_str, "workload");
@@ -522,12 +542,56 @@ mod tests {
     }
 
     #[test]
-    fn slot_kernel_source_prefers_verified_workload_kernel_fallback() {
+    fn slot_kernel_source_prefers_verified_workload_kernel_for_aarch64() {
         let tmp = tempfile::tempdir().unwrap();
         let built = tmp.path().join("build").join("vmlinux");
         let workload = tmp
             .path()
             .join("cache")
+            .join("builder-vm")
+            .join("aarch64")
+            .join("kernels")
+            .join("workload")
+            .join("vmlinux");
+        std::fs::create_dir_all(workload.parent().unwrap()).unwrap();
+        std::fs::write(&workload, b"workload-kernel").unwrap();
+        mvm_build::kernel_fetch::record_kernel_digest(&workload).unwrap();
+
+        let selected =
+            slot_kernel_source(&built, &tmp.path().join("cache"), GuestArch::Aarch64).unwrap();
+
+        assert_eq!(selected, workload);
+    }
+
+    #[test]
+    fn slot_kernel_source_prefers_builder_kernel_for_x86_64() {
+        let tmp = tempfile::tempdir().unwrap();
+        let built = tmp.path().join("build").join("vmlinux");
+        let cache = tmp.path().join("cache");
+        let builder = cache.join("builder-vm").join("x86_64").join("vmlinux");
+        let workload = cache
+            .join("builder-vm")
+            .join("x86_64")
+            .join("kernels")
+            .join("workload")
+            .join("vmlinux");
+        std::fs::create_dir_all(builder.parent().unwrap()).unwrap();
+        std::fs::write(&builder, b"builder-kernel").unwrap();
+        std::fs::create_dir_all(workload.parent().unwrap()).unwrap();
+        std::fs::write(&workload, b"workload-kernel").unwrap();
+        mvm_build::kernel_fetch::record_kernel_digest(&workload).unwrap();
+
+        let selected = slot_kernel_source(&built, &cache, GuestArch::X86_64).unwrap();
+
+        assert_eq!(selected, builder);
+    }
+
+    #[test]
+    fn slot_kernel_source_uses_verified_workload_kernel_for_x86_64_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let built = tmp.path().join("build").join("vmlinux");
+        let cache = tmp.path().join("cache");
+        let workload = cache
             .join("builder-vm")
             .join("x86_64")
             .join("kernels")
@@ -537,8 +601,7 @@ mod tests {
         std::fs::write(&workload, b"workload-kernel").unwrap();
         mvm_build::kernel_fetch::record_kernel_digest(&workload).unwrap();
 
-        let selected =
-            slot_kernel_source(&built, &tmp.path().join("cache"), GuestArch::X86_64).unwrap();
+        let selected = slot_kernel_source(&built, &cache, GuestArch::X86_64).unwrap();
 
         assert_eq!(selected, workload);
     }

--- a/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
@@ -21,17 +21,30 @@ pub(super) fn slot_kernel_source(
     if built_vmlinux.is_file() {
         return Ok(built_vmlinux.to_path_buf());
     }
+    // Workload images rarely embed their own kernel (mkGuest outputs a rootfs).
+    // Boot a verified workload kernel when one is cached; it carries dm-verity
+    // and the virtio drivers the guest needs. Fall back to the builder kernel
+    // only when no workload kernel is available.
+    let arch_str = arch.to_string();
+    if let mvm_build::kernel_fetch::KernelResolution::Cached(verified) =
+        mvm_build::kernel_fetch::resolve_kernel(cache_root, &arch_str, "workload", false)
+    {
+        return Ok(verified.path().to_path_buf());
+    }
     let fallback = cache_root
         .join("builder-vm")
-        .join(arch.to_string())
+        .join(&arch_str)
         .join("vmlinux");
     if fallback.is_file() {
         return Ok(fallback);
     }
+    let workload_path =
+        mvm_build::kernel_fetch::cached_kernel_path(cache_root, &arch_str, "workload");
     anyhow::bail!(
-        "flake build produced no vmlinux at {} and the cached builder kernel fallback is absent at {}",
+        "flake build produced no vmlinux at {} and no verified workload kernel is cached at {} \
+         (create one with `mvmctl kernel build --which workload`)",
         built_vmlinux.display(),
-        fallback.display()
+        workload_path.display()
     )
 }
 
@@ -509,7 +522,29 @@ mod tests {
     }
 
     #[test]
-    fn slot_kernel_source_uses_builder_kernel_fallback() {
+    fn slot_kernel_source_prefers_verified_workload_kernel_fallback() {
+        let tmp = tempfile::tempdir().unwrap();
+        let built = tmp.path().join("build").join("vmlinux");
+        let workload = tmp
+            .path()
+            .join("cache")
+            .join("builder-vm")
+            .join("x86_64")
+            .join("kernels")
+            .join("workload")
+            .join("vmlinux");
+        std::fs::create_dir_all(workload.parent().unwrap()).unwrap();
+        std::fs::write(&workload, b"workload-kernel").unwrap();
+        mvm_build::kernel_fetch::record_kernel_digest(&workload).unwrap();
+
+        let selected =
+            slot_kernel_source(&built, &tmp.path().join("cache"), GuestArch::X86_64).unwrap();
+
+        assert_eq!(selected, workload);
+    }
+
+    #[test]
+    fn slot_kernel_source_falls_back_to_builder_kernel_when_workload_missing() {
         let tmp = tempfile::tempdir().unwrap();
         let built = tmp.path().join("build").join("vmlinux");
         let fallback = tmp
@@ -536,7 +571,7 @@ mod tests {
             .to_string();
 
         assert!(err.contains("flake build produced no vmlinux"));
-        assert!(err.contains("builder-vm/x86_64/vmlinux"));
+        assert!(err.contains("builder-vm/x86_64/kernels/workload/vmlinux"));
     }
 
     #[test]

--- a/crates/mvm-runtime/src/workload_runner/runner/backend.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner/backend.rs
@@ -117,6 +117,14 @@ impl<D: VmmDriver + 'static, S: NetworkEndpointSpawner + 'static, B: BrokerRegis
             std::path::Path::new(&config.rootfs_path),
             config.runtime_source_policy,
         )?;
+        #[cfg(target_os = "linux")]
+        {
+            if let Err(e) = mvm_build::builderd::repair_ext4_filesystem(std::path::Path::new(
+                &config.rootfs_path,
+            )) {
+                tracing::warn!(error = %e, rootfs = %config.rootfs_path, "failed to repair workload rootfs; continuing, but the read-only guest mount may fail if the journal is dirty");
+            }
+        }
         crate::base::runtime_meta::record_from_start_config(
             &config.name,
             StartMode::Detached,

--- a/crates/mvm-runtime/src/workload_runner/runner/backend.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner/backend.rs
@@ -128,12 +128,12 @@ impl<D: VmmDriver + 'static, S: NetworkEndpointSpawner + 'static, B: BrokerRegis
             config.runtime_source_policy,
         )?;
         #[cfg(target_os = "linux")]
-        if should_repair_rootfs_before_start(config) {
-            if let Err(e) = mvm_build::builderd::repair_ext4_filesystem(std::path::Path::new(
+        if should_repair_rootfs_before_start(config)
+            && let Err(e) = mvm_build::builderd::repair_ext4_filesystem(std::path::Path::new(
                 &config.rootfs_path,
-            )) {
-                tracing::warn!(error = %e, rootfs = %config.rootfs_path, "failed to repair workload rootfs; continuing, but the read-only guest mount may fail if the journal is dirty");
-            }
+            ))
+        {
+            tracing::warn!(error = %e, rootfs = %config.rootfs_path, "failed to repair workload rootfs; continuing, but the read-only guest mount may fail if the journal is dirty");
         }
         crate::base::runtime_meta::record_from_start_config(
             &config.name,

--- a/crates/mvm-runtime/src/workload_runner/runner/backend.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner/backend.rs
@@ -3,6 +3,16 @@
 use super::*;
 use std::time::Instant;
 
+/// Whether the host may repair the rootfs immediately before launch.
+///
+/// A dm-verity sidecar authenticates the rootfs bytes as they existed when the
+/// sidecar was generated. Running e2fsck after that point changes authenticated
+/// filesystem metadata and makes every subsequent verity read fail closed.
+#[cfg(any(target_os = "linux", test))]
+fn should_repair_rootfs_before_start(config: &VmStartConfig) -> bool {
+    config.verity_path.is_none()
+}
+
 impl<D: VmmDriver + 'static, S: NetworkEndpointSpawner + 'static, B: BrokerRegistrar + 'static>
     WorkloadRunner<D, S, B>
 {
@@ -118,7 +128,7 @@ impl<D: VmmDriver + 'static, S: NetworkEndpointSpawner + 'static, B: BrokerRegis
             config.runtime_source_policy,
         )?;
         #[cfg(target_os = "linux")]
-        {
+        if should_repair_rootfs_before_start(config) {
             if let Err(e) = mvm_build::builderd::repair_ext4_filesystem(std::path::Path::new(
                 &config.rootfs_path,
             )) {
@@ -258,5 +268,33 @@ impl<D: VmmDriver + 'static, S: NetworkEndpointSpawner + 'static, B: BrokerRegis
 {
     fn egress_substitution_transport(&self) -> EgressSubstitutionTransport {
         EgressSubstitutionTransport::VsockUdsChannel
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_repair_rootfs_before_start;
+    use mvm_core::vm_backend::VmStartConfig;
+
+    #[test]
+    fn unsealed_rootfs_is_repaired_before_start() {
+        let config = VmStartConfig {
+            rootfs_path: "/images/rootfs.ext4".into(),
+            ..Default::default()
+        };
+
+        assert!(should_repair_rootfs_before_start(&config));
+    }
+
+    #[test]
+    fn verity_sealed_rootfs_remains_byte_for_byte_immutable() {
+        let config = VmStartConfig {
+            rootfs_path: "/images/rootfs.ext4".into(),
+            verity_path: Some("/images/rootfs.verity".into()),
+            roothash: Some("a".repeat(64)),
+            ..Default::default()
+        };
+
+        assert!(!should_repair_rootfs_before_start(&config));
     }
 }

--- a/crates/mvm-vmm/src/host/spec_map.rs
+++ b/crates/mvm-vmm/src/host/spec_map.rs
@@ -55,7 +55,7 @@ pub fn workload_blocks(config: &VmStartConfig) -> Vec<BlockDev> {
     let mut blocks = vec![ro(&config.rootfs_path, 0)];
 
     if let Some(verity) = &config.verity_path {
-        blocks.push(ro(verity, 1));
+        blocks.push(ro(verity, blocks.len() as u8));
     }
 
     if let (Some(overlay), Some(overlay_verity), Some(_roothash)) = (
@@ -63,8 +63,8 @@ pub fn workload_blocks(config: &VmStartConfig) -> Vec<BlockDev> {
         &config.runtime_overlay_verity_path,
         &config.runtime_overlay_roothash,
     ) {
-        blocks.push(ro(overlay, 2));
-        blocks.push(ro(overlay_verity, 3));
+        blocks.push(ro(overlay, blocks.len() as u8));
+        blocks.push(ro(overlay_verity, blocks.len() as u8));
     }
 
     for volume in config

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -334,16 +334,33 @@ let
   # The full /etc/mvm/entrypoint body. For shell + command forms,
   # setpriv-wrap as appropriate. For services (still stubbed),
   # bail out with a clear note + recovery shell.
+  #
+  # The entrypoint is invoked both by PID 1 (as root) and by the guest
+  # agent (as the agent uid). When already non-root, skip the setpriv
+  # drop: the agent has already applied the desired isolation and no
+  # longer holds CAP_SETGID, so a second setpriv would fail on
+  # setgroups(clear). PID 1 still uses the explicit drop to enforce the
+  # entrypoint uid.
   entrypointCmd =
     if entrypointKind == "services" then
       ''
         echo "mkGuest: entrypoint.services is not yet wired in this iteration"
         echo "  (W5.2 ports the multi-service supervisor binary)"
         echo "  Falling through to a recovery shell for triage."
-        ${setprivWrap entrypointUid "/bin/sh -i"}
+        if [ "$(/bin/busybox id -u)" -eq 0 ]; then
+          ${setprivWrap entrypointUid "/bin/sh -i"}
+        else
+          /bin/sh -i
+        fi
       ''
     else
-      "${setprivWrap entrypointUid rawEntrypointCmd}";
+      ''
+        if [ "$(/bin/busybox id -u)" -eq 0 ]; then
+          ${setprivWrap entrypointUid rawEntrypointCmd}
+        else
+          ${rawEntrypointCmd}
+        fi
+      '';
 
   # /init — our PID 1. Pure POSIX shell; busybox provides every
   # utility used here. Boot-time-critical path so kept terse and

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,13 +17,6 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
-- [x] **AArch64 sealed-workload witness and QEMU teardown.** The Raspberry Pi
-      QEMU path now reaches the workload entrypoint with the correct console,
-      uid transition, compressed module handling, and builder/runtime-overlay
-      artifacts. Session teardown selects the backend recorded in machine
-      state and reaps both QEMU and its vsock bridge. See
-      `specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md`.
-
 - [x] **Retained-state log diagnostics.** When a machine state directory
       survives but every output capture is absent, `machine logs` now names
       the retained state, each missing source, and the likely interrupted-boot
@@ -175,6 +168,13 @@ for detailed scope and acceptance criteria.
       live lifecycle suite covers Alpine `/tmp` writes and retains the
       absolute `/bin/ping` mediated-tool proof. Together with PRs #2690,
       #2709, and #2720, this closes the NIC-less and read-only boot-noise issue.
+
+- [x] **AArch64 sealed-workload witness and QEMU teardown.** The Raspberry Pi
+      QEMU path now reaches the workload entrypoint with the correct console,
+      uid transition, compressed module handling, and builder/runtime-overlay
+      artifacts. Session teardown selects the backend recorded in machine
+      state and reaps both QEMU and its vsock bridge. See
+      `specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md`.
 
 - [x] **Issue #2684 — a sealed boot is reachable and proven before release.**
       The CLI release train publishes both universal-initramfs archives under

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,6 +17,13 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
+- [x] **AArch64 sealed-workload witness and QEMU teardown.** The Raspberry Pi
+      QEMU path now reaches the workload entrypoint with the correct console,
+      uid transition, compressed module handling, and builder/runtime-overlay
+      artifacts. Session teardown selects the backend recorded in machine
+      state and reaps both QEMU and its vsock bridge. See
+      `specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md`.
+
 - [x] **Retained-state log diagnostics.** When a machine state directory
       survives but every output capture is absent, `machine logs` now names
       the retained state, each missing source, and the likely interrupted-boot

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -102,7 +102,10 @@ for detailed scope and acceptance criteria.
       again after the final publication copy and before its durability sync;
       the persistent-builder path preserves the hook command's real exit
       status. A mounted or damaged image fails before publication, preserving
-      the workload's hypervisor-enforced read-only rootfs contract.
+      the workload's hypervisor-enforced read-only rootfs contract. The same
+      fail-closed check is emitted into one-shot and persistent job scripts so
+      source-checkout behavior stays correct when release bootstrap deliberately
+      boots a published builder image whose hook runner predates the repair.
       The tagged release workflow separately verifies the signed
       future-format overlay through the production downloader before publish.
       The standalone hostd fuzz lock is refreshed for the current dependency

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2763,7 +2763,13 @@ now runs offline `e2fsck` after all writable mounts are dropped, accepting only
 the clean and repaired exit codes; a still-mounted or damaged image fails the
 build instead of being published. Every export route also flushes the copied
 artifact before reporting completion, and the builder toolchain GC roots now
-retain `e2fsck` alongside `mkfs.ext4`.
+retain `e2fsck` alongside `mkfs.ext4`. Manual workflow run 32763211862 then
+proved the release-bootstrap compatibility gap: it intentionally uses the last
+published builder binary, so binary-only sealing did not execute and the same
+read-only journal failure recurred. The source-rendered one-shot and persistent
+job scripts now perform the same fail-closed offline check after the hook and
+before export, so checkout behavior no longer depends on the builder image
+already containing the new hook-runner implementation.
 
 A follow-up merge-group witness proved that sealing only the writable temporary
 image was insufficient: the final copied artifact could still reach the

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2911,15 +2911,6 @@ to the configured ceiling and the first terse response immediately after it.
 - [x] Cover the retained-state path with a focused CLI regression test and record
       the delivery in `specs/sprint/delivery/2825-retained-state-logs-error.md`.
 
-## 2026-08-24 AArch64 sealed-workload witness closeout
-
-- [x] Complete the sealed-workload QEMU path on Raspberry Pi, including the
-      AArch64 console, guest uid, compressed-module, and builder-overlay fixes.
-- [x] Resolve teardown through the backend recorded in machine state so QEMU
-      and its vsock bridge are reaped reliably.
-- [x] Preserve focused regressions and the hardware witness in
-      `specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md`.
-
 ## 2026-08-23 FlowMux forward-proxy identity repair
 
 - [x] Move the secret-substitution forward proxy out of the workload-uid guest
@@ -2946,3 +2937,12 @@ to the configured ceiling and the first terse response immediately after it.
 - [x] Preserve networkless guest boot by making an absent identity optional
       only when vsock egress is not requested; unreadable and required
       identities remain fail-closed.
+
+## 2026-08-24 AArch64 sealed-workload witness closeout
+
+- [x] Complete the sealed-workload QEMU path on Raspberry Pi, including the
+      AArch64 console, guest uid, compressed-module, and builder-overlay fixes.
+- [x] Resolve teardown through the backend recorded in machine state so QEMU
+      and its vsock bridge are reaped reliably.
+- [x] Preserve focused regressions and the hardware witness in
+      `specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2911,6 +2911,15 @@ to the configured ceiling and the first terse response immediately after it.
 - [x] Cover the retained-state path with a focused CLI regression test and record
       the delivery in `specs/sprint/delivery/2825-retained-state-logs-error.md`.
 
+## 2026-08-24 AArch64 sealed-workload witness closeout
+
+- [x] Complete the sealed-workload QEMU path on Raspberry Pi, including the
+      AArch64 console, guest uid, compressed-module, and builder-overlay fixes.
+- [x] Resolve teardown through the backend recorded in machine state so QEMU
+      and its vsock bridge are reaped reliably.
+- [x] Preserve focused regressions and the hardware witness in
+      `specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md`.
+
 ## 2026-08-23 FlowMux forward-proxy identity repair
 
 - [x] Move the secret-substitution forward proxy out of the workload-uid guest

--- a/specs/plans/2026-08-22-qemu-builder-hook-artifacts.md
+++ b/specs/plans/2026-08-22-qemu-builder-hook-artifacts.md
@@ -35,6 +35,14 @@ workload rootfs is intentionally attached read-only, so the guest could not
 replay the journal and correctly refused to mount it. The writable builder
 mount must therefore be torn down and the journal sealed before publication.
 
+Manual workflow run 32763211862 proved that sealing only inside the builder
+image's hook-runner binary is insufficient for the release-bootstrap witness:
+that lane deliberately boots the last published builder VM while exercising
+job scripts rendered by the source checkout. The old hook runner returned
+success without replaying the journal, and the exact read-only mount failure
+recurred. The source-rendered one-shot and persistent job scripts must
+therefore run the same fail-closed offline check before copying the artifact.
+
 Two independent defects turned that mount failure into a merged regression:
 
 - the generated job shell used `if ! command; then hook_rc=$?`, so `hook_rc`
@@ -66,6 +74,10 @@ Two independent defects turned that mount failure into a merged regression:
 - [x] Run an offline ext4 journal repair/check after every writable hook mount,
       fail closed on mounted or damaged images, retain `e2fsck` across builder
       GC, and flush every exported rootfs before reporting completion.
+- [x] Seal the writable temp image again in the source-rendered one-shot and
+      persistent job scripts so a source checkout remains correct when the
+      release-bootstrap path intentionally uses an older published builder
+      binary; accept only `e2fsck` exit 0/1 before copying the artifact.
 - [ ] Pass focused tests, formatting, workspace check/test, all-target Clippy,
       Linux-gated checks, and the live merge-group witness.
 - [ ] Record delivery and refactor status, then merge the repair.

--- a/specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md
+++ b/specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md
@@ -14,12 +14,15 @@ privilege transition, stages available compressed modules, and receives the
 required builder/runtime-overlay artifacts. Session teardown reads the recorded
 backend marker and reaps QEMU together with its vsock bridge. An opt-in
 diagnostic setting can retain transient state without changing the secure
-default cleanup behavior.
+default cleanup behavior. Pre-launch ext4 repair is limited to unsealed
+rootfs images: once dm-verity sidecars exist, the authenticated rootfs bytes
+remain immutable through launch instead of being changed by a late `e2fsck`.
 
 ## Validation
 
 - focused unit and integration tests cover entrypoint, mount, activation,
-  backend mapping, builder, and teardown behavior;
+  backend mapping, builder, teardown behavior, and the sealed/unsealed repair
+  boundary;
 - the Raspberry Pi QEMU witness ran the sealed exit-code workload and returned
   its expected status without leaving QEMU or vsock-bridge processes;
 - workspace CI remains the merge gate for formatting, Clippy, and full tests.

--- a/specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md
+++ b/specs/sprint/delivery/2836-aarch64-sealed-workload-witness.md
@@ -1,0 +1,25 @@
+# AArch64 sealed workloads run end to end and tear down cleanly
+
+## Problem
+
+The Raspberry Pi QEMU witness exposed several architecture and lifecycle gaps:
+the wrong serial console, a repeated uid drop, compressed kernel modules,
+incomplete source-checkout overlay plumbing, and teardown through an
+auto-selected backend instead of the backend that owned the session.
+
+## Delivered behavior
+
+The AArch64 guest reaches its workload entrypoint with the correct console and
+privilege transition, stages available compressed modules, and receives the
+required builder/runtime-overlay artifacts. Session teardown reads the recorded
+backend marker and reaps QEMU together with its vsock bridge. An opt-in
+diagnostic setting can retain transient state without changing the secure
+default cleanup behavior.
+
+## Validation
+
+- focused unit and integration tests cover entrypoint, mount, activation,
+  backend mapping, builder, and teardown behavior;
+- the Raspberry Pi QEMU witness ran the sealed exit-code workload and returned
+  its expected status without leaving QEMU or vsock-bridge processes;
+- workspace CI remains the merge gate for formatting, Clippy, and full tests.


### PR DESCRIPTION
Completes the first end-to-end sealed-workload run on a Raspberry Pi (aarch64 / Debian 13 / KVM) and hardens the teardown path so transient QEMU sessions do not leak the VMM or the vsock bridge.

## What changed

Guest / init:
- Fix /dev/console permissions after devtmpfs mount so non-root workloads can write prompts and errors.
- Skip the mvm-setpriv UID drop when the caller is already non-root, fixing the agent-dispatched RunEntrypoint path.
- Tolerate .xz-compressed kernel modules and missing optional modules when staging the builder-VM vsock module.

QEMU / backend:
- Use ttyAMA0 for the QEMU virt console command line on aarch64.
- Resolve the owning backend from the VM state-dir marker file in tear_down_session_vm, so QEMU and its mvmctl __qemu-vsock-bridge child are reaped instead of being dispatched to the auto-selected backend.
- Make boot_session_vm honor an explicit backend_name (e.g. --hypervisor qemu).
- Preserve transient state dirs when MVM_PRESERVE_TRANSIENT_STATE is set.

Builder / overlay:
- Builder-VM and runtime-overlay plumbing for the Pi source-checkout path.
- Update builderd and dev-build pipeline to support the aarch64 witness flow.

## Verification

Ran 

```bash
mvmctl machine run --flake examples/exit_code --hypervisor qemu --entrypoint
```

on rpi1.local. It exits with status 7 (EXIT=7) and leaves no leftover qemu-system-aarch64 or mvmctl __qemu-vsock-bridge processes.