### PR TITLE
fix(pages): build weblinux assets from the nix/ subflake

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build weblinux demo assets
         run: |
-          nix build .#qemu-wasm-smoke-pack
+          nix build ./nix#qemu-wasm-smoke-pack
           ./web/weblinux-demo/build.sh result
 
       - name: Build wasm demo


### PR DESCRIPTION
The qemu-wasm-smoke-pack attribute is defined in nix/flake.nix, not the repo-root contributor flake. The Pages workflow ran `nix build .#qemu-wasm-smoke-pack`, which failed because the root flake does not provide that attribute. Update the command to `nix build ./nix#qemu-wasm-smoke-pack` so the weblinux demo assets can be built and staged in CI.