### PR TITLE
docs(adr): reconcile the spawned-microVM and durable-messaging designs

### DIFF
--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -28,7 +28,6 @@
       new separation. Remaining: land the change, measure post-change queue
       latency, and record the result.
 
-
 - [ ] **Quantum-safe cryptography transition for mvm and mvmd.**
       `specs/plans/2026-08-25-quantum-safe-cryptography-transition.md`.
       Inventory the classical signature and key-exchange surfaces
@@ -38,6 +37,63 @@
       integrity, plans/bundles, release trust, TLS, and mvmd control-plane
       messages to hybrid mode. Plan is staged; no implementation work has
       started.
+
+## Roadmap — the workload actor model (proposed, not started)
+
+Four documents describe one thing: microVMs as addressable, supervised,
+independently-failing units that communicate only by message. All are
+`Backing: preview` / `Validation: none` — no code, no tests. Listed here so
+they stay on the roadmap rather than drifting apart again; ADR-051 exists
+because the first two were written days apart and collided in `mvm-contract`
+without either referencing the other.
+
+Build order is the dependency order below. The planner is the last thing built,
+and nothing depends on it.
+
+- [ ] **Shared vocabulary and the kameo decision.**
+      `specs/adrs/051-workload-actor-model.md`.
+      Names the workload actor, states the four invariants (one guest is one
+      actor; every actor is an ordinary admitted workload; authority only
+      attenuates; every message is durable, bounded, and audited), gives the
+      messaging contract to the fabric, and records why a third-party
+      in-process actor framework is rejected — the actors are microVMs behind
+      vsock, and supervision/restart conflicts with the fabric's deterministic
+      replay requirement. Defines the vertical slice below.
+
+- [ ] **Durable messaging: the secure message fabric.**
+      `specs/plans/2026-08-18-secure-message-fabric.md`, governed by
+      `specs/adrs/046-secure-message-fabric.md`.
+      One `ExclusiveInbox` per workload, E2E-encrypted under workload-owned
+      keys, at-least-once delivery over a deterministic SQLite-backed state
+      machine, dedup by idempotency key, per-route ordering, bounded queues for
+      offline recipients, crash redelivery, archive-before-purge. Supersedes
+      ADR-035 for guest↔host transport and retires stdout/stdin as a control
+      protocol. Budgets: p99 ≤ 10 ms first local durable 1 KiB message,
+      ≤ 200 ms prepared-cold `communication_ready`. **Blocks everything below.**
+
+- [ ] **A controller microVM that spawns worker microVMs.**
+      `specs/plans/2026-08-18-capability-secure-intelligent-workflows.md`,
+      governed by
+      `specs/adrs/045-capability-secure-intelligent-workflow-controllers.md`,
+      research basis
+      `specs/research/intelligent-capability-secure-microvm-workflows.md`.
+      `launch_child` / `observe_child` / `release_child`, `ActorHandle`,
+      transactional capacity reservation, the clean-parent invariant, private
+      stateful actor checkpoints, and a planner over a signed action catalog.
+      Every child is an ordinary admitted workload and
+      `effective_child_authority ⊆ effective_parent_authority`. Consumes
+      `mvm_contract::fabric`; defines no message types of its own.
+
+- [ ] **First increment: the vertical slice.**
+      A parent actor spawns one child, sends one durable message, receives one
+      response, and releases it; the child is destroyed and never re-enters
+      warm capacity. Done when the four invariants have negative witnesses —
+      over-requested authority refused, over-bound message refused rather than
+      truncated, response surviving a host crash between accept and ACK, and
+      the whole exchange in the chain-signed log with no payload bytes. This is
+      the increment that forces the vocabulary to be shared in code rather than
+      described as shared in prose.
+
 ## Delivered (archive — closed to new entries)
 
 > **Do not append here.** A new delivery entry goes in its own file under

--- a/specs/adrs/045-capability-secure-intelligent-workflow-controllers.md
+++ b/specs/adrs/045-capability-secure-intelligent-workflow-controllers.md
@@ -9,6 +9,13 @@ Validation: none — this is a proposed design; no code implements it and no tes
 ADR-037 (`mvmd` production authority), ADR-040, ADR-041, ADR-042,
 ADR-047 (the agent memory plane); Plan 296,
 Plan 298, Plan 308, and Plan 329.  
+**Depends on:** ADR-046. The message fabric owns the messaging contract; this
+ADR defines no message types of its own and consumes `mvm_contract::fabric`.
+The workflow communication workstream cannot start before the fabric's local
+mailbox milestone lands.  
+**Reconciled by:** ADR-051, which names the shared workload actor model, settles
+the vocabulary split against this ADR, and records the rejection of a
+third-party actor framework.  
 **Research basis:**
 `specs/research/intelligent-capability-secure-microvm-workflows.md`.
 

--- a/specs/adrs/046-secure-message-fabric.md
+++ b/specs/adrs/046-secure-message-fabric.md
@@ -6,7 +6,7 @@ Validation: none — this is a proposed design; no code implements it and no tes
 **Status:** Proposed  
 **Date:** 2026-08-15  
 **Owner:** `mvm` maintainers  
-**Implemented by:** Plan 338  
+**Implemented by:** `specs/plans/2026-08-18-secure-message-fabric.md`  
 **Distributed counterpart:** a separately numbered `mvmd` ADR and plan consume the contracts and deterministic state machine defined here.  
 **Supersedes:** ADR-035 for guest↔host transport, inter-workload routing,
 `StreamEdge`, stdin as a workflow protocol, stdout/stderr as return protocols,
@@ -15,8 +15,10 @@ redaction, bounded telemetry retention, explicit gaps, hash chaining, sealed
 roots, fan-out, and operator debugging.  
 **Complements:** ADR-001, ADR-014, ADR-019, ADR-020, ADR-031, ADR-037,
 ADR-040, ADR-041, and ADR-042.  
-**Consumed by:** the capability-secure workflow ADR/plan after those documents
-are reconciled to depend on this fabric.
+**Consumed by:** ADR-045 and its plan, which depend on this fabric and define
+no message types of their own.  
+**Reconciled by:** ADR-051, which names the shared workload actor model and
+records that this ADR's vocabulary is the one that wins.
 
 ## Context
 

--- a/specs/adrs/051-workload-actor-model.md
+++ b/specs/adrs/051-workload-actor-model.md
@@ -1,0 +1,190 @@
+# ADR-051 — The workload actor model is one vocabulary shared by spawned microVMs and durable messaging
+
+Backing: preview
+Validation: none — this is a reconciling design decision; no code implements it and no test exercises it.
+
+**Status:** Proposed
+**Date:** 2026-08-25
+**Owner:** `mvm` maintainers
+**Reconciles:** ADR-045 (capability-secure intelligent workflow controllers) and
+ADR-046 (the secure message fabric).
+**Complements:** ADR-001, ADR-014, ADR-020, ADR-031, ADR-035, ADR-042, ADR-047.
+**Implemented by:** no plan yet. The vertical slice below is the first one to write.
+
+## Context
+
+Two proposed designs were authored a few days apart, by different passes over
+the same problem, and neither references the other.
+
+ADR-045 lets an admitted controller microVM launch admitted worker microVMs:
+`launch_child`, `observe_child`, `release_child`, `ActorHandle`, lifecycle
+receipts, per-child capacity reservation, and the rule that
+`effective_child_authority ⊆ effective_parent_authority`. Its WS7 gives those
+children "bidirectional, bounded, auditable communication".
+
+ADR-046 makes durable local messaging the workload data plane: one
+`ExclusiveInbox` per workload, E2E-encrypted with workload-owned keys,
+at-least-once delivery over a deterministic SQLite-backed state machine, dedup
+by idempotency key, per-route ordering, bounded queues for offline recipients,
+crash redelivery, and archive-before-purge.
+
+Read together, both describe the same thing: **addressable, supervised,
+independently-failing units that communicate only by message.** That is the
+actor model, with capability attenuation added. Neither document names it, so
+neither can defer to the other, and the overlap has already turned into a
+concrete collision:
+
+| Type | ADR-045 WS7 | ADR-046 M1 |
+|---|---|---|
+| `MailboxAddress` | "add under `mvm-contract`" | "define with workload-only destination" |
+| `MessageId` | "add under `mvm-contract`" | "add" |
+| `MailboxEnvelope` / message envelope | defined in WS7 | defined in M1 |
+| correlation / causation | `CorrelationId`, `CausationId` | "define causation/correlation fields" |
+| acknowledgement | `Acknowledgement`, `DeliveryReceipt` | ACK / NACK / lease commands |
+| delivery attempt | `DeliveryAttempt` | `AttemptId` |
+| cursor | `MailboxCursor` | `CommitPosition`, `DeliveryToken` |
+
+Both write those names into `mvm-contract`. Whichever lands second either
+conflicts or silently forks the model.
+
+ADR-046 already assumes the resolution — it lists itself as "consumed by the
+capability-secure workflow ADR/plan after those documents are reconciled to
+depend on this fabric" — but ADR-045 has no corresponding edge, and the
+reconciliation exists only as one unchecked box in the fabric plan.
+
+Separately: because the shape is the actor model, adopting a Rust actor
+framework has been raised. That question is answered here rather than left to
+whoever writes the first plan.
+
+## Decision
+
+### 1. Name the unit
+
+A **workload actor** is one microVM together with:
+
+- one `ExclusiveInbox` (ADR-046) — its only inbound message path;
+- one `ActorHandle` (ADR-045) — the lifecycle capability its parent holds;
+- one attenuated authority envelope;
+- one audit lineage rooted in the signed `ExecutionPlan` it booted under.
+
+An actor is not a new runtime object. It is the name for a workload seen
+through those four bindings at once.
+
+### 2. Four invariants
+
+1. **One guest is one actor.** No multi-workload guest, no nested
+   virtualization. Carried forward from ADR-045.
+2. **Every actor is an ordinary admitted workload.** Spawning a child reuses
+   plan synthesis, signing, admission, backend dispatch, secrets, network
+   policy, and the audit chain unchanged. A child is not a privileged object.
+3. **Authority only attenuates.** A child's capabilities, egress, secrets,
+   filesystem, tools, resources, and delegation are subsets of every applicable
+   parent, workflow, tenant, template, and host ceiling.
+4. **Every message is durable, bounded, and audited.** No control path may
+   deliver a message the fabric would refuse, and no lifecycle transition may
+   escape the chain-signed log.
+
+### 3. One vocabulary — the fabric's
+
+ADR-046 defines the messaging contract. ADR-045 consumes it and defines no
+message types of its own.
+
+Concretely: the WS7 "add dependency-light mailbox types under `mvm-contract`"
+list is **deleted** from the workflows plan. `MailboxAddress`, `MessageId`,
+envelopes, correlation, causation, attempts, acknowledgement, and cursors have
+exactly one definition, in `mvm_contract::fabric`.
+
+`ActorHandle` survives, because it is not an address. It is the lifecycle
+capability authorizing `observe_child` and `release_child` on one child. It
+resolves to a `MailboxAddress`; it never carries a second addressing scheme, and
+in particular it never carries a VM name, node address, CID, socket path, or
+file descriptor — which ADR-046's route contracts already forbid.
+
+The reciprocal edge is added to ADR-045: it depends on ADR-046, and the fabric
+must reach its local mailbox milestone before the workflow layer's
+communication workstream can start.
+
+### 4. No third-party actor framework
+
+`kameo` was evaluated as the substrate and is **rejected**. Two structural
+reasons, neither of them about crate quality:
+
+**The actors are microVMs.** They are separate kernels in separate address
+spaces behind vsock, running workloads in Python, TypeScript, and other
+languages. An in-process Rust actor framework addresses actors by a typed
+handle to a task in the current process. It cannot name a microVM, and the
+addressing model it provides is the one ADR-046 explicitly rejects.
+
+**Supervision conflicts with determinism.** ADR-046 requires a deterministic
+command log that replays exactly, because `mvmd` data-group replicas re-execute
+it later. An actor framework's value is panic isolation and restart policy —
+nondeterminism that would then have to be suppressed to keep replay exact. This
+also disposes of the one place such a framework could plausibly have helped
+locally, the fabric's resident shard workers: a shard worker owning a SQLite
+connection and a deterministic state machine wants a single owned loop, not
+supervised restart.
+
+Measured against what ADR-046 actually requires — durable transactional
+cursors, dedup by idempotency key, bounded encrypted queues for offline
+recipients, E2E encryption the host cannot read, capability-bound sends,
+host-stamped sender identity, payload-free audit events, and deterministic
+replay — an in-process actor framework supplies none of them. It supplies a
+bounded mailbox, which is a channel.
+
+What is adopted is the **model**: addressable mailboxes, supervised lifecycle,
+message-only communication, independent failure. Those are built on `mvm`'s own
+types, under `mvm-contract`, where the capability and audit bindings can be
+part of the contract rather than bolted beside it.
+
+This decision is recorded so it is not re-litigated per plan. Revisiting it
+requires new evidence about the microVM boundary or the determinism
+requirement, not a preference for the ergonomics.
+
+### 5. The vertical slice that demonstrates the model
+
+One scenario, exercising both ADRs end to end on one host:
+
+> A parent actor spawns one child actor, sends it one durable message, receives
+> one response, and releases it. The child is destroyed and never re-enters
+> warm capacity.
+
+It is done when all four invariants have negative witnesses, not just a happy
+path: a child that requests authority its parent lacks is refused; a message
+that exceeds a fabric bound is refused rather than silently truncated; the
+response survives a host process crash between accept and acknowledgement; and
+the whole exchange appears in the chain-signed log with no payload bytes.
+
+Both existing plans stay whole. This slice is the first increment either one
+ships, and it is the increment that forces the vocabulary to be shared rather
+than described as shared.
+
+## Consequences
+
+- ADR-045 and its plan lose their independent mailbox contract and gain a hard
+  dependency on ADR-046. The workflow layer cannot start its communication
+  workstream before the fabric's local mailbox milestone lands.
+- `mvm-contract` gains exactly one messaging module. The runtime-free and
+  `no_std + alloc` posture of the transport-free types is preserved, as ADR-046
+  already requires.
+- Sequencing becomes explicit: fabric contracts and state machine first, then
+  child lifecycle, then the planner. The planner is the last thing built, not
+  the first, and nothing depends on it.
+- The kameo question is closed. Future proposals cite this ADR.
+- Neither ADR is superseded. This one is deliberately small; its whole job is
+  to make two documents agree and to be deleted into them if they are ever
+  merged.
+
+## Alternatives considered
+
+**Amend ADR-045 and ADR-046 in place, with no new ADR.** Smallest diff, but the
+shared model stays implicit — the next document to describe actors has nothing
+to defer to, which is exactly how the current collision happened.
+
+**Build the vertical slice first and let the vocabulary reconcile in code.**
+Attractive, and correct for most of this. Rejected for the parts that cannot be
+retrofitted: capability attenuation and audit-chain binding have to be in the
+contract from the first commit. The rest of the model can and should be settled
+by working code.
+
+**Adopt an actor framework and shape the plans around it.** Rejected in
+§4 above.

--- a/specs/plans/2026-08-18-capability-secure-intelligent-workflows.md
+++ b/specs/plans/2026-08-18-capability-secure-intelligent-workflows.md
@@ -6,7 +6,7 @@ Validation: none — this is a proposed design; no code implements it and no tes
 **Status:** PROPOSED — no implementation has begun.  
 **Issue:** not yet assigned.  
 **Governing ADR:**
-`specs/adrs/043-capability-secure-intelligent-workflow-controllers.md`.  
+`specs/adrs/045-capability-secure-intelligent-workflow-controllers.md`.  
 **Research:**
 `specs/research/intelligent-capability-secure-microvm-workflows.md`.
 
@@ -208,7 +208,7 @@ performance, or storage semantics.
 
 ### Decisions
 
-- [ ] Confirm ADR-043 status and merge it before guest-reachable lifecycle code.
+- [ ] Confirm ADR-045 status and merge it before guest-reachable lifecycle code.
 - [ ] Amend ADR-001 with the controller, AI, workflow, mailbox, semantic,
       resource-amplification, and distributed threat model.
 - [ ] Decide whether ADR-037 is amended or superseded by the rule that every
@@ -654,20 +654,17 @@ turning raw stdout or direct guest addressing into a control plane.
 
 ### Mailbox contract
 
-- [ ] Add dependency-light mailbox types under `mvm-contract`:
-      - `MailboxAddress`;
-      - `MailboxEnvelope`;
-      - `MessageId`;
-      - `CorrelationId`;
-      - `CausationId`;
-      - `DeliveryAttempt`;
-      - `DeliveryReceipt`;
-      - `Acknowledgement`;
-      - `MailboxCursor`;
-      - `PayloadLocation`;
-      - `MessageClassification`;
-      - `MailboxRefusal`.
-- [ ] Every wire type uses bounded fields and `deny_unknown_fields`.
+- [ ] Consume `mvm_contract::fabric` for every messaging type. This plan defines
+      none of its own. ADR-051 settles the vocabulary: `MailboxAddress`,
+      `MessageId`, envelopes, correlation, causation, delivery attempts,
+      acknowledgement, and cursors have exactly one definition, in the message
+      fabric, and it is the fabric's.
+- [ ] Depend on the fabric's local mailbox milestone; this workstream cannot
+      start before it lands.
+- [ ] `ActorHandle` remains defined here, as the lifecycle capability
+      authorizing `observe_child`/`release_child`. It resolves to a
+      `MailboxAddress` and carries no second addressing scheme — no VM name,
+      node address, CID, socket path, or file descriptor.
 - [ ] Sender identity is absent from the authoritative guest-authored payload;
       the host stamps tenant, workflow, attempt, boot, plan digest, and
       controller generation from the authenticated channel.
@@ -1848,7 +1845,7 @@ mistaken for a production security property.
 
 Proceed only when:
 
-- ADR-043 and threat-model amendments are accepted;
+- ADR-045 and threat-model amendments are accepted;
 - production delegation rule is settled;
 - launch SLO is pinned;
 - mailbox ownership and encryption prerequisite are settled;

--- a/specs/plans/2026-08-18-secure-message-fabric.md
+++ b/specs/plans/2026-08-18-secure-message-fabric.md
@@ -5,7 +5,7 @@ Validation: none — this is a proposed design; no code implements it and no tes
 
 ## Status
 
-**READY FOR IMPLEMENTATION AFTER ADR-043 IS REVIEWED.**
+**READY FOR IMPLEMENTATION AFTER ADR-046 IS REVIEWED.**
 
 This is the `mvm` half of the work. It builds the complete one-host fabric and
 the deterministic state-machine implementation that `mvmd` will replicate.
@@ -41,7 +41,7 @@ The same `ConversationCommand` and `ConversationStateMachine` are reused by
 
 ## Scope
 
-Plan 338 includes:
+This plan includes:
 
 - all guest, host-reader, and local-workload communication inventory;
 - one mandatory secure-channel substrate;
@@ -171,18 +171,18 @@ reachable fabric path may ship before M2.
 
 - [ ] Record exact `origin/main`, branch, worktree, host, and supported backend
       matrix in the delivery note.
-- [ ] Verify ADR-043 is the next free ADR number; renumber before editing if the
-      repository changed.
-- [ ] Verify Plan 338 is the next free plan number; renumber before editing if
-      the repository changed.
+- [x] Numbering resolved: this plan's ADR is ADR-046, and the plan itself is
+      slug-named per the current convention rather than carrying a number.
 - [ ] Read current `CLAUDE.md`/`AGENTS.md` and repository workflow rules.
 - [ ] Read ADRs 001, 014, 019, 020, 031, 035, 037, 040, 041, and 042.
 - [ ] Read Plans 265, 267, 274, 293, 294, 295, 296, 299, 302, 308, 311, 314,
       315, 318, 319, 328, 329, and 330 where present.
 - [ ] Inspect current workflow ADR/plan/research documents and record required
       message-fabric dependency edits.
-- [ ] Add ADR-043 and Plan 338 cross-references to the current sprint/status
+- [ ] Add ADR-046 and this plan's cross-references to the current sprint/status
       documents without marking implementation complete.
+- [ ] Read ADR-051 and treat its vocabulary decision as binding: this plan owns
+      the messaging contract, and the workflow plan consumes it.
 
 ### Communication-channel catalog
 
@@ -946,7 +946,7 @@ reachable fabric path may ship before M2.
 
 - [ ] Models, fuzzers, failpoints, crash sweeps, static checks, and canary scans
       are green.
-- [ ] Every ambiguity updates ADR-043 before claim promotion.
+- [ ] Every ambiguity updates ADR-046 before claim promotion.
 
 ---
 
@@ -1047,8 +1047,8 @@ cargo run -p xtask -- check-fabric-archive-inert
 
 ## Definition of done
 
-- [ ] Every Plan 338 checkbox is complete with evidence.
-- [ ] ADR-043 and implementation agree.
+- [ ] Every checkbox in this plan is complete with evidence.
+- [ ] ADR-046 and implementation agree.
 - [ ] One local guest-boundary fabric remains.
 - [ ] Stdio is guest-local compatibility only.
 - [ ] Two real microVMs communicate through durable E2E encrypted messages.


### PR DESCRIPTION
Two proposed designs were authored days apart by separate passes over the same problem, and neither references the other.

- `specs/adrs/045-capability-secure-intelligent-workflow-controllers.md` — a controller microVM launches admitted worker microVMs (`launch_child` / `observe_child` / `release_child`, `ActorHandle`, attenuating authority).
- `specs/adrs/046-secure-message-fabric.md` — durable local messaging as the workload data plane (one `ExclusiveInbox` per workload, E2E encryption, at-least-once delivery over a deterministic SQLite state machine).

Both describe addressable, supervised, independently-failing units that communicate only by message. Both write `MailboxAddress`, `MessageId`, envelopes, correlation, causation, delivery attempts, acknowledgement, and cursors into `mvm-contract`. Whichever landed second would have conflicted or silently forked the model. ADR-046 already assumed the resolution ("consumed by the capability-secure workflow ADR/plan after those documents are reconciled"), but ADR-045 had no reciprocal edge and the reconciliation existed only as one unchecked box.

## What this does

**Adds ADR-051.** Names the shared unit — a *workload actor*: one microVM with one `ExclusiveInbox`, one `ActorHandle`, one attenuated authority envelope, one audit lineage. States four invariants (one guest is one actor; every actor is an ordinary admitted workload; authority only attenuates; every message is durable, bounded, and audited). Gives the messaging contract to the fabric and defines the vertical slice that proves the model.

**Closes the collision.** The workflows plan's WS7 mailbox type list is deleted; it now consumes `mvm_contract::fabric` and defines no message types of its own. There is exactly one `Define MailboxAddress` in the tree. `ActorHandle` survives as the lifecycle capability authorizing `observe_child`/`release_child` — it resolves to a `MailboxAddress` and carries no second addressing scheme.

**Records the actor-framework decision.** A third-party in-process actor framework was evaluated and is rejected, so the question is not re-litigated per plan. Two structural reasons: the actors are microVMs behind vsock running non-Rust workloads, which a typed in-process handle cannot name and whose addressing model ADR-046 already forbids; and supervision-with-restart conflicts with the fabric's requirement that its command log replay deterministically for mvmd replicas. The *model* is adopted, built on our own contract types where the capability and audit bindings are part of the contract rather than bolted beside it.

**Fixes stale numbering.** Both plans carried placeholder references — `ADR-043` (now taken by client-interface-conformance) and `Plan 338` (now taken by the weblinux plan). Pointed at the real ADR-045/046 and the slug-named plan paths.

**Adds a roadmap section to `specs/SPRINT.md`** listing all four documents in dependency order, so they stay visible instead of drifting apart again. The frozen Delivered archive is untouched.

## Scope

Documentation only — no code changes. All four documents remain `Backing: preview` / `Validation: none`; this PR does not claim any of them is implemented.

## Verification

`cargo run -p xtask -- check-all` — 61 gates clean, including `check-sprint-append` (archive still frozen at 82 entries) and `check-declared-backing`.