### PR TITLE
feat(nix): render mkGuest healthChecks into the guest probe drop-ins

### DIFF
--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -152,17 +152,49 @@ in
 , serviceGroup   ? null
 }:
 let
-  # Shape checks for the declared-but-unenforced attributes. A typo in one of
-  # these would otherwise be invisible: they are recorded, not consumed, so
-  # nothing downstream would ever notice.
+  # Shape checks. `healthChecks` is consumed (rendered into the guest's probe
+  # drop-in directory below); the rest are recorded only, so a typo in them
+  # would otherwise be invisible.
   declaredButUnenforced =
     (if builtins.isAttrs healthChecks then [ ] else throw "mkGuest: healthChecks must be an attribute set")
     ++ (if builtins.isAttrs volumeMounts then [ ] else throw "mkGuest: volumeMounts must be an attribute set")
     ++ (if serviceGroup == null || builtins.isString serviceGroup then [ ] else throw "mkGuest: serviceGroup must be a string or null");
 
+  # `healthChecks.<name> = { healthCmd; healthIntervalSecs?; healthTimeoutSecs?; }`
+  # becomes one `/etc/mvm/probes.d/<name>.json` drop-in per check.
+  #
+  # The guest agent already scans that directory at boot and runs each entry on
+  # its own interval (`probes::load_probe_dropin_dir`, then `probe_health_loop`),
+  # serving the results back over vsock as `ProbeStatus`. Every piece of that
+  # existed; nothing wrote the drop-ins, so the directory was always empty and a
+  # declared health check did nothing at all. This is the missing link.
+  probeDropIns = lib.mapAttrs'
+    (checkName: check:
+      let
+        cmd =
+          if check ? healthCmd then check.healthCmd
+          else throw "mkGuest: healthChecks.${checkName} must set `healthCmd`";
+        interval = if check ? healthIntervalSecs then check.healthIntervalSecs else 30;
+        timeout = if check ? healthTimeoutSecs then check.healthTimeoutSecs else 10;
+      in
+      lib.nameValuePair "/etc/mvm/probes.d/${checkName}.json" {
+        content = builtins.toJSON {
+          name = checkName;
+          inherit cmd;
+          interval_secs = interval;
+          timeout_secs = timeout;
+          output_format = "exit_code";
+        };
+        mode = "0444";
+      })
+    healthChecks;
+
+  # The caller's own files win: a flake that hand-writes a drop-in for the same
+  # path meant to, and silently replacing it would be worse than the collision.
+  extraFilesWithProbes = probeDropIns // extraFiles;
+
   unenforcedNames =
     (if services == { } then [ ] else [ "services" ])
-    ++ (if healthChecks == { } then [ ] else [ "healthChecks" ])
     ++ (if volumeMounts == { } then [ ] else [ "volumeMounts" ])
     ++ (if serviceGroup == null then [ ] else [ "serviceGroup" ]);
 
@@ -192,7 +224,7 @@ let
 
   extraFileLabel = path:
     let
-      rawSpec = extraFiles.${path};
+      rawSpec = extraFilesWithProbes.${path};
       spec =
         if builtins.isString rawSpec then { source = rawSpec; }
         else rawSpec;
@@ -204,13 +236,13 @@ let
   extraFileSourceRoots = lib.filter (source: source != "") (map
     (path:
       let
-        rawSpec = extraFiles.${path};
+        rawSpec = extraFilesWithProbes.${path};
         spec =
           if builtins.isString rawSpec then { source = rawSpec; }
           else rawSpec;
       in
       if spec ? source then spec.source else "")
-    (lib.attrNames extraFiles));
+    (lib.attrNames extraFilesWithProbes));
 
   sshClosureInfo = pkgs.closureInfo {
     rootPaths = packages ++ extraFileSourceRoots;
@@ -229,7 +261,7 @@ let
   assertNoSshTemplateInputs =
     let
       badPackages = lib.filter (pkg: containsSshMarker (packageLabel pkg)) packages;
-      badFiles = lib.filter (path: containsSshMarker (extraFileLabel path)) (lib.attrNames extraFiles);
+      badFiles = lib.filter (path: containsSshMarker (extraFileLabel path)) (lib.attrNames extraFilesWithProbes);
       badPackageNames = map (pkg: packageLabel pkg) badPackages;
       badFileNames = map (path: path) badFiles;
     in
@@ -1192,7 +1224,7 @@ let
   extraFilePopulation = lib.concatMapStringsSep "\n"
     (path:
       let
-        rawSpec = extraFiles.${path};
+        rawSpec = extraFilesWithProbes.${path};
         spec =
           if builtins.isString rawSpec then { source = rawSpec; }
           else rawSpec;
@@ -1221,7 +1253,7 @@ let
           "$out${path}"
       ''
     )
-    (lib.attrNames extraFiles);
+    (lib.attrNames extraFilesWithProbes);
 
   # ── Rootfs tree population ────────────────────────────────────
   #
@@ -1616,6 +1648,20 @@ let
     # that could silently degrade to a baked agent/netinit pair.
     runtimeLean = true;
     sshTemplateBan = builtins.seq assertNoSshTemplateInputs true;
+    # The probe drop-ins this guest carries, as `<path> -> <decoded entry>`.
+    # Exposed so a host (or a test) can see what the guest will actually run
+    # without building the rootfs to go and read the files.
+    #
+    # Read back out of `extraFilesWithProbes` — the exact set the rootfs
+    # population loop iterates — rather than out of `probeDropIns`. Deriving it
+    # from the rendering instead would report drop-ins that never reached the
+    # image: a first version of this did, and breaking the merge outright
+    # changed no assertion at all.
+    probes = lib.mapAttrs
+      (_: spec: builtins.fromJSON spec.content)
+      (lib.filterAttrs
+        (path: _: lib.hasPrefix "/etc/mvm/probes.d/" path)
+        extraFilesWithProbes);
     # Declared-but-unenforced, recorded so a host or an audit can see the gap
     # between what the flake asked for and what the guest actually does.
     unenforced = {

--- a/nix/tests/mk-guest-eval.nix
+++ b/nix/tests/mk-guest-eval.nix
@@ -262,12 +262,48 @@ in
   # project fail to evaluate with "unexpected argument". They are accepted and
   # recorded; nothing acts on them until the supervisor lands.
 
-  health_checks_are_accepted =
+  # `healthChecks` is consumed now, not merely recorded: each check becomes a
+  # `/etc/mvm/probes.d/<name>.json` drop-in, which the guest agent already
+  # scans at boot and runs on its own interval. Before this, the directory was
+  # always empty and a declared check did nothing.
+  health_checks_render_a_probe_dropin =
+    let
+      entry = (meta (mkGuest {
+        name = "hc";
+        entrypoint.command = [ "/bin/x" ];
+        healthChecks.app = { healthCmd = "/bin/true"; healthIntervalSecs = 5; };
+      })).probes."/etc/mvm/probes.d/app.json";
+    in
+    entry.name == "app"
+      && entry.cmd == "/bin/true"
+      && entry.interval_secs == 5
+      && entry.timeout_secs == 10          # documented default
+      && entry.output_format == "exit_code";
+
+  # A guest declaring no checks carries no drop-ins, so the agent's boot scan
+  # finds an empty directory rather than a stray file.
+  no_health_checks_renders_no_dropins =
     (meta (mkGuest {
-      name = "hc";
+      name = "plain-probe";
       entrypoint.command = [ "/bin/x" ];
-      healthChecks.app = { healthCmd = "true"; healthIntervalSecs = 5; };
-    })).unenforced.names == [ "healthChecks" ];
+    })).probes == { };
+
+  # A check with no command is a typo, not a default.
+  health_check_without_a_command_is_rejected =
+    rejects (mkGuest {
+      name = "hc-nocmd";
+      entrypoint.command = [ "/bin/x" ];
+      healthChecks.app = { healthIntervalSecs = 5; };
+    });
+
+  # `healthChecks` no longer appears in the unenforced list; the other two
+  # still do, because nothing consumes them yet.
+  health_checks_are_no_longer_unenforced =
+    (meta (mkGuest {
+      name = "hc2";
+      entrypoint.command = [ "/bin/x" ];
+      healthChecks.app = { healthCmd = "true"; };
+    })).unenforced.names == [ ];
 
   volume_mounts_are_accepted =
     (meta (mkGuest {

--- a/public/src/content/docs/getting-started/first-microvm.md
+++ b/public/src/content/docs/getting-started/first-microvm.md
@@ -3,11 +3,11 @@ title: Your First MicroVM
 description: Write a Nix flake and boot a microVM.
 ---
 
-:::caution[Declared, not enforced]
-`healthChecks`, `volumeMounts` and `serviceGroup` are accepted by `mkGuest`
-and recorded in `passthru.mvm.unenforced`, but nothing acts on them yet: the
-multi-service supervisor is still a stub. A flake using them builds, and
-prints a warning at evaluation saying so.
+:::note[Health checks run in the guest]
+`healthChecks` is rendered into `/etc/mvm/probes.d/<name>.json` in the image.
+The guest agent scans that directory at boot and runs each check on its own
+interval; results come back over vsock. `volumeMounts` and `serviceGroup` are
+still recorded rather than acted on — the multi-service supervisor is not wired.
 :::
 
 This guide walks through writing a Nix flake that builds a microVM image, then booting it with mvmctl.

--- a/public/src/content/docs/getting-started/nix-for-mvm.mdx
+++ b/public/src/content/docs/getting-started/nix-for-mvm.mdx
@@ -3,11 +3,11 @@ title: "Nix for mvm: A Beginner's Guide"
 description: Learn just enough Nix to write your first mvm flake — no prior Nix experience required.
 ---
 
-:::caution[Declared, not enforced]
-`healthChecks`, `volumeMounts` and `serviceGroup` are accepted by `mkGuest`
-and recorded in `passthru.mvm.unenforced`, but nothing acts on them yet: the
-multi-service supervisor is still a stub. A flake using them builds, and
-prints a warning at evaluation saying so.
+:::note[Health checks run in the guest]
+`healthChecks` is rendered into `/etc/mvm/probes.d/<name>.json` in the image.
+The guest agent scans that directory at boot and runs each check on its own
+interval; results come back over vsock. `volumeMounts` and `serviceGroup` are
+still recorded rather than acted on — the multi-service supervisor is not wired.
 :::
 
 You don't need to be a Nix expert to use mvm. This guide teaches you exactly what you need to know to write a flake that builds a microVM image. If you've never seen a `.nix` file before, start here.

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -3,11 +3,11 @@ title: Writing Nix Flakes
 description: Create custom Nix flakes that build microVM images for mvm.
 ---
 
-:::caution[Declared, not enforced]
-`healthChecks`, `volumeMounts` and `serviceGroup` are accepted by `mkGuest`
-and recorded in `passthru.mvm.unenforced`, but nothing acts on them yet: the
-multi-service supervisor is still a stub. A flake using them builds, and
-prints a warning at evaluation saying so.
+:::note[Health checks run in the guest]
+`healthChecks` is rendered into `/etc/mvm/probes.d/<name>.json` in the image.
+The guest agent scans that directory at boot and runs each check on its own
+interval; results come back over vsock. `volumeMounts` and `serviceGroup` are
+still recorded rather than acted on — the multi-service supervisor is not wired.
 :::
 
 mvmctl uses Nix flakes to produce reproducible microVM images. You run `mvmctl machine build` from the host, and mvm runs Nix evaluation and `nix build` inside the Linux builder VM. The result is a kernel and rootfs that can boot on any supported runtime backend, including Firecracker, HVF, libkrun, and QEMU.


### PR DESCRIPTION
A `healthChecks` block in a flake did nothing. Not because health checking was unbuilt — it is built twice — but because nothing connected the declaration to either implementation.

## What already existed

- **Guest side.** `mvm-agentd`'s guest agent scans `/etc/mvm/probes.d/*.json` at boot (`probes::load_probe_dropin_dir`), spawns `probe_health_loop`, runs each entry on its own interval with a timeout, and serves results back over vsock as `ProbeStatus`.
- **Host side.** `mvm-hostd`'s `health_probe::HealthProber` consumes `spec.health_check`, which is what `machine run --healthcheck` persists.

What did not exist: anything that *wrote* a drop-in. `probes.rs` says the directory is "populated by the Nix flake at build time", and no Nix code populated it. The agent's scan always found an empty directory, so every `healthChecks` block in the docs and in all five scaffold templates was inert.

## The change

`healthChecks.<name> = { healthCmd; healthIntervalSecs?; healthTimeoutSecs?; }` renders to `/etc/mvm/probes.d/<name>.json` in the shape `ProbeEntry` already deserializes, defaulting to the documented 30s interval and 10s timeout.

- A check without a `healthCmd` is a typo rather than a default, so it throws.
- Caller-supplied `extraFiles` still win on a path collision — a flake hand-writing a drop-in meant to.
- `healthChecks` accordingly leaves `passthru.mvm.unenforced`. `volumeMounts` and `serviceGroup` stay there, since nothing consumes them yet.

## On the tests

Four eval assertions cover it, and getting them honest took two attempts worth recording.

The first read `passthru.mvm.probes` off the *rendering*, so deleting the merge into the rootfs file set changed no assertion — the drop-in was reported present while never reaching the image. `probes` is now derived from `extraFilesWithProbes`, the exact set the population loop iterates, and breaking the merge fails the gate with a missing-attribute error.

Verified red-first through the real harness rather than by eye: with the merge removed `mk_guest_eval_assertions_all_pass_when_nix_available` FAILS; restored, it passes.

## Gates

`cargo +nightly fmt --all --check`, `xtask check-all`, `check-conformance`, `check-honesty`, 49 `nix_flake_structure` tests, 38 eval assertions — all green. BDD: 239 scenarios, 231 passed, same 7 pre-existing failures as main.