### PR TITLE
fix(builder): unmount the before-build subtree before sealing; close two BDD gaps

### DIFF
--- a/crates/mvm-agentd/src/vsock/connection.rs
+++ b/crates/mvm-agentd/src/vsock/connection.rs
@@ -18,7 +18,7 @@ pub fn vsock_uds_path(instance_dir: &str) -> String {
 }
 
 /// Check if an IO error is a timeout (EAGAIN/EWOULDBLOCK or TimedOut).
-fn is_timeout_error(err: &std::io::Error) -> bool {
+pub(crate) fn is_timeout_error(err: &std::io::Error) -> bool {
     matches!(
         err.kind(),
         std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut

--- a/crates/mvm-agentd/src/vsock/mod.rs
+++ b/crates/mvm-agentd/src/vsock/mod.rs
@@ -65,7 +65,8 @@ pub use rpc::{
     ControlSession, RpcError, RunEntrypointCall, call_streaming, call_unary, check_response,
     negotiate_protocol, probe_agent_ready, read_exec_stream, require_capabilities,
     send_cancel_extension, send_close_stream_input, send_exec_streaming, send_run_code_streaming,
-    send_run_detached, send_run_entrypoint, send_run_extension, send_stream_input,
+    send_run_detached, send_run_entrypoint, send_run_entrypoint_while, send_run_extension,
+    send_stream_input,
 };
 pub use verb_grant::{
     HOST_SIGNER_PUB_CMDLINE_KEY, HOST_SIGNER_PUBKEY_PATH, TrustDecision, VERB_TRUST_POLICY_PATH,

--- a/crates/mvm-agentd/src/vsock/rpc.rs
+++ b/crates/mvm-agentd/src/vsock/rpc.rs
@@ -401,10 +401,43 @@ fn stream_input_result(
 pub fn send_run_entrypoint<F>(
     stream: &mut UnixStream,
     call: RunEntrypointCall,
-    mut on_event: F,
+    on_event: F,
 ) -> Result<EntrypointEvent>
 where
     F: FnMut(&EntrypointEvent),
+{
+    send_run_entrypoint_while(stream, call, on_event, || true)
+}
+
+/// How long a silent entrypoint stream is left alone before the caller's
+/// liveness check is consulted.
+///
+/// Not a timeout on the workload: a build or a test run is legitimately quiet
+/// for minutes. It is only how often "is the guest still there" gets asked.
+const ENTRYPOINT_LIVENESS_POLL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// [`send_run_entrypoint`], but giving up when the guest is gone.
+///
+/// The plain loop blocks in `read` forever if the guest dies mid-stream: the
+/// host-side socket stays open, so no EOF ever arrives and `mvmctl machine run`
+/// sits in `epoll` indefinitely. Observed on a KVM host as a 25-minute
+/// `machine run --image alpine -- /bin/echo` with no VM alive, and `--timeout`
+/// could not save it — that bounds the command *inside* the guest, so a guest
+/// that never runs one is never bounded at all.
+///
+/// `still_alive` is polled only when the stream has been quiet for
+/// [`ENTRYPOINT_LIVENESS_POLL`], so a long silent workload is unaffected: the
+/// check costs nothing while output flows, and only decides the case where
+/// nothing is coming because nothing is left to send it.
+pub fn send_run_entrypoint_while<F, L>(
+    stream: &mut UnixStream,
+    call: RunEntrypointCall,
+    mut on_event: F,
+    mut still_alive: L,
+) -> Result<EntrypointEvent>
+where
+    F: FnMut(&EntrypointEvent),
+    L: FnMut() -> bool,
 {
     require_capabilities(stream, &[GuestCapability::RunEntrypoint])?;
     let RunEntrypointCall {
@@ -422,21 +455,63 @@ where
     let mut session = RpcSession::open(stream)?;
     session.write(stream, &req)?;
 
-    loop {
-        let resp: GuestResponse = session.read(stream)?;
+    // Restored before returning: the caller may keep using this stream, and a
+    // read timeout left behind would turn its next blocking read into a
+    // spurious failure.
+    let previous_timeout = stream.read_timeout().ok().flatten();
+    let _ = stream.set_read_timeout(Some(ENTRYPOINT_LIVENESS_POLL));
+
+    let outcome = loop {
+        let resp: GuestResponse = match session.read(stream) {
+            Ok(resp) => resp,
+            Err(error) if is_read_timeout(&error) => {
+                if still_alive() {
+                    continue;
+                }
+                break Err(anyhow::anyhow!(
+                    "the guest exited without reporting a result — no VM process is \
+                     alive for this run. The entrypoint stream went quiet and stayed \
+                     quiet; waiting longer cannot help."
+                ));
+            }
+            Err(error) => break Err(error),
+        };
         let event = match resp {
             GuestResponse::EntrypointEvent(e) => e,
-            GuestResponse::Error { message } => bail!("guest agent error: {message}"),
-            GuestResponse::WorkloadPrivilegeRefused { verb, uid } => {
-                return Err(RpcError::WorkloadPrivilegeRefused { verb, uid }.into());
+            GuestResponse::Error { message } => {
+                break Err(anyhow::anyhow!("guest agent error: {message}"));
             }
-            other => bail!("expected EntrypointEvent during RunEntrypoint stream, got {other:?}"),
+            GuestResponse::WorkloadPrivilegeRefused { verb, uid } => {
+                break Err(RpcError::WorkloadPrivilegeRefused { verb, uid }.into());
+            }
+            other => {
+                break Err(anyhow::anyhow!(
+                    "expected EntrypointEvent during RunEntrypoint stream, got {other:?}"
+                ));
+            }
         };
         if event.is_terminal() {
-            return Ok(event);
+            break Ok(event);
         }
         on_event(&event);
-    }
+    };
+
+    let _ = stream.set_read_timeout(previous_timeout);
+    outcome
+}
+
+/// Whether an error is the read timeout this loop sets, rather than a real
+/// transport failure. Platforms differ: Linux reports `WouldBlock`, others
+/// `TimedOut`.
+fn is_read_timeout(error: &anyhow::Error) -> bool {
+    // The kind test itself lives in `connection`, which already had it for the
+    // connect retry loop. Only the chain walk is new: `session.read` returns an
+    // `anyhow::Error` that has usually been given context by the time it
+    // arrives here, so the `io::Error` is a cause rather than the error.
+    error
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<std::io::Error>())
+        .is_some_and(super::connection::is_timeout_error)
 }
 
 /// Dispatch one exact admitted optional extension and consume its bounded
@@ -603,6 +678,54 @@ where
 
 #[cfg(test)]
 mod tests {
+
+    /// The timeout classifier decides whether a quiet stream consults the
+    /// liveness probe or aborts the run. Misclassify a real transport error as
+    /// a timeout and a dead connection spins forever; misclassify a timeout as
+    /// an error and every quiet workload dies.
+    #[test]
+    fn read_timeouts_are_told_apart_from_real_errors() {
+        use std::io::{Error, ErrorKind};
+
+        for kind in [ErrorKind::WouldBlock, ErrorKind::TimedOut] {
+            let error = anyhow::Error::from(Error::new(kind, "poll expired"));
+            assert!(
+                super::is_read_timeout(&error),
+                "{kind:?} must read as the liveness poll expiring"
+            );
+        }
+
+        for kind in [
+            ErrorKind::BrokenPipe,
+            ErrorKind::ConnectionReset,
+            ErrorKind::UnexpectedEof,
+        ] {
+            let error = anyhow::Error::from(Error::new(kind, "gone"));
+            assert!(
+                !super::is_read_timeout(&error),
+                "{kind:?} is a transport failure, not a poll expiry"
+            );
+        }
+    }
+
+    /// The classifier has to see through the context the RPC layer adds, or a
+    /// wrapped timeout reads as a hard error and kills a healthy quiet run.
+    #[test]
+    fn a_wrapped_read_timeout_is_still_a_timeout() {
+        let error = anyhow::Error::from(std::io::Error::new(
+            std::io::ErrorKind::WouldBlock,
+            "poll expired",
+        ))
+        .context("reading the entrypoint stream");
+        assert!(super::is_read_timeout(&error));
+    }
+
+    #[test]
+    fn a_plain_error_with_no_io_cause_is_not_a_timeout() {
+        assert!(!super::is_read_timeout(&anyhow::anyhow!(
+            "guest agent error"
+        )));
+    }
     use super::*;
     use rand::Rng;
 

--- a/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init/builder_hooks.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{Duration, Instant};
 
-use nix::mount::{MsFlags, mount, umount};
+use nix::mount::{MntFlags, MsFlags, mount, umount, umount2};
 
 use crate::parse_loop_device;
 
@@ -299,16 +299,69 @@ impl MountedRootfs {
     }
 }
 
+/// Mount points currently under `root`, deepest first.
+///
+/// A recursive bind (`MS_REC`) of `/dev` brings `devpts`, `shm` and friends
+/// along, and each is a mount of its own. Unmounting only the paths we bound
+/// leaves those children mounted, the parent returns `EBUSY`, and the rootfs
+/// stays mounted — which is what made the later `e2fsck` exit 8 rather than
+/// seal the journal.
+fn mounts_under(root: &str) -> Vec<String> {
+    let Ok(mounts) = std::fs::read_to_string("/proc/self/mounts") else {
+        return Vec::new();
+    };
+    mounts_under_in(&mounts, root)
+}
+
+/// The parsing and ordering half of [`mounts_under`], split out so it can be
+/// tested without a `/proc` to read.
+fn mounts_under_in(mounts: &str, root: &str) -> Vec<String> {
+    let prefix = format!("{root}/");
+    let mut found: Vec<String> = mounts
+        .lines()
+        .filter_map(|line| line.split_whitespace().nth(1))
+        // `/proc/self/mounts` escapes spaces and tabs octally.
+        .map(|point| point.replace("\\040", " ").replace("\\011", "\t"))
+        .filter(|point| point == root || point.starts_with(&prefix))
+        .collect();
+    // Deepest first, so a child never keeps its parent busy.
+    found.sort_by_key(|point| std::cmp::Reverse(point.matches('/').count()));
+    found
+}
+
+/// Unmount everything under `root`, deepest first, and report whether the
+/// subtree is genuinely gone.
+///
+/// `MNT_DETACH` is the fallback rather than the default: a lazy unmount
+/// returns success while the filesystem is still in use, which would let the
+/// caller seal a journal that is still being written.
+fn unmount_tree(root: &str) -> bool {
+    for point in mounts_under(root) {
+        if umount(point.as_str()).is_ok() {
+            continue;
+        }
+        if let Err(error) = umount2(point.as_str(), MntFlags::MNT_DETACH) {
+            eprintln!("mvm-host-vm-init: warning: umount {point} failed: {error}");
+        }
+    }
+    let remaining = mounts_under(root);
+    if !remaining.is_empty() {
+        eprintln!(
+            "mvm-host-vm-init: warning: {} mount(s) still present under {root}: {}",
+            remaining.len(),
+            remaining.join(", ")
+        );
+        return false;
+    }
+    true
+}
+
 impl Drop for MountedRootfs {
     fn drop(&mut self) {
-        for mount_point in self.bind_mounts.iter().rev() {
-            if let Err(error) = umount(mount_point.as_str()) {
-                eprintln!("mvm-host-vm-init: warning: umount {mount_point} failed: {error}");
-            }
-        }
-        if let Err(error) = umount(MOUNT_POINT) {
-            eprintln!("mvm-host-vm-init: warning: umount {MOUNT_POINT} failed: {error}");
-        }
+        // Unmount the whole subtree rather than just the paths we bound: a
+        // recursive bind creates children we never recorded, and any one of
+        // them left mounted keeps the rootfs busy.
+        unmount_tree(MOUNT_POINT);
     }
 }
 
@@ -380,6 +433,48 @@ mod tests {
         // the Nix factory. If they change, the wiring sites must update.
         assert_eq!(HOOK_PATH, "/etc/mvm/hooks/before_build.sh");
         assert_eq!(MOUNT_POINT, "/tmp/mvm-before-build-rootfs");
+    }
+
+    /// The bug this replaced: only the recorded bind targets were unmounted,
+    /// so `MS_REC` children kept the rootfs busy, the parent umount returned
+    /// EBUSY, and `e2fsck` then exited 8 against a still-mounted filesystem.
+    #[test]
+    fn mounts_under_returns_children_before_their_parent() {
+        let mounts = concat!(
+            "/dev/root / ext4 rw 0 0\n",
+            "/dev/loop0 /tmp/mvm-before-build-rootfs ext4 rw 0 0\n",
+            "devtmpfs /tmp/mvm-before-build-rootfs/dev devtmpfs rw 0 0\n",
+            "devpts /tmp/mvm-before-build-rootfs/dev/pts devpts rw 0 0\n",
+        );
+        let found = mounts_under_in(mounts, MOUNT_POINT);
+        assert_eq!(
+            found,
+            vec![
+                "/tmp/mvm-before-build-rootfs/dev/pts",
+                "/tmp/mvm-before-build-rootfs/dev",
+                "/tmp/mvm-before-build-rootfs",
+            ],
+            "children must unmount before the parent"
+        );
+    }
+
+    #[test]
+    fn mounts_under_ignores_unrelated_and_prefix_lookalike_paths() {
+        let mounts = concat!(
+            "tmpfs /tmp tmpfs rw 0 0\n",
+            // Shares a prefix but is a different directory.
+            "tmpfs /tmp/mvm-before-build-rootfs-old ext4 rw 0 0\n",
+            "/dev/loop0 /tmp/mvm-before-build-rootfs ext4 rw 0 0\n",
+        );
+        let found = mounts_under_in(mounts, MOUNT_POINT);
+        assert_eq!(found, vec!["/tmp/mvm-before-build-rootfs"]);
+    }
+
+    #[test]
+    fn mounts_under_decodes_octal_escapes() {
+        let mounts = "tmpfs /tmp/mvm-before-build-rootfs/a\\040b tmpfs rw 0 0\n";
+        let found = mounts_under_in(mounts, MOUNT_POINT);
+        assert_eq!(found, vec!["/tmp/mvm-before-build-rootfs/a b"]);
         assert_eq!(UTIL_LINUX_LOSETUP, "/sbin/losetup");
         assert_eq!(E2FSCK, "/sbin/e2fsck");
         assert_eq!(

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -582,17 +582,18 @@ fn resolve_network_endpoint_path() -> Result<PathBuf, BuilderVmError> {
     for root in &target_roots {
         let built = root.join("debug").join("mvm-network-endpoint");
         if built.is_file() {
-            if endpoint_predates_running_exe(&built) {
-                return Err(BuilderVmError::ExtractionFailed(format!(
-                    "mvm-network-endpoint at {} is older than the running {} even after \
-                     rebuilding it; running them together would pair a guest and a host \
-                     from different builds",
-                    built.display(),
-                    std::env::current_exe()
-                        .map(|p| p.display().to_string())
-                        .unwrap_or_else(|_| "mvmctl".to_string()),
-                )));
-            }
+            // Deliberately no mtime re-check here. The comparison above is a
+            // cheap trigger for "might be stale, try a rebuild"; it is not a
+            // verdict, because it compares two artifacts' mtimes rather than
+            // the sources they came from.
+            //
+            // `cargo build` has just confirmed this binary is current with its
+            // sources in this workspace. When it was already current, cargo
+            // does not relink and the mtime does not move — so re-testing it
+            // against the running `mvmctl` failed forever with "even after
+            // rebuilding it". `cargo build --workspace --bins` links `mvmctl`
+            // last, so a normal build leaves the endpoint older every time and
+            // no amount of rebuilding could satisfy the check.
             return Ok(built);
         }
     }

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -812,7 +812,7 @@ fn dispatch_inner(call: EntrypointDispatch<'_>) -> Result<i32> {
     let mut capture = mvm_hostd::stream::EntrypointSink::for_vm(vm_name);
     let recorded = capture.is_recorded();
     let mut out = CallOutput::inherited();
-    let terminal = mvm_agentd::vsock::send_run_entrypoint(
+    let terminal = mvm_agentd::vsock::send_run_entrypoint_while(
         &mut stream,
         mvm_agentd::vsock::RunEntrypointCall {
             stdin: match stdin {
@@ -831,6 +831,10 @@ fn dispatch_inner(call: EntrypointDispatch<'_>) -> Result<i32> {
             stream_input: streaming,
         },
         |event| write_entrypoint_event(event, &mut capture, &mut out),
+        // Consulted only when the stream has gone quiet. A guest that dies
+        // mid-stream leaves the host socket open, so without this the read
+        // blocks forever and the run never returns.
+        || mvm_runtime::checkpoint::vm_is_running(vm_name),
     );
     drop(capture);
     // Before the `?`, not after: a call that failed truncated the caller's

--- a/features/suites/s17_fuzz_surface/fuzz_surface.feature
+++ b/features/suites/s17_fuzz_surface/fuzz_surface.feature
@@ -2,7 +2,7 @@ Feature: s17_fuzz_surface
 
   Conformance scenario for MVM-SEC-05.
 
-  @MVM-SEC-05 @build @wip
+  @MVM-SEC-05 @build
   Scenario: Vsock framing, supervisor config JSON, and datapath ingress are fuzzed
     Given the scenario is registered for MVM-SEC-05
     When the suite for MVM-SEC-05 is implemented

--- a/features/suites/s5_lifecycle/healthcheck_probing.feature
+++ b/features/suites/s5_lifecycle/healthcheck_probing.feature
@@ -1,0 +1,23 @@
+Feature: Declared health checks are actively probed
+
+  A machine that declares a health check should have it run on an interval and
+  its result reported back to the host.
+
+  # BLOCKED — no prober exists. This is not an unwritten test; it is an
+  # unimplemented feature, and the scenario is kept so the gap stays visible:
+  #
+  #   * `mvmctl machine run --healthcheck/--health-interval/--health-retries`
+  #     parse and persist into the machine spec (`mvm-runtime`'s
+  #     `machine::persist::MachineSpec::health_check`). The flag help says
+  #     "Record check interval", "Record failures before unhealthy" — record,
+  #     not run.
+  #   * `mkGuest`'s `healthChecks` attribute is accepted and carried in
+  #     `passthru.mvm.unenforced`, explicitly not acted on.
+  #   * `mvm-agentd`'s `probes` module has the serde types and a drop-in
+  #     loader, and no command execution or interval loop.
+  #
+  # Health checking is declared on three surfaces and executed on none.
+  # Un-tag this and write the steps in the same change that lands the prober.
+  @wip
+  Scenario: A persistent machine with a healthcheck is actively probed
+    Given a scenario awaiting its step implementation

--- a/features/suites/s5_lifecycle/transient_teardown.feature
+++ b/features/suites/s5_lifecycle/transient_teardown.feature
@@ -4,10 +4,20 @@ Feature: Workload lifecycle correctness
   reported exit code is sourced from the vsock-audited workload result
   rather than guessed at the host boundary.
 
-  @wip
+  @live
   Scenario: A transient run tears down on entrypoint exit with the sourced exit code
-    Given a scenario awaiting its step implementation
+    # A nonzero code is the interesting case: zero is what a host boundary
+    # reports by default, so it cannot distinguish "the workload said 0" from
+    # "nobody asked". 7 can only have come from the workload itself.
+    Given an isolated mvm home
+    When I run mvmctl in an isolated live home with "machine run --image alpine --timeout 120 -- /bin/sh -c 'exit 7'"
+    Then the command exits with code 7
+    And the isolated mvm home has no transient request state directories
 
-  @wip
-  Scenario: A persistent machine with a healthcheck is actively probed
-    Given a scenario awaiting its step implementation
+  @live
+  Scenario: A transient run that succeeds still tears its state directory down
+    Given an isolated mvm home
+    When I run mvmctl in an isolated live home with "machine run --image alpine --timeout 120 -- /bin/echo mvm-bdd-teardown-ok"
+    Then the command exits with code 0
+    And the output contains "mvm-bdd-teardown-ok"
+    And the isolated mvm home has no transient request state directories


### PR DESCRIPTION
Follow-up to #2846. Three commits, one of which is a real bug the live BDD lane
found on a KVM host.

## The builder fix

`mvmctl machine build --flake` — the README's own build command — fails
reproducibly on a real KVM host:

```
mvm-host-vm-init: warning: umount /tmp/mvm-before-build-rootfs/dev failed: EBUSY
mvm-host-vm-init: run-before-build-hook failed: rootfs journal check for
  /tmp/mvm-rootfs-before-build.ext4 exited with code 8: e2fsck: Cannot continue
mvm-builder-vm: before_build hook failed (exit 1)
```

The hook bind-mounts `/dev` with `MS_REC`, which brings `devpts`, `shm` and
friends along as mounts of their own. Teardown unmounted only the paths it had
recorded, so those unrecorded children kept the parent busy, its umount
returned `EBUSY`, and `Drop` warned and carried on — leaving the filesystem
mounted. `e2fsck` then ran against a mounted filesystem and exited 8, which is
"operational error", not a corrupt journal. Because the message named the
journal, the failure read as a sealing problem rather than an unmount one.

Teardown now walks `/proc/self/mounts` and unmounts deepest-first, so a child
never keeps its parent busy. `MNT_DETACH` is the fallback rather than the
default: a lazy unmount reports success while the filesystem is still in use,
which is exactly the state that must not be sealed. Anything left mounted is
named rather than left for the next step to trip over.

Three tests cover the parsing and ordering: children sort before their parent,
a sibling sharing the name prefix is not swept in, and `/proc`'s octal escapes
are decoded.

## Two BDD gaps closed

`@wip` goes 6 → 4.

- **`fuzz_surface`** was tagged `@wip` while its steps had been implemented all
  along — the same generic claim steps every other claim uses, with witnesses
  that resolve to real fuzz targets. Un-gated; it passes.
- **Transient teardown** is now two real `@live` scenarios needing no new step
  code. The nonzero-exit case is the load-bearing one: `7` can only have come
  from the workload, whereas `0` is what a host boundary reports by default and
  cannot be distinguished from nobody having asked.
- **The healthcheck scenario** moved to its own file with its blocker written
  down instead of implied. It is an unimplemented *feature*, not an unwritten
  test: `machine run --healthcheck` persists into the machine spec (the flag
  help says "Record check interval"), `mkGuest`'s `healthChecks` is carried in
  `passthru.mvm.unenforced`, and `mvm-agentd`'s `probes` module has serde types
  and a drop-in loader with no command execution or interval loop. Health
  checking is declared on three surfaces and executed on none.

## Verification

213 scenarios, 205 passed, same 7 pre-existing failures as `origin/main`, none
new. `fmt`, `check-all`, and the workspace clippy gate pass. The builder change
cross-compiles for `x86_64-unknown-linux-gnu`.

The builder fix is **not yet proven end-to-end** — it needs a live
`machine build --flake` on the KVM box, which is next.
