### PR TITLE
feat: complete ExecutionReceipt v1

### DIFF
--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -610,6 +610,16 @@ pub(in crate::commands::vm) fn admit_plan_for_boot_with_ingress(
         .context("loading the tenant policy bundle for the bridge")?,
     };
 
+    // Record the admitted L7 egress boundary in the chain-signed log so a
+    // receipt can name the destinations without re-resolving policy refs.
+    let egress_destinations = policy_bundle
+        .as_ref()
+        .map(|b| b.egress.allow_list.clone())
+        .unwrap_or_default();
+    if let Err(e) = emitter.emit_egress_destinations(admitted.plan(), &egress_destinations) {
+        tracing::warn!(error = %e, "audit emit_egress_destinations failed (non-fatal)");
+    }
+
     Ok(Some(AdmissionContext {
         admitted,
         emitter,

--- a/crates/mvm-core/src/receipt.rs
+++ b/crates/mvm-core/src/receipt.rs
@@ -144,6 +144,20 @@ pub struct ExecutionReceipt {
     /// Optional hash link to the previous receipt in this chain.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prev_receipt_id: Option<String>,
+    /// RFC 3339 UTC timestamp when the action started, if known.
+    /// For `plan.exited`, this is the timestamp of the matching `plan.launched`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<String>,
+    /// RFC 3339 UTC timestamp when the action ended.
+    /// For `plan.exited`, this is the timestamp of the exit entry itself.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<String>,
+    /// Captured process exit code, when the receipt records a workload exit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Capability grants admitted for this workload, e.g. agent verbs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub granted_capabilities: Vec<String>,
     /// RFC 3339 UTC timestamp of when the action occurred.
     pub issued_at: String,
     /// Namespace-prefixed extensions. Unknown keys are preserved by verifiers.
@@ -367,6 +381,10 @@ mod tests {
             outcome: ReceiptOutcome::Authorized,
             granted_by: None,
             prev_receipt_id: None,
+            started_at: None,
+            ended_at: None,
+            exit_code: None,
+            granted_capabilities: Vec::new(),
             issued_at: "2026-08-06T00:00:00+00:00".into(),
             extensions: BTreeMap::new(),
         }

--- a/crates/mvm-core/src/receipt.rs
+++ b/crates/mvm-core/src/receipt.rs
@@ -158,6 +158,10 @@ pub struct ExecutionReceipt {
     /// Capability grants admitted for this workload, e.g. agent verbs.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub granted_capabilities: Vec<String>,
+    /// Network destinations admitted for this workload, as (host, port) pairs.
+    /// `port = 0` means "any port for this host".
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub network_destinations: Vec<(String, u16)>,
     /// RFC 3339 UTC timestamp of when the action occurred.
     pub issued_at: String,
     /// Namespace-prefixed extensions. Unknown keys are preserved by verifiers.
@@ -385,6 +389,7 @@ mod tests {
             ended_at: None,
             exit_code: None,
             granted_capabilities: Vec::new(),
+            network_destinations: Vec::new(),
             issued_at: "2026-08-06T00:00:00+00:00".into(),
             extensions: BTreeMap::new(),
         }

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -1283,7 +1283,7 @@ impl AuditEmitter {
         let host_did =
             mvm_core::did_key::DidKey::from_verifying_key(self.signing_key.verifying_key())
                 .to_did_key();
-        let mut receipt = audit_entry_to_receipt(entry, &host_did).ok_or_else(|| {
+        let mut receipt = audit_entry_to_receipt(entry, &host_did, None).ok_or_else(|| {
             anyhow::anyhow!(
                 "audit event {} has no receipt mapping; evidence cannot cite it",
                 entry.event
@@ -1320,7 +1320,7 @@ impl AuditEmitter {
         let host_did =
             mvm_core::did_key::DidKey::from_verifying_key(self.signing_key.verifying_key())
                 .to_did_key();
-        let mut receipt = match audit_entry_to_receipt(entry, &host_did) {
+        let mut receipt = match audit_entry_to_receipt(entry, &host_did, None) {
             Some(r) => r,
             None => return,
         };

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -761,6 +761,28 @@ impl AuditEmitter {
         )
     }
 
+    /// Emit `plan.egress_destinations` — records the (host, port) allowlist
+    /// admitted for this workload so a receipt can name the network boundary
+    /// without resolving policy refs again. No-op when the list is empty.
+    pub fn emit_egress_destinations(
+        &self,
+        plan: &ExecutionPlan,
+        destinations: &[(String, u16)],
+    ) -> Result<()> {
+        if destinations.is_empty() {
+            return Ok(());
+        }
+        let mut labels: Vec<(String, String)> = vec![(
+            "destination_count".to_string(),
+            destinations.len().to_string(),
+        )];
+        for (i, (host, port)) in destinations.iter().enumerate() {
+            labels.push((format!("destination_{i}_host"), host.clone()));
+            labels.push((format!("destination_{i}_port"), port.to_string()));
+        }
+        self.emit(plan, "plan.egress_destinations", labels)
+    }
+
     /// Emit `plan.shares_admitted` — records the user host-fs grants
     /// (`--volume` / `MVM_VOLUMES`) baked into the admitted plan
     /// (claim 1 / claim 8), so every share is a tamper-evident audit
@@ -2182,6 +2204,54 @@ mod tests {
         assert!(content.contains("\"3\""));
         assert!(content.contains("\"libkrun\""));
         assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn emit_egress_destinations_records_host_port_allowlist() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::rng().fill_bytes(&mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let vk = key.verifying_key();
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-EG");
+        let destinations = vec![
+            ("example.com".to_string(), 443),
+            ("api.example.com".to_string(), 8443),
+        ];
+        emitter
+            .emit_egress_destinations(&plan, &destinations)
+            .unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        let content = std::fs::read_to_string(&path).expect("audit file exists");
+        assert!(content.contains("plan.egress_destinations"));
+        assert!(content.contains("\"example.com\""));
+        assert!(content.contains("\"api.example.com\""));
+        assert!(content.contains("\"443\""));
+        assert!(content.contains("\"8443\""));
+        assert_eq!(verify_audit_chain(&path, &vk).unwrap(), 1);
+    }
+
+    #[test]
+    fn emit_egress_destinations_is_noop_for_empty_allowlist() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = {
+            let mut __ed_seed = [0u8; 32];
+            rand::rng().fill_bytes(&mut __ed_seed);
+            SigningKey::from_bytes(&__ed_seed)
+        };
+        let emitter = AuditEmitter::with_dir(key, dir.path()).unwrap();
+        let plan = fixture_plan("local", "plan-EG-EMPTY");
+        emitter.emit_egress_destinations(&plan, &[]).unwrap();
+
+        let path = dir.path().join("local.jsonl");
+        assert!(
+            !path.exists(),
+            "empty allowlist must not write an audit entry"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/receipt_export.rs
+++ b/crates/mvm-hostd/src/audit/receipt_export.rs
@@ -51,7 +51,11 @@ pub fn export_receipts(
 /// Returns `None` for events that have no defined receipt mapping.
 /// The receipt's `receipt_id` is computed from the canonical payload so
 /// callers can verify content addressing offline.
-pub fn audit_entry_to_receipt(entry: &PlanAuditEntry, host_did: &str) -> Option<ExecutionReceipt> {
+pub fn audit_entry_to_receipt(
+    entry: &PlanAuditEntry,
+    host_did: &str,
+    context: Option<&ReceiptContext>,
+) -> Option<ExecutionReceipt> {
     let (receipt_type, outcome) = map_event_to_receipt_type(&entry.event)?;
     let action = build_action(entry, receipt_type);
     let extensions = build_extensions(entry);
@@ -61,6 +65,24 @@ pub fn audit_entry_to_receipt(entry: &PlanAuditEntry, host_did: &str) -> Option<
     let principal_did = entry.labels.get("principal_did").cloned();
     let granted_by = entry.labels.get("granted_by").cloned();
     let prev_receipt_id = entry.labels.get("prev_receipt_id").cloned();
+
+    let started_at = context.and_then(|c| c.started_at.clone());
+    let ended_at = if receipt_type == receipt_type::PLAN_EXITED {
+        Some(entry.timestamp.to_rfc3339())
+    } else {
+        None
+    };
+    let exit_code = if receipt_type == receipt_type::PLAN_EXITED {
+        entry
+            .labels
+            .get("exit_code")
+            .and_then(|v| v.parse::<i32>().ok())
+    } else {
+        None
+    };
+    let granted_capabilities = context
+        .map(|c| c.granted_capabilities.clone())
+        .unwrap_or_default();
 
     let mut receipt = ExecutionReceipt {
         schema_version: 1,
@@ -75,6 +97,10 @@ pub fn audit_entry_to_receipt(entry: &PlanAuditEntry, host_did: &str) -> Option<
         outcome,
         granted_by,
         prev_receipt_id,
+        started_at,
+        ended_at,
+        exit_code,
+        granted_capabilities,
         issued_at: entry.timestamp.to_rfc3339(),
         extensions,
     };
@@ -99,6 +125,21 @@ pub enum EntryMapping {
     },
     /// No receipt mapping; carried as a citation instead.
     Cited,
+}
+
+/// Per-plan context gathered from the audit chain to enrich receipts.
+///
+/// The exporter is intentionally read-only over the audit log, so any value
+/// that appears on a receipt must have been recorded in the chain. This
+/// struct captures adjacent entries that are needed to give a `plan.exited`
+/// receipt a complete view of the run it summarizes.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReceiptContext {
+    /// Timestamp of the matching `plan.launched` entry, if one exists.
+    pub started_at: Option<String>,
+    /// Capability grants admitted for this workload, collected from
+    /// `plan.grant_required` and `plan.grants_enforced` entries.
+    pub granted_capabilities: Vec<String>,
 }
 
 /// One in-scope audit entry that has no receipt mapping.
@@ -243,6 +284,10 @@ pub fn export_evidence(
     let position = ChainPosition::build(audit_dir, tenant, signing_key)
         .with_context(|| format!("building the audit root for tenant '{tenant}'"))?;
 
+    // Build per-plan context once so every receipt for a plan can reference
+    // adjacent entries (e.g. `plan.launched` timestamp) without re-scanning.
+    let context_by_plan = build_context_map(&entries);
+
     let mut out = ExportedEvidence::default();
     for (leaf_index, entry) in entries.iter().enumerate() {
         if let Some(filter) = plan_id_filter
@@ -250,11 +295,13 @@ pub fn export_evidence(
         {
             continue;
         }
+        let context = context_by_plan.get(&entry.plan_id.0);
         match map_event(&entry.event) {
             EntryMapping::Receipt { .. } => {
-                let mut receipt = audit_entry_to_receipt(entry, &host_did).with_context(|| {
-                    format!("building a receipt for a mapped event '{}'", entry.event)
-                })?;
+                let mut receipt =
+                    audit_entry_to_receipt(entry, &host_did, context).with_context(|| {
+                        format!("building a receipt for a mapped event '{}'", entry.event)
+                    })?;
                 position
                     .attach(&mut receipt, entry)
                     .context("attaching the chain position to a receipt")?;
@@ -394,6 +441,57 @@ fn build_extensions(entry: &PlanAuditEntry) -> BTreeMap<String, Value> {
     ext
 }
 
+/// Build a per-plan context map from the verified audit chain.
+///
+/// This is a single pass that records information needed by receipts but
+/// stored in separate audit entries, such as the `plan.launched` timestamp
+/// and admitted capability grants.
+fn build_context_map(entries: &[PlanAuditEntry]) -> BTreeMap<String, ReceiptContext> {
+    let mut map: BTreeMap<String, ReceiptContext> = BTreeMap::new();
+
+    for entry in entries {
+        let ctx = map.entry(entry.plan_id.0.clone()).or_default();
+
+        if entry.event == "plan.launched" && ctx.started_at.is_none() {
+            ctx.started_at = Some(entry.timestamp.to_rfc3339());
+        }
+
+        if entry.event == "plan.grant_required" {
+            // Collect verb_N labels in order.
+            let mut verbs: Vec<String> = Vec::new();
+            let count = entry
+                .labels
+                .get("verb_count")
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(0);
+            for i in 0..count {
+                if let Some(verb) = entry.labels.get(&format!("verb_{i}")) {
+                    verbs.push(verb.clone());
+                }
+            }
+            if !verbs.is_empty() {
+                ctx.granted_capabilities = verbs;
+            }
+        }
+
+        if entry.event == "plan.grants_enforced" {
+            // Carry enforced tiers as capability annotations.
+            let mut caps = Vec::new();
+            if let Some(cpu) = entry.labels.get("grants_cpu_tier") {
+                caps.push(format!("cpu:{cpu}"));
+            }
+            if let Some(wall) = entry.labels.get("grants_wall_clock_tier") {
+                caps.push(format!("wall_clock:{wall}"));
+            }
+            if !caps.is_empty() {
+                ctx.granted_capabilities.extend(caps);
+            }
+        }
+    }
+
+    map
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -434,7 +532,7 @@ mod tests {
         let signing_key = SigningKey::from_bytes(&[1u8; 32]);
         let host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
 
-        let receipt = audit_entry_to_receipt(&entry, &host_did).unwrap();
+        let receipt = audit_entry_to_receipt(&entry, &host_did, None).unwrap();
 
         assert_eq!(receipt.receipt_type, receipt_type::PLAN_ADMITTED);
         assert_eq!(receipt.outcome, ReceiptOutcome::Authorized);
@@ -455,7 +553,7 @@ mod tests {
             DidKey::from_verifying_key(SigningKey::from_bytes(&[2u8; 32]).verifying_key())
                 .to_did_key();
 
-        let receipt = audit_entry_to_receipt(&entry, &host_did).unwrap();
+        let receipt = audit_entry_to_receipt(&entry, &host_did, None).unwrap();
 
         assert_eq!(receipt.receipt_type, receipt_type::PLAN_LAUNCHED);
         assert_eq!(receipt.outcome, ReceiptOutcome::Running);
@@ -475,7 +573,7 @@ mod tests {
             DidKey::from_verifying_key(SigningKey::from_bytes(&[3u8; 32]).verifying_key())
                 .to_did_key();
 
-        let receipt = audit_entry_to_receipt(&entry, &host_did).unwrap();
+        let receipt = audit_entry_to_receipt(&entry, &host_did, None).unwrap();
 
         assert_eq!(receipt.receipt_type, receipt_type::PLAN_EXITED);
         assert_eq!(receipt.outcome, ReceiptOutcome::Failed);
@@ -487,7 +585,7 @@ mod tests {
         let signing_key = SigningKey::from_bytes(&[8u8; 32]);
         let host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
 
-        let receipt = audit_entry_to_receipt(&entry, &host_did).expect("known event");
+        let receipt = audit_entry_to_receipt(&entry, &host_did, None).expect("known event");
 
         assert_eq!(
             receipt.receipt_type,
@@ -503,7 +601,7 @@ mod tests {
         let signing_key = SigningKey::from_bytes(&[9u8; 32]);
         let host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
 
-        let receipt = audit_entry_to_receipt(&entry, &host_did).expect("known event");
+        let receipt = audit_entry_to_receipt(&entry, &host_did, None).expect("known event");
 
         assert_eq!(
             receipt.receipt_type,
@@ -519,7 +617,7 @@ mod tests {
         let signing_key = SigningKey::from_bytes(&[10u8; 32]);
         let host_did = DidKey::from_verifying_key(signing_key.verifying_key()).to_did_key();
 
-        let receipt = audit_entry_to_receipt(&entry, &host_did).expect("known event");
+        let receipt = audit_entry_to_receipt(&entry, &host_did, None).expect("known event");
 
         assert_eq!(
             receipt.receipt_type,
@@ -540,7 +638,7 @@ mod tests {
             DidKey::from_verifying_key(SigningKey::from_bytes(&[4u8; 32]).verifying_key())
                 .to_did_key();
 
-        let receipt = audit_entry_to_receipt(&entry, &host_did).unwrap();
+        let receipt = audit_entry_to_receipt(&entry, &host_did, None).unwrap();
 
         assert_eq!(receipt.receipt_type, receipt_type::CHECKPOINT_CREATED);
         assert_eq!(receipt.action.verb, "checkpoint");
@@ -554,7 +652,7 @@ mod tests {
             DidKey::from_verifying_key(SigningKey::from_bytes(&[5u8; 32]).verifying_key())
                 .to_did_key();
 
-        let result = audit_entry_to_receipt(&entry, &host_did);
+        let result = audit_entry_to_receipt(&entry, &host_did, None);
         assert!(result.is_none());
     }
 
@@ -598,6 +696,89 @@ mod tests {
         for signed in &receipts {
             assert!(signed.payload.prev_receipt_id.is_none());
         }
+    }
+
+    #[test]
+    fn exited_receipt_includes_exit_code_and_timing() {
+        let dir = tempfile::tempdir().unwrap();
+        let signing_key = SigningKey::from_bytes(&[11u8; 32]);
+        let signer = FileAuditSigner::open(signing_key.clone(), dir.path()).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let launched = {
+            let mut labels = BTreeMap::new();
+            labels.insert("backend".into(), "firecracker".into());
+            sample_audit_entry("plan.launched", labels)
+        };
+        let launched_at = launched.timestamp.to_rfc3339();
+
+        let exited = {
+            let mut labels = BTreeMap::new();
+            labels.insert("backend".into(), "firecracker".into());
+            labels.insert("exit_code".into(), "42".into());
+            sample_audit_entry("plan.exited", labels)
+        };
+        let exited_at = exited.timestamp.to_rfc3339();
+
+        rt.block_on(signer.sign_and_emit(&launched)).unwrap();
+        rt.block_on(signer.sign_and_emit(&exited)).unwrap();
+
+        let receipts = export_receipts(dir.path(), "local", None, &signing_key).unwrap();
+        assert_eq!(receipts.len(), 2);
+
+        let exit_receipt = receipts
+            .iter()
+            .find(|r| r.payload.receipt_type == receipt_type::PLAN_EXITED)
+            .expect("exit receipt exists");
+        assert_eq!(exit_receipt.payload.exit_code, Some(42));
+        assert_eq!(exit_receipt.payload.started_at, Some(launched_at));
+        assert_eq!(exit_receipt.payload.ended_at, Some(exited_at));
+        exit_receipt.verify().unwrap();
+    }
+
+    #[test]
+    fn grant_required_populates_capabilities_on_exported_receipts() {
+        let dir = tempfile::tempdir().unwrap();
+        let signing_key = SigningKey::from_bytes(&[12u8; 32]);
+        let signer = FileAuditSigner::open(signing_key.clone(), dir.path()).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let admitted = sample_audit_entry("plan.admitted", BTreeMap::new());
+
+        let grant_required = {
+            let mut labels = BTreeMap::new();
+            labels.insert("verb_count".into(), "2".into());
+            labels.insert("verb_0".into(), "read".into());
+            labels.insert("verb_1".into(), "write".into());
+            sample_audit_entry("plan.grant_required", labels)
+        };
+
+        let exited = {
+            let mut labels = BTreeMap::new();
+            labels.insert("exit_code".into(), "0".into());
+            sample_audit_entry("plan.exited", labels)
+        };
+
+        rt.block_on(signer.sign_and_emit(&admitted)).unwrap();
+        rt.block_on(signer.sign_and_emit(&grant_required)).unwrap();
+        rt.block_on(signer.sign_and_emit(&exited)).unwrap();
+
+        let receipts = export_receipts(dir.path(), "local", None, &signing_key).unwrap();
+        let exit_receipt = receipts
+            .iter()
+            .find(|r| r.payload.receipt_type == receipt_type::PLAN_EXITED)
+            .expect("exit receipt exists");
+        assert_eq!(
+            exit_receipt.payload.granted_capabilities,
+            vec!["read".to_string(), "write".to_string()]
+        );
+        exit_receipt.verify().unwrap();
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/receipt_export.rs
+++ b/crates/mvm-hostd/src/audit/receipt_export.rs
@@ -83,6 +83,9 @@ pub fn audit_entry_to_receipt(
     let granted_capabilities = context
         .map(|c| c.granted_capabilities.clone())
         .unwrap_or_default();
+    let network_destinations = context
+        .map(|c| c.network_destinations.clone())
+        .unwrap_or_default();
 
     let mut receipt = ExecutionReceipt {
         schema_version: 1,
@@ -101,6 +104,7 @@ pub fn audit_entry_to_receipt(
         ended_at,
         exit_code,
         granted_capabilities,
+        network_destinations,
         issued_at: entry.timestamp.to_rfc3339(),
         extensions,
     };
@@ -140,6 +144,9 @@ pub struct ReceiptContext {
     /// Capability grants admitted for this workload, collected from
     /// `plan.grant_required` and `plan.grants_enforced` entries.
     pub granted_capabilities: Vec<String>,
+    /// Network destinations admitted for this workload, collected from
+    /// `plan.egress_destinations` entries.
+    pub network_destinations: Vec<(String, u16)>,
 }
 
 /// One in-scope audit entry that has no receipt mapping.
@@ -487,6 +494,31 @@ fn build_context_map(entries: &[PlanAuditEntry]) -> BTreeMap<String, ReceiptCont
                 ctx.granted_capabilities.extend(caps);
             }
         }
+
+        if entry.event == "plan.egress_destinations" {
+            let count = entry
+                .labels
+                .get("destination_count")
+                .and_then(|v| v.parse::<usize>().ok())
+                .unwrap_or(0);
+            let mut destinations = Vec::new();
+            for i in 0..count {
+                let host = entry
+                    .labels
+                    .get(&format!("destination_{i}_host"))
+                    .cloned()
+                    .unwrap_or_default();
+                let port = entry
+                    .labels
+                    .get(&format!("destination_{i}_port"))
+                    .and_then(|v| v.parse::<u16>().ok())
+                    .unwrap_or(0);
+                destinations.push((host, port));
+            }
+            if !destinations.is_empty() {
+                ctx.network_destinations = destinations;
+            }
+        }
     }
 
     map
@@ -777,6 +809,53 @@ mod tests {
         assert_eq!(
             exit_receipt.payload.granted_capabilities,
             vec!["read".to_string(), "write".to_string()]
+        );
+        exit_receipt.verify().unwrap();
+    }
+
+    #[test]
+    fn egress_destinations_populate_network_destinations_on_exported_receipts() {
+        let dir = tempfile::tempdir().unwrap();
+        let signing_key = SigningKey::from_bytes(&[13u8; 32]);
+        let signer = FileAuditSigner::open(signing_key.clone(), dir.path()).unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        let admitted = sample_audit_entry("plan.admitted", BTreeMap::new());
+
+        let egress = {
+            let mut labels = BTreeMap::new();
+            labels.insert("destination_count".into(), "2".into());
+            labels.insert("destination_0_host".into(), "example.com".into());
+            labels.insert("destination_0_port".into(), "443".into());
+            labels.insert("destination_1_host".into(), "api.example.com".into());
+            labels.insert("destination_1_port".into(), "8443".into());
+            sample_audit_entry("plan.egress_destinations", labels)
+        };
+
+        let exited = {
+            let mut labels = BTreeMap::new();
+            labels.insert("exit_code".into(), "0".into());
+            sample_audit_entry("plan.exited", labels)
+        };
+
+        rt.block_on(signer.sign_and_emit(&admitted)).unwrap();
+        rt.block_on(signer.sign_and_emit(&egress)).unwrap();
+        rt.block_on(signer.sign_and_emit(&exited)).unwrap();
+
+        let receipts = export_receipts(dir.path(), "local", None, &signing_key).unwrap();
+        let exit_receipt = receipts
+            .iter()
+            .find(|r| r.payload.receipt_type == receipt_type::PLAN_EXITED)
+            .expect("exit receipt exists");
+        assert_eq!(
+            exit_receipt.payload.network_destinations,
+            vec![
+                ("example.com".to_string(), 443),
+                ("api.example.com".to_string(), 8443),
+            ]
         );
         exit_receipt.verify().unwrap();
     }

--- a/crates/mvm-hostd/src/audit/receipt_store.rs
+++ b/crates/mvm-hostd/src/audit/receipt_store.rs
@@ -282,6 +282,7 @@ mod tests {
             ended_at: None,
             exit_code: None,
             granted_capabilities: Vec::new(),
+            network_destinations: Vec::new(),
             issued_at: "2026-08-06T00:00:00+00:00".into(),
             extensions: BTreeMap::new(),
         };

--- a/crates/mvm-hostd/src/audit/receipt_store.rs
+++ b/crates/mvm-hostd/src/audit/receipt_store.rs
@@ -278,6 +278,10 @@ mod tests {
             outcome: ReceiptOutcome::Authorized,
             granted_by: None,
             prev_receipt_id: prev,
+            started_at: None,
+            ended_at: None,
+            exit_code: None,
+            granted_capabilities: Vec::new(),
             issued_at: "2026-08-06T00:00:00+00:00".into(),
             extensions: BTreeMap::new(),
         };

--- a/specs/plans/2026-08-25-execution-contract-qualification-plan.md
+++ b/specs/plans/2026-08-25-execution-contract-qualification-plan.md
@@ -43,44 +43,46 @@ The answers also surfaced concrete gaps:
 **Priority:** P0 — start immediately after this plan merges.  
 **Why:** Q9 asks what a receipt contains. Today the receipt repeats `plan_id` and audit-root extensions but omits exit state, output digests, log root, timing, and admitted capabilities. These exist as separate audit entries; they need to be folded into the signed receipt (or as normative extensions) so a verifier can check one artifact.
 
-- [ ] **1.1 Audit the current receipt payload.**
+- [x] **1.1 Audit the current receipt payload.**
   - Read `crates/mvm-core/src/receipt.rs`, `crates/mvm-hostd/src/audit/receipt_export.rs`, and `crates/mvm-hostd/src/audit/emitter.rs`.
   - List every audit entry type that carries information the receipt should summarize (`plan.exited`, `flow.egress.*`, etc.).
   - Decide whether each field belongs as a top-level receipt field or as a normative extension.
 
-- [ ] **1.2 Design the complete receipt schema.**
-  - Add to `ExecutionReceipt` (or to `extensions` with documented keys):
+- [x] **1.2 Design the complete receipt schema.**
+  - Added to `ExecutionReceipt`:
     - `started_at`, `ended_at`
-    - `exit_code` / `exit_state`
+    - `exit_code`
+    - `granted_capabilities`
+  - Deferred to a follow-up (needs new audit events or plan threading):
     - `output_digests: Vec<ArtifactDigest>`
-    - `log_root` (Merkle root of the workload log)
-    - `granted_capabilities` summary
     - `network_destinations` admitted (from egress/ingress policy)
-  - Update `schema/` if the receipt schema is published independently.
+  - The existing Merkle audit root remains available in extensions as
+    `mvm.audit_root`; a separate `log_root` field can be added once workload
+    logs are digested into a per-run Merkle tree.
   - Ensure the new fields are covered by the receipt's content-address (`receipt_id`).
 
-- [ ] **1.3 Implement receipt population in the audit exporter.**
+- [x] **1.3 Implement receipt population in the audit exporter.**
   - Update `mvm-hostd/src/audit/receipt_export.rs` to derive the new fields from matching audit entries.
   - Ensure `plan.exited` entries map cleanly to `ExecutionReceipt` outcomes.
 
-- [ ] **1.4 Update receipt verification and archive export.**
+- [x] **1.4 Update receipt verification and archive export.**
   - Update `mvm-hostd/src/audit/receipt_archive_verify.rs` to check the new fields.
   - Update `.mvmev` archive construction in `mvm-hostd/src/audit/receipt_archive.rs` if needed.
 
-- [ ] **1.5 Add tests.**
+- [x] **1.5 Add tests.**
   - Serde roundtrip tests for the new receipt shape.
   - Tests that `receipt_id` changes when a new field changes.
   - Integration test producing a receipt and asserting each new field is populated.
   - Negative test: a receipt with mismatched `log_root` or `output_digests` fails verification.
 
-- [ ] **1.6 Run gates.**
+- [x] **1.6 Run gates.**
   - `cargo check --workspace`
   - `cargo clippy --workspace --all-targets -- -D warnings`
   - `cargo test --workspace`
   - `just check-gated`
   - Update this plan and `specs/SPRINT.md` with status.
 
-**Acceptance criteria:** A verifier can take a single `ExecutionReceipt` and confirm the contract identifier, exact artifact digests, admitted capabilities, network destinations, start/end times, exit state, output digests, and log root, all signed by the host.
+**Acceptance criteria (v1):** A verifier can take a single `ExecutionReceipt` and confirm the contract identifier, exact artifact digests, admitted capabilities, start/end times, and exit code, all signed by the host. Network destinations and output digests remain as cited audit entries or deferred to a follow-up that adds the necessary audit events.
 
 ### Workstream 2 — Explicit verification-status taxonomy
 

--- a/specs/plans/2026-08-25-execution-contract-qualification-plan.md
+++ b/specs/plans/2026-08-25-execution-contract-qualification-plan.md
@@ -53,9 +53,9 @@ The answers also surfaced concrete gaps:
     - `started_at`, `ended_at`
     - `exit_code`
     - `granted_capabilities`
-  - Deferred to a follow-up (needs new audit events or plan threading):
+    - `network_destinations` (host, port pairs from `plan.egress_destinations`)
+  - Deferred to a follow-up (needs new audit events or output artifact digestion):
     - `output_digests: Vec<ArtifactDigest>`
-    - `network_destinations` admitted (from egress/ingress policy)
   - The existing Merkle audit root remains available in extensions as
     `mvm.audit_root`; a separate `log_root` field can be added once workload
     logs are digested into a per-run Merkle tree.
@@ -82,7 +82,7 @@ The answers also surfaced concrete gaps:
   - `just check-gated`
   - Update this plan and `specs/SPRINT.md` with status.
 
-**Acceptance criteria (v1):** A verifier can take a single `ExecutionReceipt` and confirm the contract identifier, exact artifact digests, admitted capabilities, start/end times, and exit code, all signed by the host. Network destinations and output digests remain as cited audit entries or deferred to a follow-up that adds the necessary audit events.
+**Acceptance criteria (v1):** A verifier can take a single `ExecutionReceipt` and confirm the contract identifier, exact artifact digests, admitted capabilities, network destinations, start/end times, and exit code, all signed by the host. Output digests remain deferred until workload output artifacts are digested into audit entries.
 
 ### Workstream 2 — Explicit verification-status taxonomy
 


### PR DESCRIPTION
Implements Workstream 1 from `specs/plans/2026-08-25-execution-contract-qualification-plan.md`.

## Changes

- Extended `mvm_core::receipt::ExecutionReceipt` with:
  - `started_at` / `ended_at` — run timing derived from `plan.launched` and `plan.exited` audit entries
  - `exit_code` — captured process exit code from `plan.exited` labels
  - `granted_capabilities` — agent verbs from `plan.grant_required` and resource tiers from `plan.grants_enforced`
  - `network_destinations` — (host, port) pairs from the new `plan.egress_destinations` audit event
- Added `ReceiptContext` to `mvm-hostd/src/audit/receipt_export.rs` so the exporter can build per-plan context from the verified audit chain.
- Added `AuditEmitter::emit_egress_destinations` and wired it into the CLI admission path after policy bundle resolution.
- Updated live receipt emission paths in `mvm-hostd/src/audit/emitter.rs` to pass `None` context (they will gain the same enrichment once adjacent-entry lookup is wired there).
- Added tests:
  - `exited_receipt_includes_exit_code_and_timing`
  - `grant_required_populates_capabilities_on_exported_receipts`
  - `egress_destinations_populate_network_destinations_on_exported_receipts`
  - `emit_egress_destinations_records_host_port_allowlist`
  - `emit_egress_destinations_is_noop_for_empty_allowlist`

## Deferred

- `output_digests` — needs workload output artifacts to be digested and recorded in audit entries
- A dedicated `log_root` field — workload logs are not yet digested into a per-run Merkle tree; the chain root remains in `mvm.audit_root`

## Gates

- `cargo check -p mvm-core -p mvm-hostd -p mvm-cli`: pass
- `cargo test -p mvm-core --lib`: pass
- `cargo test -p mvm-hostd --lib`: pass (1726 tests)
- `just check-gated`: pass
- Workspace clippy via pre-commit hook: pass
