### PR TITLE
gitignore: ignore .qwen/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ __pycache__/
 # graft's local graph cache — regenerable, not committed (run `graft build`).
 graft/
 ./weblinux-pack-out/
+
+# Qwen Code session directory
+.qwen/


### PR DESCRIPTION
This commit adds .qwen/ to .gitignore to prevent Qwen Code session directories from being tracked.

Generated with Qwen Code