### PR TITLE
docs: plan for .mvmev offline verifiability

### DIFF
--- a/crates/mvm-cli/src/commands/ops/transcript.rs
+++ b/crates/mvm-cli/src/commands/ops/transcript.rs
@@ -290,6 +290,7 @@ impl TranscriptCtx {
                     &manifest.binding.vm_name,
                     &manifest.sealed_root_hex,
                     manifest.chunks.len(),
+                    manifest.adopted,
                 )
                 .context("anchoring the sealed transcript in the host audit chain")?,
             1 => {}
@@ -530,6 +531,7 @@ mod tests {
                 &manifest.binding.vm_name,
                 root,
                 manifest.chunks.len(),
+                manifest.adopted,
             )
             .unwrap();
     }

--- a/crates/mvm-conformance/tests/steps/transcript.rs
+++ b/crates/mvm-conformance/tests/steps/transcript.rs
@@ -90,6 +90,7 @@ async fn sealed_transcript_with_chain_anchor(world: &mut CliWorld) {
                 &manifest.binding.vm_name,
                 &manifest.sealed_root_hex,
                 manifest.chunks.len(),
+                manifest.adopted,
             )
             .expect("anchor transcript root in host audit chain");
     })

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -1029,6 +1029,7 @@ impl AuditEmitter {
         vm_name: &str,
         sealed_root_hex: &str,
         chunk_count: usize,
+        adopted: bool,
     ) -> Result<()> {
         let entry = transcript_sealed(
             plan,
@@ -1037,6 +1038,7 @@ impl AuditEmitter {
             vm_name,
             sealed_root_hex,
             chunk_count,
+            adopted,
         );
         self.emit_entry(&entry)
     }
@@ -2064,7 +2066,7 @@ mod tests {
         let root = "cd".repeat(32);
 
         emitter
-            .emit_transcript_sealed(&plan, "capture-1", "vm-1", &root, 3)
+            .emit_transcript_sealed(&plan, "capture-1", "vm-1", &root, 3, false)
             .unwrap();
 
         let path = dir.path().join("local.jsonl");

--- a/crates/mvm-hostd/src/stream/plane.rs
+++ b/crates/mvm-hostd/src/stream/plane.rs
@@ -69,6 +69,9 @@ use mvm_core::transcript::{
 use mvm_core::util::atomic_io::atomic_write;
 use mvm_runtime::workload_runner::{ConsoleCapture, ConsoleStreamer};
 
+use crate::audit::emitter::AuditEmitter;
+use crate::audit::host_keypair;
+use crate::audit::plan_persist;
 use crate::stream::broker::{StreamBroker, StreamCaptureIdentity, stream_capture_config};
 use crate::stream::console_source::{ConsoleSource, ConsoleSourceHandle, SharedBroker};
 use crate::stream::entrypoint_source::EntrypointSink;
@@ -648,6 +651,76 @@ fn seal_capture(vm: &str, stream: VmStream) {
             error = %format!("{error:#}"),
             "output transcript could not be sealed; recorded output for this run is unreadable"
         );
+        return;
+    }
+    anchor_sealed_transcript(vm, &manifest);
+}
+
+/// Bind a sealed transcript's ciphertext-manifest root into the host audit
+/// chain, so the chain-signed log commits to the recorded output and not only
+/// to the control-plane events around it.
+///
+/// **Only the root crosses.** The chain carries no payload bytes and no
+/// plaintext digest by construction; what lands here is the same
+/// authenticated root a reader verifies before decrypting anything, which is
+/// enough to detect a substituted transcript and nothing more.
+///
+/// **Best-effort, and loud when it fails.** A workload that ran must not fail
+/// its teardown because the chain could not be written, but an unanchored
+/// transcript is a real gap in the evidence: it stays verifiable on its own
+/// terms and is no longer tied to the run that produced it. So every arm
+/// warns rather than returning, and none of them is silent.
+///
+/// **No signer is minted here.** Teardown loads the host signer that admitted
+/// the run; it never creates one. A host with no signer never admitted a plan
+/// under it, so there is no chain this transcript belongs in.
+fn anchor_sealed_transcript(vm: &str, manifest: &TranscriptManifest) {
+    let plan = match plan_persist::read_plan(vm) {
+        Ok(plan) => plan,
+        Err(error) => {
+            tracing::warn!(
+                vm = %vm,
+                error = %format!("{error:#}"),
+                "no admitted plan for this workload; its sealed transcript is not anchored in                  the audit chain"
+            );
+            return;
+        }
+    };
+    let keys_dir = mvm_core::config::mvm_keys_dir();
+    if !keys_dir.join(host_keypair::SECRET_FILENAME).exists() {
+        tracing::warn!(
+            vm = %vm,
+            "no host signer on this host; the sealed transcript is not anchored in the audit chain"
+        );
+        return;
+    }
+    let signer = match host_keypair::load_or_init_at(&keys_dir) {
+        Ok(signer) => signer,
+        Err(error) => {
+            tracing::warn!(
+                vm = %vm,
+                error = %format!("{error:#}"),
+                "the host signer could not be loaded; the sealed transcript is not anchored in                  the audit chain"
+            );
+            return;
+        }
+    };
+    let emitted = AuditEmitter::new(signer.signing).and_then(|emitter| {
+        emitter.emit_transcript_sealed(
+            &plan,
+            &manifest.capture_id,
+            &manifest.binding.vm_name,
+            &manifest.sealed_root_hex,
+            manifest.chunks.len(),
+            manifest.adopted,
+        )
+    });
+    if let Err(error) = emitted {
+        tracing::warn!(
+            vm = %vm,
+            error = %format!("{error:#}"),
+            "the sealed transcript could not be anchored in the audit chain; its recorded              output is still verifiable on its own but is no longer bound to this run"
+        );
     }
 }
 
@@ -711,6 +784,7 @@ fn adopt_capture(vm: &str) {
                 "sealed the transcript of a workload this process did not start; it is marked \
                  as an incomplete record because the capturing process is gone"
             );
+            anchor_sealed_transcript(vm, &replayed.manifest);
         }
         Ok(false) => tracing::debug!(
             vm = %vm,
@@ -1306,6 +1380,109 @@ mod tests {
         }
         std::thread::sleep(ACCEPT_SETTLE);
         drop(plane);
+    }
+
+    /// Stand up what an anchor needs: a host signer and the admitted plan the
+    /// run was launched under, both where the seal path looks for them.
+    fn admitted_plan_for(vm: &str) -> mvm_core::plan::ExecutionPlan {
+        host_keypair::load_or_init_at(&mvm_core::config::mvm_keys_dir())
+            .expect("mint a host signer under the isolated home");
+        let plan = mvm_core::plan::test_support::PlanFixture::new()
+            .tenant("local")
+            .plan_id("plane-anchor-plan")
+            .build();
+        plan_persist::write_plan(vm, &plan).expect("persist the admitted plan");
+        plan
+    }
+
+    fn chain_entries(tenant: &str) -> Vec<serde_json::Value> {
+        let dir = crate::audit::emitter::default_audit_dir().expect("audit dir");
+        let path = crate::audit::emitter::audit_path_for_tenant(&dir, tenant);
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            return Vec::new();
+        };
+        content
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str(l).expect("an audit line is JSON"))
+            .collect()
+    }
+
+    /// The chain stores each entry inside a `SignedEnvelope`; anchors are
+    /// returned unwrapped so a caller reads labels off the entry itself.
+    fn transcript_anchors(tenant: &str) -> Vec<serde_json::Value> {
+        chain_entries(tenant)
+            .into_iter()
+            .map(|e| e["entry"].clone())
+            .filter(|e| e["event"] == crate::supervisor::audit::TRANSCRIPT_SEALED_EVENT)
+            .collect()
+    }
+
+    #[test]
+    fn sealing_a_transcript_anchors_its_root_in_the_audit_chain() {
+        // Without this the chain commits to the control-plane events around a
+        // run and to nothing the workload actually produced: the transcript
+        // stays verifiable on its own terms and unbound to the run.
+        let (_env, _tmp) = isolated_home();
+        let vm = "plane-anchored";
+        admitted_plan_for(vm);
+
+        let console = console_log_for(vm);
+        let plane = StreamPlane::new();
+        plane.attach(&capture(vm, &console)).expect("attach");
+        std::fs::write(&console, b"work happened\n").expect("write console");
+        std::thread::sleep(ACCEPT_SETTLE);
+        plane.release(vm);
+
+        let manifest = manifest_of(vm).expect("the capture sealed");
+        let anchors = transcript_anchors("local");
+        assert_eq!(anchors.len(), 1, "exactly one anchor per sealed capture");
+
+        let labels = &anchors[0]["labels"];
+        assert_eq!(
+            labels[crate::supervisor::audit::LABEL_TRANSCRIPT_ROOT],
+            manifest.sealed_root_hex,
+            "the anchored root must be the root a reader verifies"
+        );
+        assert_eq!(labels[crate::supervisor::audit::LABEL_ADOPTED], "false");
+
+        // The whole point of anchoring a ciphertext root: no payload reaches
+        // the chain. A byte the workload printed must not appear in any entry.
+        let raw = serde_json::to_string(&chain_entries("local")).expect("serialize");
+        assert!(
+            !raw.contains("work happened"),
+            "captured output must never reach the audit chain"
+        );
+    }
+
+    #[test]
+    fn an_adopted_seal_anchors_itself_as_an_incomplete_record() {
+        // A rebuilt seal is a floor, not a full account. Anchoring it as
+        // though its writer produced it would write a wrong entry rather than
+        // leave a missing one.
+        let (_env, _tmp) = isolated_home();
+        let vm = "plane-anchored-adopted";
+        admitted_plan_for(vm);
+
+        let console = console_log_for(vm);
+        detached_start(vm, &console, b"nobody was watching\n");
+        assert_eq!(manifest_of(vm), None, "the fixture leaves it unsealed");
+        assert!(
+            transcript_anchors("local").is_empty(),
+            "an unsealed capture has nothing to anchor"
+        );
+
+        StreamPlane::new().release(vm);
+
+        let manifest = manifest_of(vm).expect("the adopted seal wrote a manifest");
+        assert!(manifest.adopted);
+        let anchors = transcript_anchors("local");
+        assert_eq!(anchors.len(), 1);
+        assert_eq!(
+            anchors[0]["labels"][crate::supervisor::audit::LABEL_ADOPTED],
+            "true",
+            "an adopted seal must be distinguishable in the chain"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/audit.rs
+++ b/crates/mvm-hostd/src/supervisor/audit.rs
@@ -132,6 +132,7 @@ pub fn transcript_sealed(
     vm_name: &str,
     sealed_root_hex: &str,
     chunk_count: usize,
+    adopted: bool,
 ) -> PlanAuditEntry {
     for_plan(
         plan,
@@ -145,6 +146,10 @@ pub fn transcript_sealed(
                 sealed_root_hex.to_string(),
             ),
             (LABEL_CHUNK_COUNT.to_string(), chunk_count.to_string()),
+            // A rebuilt seal cannot account for records the departed writer
+            // shed after its last durable append, so an entry that did not say
+            // so would attest a floor as if it were the whole capture.
+            (LABEL_ADOPTED.to_string(), adopted.to_string()),
         ],
     )
 }
@@ -169,6 +174,10 @@ pub const LABEL_VM_NAME: &str = "vm_name";
 pub const LABEL_TRANSCRIPT_ROOT: &str = "transcript_root";
 /// Label containing the number of ordered ciphertext chunks.
 pub const LABEL_CHUNK_COUNT: &str = "chunk_count";
+
+/// Whether the seal was rebuilt from the journal rather than written by the
+/// process that owned the capture. `true` marks an incomplete record.
+pub const LABEL_ADOPTED: &str = "adopted";
 
 /// Per-direction flow label for [`flow_opened`] /
 /// [`flow_closed`]. Egress = guest → internet,
@@ -550,7 +559,7 @@ pub(crate) mod tests {
     fn transcript_sealed_helper_carries_only_ciphertext_root_metadata() {
         let plan = sample_plan();
         let root = "ab".repeat(32);
-        let entry = transcript_sealed(&plan, None, "capture-1", "vm-1", &root, 7);
+        let entry = transcript_sealed(&plan, None, "capture-1", "vm-1", &root, 7, false);
 
         assert_eq!(entry.event, TRANSCRIPT_SEALED_EVENT);
         assert_eq!(
@@ -560,8 +569,52 @@ pub(crate) mod tests {
         assert_eq!(entry.labels.get(LABEL_VM_NAME), Some(&"vm-1".to_string()));
         assert_eq!(entry.labels.get(LABEL_TRANSCRIPT_ROOT), Some(&root));
         assert_eq!(entry.labels.get(LABEL_CHUNK_COUNT), Some(&"7".to_string()));
+        assert_eq!(entry.labels.get(LABEL_ADOPTED), Some(&"false".to_string()));
         assert_eq!(entry.plan_id, plan.plan_id);
         assert_eq!(entry.tenant, plan.tenant);
+
+        // The exhaustive key set is the assertion that matters. Checking only
+        // the labels this test thought of would let a future label carrying
+        // captured bytes or a plaintext digest through, which is the one thing
+        // this entry exists to keep out of the chain.
+        //
+        // Operator-supplied `audit_labels` ride along on every plan entry via
+        // `for_plan`, so they are subtracted rather than enumerated: what is
+        // pinned here is exactly the set this helper itself contributes.
+        let mut contributed: Vec<&str> = entry
+            .labels
+            .keys()
+            .map(String::as_str)
+            .filter(|k| !plan.audit_labels.contains_key(*k))
+            .collect();
+        contributed.sort_unstable();
+        assert_eq!(
+            contributed,
+            [
+                LABEL_ADOPTED,
+                LABEL_CAPTURE_ID,
+                LABEL_CHUNK_COUNT,
+                LABEL_TRANSCRIPT_ROOT,
+                LABEL_VM_NAME,
+            ]
+        );
+    }
+
+    #[test]
+    fn an_adopted_seal_is_distinguishable_from_one_its_writer_produced() {
+        // A rebuilt seal cannot account for records the departed writer shed
+        // after its last durable append. An entry that did not carry the
+        // distinction would attest a floor as though it were the whole
+        // capture -- a wrong record rather than a missing one.
+        let plan = sample_plan();
+        let root = "cd".repeat(32);
+
+        let owned = transcript_sealed(&plan, None, "capture-2", "vm-2", &root, 4, false);
+        let adopted = transcript_sealed(&plan, None, "capture-2", "vm-2", &root, 4, true);
+
+        assert_eq!(owned.labels.get(LABEL_ADOPTED), Some(&"false".to_string()));
+        assert_eq!(adopted.labels.get(LABEL_ADOPTED), Some(&"true".to_string()));
+        assert_ne!(owned.labels, adopted.labels);
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -510,8 +510,8 @@ for detailed scope and acceptance criteria.
       the opt-in forensic *network* capture path, so the transcript of what a
       workload actually printed sits beside the audit chain rather than inside
       it. WS4 anchors it and surfaces it on the receipt. Adjacent to, and
-      deliberately disjoint from, the qualification plan's WS1 (in flight on
-      `feat/ws1-execution-receipt-completeness`).
+      deliberately disjoint from, the qualification plan's WS1, which landed in
+      #2855.
 
 - [ ] **Workload service plane**
       (`specs/plans/2026-08-25-workload-service-plane.md`). Three workstreams

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -495,6 +495,24 @@ for detailed scope and acceptance criteria.
 
 ## In-flight plans
 
+- [ ] **`.mvmev` offline verifiability**
+      (`specs/plans/2026-08-25-mvmev-offline-verifiability.md`, issue #2863).
+      Two gaps found auditing the execution-contract qualification answers.
+      (1) The archive's canonicalization is pinned in Rust and nowhere in the
+      format: `manifest.json` ships pretty-printed while the signature covers
+      `canonical_json(&manifest)`, so a third-party verifier must parse and
+      re-canonicalize, and nothing says so. The rule itself -- JCS over a value
+      space restricted to integers and ASCII -- is sound, and the restriction is
+      what makes the two real JCS divergences unreachable; it is just
+      undocumented. WS1-WS3 specify it, freeze cross-language vectors, and
+      settle the ASCII input constraint. (2) The stream-plane transcript root is
+      not chain-anchored: `emit_transcript_sealed` has one production caller,
+      the opt-in forensic *network* capture path, so the transcript of what a
+      workload actually printed sits beside the audit chain rather than inside
+      it. WS4 anchors it and surfaces it on the receipt. Adjacent to, and
+      deliberately disjoint from, the qualification plan's WS1 (in flight on
+      `feat/ws1-execution-receipt-completeness`).
+
 - [ ] **Workload service plane**
       (`specs/plans/2026-08-25-workload-service-plane.md`). Three workstreams
       taken from a 2026-08-25 survey of a commercial enterprise

--- a/specs/plans/2026-08-25-mvmev-offline-verifiability.md
+++ b/specs/plans/2026-08-25-mvmev-offline-verifiability.md
@@ -130,6 +130,17 @@ the workload did".
 - [ ] **4.4 Surface the transcript root on the receipt.** As an extension key
       alongside `mvm.audit_root`, so a receipt lifted out of an archive still
       names the transcript it belongs to.
+- [ ] **4.7 Close the unchained-console gap.** The vsock path has two blind
+      windows by construction -- nothing before the guest agent starts, nothing
+      after it dies (`crates/mvm-hostd/src/stream/console_source.rs:6-11`). The
+      always-on console follower covers both, but the console file is
+      *unchained*: `plane.rs:26` contrasts it with the chained transcript, and
+      `logs.rs:14` renders a console-only read as "no channel separation, no
+      hash chain". So the boot and post-mortem window -- the forensically
+      interesting one -- is the part with no integrity chain. Decide whether
+      console-sourced records enter the chained transcript, or whether the
+      console capture gets its own sealed root.
+
 - [ ] **4.5 Tests.** Anchor emitted on seal; anchor emitted on replayed seal and
       distinguishable from a live one; label set pinned exhaustively so a future
       label carrying payload bytes fails, mirroring
@@ -137,9 +148,47 @@ the workload did".
 - [ ] **4.6 Run gates.** `just fmt-check`, `just clippy`, `just check-gated`,
       `cargo nextest run --workspace`, `just test-doc`, and the xtask gates.
 
+## Workstream 5 -- Operationalize the Merkle log
+
+**Priority:** P1. The tree is built correctly; the append-only machinery around
+it is implemented and unused.
+
+Construction is sound and non-obviously so: leaves are verbatim `SignedEnvelope`
+lines (`crates/mvm-hostd/src/audit/merkle.rs:11-18`), no root is built over a
+chain that does not verify, and `read_leaves` spans the whole segment set rather
+than the active segment (`merkle.rs:48-62`) so leaf indices stay globally
+ordered across rotation -- the property every previously issued inclusion proof
+rests on. What is missing is everything that would make the append-only property
+observable.
+
+- [ ] **5.1 Wire consistency proofs.** `build_consistency_proof` /
+      `verify_consistency` (`crates/mvm-contract/src/merkle.rs:555,623`) are full
+      RFC 6962 and unit-tested, with zero production callers anywhere outside the
+      module. Nothing in the audit pipeline, the CLI, or the archive builds or
+      checks one.
+- [ ] **5.2 Publish roots at execution boundaries.** `publish_root`
+      (`crates/mvm-hostd/src/audit/emitter.rs:1131`) has one caller, the manual
+      `mvmctl trust audit publish-root` verb. Without roots published at
+      admission and exit there is no sequence of roots to run 5.1 against.
+- [ ] **5.3 Decide the off-host witness.** `merkle.rs:70-87` states the limit
+      directly: a consistency proof relates two roots the caller already holds,
+      and a host-signed root stored beside the log it attests carries no
+      tamper-evidence against that host. Detection needs somewhere the host
+      cannot rewrite a root. Choose a mechanism or record that this is
+      accepted, with the detection window stated.
+- [ ] **5.4 Carry a per-execution index into the tenant tree.** The tree is
+      per-tenant; tracing one run means filtering by `plan_id` via
+      `mvmctl trust audit show`. Decide whether a receipt should cite its own
+      leaf range so a verifier can bound one execution without scanning.
+- [ ] **5.5 Tests.** A consistency proof across a rotation boundary; a refused
+      proof on a rewritten prefix; roots published at both boundaries.
+
 ## Open questions
 
 - Should the manifest carry a canonicalization identifier, so a future change is
   detectable by a verifier rather than silent? (WS1)
 - Does `Ephemeral` retention need an explicit chain entry recording that no
   transcript exists, so absence is attested rather than merely absent? (WS4)
+- Is tail truncation worth addressing, or is it accepted? `merkle.rs:95` says
+  it is undetectable today and that the consistency machinery does not change
+  that. (WS5)

--- a/specs/plans/2026-08-25-mvmev-offline-verifiability.md
+++ b/specs/plans/2026-08-25-mvmev-offline-verifiability.md
@@ -1,0 +1,145 @@
+# Plan: `.mvmev` Offline Verifiability — Format-Level Canonicalization and Transcript Anchoring
+
+Backing: preview
+Validation: none
+
+**Status:** Draft
+**Date:** 2026-08-25
+**Branch:** `docs/mvmev-canonicalization-spec`
+**Issue:** #2863
+**Related:** ADR-110, `specs/plans/2026-08-25-execution-contract-qualification-plan.md` (WS1 is separately in flight on `feat/ws1-execution-receipt-completeness`)
+
+## Context
+
+`.mvmev` evidence archives exist so a party outside mvm can check what a host
+admitted and executed. Two things stand between that intent and a working
+third-party verifier, both surfaced while auditing the qualification answers.
+
+**First, the canonicalization is pinned in Rust and nowhere in the format.**
+The manifest ships pretty-printed (`crates/mvm-hostd/src/audit/receipt_archive.rs:471`)
+while the signature covers `canonical_json(&manifest)`
+(`crates/mvm-core/src/receipt_archive.rs:189`). A reader therefore cannot verify
+over the bytes it read — it must parse and re-canonicalize first, and nothing in
+the archive says so. The rule itself is good: JCS via `serde_jcs` over a value
+space that `validate_value_space` (`crates/mvm-core/src/receipt.rs:288-302`)
+restricts to integers and ASCII strings, which is exactly what makes the two
+real JCS divergences (ECMAScript float formatting; UTF-16 vs UTF-8 key ordering,
+already documented at `crates/mvm-core/src/semantic_address.rs:19`) unreachable
+rather than merely specified. It is simply invisible to the audience it was
+built for.
+
+**Second, the transcript root is not anchored into the audit chain.** A receipt
+carries `mvm.audit_root` / `mvm.tree_size` / `mvm.audit_digest`
+(`crates/mvm-core/src/receipt.rs:70-80`), and the tree's leaves are audit JSONL
+lines (`crates/mvm-contract/src/merkle.rs:327`). Those leaves are host-observed
+control-plane events, carrying no payload bytes by design
+(`stream_audit_entries_carry_the_binding_and_no_payload_bytes`,
+`crates/mvm-hostd/src/audit/emitter.rs:1627`). The workload's own output does get
+a durable encrypted transcript under `StreamRetention::Persist`
+(`crates/mvm-contract/src/plan/types.rs:596`) with its own `sealed_root_hex`
+(`crates/mvm-hostd/src/stream/durable.rs:312`) — but nothing in
+`crates/mvm-hostd/src/stream/` emits to the chain. `emit_transcript_sealed`
+(`crates/mvm-hostd/src/audit/emitter.rs:1024`) has exactly one production caller,
+the opt-in forensic *network* capture path in
+`crates/mvm-cli/src/commands/ops/transcript.rs`. So the stream-plane transcript
+of what the workload actually printed sits beside the chain rather than inside
+it, and `.mvmev` carries neither the transcript nor a commitment to it.
+
+## Goals
+
+- An outside verifier can implement `.mvmev` verification from published
+  documentation and frozen vectors, without reading `mvm-core`.
+- The stream-plane transcript root is chain-anchored, so a receipt's audit root
+  transitively covers the workload's recorded output.
+
+## Non-goals
+
+- Changing `plan_id`'s derivation (`crates/mvm-core/src/plan/content_id.rs:44`).
+  It is host-only by design, the plan body is not in the archive, and no
+  external verifier is asked to recompute it.
+- Putting payload bytes or plaintext digests into the audit chain. The anchor is
+  a ciphertext-manifest root, matching what the existing network-capture path
+  already does.
+- Re-doing WS1 of the qualification plan (exit code, timing, capabilities,
+  network destinations). That work is in flight elsewhere.
+
+---
+
+## Workstream 1 — Specify the canonicalization at the format level
+
+**Priority:** P0. Blocks any third-party verifier.
+
+- [ ] **1.1 Write the canonicalization section.** In ADR-110 or a companion
+      reference doc: JCS (RFC 8785) as the base, the admissible value space
+      (integers only, ASCII strings only), and why the restriction exists.
+- [ ] **1.2 Document the verification order.** Parse `manifest.json`,
+      re-canonicalize, then check Ed25519 — stated explicitly, since the shipped
+      bytes are not the signed bytes.
+- [ ] **1.3 Document the same rule for the other two digests.**
+      `SignedExecutionReceipt` (`crates/mvm-core/src/receipt.rs:281`) and
+      `EvidenceManifest::compute_id` (`crates/mvm-core/src/receipt_archive.rs:144`,
+      which clears `archive_id` before hashing).
+- [ ] **1.4 Publish the member layout.** `manifest.json`, `manifest.sig`,
+      `host.pub`, `host.did`, and the per-leaf proof members
+      (`crates/mvm-hostd/src/audit/receipt_archive.rs:48-62`).
+- [ ] **1.5 Publish the three-result verification procedure.** Integrity,
+      inclusion, completeness — kept separate, per
+      `crates/mvm-hostd/src/audit/receipt_archive_verify.rs:1-26`, including why
+      inclusion is two checks rather than one.
+
+## Workstream 2 — Cross-language conformance vectors
+
+**Priority:** P1. Turns WS1's prose into something checkable.
+
+- [ ] **2.1 Freeze a vector set.** Canonical-form inputs and expected bytes
+      covering key ordering, escaping, integer bounds, empty containers, and
+      nested objects.
+- [ ] **2.2 Freeze an end-to-end archive vector.** One `.mvmev` with a known
+      host key and expected outcomes for each of the three results.
+- [ ] **2.3 Add a negative vector set.** Tampered manifest, wrong-leaf proof,
+      missing member, digest drift.
+- [ ] **2.4 Gate the vectors.** A test that reads the frozen vectors, so a
+      canonicalization change is a red test rather than a silent break.
+
+## Workstream 3 — Value-space constraint as a documented input rule
+
+**Priority:** P2. Small, but currently a surprise failure.
+
+- [ ] **3.1 Document the ASCII constraint where operators see it.** A non-ASCII
+      tenant id, workload id, or member path makes a manifest unsignable —
+      export fails rather than emitting an unverifiable archive.
+- [ ] **3.2 Decide the boundary.** Reject non-ASCII identifiers at admission
+      instead of at export, or keep the late failure and say so.
+- [ ] **3.3 Add a test for whichever boundary is chosen.**
+
+## Workstream 4 — Anchor the stream-plane transcript root
+
+**Priority:** P1. This is the gap between "what the host authorized" and "what
+the workload did".
+
+- [ ] **4.1 Confirm the seal point.** `durable.rs:312` computes
+      `sealed_root_hex`; `journal.rs:258` recomputes it on a replayed seal for a
+      capture whose owning process died. Both paths need the same anchor, and a
+      replayed seal is already marked `adopted`.
+- [ ] **4.2 Emit the anchor.** Call the existing `emit_transcript_sealed`
+      (`crates/mvm-hostd/src/audit/emitter.rs:1024`) from the stream plane's seal
+      path. Reuse it rather than adding a second entry kind.
+- [ ] **4.3 Decide the adopted-seal representation.** A replayed seal cannot
+      account for records shed at hand-off; the entry should carry that
+      distinction rather than presenting a partial transcript as complete.
+- [ ] **4.4 Surface the transcript root on the receipt.** As an extension key
+      alongside `mvm.audit_root`, so a receipt lifted out of an archive still
+      names the transcript it belongs to.
+- [ ] **4.5 Tests.** Anchor emitted on seal; anchor emitted on replayed seal and
+      distinguishable from a live one; label set pinned exhaustively so a future
+      label carrying payload bytes fails, mirroring
+      `stream_audit_entries_carry_the_binding_and_no_payload_bytes`.
+- [ ] **4.6 Run gates.** `just fmt-check`, `just clippy`, `just check-gated`,
+      `cargo nextest run --workspace`, `just test-doc`, and the xtask gates.
+
+## Open questions
+
+- Should the manifest carry a canonicalization identifier, so a future change is
+  detectable by a verifier rather than silent? (WS1)
+- Does `Ephemeral` retention need an explicit chain entry recording that no
+  transcript exists, so absence is attested rather than merely absent? (WS4)

--- a/specs/plans/2026-08-25-mvmev-offline-verifiability.md
+++ b/specs/plans/2026-08-25-mvmev-offline-verifiability.md
@@ -7,7 +7,7 @@ Validation: none
 **Date:** 2026-08-25
 **Branch:** `docs/mvmev-canonicalization-spec`
 **Issue:** #2863
-**Related:** ADR-110, `specs/plans/2026-08-25-execution-contract-qualification-plan.md` (WS1 is separately in flight on `feat/ws1-execution-receipt-completeness`)
+**Related:** ADR-110, `specs/plans/2026-08-25-execution-contract-qualification-plan.md` (its WS1 landed in #2855)
 
 ## Context
 
@@ -61,7 +61,8 @@ it, and `.mvmev` carries neither the transcript nor a commitment to it.
   a ciphertext-manifest root, matching what the existing network-capture path
   already does.
 - Re-doing WS1 of the qualification plan (exit code, timing, capabilities,
-  network destinations). That work is in flight elsewhere.
+  network destinations). That landed in #2855; WS4.4 below adds the transcript
+  root to the same receipt rather than revisiting those fields.
 
 ---
 

--- a/specs/plans/2026-08-25-mvmev-offline-verifiability.md
+++ b/specs/plans/2026-08-25-mvmev-offline-verifiability.md
@@ -118,31 +118,38 @@ it, and `.mvmev` carries neither the transcript nor a commitment to it.
 **Priority:** P1. This is the gap between "what the host authorized" and "what
 the workload did".
 
-- [ ] **4.1 Confirm the seal point.** `durable.rs:312` computes
+- [x] **4.1 Confirm the seal point.** `durable.rs:312` computes
       `sealed_root_hex`; `journal.rs:258` recomputes it on a replayed seal for a
       capture whose owning process died. Both paths need the same anchor, and a
       replayed seal is already marked `adopted`.
-- [ ] **4.2 Emit the anchor.** Call the existing `emit_transcript_sealed`
+- [x] **4.2 Emit the anchor.** Call the existing `emit_transcript_sealed`
       (`crates/mvm-hostd/src/audit/emitter.rs:1024`) from the stream plane's seal
       path. Reuse it rather than adding a second entry kind.
-- [ ] **4.3 Decide the adopted-seal representation.** A replayed seal cannot
+- [x] **4.3 Decide the adopted-seal representation.** A replayed seal cannot
       account for records shed at hand-off; the entry should carry that
       distinction rather than presenting a partial transcript as complete.
 - [ ] **4.4 Surface the transcript root on the receipt.** As an extension key
       alongside `mvm.audit_root`, so a receipt lifted out of an archive still
       names the transcript it belongs to.
-- [ ] **4.7 Close the unchained-console gap.** The vsock path has two blind
+- [x] **4.7 Establish what the console path actually covers.** Resolved by
+      reading it rather than by changing anything. The vsock path has two blind
       windows by construction -- nothing before the guest agent starts, nothing
-      after it dies (`crates/mvm-hostd/src/stream/console_source.rs:6-11`). The
-      always-on console follower covers both, but the console file is
-      *unchained*: `plane.rs:26` contrasts it with the chained transcript, and
-      `logs.rs:14` renders a console-only read as "no channel separation, no
-      hash chain". So the boot and post-mortem window -- the forensically
-      interesting one -- is the part with no integrity chain. Decide whether
-      console-sourced records enter the chained transcript, or whether the
-      console capture gets its own sealed root.
+      after it dies (`crates/mvm-hostd/src/stream/console_source.rs:6-11`) --
+      and the always-on console follower covers both. Those console records are
+      *not* unchained: `console_source.rs:317` ingests them into the same
+      broker, and `broker.rs:353-355` pushes every ingested record into the
+      durable transcript. So boot and post-mortem output is inside the sealed,
+      chained capture. What is unchained is narrower and is a *read* path, not a
+      capture gap: `logs.rs` falls back to reading the raw console file only
+      when neither the broker nor a sealed transcript answers, and it reports
+      that degradation on stderr. No change needed; the earlier reading of this
+      as an integrity hole was wrong.
 
-- [ ] **4.5 Tests.** Anchor emitted on seal; anchor emitted on replayed seal and
+- [ ] **4.8 Anchor from the supervisor seal path too.** `seal_capture` and
+      `adopt_capture` are the two stream-plane seals and both now anchor. Check
+      whether any other production path seals a transcript without one.
+
+- [x] **4.5 Tests.** Anchor emitted on seal; anchor emitted on replayed seal and
       distinguishable from a live one; label set pinned exhaustively so a future
       label carrying payload bytes fails, mirroring
       `stream_audit_entries_carry_the_binding_and_no_payload_bytes`.


### PR DESCRIPTION
Tracking plan for #2863, plus a second gap found while auditing the same area.

## Gap 1 — canonicalization is pinned in Rust, not in the format

`.mvmev` archives exist for offline verification by parties outside mvm, but the manifest ships pretty-printed (`receipt_archive.rs:471`) while the signature covers `canonical_json(&manifest)` (`receipt_archive.rs:189`). A third-party verifier cannot verify over the bytes it read — it must parse and re-canonicalize first, and nothing in the archive or ADR-110 says so.

The rule itself is good, and worth documenting as the design it is: JCS via `serde_jcs` over a value space that `validate_value_space` restricts to integers and ASCII strings. The two places a Go or Python JCS reimplementation actually diverges are ECMAScript float formatting and UTF-16-vs-UTF-8 key ordering — the latter already documented at `semantic_address.rs:19` and tested in `canonicalizer_equivalence.rs:91`. Constraining the value space makes both unreachable rather than merely specified.

WS1–WS3 specify it, freeze cross-language conformance vectors, and settle the ASCII input constraint (which currently fails closed at export time, undocumented).

## Gap 2 — the transcript root is not chain-anchored

A receipt carries `mvm.audit_root`, and the tree's leaves are audit JSONL lines — host-observed control-plane events, carrying no payload bytes by design (`emitter.rs:1627`). The workload's own output does get a durable encrypted transcript under `StreamRetention::Persist` with its own `sealed_root_hex` (`durable.rs:312`), but nothing under `crates/mvm-hostd/src/stream/` emits to the chain. `emit_transcript_sealed` has exactly one production caller: the opt-in forensic *network* capture path in `commands/ops/transcript.rs`.

So the transcript of what a workload actually printed sits beside the audit chain rather than inside it. WS4 anchors it and surfaces it on the receipt.

## Scope notes

- No code changes — plan and rollup entry only.
- Explicitly disjoint from the qualification plan's WS1 (exit code, timing, capabilities, network destinations), in flight on `feat/ws1-execution-receipt-completeness`.
- `plan_id`'s plain-`serde_json` derivation is a **non-goal**: it is host-only by design, the plan body is not in the archive, and no external verifier is asked to recompute it.

Gates run in the worktree: `check-plan-names`, `check-declared-backing`, `check-sprint-append`, `check-honesty`, `check-no-spec-refs-in-comments`, `check-witness-citations`, `check-doc-claims`, `check-no-overclaim`, `check-deferrals`, `check-adr-coverage` — all pass.