### PR TITLE
fix(weblinux): make staged demo assets writable

### DIFF
--- a/web/weblinux-demo/build.sh
+++ b/web/weblinux-demo/build.sh
@@ -37,6 +37,7 @@ mkdir -p "$DEST_DIR"
 # index.html, demo.js, and worker.js take precedence over any files that
 # happen to share a name in the pack.
 cp -R "$PACK_DIR/." "$DEST_DIR/"
+chmod -R u+w "$DEST_DIR"
 rm -f "$DEST_DIR/index.html"
 cp "$SCRIPT_DIR/index.html" "$DEST_DIR/index.html"
 cp "$SCRIPT_DIR/demo.js" "$DEST_DIR/demo.js"


### PR DESCRIPTION
The qemu-wasm-smoke-pack is copied from the Nix store, so files land in public/public/demo/weblinux/ with read-only permissions. Later CI steps (e.g. the wasm demo build) may need to remove or overwrite files in that tree, so chmod the staged directory after copying.
