### PR TITLE
fix(builder): make copied rootfs writable before sealing

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -138,6 +138,11 @@ pub const MVM_BUILDER_STORE_GC_GIB_ENV: &str = "MVM_BUILDER_STORE_GC_GIB";
 pub(crate) fn seal_rootfs_journal_sh(rootfs_path: &str) -> String {
     format!(
         r#"echo "mvm-builder-vm: sealing rootfs journal" >&2
+if ! chmod 0644 {rootfs_path}; then
+    echo "mvm-builder-vm: rootfs permission normalization failed" >&2
+    rm -f {rootfs_path}
+    exit 1
+fi
 set +e
 /sbin/e2fsck -p -f {rootfs_path} >&2
 fsck_rc=$?
@@ -2098,11 +2103,14 @@ mod tests {
         let journal_idx = body
             .find(r#"/sbin/e2fsck -p -f "/out/rootfs.ext4""#)
             .expect("offline rootfs journal check present");
+        let writable_idx = body
+            .find(r#"chmod 0644 "/out/rootfs.ext4""#)
+            .expect("final rootfs permission normalization present");
         let out_copy_idx = body
             .find(r#"cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4"#)
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < out_copy_idx && out_copy_idx < journal_idx,
+            hook_idx < out_copy_idx && out_copy_idx < writable_idx && writable_idx < journal_idx,
             "the exported rootfs must be checked after the hook and final copy"
         );
         let sync_idx = body
@@ -2142,6 +2150,11 @@ mod tests {
         assert!(
             body.contains("rootfs journal check failed (exit $fsck_rc)"),
             "the offline checker must fail closed for every other exit code in:\n{body}"
+        );
+        assert!(
+            body.contains("rootfs permission normalization failed")
+                && body.contains("rm -f \"/out/rootfs.ext4\""),
+            "an artifact that cannot be made writable for repair must be removed in:\n{body}"
         );
         assert!(
             !body.contains("/sbin/mvm-host-vm-init seal-rootfs-journal"),

--- a/crates/mvm-build/src/builder_vm_runtime.rs
+++ b/crates/mvm-build/src/builder_vm_runtime.rs
@@ -135,19 +135,23 @@ pub const MVM_BUILDER_STORE_GC_GIB_ENV: &str = "MVM_BUILDER_STORE_GC_GIB";
 /// newer host code. Running the offline checker in the generated job script
 /// therefore guarantees that the source-under-test can seal an image even
 /// when the builder image's hook-runner binary predates journal sealing.
-pub(crate) const SEAL_ROOTFS_JOURNAL_SH: &str = r#"echo "mvm-builder-vm: sealing rootfs journal" >&2
+pub(crate) fn seal_rootfs_journal_sh(rootfs_path: &str) -> String {
+    format!(
+        r#"echo "mvm-builder-vm: sealing rootfs journal" >&2
 set +e
-/sbin/e2fsck -p -f "$BUILD_HOOK_ROOTFS" >&2
+/sbin/e2fsck -p -f {rootfs_path} >&2
 fsck_rc=$?
 set -e
 case "$fsck_rc" in
   0|1) ;;
   *)
     echo "mvm-builder-vm: rootfs journal check failed (exit $fsck_rc)" >&2
-    rm -f "$BUILD_HOOK_ROOTFS"
+    rm -f {rootfs_path}
     exit "$fsck_rc"
     ;;
-esac"#;
+esac"#
+    )
+}
 
 /// Resolve the builder-store GC cap, in KiB, for substitution into the
 /// in-guest build script's `du -k` comparison. Reads
@@ -660,9 +664,8 @@ if [ "$hook_rc" -ne 0 ]; then
     rm -f "$BUILD_HOOK_ROOTFS"
     exit $hook_rc
 fi
-{seal_rootfs_journal_sh}
 cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4
-/sbin/mvm-host-vm-init seal-rootfs-journal /out/rootfs.ext4
+{seal_rootfs_journal_sh}
 sync
 rm -f "$BUILD_HOOK_ROOTFS"
 
@@ -733,7 +736,7 @@ fi
         override_flag = override_flag,
         attr_path = shell_single_quote_escape(attr_path),
         gc_cap_kib = gc_cap_kib,
-        seal_rootfs_journal_sh = SEAL_ROOTFS_JOURNAL_SH,
+        seal_rootfs_journal_sh = seal_rootfs_journal_sh("\"/out/rootfs.ext4\""),
     )
 }
 
@@ -2075,7 +2078,7 @@ mod tests {
     }
 
     #[test]
-    fn render_flake_cmd_sh_runs_before_build_hook_before_copying_artifact() {
+    fn render_flake_cmd_sh_seals_final_artifact_without_a_new_builder_subcommand() {
         let body = render_flake_cmd_sh(".", "default", false);
         // The hook runner is invoked on a writable temp copy so the Nix
         // store output is never modified in place.
@@ -2087,19 +2090,20 @@ mod tests {
             body.contains("/tmp/mvm-rootfs-before-build.ext4"),
             "missing writable temp rootfs path in:\n{body}"
         );
-        // The hook must run before the final rootfs is copied to /out.
+        // The hook must run before the final rootfs is copied to /out, and the
+        // source-rendered script must seal that exact artifact itself.
         let hook_idx = body
             .find("/sbin/mvm-host-vm-init run-before-build-hook")
             .expect("hook runner present");
         let journal_idx = body
-            .find(r#"/sbin/e2fsck -p -f "$BUILD_HOOK_ROOTFS""#)
+            .find(r#"/sbin/e2fsck -p -f "/out/rootfs.ext4""#)
             .expect("offline rootfs journal check present");
         let out_copy_idx = body
             .find(r#"cp -L "$BUILD_HOOK_ROOTFS" /out/rootfs.ext4"#)
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < journal_idx && journal_idx < out_copy_idx,
-            "the hook and offline journal check must run before /out/rootfs.ext4 is copied"
+            hook_idx < out_copy_idx && out_copy_idx < journal_idx,
+            "the exported rootfs must be checked after the hook and final copy"
         );
         let sync_idx = body
             .find("sync\nrm -f \"$BUILD_HOOK_ROOTFS\"")
@@ -2108,11 +2112,8 @@ mod tests {
             out_copy_idx < sync_idx,
             "the exported rootfs must be flushed before the temporary image is removed"
         );
-        let final_seal_idx = body
-            .find("/sbin/mvm-host-vm-init seal-rootfs-journal /out/rootfs.ext4")
-            .expect("final exported artifact journal seal present");
         assert!(
-            out_copy_idx < final_seal_idx && final_seal_idx < sync_idx,
+            out_copy_idx < journal_idx && journal_idx < sync_idx,
             "the final copied rootfs must be sealed before it is published"
         );
         // A failed hook must fail the build, leaving no partial artifact.
@@ -2141,6 +2142,10 @@ mod tests {
         assert!(
             body.contains("rootfs journal check failed (exit $fsck_rc)"),
             "the offline checker must fail closed for every other exit code in:\n{body}"
+        );
+        assert!(
+            !body.contains("/sbin/mvm-host-vm-init seal-rootfs-journal"),
+            "source-rendered jobs must remain compatible with published builder binaries that predate the seal subcommand"
         );
     }
 

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -1756,11 +1756,14 @@ mod tests {
         let journal_idx = body
             .find("/sbin/e2fsck -p -f \"$OUT_DIR/rootfs.ext4\"")
             .expect("offline rootfs journal check present");
+        let writable_idx = body
+            .find("chmod 0644 \"$OUT_DIR/rootfs.ext4\"")
+            .expect("final rootfs permission normalization present");
         let out_copy_idx = body
             .find("cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"")
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < out_copy_idx && out_copy_idx < journal_idx,
+            hook_idx < out_copy_idx && out_copy_idx < writable_idx && writable_idx < journal_idx,
             "the exported rootfs must be checked after the hook and final copy"
         );
         let sync_idx = body
@@ -1795,6 +1798,11 @@ mod tests {
         assert!(
             body.contains("rootfs journal check failed (exit $fsck_rc)"),
             "the offline checker must fail closed for every other exit code in:\n{body}"
+        );
+        assert!(
+            body.contains("rootfs permission normalization failed")
+                && body.contains("rm -f \"$OUT_DIR/rootfs.ext4\""),
+            "an artifact that cannot be made writable for repair must be removed in:\n{body}"
         );
         assert!(
             !body.contains("/sbin/mvm-host-vm-init seal-rootfs-journal"),

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -1127,9 +1127,8 @@ pub fn stage_flake_dispatch_job(
              rm -f \"$BUILD_HOOK_ROOTFS\"\n\
              exit $hook_rc\n\
          fi\n\
-         {seal_rootfs_journal_sh}\n\
          cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"\n\
-         /sbin/mvm-host-vm-init seal-rootfs-journal \"$OUT_DIR/rootfs.ext4\"\n\
+         {seal_rootfs_journal_sh}\n\
          sync\n\
          rm -f \"$BUILD_HOOK_ROOTFS\"\n\
          if [ -f \"$STORE_PATH/manifest.json\" ]; then\n\
@@ -1139,7 +1138,8 @@ pub fn stage_flake_dispatch_job(
         store_path_sidecar = STORE_PATH_SIDECAR,
         flake_ref = shell_single_quote(flake_ref),
         attr = shell_single_quote(attr),
-        seal_rootfs_journal_sh = crate::builder_vm_runtime::SEAL_ROOTFS_JOURNAL_SH,
+        seal_rootfs_journal_sh =
+            crate::builder_vm_runtime::seal_rootfs_journal_sh("\"$OUT_DIR/rootfs.ext4\""),
     );
     let cmd_path = sub.join("cmd.sh");
     std::fs::write(&cmd_path, script)?;
@@ -1735,7 +1735,7 @@ mod tests {
     }
 
     #[test]
-    fn stage_flake_dispatch_job_runs_before_build_hook_before_copying_rootfs() {
+    fn stage_flake_dispatch_job_seals_final_artifact_without_a_new_builder_subcommand() {
         let scratch = tempfile::tempdir().expect("tempdir");
         let job_dir = scratch.path().to_path_buf();
         let job_id =
@@ -1754,14 +1754,14 @@ mod tests {
             .find("/sbin/mvm-host-vm-init run-before-build-hook")
             .expect("hook runner present");
         let journal_idx = body
-            .find("/sbin/e2fsck -p -f \"$BUILD_HOOK_ROOTFS\"")
+            .find("/sbin/e2fsck -p -f \"$OUT_DIR/rootfs.ext4\"")
             .expect("offline rootfs journal check present");
         let out_copy_idx = body
             .find("cp -L \"$BUILD_HOOK_ROOTFS\" \"$OUT_DIR/rootfs.ext4\"")
             .expect("final rootfs copy present");
         assert!(
-            hook_idx < journal_idx && journal_idx < out_copy_idx,
-            "the hook and offline journal check must run before rootfs.ext4 is copied to OUT_DIR"
+            hook_idx < out_copy_idx && out_copy_idx < journal_idx,
+            "the exported rootfs must be checked after the hook and final copy"
         );
         let sync_idx = body
             .find("sync\nrm -f \"$BUILD_HOOK_ROOTFS\"")
@@ -1770,11 +1770,8 @@ mod tests {
             out_copy_idx < sync_idx,
             "the exported rootfs must be flushed before the temporary image is removed"
         );
-        let final_seal_idx = body
-            .find("/sbin/mvm-host-vm-init seal-rootfs-journal \"$OUT_DIR/rootfs.ext4\"")
-            .expect("final exported artifact journal seal present");
         assert!(
-            out_copy_idx < final_seal_idx && final_seal_idx < sync_idx,
+            out_copy_idx < journal_idx && journal_idx < sync_idx,
             "the final copied rootfs must be sealed before it is published"
         );
         assert!(
@@ -1798,6 +1795,10 @@ mod tests {
         assert!(
             body.contains("rootfs journal check failed (exit $fsck_rc)"),
             "the offline checker must fail closed for every other exit code in:\n{body}"
+        );
+        assert!(
+            !body.contains("/sbin/mvm-host-vm-init seal-rootfs-journal"),
+            "source-rendered jobs must remain compatible with published builder binaries that predate the seal subcommand"
         );
     }
 


### PR DESCRIPTION
Follow-up to #2852.

The self-contained rootfs journal seal added in #2852 runs `e2fsck -p -f` on the copied rootfs artifact. Some copy paths leave the file read-only (e.g. mode 0444), which causes `e2fsck` to fail because it cannot open the filesystem read-write for repair.

This change normalizes the copied rootfs to mode 0644 immediately before the offline journal check, and removes the artifact if normalization fails so a broken file is never published.

## Changes

- `crates/mvm-build/src/builder_vm_runtime.rs`
  - `seal_rootfs_journal_sh`: add `chmod 0644` before `e2fsck`; delete and exit on failure
- `crates/mvm-build/src/persistent_builder.rs`
  - Updated existing tests to assert the new ordering and failure path

## Verification

- `cargo test -p mvm-build` for the affected modules
- Workspace clippy via pre-commit hook
