### PR TITLE
fix(pages): disable Determinate Nix FlakeHub login in Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Install nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
         with:
+          determinate: false
           extra-conf: |
             extra-system-paths = /usr/bin
 


### PR DESCRIPTION
The Pages deploy workflow fails at the weblinux demo asset build step because Determinate Nix tries to log into FlakeHub and cannot authenticate. This adds `determinate: false` so the workflow installs upstream Nix instead, allowing `nix build .#qemu-wasm-smoke-pack` to succeed and stage the demo assets for the live site.