### PR TITLE
ci: move aarch64-no-kvm-smoke out of merge queue

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -447,3 +447,156 @@ jobs:
           MVM_FC_SMOKE_KERNEL: ${{ github.workspace }}/ci-artifacts/vmlinux
           MVM_FC_SMOKE_ROOTFS: ${{ github.workspace }}/ci-artifacts/rootfs.ext4
         run: cargo test -p mvm-build --bin mvm-host-vm-init live_firecracker_boot_smoke -- --nocapture
+
+  # aarch64 no-KVM smoke test. GitHub's ubuntu-24.04-arm runners expose no
+  # nested KVM, so this exercises the same QEMU TCG fallback path a Raspberry
+  # Pi without /dev/kvm would take: build the workload flake through the Linux
+  # Stage 0 QEMU builder, seal it as a signed .mvmpkg, install it, and boot the
+  # installed bundle with the QEMU backend.
+  #
+  # This lane is intentionally outside the merge queue: a cold TCG build can
+  # take hours, and blocking every merge behind it collapses queue throughput.
+  # It runs nightly and on manual dispatch so the path stays exercised without
+  # serializing PR merges.
+  aarch64-no-kvm-smoke:
+    name: Aarch64 no-KVM bundle smoke (QEMU TCG)
+    runs-on: ubuntu-24.04-arm
+    # Cold paths may compile the workload kernel inside Stage 0 under TCG.
+    timeout-minutes: 300
+    env:
+      CARGO_TERM_COLOR: always
+      MVM_HOME: ${{ github.workspace }}/.mvm-ci
+      # A cold no-KVM build compiles the workload under TCG and can exceed
+      # the normal 30-minute builder deadline while still making progress.
+      MVM_BUILDER_VM_TIMEOUT_SECS: 7200
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/free-disk
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - uses: ./.github/actions/install-zigbuild
+
+      - uses: ./.github/actions/apt-deps
+        with:
+          # qemu-system-arm provides qemu-system-aarch64; ipxe-qemu provides
+          # efi-virtio.rom; virtiofsd shares the checkout with the builder VM;
+          # e2fsprogs provides the mkfs.ext4 and debugfs image-packing tools.
+          packages: qemu-system-arm ipxe-qemu virtiofsd e2fsprogs attr jq
+
+      - name: Allow unprivileged QEMU to use host vsock
+        run: |
+          test -c /dev/vhost-vsock
+          sudo chown "$(id -u):$(id -g)" /dev/vhost-vsock
+          test -r /dev/vhost-vsock && test -w /dev/vhost-vsock
+
+      - uses: ./.github/actions/rust-cache
+        with:
+          key: aarch64-no-kvm-smoke
+
+      - name: Grant QEMU access to vhost-vsock
+        run: |
+          test -c /dev/vhost-vsock
+          sudo chown "$USER" /dev/vhost-vsock
+          sudo chmod 0600 /dev/vhost-vsock
+
+      # The source binary is the end-to-end subject. Keep a copy before building
+      # the release-channel helper, whose only job is to download the already-
+      # published builder VM. Building that VM from scratch under TCG is far
+      # too slow for a CI gate.
+      - name: Build source mvmctl and published-builder bootstrap helper
+        env:
+          # This witness boots embedded builder-guest code. A restored Cargo
+          # cache may contain binaries built from an older source tree, which
+          # would make the live gate validate stale mvm-host-vm-init behavior.
+          MVM_EMBED_NO_CACHE: 1
+        run: |
+          cargo build --release -p mvmctl --features user
+          cp target/release/mvmctl /tmp/mvmctl-source-under-test
+          cargo build --release -p mvmctl --features user,release-artifact-bootstrap,release-channel
+
+      - name: Use published builder VM bootstrap path
+        run: mv nix/images/builder-vm nix/images/builder-vm.hidden
+
+      - name: Download published builder VM
+        run: ./target/release/mvmctl --builder qemu __builder-vm-bootstrap -v
+
+      - name: Bootstrap source-matched launch artifacts
+        env:
+          MVM_KERNEL_SOURCE: auto
+        run: /tmp/mvmctl-source-under-test --builder qemu bootstrap --production -v
+
+      - name: Build and boot the sealed exit_code workload under QEMU TCG
+        id: first-boot
+        env:
+          MVM_KERNEL_SOURCE: auto
+        run: |
+          set -euo pipefail
+          mkdir -p "$MVM_HOME"
+          set +e
+          /tmp/mvmctl-source-under-test machine run \
+            --flake examples/exit_code \
+            --builder qemu \
+            --hypervisor qemu \
+            -v \
+            -- /bin/true \
+            > /tmp/mvmctl-first-boot.log 2>&1
+          actual=$?
+          set -e
+          if [ "$actual" -ne 7 ]; then
+            echo "::error::expected guest exit code 7 from first boot, got $actual"
+            tail -250 /tmp/mvmctl-first-boot.log
+            exit 1
+          fi
+          echo "ok: sealed aarch64 workload built and exited $actual under QEMU TCG"
+
+      - name: Export, install, and re-run the bundle
+        id: bundle-roundtrip
+        run: |
+          set -euo pipefail
+          slot_hash=$(/tmp/mvmctl-source-under-test manifest ls --json 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | jq -r '.[0].slot_hash')
+          /tmp/mvmctl-source-under-test bundle export "$slot_hash" \
+            --out /tmp/exit-code-aarch64.mvmpkg \
+            > /tmp/mvmctl-export.log 2>&1
+          /tmp/mvmctl-source-under-test trust add "$MVM_HOME/keys/host-signer.pub"
+          install_output=$(/tmp/mvmctl-source-under-test bundle install /tmp/exit-code-aarch64.mvmpkg 2>&1 | tee /tmp/mvmctl-install.log)
+          installed_sha=$(printf '%s' "$install_output" | sed 's/\x1b\[[0-9;]*m//g' | awk '/Installed bundle / {print $3}')
+          echo "installed bundle content address: $installed_sha"
+          set +e
+          /tmp/mvmctl-source-under-test machine run \
+            --manifest "$installed_sha" \
+            --hypervisor qemu \
+            -v \
+            -- /bin/true \
+            > /tmp/mvmctl-bundle-run.log 2>&1
+          actual=$?
+          set -e
+          if [ "$actual" -ne 7 ]; then
+            echo "::error::expected guest exit code 7 from installed bundle, got $actual"
+            tail -250 /tmp/mvmctl-bundle-run.log
+            exit 1
+          fi
+          echo "ok: installed aarch64 bundle exited $actual under QEMU TCG"
+
+      - name: Dump diagnostics on failure
+        if: failure()
+        run: |
+          for log in /tmp/mvmctl-first-boot.log /tmp/mvmctl-export.log \
+                     /tmp/mvmctl-install.log /tmp/mvmctl-bundle-run.log; do
+            if [ -f "$log" ]; then
+              echo "===== $log ====="
+              tail -250 "$log" || true
+            fi
+          done
+          echo "===== VM state dirs ====="
+          for d in "$MVM_HOME"/vms/*/ "$MVM_HOME"/cache/builder-vm/vms/*/; do
+            echo "--- $d ---"
+            ls -la "$d" || true
+            for f in console.log firecracker.log qemu.log; do
+              if [ -s "$d$f" ]; then
+                echo "--- $f ---"; tail -100 "$d$f" || true
+              fi
+            done
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,7 +562,7 @@ jobs:
   test:
     name: Test
     if: ${{ always() }}
-    needs: [scope, test-workspace, test-workspace-aarch64, test-linux, test-release-witness, test-ebpf-telemetry, bdd-conformance, kernel, aarch64-no-kvm-smoke]
+    needs: [scope, test-workspace, test-workspace-aarch64, test-linux, test-release-witness, test-ebpf-telemetry, bdd-conformance, kernel]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -579,8 +579,6 @@ jobs:
           BDD_RESULT: ${{ needs.bdd-conformance.result }}
           KERNEL_SCOPE: ${{ needs.scope.outputs.kernel }}
           KERNEL_RESULT: ${{ needs.kernel.result }}
-          NO_KVM_REQUIRED: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
-          NO_KVM_RESULT: ${{ needs.aarch64-no-kvm-smoke.result }}
         run: |
           set -euo pipefail
           if [ "$SCOPE_RESULT" != success ]; then
@@ -621,19 +619,6 @@ jobs:
           # was removed — failed every PR that does not touch a kernel path.
           if [ "$KERNEL_RESULT" != success ]; then
             echo "Kernel validation did not succeed (scope $KERNEL_SCOPE): $KERNEL_RESULT"
-            exit 1
-          fi
-          case "$NO_KVM_REQUIRED" in
-            true|false) ;;
-            *) echo "Invalid no-KVM event requirement: $NO_KVM_REQUIRED"; exit 1 ;;
-          esac
-          if [ "$SCOPE_CODE" = true ] && [ "$NO_KVM_REQUIRED" = true ]; then
-            no_kvm_expected=success
-          else
-            no_kvm_expected=skipped
-          fi
-          if [ "$NO_KVM_RESULT" != "$no_kvm_expected" ]; then
-            echo "Aarch64 no-KVM smoke did not match code scope $SCOPE_CODE and event requirement $NO_KVM_REQUIRED: $NO_KVM_RESULT"
             exit 1
           fi
 
@@ -1473,158 +1458,3 @@ jobs:
             --sdk-sidecar "$sidecar_path/sdk.ext4" \
             --json
 
-  # aarch64 no-KVM smoke test. GitHub's ubuntu-24.04-arm runners expose no
-  # nested KVM, so this exercises the same QEMU TCG fallback path a Raspberry
-  # Pi without /dev/kvm would take: build the workload flake through the Linux
-  # Stage 0 QEMU builder, seal it as a signed .mvmpkg, install it, and boot the
-  # installed bundle with the QEMU backend.
-  aarch64-no-kvm-smoke:
-    name: Aarch64 no-KVM bundle smoke (QEMU TCG)
-    needs: [scope]
-    if: >-
-      needs.scope.outputs.code == 'true'
-      && (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-    runs-on: ubuntu-24.04-arm
-    # Cold paths may compile the workload kernel inside Stage 0 under TCG.
-    timeout-minutes: 300
-    env:
-      CARGO_TERM_COLOR: always
-      MVM_HOME: ${{ github.workspace }}/.mvm-ci
-      # A cold no-KVM build compiles the workload under TCG and can exceed
-      # the normal 30-minute builder deadline while still making progress.
-      MVM_BUILDER_VM_TIMEOUT_SECS: 7200
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: ./.github/actions/free-disk
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - uses: ./.github/actions/install-zigbuild
-
-      - uses: ./.github/actions/apt-deps
-        with:
-          # qemu-system-arm provides qemu-system-aarch64; ipxe-qemu provides
-          # efi-virtio.rom; virtiofsd shares the checkout with the builder VM;
-          # e2fsprogs provides the mkfs.ext4 and debugfs image-packing tools.
-          packages: qemu-system-arm ipxe-qemu virtiofsd e2fsprogs attr jq
-
-      - name: Allow unprivileged QEMU to use host vsock
-        run: |
-          test -c /dev/vhost-vsock
-          sudo chown "$(id -u):$(id -g)" /dev/vhost-vsock
-          test -r /dev/vhost-vsock && test -w /dev/vhost-vsock
-
-      - uses: ./.github/actions/rust-cache
-        with:
-          key: aarch64-no-kvm-smoke
-
-      - name: Grant QEMU access to vhost-vsock
-        run: |
-          test -c /dev/vhost-vsock
-          sudo chown "$USER" /dev/vhost-vsock
-          sudo chmod 0600 /dev/vhost-vsock
-
-      # The source binary is the end-to-end subject: merge-group code cannot
-      # download its new release-format runtime overlay until that code has
-      # merged and a release has published it. Keep a copy before building the
-      # release-channel helper, whose only job is to download the already-
-      # published builder VM. Building that VM from scratch under TCG is far
-      # too slow for a CI gate. The tagged release workflow separately drives
-      # the newly packaged overlay through the exact production downloader
-      # before publishing it.
-      - name: Build source mvmctl and published-builder bootstrap helper
-        env:
-          # This witness boots embedded builder-guest code. A restored Cargo
-          # cache may contain binaries built from an older source tree, which
-          # would make the live gate validate stale mvm-host-vm-init behavior.
-          MVM_EMBED_NO_CACHE: 1
-        run: |
-          cargo build --release -p mvmctl --features user
-          cp target/release/mvmctl /tmp/mvmctl-source-under-test
-          cargo build --release -p mvmctl --features user,release-artifact-bootstrap,release-channel
-
-      - name: Use published builder VM bootstrap path
-        run: mv nix/images/builder-vm nix/images/builder-vm.hidden
-
-      - name: Download published builder VM
-        run: ./target/release/mvmctl --builder qemu __builder-vm-bootstrap -v
-
-      - name: Bootstrap source-matched launch artifacts
-        env:
-          MVM_KERNEL_SOURCE: auto
-        run: /tmp/mvmctl-source-under-test --builder qemu bootstrap --production -v
-
-      - name: Build and boot the sealed exit_code workload under QEMU TCG
-        id: first-boot
-        env:
-          MVM_KERNEL_SOURCE: auto
-        run: |
-          set -euo pipefail
-          mkdir -p "$MVM_HOME"
-          set +e
-          /tmp/mvmctl-source-under-test machine run \
-            --flake examples/exit_code \
-            --builder qemu \
-            --hypervisor qemu \
-            -v \
-            -- /bin/true \
-            > /tmp/mvmctl-first-boot.log 2>&1
-          actual=$?
-          set -e
-          if [ "$actual" -ne 7 ]; then
-            echo "::error::expected guest exit code 7 from first boot, got $actual"
-            tail -250 /tmp/mvmctl-first-boot.log
-            exit 1
-          fi
-          echo "ok: sealed aarch64 workload built and exited $actual under QEMU TCG"
-
-      - name: Export, install, and re-run the bundle
-        id: bundle-roundtrip
-        run: |
-          set -euo pipefail
-          slot_hash=$(/tmp/mvmctl-source-under-test manifest ls --json 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | jq -r '.[0].slot_hash')
-          /tmp/mvmctl-source-under-test bundle export "$slot_hash" \
-            --out /tmp/exit-code-aarch64.mvmpkg \
-            > /tmp/mvmctl-export.log 2>&1
-          /tmp/mvmctl-source-under-test trust add "$MVM_HOME/keys/host-signer.pub"
-          install_output=$(/tmp/mvmctl-source-under-test bundle install /tmp/exit-code-aarch64.mvmpkg 2>&1 | tee /tmp/mvmctl-install.log)
-          installed_sha=$(printf '%s' "$install_output" | sed 's/\x1b\[[0-9;]*m//g' | awk '/Installed bundle / {print $3}')
-          echo "installed bundle content address: $installed_sha"
-          set +e
-          /tmp/mvmctl-source-under-test machine run \
-            --manifest "$installed_sha" \
-            --hypervisor qemu \
-            -v \
-            -- /bin/true \
-            > /tmp/mvmctl-bundle-run.log 2>&1
-          actual=$?
-          set -e
-          if [ "$actual" -ne 7 ]; then
-            echo "::error::expected guest exit code 7 from installed bundle, got $actual"
-            tail -250 /tmp/mvmctl-bundle-run.log
-            exit 1
-          fi
-          echo "ok: installed aarch64 bundle exited $actual under QEMU TCG"
-
-      - name: Dump diagnostics on failure
-        if: failure()
-        run: |
-          for log in /tmp/mvmctl-first-boot.log /tmp/mvmctl-export.log \
-                     /tmp/mvmctl-install.log /tmp/mvmctl-bundle-run.log; do
-            if [ -f "$log" ]; then
-              echo "===== $log ====="
-              tail -250 "$log" || true
-            fi
-          done
-          echo "===== VM state dirs ====="
-          for d in "$MVM_HOME"/vms/*/ "$MVM_HOME"/cache/builder-vm/vms/*/; do
-            echo "--- $d ---"
-            ls -la "$d" || true
-            for f in console.log firecracker.log qemu.log; do
-              if [ -s "$d$f" ]; then
-                echo "--- $f ---"; tail -100 "$d$f" || true
-              fi
-            done
-          done

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -19,6 +19,15 @@
       All phases are complete and green (`cargo check`, `cargo clippy`,
       `just check-gated`, unit/integration tests, and SDK tests).
 
+- [ ] **Merge-queue throughput recovery.**
+      `specs/plans/2026-08-15-merge-queue-throughput.md`.
+      The `aarch64-no-kvm-smoke` job was promoted to a required merge-queue
+      gate and can take hours under QEMU TCG, serializing every merge. Moved
+      the job to `ci-full.yml` (nightly + manual dispatch) and removed it from
+      the `Test` aggregate so the queue can move. Structural tests assert the
+      new separation. Remaining: land the change, measure post-change queue
+      latency, and record the result.
+
 ## Delivered (archive — closed to new entries)
 
 > **Do not append here.** A new delivery entry goes in its own file under

--- a/specs/adrs/012-ci-execution-policy.md
+++ b/specs/adrs/012-ci-execution-policy.md
@@ -23,7 +23,7 @@ day-to-day development for no proportional benefit.
 |---|---|---|
 | `ci.yml` | `pull_request` + `merge_group` + `workflow_dispatch` | parallel compiler/policy/feature and workspace/Linux lanes with stable `lint` and `test` aggregate checks; Nix is added in the merge queue / manual dispatch |
 | `architecture.yml` | `workflow_dispatch` only | structural/architectural invariants. Its required check name `Invariant` moved to `ci.yml`'s `lint-policy` job, and its one script is a step there, so the file no longer runs on a pull request despite this row once saying it did |
-| `ci-full.yml` (`Extended CI`) | nightly cron + `workflow_dispatch` | the platform + live-VM matrix. Was `workflow_dispatch` only, and in that state ran **zero times** between being written and 2026-08-21 — including the only macOS lanes in the repository. "Operator-triggered" turned out to mean "never", so it now has a cadence |
+| `ci-full.yml` (`Extended CI`) | nightly cron + `workflow_dispatch` | the platform + live-VM matrix, including the `aarch64-no-kvm-smoke` QEMU TCG path. Was `workflow_dispatch` only, and in that state ran **zero times** between being written and 2026-08-21 — including the only macOS lanes in the repository. "Operator-triggered" turned out to mean "never", so it now has a cadence |
 | `security.yml` | `push: tags: v*` + nightly cron + `workflow_dispatch` | dependency audit / advisory scan, plus every claim witness that is not a `fn:` test. Release-time backstop plus nightly catch for new advisories. **See "Open: no security lane gates a merge" below** |
 | `pack-signing-smoke.yml` | nightly cron + `workflow_dispatch` | keyless cosign round-trip against the real Sigstore stack. Also ran zero times while dispatch-only |
 | `release.yml` | `push: tags: v*` | builds and publishes release artifacts |
@@ -164,10 +164,12 @@ commit on `main` does not run them a third time. An operator opts into the expen
 SDK-publication dry-run, and OCI-ratification matrix deliberately through
 `ci-full.yml`, rather than paying for it on every update.
 
-A change that only breaks on macOS or under live KVM is not caught until
-someone runs `ci-full.yml`, or until a release-time gate runs — there is
-a real gap between "the PR is green" and "every platform has been
-exercised."
+A change that only breaks on macOS, under live KVM, or on the aarch64 no-KVM
+QEMU TCG path is not caught until `ci-full.yml` runs (nightly or on manual
+dispatch) — there is a real gap between "the PR is green" and "every
+platform has been exercised." The `aarch64-no-kvm-smoke` job was moved out
+of the merge queue because a cold TCG build can take hours and serialized
+merges; it remains in `ci-full.yml` so the path is still exercised.
 
 Release-time-only gates (`security.yml`, `windows.yml`, `release.yml`)
 stay timed to minimize development cost while still forming a hard backstop

--- a/specs/plans/2026-08-15-merge-queue-throughput.md
+++ b/specs/plans/2026-08-15-merge-queue-throughput.md
@@ -43,6 +43,11 @@ which is enough to saturate that pool before ordinary pull-request work.
       default-branch cache warmer; restore them in validation jobs.
 - [x] Remove duplicated feature-test work and validate the optimized workflow
       shape with actionlint and focused tests.
+- [x] Move the `aarch64-no-kvm-smoke` job out of the merge queue. The cold
+      QEMU TCG path can take hours, and making it a required gate serialized
+      every merge. It remains in `ci-full.yml` (nightly + manual dispatch) so
+      the path is still exercised, and the structural tests assert it no longer
+      blocks the `Test` aggregate.
 - [ ] Run formatting, workspace check, the complete workspace test suite, and
       Linux all-target Clippy.
 - [ ] Land the workflow change through the merge queue, then update and read

--- a/tests/ci_scope_aggregate.rs
+++ b/tests/ci_scope_aggregate.rs
@@ -71,8 +71,6 @@ struct Verdict {
     bdd: &'static str,
     kernel_scope: &'static str,
     kernel: &'static str,
-    no_kvm_required: &'static str,
-    no_kvm: &'static str,
 }
 
 impl Verdict {
@@ -86,12 +84,10 @@ impl Verdict {
             bdd: "success",
             kernel_scope: "true",
             kernel: "success",
-            no_kvm_required: "true",
-            no_kvm: "success",
         }
     }
 
-    /// A docs-only run: every lane correctly skipped. The kernel job has no
+    /// A docs-only run: every lane it should skips. The kernel job has no
     /// job-level `if:`, so it still runs and still reports `success`.
     fn out_of_scope() -> Self {
         Self {
@@ -102,8 +98,6 @@ impl Verdict {
             bdd: "skipped",
             kernel_scope: "false",
             kernel: "success",
-            no_kvm_required: "false",
-            no_kvm: "skipped",
         }
     }
 
@@ -114,9 +108,9 @@ impl Verdict {
             .env("SCOPE_RESULT", self.scope_result)
             .env("SCOPE_CODE", self.code)
             .env("WORKSPACE_RESULT", self.lanes)
-            // The aarch64 lane carries the same `code` scope as the other four
-            // in the loop, so it moves with them rather than getting its own
-            // field.
+            // The aarch64 workspace lane carries the same `code` scope as the
+            // other four in the loop, so it moves with them rather than getting
+            // its own field.
             .env("WORKSPACE_AARCH64_RESULT", self.lanes)
             .env("LINUX_RESULT", self.lanes)
             .env("RELEASE_WITNESS_RESULT", self.lanes)
@@ -125,8 +119,6 @@ impl Verdict {
             .env("BDD_RESULT", self.bdd)
             .env("KERNEL_SCOPE", self.kernel_scope)
             .env("KERNEL_RESULT", self.kernel)
-            .env("NO_KVM_REQUIRED", self.no_kvm_required)
-            .env("NO_KVM_RESULT", self.no_kvm)
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -161,23 +153,11 @@ fn a_fully_in_scope_green_run_is_admitted() {
     assert!(Verdict::in_scope().accepts());
 }
 
-#[test]
-fn an_in_scope_pull_request_may_skip_the_merge_group_only_smoke() {
-    assert!(
-        Verdict {
-            no_kvm_required: "false",
-            no_kvm: "skipped",
-            ..Verdict::in_scope()
-        }
-        .accepts()
-    );
-}
-
 /// The gate must not have been widened into a rubber stamp. Each of these is a
 /// real failure that has to keep being caught, in whichever scope it can occur.
 #[test]
 fn a_genuine_failure_is_still_refused_in_either_scope() {
-    let cases: [(&str, Verdict); 7] = [
+    let cases: [(&str, Verdict); 6] = [
         (
             "a failing kernel build, in scope",
             Verdict {
@@ -220,13 +200,6 @@ fn a_genuine_failure_is_still_refused_in_either_scope() {
                 ..Verdict::in_scope()
             },
         ),
-        (
-            "the required aarch64 no-KVM smoke failing",
-            Verdict {
-                no_kvm: "failure",
-                ..Verdict::in_scope()
-            },
-        ),
     ];
     for (what, verdict) in cases {
         assert!(!verdict.accepts(), "the aggregate must refuse {what}");
@@ -234,7 +207,7 @@ fn a_genuine_failure_is_still_refused_in_either_scope() {
 }
 
 #[test]
-fn aggregate_depends_on_the_aarch64_no_kvm_smoke() {
+fn aggregate_does_not_depend_on_the_aarch64_no_kvm_smoke() {
     let workflow = std::fs::read_to_string(".github/workflows/ci.yml")
         .expect("failed to read .github/workflows/ci.yml");
     let test_job = workflow
@@ -243,10 +216,13 @@ fn aggregate_depends_on_the_aarch64_no_kvm_smoke() {
         .and_then(|rest| rest.split_once("\n  test-workspace:\n").map(|(job, _)| job))
         .expect("Test aggregate job must remain delimited by test-workspace");
     assert!(
-        test_job.contains("aarch64-no-kvm-smoke"),
-        "the required Test aggregate must depend on the live no-KVM smoke"
+        !test_job.contains("aarch64-no-kvm-smoke"),
+        "the Test aggregate must not depend on the no-KVM smoke; it lives in ci-full.yml"
     );
-    assert!(test_job.contains("NO_KVM_RESULT"));
+    assert!(
+        !test_job.contains("NO_KVM_RESULT"),
+        "the Test aggregate must not reference the no-KVM smoke result"
+    );
 }
 
 /// A malformed scope output must fail closed rather than be read as one of the

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -1,4 +1,9 @@
 //! Regression checks for the aarch64 no-KVM smoke's binary build contract.
+//!
+//! The smoke lives in `ci-full.yml` (nightly / manual dispatch), not in the
+//! merge queue, because a cold QEMU TCG build can take hours and blocks the
+//! queue. The contract it exercises is still worth pinning: source binary
+//! preservation, release-helper separation, and the vsock/device setup.
 
 use std::fs;
 
@@ -20,16 +25,23 @@ const FIRST_MACHINE_RUN: &str = "/tmp/mvmctl-source-under-test machine run";
 
 #[test]
 fn aarch64_no_kvm_smokes_build_the_mvmctl_binary_they_execute() {
-    let workflow = fs::read_to_string(".github/workflows/ci.yml").expect("read CI workflow");
+    let ci_workflow = fs::read_to_string(".github/workflows/ci.yml").expect("read CI workflow");
+    assert!(
+        !ci_workflow.contains("aarch64-no-kvm-smoke:"),
+        "the merge-queue CI workflow must not define the aarch64 no-KVM smoke job"
+    );
+
+    let workflow =
+        fs::read_to_string(".github/workflows/ci-full.yml").expect("read extended CI workflow");
     let job = workflow
         .split("  aarch64-no-kvm-smoke:\n")
         .nth(1)
-        .expect("CI workflow must define the aarch64 no-KVM smoke job");
+        .expect("extended CI workflow must define the aarch64 no-KVM smoke job");
     let script = fs::read_to_string("scripts/local-aarch64-no-kvm-smoke.sh")
         .expect("read local aarch64 no-KVM smoke script");
 
     for (source, contents) in [
-        ("CI workflow", job),
+        ("extended CI workflow", job),
         ("local smoke script", script.as_str()),
     ] {
         assert!(
@@ -86,7 +98,7 @@ fn aarch64_no_kvm_smokes_build_the_mvmctl_binary_they_execute() {
 
     assert!(
         job.contains(REQUIRED_CI_VSOCK_OWNERSHIP),
-        "CI workflow must let the unprivileged QEMU process open /dev/vhost-vsock"
+        "extended CI workflow must let the unprivileged QEMU process open /dev/vhost-vsock"
     );
     assert!(
         script.contains(REQUIRED_LOCAL_VSOCK_DEVICE),

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -586,6 +586,10 @@ mod tests {
         workflow("ci.yml")
     }
 
+    fn ci_full_workflow() -> String {
+        workflow("ci-full.yml")
+    }
+
     fn workflow(name: &str) -> String {
         std::fs::read_to_string(
             Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -734,8 +738,7 @@ mod tests {
         assert!(test.contains("name: Test"));
         assert!(test.contains(
             "needs: [scope, test-workspace, test-workspace-aarch64, test-linux, \
-             test-release-witness, test-ebpf-telemetry, bdd-conformance, kernel, \
-             aarch64-no-kvm-smoke]"
+             test-release-witness, test-ebpf-telemetry, bdd-conformance, kernel]"
         ));
 
         // Every lane the aggregate names must also be read back in the loop that
@@ -752,7 +755,6 @@ mod tests {
             "\"$EBPF_RESULT\"",
             "\"$BDD_RESULT\"",
             "\"$KERNEL_RESULT\"",
-            "\"$NO_KVM_RESULT\"",
         ] {
             assert!(
                 test.contains(expected),
@@ -906,7 +908,7 @@ mod tests {
 
     #[test]
     fn aarch64_no_kvm_smoke_grants_runner_vhost_vsock_access() {
-        let workflow = ci_workflow();
+        let workflow = ci_full_workflow();
         let smoke = job_block(&workflow, "aarch64-no-kvm-smoke");
         assert!(
             smoke.contains("MVM_BUILDER_VM_TIMEOUT_SECS: 7200"),


### PR DESCRIPTION
The "Aarch64 no-KVM bundle smoke (QEMU TCG)" job has a 5-hour timeout and can legitimately run for hours when the Stage 0 builder compiles the workload kernel under TCG. Requiring it in the merge queue serialized every merge behind that one job.

Move the job out of the required merge-queue gate:

- Remove it from the "Test" aggregate in "ci.yml"
- Delete the job definition from "ci.yml"
- Add the same job to "ci-full.yml" so it still runs nightly and on manual dispatch

The aarch64/QEMU TCG path stays exercised, but it no longer blocks merges.

Structural tests are updated to assert the new separation:

- "tests/ci_scope_aggregate.rs": the Test aggregate no longer depends on the smoke
- "tests/github_actions_aarch64_no_kvm.rs": the smoke lives in "ci-full.yml"
- "xtask/src/check_workflow_paths.rs": same assertions, plus a new "ci_full_workflow" helper

ADR-012 and the merge-queue throughput plan are updated to reflect that the aarch64 no-KVM path is now part of Extended CI, not the merge queue.

## Manual step before merging

If "Aarch64 no-KVM bundle smoke (QEMU TCG)" was added to the branch-protection required checks when it was promoted, remove it from the required list before this PR merges. The job no longer runs on merge_group, so leaving it required would leave PRs waiting for a check that never reports.