### PR TITLE
docs: document vsock binary protocol over guest agent and FlowMux

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,29 @@ The admitted domain cannot represent the removed raw-network mode. Every
 network operation instead receives the endpoint's one signed-plan projection:
 the same policy, per-VM resource budget, identity, and payload-free audit sink.
 
+### vsock Protocol
+
+All communication between host and guest uses **vsock**, a Linux kernel facility for guest-host messaging:
+
+**Guest agent (port 5252)**: Uses a binary protocol with length-prefixed JSON frames:
+
+- 4-byte big-endian length header indicating payload size
+- JSON serialized request/response objects
+- Connection begins with `CONNECT 5252\n` / `OK 5252\n` handshake
+
+**FlowMux (port 5253)**: Authenticated frame-based protocol for egress and ingress, supporting:
+
+- TCP connections (via SOCKS5-like framing)
+- UDP datagrams
+- DNS queries
+- Typed connectors for secrets, PII detection, and audit logging
+
+All guest-to-host traffic crosses the host's control plane where it can be:
+
+- Audited (without exposing payload bytes)
+- Substituted (secrets replaced with placeholders)
+  -Admitted/denied (per signed execution plan)
+
 **The builder VM is the deliberate exception.** It runs `nix build` and does
 have a NIC, because it must reach package mirrors. It carries no untrusted
 tenant workload — a different tier with a different contract, and its network
@@ -716,11 +739,11 @@ docs** is a checked assertion, not prose. `just bdd` extracts all of them —
 currently 600+ invocations across 130+ pages, each with `file:line` provenance —
 and verifies each at one of three tiers:
 
-| Tier | What it proves | Runs |
-| --- | --- | --- |
-| `parse` | The real clap tree parses the invocation with full argument validation: a removed verb, renamed flag, rejected value, or wrong arity fails here. | Every PR, no VM |
-| `exec` | Additionally executed for real against an isolated `MVM_HOME`. | Every PR, no VM |
-| `live` | Additionally boots a real microVM. | `MVM_BDD_LIVE=1`, KVM/HVF host |
+| Tier    | What it proves                                                                                                                                   | Runs                           |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| `parse` | The real clap tree parses the invocation with full argument validation: a removed verb, renamed flag, rejected value, or wrong arity fails here. | Every PR, no VM                |
+| `exec`  | Additionally executed for real against an isolated `MVM_HOME`.                                                                                   | Every PR, no VM                |
+| `live`  | Additionally boots a real microVM.                                                                                                               | `MVM_BDD_LIVE=1`, KVM/HVF host |
 
 The tier assignment in `features/suites/s29_doc_examples/tiers.toml` is
 **total**: a documented command with no entry fails the suite by name, so a

--- a/public/src/content/docs/guides/networking.md
+++ b/public/src/content/docs/guides/networking.md
@@ -7,12 +7,12 @@ description: Network layout and connectivity in mvmctl microVMs.
 
 Networking differs by backend:
 
-| Backend | Network Type | Guest IP | Host Access |
-|---------|-------------|----------|-------------|
-| Firecracker (Linux native) | NIC-less vsock egress | — | Host endpoint; default-deny policy gate |
-| HVF (macOS 26+, default) | NIC-less vsock egress | — | Host endpoint; default-deny policy gate |
-| libkrun (macOS) | NIC-less vsock egress | — | Host endpoint; default-deny policy gate |
-| QEMU (Linux dev/test) | Rootless user-mode virtio | 10.0.2.15/24 | QEMU user-mode network; outside production claims |
+| Backend                    | Network Type              | Guest IP     | Host Access                                       |
+| -------------------------- | ------------------------- | ------------ | ------------------------------------------------- |
+| Firecracker (Linux native) | NIC-less vsock egress     | —            | Host endpoint; default-deny policy gate           |
+| HVF (macOS 26+, default)   | NIC-less vsock egress     | —            | Host endpoint; default-deny policy gate           |
+| libkrun (macOS)            | NIC-less vsock egress     | —            | Host endpoint; default-deny policy gate           |
+| QEMU (Linux dev/test)      | Rootless user-mode virtio | 10.0.2.15/24 | QEMU user-mode network; outside production claims |
 
 ## Production Network Layout
 
@@ -68,14 +68,42 @@ refused; update the machine declaration and restart when the mapping changes.
 
 ## vsock Communication
 
-MicroVMs don't use networking for host communication -- they use **vsock**:
+MicroVMs don't use networking for host communication -- they use **vsock** with two distinct protocols:
 
-| Port | Protocol | Purpose |
-|------|----------|---------|
-| 5252 | Length-prefixed JSON | Guest agent (health checks, status, snapshot lifecycle) |
+### Guest Agent Protocol (Port 5252)
+
+The guest agent (`mvm-guest-agent`) uses a **binary protocol with length-prefixed JSON frames**:
+
+1. **Connection handshake**:
+   - Host writes `CONNECT 5252\n` to the vsock socket
+   - Agent responds with `OK 5252\n`
+
+2. **Frame structure**:
+   - **4-byte length header** (big-endian `u32`) - payload size in bytes
+   - **JSON payload** - serialized request or response object
+
+3. **Features**:
+   - Health checks
+   - Worker status tracking
+   - Snapshot lifecycle coordination
+   - Remote command execution (dev-mode only)
+   - Filesystem diff reporting
+
+### FlowMux Protocol (Port 5253)
+
+**Authenticated FlowMux frames** for all egress and ingress traffic:
+
+- TCP connections (SOCKS5-like framing)
+- UDP datagrams
+- DNS queries
+- Typed connectors for secrets, PII detection, and audit logging
+
+All traffic crosses the host's control plane for audit, secret substitution, and policy enforcement.
+
+| Port | Protocol                     | Purpose                                                          |
+| ---- | ---------------------------- | ---------------------------------------------------------------- |
+| 5252 | Length-prefixed JSON frames  | Guest agent (health checks, status, snapshot lifecycle)          |
 | 5253 | Authenticated FlowMux frames | TCP, UDP, DNS, mediated ping, typed connectors, declared ingress |
-
-The host connects by writing `CONNECT 5252\n` to the vsock socket and reading `OK 5252\n`. All requests are request/response pairs. vsock is supported on Firecracker, HVF, and microvm.nix backends.
 
 For Firecracker, the host-side vsock UDS is scoped to the running VM directory:
 `<vm-dir>/runtime/v.sock`. It is not a global or master socket. `mvmctl machine run`
@@ -166,12 +194,12 @@ mvmctl machine run --flake . --profile dev           # dev ergonomics: explicit 
 
 The resolved profile is copied into the signed `ExecutionPlan` admission record — audit/provenance data binding the declared workload intent to the chosen posture, policy refs, secret-release posture, and audit labels — so `mvmctl trust audit verify` can prove which posture was admitted.
 
-| Profile | Env injection | Host shares |
-|---------|---------------|-------------|
-| `restrictive` | none | none |
-| `standard` (default) | explicit `-e KEY=VALUE` | read-only |
-| `dev` | explicit `-e KEY=VALUE` | read-write allowed |
-| `permissive` | explicit | read-write (requires `MVM_ACK_PERMISSIVE_RUN=1`) |
+| Profile              | Env injection           | Host shares                                      |
+| -------------------- | ----------------------- | ------------------------------------------------ |
+| `restrictive`        | none                    | none                                             |
+| `standard` (default) | explicit `-e KEY=VALUE` | read-only                                        |
+| `dev`                | explicit `-e KEY=VALUE` | read-write allowed                               |
+| `permissive`         | explicit                | read-write (requires `MVM_ACK_PERMISSIVE_RUN=1`) |
 
 ## DNS
 

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -22,15 +22,15 @@ their next boot.
 
 ## Capabilities
 
-| Capability | Description |
-|------------|-------------|
-| **Health checks** | Runs per-service health commands on a schedule, reports results to the host |
-| **Worker status** | Tracks idle/busy state by sampling `/proc/loadavg` — used by fleet autoscaling |
-| **Snapshot lifecycle** | Coordinates sleep/wake: flushes data, drops page cache before snapshot, signals restore |
-| **Integration management** | Loads service definitions from `/etc/mvm/integrations.d/*.json` |
-| **Probes** | Loads read-only system checks from `/etc/mvm/probes.d/*.json` (disk usage, custom metrics) |
-| **Filesystem diff** | Walks the overlay upper dir to report files created, modified, or deleted since boot |
-| **Remote command** | Dev-only: execute commands inside the guest via vsock |
+| Capability                 | Description                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------ |
+| **Health checks**          | Runs per-service health commands on a schedule, reports results to the host                |
+| **Worker status**          | Tracks idle/busy state by sampling `/proc/loadavg` — used by fleet autoscaling             |
+| **Snapshot lifecycle**     | Coordinates sleep/wake: flushes data, drops page cache before snapshot, signals restore    |
+| **Integration management** | Loads service definitions from `/etc/mvm/integrations.d/*.json`                            |
+| **Probes**                 | Loads read-only system checks from `/etc/mvm/probes.d/*.json` (disk usage, custom metrics) |
+| **Filesystem diff**        | Walks the overlay upper dir to report files created, modified, or deleted since boot       |
+| **Remote command**         | Dev-only: execute commands inside the guest via vsock                                      |
 
 ## Runtime location
 
@@ -53,14 +53,36 @@ and version-pinned for the life of a running VM.
 
 ## Protocol
 
-The agent communicates using **length-prefixed JSON frames** over vsock on every
-supported microVM backend:
+The agent communicates using a **binary protocol with length-prefixed JSON frames** over vsock on every supported microVM backend.
+
+### Frame Structure
+
+Each message consists of:
+
+1. **4-byte length header** (big-endian `u32`) - the size of the JSON payload in bytes
+2. **JSON payload** - a serialized request or response object
+
+```
+[4-byte length][JSON payload bytes...]
+```
+
+### Connection Establishment
 
 1. Host writes `CONNECT 5252\n` to the socket
 2. Agent responds with `OK 5252\n`
-3. All subsequent communication is request/response pairs
+3. All subsequent communication uses length-prefixed frames
 
-Request types: `ping`, `status`, `sleep-prep`, `wake`, and more.
+### Request/Response Flow
+
+Each request receives exactly one response:
+
+- **Requests** are serialized JSON objects with a `type` field indicating the verb (e.g., `{"ping": {}}`)
+- **Responses** are serialized JSON objects with a `type` field indicating the response type (e.g., `{"pong": {}}`)
+
+### Frame Size Limits
+
+- Maximum frame size: **256 KiB** (including length header + JSON payload)
+- User-content chunks: **15.5 KiB** maximum (for streaming operations)
 
 ## Control plane and data plane
 
@@ -87,37 +109,37 @@ orthogonal to the agent profile gate: `Exec` is dev-only and data-plane;
 
 Small bounded JSON in and out, with no user process or file payload bytes.
 
-| Verb | Response shape | Notes |
-|---|---|---|
-| `ProtocolHello` | `ProtocolHelloAck` / `ProtocolMismatch` | Required first request in every session; protocol v2 is a hard cutover. |
-| `Ping` | `Pong` | Reachability probe. Requires `Ping` capability. |
-| `WorkerStatus` | `WorkerStatus { status, last_busy_at }` | Idle/busy sampled from `/proc/loadavg`. |
-| `ReadinessStatus` | `ReadinessStatusReport` | Component-level readiness (see "Readiness model" below). |
-| `IntegrationStatus` | `IntegrationStatusReport { integrations: Vec<…> }` | One per declared integration. |
-| `EntrypointStatus` | `EntrypointStatusReport` | Validation result + warm-pool state. |
-| `ProbeStatus` | `ProbeStatusReport { probes: Vec<ProbeResult> }` | One per declared probe. |
-| `SleepPrep` / `Wake` / `PostRestore` / `CheckpointIntegrations` | Ack | Snapshot lifecycle handshakes. |
-| `UpdateIdleTimeout` | Ack with previous + new values | Adjusts the idle-eviction window. |
-| `MountVolume` / `UnmountVolume` | `MountVolumeResult` (closed enum) | Volume metadata only — no file contents. |
-| `ProcStart` / `ProcSignal` / `ProcKill` / `ProcList` | `ProcResult` (closed enum) | Process control. `ProcStart` accepts an `argv` up to capped length but does not echo it back. |
-| `FsStat` / `FsMkdir` / `FsRemove` / `FsMove` | `FsResult` (closed enum) | Bounded filesystem metadata and mutations. |
-| `ConsoleOpen` / `ConsoleClose` / `ConsoleResize` | Ack with vsock port | Allocates a PTY forwarder. The PTY itself runs on a different vsock port — that's the data plane. |
+| Verb                                                            | Response shape                                     | Notes                                                                                             |
+| --------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `ProtocolHello`                                                 | `ProtocolHelloAck` / `ProtocolMismatch`            | Required first request in every session; protocol v2 is a hard cutover.                           |
+| `Ping`                                                          | `Pong`                                             | Reachability probe. Requires `Ping` capability.                                                   |
+| `WorkerStatus`                                                  | `WorkerStatus { status, last_busy_at }`            | Idle/busy sampled from `/proc/loadavg`.                                                           |
+| `ReadinessStatus`                                               | `ReadinessStatusReport`                            | Component-level readiness (see "Readiness model" below).                                          |
+| `IntegrationStatus`                                             | `IntegrationStatusReport { integrations: Vec<…> }` | One per declared integration.                                                                     |
+| `EntrypointStatus`                                              | `EntrypointStatusReport`                           | Validation result + warm-pool state.                                                              |
+| `ProbeStatus`                                                   | `ProbeStatusReport { probes: Vec<ProbeResult> }`   | One per declared probe.                                                                           |
+| `SleepPrep` / `Wake` / `PostRestore` / `CheckpointIntegrations` | Ack                                                | Snapshot lifecycle handshakes.                                                                    |
+| `UpdateIdleTimeout`                                             | Ack with previous + new values                     | Adjusts the idle-eviction window.                                                                 |
+| `MountVolume` / `UnmountVolume`                                 | `MountVolumeResult` (closed enum)                  | Volume metadata only — no file contents.                                                          |
+| `ProcStart` / `ProcSignal` / `ProcKill` / `ProcList`            | `ProcResult` (closed enum)                         | Process control. `ProcStart` accepts an `argv` up to capped length but does not echo it back.     |
+| `FsStat` / `FsMkdir` / `FsRemove` / `FsMove`                    | `FsResult` (closed enum)                           | Bounded filesystem metadata and mutations.                                                        |
+| `ConsoleOpen` / `ConsoleClose` / `ConsoleResize`                | Ack with vsock port                                | Allocates a PTY forwarder. The PTY itself runs on a different vsock port — that's the data plane. |
 
 ### Data-plane verbs
 
 Streaming, chunked, or potentially large bounded transfers. These requests
 share the 48-request data admission budget.
 
-| Verb | Flow | Frame cap | Chunk size | Terminal | Backpressure | Payload in audit? |
-|---|---|---|---|---|---|---|
-| `RunEntrypoint` | Request → `EntrypointEvent` stream | 256 KiB per event | 15.5 KiB stdout/stderr | `Exit` / `Killed` / `TimedOut` / `Error` | Bounded process buffers. | No. |
-| `ProcWait` | Request → `ProcWaitEvent` stream | 256 KiB per event | 15.5 KiB stdout/stderr | `Exit` / `Killed` / `TimedOut` / `Error` | Typed non-terminal backpressure events. | No. |
-| `ProcSendInput` | Bounded request → ack | 256 KiB | At most 15.5 KiB per protocol frame | `InputAccepted` | Caller retries subsequent chunks. | No; byte count only. |
-| `FsRead` / `FsWrite` | Repeated offset requests → bounded responses | 256 KiB | 15.5 KiB | Each chunk response | Caller advances the offset; the first write truncates and later chunks do not. | No; offsets, sizes, and counts only. |
-| `FsList` / `FsDiff` | Request → bounded metadata response | 256 KiB | Protocol-bounded result | Response itself | Result caps and frame cap fail closed. | No file contents. |
-| `Exec` / `ExecBatch` / `RunCode` (dev-only) | One-shot request and capture | 256 KiB | Protocol-bounded result | Response itself | Oversized encoded responses fail closed. | No. |
-| Console PTY traffic | Raw bytes on a dedicated vsock port | Raw transport | TTY-shaped reads | Close or PTY exit | Kernel/socket backpressure; only the host CID may connect. | No. |
-| Declared ingress | Authenticated FlowMux frames on `NetworkFlow` | 256 KiB per frame | Credit-bounded stream chunks | Flow close/refusal | Shared per-VM FlowMux budget. | Metadata only; payload bytes never enter audit. |
+| Verb                                        | Flow                                          | Frame cap         | Chunk size                          | Terminal                                 | Backpressure                                                                   | Payload in audit?                               |
+| ------------------------------------------- | --------------------------------------------- | ----------------- | ----------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------- |
+| `RunEntrypoint`                             | Request → `EntrypointEvent` stream            | 256 KiB per event | 15.5 KiB stdout/stderr              | `Exit` / `Killed` / `TimedOut` / `Error` | Bounded process buffers.                                                       | No.                                             |
+| `ProcWait`                                  | Request → `ProcWaitEvent` stream              | 256 KiB per event | 15.5 KiB stdout/stderr              | `Exit` / `Killed` / `TimedOut` / `Error` | Typed non-terminal backpressure events.                                        | No.                                             |
+| `ProcSendInput`                             | Bounded request → ack                         | 256 KiB           | At most 15.5 KiB per protocol frame | `InputAccepted`                          | Caller retries subsequent chunks.                                              | No; byte count only.                            |
+| `FsRead` / `FsWrite`                        | Repeated offset requests → bounded responses  | 256 KiB           | 15.5 KiB                            | Each chunk response                      | Caller advances the offset; the first write truncates and later chunks do not. | No; offsets, sizes, and counts only.            |
+| `FsList` / `FsDiff`                         | Request → bounded metadata response           | 256 KiB           | Protocol-bounded result             | Response itself                          | Result caps and frame cap fail closed.                                         | No file contents.                               |
+| `Exec` / `ExecBatch` / `RunCode` (dev-only) | One-shot request and capture                  | 256 KiB           | Protocol-bounded result             | Response itself                          | Oversized encoded responses fail closed.                                       | No.                                             |
+| Console PTY traffic                         | Raw bytes on a dedicated vsock port           | Raw transport     | TTY-shaped reads                    | Close or PTY exit                        | Kernel/socket backpressure; only the host CID may connect.                     | No.                                             |
+| Declared ingress                            | Authenticated FlowMux frames on `NetworkFlow` | 256 KiB per frame | Credit-bounded stream chunks        | Flow close/refusal                       | Shared per-VM FlowMux budget.                                                  | Metadata only; payload bytes never enter audit. |
 
 ### Redaction invariant
 
@@ -155,11 +177,11 @@ Every guest image declares an **agent profile** in its
 dispatcher-side allowlist for vsock verbs — dev-only requests
 sent to a sealed-prod agent are rejected before any handler runs:
 
-| Profile | Effective verb set | Used by |
-|---------|-------------------|---------|
-| `sealed-prod` (default) | Lifecycle, status, entrypoint, sleep/wake, volume mount/unmount, idle-timeout updates, and the entrypoint stdin verbs `StreamInput` / `CloseStreamInput`. The full ADR-001 production-safe surface. The stdin verbs write to an entrypoint fixed at admission and select nothing; the host gates them on a grant in the signed plan, so a prod-safe verb is not an ungated one — see [Workload input](/guides/workload-input/). | Production images. The policy file lives on a dm-verity rootfs (ADR-001 §W3) so the profile cannot be widened at runtime. |
-| `dev` | `sealed-prod` plus shell `Exec`, process RPC, filesystem RPC, console PTY, port forwarding, and `RunCode`. | Dev-tier images built with the `interactive` feature — the ones `mvmctl machine console` or `mvmctl machine run -it` can attach to. |
-| `builder` | Reserved for builder-only verbs. The current builder agent speaks a separate `BuilderRequest` protocol, so this profile is wire-stable but unused for the tenant agent. | Future builder VM agent if/when its verbs land on the tenant wire. |
+| Profile                 | Effective verb set                                                                                                                                                                                                                                                                                                                                                                                                              | Used by                                                                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `sealed-prod` (default) | Lifecycle, status, entrypoint, sleep/wake, volume mount/unmount, idle-timeout updates, and the entrypoint stdin verbs `StreamInput` / `CloseStreamInput`. The full ADR-001 production-safe surface. The stdin verbs write to an entrypoint fixed at admission and select nothing; the host gates them on a grant in the signed plan, so a prod-safe verb is not an ungated one — see [Workload input](/guides/workload-input/). | Production images. The policy file lives on a dm-verity rootfs (ADR-001 §W3) so the profile cannot be widened at runtime.           |
+| `dev`                   | `sealed-prod` plus shell `Exec`, process RPC, filesystem RPC, console PTY, port forwarding, and `RunCode`.                                                                                                                                                                                                                                                                                                                      | Dev-tier images built with the `interactive` feature — the ones `mvmctl machine console` or `mvmctl machine run -it` can attach to. |
+| `builder`               | Reserved for builder-only verbs. The current builder agent speaks a separate `BuilderRequest` protocol, so this profile is wire-stable but unused for the tenant agent.                                                                                                                                                                                                                                                         | Future builder VM agent if/when its verbs land on the tenant wire.                                                                  |
 
 Rejected requests return a typed `UnsupportedInProfile` response:
 
@@ -235,12 +257,12 @@ A host queries the live state via the `ReadinessStatus` verb:
 
 `ComponentState` values:
 
-| State | Meaning |
-|-------|---------|
-| `disabled` | Subsystem isn't configured for this image (no policy → no state machine to advance). Distinct from `ready` so the host can tell "image opted out" from "still warming". |
-| `starting` | Background init in progress. `RunEntrypoint` while `entrypoint = starting` returns `NotReady` — the host should poll readiness and retry. |
-| `ready` | Subsystem is up and accepting work. |
-| `failed` | Subsystem failed to initialize. Carries a short human-readable `message` (no secrets, no host paths the caller doesn't already know). For `entrypoint`, this maps to `RunEntrypoint` returning the existing `EntrypointInvalid`. |
+| State      | Meaning                                                                                                                                                                                                                          |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `disabled` | Subsystem isn't configured for this image (no policy → no state machine to advance). Distinct from `ready` so the host can tell "image opted out" from "still warming".                                                          |
+| `starting` | Background init in progress. `RunEntrypoint` while `entrypoint = starting` returns `NotReady` — the host should poll readiness and retry.                                                                                        |
+| `ready`    | Subsystem is up and accepting work.                                                                                                                                                                                              |
+| `failed`   | Subsystem failed to initialize. Carries a short human-readable `message` (no secrets, no host paths the caller doesn't already know). For `entrypoint`, this maps to `RunEntrypoint` returning the existing `EntrypointInvalid`. |
 
 `BootTimingReport` exposes monotonic milliseconds since agent
 process start. Phase 3 closed out the per-component `*_ready_ms`


### PR DESCRIPTION
This PR documents the vsock binary protocol used for guest-host communication in mvm.

## Changes
- Add 'vsock Protocol' section to README covering guest agent (port 5252) binary protocol with length-prefixed JSON frames and FlowMux (port 5253)
- Expand guest-agent.md Protocol section with frame structure, handshake, and size limits  
- Enhance networking.md with detailed vsock Communication section for both protocols

## Protocol Details

### Guest Agent (port 5252)
- Binary protocol with length-prefixed JSON frames
- 4-byte big-endian length header + JSON payload
- Connection: CONNECT 5252\n / OK 5252\n handshake

### FlowMux (port 5253)
- Authenticated frame-based egress/ingress
- TCP, UDP, DNS, and typed connectors support
- All traffic crosses host control plane for audit, secret substitution, and admission policy

Generated with Qwen Code