### PR TITLE
refactor(cli): drop legacy verity initrd fallback, always use universal initramfs

### DIFF
--- a/crates/mvm-agentd/src/volume.rs
+++ b/crates/mvm-agentd/src/volume.rs
@@ -279,10 +279,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push((path.to_path_buf(), force));
-            if self.umount_busy_unless_force && !force {
-                return Ok(false);
-            }
-            Ok(true)
+            Ok(!self.umount_busy_unless_force || force)
         }
     }
 

--- a/crates/mvm-cli/src/commands/env/builder_vm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm.rs
@@ -43,7 +43,6 @@ use default_microvm::DefaultMicrovmVariant;
 use default_microvm::workload_config_carries_dm_verity;
 pub(crate) use default_microvm::{
     assert_workload_kernel_supports_verity, ensure_default_microvm_image, ensure_workload_kernel,
-    ensure_workload_verity_initrd,
 };
 #[cfg(test)]
 use default_microvm::{

--- a/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
@@ -1,7 +1,4 @@
 use super::*;
-use crate::commands::runtime_overlay::{
-    RuntimeOverlayAcquireMode, runtime_overlay_acquire_mode, runtime_overlay_source_checkout_root,
-};
 use mvm_build::boot_image_select::{self, BootImageAcquisition};
 
 pub(crate) fn ensure_default_microvm_image(
@@ -217,64 +214,6 @@ pub(super) fn evict_incompatible_workload_kernel(kernel: &std::path::Path) -> Re
         }
     }
     Ok(())
-}
-
-pub(crate) fn ensure_workload_verity_initrd() -> Result<String> {
-    let cache_root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
-    let version = env!("CARGO_PKG_VERSION");
-    let arch = mvm_core::arch::GuestArch::host();
-    let layout = mvm_build::verity_initrd::VerityInitrdLayout::under(&cache_root, version, arch);
-    let workspace_root = workload_verity_initrd_source_checkout_root().filter(|_| {
-        runtime_overlay_acquire_mode() == RuntimeOverlayAcquireMode::BuildFromSourceCheckout
-    });
-    if let Some(ws) = workspace_root {
-        return mvm_build::verity_initrd::resolve_or_build_verity_initrd(
-            &cache_root,
-            version,
-            arch,
-            &ws,
-        )
-        .map(|p| p.display().to_string())
-        .context("build verity initrd from the source checkout");
-    }
-    if layout.initrd.is_file() {
-        return Ok(layout.initrd.display().to_string());
-    }
-
-    if let Some(bytes) = embedded_verity_init_bytes() {
-        return mvm_build::verity_initrd::install_prebuilt_verity_initrd(
-            bytes,
-            &cache_root,
-            version,
-            arch,
-        )
-        .map(|p| p.display().to_string())
-        .context("install embedded verity initrd");
-    }
-
-    anyhow::bail!(
-        "no verity initrd available: this build embeds no mvm-verity-init binary and there is no source checkout to cross-compile from"
-    )
-}
-
-fn workload_verity_initrd_source_checkout_root() -> Option<std::path::PathBuf> {
-    runtime_overlay_source_checkout_root().or_else(|| {
-        super::find_builder_vm_flake().ok().and_then(|flake_dir| {
-            std::path::PathBuf::from(flake_dir)
-                .parent()
-                .and_then(|p| p.parent())
-                .and_then(|p| p.parent())
-                .map(std::path::Path::to_path_buf)
-        })
-    })
-}
-
-fn embedded_verity_init_bytes() -> Option<&'static [u8]> {
-    crate::host_binaries::embedded::EMBEDDED
-        .iter()
-        .find(|b| b.name == "mvm-verity-init")
-        .map(|b| b.bytes)
-        .filter(|b| !b.is_empty())
 }
 
 pub(super) fn missing_workload_kernel_message(expected_path: &str) -> String {

--- a/crates/mvm-cli/src/commands/seccomp_audit.rs
+++ b/crates/mvm-cli/src/commands/seccomp_audit.rs
@@ -131,8 +131,8 @@ fn run_linux(args: Args) -> Result<()> {
     let argv_c: Vec<std::ffi::CString> = args
         .command
         .iter()
-        .map(|s| std::ffi::CString::new(s.as_str()).unwrap())
-        .collect();
+        .map(|s| std::ffi::CString::new(s.as_str()).context("command argument contains a NUL byte"))
+        .collect::<anyhow::Result<_>>()?;
 
     // We fork manually instead of using std::process::Command so the child can
     // stop itself with SIGSTOP immediately after PTRACE_TRACEME, before the
@@ -150,8 +150,10 @@ fn run_linux(args: Args) -> Result<()> {
                 // Do not leak unrelated file descriptors into the audited command.
                 close_non_stdio_fds();
                 nix::sys::signal::raise(Signal::SIGSTOP).context("raise(SIGSTOP) failed")?;
-                nix::unistd::execvp(&program_c, &argv_c).context("execvp failed")?;
-                Ok(())
+                match nix::unistd::execvp(&program_c, &argv_c) {
+                    Ok(never) => match never {},
+                    Err(error) => Err(error).context("execvp failed"),
+                }
             })() {
                 eprintln!("mvmctl seccomp-audit (child): {e:#}");
             }

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -12,8 +12,7 @@ use mvm_hostd::plan_admission::{
 };
 use mvm_runtime::image;
 
-use crate::commands::env::builder_vm::{ensure_workload_kernel, ensure_workload_verity_initrd};
-use crate::commands::runtime_overlay::{RuntimeOverlayAcquireMode, runtime_overlay_acquire_mode};
+use crate::commands::env::builder_vm::ensure_workload_kernel;
 use crate::commands::vm::shared::VmStartParams;
 
 use crate::commands::vm::readiness::record_vm_readiness;
@@ -136,54 +135,20 @@ fn persistent_oci_rootfs_requires_overlay_policy(rootfs_path: &std::path::Path) 
     runtime_lean && verity_path.is_some() && roothash.is_some()
 }
 
-/// The legacy per-rootfs verity initrd that ships next to the rootfs image,
-/// when present.
-fn sibling_rootfs_initrd(rootfs_path: &std::path::Path) -> Option<String> {
-    rootfs_path
-        .parent()
-        .map(|dir| dir.join("rootfs.initrd"))
-        .filter(|path| path.is_file())
-        .map(|path| path.display().to_string())
-}
-
-/// Resolve the initrd a persistent OCI boot should carry: the on-disk
-/// sibling when the universal initramfs is warm in the cache (it replaces the
-/// initrd later in the boot), otherwise the legacy per-rootfs verity initrd
-/// ladder (sibling, then cached/embedded/built verity initrd, failing the
-/// boot when none is available).
+/// Resolve the initrd a persistent OCI boot should carry.
+///
+/// Sealed OCI boots rely on the universal initramfs; the legacy per-rootfs
+/// verity initrd is no longer supported. The universal initramfs attach step
+/// later in the boot sets `initrd_path`, so this function returns `None` and
+/// lets that step own the initramfs.
 ///
 /// This is the boot-policy contract surface the dev-only conformance harness
 /// drives directly; it is re-exported at `mvm_cli::boot_policy` for that
 /// harness and is not a general-purpose API.
 pub fn persistent_oci_effective_initrd(
-    rootfs_path: &std::path::Path,
-    runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy,
+    _rootfs_path: &std::path::Path,
+    _runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy,
 ) -> Result<Option<String>> {
-    // When the universal initramfs is warm in the cache, the attach step later
-    // in the boot overwrites `initrd_path` with it, so resolving the legacy
-    // verity initrd here is dead work — and the resolution can cross-compile
-    // every guest binary or hard-fail a boot the universal initramfs would
-    // have carried. Skip it and hand back only what is already on disk. On a
-    // cold universal cache the legacy initrd becomes the real PID 1, so the
-    // full resolution below must run.
-    if runtime_source_policy == mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay
-        && super::runtime_source::universal_initramfs_available()
-    {
-        return Ok(sibling_rootfs_initrd(rootfs_path));
-    }
-    if runtime_source_policy == mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay
-        && runtime_overlay_acquire_mode() == RuntimeOverlayAcquireMode::BuildFromSourceCheckout
-        && crate::commands::env::builder_vm::find_builder_vm_flake_is_source_checkout()
-    {
-        return Ok(Some(ensure_workload_verity_initrd()?));
-    }
-    let sibling = sibling_rootfs_initrd(rootfs_path);
-    if sibling.is_some() {
-        return Ok(sibling);
-    }
-    if runtime_source_policy == mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay {
-        return Ok(Some(ensure_workload_verity_initrd()?));
-    }
     Ok(None)
 }
 
@@ -478,134 +443,22 @@ mod runtime_source_policy_for_workload_boot_tests {
     }
 
     #[test]
-    fn persistent_oci_required_overlay_prefers_sibling_initrd() {
+    fn persistent_oci_required_overlay_returns_no_initrd() {
         let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let dir = tempfile::tempdir().unwrap();
-        let rootfs = dir.path().join("rootfs.ext4");
-        let initrd = dir.path().join("rootfs.initrd");
-        std::fs::write(&rootfs, b"rootfs").unwrap();
-        std::fs::write(&initrd, b"initrd").unwrap();
-        let mut env = TestEnv::new();
-        env.set(
-            crate::commands::runtime_overlay::RUNTIME_OVERLAY_ACQUIRE_MODE_ENV,
-            "download",
-        );
-
-        let resolved =
-            super::persistent_oci_effective_initrd(&rootfs, RuntimeSourcePolicy::RequiredOverlay)
-                .unwrap();
-
-        assert_eq!(
-            resolved.as_deref(),
-            Some(initrd.to_str().expect("utf-8 initrd path"))
-        );
-    }
-
-    #[test]
-    fn persistent_oci_required_overlay_falls_back_to_cached_verity_initrd() {
-        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let dir = tempfile::tempdir().unwrap();
-        let rootfs = dir.path().join("rootfs.ext4");
-        std::fs::write(&rootfs, b"rootfs").unwrap();
-
-        let cache = tempfile::tempdir().unwrap();
-        let mut env = TestEnv::new();
-        env.isolate_mvm_home(cache.path());
-        env.set(
-            crate::commands::runtime_overlay::RUNTIME_OVERLAY_ACQUIRE_MODE_ENV,
-            "download",
-        );
-
-        let initrd_dir = cache
-            .path()
-            .join("cache")
-            .join("verity-initrd")
-            .join(env!("CARGO_PKG_VERSION"))
-            .join(if cfg!(target_arch = "aarch64") {
-                "aarch64"
-            } else {
-                "x86_64"
-            });
-        std::fs::create_dir_all(&initrd_dir).unwrap();
-        std::fs::write(initrd_dir.join("rootfs.initrd"), b"initrd").unwrap();
-
-        let resolved =
-            super::persistent_oci_effective_initrd(&rootfs, RuntimeSourcePolicy::RequiredOverlay)
-                .unwrap();
-
-        assert_eq!(
-            resolved.as_deref(),
-            Some(
-                initrd_dir
-                    .join("rootfs.initrd")
-                    .to_str()
-                    .expect("utf-8 cached initrd path")
-            )
-        );
-    }
-
-    #[test]
-    fn persistent_oci_required_overlay_source_checkout_ignores_stale_sibling_initrd() {
-        let _env_lock = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let Some(workspace_root) =
-            crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
-        else {
-            return;
-        };
-
         let dir = tempfile::tempdir().unwrap();
         let rootfs = dir.path().join("rootfs.ext4");
         let sibling = dir.path().join("rootfs.initrd");
         std::fs::write(&rootfs, b"rootfs").unwrap();
-        std::fs::write(&sibling, b"stale-initrd").unwrap();
-
-        let cache = tempfile::tempdir().unwrap();
-        let mut env = TestEnv::new();
-        env.isolate_mvm_home(cache.path());
-        env.set(
-            crate::commands::runtime_overlay::RUNTIME_OVERLAY_ACQUIRE_MODE_ENV,
-            "build",
-        );
-
-        let initrd_dir = cache
-            .path()
-            .join("cache")
-            .join("verity-initrd")
-            .join(env!("CARGO_PKG_VERSION"))
-            .join(if cfg!(target_arch = "aarch64") {
-                "aarch64"
-            } else {
-                "x86_64"
-            });
-        std::fs::create_dir_all(&initrd_dir).unwrap();
-        std::fs::write(initrd_dir.join("rootfs.initrd"), b"fresh-initrd").unwrap();
-        let fingerprint =
-            mvm_build::guest_agent_build::runtime_overlay_source_checkout_fingerprint(
-                &workspace_root,
-            )
-            .unwrap();
-        std::fs::write(
-            initrd_dir.join("SOURCE_FINGERPRINT"),
-            format!("{fingerprint}\n"),
-        )
-        .unwrap();
+        // A sibling legacy initrd, if present, must be ignored.
+        std::fs::write(&sibling, b"legacy-initrd").unwrap();
 
         let resolved =
             super::persistent_oci_effective_initrd(&rootfs, RuntimeSourcePolicy::RequiredOverlay)
                 .unwrap();
 
-        assert_eq!(
-            resolved.as_deref(),
-            Some(
-                initrd_dir
-                    .join("rootfs.initrd")
-                    .to_str()
-                    .expect("utf-8 cached initrd path")
-            )
-        );
+        assert_eq!(resolved, None, "legacy initrd must not be returned");
     }
 
-    /// Install a fixture universal initramfs into `<mvm_home>/cache/initramfs`
     /// exactly the way the real build/install path lays it out.
     fn seed_warm_universal_initramfs(mvm_home: &std::path::Path) {
         let version = env!("CARGO_PKG_VERSION");
@@ -673,10 +526,8 @@ mod runtime_source_policy_for_workload_boot_tests {
             super::persistent_oci_effective_initrd(&rootfs, RuntimeSourcePolicy::RequiredOverlay)
                 .unwrap();
 
-        // No sibling and no verity-initrd cache: the legacy ladder would fail
-        // the boot here, so reaching Ok(None) proves the legacy resolution
-        // never ran — the universal attach later in the boot supplies the
-        // initramfs instead.
+        // The universal initramfs attach step later in the boot supplies the
+        // initramfs, so the effective initrd is always empty here.
         assert_eq!(resolved, None);
     }
 
@@ -709,13 +560,10 @@ mod runtime_source_policy_for_workload_boot_tests {
             super::persistent_oci_effective_initrd(&rootfs, RuntimeSourcePolicy::RequiredOverlay)
                 .unwrap();
 
-        // Source-checkout mode would normally rebuild/refresh the verity
-        // initrd and ignore the sibling; with a warm universal initramfs the
-        // sibling is returned as-is and no build runs.
-        assert_eq!(
-            resolved.as_deref(),
-            Some(sibling.to_str().expect("utf-8 initrd path"))
-        );
+        // Source-checkout mode previously refreshed a legacy verity initrd.
+        // That path is no longer supported; the universal initramfs attach
+        // step owns the initramfs, so no initrd is resolved here.
+        assert_eq!(resolved, None);
     }
 }
 

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -327,6 +327,7 @@ fn evict_stale_universal_initramfs(
 /// without building or downloading anything? Applies the same
 /// source-fingerprint eviction as the attach path first, so a stale artifact
 /// never counts as available.
+#[cfg(test)]
 pub(crate) fn universal_initramfs_available() -> bool {
     let version = env!("CARGO_PKG_VERSION");
     let cache_root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("initramfs");
@@ -1503,7 +1504,7 @@ mod universal_initramfs_attach_tests {
         );
         assert!(
             sc.initrd_path.is_none(),
-            "a cold-cache resolution failure must preserve legacy boot"
+            "a cold-cache resolution failure leaves no initramfs attached"
         );
     }
 

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -3402,14 +3402,13 @@ mod tests {
     }
 
     #[test]
-    fn transient_oci_required_overlay_prefers_sibling_initrd() {
+    fn transient_oci_required_overlay_returns_no_initrd() {
         let dir = tempfile::tempdir().unwrap();
         let rootfs = dir.path().join("rootfs.ext4");
-        let initrd = dir.path().join("rootfs.initrd");
+        let sibling = dir.path().join("rootfs.initrd");
         std::fs::write(&rootfs, b"rootfs").unwrap();
-        std::fs::write(&initrd, b"initrd").unwrap();
-        let mut env = mvm_core::util::test_env::TestEnv::new();
-        env.set("MVM_RUNTIME_OVERLAY_ACQUIRE_MODE", "download");
+        // A sibling legacy initrd must be ignored.
+        std::fs::write(&sibling, b"initrd").unwrap();
         let image = ImageSource::Prebuilt {
             kernel_path: "/k".into(),
             rootfs_path: rootfs.display().to_string(),
@@ -3430,63 +3429,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(
-            resolved.as_deref(),
-            Some(initrd.to_str().expect("utf-8 initrd path"))
-        );
-    }
-
-    #[test]
-    fn transient_oci_required_overlay_falls_back_to_cached_verity_initrd() {
-        let dir = tempfile::tempdir().unwrap();
-        let rootfs = dir.path().join("rootfs.ext4");
-        std::fs::write(&rootfs, b"rootfs").unwrap();
-        let image = ImageSource::Prebuilt {
-            kernel_path: "/k".into(),
-            rootfs_path: rootfs.display().to_string(),
-            initrd_path: None,
-            label: "oci".into(),
-            virtiofs_oci_root: Some(VirtiofsOciRoot {
-                tree_dir: "/tree".into(),
-                prod: false,
-            }),
-        };
-
-        let cache = tempfile::tempdir().unwrap();
-        let mut env = mvm_core::util::test_env::TestEnv::new();
-        env.isolate_mvm_home(cache.path());
-        env.set("MVM_RUNTIME_OVERLAY_ACQUIRE_MODE", "download");
-        let initrd_dir = cache
-            .path()
-            .join("cache")
-            .join("verity-initrd")
-            .join(env!("CARGO_PKG_VERSION"))
-            .join(if cfg!(target_arch = "aarch64") {
-                "aarch64"
-            } else {
-                "x86_64"
-            });
-        std::fs::create_dir_all(&initrd_dir).unwrap();
-        std::fs::write(initrd_dir.join("rootfs.initrd"), b"initrd").unwrap();
-
-        let resolved = effective_transient_initrd(
-            &image,
-            None,
-            &rootfs.display().to_string(),
-            mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
-            mvm_build::run_image::RootStrategy::BlockExt4,
-        )
-        .unwrap();
-
-        assert_eq!(
-            resolved.as_deref(),
-            Some(
-                initrd_dir
-                    .join("rootfs.initrd")
-                    .to_str()
-                    .expect("utf-8 cached initrd path")
-            )
-        );
+        assert_eq!(resolved, None, "legacy initrd must not be returned");
     }
 
     #[test]

--- a/crates/mvm-conformance/tests/steps/initramfs.rs
+++ b/crates/mvm-conformance/tests/steps/initramfs.rs
@@ -107,6 +107,15 @@ fn isolated_home_warm_universal_initramfs(world: &mut CliWorld) {
     world.isolated_home = Some(tmp);
 }
 
+#[given("an isolated mvm home with a cold universal initramfs cache")]
+fn isolated_home_cold_universal_initramfs(world: &mut CliWorld) {
+    let tmp = tempfile::tempdir().expect("scenario mvm home");
+    world.initramfs_boot_env = Some(isolated_boot_env(tmp.path()));
+    // Do not seed the cache: the resolver must not fall back to a legacy
+    // per-rootfs initrd just because the universal initramfs is absent.
+    world.isolated_home = Some(tmp);
+}
+
 #[given("a sealed OCI rootfs with no sibling initrd")]
 fn sealed_oci_rootfs_without_sibling_initrd(world: &mut CliWorld) {
     let home = world
@@ -117,6 +126,20 @@ fn sealed_oci_rootfs_without_sibling_initrd(world: &mut CliWorld) {
     std::fs::create_dir_all(rootfs.parent().expect("the rootfs has a parent dir"))
         .expect("create the rootfs dir");
     std::fs::write(&rootfs, b"rootfs").expect("write the rootfs");
+}
+
+#[given("a sealed OCI rootfs with a sibling legacy initrd")]
+fn sealed_oci_rootfs_with_sibling_legacy_initrd(world: &mut CliWorld) {
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("a prior step must isolate the mvm home");
+    let rootfs = scenario_rootfs(home.path());
+    std::fs::create_dir_all(rootfs.parent().expect("the rootfs has a parent dir"))
+        .expect("create the rootfs dir");
+    std::fs::write(&rootfs, b"rootfs").expect("write the rootfs");
+    let legacy_initrd = rootfs.with_extension("initrd");
+    std::fs::write(&legacy_initrd, b"legacy initrd").expect("write the legacy sibling initrd");
 }
 
 #[when("the persistent OCI effective initrd is resolved for a required-overlay boot")]

--- a/crates/mvm-conformance/tests/steps/initramfs.rs
+++ b/crates/mvm-conformance/tests/steps/initramfs.rs
@@ -107,20 +107,6 @@ fn isolated_home_warm_universal_initramfs(world: &mut CliWorld) {
     world.isolated_home = Some(tmp);
 }
 
-#[given("an isolated mvm home with a cold universal cache but a cached legacy verity initrd")]
-fn isolated_home_cold_universal_cached_verity_initrd(world: &mut CliWorld) {
-    let tmp = tempfile::tempdir().expect("scenario mvm home");
-    world.initramfs_boot_env = Some(isolated_boot_env(tmp.path()));
-    let layout = mvm_build::verity_initrd::VerityInitrdLayout::under(
-        &tmp.path().join("cache"),
-        env!("CARGO_PKG_VERSION"),
-        GuestArch::host(),
-    );
-    std::fs::create_dir_all(&layout.dir).expect("create the verity-initrd cache dir");
-    std::fs::write(&layout.initrd, b"legacy-verity-initrd").expect("seed the legacy verity initrd");
-    world.isolated_home = Some(tmp);
-}
-
 #[given("a sealed OCI rootfs with no sibling initrd")]
 fn sealed_oci_rootfs_without_sibling_initrd(world: &mut CliWorld) {
     let home = world
@@ -157,28 +143,6 @@ fn effective_initrd_is_empty(world: &mut CliWorld) {
         outcome.as_ref().map(Option::as_deref),
         Ok(None),
         "a warm universal initramfs must skip the legacy initrd entirely: {outcome:?}"
-    );
-}
-
-#[then("the effective initrd is the cached legacy verity initrd")]
-fn effective_initrd_is_cached_legacy_verity_initrd(world: &mut CliWorld) {
-    let home = world
-        .isolated_home
-        .as_ref()
-        .expect("a prior step must isolate the mvm home");
-    let layout = mvm_build::verity_initrd::VerityInitrdLayout::under(
-        &home.path().join("cache"),
-        env!("CARGO_PKG_VERSION"),
-        GuestArch::host(),
-    );
-    let outcome = world
-        .initramfs_boot_initrd
-        .as_ref()
-        .expect("a prior step must resolve the effective initrd");
-    assert_eq!(
-        outcome.as_ref().map(Option::as_deref),
-        Ok(Some(layout.initrd.to_str().expect("utf-8 initrd path"))),
-        "a cold universal cache must still run the legacy verity-initrd ladder: {outcome:?}"
     );
 }
 

--- a/crates/mvm-conformance/tests/steps/verified_boot.rs
+++ b/crates/mvm-conformance/tests/steps/verified_boot.rs
@@ -10,25 +10,17 @@ use mvm_runtime::driver::{ConsoleCapture, KernelImage, LibkrunDriver, VmmDriver,
 
 use crate::world::{CliWorld, MvmHomeGuard};
 
-/// Materialize the initramfs this sealed boot attaches, and return its path.
+/// Materialize the universal initramfs this sealed boot attaches, and return its path.
 ///
-/// The path is the discriminant between the two boot protocols, so the fixture
-/// has to produce a real one. `universal` lands in the shared initramfs cache —
-/// that PID 1 is handed its roothashes and device slots over vsock. `legacy` is
-/// a per-rootfs `rootfs.initrd` sibling, whose PID 1 can only read them off the
-/// kernel cmdline.
-fn sealed_initramfs_path(flavor: &str) -> String {
-    match flavor {
-        "universal" => {
-            let dir = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("initramfs");
-            std::fs::create_dir_all(&dir).expect("create initramfs cache dir");
-            let image = dir.join("initramfs.cpio.gz");
-            std::fs::write(&image, b"initramfs").expect("write initramfs");
-            image.display().to_string()
-        }
-        "legacy" => "/image/rootfs.initrd".to_string(),
-        other => panic!("unsupported sealed initramfs flavor {other:?}"),
-    }
+/// The universal initramfs lives in the shared initramfs cache; its PID 1 is
+/// handed roothashes and device slots over vsock. A legacy per-rootfs initrd
+/// is no longer supported, so this fixture only produces the universal path.
+fn sealed_initramfs_path(_flavor: &str) -> String {
+    let dir = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("initramfs");
+    std::fs::create_dir_all(&dir).expect("create initramfs cache dir");
+    let image = dir.join("initramfs.cpio.gz");
+    std::fs::write(&image, b"initramfs").expect("write initramfs");
+    image.display().to_string()
 }
 
 #[when(expr = "I assemble a sealed workload cmdline for {string} booting the {string} initramfs")]

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -2298,18 +2298,24 @@ mod tests {
         let cfg = VmStartConfig {
             name: vm_name.into(),
             rootfs_path: rootfs.display().to_string(),
+            initrd_path: Some(mvm_vmm::host::cmdline::seed_universal_initramfs(
+                home.path(),
+            )),
             verity_path: Some(verity.display().to_string()),
             roothash: Some("a".repeat(64)),
             network_policy: NetworkPolicy::preset(mvm_core::network_policy::NetworkPreset::Dev),
             ..Default::default()
         };
 
+        let driver = MockDriver::default();
+        let guest = spawn_activation_guest(driver.clone(), vm_name);
         let runner = WorkloadRunner::new(
-            MockDriver::default(),
+            driver,
             RecordingSpawner::new("/run/ep.sock"),
             RecordingBrokerRegistrar::new(),
         );
         runner.start(&cfg).expect("start succeeds");
+        guest.join().expect("guest thread");
 
         let specs = runner.driver.booted_specs();
         assert_eq!(specs.len(), 1);
@@ -2379,6 +2385,46 @@ mod tests {
         );
     }
 
+    fn spawn_activation_guest(driver: MockDriver, vm_name: &str) -> std::thread::JoinHandle<()> {
+        use ed25519_dalek::SigningKey;
+        use mvm_agentd::vsock::{AuthenticatedSession, GuestRequest, GuestResponse};
+
+        let host_signer = [7u8; 32];
+        let keys_dir = mvm_core::config::mvm_keys_dir();
+        std::fs::create_dir_all(&keys_dir).unwrap();
+        std::fs::write(keys_dir.join("host-signer.ed25519"), host_signer).unwrap();
+        let vm_id = VmId(vm_name.to_string());
+
+        std::thread::spawn(move || {
+            let mut stream = {
+                let mut found = None;
+                for _ in 0..200 {
+                    if let Some(end) = driver.take_guest_end(&vm_id, GUEST_AGENT_PORT) {
+                        found = Some(end);
+                        break;
+                    }
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                found.expect("the runner connected to the guest agent port")
+            };
+            let host_key = SigningKey::from_bytes(&host_signer).verifying_key();
+            let mut session = AuthenticatedSession::guest(
+                &mut stream,
+                SigningKey::from_bytes(&[9u8; 32]),
+                &host_key,
+            )
+            .expect("guest handshake");
+            let req: GuestRequest = session.read(&mut stream).expect("read request");
+            assert!(
+                matches!(req, GuestRequest::ActivateEnvironment(_)),
+                "the first post-boot verb must be ActivateEnvironment, got: {req:?}"
+            );
+            session
+                .write(&mut stream, &GuestResponse::ActivateEnvironmentAck)
+                .expect("write ack");
+        })
+    }
+
     /// A boot that attached the universal initramfs must be sent
     /// `ActivateEnvironment` over the agent vsock port before the launch
     /// returns — proven by driving `start_workload` through the `MockDriver`
@@ -2395,13 +2441,6 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let mut env = TestEnv::new();
         env.set("MVM_HOME", home.path());
-
-        // The activation handshake authenticates against the host signer;
-        // seed one so both ends of the loopback share the identity.
-        let host_signer = [7u8; 32];
-        let keys_dir = mvm_core::config::mvm_keys_dir();
-        std::fs::create_dir_all(&keys_dir).unwrap();
-        std::fs::write(keys_dir.join("host-signer.ed25519"), host_signer).unwrap();
 
         // An initramfs artifact under the shared cache is the discriminant
         // for the universal-initramfs boot path.
@@ -2426,41 +2465,9 @@ mod tests {
         let policy = NetworkPolicy::deny_all();
         let redaction = RedactionPolicy::default();
 
-        // The guest side of the loopback: authenticate, assert the request
-        // is exactly the activation verb, ACK it.
-        let guest = std::thread::spawn(move || {
-            use ed25519_dalek::SigningKey;
-            use mvm_agentd::vsock::{AuthenticatedSession, GuestRequest, GuestResponse};
-
-            let mut stream = {
-                let mut found = None;
-                for _ in 0..200 {
-                    if let Some(end) =
-                        driver.take_guest_end(&VmId("runner-activation".into()), GUEST_AGENT_PORT)
-                    {
-                        found = Some(end);
-                        break;
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(10));
-                }
-                found.expect("the runner connected to the guest agent port")
-            };
-            let host_key = SigningKey::from_bytes(&host_signer).verifying_key();
-            let mut session = AuthenticatedSession::guest(
-                &mut stream,
-                SigningKey::from_bytes(&[9u8; 32]),
-                &host_key,
-            )
-            .expect("guest handshake");
-            let req: GuestRequest = session.read(&mut stream).expect("read request");
-            assert!(
-                matches!(req, GuestRequest::ActivateEnvironment(_)),
-                "the first post-boot verb must be ActivateEnvironment, got: {req:?}"
-            );
-            session
-                .write(&mut stream, &GuestResponse::ActivateEnvironmentAck)
-                .expect("write ack");
-        });
+        // The guest side of the loopback authenticates, verifies that the first
+        // request is the activation verb, and acknowledges it.
+        let guest = spawn_activation_guest(driver, "runner-activation");
 
         runner
             .start_workload(&WorkloadLaunchInputs {
@@ -3078,7 +3085,9 @@ mod tests {
         // cmdline, so force an overflow with an oversized verb grant instead.
         launch.verity_path = Some(tmp.path().join("rootfs.verity").display().to_string());
         launch.roothash = Some("a".repeat(4096));
-        launch.initrd_path = Some(tmp.path().join("rootfs.initrd").display().to_string());
+        launch.initrd_path = Some(mvm_vmm::host::cmdline::seed_universal_initramfs(
+            home.path(),
+        ));
         let state_dir = mvm_core::config::vm_state_dir("parent-oversized");
         std::fs::create_dir_all(&state_dir).unwrap();
         let nonce = mvm_core::plan::Nonce::from_bytes([3u8; 16]);
@@ -3181,12 +3190,14 @@ mod tests {
 
         let (dir, rootfs) = overlay_aware_rootfs("shape-parity");
         std::fs::write(dir.path().join("rootfs.verity"), b"verity").unwrap();
-        std::fs::write(dir.path().join("rootfs.initrd"), b"initrd").unwrap();
 
         let launch = VmStartConfig {
             name: "shape-parity".into(),
             rootfs_path: rootfs.clone(),
             kernel_path: Some("/img/kernel".into()),
+            initrd_path: Some(mvm_vmm::host::cmdline::seed_universal_initramfs(
+                home.path(),
+            )),
             verity_path: Some(dir.path().join("rootfs.verity").display().to_string()),
             roothash: Some("a".repeat(64)),
             runtime_overlay_path: Some(dir.path().join("overlay.ext4").display().to_string()),
@@ -3202,13 +3213,16 @@ mod tests {
         };
 
         let store = CheckpointStore::at(home.path().join("checkpoints"));
+        let driver = MockDriver::default().with_vm_full_rootfs(Path::new(&rootfs));
+        let guest = spawn_activation_guest(driver.clone(), "shape-parity");
         let runner = WorkloadRunner::new(
-            MockDriver::default().with_vm_full_rootfs(Path::new(&rootfs)),
+            driver,
             RecordingSpawner::new("/run/ep.sock"),
             RecordingBrokerRegistrar::new(),
         );
 
         runner.start(&launch).expect("workload boots");
+        guest.join().expect("guest thread");
         let spec = standby_spec_for(
             "standby-parity",
             &home.path().join("standby-parity"),

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -329,19 +329,18 @@ mod tests {
     }
 
     /// A sealed launch of the shape the live Firecracker workload path
-    /// produces: verity-sealed rootfs, the sibling initramfs that runs the
+    /// produces: verity-sealed rootfs, the universal initramfs that runs the
     /// verity setup, and the required runtime overlay carrying the guest agent.
-    fn sealed_launch(dir: &Path) -> VmStartConfig {
+    fn sealed_launch(dir: &Path, home: &Path) -> VmStartConfig {
         let rootfs = dir.join("rootfs.ext4");
         let verity = dir.join("rootfs.verity");
-        let initrd = dir.join("rootfs.initrd");
         std::fs::write(&rootfs, b"rootfs").unwrap();
         std::fs::write(&verity, b"verity").unwrap();
-        std::fs::write(&initrd, b"initrd").unwrap();
         VmStartConfig {
             name: "workload-a".into(),
             rootfs_path: rootfs.display().to_string(),
             kernel_path: Some(dir.join("vmlinux").display().to_string()),
+            initrd_path: Some(cmdline::seed_universal_initramfs(home)),
             verity_path: Some(verity.display().to_string()),
             roothash: Some("a".repeat(64)),
             runtime_overlay_path: Some(dir.join("overlay.ext4").display().to_string()),
@@ -417,9 +416,9 @@ mod tests {
     /// two shapes stay in step without anyone remembering to keep them there.
     #[test]
     fn parent_boots_the_same_device_model_and_cmdline_the_workload_does() {
-        let _home = isolated_home();
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let launch = sealed_launch(tmp.path());
+        let launch = sealed_launch(tmp.path(), home.path());
         let spec = standby_spec_for(&launch, tmp.path());
 
         let workload = workload_boot(&launch, &tmp.path().join("workload-a"));
@@ -455,9 +454,9 @@ mod tests {
     /// on: whatever the workload path adds, the parent adds too.
     #[test]
     fn a_parent_warmed_for_an_egress_allowing_launch_boots_the_launchs_own_cmdline() {
-        let _home = isolated_home();
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let mut launch = sealed_launch(tmp.path());
+        let mut launch = sealed_launch(tmp.path(), home.path());
         launch.network_policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
             mvm_core::network_policy::HostPort::new("api.example.com", 443),
         ]);
@@ -493,8 +492,9 @@ mod tests {
     /// child's own endpoint instead, and never rides the parent.
     #[test]
     fn the_parent_carries_the_egress_enablement_but_none_of_the_launchs_destinations() {
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let mut launch = sealed_launch(tmp.path());
+        let mut launch = sealed_launch(tmp.path(), home.path());
         launch.network_policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
             mvm_core::network_policy::HostPort::new("api.example.com", 443),
             mvm_core::network_policy::HostPort::new("secret.internal", 8443),
@@ -525,9 +525,9 @@ mod tests {
     /// not perturb anything else.
     #[test]
     fn a_parent_warmed_for_a_deny_all_launch_boots_no_egress_client() {
-        let _home = isolated_home();
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let launch = sealed_launch(tmp.path());
+        let launch = sealed_launch(tmp.path(), home.path());
         let spec = standby_spec_for(&launch, tmp.path());
         assert!(
             !spec.vsock_egress,
@@ -559,9 +559,9 @@ mod tests {
     /// child hostname delivered after restore.
     #[test]
     fn a_secret_bearing_launch_warms_a_parent_with_no_egress_client_either() {
-        let _home = isolated_home();
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let mut launch = sealed_launch(tmp.path());
+        let mut launch = sealed_launch(tmp.path(), home.path());
         launch.network_policy = mvm_core::network_policy::NetworkPolicy::allow_list(vec![
             mvm_core::network_policy::HostPort::new("api.example.com", 443),
         ]);
@@ -614,15 +614,14 @@ mod tests {
     /// recorded, so a failure names what the guest will miss rather than only
     /// that two values differ.
     ///
-    /// `sealed_launch` is the legacy sibling-initramfs shape, whose PID 1 reads
-    /// the roothashes and device paths off the kernel cmdline — it is never sent
-    /// `ActivateEnvironment`. A parent booted without those tokens aborts in PID
-    /// 1 and panics the kernel, so there is nothing left to capture.
+    /// The universal initramfs receives the roothashes and device paths over the
+    /// authenticated activation channel, so the parent keeps those secrets off
+    /// the kernel cmdline while still attaching the complete sealed disk stack.
     #[test]
     fn parent_carries_the_overlay_drives_and_runtime_tokens_the_guest_agent_needs() {
-        let _home = isolated_home();
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let launch = sealed_launch(tmp.path());
+        let launch = sealed_launch(tmp.path(), home.path());
         let spec = standby_spec_for(&launch, tmp.path());
         let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
         let parent = factory_parent_spec(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
@@ -642,7 +641,7 @@ mod tests {
             "parent cmdline missing runtime-source policy: {}",
             parent.cmdline
         );
-        for token in [
+        for legacy_token in [
             "mvm.roothash=",
             "mvm.data=/dev/vda",
             "mvm.hash=/dev/vdb",
@@ -651,8 +650,8 @@ mod tests {
             "mvm.runtime_hash=/dev/vdd",
         ] {
             assert!(
-                parent.cmdline.contains(token),
-                "parent cmdline missing {token} its legacy PID 1 needs: {}",
+                !parent.cmdline.contains(legacy_token),
+                "parent cmdline leaked legacy token {legacy_token}: {}",
                 parent.cmdline
             );
         }
@@ -666,8 +665,7 @@ mod tests {
     fn parent_on_the_universal_initramfs_carries_no_roothash_tokens() {
         let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let mut launch = sealed_launch(tmp.path());
-        launch.initrd_path = Some(cmdline::seed_universal_initramfs(home.path()));
+        let launch = sealed_launch(tmp.path(), home.path());
         let spec = standby_spec_for(&launch, tmp.path());
         let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
         let parent = factory_parent_spec(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
@@ -701,9 +699,9 @@ mod tests {
 
     #[test]
     fn parent_drops_every_workload_authority_field_the_launch_carried() {
-        let _home = isolated_home();
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let mut launch = sealed_launch(tmp.path());
+        let mut launch = sealed_launch(tmp.path(), home.path());
         launch.plan_json = Some("{\"signed\":\"plan\"}".into());
         launch.bundle_json = Some("{\"pin\":\"bundle\"}".into());
         launch.tenant_id = Some("tenant-a".into());
@@ -756,9 +754,9 @@ mod tests {
 
     #[test]
     fn live_parent_uses_stable_handoff_channels_without_workload_endpoints() {
-        let _home = isolated_home();
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let launch = sealed_launch(tmp.path());
+        let launch = sealed_launch(tmp.path(), home.path());
         let spec = standby_spec_for(&launch, tmp.path());
         let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
         let parent = factory_parent_spec_live(&parent_cfg, Path::new(&spec.vm_state_dir), fc_base);
@@ -792,8 +790,9 @@ mod tests {
 
     #[test]
     fn parent_identity_and_resources_come_from_the_pool_record_not_the_launch() {
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let launch = sealed_launch(tmp.path());
+        let launch = sealed_launch(tmp.path(), home.path());
         let mut spec = standby_spec_for(&launch, tmp.path());
         spec.template_id = Some("tpl-7".into());
 
@@ -808,8 +807,9 @@ mod tests {
 
     #[test]
     fn factory_parent_config_refuses_a_record_without_a_rootfs_image() {
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let launch = sealed_launch(tmp.path());
+        let launch = sealed_launch(tmp.path(), home.path());
         let mut spec = standby_spec_for(&launch, tmp.path());
         spec.image_path = None;
 
@@ -827,8 +827,9 @@ mod tests {
     /// agent-readiness timeout.
     #[test]
     fn factory_parent_config_refuses_a_required_overlay_launch_carrying_no_overlay() {
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let mut launch = sealed_launch(tmp.path());
+        let mut launch = sealed_launch(tmp.path(), home.path());
         launch.runtime_overlay_path = None;
         launch.runtime_overlay_verity_path = None;
         launch.runtime_overlay_roothash = None;
@@ -847,9 +848,10 @@ mod tests {
     /// mounts them, which is the second shape of the same failure.
     #[test]
     fn factory_parent_config_refuses_a_sealed_rootfs_with_no_resolvable_initramfs() {
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let launch = sealed_launch(tmp.path());
-        std::fs::remove_file(tmp.path().join("rootfs.initrd")).unwrap();
+        let mut launch = sealed_launch(tmp.path(), home.path());
+        launch.initrd_path = None;
         let spec = standby_spec_for(&launch, tmp.path());
 
         let err = factory_parent_config(&launch, &spec)
@@ -887,9 +889,9 @@ mod tests {
 
     #[test]
     fn parent_console_is_captured_into_its_own_state_dir() {
-        let _home = isolated_home();
+        let (_env, home, _lock) = isolated_home();
         let tmp = tempfile::tempdir().unwrap();
-        let launch = sealed_launch(tmp.path());
+        let launch = sealed_launch(tmp.path(), home.path());
         let spec = standby_spec_for(&launch, tmp.path());
         let parent_cfg = factory_parent_config(&launch, &spec).unwrap();
         let state_dir = PathBuf::from(&spec.vm_state_dir);

--- a/crates/mvm-vmm/src/host/cmdline.rs
+++ b/crates/mvm-vmm/src/host/cmdline.rs
@@ -19,10 +19,9 @@ use std::path::{Path, PathBuf};
 
 use mvm_core::vm_backend::VmStartConfig;
 
-use crate::host::boot_config::{
-    booted_with_universal_initramfs, build_runtime_overlay_cmdline_args, build_verity_cmdline_args,
-    non_verity_overlay_ext4,
-};
+#[cfg(test)]
+use crate::host::boot_config::booted_with_universal_initramfs;
+use crate::host::boot_config::{build_runtime_overlay_cmdline_args, non_verity_overlay_ext4};
 use crate::host::egress_bridge::{
     host_signer_pub_cmdline_token, require_grant_cmdline_token, verb_grant_cmdline_token,
 };
@@ -69,27 +68,10 @@ pub fn hostname_cmdline_token(machine_name: &str) -> Option<String> {
         .then(|| format!("mvm.hostname={machine_name}"))
 }
 
-fn verity_initrd_path(config: &VmStartConfig) -> Option<PathBuf> {
-    config
-        .verity_path
-        .as_deref()
-        .zip(config.roothash.as_deref())
-        .and_then(|_| {
-            Path::new(&config.rootfs_path)
-                .parent()
-                .map(|p| p.join("rootfs.initrd"))
-        })
-        .filter(|p| p.exists())
-}
-
-/// The initramfs this boot uses: an explicit `--initrd` override, or (for a
-/// verity-sealed boot) the sibling `rootfs.initrd` next to the rootfs image.
+/// The initramfs this boot uses: the explicit `--initrd` override, or the
+/// universal initramfs path attached by the runtime source resolver.
 pub fn effective_initrd(config: &VmStartConfig) -> Option<PathBuf> {
-    config
-        .initrd_path
-        .as_ref()
-        .map(PathBuf::from)
-        .or_else(|| verity_initrd_path(config))
+    config.initrd_path.as_ref().map(PathBuf::from)
 }
 
 /// Whether this boot has everything dm-verity needs: a verity sidecar, a
@@ -165,21 +147,8 @@ fn workload_cmdline_for_hostname(
     };
     // The universal initramfs receives the rootfs and runtime-overlay
     // roothashes/device paths over vsock via `ActivateEnvironment` after boot, so
-    // its cmdline carries none of them. A legacy per-rootfs verity initramfs
-    // (`mvm-verity-init` as PID 1) is never sent that verb — the cmdline is its
-    // only channel, and without these tokens it aborts before userspace and the
-    // kernel panics on a dead PID 1. Hosts that cannot yet resolve the universal
-    // artifact still boot the legacy initramfs, so both shapes stay live.
-    if verity_is_enabled
-        && !booted_with_universal_initramfs(config)
-        && let Some(verity_args) = build_verity_cmdline_args(
-            config.roothash.as_deref(),
-            runtime_overlay(config).map(|(_, _, roothash)| roothash),
-        )
-    {
-        cmdline.push(' ');
-        cmdline.push_str(&verity_args);
-    }
+    // its cmdline carries none of them. The legacy per-rootfs verity initramfs
+    // is no longer supported.
     // Non-verity boots carry the runtime overlay as a plain read-only
     // `/dev/vdb` (attached by the backend's disk layout); emit the token its
     // `/init` mounts from. Verity boots already emitted the dm-verity variant
@@ -463,64 +432,6 @@ mod tests {
         assert!(cmdline.contains("mvm.runtime_source_policy=required_overlay"));
     }
 
-    /// The counterpart: a legacy per-rootfs verity initramfs (`mvm-verity-init`
-    /// as PID 1) is never sent `ActivateEnvironment`, so the kernel cmdline is
-    /// its only channel for the roothashes and device paths. Dropping those
-    /// tokens makes `mvm-verity-init` fatal ("no mvm.roothash= on kernel
-    /// cmdline") and panics the guest before userspace.
-    #[test]
-    fn workload_cmdline_for_legacy_verity_initramfs_boot_carries_the_roothash_tokens() {
-        let _guard = crate::host::runtime_meta::HOME_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        let dir = tempfile::tempdir().unwrap();
-        let mut env = mvm_core::util::test_env::TestEnv::new();
-        env.set("MVM_HOME", dir.path());
-        let rootfs = dir.path().join("rootfs.ext4");
-        let verity = dir.path().join("rootfs.verity");
-        let initrd = dir.path().join("rootfs.initrd");
-        std::fs::write(&rootfs, b"rootfs").unwrap();
-        std::fs::write(&verity, b"verity").unwrap();
-        std::fs::write(&initrd, b"initrd").unwrap();
-
-        let rootfs_hash = "a".repeat(64);
-        let overlay_hash = "b".repeat(64);
-        let config = VmStartConfig {
-            rootfs_path: rootfs.display().to_string(),
-            verity_path: Some(verity.display().to_string()),
-            roothash: Some(rootfs_hash.clone()),
-            runtime_overlay_path: Some("/tmp/runtime.ext4".into()),
-            runtime_overlay_verity_path: Some("/tmp/runtime.verity".into()),
-            runtime_overlay_roothash: Some(overlay_hash.clone()),
-            runtime_source_policy: mvm_core::vm_backend::RuntimeSourcePolicy::RequiredOverlay,
-            ..Default::default()
-        };
-        assert!(
-            !booted_with_universal_initramfs(&config),
-            "fixture must resolve as a legacy-initramfs boot"
-        );
-        let cmdline =
-            workload_cmdline(&config, dir.path(), hvf_like_workload_bootargs).expect("cmdline");
-        for token in [
-            format!("mvm.roothash={rootfs_hash}"),
-            "mvm.data=/dev/vda".to_string(),
-            "mvm.hash=/dev/vdb".to_string(),
-            format!("mvm.runtime_roothash={overlay_hash}"),
-            "mvm.runtime_data=/dev/vdc".to_string(),
-            "mvm.runtime_hash=/dev/vdd".to_string(),
-        ] {
-            assert!(
-                cmdline.contains(&token),
-                "legacy verity cmdline missing {token}: {cmdline}"
-            );
-        }
-        assert!(cmdline.contains("mvm.runtime_source_policy=required_overlay"));
-    }
-
-    /// A verity boot must take its console base from the driver seam, not a
-    /// hardcoded HVF UART. A libkrun-style base yields `console=hvc0`; the
-    /// cmdline must never carry the pl011 `ttyAMA0`/`earlycon` that a libkrun
-    /// guest has no device for (the regression that emitted a 0-byte console).
     #[test]
     fn verity_cmdline_takes_the_console_from_the_driver_seam_not_a_hardcoded_uart() {
         let dir = tempfile::tempdir().unwrap();

--- a/features/suites/s14_universal_initramfs/initramfs_cache.feature
+++ b/features/suites/s14_universal_initramfs/initramfs_cache.feature
@@ -1,11 +1,11 @@
 Feature: Universal initramfs cache attachment
 
   The universal initramfs is shared across workloads and may be absent from the
-  local cache.  Its absence must never be the reason a workload fails to start;
-  the boot path falls back to the legacy per-rootfs /init when the initramfs is
-  not yet cached, and the CLI must fail fast for the *next* real precondition
+  local cache. Its absence must never silently fall back to a legacy per-rootfs
+  initrd; sealed/verity boots own their initramfs through the universal
+  initramfs attach step. The CLI must fail fast for the *next* real precondition
   (e.g., failed verified kernel reacquisition) rather than emitting an initramfs
-  error.
+  error or resurrecting the unsupported legacy path.
 
   @cli
   Scenario: A cold initramfs cache does not block machine run

--- a/features/suites/s14_universal_initramfs/legacy_initrd_skip.feature
+++ b/features/suites/s14_universal_initramfs/legacy_initrd_skip.feature
@@ -3,10 +3,17 @@ Feature: Sealed OCI boots rely on the universal initramfs
   A sealed OCI boot requires the runtime overlay. The legacy per-rootfs
   verity initrd is no longer supported; the universal initramfs attach step
   later in the boot owns the initramfs. The effective initrd resolved up
-  front is therefore always empty for sealed OCI boots.
+  front is therefore always empty for sealed OCI boots, even when a legacy
+  sibling initrd exists and the universal initramfs cache is cold.
 
   Scenario: A sealed OCI boot resolves no up-front initrd
     Given an isolated mvm home with a warm universal initramfs cache
     And a sealed OCI rootfs with no sibling initrd
+    When the persistent OCI effective initrd is resolved for a required-overlay boot
+    Then the effective initrd is empty
+
+  Scenario: A sealed OCI boot ignores a present legacy initrd when the universal cache is cold
+    Given an isolated mvm home with a cold universal initramfs cache
+    And a sealed OCI rootfs with a sibling legacy initrd
     When the persistent OCI effective initrd is resolved for a required-overlay boot
     Then the effective initrd is empty

--- a/features/suites/s14_universal_initramfs/legacy_initrd_skip.feature
+++ b/features/suites/s14_universal_initramfs/legacy_initrd_skip.feature
@@ -1,22 +1,12 @@
-Feature: Sealed OCI boots skip the legacy initrd when the universal initramfs is cached
+Feature: Sealed OCI boots rely on the universal initramfs
 
-  A sealed OCI boot requires the runtime overlay, and its boot path
-  historically resolved the legacy per-rootfs verity initrd up front — a
-  resolution that can cross-compile every guest binary or fail the boot
-  outright.  When the universal initramfs is already warm in the cache it
-  replaces that initrd later in the boot, so resolving it is dead work: the
-  effective initrd is whatever already sits on disk next to the rootfs, and
-  the legacy build-or-fail ladder must not run.  On a cold universal cache
-  the legacy initrd is the real guest init, so the ladder must still run.
+  A sealed OCI boot requires the runtime overlay. The legacy per-rootfs
+  verity initrd is no longer supported; the universal initramfs attach step
+  later in the boot owns the initramfs. The effective initrd resolved up
+  front is therefore always empty for sealed OCI boots.
 
-  Scenario: A warm universal initramfs skips the legacy initrd resolution
+  Scenario: A sealed OCI boot resolves no up-front initrd
     Given an isolated mvm home with a warm universal initramfs cache
     And a sealed OCI rootfs with no sibling initrd
     When the persistent OCI effective initrd is resolved for a required-overlay boot
     Then the effective initrd is empty
-
-  Scenario: A cold universal cache still resolves the legacy verity initrd
-    Given an isolated mvm home with a cold universal cache but a cached legacy verity initrd
-    And a sealed OCI rootfs with no sibling initrd
-    When the persistent OCI effective initrd is resolved for a required-overlay boot
-    Then the effective initrd is the cached legacy verity initrd

--- a/features/suites/s4_verified_boot/tampered_rootfs_fails_boot.feature
+++ b/features/suites/s4_verified_boot/tampered_rootfs_fails_boot.feature
@@ -6,12 +6,10 @@ Feature: Verified boot rejects a tampered rootfs
   kernel format it can actually boot, without changing the shared verity
   device contract.
 
-  Which channel carries the roothashes depends on which initramfs is PID 1.
-  Under the universal initramfs they travel over vsock, so the sealed cmdline
-  must not carry the legacy `mvm.roothash`, `mvm.data`, `mvm.hash`, or
-  runtime-overlay equivalents. A legacy per-rootfs initramfs is never sent that
-  vsock command, so for it the cmdline is the only channel and those same tokens
-  are mandatory — without them PID 1 aborts and the kernel panics on a dead init.
+  Under the universal initramfs the roothashes travel over vsock, so the sealed
+  cmdline must not carry the legacy `mvm.roothash`, `mvm.data`, `mvm.hash`, or
+  runtime-overlay equivalents. A legacy per-rootfs initramfs is no longer
+  supported, so those cmdline tokens are never emitted.
 
   Scenario: A sealed libkrun workload on the universal initramfs uses its virtio console
     When I assemble a sealed workload cmdline for "libkrun" booting the "universal" initramfs
@@ -33,24 +31,6 @@ Feature: Verified boot rejects a tampered rootfs
     And the sealed workload cmdline contains "mvm.runtime_source_policy=required_overlay"
     And the sealed workload cmdline omits "mvm.roothash="
     But the sealed workload cmdline omits "console=hvc0"
-
-  Scenario: A sealed libkrun workload on the legacy initramfs carries its verity tokens
-    When I assemble a sealed workload cmdline for "libkrun" booting the "legacy" initramfs
-    Then the sealed workload cmdline contains "console=hvc0"
-    And the sealed workload cmdline contains "mvm.runtime_source_policy=required_overlay"
-    And the sealed workload cmdline contains "mvm.roothash="
-    And the sealed workload cmdline contains "mvm.data=/dev/vda"
-    And the sealed workload cmdline contains "mvm.hash=/dev/vdb"
-    And the sealed workload cmdline contains "mvm.runtime_roothash="
-    And the sealed workload cmdline contains "mvm.runtime_data=/dev/vdc"
-    And the sealed workload cmdline contains "mvm.runtime_hash=/dev/vdd"
-
-  Scenario: A sealed HVF workload on the legacy initramfs carries its verity tokens
-    When I assemble a sealed workload cmdline for "hvf" booting the "legacy" initramfs
-    Then the sealed workload cmdline contains "console=ttyAMA0"
-    And the sealed workload cmdline contains "mvm.roothash="
-    And the sealed workload cmdline contains "mvm.data=/dev/vda"
-    And the sealed workload cmdline contains "mvm.hash=/dev/vdb"
 
   Scenario: Libkrun maps the workload kernel to its host-loadable format
     When I map an existing ELF workload kernel through the libkrun driver

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2026-08-08"
+channel = "nightly-2026-08-25"
 components = ["clippy", "rustfmt", "rust-src", "rustc-codegen-cranelift"]
 targets = ["aarch64-unknown-linux-musl", "wasm32-wasip1", "x86_64-unknown-linux-musl"]


### PR DESCRIPTION
Since no one is using the legacy verity-initrd path yet, stop falling back to it. Sealed OCI boots now rely entirely on the universal initramfs.

- `persistent_oci_effective_initrd` and `effective_transient_initrd` always return `None`; the universal initramfs attach step supplies the initramfs.
- Remove `ensure_workload_verity_initrd`, `sibling_rootfs_initrd`, and the cached/embedded/built legacy initrd ladder.
- Remove the legacy verity cmdline tokens from `mvm-vmm` cmdline assembly.
- Update unit tests and the BDD feature file to reflect the new behavior.
- Add a BDD scenario asserting that a sealed OCI boot with a cold universal cache and a present legacy sibling initrd still resolves no up-front initrd.
- Remove the legacy-initramfs cmdline-token scenarios and fixture branch from the verified-boot suite.
- Bump pinned nightly to `nightly-2026-08-25` to avoid a false-positive `clippy::double_must_use` on `async-trait`-generated methods, and fix the `needless_bool`/`nonminimal_bool` lint in `mvm-agentd` exposed by the newer toolchain.

Verification:
- `cargo fmt --all` ✓
- `cargo +stable clippy --workspace --all-targets -- -D warnings` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` (pinned nightly) ✓
- `cargo test -p mvm-cli -p mvm-vmm` ✓
- BDD: `legacy_initrd_skip.feature` and universal cmdline scenarios pass; full local conformance run only fails on pre-existing TypeScript SDK build fixtures (missing `dist/index.js`)