### PR TITLE
gitignore: ignore .qwen/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ __pycache__/
 # graft's local graph cache — regenerable, not committed (run `graft build`).
 graft/
 ./weblinux-pack-out/
+
+# Qwen Code session directory
+.qwen/


### PR DESCRIPTION
This PR adds .qwen/ to .gitignore to ignore the Qwen Code session directory.

Generated with Qwen Code