### PR TITLE
fix(cli): stop telling users to run commands that do not exist

### DIFF
--- a/crates/mvm-cli/src/commands/build/build.rs
+++ b/crates/mvm-cli/src/commands/build/build.rs
@@ -282,7 +282,10 @@ fn build_manifest(
         ui::step(2, 2, "Build complete");
         ui::info(&format!("  Slot:     {}", persisted.manifest_hash));
         ui::info(&format!("  Revision: {}", revision.revision_hash));
-        ui::info(&format!("\nRun with: mvmctl up {}", canonical.display()));
+        ui::info(&format!(
+            "\nRun with: mvmctl machine run --manifest {}",
+            canonical.display()
+        ));
     }
 
     Ok(())
@@ -401,7 +404,6 @@ fn build_mvmfile(path: &str, output: Option<&str>) -> Result<()> {
     };
     audit_build_ok("mvmfile", path, "", &elf_path);
     ui::success(&format!("\nImage ready: {}", elf_path));
-    ui::info(&format!("Run with: mvmctl start {}", elf_path));
     Ok(())
 }
 

--- a/crates/mvm-cli/src/commands/build/compile.rs
+++ b/crates/mvm-cli/src/commands/build/compile.rs
@@ -1,4 +1,4 @@
-//! `mvmctl compile` — Workload IR to staged build artifacts.
+//! `mvmctl build compile` — Workload IR to staged build artifacts.
 //!
 //! Renders `flake.nix`, `launch.json`, and the bundled source tree
 //! into `--out <dir>` (or a deterministic `.tar.gz`/`.tgz` archive when
@@ -84,15 +84,15 @@ pub(in crate::commands) struct Args {
     )]
     pub out: PathBuf,
 
-    /// Explicit mode. `record` is the default for `mvmctl compile`.
+    /// Explicit mode. `record` is the default for `mvmctl build compile`.
     #[arg(long = "mode", value_enum)]
     pub mode: Option<Mode>,
 
-    /// Friendly alias — resolves to `--mode record` on `mvmctl compile`.
+    /// Friendly alias — resolves to `--mode record` on `mvmctl build compile`.
     #[arg(long = "prod", conflicts_with_all = ["dev", "mode"])]
     pub prod: bool,
 
-    /// Refused on `mvmctl compile` — use `mvmctl run` for the live
+    /// Refused on `mvmctl build compile` — use `mvmctl run` for the live
     /// transport. Accepted only to surface the rejection clearly.
     #[arg(long = "dev", conflicts_with_all = ["prod", "mode"])]
     pub dev: bool,
@@ -115,7 +115,7 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     let resolved_mode = resolve_mode(&args)?;
     if !matches!(resolved_mode, Mode::Record) {
         bail!(
-            "mvmctl compile only supports --mode record (alias --prod) in v1; \
+            "mvmctl build compile only supports --mode record (alias --prod) in v1; \
              received {resolved_mode:?}. Use `mvmctl run` for live/plan modes \
              (lands in SDK-port Phase 7)."
         );
@@ -194,7 +194,7 @@ fn resolve_mode(args: &Args) -> Result<Mode> {
     }
     if args.dev {
         bail!(
-            "--dev is refused on `mvmctl compile` (it boots a live microVM, which is the \
+            "--dev is refused on `mvmctl build compile` (it boots a live microVM, which is the \
              `mvmctl run` verb). Drop the flag, or run `mvmctl run --dev <script>` instead."
         );
     }

--- a/crates/mvm-cli/src/commands/bundle/install.rs
+++ b/crates/mvm-cli/src/commands/bundle/install.rs
@@ -82,6 +82,9 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         installed.manifest.key_id.0,
     );
     println!("  registry root: {}", installed.root.display());
-    println!("  launch with:   mvmctl up --manifest {}", installed.sha256);
+    println!(
+        "  launch with:   mvmctl machine run --manifest {}",
+        installed.sha256
+    );
     Ok(())
 }

--- a/crates/mvm-cli/src/commands/env/cleanup.rs
+++ b/crates/mvm-cli/src/commands/env/cleanup.rs
@@ -181,7 +181,7 @@ pub(in crate::commands) fn run(cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resul
     {
         anyhow::bail!(
             "refusing to run cleanup --{} while VM '{}' appears to be running.\n\
-             Stop it first (`mvmctl stop {}`), or pass --force to wipe anyway.",
+             Stop it first (`mvmctl machine stop {}`), or pass --force to wipe anyway.",
             t.name(),
             running,
             running,

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1248,7 +1248,7 @@ fn load_machine_manifest_source(arg: &Path) -> Result<MachineManifestSource> {
         .with_context(|| format!("reading machine manifest {}", manifest_path.display()))?;
     let workflow = manifest.machine_workflow().ok_or_else(|| {
         anyhow!(
-            "machine create --manifest requires an image-backed manifest; flake-backed manifests belong to `mvmctl up`"
+            "machine create --manifest requires an image-backed manifest; flake-backed manifests belong to `mvmctl machine run --flake`"
         )
     })?;
     let base_dir = manifest_path

--- a/crates/mvm-cli/src/commands/ops/audit.rs
+++ b/crates/mvm-cli/src/commands/ops/audit.rs
@@ -734,7 +734,7 @@ fn verify_cert(
     };
 
     // 1. Slurp the cert. `-` reads from stdin so an auditor can
-    //    `cat certs.json | mvmctl audit verify-cert -`.
+    //    `cat certs.json | mvmctl trust audit verify-cert -`.
     let raw = if cert == "-" {
         let mut buf = String::new();
         std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
@@ -831,7 +831,7 @@ fn verify_cert(
     // 6. Render. Human summary to stderr always; receipts JSON to
     //    stdout when --json.
     eprintln!(
-        "mvmctl audit verify-cert: {} certificate(s) verified",
+        "mvmctl trust audit verify-cert: {} certificate(s) verified",
         verified.len()
     );
     for (r, chain_match) in verified.iter().zip(chain_matches.iter()) {
@@ -1268,7 +1268,7 @@ fn audit_verify(tenant: &str) -> Result<()> {
     }
 
     // Print a clear error AND propagate so the process exits nonzero.
-    // `mvmctl audit verify` is meant for scripting.
+    // `mvmctl trust audit verify` is meant for scripting.
     if let Some(refusal) = outcome.refusals.first() {
         anyhow::bail!(
             "{} verify failed ({}): {}",

--- a/crates/mvm-cli/src/commands/ops/audit_posture.rs
+++ b/crates/mvm-cli/src/commands/ops/audit_posture.rs
@@ -1,4 +1,4 @@
-//! `mvmctl audit posture` — security posture self-test.
+//! `mvmctl trust audit posture` — security posture self-test.
 //!
 //! Read-only diagnostic that reports which host-hardening
 //! mitigations are active on the calling host. Operators run it
@@ -28,7 +28,7 @@
 //! - No network calls. Doesn't probe upstreams to confirm they
 //!   advertise TLS 1.3; that would be a runtime cost + flake.
 //! - No write side effects. Operators on production hosts can
-//!   run `mvmctl audit posture --json` from a monitoring agent
+//!   run `mvmctl trust audit posture --json` from a monitoring agent
 //!   without risk of mutating state.
 
 use anyhow::Result;
@@ -109,7 +109,7 @@ pub fn build_report(home: Option<&std::path::Path>) -> PostureReport {
 fn render_human(report: &PostureReport) {
     let (ok, warn, fail) = report.summary_counts();
     eprintln!(
-        "mvmctl audit posture — security self-test ({} ok / {} warn / {} fail)",
+        "mvmctl trust audit posture — security self-test ({} ok / {} warn / {} fail)",
         ok, warn, fail
     );
     for c in &report.checks {

--- a/crates/mvm-cli/src/commands/shared/hints.rs
+++ b/crates/mvm-cli/src/commands/shared/hints.rs
@@ -9,7 +9,7 @@ pub fn with_hints(result: Result<()>) -> Result<()> {
         let msg = format!("{:#}", e);
         if msg.contains("firecracker: command not found") || msg.contains("firecracker: not found")
         {
-            ui::warn("Hint: Run 'mvmctl setup' to install Firecracker.");
+            ui::warn("Hint: Run 'mvmctl bootstrap' to install Firecracker.");
         } else if msg.contains("/dev/kvm") {
             ui::warn(
                 "Hint: Enable KVM/virtualization in your BIOS or VM settings.\n      \
@@ -20,7 +20,7 @@ pub fn with_hints(result: Result<()>) -> Result<()> {
         } else if msg.contains("nix: command not found") || msg.contains("nix: not found") {
             ui::warn("Hint: Nix runs inside the builder VM; builds invoke it automatically.");
         } else if msg.contains("dev VM is not running") || msg.contains("VM is not started") {
-            ui::warn("Hint: Run 'mvmctl bootstrap' or 'mvmctl setup' to initialise it first.");
+            ui::warn("Hint: Run 'mvmctl bootstrap' to initialise it first.");
         } else if msg.contains("already exists") && msg.contains("template") {
             ui::warn("Hint: Use '--force' to overwrite the existing template.");
         } else if msg.contains("error: builder for") && msg.contains("failed with exit code") {
@@ -50,7 +50,7 @@ pub fn with_hints(result: Result<()>) -> Result<()> {
         } else if msg.contains("hash mismatch") && msg.contains("got:") {
             ui::warn(
                 "Hint: Fixed-output derivation hash changed. Run \
-                 'mvmctl template build <name> --update-hash' to recompute.",
+                 'mvmctl machine build <name> --update-hash' to recompute.",
             );
         } else if msg.contains("does it exist?") && msg.contains("template") {
             ui::warn("Hint: List available templates with 'mvmctl template list'.");

--- a/crates/mvm-cli/src/commands/vm/checkpoint/vm_state.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/vm_state.rs
@@ -38,8 +38,8 @@ pub(super) fn resolve_quiesced_vm_rootfs(name: &str) -> Result<PathBuf> {
         if !path.exists() {
             bail!(
                 "fs_quick checkpoint needs the VM's rootfs ({}), which is no longer \
-                 on disk. Pause instead of stopping: `mvmctl vm pause {name}`, \
-                 checkpoint, then `mvmctl vm resume {name}` — or use \
+                 on disk. Pause instead of stopping: `mvmctl machine pause {name}`, \
+                 checkpoint, then `mvmctl machine resume {name}` — or use \
                  `--class vm-full` on a running VM.",
                 path.display()
             );

--- a/crates/mvm-cli/src/commands/vm/cp.rs
+++ b/crates/mvm-cli/src/commands/vm/cp.rs
@@ -74,10 +74,12 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
             copy_guest_to_host(vm, path, host, &args)
         }
         (Endpoint::Guest { .. }, Endpoint::Guest { .. }) => {
-            bail!("mvmctl cp supports exactly one VM endpoint; use `mvmctl fs mv` inside one VM")
+            bail!(
+                "mvmctl machine cp supports exactly one VM endpoint; use `mvmctl machine fs mv` inside one VM"
+            )
         }
         (Endpoint::Host(_), Endpoint::Host(_)) => {
-            bail!("mvmctl cp requires one endpoint in `VM:/absolute/path` form")
+            bail!("mvmctl machine cp requires one endpoint in `VM:/absolute/path` form")
         }
     }?;
     if args.json {

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -521,7 +521,7 @@ pub(in crate::commands) struct SdkTransportArgs {
     /// - `--mode live`: spawn the user's script with `MVM_SDK_MODE=live`
     ///   so the SDK shells each `Sandbox` operation to existing
     ///   `mvmctl` verbs against a real microVM.
-    /// - `--mode record` redirects users to `mvmctl compile` (where
+    /// - `--mode record` redirects users to `mvmctl build compile` (where
     ///   record is the default mode).
     ///
     /// When unset, the verb behaves as a transient-sandbox runner
@@ -600,7 +600,7 @@ impl Default for RunArgs {
 }
 
 /// SDK transport modes for `mvmctl run`. Mirrors the `Mode` enum on
-/// `mvmctl compile` but specialises the rejection messages to point
+/// `mvmctl build compile` but specialises the rejection messages to point
 /// users at the right verb when they pick the wrong default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
 pub(in crate::commands) enum RunMode {
@@ -613,7 +613,7 @@ pub(in crate::commands) enum RunMode {
     Plan,
     /// Record transport — capture Sandbox operations into a
     /// recording and lower to a Workload. `mvmctl run --mode
-    /// record` redirects users to `mvmctl compile`, whose default
+    /// record` redirects users to `mvmctl build compile`, whose default
     /// mode is record.
     Record,
 }
@@ -725,7 +725,7 @@ pub(in crate::commands) fn run_secure_with_source(
     // When an SDK transport mode is requested, peel off the
     // SDK-shaped surface before the sandbox-runner validation kicks
     // in. `--dev` (alias for live) is refused in v1; `--prod` (alias
-    // for record) redirects to `mvmctl compile`; `--mode plan` routes
+    // for record) redirects to `mvmctl build compile`; `--mode plan` routes
     // through the plan-mode admission dry-run.
     validate_run_profile(&args)?;
     if args.dry_run {
@@ -980,7 +980,7 @@ pub(in crate::commands) fn run_secure_with_source(
 /// mode was requested — in that case the verb falls back to the
 /// transient-sandbox runner over the trailing argv.
 ///
-/// Env-var precedence matches `mvmctl compile`: `MVM_SDK_MODE`
+/// Env-var precedence matches `mvmctl build compile`: `MVM_SDK_MODE`
 /// supersedes any flag-only override so a wrapper script can pin a
 /// mode without the user retyping `--mode`.
 pub(in crate::commands) fn resolve_run_mode(
@@ -998,8 +998,8 @@ pub(in crate::commands) fn resolve_run_mode(
             return Ok(None);
         }
         anyhow::bail!(
-            "`mvmctl run --prod` (alias for --mode record) redirects to `mvmctl compile`, where \
-             record is the default mode. Re-run as `mvmctl compile <script>` (the trailing argv \
+            "`mvmctl run --prod` (alias for --mode record) redirects to `mvmctl build compile`, where \
+             record is the default mode. Re-run as `mvmctl build compile <script>` (the trailing argv \
              on `mvmctl run` is for the live sandbox runner, not for SDK record-mode)."
         );
     }
@@ -1007,7 +1007,7 @@ pub(in crate::commands) fn resolve_run_mode(
         None => Ok(None),
         Some(RunMode::Live) => Ok(Some(RunMode::Live)),
         Some(RunMode::Record) => anyhow::bail!(
-            "`mvmctl run --mode record` is unsupported — `mvmctl compile` is the record-mode verb \
+            "`mvmctl run --mode record` is unsupported — `mvmctl build compile` is the record-mode verb \
              (record is the default; pass the script as the positional entry)."
         ),
         Some(RunMode::Plan) => Ok(Some(RunMode::Plan)),
@@ -1019,7 +1019,7 @@ fn parse_env_run_mode(raw: &str) -> Result<RunMode> {
         "live" => Ok(RunMode::Live),
         "plan" => Ok(RunMode::Plan),
         "record" => anyhow::bail!(
-            "MVM_SDK_MODE=record on `mvmctl run` is unsupported — `mvmctl compile` is the \
+            "MVM_SDK_MODE=record on `mvmctl run` is unsupported — `mvmctl build compile` is the \
              record-mode verb (record is its default)."
         ),
         other => anyhow::bail!(
@@ -2459,7 +2459,7 @@ mod tests {
         let mut args = run_args(RunProfile::Standard);
         args.prod = true;
         let err = resolve_run_mode(&sdk(None, false), &args).expect_err("--prod must bail");
-        assert!(err.to_string().contains("mvmctl compile"));
+        assert!(err.to_string().contains("mvmctl build compile"));
     }
 
     #[test]
@@ -2488,7 +2488,7 @@ mod tests {
         let args = run_args(RunProfile::Standard);
         let err = resolve_run_mode(&sdk(Some(RunMode::Record), false), &args)
             .expect_err("--mode record must bail");
-        assert!(err.to_string().contains("mvmctl compile"));
+        assert!(err.to_string().contains("mvmctl build compile"));
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/explain.rs
+++ b/crates/mvm-cli/src/commands/vm/explain.rs
@@ -2,7 +2,7 @@
 //! chain-signed audit log.
 //!
 //! Reads the same tamper-evident `~/.mvm/audit/<tenant>.jsonl` stream
-//! `mvmctl audit tail --chain` / `mvmctl audit verify` already read,
+//! `mvmctl trust audit tail --chain` / `mvmctl audit verify` already read,
 //! selects the entries bound to one run, and renders its lifecycle,
 //! outcome, backend, and source provenance — with a loud footer when
 //! the chain fails verification. No new storage or signing surface;
@@ -207,7 +207,7 @@ pub(in crate::commands) fn collect_run(
     if matches.is_empty() {
         bail!(
             "no run {run_id:?} found in the audit chain for tenant {tenant:?}; \
-             try `mvmctl audit tail` to list recent runs"
+             try `mvmctl trust audit tail` to list recent runs"
         );
     }
 

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -20,7 +20,7 @@
 //!     own stdout / stderr as they arrive, byte for byte, while handing the
 //!     same frames to the VM's output capture — which redacts, chains, and
 //!     persists a copy of its own. The caller gets the workload's bytes;
-//!     `mvmctl logs` gets the masked ones; any divergence between the two is
+//!     `mvmctl machine logs` gets the masked ones; any divergence between the two is
 //!     named on stderr rather than left for the caller to discover,
 //!   - tears the VM down (unless `keep_alive`),
 //!   - exits with the wrapper's exit code (or non-zero on error).
@@ -967,7 +967,7 @@ impl CallOutput<'_> {
                 &mut self.sinks,
                 &format!(
                     "this call's output was not recorded: no output capture for microVM \
-                     {vm_name:?} in this process, so `mvmctl logs {vm_name}` will not show it"
+                     {vm_name:?} in this process, so `mvmctl machine logs {vm_name}` will not show it"
                 ),
             );
             return;
@@ -1061,7 +1061,7 @@ impl RecordedDivergence {
         }
         Some(format!(
             "recorded output differs from what this call printed — {}; \
-             the bytes above are the workload's own, `mvmctl logs {vm_name}` shows the \
+             the bytes above are the workload's own, `mvmctl machine logs {vm_name}` shows the \
              redacted copy",
             parts.join("; ")
         ))
@@ -1484,7 +1484,7 @@ mod streaming_tests {
     #[test]
     fn an_uncaptured_call_says_so_rather_than_leaving_the_operator_to_find_out() {
         // The residual from a `--attach` into a machine some other process
-        // booted: the call runs, but `mvmctl logs` will not show it.
+        // booted: the call runs, but `mvmctl machine logs` will not show it.
         let (mut out, mut err) = (Vec::new(), Vec::new());
         {
             let mut sinks = buffers(&mut out, &mut err);
@@ -1665,7 +1665,7 @@ mod stdin_grant_tests {
 
 #[cfg(test)]
 mod captured_tests {
-    //! What a call leaves behind, read back the way `mvmctl logs` reads it.
+    //! What a call leaves behind, read back the way `mvmctl machine logs` reads it.
     //!
     //! Driven against a real plane over a real encrypted transcript: the
     //! entrypoint source's whole reason to exist is that a reader can ask for

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -11,7 +11,7 @@
 //! v1 ships the table + the verbs. Sessions are populated by
 //! `crate::exec::boot_session_vm` (which now registers an entry per
 //! booted VM) and removed by `tear_down_session_vm` (which marks
-//! `state = Killed` for human-initiated `mvmctl session kill` calls or
+//! `state = Killed` for human-initiated `mvmctl machine session kill` calls or
 //! removes the file on graceful exit). Because `mvmctl invoke` today
 //! still boots-and-tears-down per call, sessions are short-lived; the
 //! warm-process pool path is what keeps a session materialised across
@@ -430,7 +430,7 @@ fn emit_stale_warnings(sessions: &[mvm_core::session::SessionRecord]) {
     if !long_lived_dev.is_empty() {
         eprintln!(
             "[mvm] WARN: {} long-lived dev session(s) older than 1 hour — \
-             check `mvmctl session info <id>` and consider `mvmctl session kill`:",
+             check `mvmctl machine session info <id>` and consider `mvmctl machine session kill`:",
             long_lived_dev.len()
         );
         for r in long_lived_dev {
@@ -500,7 +500,7 @@ fn cmd_set_timeout(args: SetTimeoutArgs) -> Result<()> {
         bail!(
             "--seconds {} exceeds the {}s hard ceiling (24h). \
              Long-running sessions are a foot-gun: extend periodically with \
-             repeated `mvmctl session set-timeout` calls, or split work \
+             repeated `mvmctl machine session set-timeout` calls, or split work \
              across shorter-lived sessions.",
             args.seconds,
             MAX_IDLE_TIMEOUT_SECS
@@ -728,7 +728,7 @@ fn cmd_attach(args: AttachArgs) -> Result<()> {
     })?;
 
     // Bump the session's invoke counter / last-used timestamp so
-    // observers (`mvmctl session info`) see the activity.
+    // observers (`mvmctl machine session info`) see the activity.
     if let Err(e) = session::update_session(&id, |r| {
         r.invoke_count = r.invoke_count.saturating_add(1);
         r.last_invoke_at = Some(rfc3339_now());
@@ -978,7 +978,7 @@ fn cmd_start(args: StartArgs) -> Result<()> {
     if args.idle_timeout > MAX_IDLE_TIMEOUT_SECS {
         bail!(
             "--idle-timeout {} exceeds the {}s hard ceiling (24h). \
-             Use `mvmctl session set-timeout` to extend periodically \
+             Use `mvmctl machine session set-timeout` to extend periodically \
              instead of opting in to an unbounded keepalive.",
             args.idle_timeout,
             MAX_IDLE_TIMEOUT_SECS

--- a/crates/mvm-cli/src/doctor/platform_checks.rs
+++ b/crates/mvm-cli/src/doctor/platform_checks.rs
@@ -269,14 +269,14 @@ pub(super) fn residency_check() -> Check {
     }
 }
 
-/// TypeScript runner probe — `mvmctl compile <script.ts>` auto-runs
+/// TypeScript runner probe — `mvmctl build compile <script.ts>` auto-runs
 /// the script on the host with `MVM_SDK_MODE=record` and lowers the
 /// emitted recording into a Workload. That path needs a TS-aware
 /// runner (`tsx`, `bun`, or `deno`); plain `node` can't execute `.ts`
 /// in mvm's supported Node range.
 ///
 /// **WARN (not FAIL) when missing.** A TS runner is only required if
-/// the user actually runs `mvmctl compile` on a `.ts` script — most
+/// the user actually runs `mvmctl build compile` on a `.ts` script — most
 /// mvm workflows (Python, IR-JSON, decorator-only TS) don't need one.
 /// Doctor surfaces the install hint so the gap is discoverable, but
 /// `mvmctl doctor` still exits 0 to avoid breaking CI on hosts that
@@ -293,7 +293,7 @@ pub(super) fn ts_runner_check() -> Check {
             category: "tools",
             ok: true,
             info: format!(
-                "project-local at {} (used by `mvmctl compile <script.ts>`)",
+                "project-local at {} (used by `mvmctl build compile <script.ts>`)",
                 p.display()
             ),
         };
@@ -321,7 +321,7 @@ pub(super) fn ts_runner_check() -> Check {
         // discover the project-local + global recipes.
         ok: true,
         info: format!(
-            "not found — {} (only required if you run `mvmctl compile <script.ts>`)",
+            "not found — {} (only required if you run `mvmctl build compile <script.ts>`)",
             crate::ts_runner::install_hint()
         ),
     }

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -674,7 +674,7 @@ fn parse_workload_ir(apps: Vec<RawLaunchApp>, source: &str) -> Result<LaunchEntr
             .map(|a| a.name.as_deref().unwrap_or("<unnamed>"))
             .collect();
         anyhow::bail!(
-            "launch plan '{source}' has {} apps ({}); `mvmctl exec` v1 supports single-app workloads only",
+            "launch plan '{source}' has {} apps ({}); `mvmctl machine exec` v1 supports single-app workloads only",
             apps.len(),
             names.join(", "),
         );

--- a/crates/mvm-cli/src/shell_init.rs
+++ b/crates/mvm-cli/src/shell_init.rs
@@ -106,7 +106,7 @@ pub fn ensure_shell_init() -> Result<()> {
     fs::write(&rc_path, new_contents)
         .with_context(|| format!("Failed to write {}", rc_path.display()))?;
 
-    ui::success(&format!("Added mvmctl shell init to {}", rc_path.display()));
+    ui::success(&format!("Added mvmctl shell-init to {}", rc_path.display()));
     Ok(())
 }
 

--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod claims;
 pub mod doc_examples;
+pub mod source_commands;
 
 /// Cucumber tag for a scenario whose steps aren't implemented yet; always skipped.
 pub const PENDING_TAG: &str = "wip";

--- a/crates/mvm-conformance/src/source_commands.rs
+++ b/crates/mvm-conformance/src/source_commands.rs
@@ -1,0 +1,280 @@
+//! Extract the `mvmctl …` commands that mvmctl's own output names.
+//!
+//! The documentation harness reads Markdown. It cannot see the other place a
+//! reader is told to run something: the CLI's own strings — hints, error
+//! messages, "Run with:" lines. Those drift exactly like docs do, and nothing
+//! checked them, so `mvmctl bundle install` closed by printing
+//! `launch with: mvmctl up --manifest <sha>` long after `up` stopped being a
+//! dispatched verb.
+//!
+//! This module is only the extractor; deciding whether a command is real needs
+//! the clap tree and lives with the step that owns it.
+
+/// A `mvmctl …` command named inside a Rust string literal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceCommand {
+    pub file: String,
+    /// 1-based line of the `mvmctl` token itself, not of the literal's start —
+    /// a multi-line message should point at the offending line.
+    pub line: usize,
+    /// The command words following `mvmctl`, at most two. Only the first two
+    /// are ever judged — a third word is an argument, not a command path — and
+    /// capturing more only drags prose in ("mvmctl bootstrap or mvmctl doctor").
+    pub words: Vec<String>,
+}
+
+impl SourceCommand {
+    /// The command as written, for reporting and for allow-list matching.
+    pub fn rendered(&self) -> String {
+        format!("mvmctl {}", self.words.join(" "))
+    }
+}
+
+/// One string literal's body together with the offset it started at.
+struct Literal {
+    body: String,
+    /// Offset of the body's first byte within the original source.
+    offset: usize,
+}
+
+/// Scan Rust source for string literals, skipping comments.
+///
+/// Hand-rolled rather than regex-driven for two reasons, both of which cost me
+/// a wrong answer first: a literal may contain escapes (`"\nRun with: …"`), and
+/// a literal may span lines (a `\`-continued error message). A regex that
+/// excludes backslashes silently drops the first, and a line-at-a-time scan
+/// silently drops the second. Both failures are invisible — the extractor
+/// returns fewer items and every downstream assertion still passes.
+fn string_literals(source: &str) -> Vec<Literal> {
+    let bytes = source.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        // Line comment.
+        if bytes[i..].starts_with(b"//") {
+            i += source[i..].find('\n').map_or(source.len() - i, |n| n + 1);
+            continue;
+        }
+        // Block comment. Rust nests them; track depth so an inner `*/` does not
+        // end the outer comment early.
+        if bytes[i..].starts_with(b"/*") {
+            let mut depth = 1;
+            i += 2;
+            while i < bytes.len() && depth > 0 {
+                if bytes[i..].starts_with(b"/*") {
+                    depth += 1;
+                    i += 2;
+                } else if bytes[i..].starts_with(b"*/") {
+                    depth -= 1;
+                    i += 2;
+                } else {
+                    i += 1;
+                }
+            }
+            continue;
+        }
+        // Raw string: r, r#, r##… followed by a quote. Escapes are literal and
+        // the terminator is the quote plus the same run of hashes.
+        if bytes[i] == b'r' && !preceded_by_ident_char(bytes, i) {
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j] == b'#' {
+                j += 1;
+            }
+            if j < bytes.len() && bytes[j] == b'"' {
+                let hashes = j - (i + 1);
+                let terminator = format!("\"{}", "#".repeat(hashes));
+                let start = j + 1;
+                if let Some(end) = source[start..].find(&terminator) {
+                    out.push(Literal {
+                        body: source[start..start + end].to_string(),
+                        offset: start,
+                    });
+                    i = start + end + terminator.len();
+                    continue;
+                }
+                break;
+            }
+        }
+        if bytes[i] == b'"' {
+            let start = i + 1;
+            let mut j = start;
+            while j < bytes.len() {
+                match bytes[j] {
+                    b'\\' => j += 2,
+                    b'"' => break,
+                    _ => j += 1,
+                }
+            }
+            let end = j.min(bytes.len());
+            out.push(Literal {
+                body: source[start..end].to_string(),
+                offset: start,
+            });
+            i = end + 1;
+            continue;
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Is the byte before `i` part of an identifier? Guards against reading the
+/// `r` of `letर…`-style identifiers (or `char_indices`) as a raw-string sigil.
+fn preceded_by_ident_char(bytes: &[u8], i: usize) -> bool {
+    i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_')
+}
+
+/// A bare lowercase command word: `machine`, `shell-init`, `verify-cert`.
+///
+/// Edge punctuation is trimmed first. CLI messages overwhelmingly write a
+/// command as `` `mvmctl compile` ``, and a scanner that rejects the trailing
+/// backtick drops the occurrence entirely rather than reporting it — the
+/// failure mode that hides the very drift this exists to catch.
+fn command_word(token: &str) -> Option<&str> {
+    let token = token.trim_matches(|c: char| "`'\"(),.:;?!".contains(c));
+    let ok = !token.is_empty()
+        && token.starts_with(|c: char| c.is_ascii_lowercase())
+        && token
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-');
+    ok.then_some(token)
+}
+
+/// How many words of a command path are ever meaningful: a verb and its
+/// subcommand. `mvmctl image pull alpine` — `alpine` is an argument.
+const MAX_COMMAND_WORDS: usize = 2;
+
+/// Every `mvmctl …` command named in `contents`.
+pub fn source_commands(file: &str, contents: &str) -> Vec<SourceCommand> {
+    let mut out = Vec::new();
+    for literal in string_literals(contents) {
+        let mut search = 0;
+        while let Some(found) = literal.body[search..].find("mvmctl ") {
+            let at = search + found;
+            let rest = &literal.body[at + "mvmctl ".len()..];
+            let words: Vec<String> = rest
+                .split_whitespace()
+                // A second `mvmctl` starts a new command; it is not an
+                // argument of this one.
+                .take_while(|token| *token != "mvmctl")
+                .map_while(|token| command_word(token).map(str::to_string))
+                .take(MAX_COMMAND_WORDS)
+                .collect();
+            if !words.is_empty() {
+                let absolute = literal.offset + at;
+                out.push(SourceCommand {
+                    file: file.to_string(),
+                    line: contents[..absolute.min(contents.len())]
+                        .matches('\n')
+                        .count()
+                        + 1,
+                    words,
+                });
+            }
+            search = at + "mvmctl ".len();
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn commands(source: &str) -> Vec<String> {
+        source_commands("x.rs", source)
+            .iter()
+            .map(SourceCommand::rendered)
+            .collect()
+    }
+
+    #[test]
+    fn reads_a_plain_literal() {
+        assert_eq!(
+            commands(r#"println!("launch with: mvmctl machine run");"#),
+            ["mvmctl machine run"]
+        );
+    }
+
+    /// The first bug this extractor had. A regex body of `[^"\\]*` cannot match
+    /// a literal containing `\n`, so every message that opens with a newline —
+    /// which is most "Run with:" hints — was invisible.
+    #[test]
+    fn reads_a_literal_containing_escapes() {
+        assert_eq!(
+            commands(r#"ui::info(&format!("\nRun with: mvmctl machine start {}", n));"#),
+            ["mvmctl machine start"]
+        );
+    }
+
+    /// The second bug. A line-at-a-time scan needs the closing quote on the
+    /// same line, so `\`-continued messages were dropped whole.
+    #[test]
+    fn reads_a_literal_spanning_lines() {
+        let source = "let e = format!(\n    \"`mvmctl run --prod` redirects to \\\n     `mvmctl build compile`, where record is default\"\n);";
+        assert_eq!(
+            commands(source),
+            ["mvmctl run", "mvmctl build compile"],
+            "a continued literal must be scanned as one string"
+        );
+    }
+
+    #[test]
+    fn line_number_points_at_the_mvmctl_token_not_the_literal_start() {
+        let source = "let e = format!(\n    \"a long preamble \\\n     mvmctl machine run\"\n);";
+        let found = source_commands("x.rs", source);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].line, 3, "should point at the line naming it");
+    }
+
+    #[test]
+    fn ignores_comments() {
+        assert_eq!(commands("// mvmctl up --manifest x\nlet a = 1;"), [""; 0]);
+        assert_eq!(commands("/* mvmctl up */ let a = 1;"), [""; 0]);
+    }
+
+    #[test]
+    fn ignores_nested_block_comments() {
+        assert_eq!(
+            commands("/* outer /* inner */ mvmctl up */ let a = 1;"),
+            [""; 0]
+        );
+    }
+
+    #[test]
+    fn reads_raw_strings() {
+        assert_eq!(
+            commands(r##"let s = r#"run mvmctl machine ls now"#;"##),
+            ["mvmctl machine ls"]
+        );
+    }
+
+    #[test]
+    fn stops_at_the_first_non_word_token() {
+        assert_eq!(
+            commands(r#"let s = "mvmctl machine run --manifest {sha}";"#),
+            ["mvmctl machine run"]
+        );
+        assert_eq!(
+            commands(r#"let s = "mvmctl image pull alpine:latest";"#),
+            ["mvmctl image pull"]
+        );
+    }
+
+    #[test]
+    fn finds_every_occurrence_in_one_literal() {
+        assert_eq!(
+            commands(r#"let s = "use mvmctl bootstrap or mvmctl doctor";"#),
+            ["mvmctl bootstrap or", "mvmctl doctor"]
+        );
+    }
+
+    #[test]
+    fn keeps_hyphenated_verbs() {
+        assert_eq!(
+            commands(r#"let s = "mvmctl shell-init";"#),
+            ["mvmctl shell-init"]
+        );
+    }
+}

--- a/crates/mvm-conformance/tests/steps/doc_examples.rs
+++ b/crates/mvm-conformance/tests/steps/doc_examples.rs
@@ -67,6 +67,24 @@ struct Manifest {
     absent: Vec<AbsentEntry>,
     #[serde(default)]
     nix_attribute: Vec<NixAttributeEntry>,
+    #[serde(default)]
+    prose: Vec<ProseEntry>,
+}
+
+/// A `mvmctl …` phrase in a CLI string that is English, not an invocation:
+/// "the mvmctl binary", "mvmctl cannot build a boot image locally".
+///
+/// Declared rather than pattern-matched. Every heuristic I tried for telling
+/// prose from a command was wrong in one direction or the other — filtering on
+/// "is the first word a real verb" is worst of all, because a string naming a
+/// *removed* verb is exactly the defect, and that filter drops precisely those.
+/// So the rule is totality: a phrase either resolves against the clap tree or
+/// is written down here with a reason.
+#[derive(serde::Deserialize)]
+struct ProseEntry {
+    text: String,
+    #[allow(dead_code)]
+    reason: String,
 }
 
 /// A `mkGuest` attribute the docs teach while its argument set does not accept
@@ -966,4 +984,113 @@ fn documented_typescript_examples_typecheck(_world: &mut CliWorld) {
     let findings: Vec<Finding> =
         serde_json::from_slice(&output.stdout).expect("parse typecheck findings");
     report(&findings, "TypeScript typecheck", blocks.len());
+}
+
+/// Every `*.rs` file under a crate's `src/`.
+fn rust_sources(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Resolve a command path against the clap tree, returning the depth matched.
+///
+/// Only the leading verb chain is judged. Trailing words are arguments, and
+/// demanding they parse would let prose through: `machine cp` takes positionals,
+/// so "mvmctl cp supports exactly one" *parses* with "supports exactly one"
+/// absorbed as arguments — a check built on "does it parse" calls that healthy.
+fn resolved_depth(root: &ClapCommand, words: &[String]) -> usize {
+    let mut cursor = root;
+    let mut depth = 0;
+    for word in words {
+        let Some(next) = cursor
+            .get_subcommands()
+            .find(|sub| sub.get_name() == word || sub.get_all_aliases().any(|alias| alias == word))
+        else {
+            break;
+        };
+        cursor = next;
+        depth += 1;
+    }
+    depth
+}
+
+#[then(expr = "every command named in mvmctl's own output is a real command")]
+fn cli_output_names_real_commands(_world: &mut CliWorld) {
+    let command = mvm_cli::commands::cli_command();
+    let prose: BTreeSet<String> = manifest()
+        .prose
+        .into_iter()
+        .map(|entry| entry.text)
+        .collect();
+
+    let mut sources = Vec::new();
+    rust_sources(&repo_root().join("crates/mvm-cli/src"), &mut sources);
+    assert!(
+        sources.len() > 100,
+        "found only {} Rust source(s) under crates/mvm-cli/src — the walk went blind",
+        sources.len()
+    );
+
+    let mut checked = 0usize;
+    let mut failures = Vec::new();
+    for path in sources {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let relative = path
+            .strip_prefix(repo_root())
+            .unwrap_or(&path)
+            .display()
+            .to_string();
+        for found in mvm_conformance::source_commands::source_commands(&relative, &text) {
+            let rendered = found.rendered();
+            if prose.contains(&rendered) {
+                continue;
+            }
+            checked += 1;
+            let depth = resolved_depth(&command, &found.words);
+            if depth == 0 {
+                failures.push(format!(
+                    "  {}:{}\n     {rendered}\n     `{}` is not a command",
+                    found.file, found.line, found.words[0]
+                ));
+            } else if depth == 1 && found.words.len() > 1 {
+                // The verb resolved but its subcommand did not. Only a failure
+                // when the verb actually has subcommands — otherwise the second
+                // word is an argument (`mvmctl doctor json`).
+                let verb = command
+                    .get_subcommands()
+                    .find(|sub| {
+                        sub.get_name() == found.words[0]
+                            || sub.get_all_aliases().any(|a| a == found.words[0])
+                    })
+                    .expect("depth 1 means the verb resolved");
+                if verb.has_subcommands() {
+                    failures.push(format!(
+                        "  {}:{}\n     {rendered}\n     `{}` has no `{}` subcommand",
+                        found.file, found.line, found.words[0], found.words[1]
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} command(s) named in mvmctl's own output do not exist \
+         (checked {checked}). Fix the string, or if it is English rather than an \
+         invocation add a [[prose]] entry with a reason to \
+         features/suites/s29_doc_examples/tiers.toml:\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
 }

--- a/features/suites/s29_doc_examples/cli_output_commands.feature
+++ b/features/suites/s29_doc_examples/cli_output_commands.feature
@@ -1,0 +1,16 @@
+Feature: mvmctl's own output names real commands
+
+  The documentation harness reads Markdown. It cannot see the other place a
+  reader is told what to run: mvmctl's own strings — hints, error messages,
+  "Run with:" lines. Those drift exactly like docs do, and until this scenario
+  existed nothing checked them, so `mvmctl bundle install` finished by printing
+  `launch with: mvmctl up --manifest <sha>` long after `up` stopped being a
+  dispatched verb. A reader who followed it got "unrecognized subcommand".
+
+  Only the leading verb chain is judged; trailing words are arguments. A phrase
+  that is English rather than an invocation is declared in tiers.toml with a
+  reason, so the check stays total: a `mvmctl …` string either resolves against
+  the real clap tree or is written down.
+
+  Scenario: no CLI message names a command that does not exist
+    Then every command named in mvmctl's own output is a real command

--- a/features/suites/s29_doc_examples/tiers.toml
+++ b/features/suites/s29_doc_examples/tiers.toml
@@ -494,3 +494,89 @@ reason = "the addon CLI is unbuilt; the migration guide says 'once the addon CLI
 [[absent]]
 path = "exec"
 reason = "the bare verb was merged into `run`; the CLI reference records the merge in the past tense"
+
+# `mvmctl …` phrases in CLI strings that are English, not invocations. Declared
+# rather than guessed at: every heuristic for telling prose from a command was
+# wrong in one direction or the other, and the worst — "is the first word a real
+# verb?" — drops exactly the strings that name a removed verb, which is the
+# defect this check exists to find.
+
+[[prose]]
+text = "mvmctl inside your"
+reason = "\"...the mvmctl inside your checkout\" — a noun phrase"
+
+[[prose]]
+text = "mvmctl for"
+reason = "\"...asks mvmctl for the kernel\" — a preposition"
+
+[[prose]]
+text = "mvmctl with it"
+reason = "\"...rebuild mvmctl with it enabled\" — a preposition"
+
+[[prose]]
+text = "mvmctl build will"
+reason = "\"a `mvmctl build` will...\" — the verb is real; `will` is the sentence"
+
+[[prose]]
+text = "mvmctl build to"
+reason = "\"...asks mvmctl build to emit\" — the verb is real; `to` is the sentence"
+
+[[prose]]
+text = "mvmctl build with"
+reason = "\"...a mvmctl build with keyless pack verification\" — a preposition"
+
+[[prose]]
+text = "mvmctl or under"
+reason = "\"...beside mvmctl or under the cache\" — a conjunction"
+
+[[prose]]
+text = "mvmctl binary"
+reason = "\"the mvmctl binary\" — a noun phrase"
+
+[[prose]]
+text = "mvmctl binary built"
+reason = "\"a mvmctl binary built from that checkout\" — a noun phrase"
+
+[[prose]]
+text = "mvmctl binary path"
+reason = "\"the mvmctl binary path for ...\" — a noun phrase"
+
+[[prose]]
+text = "mvmctl has no"
+reason = "\"mvmctl has no boot image\" — a sentence about the tool"
+
+[[prose]]
+text = "mvmctl cannot build"
+reason = "\"mvmctl cannot build a boot image locally\" — a sentence about the tool"
+
+[[prose]]
+text = "mvmctl was built"
+reason = "\"mvmctl was built without the feature\" — a sentence about the tool"
+
+[[prose]]
+text = "mvmctl was"
+reason = "\"mvmctl was updated\" — a sentence about the tool"
+
+[[prose]]
+text = "mvmctl built with"
+reason = "\"a mvmctl built with pack support\" — a noun phrase"
+
+[[prose]]
+text = "mvmctl release"
+reason = "\"the mvmctl release channel\" — a noun phrase"
+
+[[prose]]
+text = "mvmctl does not"
+reason = "\"mvmctl does not yet cross-compile\" — a sentence about the tool"
+
+[[prose]]
+text = "mvmctl must hand"
+reason = "\"mvmctl must hand the runner a console streamer\" — a test's description of an invariant"
+
+[[prose]]
+text = "mvmctl command that"
+reason = "\"any mvmctl command that signs to initialize\" — a noun phrase"
+
+[[prose]]
+text = "mvmctl template init"
+reason = "correctly describes a removed mode in the past tense: \"was a `mvmctl template init --vm` mode that no longer exists\""

--- a/specs/sprint/delivery/cli-output-names-real-commands.md
+++ b/specs/sprint/delivery/cli-output-names-real-commands.md
@@ -1,0 +1,92 @@
+# mvmctl's own output no longer names commands that do not exist
+
+Backing: shipped-source
+Validation: just bdd
+
+The documentation harness reads Markdown. It cannot see the other place a reader
+is told what to run: mvmctl's own strings — hints, error messages, "Run with:"
+lines. Those drift exactly like docs do, and nothing checked them.
+
+`mvmctl bundle install` finished by printing:
+
+```
+  launch with:   mvmctl up --manifest 830c330a…
+```
+
+`up` has not been a dispatched verb for a long time. A reader who followed the
+instruction the tool had just given them got `error: unrecognized subcommand`.
+
+## What was wrong
+
+56 command-shaped strings did not resolve against the real clap tree. About
+thirty were genuine, and they cluster by refactor:
+
+- **`mvmctl up`** (3) — the verb has no dispatch path at all.
+- **`mvmctl compile`** (21 occurrences across 4 files) — now `build compile`.
+  This is the string the doc-examples delivery note flagged as a known gap; it
+  turned out not to be one string.
+- **`mvmctl audit …`** (6) — now `trust audit …`.
+- **Verbs re-parented under `machine`** — `start`, `stop`, `logs`, `exec`,
+  `cp`, `session …`, `vm pause` / `vm resume`, `fs mv`.
+- **`mvmctl setup`** (2) — never existed; the hint meant `bootstrap`.
+- **`mvmctl shell init`** — the verb is spelled `shell-init`.
+- **`mvmctl template build`** — `template` is a read-only registry browser now;
+  the hint meant `machine build --update-hash`.
+
+One string was removed rather than repointed: `build_mvmfile` printed
+`Run with: mvmctl start <elf>`, and nothing in the CLI boots an mvmfile ELF.
+Substituting a different wrong verb would have been worse than saying nothing.
+
+A unit test was pinning the defect in place: `run_prod_alias_redirects_to_mvmctl_compile`
+asserted the redirect names `mvmctl compile`, so the wrong spelling was the
+thing under test. It now asserts `mvmctl build compile`.
+
+## The gate
+
+`features/suites/s29_doc_examples/cli_output_commands.feature` extracts every
+`mvmctl …` phrase from string literals in `crates/mvm-cli/src` and resolves it
+against `mvm_cli::commands::cli_command()`.
+
+**Only the leading verb chain is judged.** Trailing words are arguments, and
+demanding they parse lets prose through: `machine cp` takes positionals, so
+"mvmctl cp supports exactly one" *parses*, with "supports exactly one" absorbed
+as arguments. A check built on "does the whole thing parse" calls that healthy.
+
+**Prose is declared, not detected.** Every heuristic for telling English from an
+invocation was wrong in one direction or the other, and the most natural one is
+catastrophically wrong: filtering on "is the first word a real verb" drops
+exactly the strings that name a *removed* verb. I wrote that filter first, and it
+reported one finding where there were fifty-six. So `[[prose]]` entries in
+`tiers.toml` carry the phrase and a reason, and anything undeclared must resolve.
+
+### Two extractor bugs worth recording
+
+Both made the extractor silently return fewer items, which is the failure mode
+that matters: every downstream assertion still passes.
+
+1. **Escapes.** A literal body matched as `[^"\\]*` cannot contain `\n`, so
+   `"\nRun with: mvmctl up {}"` — and most "Run with:" hints, which open with a
+   newline — were invisible. Fixing it took the corpus from 94 to 100.
+2. **Multi-line literals.** A line-at-a-time scan needs the closing quote on the
+   same line, so `\`-continued error messages were dropped whole. That is where
+   the `mvmctl compile` cluster lived. Fixing it took the corpus from 100 to 200
+   and the findings from 24 to 56.
+
+Both have regression tests naming the failure, alongside raw strings, nested
+block comments, and punctuation trimming — a message writes `` `mvmctl compile` ``
+far more often than bare, and a scanner that chokes on the backtick drops the
+occurrence rather than reporting it.
+
+## Evidence
+
+The gate was mutation-tested against the defect it was built for: restoring
+`mvmctl up --manifest` in `bundle/install.rs` turns it red naming that file and
+line; reverting turns it green.
+
+`just bdd`, macOS 26 / Apple Silicon: 240 scenarios, 232 passed, 7 failed — the
+same 7 that fail on main (TypeScript SDK `dist/` unbuilt, SDK codegen binary
+absent). Workspace: 12514 tests, 12513 passed.
+
+Two clippy findings in `mvm-fs` and `mvm-core` (`#[must_use]` on an
+`#[async_trait]` method) reproduce at HEAD without this change and are not
+addressed here.

--- a/specs/sprint/delivery/doc-examples-e2e-verification.md
+++ b/specs/sprint/delivery/doc-examples-e2e-verification.md
@@ -135,10 +135,13 @@ binary is absent. This branch adds 9 scenarios, all passing, and introduces no
 new failures. 28 `@live` scenarios were skipped for want of a hypervisor, as
 designed; the live tier is proven on a KVM host, not here.
 
-## Known gap
+## The gap this left, since closed
 
-`mvmctl build compile --dev`'s own help text still says "Refused on `mvmctl
-compile` — use `mvmctl …`", naming the pre-`build` spelling. That string lives
-in the CLI source, not the docs, so this gate does not see it; the harness reads
-documentation, and help text is the CLI describing itself. Worth a follow-up
-sweep of user-facing strings in `crates/mvm-cli`.
+`mvmctl build compile --dev`'s own help text still said "Refused on `mvmctl
+compile`", naming the pre-`build` spelling. That string lives in the CLI source,
+not the docs, so this gate could not see it — the harness reads documentation,
+and help text is the CLI describing itself.
+
+The follow-up sweep found the gap was not one string but fifty-six, and is
+covered now by `cli_output_commands.feature`. See
+`specs/sprint/delivery/cli-output-names-real-commands.md`.

--- a/tests/run_plan_mode.rs
+++ b/tests/run_plan_mode.rs
@@ -111,7 +111,7 @@ fn run_plan_mode_admits_clean_recording_and_exits_zero() {
 }
 
 #[test]
-fn run_prod_alias_redirects_to_mvmctl_compile() {
+fn run_prod_alias_redirects_to_mvmctl_build_compile() {
     let tmp = TempDir::new().unwrap();
     let script = tmp.path().join("hello.py");
     std::fs::write(&script, "print('noop')\n").unwrap();
@@ -130,8 +130,10 @@ fn run_prod_alias_redirects_to_mvmctl_compile() {
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("mvmctl compile"),
-        "--prod must redirect users to `mvmctl compile`; stderr was:\n{stderr}"
+        stderr.contains("mvmctl build compile"),
+        "--prod must redirect users to `mvmctl build compile` — the verb as it is \
+         actually spelled, since a redirect naming a command that does not parse \
+         is worse than no redirect; stderr was:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
`mvmctl bundle install` finished by printing:

```
  launch with:   mvmctl up --manifest 830c330a…
```

`up` has no dispatch path. A reader who followed the instruction the tool had just given them got `error: unrecognized subcommand`.

The doc-examples harness reads Markdown, so it never saw this — hints, error messages and "Run with:" lines are the CLI describing itself. That was flagged as a "Known gap" in the doc-examples delivery note, on the assumption it was one string. **56 command-shaped strings in `crates/mvm-cli` do not resolve against the real clap tree.**

## What was broken

About thirty were genuine, clustering by refactor:

| Was | Is | n |
| --- | --- | --- |
| `mvmctl up` | `machine run --manifest` / `--flake` | 3 |
| `mvmctl compile` | `build compile` | 21 |
| `mvmctl audit …` | `trust audit …` | 6 |
| `start`, `stop`, `logs`, `exec`, `cp`, `session …`, `vm pause`/`resume`, `fs mv` | re-parented under `machine` | ~12 |
| `mvmctl setup` | never existed; meant `bootstrap` | 2 |
| `mvmctl shell init` | `shell-init` | 1 |
| `mvmctl template build` | `machine build --update-hash` | 1 |

One string is **deleted rather than repointed**: `build_mvmfile` printed `Run with: mvmctl start <elf>`, and nothing in the CLI boots an mvmfile ELF. Substituting a different wrong verb would be worse than saying nothing.

A unit test was pinning the defect in place — `run_prod_alias_redirects_to_mvmctl_compile` asserted the redirect names `mvmctl compile`, making the wrong spelling the thing under test. It now asserts `mvmctl build compile`.

## The gate

`cli_output_commands.feature` resolves every `mvmctl …` phrase in `crates/mvm-cli` string literals against `cli_command()`.

**Only the leading verb chain is judged.** "Does the whole thing parse" is not a check: `machine cp` takes positionals, so `"mvmctl cp supports exactly one"` *parses*, with the prose absorbed as arguments.

**Prose is declared, not detected.** The natural heuristic — "is the first word a real verb?" — drops precisely the strings naming a *removed* verb. I wrote that filter first and it reported **1** finding where there were **56**. So `[[prose]]` entries carry the phrase and a reason, and anything undeclared must resolve.

## Two extractor bugs worth flagging

Both made the extractor return fewer items while every downstream assertion still passed — the failure mode that matters.

1. **Escapes.** A body matched as `[^"\\]*` cannot contain `\n`, so hints opening with a newline were invisible. 94 → 100 candidates.
2. **Multi-line literals.** A line-at-a-time scan needs the closing quote on the same line, so `\`-continued messages were dropped whole — where the `compile` cluster lived. 100 → 200 candidates, 24 → 56 findings.

Both have regression tests, alongside raw strings, nested block comments, and punctuation trimming (a message writes `` `mvmctl compile` `` far more often than bare; a scanner that chokes on the backtick drops the occurrence rather than reporting it).

## Evidence

Mutation-tested: restoring `mvmctl up --manifest` in `bundle/install.rs` turns the gate red naming that file and line; reverting turns it green.

- `just bdd`: 240 scenarios, 232 passed, 7 failed — the same 7 that fail on main (TS SDK `dist/` unbuilt, SDK codegen binary absent)
- Workspace: 12514 tests, 12513 passed
- fmt, stable `clippy --workspace --all-targets -D warnings`, `check-all`, `check-conformance`, `check-honesty`, `check-cli-help-matches-docs`, `check-cli-runtime-surface`, `check-nextest-groups`, `check-no-overclaim`, `check-mutation-witnesses` — all green