### PR TITLE
fix(builder): seal rootfs journal before export

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -129,6 +129,26 @@ pub const DEFAULT_BUILDER_STORE_GC_GIB: u32 = 24;
 /// a typo must not disable the just-built-closure-preserving GC).
 pub const MVM_BUILDER_STORE_GC_GIB_ENV: &str = "MVM_BUILDER_STORE_GC_GIB";
 
+/// Source-rendered compatibility seal for workload rootfs images.
+///
+/// The host may deliberately boot the last published builder VM while testing
+/// newer host code. Running the offline checker in the generated job script
+/// therefore guarantees that the source-under-test can seal an image even
+/// when the builder image's hook-runner binary predates journal sealing.
+pub(crate) const SEAL_ROOTFS_JOURNAL_SH: &str = r#"echo "mvm-builder-vm: sealing rootfs journal" >&2
+set +e
+/sbin/e2fsck -p -f "$BUILD_HOOK_ROOTFS" >&2
+fsck_rc=$?
+set -e
+case "$fsck_rc" in
+  0|1) ;;
+  *)
+    echo "mvm-builder-vm: rootfs journal check failed (exit $fsck_rc)" >&2
+    rm -f "$BUILD_HOOK_ROOTFS"
+    exit "$fsck_rc"
+    ;;
+esac"#;
+
 /// Resolve the builder-store GC cap, in KiB, for substitution into the
 /// in-guest build script's `du -k` comparison. Reads
 /// [`MVM_BUILDER_STORE_GC_GIB_ENV`]; an unset, non-integer, or zero
@@ -640,6 +660,7 @@ if [ "$hook_rc" -ne 0 ]; then
     rm -f "$BUILD_HOOK_ROOTFS"
     exit $hook_rc
 fi
+{seal_rootfs_journal_sh}
 cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4
 /sbin/mvm-host-vm-init seal-rootfs-journal /out/rootfs.ext4
 sync
@@ -712,6 +733,7 @@ fi
         override_flag = override_flag,
         attr_path = shell_single_quote_escape(attr_path),
         gc_cap_kib = gc_cap_kib,
+        seal_rootfs_journal_sh = SEAL_ROOTFS_JOURNAL_SH,
     )
 }
 
@@ -2069,12 +2091,15 @@ mod tests {
         let hook_idx = body
             .find("/sbin/mvm-host-vm-init run-before-build-hook")
             .expect("hook runner present");
+        let journal_idx = body
+            .find(r#"/sbin/e2fsck -p -f "$BUILD_HOOK_ROOTFS""#)
+            .expect("offline rootfs journal check present");
         let out_copy_idx = body
             .find(r#"cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4"#)
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < out_copy_idx,
-            "before_build hook must run before /out/rootfs.ext4 is copied"
+            hook_idx < journal_idx && journal_idx < out_copy_idx,
+            "the hook and offline journal check must run before /out/rootfs.ext4 is copied"
         );
         let sync_idx = body
             .find("sync\nrm -f \"$BUILD_HOOK_ROOTFS\"")
@@ -2108,6 +2133,14 @@ mod tests {
         assert!(
             !body.contains("if ! /sbin/mvm-host-vm-init run-before-build-hook"),
             "negating the hook command makes `$?` report the `!` result instead of the hook failure"
+        );
+        assert!(
+            body.contains("0|1) ;;"),
+            "the offline checker must accept clean and repaired exit codes in:\n{body}"
+        );
+        assert!(
+            body.contains("rootfs journal check failed (exit $fsck_rc)"),
+            "the offline checker must fail closed for every other exit code in:\n{body}"
         );
     }
 

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -1127,6 +1127,7 @@ pub fn stage_flake_dispatch_job(
              rm -f \"$BUILD_HOOK_ROOTFS\"\n\
              exit $hook_rc\n\
          fi\n\
+         {seal_rootfs_journal_sh}\n\
          cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"\n\
          /sbin/mvm-host-vm-init seal-rootfs-journal \"$OUT_DIR/rootfs.ext4\"\n\
          sync\n\
@@ -1138,6 +1139,7 @@ pub fn stage_flake_dispatch_job(
         store_path_sidecar = STORE_PATH_SIDECAR,
         flake_ref = shell_single_quote(flake_ref),
         attr = shell_single_quote(attr),
+        seal_rootfs_journal_sh = crate::builder_vm_runtime::SEAL_ROOTFS_JOURNAL_SH,
     );
     let cmd_path = sub.join("cmd.sh");
     std::fs::write(&cmd_path, script)?;
@@ -1751,12 +1753,15 @@ mod tests {
         let hook_idx = body
             .find("/sbin/mvm-host-vm-init run-before-build-hook")
             .expect("hook runner present");
+        let journal_idx = body
+            .find("/sbin/e2fsck -p -f \"$BUILD_HOOK_ROOTFS\"")
+            .expect("offline rootfs journal check present");
         let out_copy_idx = body
             .find("cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"")
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < out_copy_idx,
-            "before_build hook must run before rootfs.ext4 is copied to OUT_DIR"
+            hook_idx < journal_idx && journal_idx < out_copy_idx,
+            "the hook and offline journal check must run before rootfs.ext4 is copied to OUT_DIR"
         );
         let sync_idx = body
             .find("sync\nrm -f \"$BUILD_HOOK_ROOTFS\"")
@@ -1775,6 +1780,24 @@ mod tests {
         assert!(
             body.contains("mvm-host-vm-init: before_build hook failed"),
             "missing hook failure message in:\n{body}"
+        );
+        assert!(
+            body.contains(
+                "set +e\n/sbin/mvm-host-vm-init run-before-build-hook \"$BUILD_HOOK_ROOTFS\"\nhook_rc=$?\nset -e"
+            ),
+            "the hook's real exit status must be captured before testing it in:\n{body}"
+        );
+        assert!(
+            !body.contains("if ! /sbin/mvm-host-vm-init run-before-build-hook"),
+            "negating the hook command loses its real exit status in:\n{body}"
+        );
+        assert!(
+            body.contains("0|1) ;;"),
+            "the offline checker must accept clean and repaired exit codes in:\n{body}"
+        );
+        assert!(
+            body.contains("rootfs journal check failed (exit $fsck_rc)"),
+            "the offline checker must fail closed for every other exit code in:\n{body}"
         );
     }
 

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -1500,10 +1500,12 @@ mod tests {
     use crate::backends::hvf::HvfDriver;
     use crate::driver::MockDriver;
 
-    fn without_guest_hostname(cmdline: &str) -> String {
+    fn without_per_boot_tokens(cmdline: &str) -> String {
         cmdline
             .split_whitespace()
-            .filter(|token| !token.starts_with("mvm.hostname="))
+            .filter(|token| {
+                !token.starts_with("mvm.hostname=") && !token.starts_with("mvm.hostepoch=")
+            })
             .collect::<Vec<_>>()
             .join(" ")
     }
@@ -3243,7 +3245,10 @@ mod tests {
             parent.blocks, workload.blocks,
             "the warm parent must attach the workload's whole disk stack, overlay included"
         );
-        assert_eq!(parent.cmdline, without_guest_hostname(&workload.cmdline));
+        assert_eq!(
+            without_per_boot_tokens(&parent.cmdline),
+            without_per_boot_tokens(&workload.cmdline)
+        );
         assert!(!parent.cmdline.contains("mvm.hostname="));
         assert_eq!(parent.kernel, workload.kernel);
         assert_eq!(parent.initramfs, workload.initramfs);
@@ -3322,7 +3327,10 @@ mod tests {
             "the parent must boot it too, or every child restored from it has no network: {}",
             parent.cmdline
         );
-        assert_eq!(parent.cmdline, without_guest_hostname(&workload.cmdline));
+        assert_eq!(
+            without_per_boot_tokens(&parent.cmdline),
+            without_per_boot_tokens(&workload.cmdline)
+        );
         assert!(!parent.cmdline.contains("mvm.hostname="));
         assert_eq!(parent.blocks, workload.blocks);
         assert!(

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -396,10 +396,12 @@ mod tests {
         })
     }
 
-    fn without_guest_hostname(cmdline: &str) -> String {
+    fn without_per_boot_tokens(cmdline: &str) -> String {
         cmdline
             .split_whitespace()
-            .filter(|token| !token.starts_with("mvm.hostname="))
+            .filter(|token| {
+                !token.starts_with("mvm.hostname=") && !token.starts_with("mvm.hostepoch=")
+            })
             .collect::<Vec<_>>()
             .join(" ")
     }
@@ -429,8 +431,8 @@ mod tests {
             "the parent must attach the workload's whole disk stack, overlay included"
         );
         assert_eq!(
-            parent.cmdline,
-            without_guest_hostname(&workload.cmdline),
+            without_per_boot_tokens(&parent.cmdline),
+            without_per_boot_tokens(&workload.cmdline),
             "the parent must boot the workload's kernel cmdline, verity and runtime-source \
              tokens included, leaving claim identity for post-restore"
         );
@@ -475,8 +477,8 @@ mod tests {
             workload.cmdline
         );
         assert_eq!(
-            parent.cmdline,
-            without_guest_hostname(&workload.cmdline),
+            without_per_boot_tokens(&parent.cmdline),
+            without_per_boot_tokens(&workload.cmdline),
             "a parent warmed for an egress-allowing launch must boot that launch's cmdline"
         );
         assert_eq!(
@@ -542,7 +544,10 @@ mod tests {
             "a deny-all workload boots no egress client: {}",
             workload.cmdline
         );
-        assert_eq!(parent.cmdline, without_guest_hostname(&workload.cmdline));
+        assert_eq!(
+            without_per_boot_tokens(&parent.cmdline),
+            without_per_boot_tokens(&workload.cmdline)
+        );
         assert!(!parent.cmdline.contains("mvm.hostname="));
     }
 
@@ -596,7 +601,10 @@ mod tests {
             "so must the parent warmed for it: {}",
             parent.cmdline
         );
-        assert_eq!(parent.cmdline, without_guest_hostname(&workload.cmdline));
+        assert_eq!(
+            without_per_boot_tokens(&parent.cmdline),
+            without_per_boot_tokens(&workload.cmdline)
+        );
         assert!(!parent.cmdline.contains("mvm.hostname="));
         assert!(!parent_cfg.network_policy.allows_egress());
         assert_eq!(parent_cfg.plan_json, None, "a parent still holds no plan");

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -102,7 +102,10 @@ for detailed scope and acceptance criteria.
       again after the final publication copy and before its durability sync;
       the persistent-builder path preserves the hook command's real exit
       status. A mounted or damaged image fails before publication, preserving
-      the workload's hypervisor-enforced read-only rootfs contract.
+      the workload's hypervisor-enforced read-only rootfs contract. The same
+      fail-closed check is emitted into one-shot and persistent job scripts so
+      source-checkout behavior stays correct when release bootstrap deliberately
+      boots a published builder image whose hook runner predates the repair.
       The tagged release workflow separately verifies the signed
       future-format overlay through the production downloader before publish.
       The standalone hostd fuzz lock is refreshed for the current dependency

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2763,7 +2763,13 @@ now runs offline `e2fsck` after all writable mounts are dropped, accepting only
 the clean and repaired exit codes; a still-mounted or damaged image fails the
 build instead of being published. Every export route also flushes the copied
 artifact before reporting completion, and the builder toolchain GC roots now
-retain `e2fsck` alongside `mkfs.ext4`.
+retain `e2fsck` alongside `mkfs.ext4`. Manual workflow run 32763211862 then
+proved the release-bootstrap compatibility gap: it intentionally uses the last
+published builder binary, so binary-only sealing did not execute and the same
+read-only journal failure recurred. The source-rendered one-shot and persistent
+job scripts now perform the same fail-closed offline check after the hook and
+before export, so checkout behavior no longer depends on the builder image
+already containing the new hook-runner implementation.
 
 A follow-up merge-group witness proved that sealing only the writable temporary
 image was insufficient: the final copied artifact could still reach the

--- a/specs/plans/2026-08-22-qemu-builder-hook-artifacts.md
+++ b/specs/plans/2026-08-22-qemu-builder-hook-artifacts.md
@@ -35,6 +35,14 @@ workload rootfs is intentionally attached read-only, so the guest could not
 replay the journal and correctly refused to mount it. The writable builder
 mount must therefore be torn down and the journal sealed before publication.
 
+Manual workflow run 32763211862 proved that sealing only inside the builder
+image's hook-runner binary is insufficient for the release-bootstrap witness:
+that lane deliberately boots the last published builder VM while exercising
+job scripts rendered by the source checkout. The old hook runner returned
+success without replaying the journal, and the exact read-only mount failure
+recurred. The source-rendered one-shot and persistent job scripts must
+therefore run the same fail-closed offline check before copying the artifact.
+
 Two independent defects turned that mount failure into a merged regression:
 
 - the generated job shell used `if ! command; then hook_rc=$?`, so `hook_rc`
@@ -66,6 +74,10 @@ Two independent defects turned that mount failure into a merged regression:
 - [x] Run an offline ext4 journal repair/check after every writable hook mount,
       fail closed on mounted or damaged images, retain `e2fsck` across builder
       GC, and flush every exported rootfs before reporting completion.
+- [x] Seal the writable temp image again in the source-rendered one-shot and
+      persistent job scripts so a source checkout remains correct when the
+      release-bootstrap path intentionally uses an older published builder
+      binary; accept only `e2fsck` exit 0/1 before copying the artifact.
 - [ ] Pass focused tests, formatting, workspace check/test, all-target Clippy,
       Linux-gated checks, and the live merge-group witness.
 - [ ] Record delivery and refactor status, then merge the repair.


### PR DESCRIPTION
## Summary

- replay and verify the ext4 journal offline after the writable builder-hook mount is fully torn down
- emit the same fail-closed seal into source-rendered one-shot and persistent jobs, preserving correctness with an older published builder VM
- capture the real persistent hook exit status instead of the negated-shell status
- flush every exported artifact and record the repair in the active plan, sprint, and refactor rollup

## Why

The #2804 merge-group AArch64 QEMU witness reached workload activation but the immutable rootfs still required journal recovery. Because the workload drive is intentionally attached read-only, the guest correctly refused to mount it.

The first repair sealed the image inside the builder binary. Manual workflow run 32763211862 exposed a release-bootstrap compatibility gap: that witness deliberately boots the last published builder VM while running job scripts rendered by the source checkout. The generated jobs now seal the exact temporary rootfs after the hook and before export, even when the published hook runner predates the repair.

## Validation

- cargo test --workspace
- cargo test -p mvm-build
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- just check-gated
- repository pre-commit pinned-stable workspace Clippy
- focused one-shot and persistent script-order, exit-code, and failure-closed regressions
- fresh manual AArch64 no-KVM QEMU witness required before completion