### PR TITLE
fix(builder): make copied rootfs writable before sealing

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -138,6 +138,11 @@ pub const MVM_BUILDER_STORE_GC_GIB_ENV: &str = "MVM_BUILDER_STORE_GC_GIB";
 pub(crate) fn seal_rootfs_journal_sh(rootfs_path: &str) -> String {
     format!(
         r#"echo "mvm-builder-vm: sealing rootfs journal" >&2
+if ! chmod 0644 {rootfs_path}; then
+    echo "mvm-builder-vm: rootfs permission normalization failed" >&2
+    rm -f {rootfs_path}
+    exit 1
+fi
 set +e
 /sbin/e2fsck -p -f {rootfs_path} >&2
 fsck_rc=$?
@@ -2098,11 +2103,14 @@ mod tests {
         let journal_idx = body
             .find(r#"/sbin/e2fsck -p -f "/out/rootfs.ext4""#)
             .expect("offline rootfs journal check present");
+        let writable_idx = body
+            .find(r#"chmod 0644 "/out/rootfs.ext4""#)
+            .expect("final rootfs permission normalization present");
         let out_copy_idx = body
             .find(r#"cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4"#)
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < out_copy_idx && out_copy_idx < journal_idx,
+            hook_idx < out_copy_idx && out_copy_idx < writable_idx && writable_idx < journal_idx,
             "the exported rootfs must be checked after the hook and final copy"
         );
         let sync_idx = body
@@ -2142,6 +2150,11 @@ mod tests {
         assert!(
             body.contains("rootfs journal check failed (exit $fsck_rc)"),
             "the offline checker must fail closed for every other exit code in:\n{body}"
+        );
+        assert!(
+            body.contains("rootfs permission normalization failed")
+                && body.contains("rm -f \"/out/rootfs.ext4\""),
+            "an artifact that cannot be made writable for repair must be removed in:\n{body}"
         );
         assert!(
             !body.contains("/sbin/mvm-host-vm-init seal-rootfs-journal"),

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -1756,11 +1756,14 @@ mod tests {
         let journal_idx = body
             .find("/sbin/e2fsck -p -f \"$OUT_DIR/rootfs.ext4\"")
             .expect("offline rootfs journal check present");
+        let writable_idx = body
+            .find("chmod 0644 \"$OUT_DIR/rootfs.ext4\"")
+            .expect("final rootfs permission normalization present");
         let out_copy_idx = body
             .find("cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"")
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < out_copy_idx && out_copy_idx < journal_idx,
+            hook_idx < out_copy_idx && out_copy_idx < writable_idx && writable_idx < journal_idx,
             "the exported rootfs must be checked after the hook and final copy"
         );
         let sync_idx = body
@@ -1795,6 +1798,11 @@ mod tests {
         assert!(
             body.contains("rootfs journal check failed (exit $fsck_rc)"),
             "the offline checker must fail closed for every other exit code in:\n{body}"
+        );
+        assert!(
+            body.contains("rootfs permission normalization failed")
+                && body.contains("rm -f \"$OUT_DIR/rootfs.ext4\""),
+            "an artifact that cannot be made writable for repair must be removed in:\n{body}"
         );
         assert!(
             !body.contains("/sbin/mvm-host-vm-init seal-rootfs-journal"),


### PR DESCRIPTION
Recovers work that was stranded when PR #2852 squash-merged.

`fix/2837-rootfs-compat-closeout` carried two commits. #2852 merged the first
("keep rendered rootfs sealing self-contained"). The second — "make copied
rootfs writable before sealing" (`2e881006c9`, authored 2026-08-25 15:11) —
never landed: it is not reachable from `main`, and the two files it touches
still differ from `main` by exactly its 23 added lines.

This is the squash-merge stranding case: the PR reads as merged, the branch
looks done, and a later commit on it silently never ships. Verified by content
rather than by PR state.

Cherry-picked onto current `main` rather than reopening the original branch,
because that branch is based on a pre-#2852 `main` and a PR from it would
re-propose the already-merged commit alongside this one.

### What it does

Normalizes the copied rootfs to writable before the sealing step, and removes
an artifact that cannot be made writable rather than leaving a half-repaired
one behind. The test asserts the ordering — hook, out-copy, permission
normalization, journal — and that the failure path deletes the artifact.

### Verification

- `cargo test -p mvm-build --lib` — 649 passed, 0 failed
- Cherry-pick applied cleanly with no conflicts