### PR TITLE
ci: build weblinux demo assets in CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -57,6 +57,17 @@ jobs:
       - name: Install binaryen (wasm-opt)
         run: sudo apt-get update && sudo apt-get install -y binaryen
 
+      - name: Install nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+        with:
+          extra-conf: |
+            extra-system-paths = /usr/bin
+
+      - name: Build weblinux demo assets
+        run: |
+          nix build .#qemu-wasm-smoke-pack
+          ./web/weblinux-demo/build.sh result
+
       - name: Build wasm demo
         working-directory: web/mvm-demo
         run: ./build.sh

--- a/Justfile
+++ b/Justfile
@@ -546,9 +546,16 @@ docs-publish:
 demo-build:
     ./web/mvm-demo/build.sh
 
+# Build the weblinux demo assets (requires Linux builder)
+weblinux-demo-build:
+    ./web/weblinux-demo/build.sh
+
 # Stage the /demo assets only if they're missing; `just demo-build` forces a rebuild
 demo-assets:
     [ -d public/public/demo ] || just demo-build
+
+# Build all demo assets (wasm + weblinux); requires Linux for weblinux
+demo-build-all: demo-build weblinux-demo-build
 
 # ── VMM setup ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Fix the weblinux demo 404 error by adding asset building to CI and providing local build targets.

## Why

The weblinux demo at `/demo/weblinux/` requires `qemu-wasm-smoke-pack` which can only be built on Linux. The CI was only building the old WASI sandbox demo, causing 404 errors when users visited the demo page.

## How

- **CI (pages.yml):** Added nix installation and weblinux demo asset build step before the Astro build
- **Justfile:** Added `just weblinux-demo-build` and `just demo-build-all` targets for local development

## Testing

The weblinux demo assets will now be built in CI and deployed with the site. For local development on macOS, users can run `just weblinux-demo-build` from a Linux builder or system with nix.


Generated with Qwen Code