### PR TITLE
fix(ci): restore scheduled security witnesses

### DIFF
--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -1239,6 +1239,19 @@ mod tests {
         assert_eq!(runtime_overlay_source_checkout_root(), None);
     }
 
+    #[cfg(not(feature = "release-channel"))]
+    #[test]
+    fn contributor_build_detects_the_compiled_in_runtime_overlay_flake() {
+        let workspace_root = runtime_overlay_source_checkout_root()
+            .expect("a contributor build must detect its source checkout");
+        assert!(
+            workspace_root
+                .join("nix/images/runtime-overlay/flake.nix")
+                .is_file(),
+            "detected workspace root must contain the runtime-overlay flake"
+        );
+    }
+
     fn valid_overlay_ext4_bytes() -> Vec<u8> {
         let paths: &[&str] = &[
             "/agent",

--- a/crates/mvm-hostd/src/bin/mvm-network-endpoint.rs
+++ b/crates/mvm-hostd/src/bin/mvm-network-endpoint.rs
@@ -162,7 +162,10 @@ fn main() -> Result<()> {
     // applies to the runtime thread that drives the accept loop. Fail-closed:
     // any confinement error aborts before the first guest connection.
     runtime.block_on(async move {
+        #[cfg(target_os = "linux")]
         confine_endpoint(&cfg)?;
+        #[cfg(not(target_os = "linux"))]
+        confine_endpoint_without_lsm(&cfg)?;
         serve(
             ServeParams::builder()
                 .cfg(&cfg)
@@ -566,7 +569,7 @@ fn confine_endpoint(cfg: &EndpointConfig) -> Result<()> {
 /// is exercised — and therefore testable — on every host, matching the parity
 /// the jailer module keeps for its own types.
 #[cfg(not(target_os = "linux"))]
-fn confine_endpoint(cfg: &EndpointConfig) -> Result<()> {
+fn confine_endpoint_without_lsm(cfg: &EndpointConfig) -> Result<()> {
     let _ = resolver_uds_path(cfg);
     Ok(())
 }

--- a/scripts/check-sealed-prod-allowlist.sh
+++ b/scripts/check-sealed-prod-allowlist.sh
@@ -16,23 +16,23 @@
 set -euo pipefail
 
 # Test names locked by plan 76 Phase 1. Adding a test to this list
-# requires updating EXPECTED_GUEST_COUNT / EXPECTED_CORE_COUNT to
+# requires updating EXPECTED_GUEST_COUNT / EXPECTED_CONTRACT_COUNT to
 # match.
 GUEST_TESTS=(
-  "vsock::tests::test_request_class_coverage_matches_sealed_prod_allowlist"
-  "vsock::tests::test_sealed_prod_rejects_dev_only_verbs"
-  "vsock::tests::test_sealed_prod_accepts_prod_safe_verbs"
-  "vsock::tests::test_unsupported_in_profile_response_roundtrip"
+  "vsock::request_policy::tests::test_request_class_coverage_matches_sealed_prod_allowlist"
+  "vsock::request_policy::tests::test_sealed_prod_rejects_dev_only_verbs"
+  "vsock::request_policy::tests::test_sealed_prod_accepts_prod_safe_verbs"
+  "vsock::response::tests::test_unsupported_in_profile_response_roundtrip"
 )
 EXPECTED_GUEST_COUNT=${#GUEST_TESTS[@]}
 
-CORE_TESTS=(
+CONTRACT_TESTS=(
   "policy::security::tests::test_security_policy_defaults"
   "policy::security::tests::test_security_policy_missing_profile_field_is_sealed_prod"
   "policy::security::tests::test_security_policy_dev_defaults_carries_dev_profile"
   "policy::security::tests::test_agent_profile_serde_kebab_case"
 )
-EXPECTED_CORE_COUNT=${#CORE_TESTS[@]}
+EXPECTED_CONTRACT_COUNT=${#CONTRACT_TESTS[@]}
 
 run_locked_tests() {
   local crate="$1"
@@ -70,7 +70,7 @@ run_locked_tests() {
 }
 
 run_locked_tests mvm-agentd "${EXPECTED_GUEST_COUNT}" "${GUEST_TESTS[@]}"
-run_locked_tests mvm-core   "${EXPECTED_CORE_COUNT}"  "${CORE_TESTS[@]}"
+run_locked_tests mvm-contract "${EXPECTED_CONTRACT_COUNT}" "${CONTRACT_TESTS[@]}"
 
 echo
-echo "✅ Sealed-prod vsock allowlist locked: ${EXPECTED_GUEST_COUNT} mvm-agentd + ${EXPECTED_CORE_COUNT} mvm-core tests pass."
+echo "✅ Sealed-prod vsock allowlist locked: ${EXPECTED_GUEST_COUNT} mvm-agentd + ${EXPECTED_CONTRACT_COUNT} mvm-contract tests pass."

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-24
+Last updated: 2026-08-25
 ## Completed
 
 - [x] **AI egress metering and token budgets** —
@@ -16,6 +16,14 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
+
+- [x] **Issues #2841 and #2842 — scheduled security evidence is executable.**
+      Sealed-production policy witnesses now follow the refactored agent
+      modules and the `mvm-contract` source of truth. A contributor-checkout
+      witness catches the runtime-overlay predicate mutation, obsolete
+      accepted misses are removed, and the non-Linux confinement compatibility
+      stub can no longer mask mutations of Linux fail-closed confinement. See
+      `specs/sprint/delivery/2841-security-claim-witness-repair.md`.
 
 - [x] **Missing-state log recovery guidance.** The lifecycle-aware
       `machine logs` failure now gives operators the concrete `machine ls`

--- a/specs/sprint/delivery/2841-security-claim-witness-repair.md
+++ b/specs/sprint/delivery/2841-security-claim-witness-repair.md
@@ -1,0 +1,25 @@
+# Scheduled security claim witnesses execute their current surfaces
+
+The scheduled Security workflow again runs the exact witnesses that back the
+sealed-production request policy. The locked agent tests follow their
+post-refactor modules, and the shared security-policy tests run from their
+source-of-truth `mvm-contract` crate instead of the compatibility facade.
+
+Mutation evidence is current as well. A contributor-channel test proves that
+the in-tree runtime-overlay flake is detected, catching the checkout-predicate
+mutation that previously survived. Baseline entries for mutations now caught
+by the expanded suite are removed. The macOS/Windows confinement compatibility
+stub has a distinct name and a narrowly documented baseline entry, so its
+platform no-op cannot hide a mutation of the Linux fail-closed confinement
+function.
+
+Validation:
+
+- `scripts/check-sealed-prod-allowlist.sh` (8 exact witnesses)
+- `cargo test -p mvm-build --features pure-mkfs contributor_build_detects_the_compiled_in_runtime_overlay_flake`
+- `cargo test -p mvm-hostd --bin mvm-network-endpoint` (24 tests)
+- `cargo run -p xtask -- check-mutation-witnesses`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+
+This repairs the failed scheduled Security evidence and the downstream claim
+freshness report tracked by issues #2841 and #2842.

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -909,46 +909,6 @@
       "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
     },
     {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace match guard local_source_cache_is_fresh( &resolver.layout(&arch.to_string()), &expected_fingerprint, )? with false in resolve_or_build_local_runtime_overlay",
-      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace match guard local_source_cache_is_fresh( &resolver.layout(&arch.to_string()), &expected_fingerprint, )? with true in resolve_or_build_local_runtime_overlay",
-      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace match guard out.status.success() with true in curl_download",
-      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace run_nix_build -> Result<(), RuntimeOverlayError> with Ok(())",
-      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace runtime_overlay_source_checkout_root -> Option<PathBuf> with None",
-      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace runtime_overlay_source_checkout_root -> Option<PathBuf> with Some(Default::default())",
-      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace write_local_build_epoch -> Result<(), RuntimeOverlayError> with Ok(())",
-      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
-      "file": "crates/mvm-build/src/runtime_overlay.rs",
-      "mutant": "replace write_local_source_fingerprint -> Result<(), RuntimeOverlayError> with Ok(())",
-      "reason": "the only witness is runtime_overlay_build.rs, which shells out to a real nix build and skips when nix is absent. The mutation lane installs no nix, so these paths never execute there. Coverage debt tracked in #2033."
-    },
-    {
       "file": "crates/mvm-cli/src/commands/image/pull_core.rs",
       "mutant": "replace && with || in pull_image_with_trust",
       "reason": "widens the prod digest-pin refusal to fire on any unpinned reference rather than only under --prod, so it refuses strictly more than the real gate. Fail-closed: claim 14 asks that --prod refuses a mutable tag, which it still does. Catching it needs a dev-mode pull asserted not to bail, which reaches the network."
@@ -1017,6 +977,11 @@
       "file": "crates/mvm-core/src/plan/synthesis.rs",
       "mutant": "replace SynthesisInput<'a>::builder -> SynthesisInputBuilder<'a> with Default::default()",
       "reason": "provably equivalent: `SynthesisInput::builder` is a one-line alias for `SynthesisInputBuilder::new()`, and this file's `impl Default for SynthesisInputBuilder` returns `Self::new()`, so `Default::default()` evaluates the identical expression. No test can distinguish the two, and the builder's own required-field refusal is asserted directly by the empty-builder test beside it."
+    },
+    {
+      "file": "crates/mvm-hostd/src/bin/mvm-network-endpoint.rs",
+      "mutant": "replace confine_endpoint_without_lsm -> Result<()> with Ok(())",
+      "reason": "This is the macOS/Windows compatibility stub: those hosts have no Landlock or seccomp confinement to witness. The distinct function name keeps this exception from masking mutations of the Linux fail-closed confine_endpoint implementation."
     },
     {
       "file": "crates/mvm-hostd/src/admission_budget.rs",


### PR DESCRIPTION
## Summary
- update sealed-production witness locks to their post-refactor agent modules and mvm-contract source of truth
- add a contributor runtime-overlay checkout witness and remove mutation misses now caught by tests
- separate the non-Linux confinement compatibility stub so its baseline cannot mask Linux fail-closed confinement

## Validation
- scripts/check-sealed-prod-allowlist.sh (8 exact witnesses)
- cargo test -p mvm-build --features pure-mkfs contributor_build_detects_the_compiled_in_runtime_overlay_flake
- cargo test -p mvm-hostd --bin mvm-network-endpoint (24 passed)
- cargo run -p xtask -- check-mutation-witnesses
- cargo clippy --workspace --all-targets -- -D warnings

Fixes #2841
Fixes #2842