### PR TITLE
fix(ci): repair extended platform witnesses

### DIFF
--- a/.github/actions/install-libkrun/action.yml
+++ b/.github/actions/install-libkrun/action.yml
@@ -1,0 +1,31 @@
+name: Install libkrun
+description: Install libkrun and its firmware from the trusted upstream Homebrew tap.
+
+runs:
+  using: composite
+  steps:
+    - name: Install libkrun and firmware
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew tap slp/krun
+        brew trust slp/krun
+
+        # The firmware tap currently resolves a bottle basename that its
+        # release does not publish on some hosted-runner Homebrew versions.
+        # Build that small, checksum-pinned formula from source, then install
+        # libkrun normally. Retry the complete transaction for transient
+        # downloads without trusting a nonexistent bottle name.
+        for attempt in 1 2 3; do
+          if brew install --build-from-source slp/krun/libkrunfw \
+            && brew install slp/krun/libkrun; then
+            exit 0
+          fi
+
+          if [ "$attempt" -eq 3 ]; then
+            echo "::error::libkrun installation failed after $attempt attempts" >&2
+            exit 1
+          fi
+
+          sleep "$((attempt * 30))"
+        done

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -220,11 +220,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 
+      - uses: ./.github/actions/install-zigbuild
+
       - name: Install libkrun
-        run: |
-          brew tap slp/krun
-          brew trust slp/krun
-          brew install slp/krun/libkrun
+        uses: ./.github/actions/install-libkrun
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -292,10 +291,7 @@ jobs:
         # `libkrun.dylib` under `/opt/homebrew/{include,lib}` on Apple
         # Silicon - exactly the layout `crates/deps/libkrun-sys/build.rs`
         # probes for.
-        run: |
-          brew tap slp/krun
-          brew trust slp/krun
-          brew install slp/krun/libkrun
+        uses: ./.github/actions/install-libkrun
 
       - name: Cache cargo
         if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
@@ -549,8 +545,8 @@ jobs:
             --flake examples/exit_code \
             --builder qemu \
             --hypervisor qemu \
+            --entrypoint \
             -v \
-            -- /bin/true \
             > /tmp/mvmctl-first-boot.log 2>&1
           actual=$?
           set -e
@@ -577,8 +573,8 @@ jobs:
           /tmp/mvmctl-source-under-test machine run \
             --manifest "$installed_sha" \
             --hypervisor qemu \
+            --entrypoint \
             -v \
-            -- /bin/true \
             > /tmp/mvmctl-bundle-run.log 2>&1
           actual=$?
           set -e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,7 @@ jobs:
       # formula ... from untrusted tap slp/krun". Tap + trust before installing.
       - name: Install libkrun (macOS backend FFI)
         if: runner.os == 'macOS'
-        run: |
-          brew tap slp/krun
-          brew trust slp/krun
-          brew install slp/krun/libkrun slp/krun/libkrunfw
+        uses: ./.github/actions/install-libkrun
 
       - name: Install cross-compilation tools (Linux aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'

--- a/scripts/local-aarch64-no-kvm-smoke.sh
+++ b/scripts/local-aarch64-no-kvm-smoke.sh
@@ -87,8 +87,8 @@ set +e
     --flake examples/exit_code \
     --builder qemu \
     --hypervisor qemu \
+    --entrypoint \
     -v \
-    -- /bin/true \
     > /tmp/mvmctl-first-boot.log 2>&1
 actual=$?
 set -e
@@ -122,8 +122,8 @@ set +e
 /tmp/mvmctl-source-under-test machine run \
     --manifest "$installed_sha" \
     --hypervisor qemu \
+    --entrypoint \
     -v \
-    -- /bin/true \
     > /tmp/mvmctl-bundle-run.log 2>&1
 actual=$?
 set -e

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -139,6 +139,15 @@ for detailed scope and acceptance criteria.
       the host-binary manifest, including `mvm-builderd`. Structural tests pin
       the two workflow contracts.
 
+- [x] **Issue #2870 — Extended CI failures repaired.** The AArch64 no-KVM
+      witness executes the sealed exit-code image's baked entrypoint instead of
+      replacing it with `/bin/true`, and both macOS lanes use one trusted-tap
+      installer that builds the checksum-pinned firmware formula from source
+      instead of requesting an upstream bottle basename that does not exist.
+      The Apple workspace lane also installs the pinned embedded-host Zig/Rust
+      toolchain before mvm-cli's build script needs it. The release workflow
+      reuses the same installer and bounded retries.
+
 - [x] **Issue #2789 — guest hostname follows the machine name.** The shared
       workload cmdline carries one validated `mvm.hostname=` token for cold
       boots, while warm children receive their final name through the existing

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3044,6 +3044,21 @@ to the configured ceiling and the first terse response immediately after it.
 - [x] Document the fail-closed ASCII export boundary without imposing a new
       admission restriction on historical identifiers.
 
+## 2026-08-26 Extended CI recovery
+
+- [x] Run the AArch64 sealed `exit_code` workload through its baked entrypoint
+      on both first boot and installed-bundle replay.
+- [x] Remove the `/bin/true` override that converted the intended exit 7 into a
+      successful exit 0.
+- [x] Reuse one trusted Homebrew installer for scheduled macOS and release
+      lanes, building checksum-pinned firmware from source to avoid the
+      upstream bottle-name mismatch and retaining bounded download retries.
+- [x] Install the pinned embedded-host cross toolchain before the Apple
+      workspace build invokes mvm-cli's build script.
+- [x] Pin both repairs with focused workflow-structure tests and actionlint.
+- [x] Record the delivery in
+      `specs/sprint/delivery/2870-extended-ci-recovery.md`.
+
 ## Follow-up (not started) — repository-to-signed-workload generator
 
 Prompted by the same 2026-08-25 survey of a commercial enterprise

--- a/specs/sprint/delivery/2870-extended-ci-recovery.md
+++ b/specs/sprint/delivery/2870-extended-ci-recovery.md
@@ -1,0 +1,28 @@
+# Extended CI executes the intended witnesses reliably
+
+## Problem
+
+The scheduled AArch64 no-KVM smoke supplied `/bin/true` as an ad-hoc command,
+which replaced the sealed fixture's baked `exit 7` entrypoint and correctly
+returned zero. On one current macOS runner, Homebrew resolved the firmware
+formula to a bottle basename absent from the tap's release, so retrying the same
+404 could never repair the install. Once installation succeeded, the Apple
+workspace build also lacked the pinned embedded-host Rust target and Zig
+wrapper required by mvm-cli's build script.
+
+## Delivered behavior
+
+Both AArch64 launches select `machine run --entrypoint`, so the first boot and
+the exported-and-reinstalled bundle exercise the workload the witness claims to
+test. Scheduled and release macOS jobs share one trusted-tap libkrun installer;
+it builds the checksum-pinned firmware formula from source before installing
+libkrun, and retries the complete transaction three times with bounded backoff
+for genuinely transient downloads. The Apple lane installs the repository's
+shared embedded-host toolchain action before its workspace build.
+
+## Validation
+
+- `cargo test --test github_actions_aarch64_no_kvm`;
+- `cargo test -p xtask check_workflow_paths`;
+- actionlint over `ci-full.yml` and `release.yml`;
+- the required PR and merge-group checks remain the merge gate.

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -22,6 +22,8 @@ const REQUIRED_BUILDER_DOWNLOAD: &str =
 const REQUIRED_BOOTSTRAP: &str =
     "/tmp/mvmctl-source-under-test --builder qemu bootstrap --production -v";
 const FIRST_MACHINE_RUN: &str = "/tmp/mvmctl-source-under-test machine run";
+const REQUIRED_BAKED_ENTRYPOINT: &str = "--entrypoint";
+const FORBIDDEN_ENTRYPOINT_OVERRIDE: &str = "-- /bin/true";
 
 #[test]
 fn aarch64_no_kvm_smokes_build_the_mvmctl_binary_they_execute() {
@@ -59,6 +61,14 @@ fn aarch64_no_kvm_smokes_build_the_mvmctl_binary_they_execute() {
         assert!(
             !contents.contains(LIBRARY_ONLY_BUILD),
             "{source} must not build only the mvm-cli library"
+        );
+        assert!(
+            contents.contains(REQUIRED_BAKED_ENTRYPOINT),
+            "{source} must exercise the exit_code image's baked entrypoint"
+        );
+        assert!(
+            !contents.contains(FORBIDDEN_ENTRYPOINT_OVERRIDE),
+            "{source} must not replace the exit_code image's baked command with /bin/true"
         );
         assert!(
             contents.contains(REQUIRED_VIRTIOFS_PACKAGE),

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -1134,17 +1134,42 @@ mod tests {
         let extended = workflow("ci-full.yml");
         for job in ["apple", "libkrun-macos"] {
             let body = job_body(&extended, job).expect("extended CI job must exist");
-            for command in [
-                "brew tap slp/krun",
-                "brew trust slp/krun",
-                "brew install slp/krun/libkrun",
-            ] {
-                assert!(
-                    body.contains(command),
-                    "{job} must run `{command}` before compiling libkrun consumers"
-                );
-            }
+            assert!(
+                body.contains("uses: ./.github/actions/install-libkrun"),
+                "{job} must use the shared resilient libkrun installer"
+            );
         }
+
+        let action = std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join(".github/actions/install-libkrun/action.yml"),
+        )
+        .expect("shared libkrun installer must be readable");
+        for command in [
+            "brew tap slp/krun",
+            "brew trust slp/krun",
+            "brew install --build-from-source slp/krun/libkrunfw",
+            "brew install slp/krun/libkrun",
+            "for attempt in 1 2 3",
+        ] {
+            assert!(
+                action.contains(command),
+                "shared libkrun installer must contain `{command}`"
+            );
+        }
+
+        let apple = job_body(&extended, "apple").expect("Apple job must exist");
+        let embedded_toolchain = apple
+            .find("uses: ./.github/actions/install-zigbuild")
+            .expect("Apple workspace build must install the embedded-host toolchain");
+        let build = apple
+            .find("      - name: Build")
+            .expect("Apple workspace build step must exist");
+        assert!(
+            embedded_toolchain < build,
+            "Apple must install the embedded-host toolchain before building mvm-cli"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- run the AArch64 exit-code fixture through its baked entrypoint instead of overriding it with /bin/true
- share a bounded-retry trusted-tap libkrun installer across Extended CI and release jobs
- pin both workflow contracts with focused structural regressions

## Validation

- cargo test --test github_actions_aarch64_no_kvm
- cargo test -p xtask check_workflow_paths
- actionlint .github/workflows/*.yml
- pre-commit workspace all-target Clippy
- live Extended CI dispatch: https://github.com/tinylabscom/mvm/actions/runs/32950093372

Addresses issue #2870 without closing it.