### PR TITLE
test(conformance): give the bundle scenarios a trust anchor and a fixture recipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,7 +3629,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]

--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -38,10 +38,12 @@ pub const FIRECRACKER_TAG: &str = "firecracker";
 /// run's own skip tally counts it instead of the scenario passing on no work.
 pub const NODE_TAG: &str = "node";
 
-/// Cucumber tag for a scenario that boots from a pre-built signed bundle.
+/// Cucumber tag for a scenario that installs a pre-built signed bundle.
 /// Sealing a bundle means a full image build, far too slow to run inline, so
-/// the operator supplies one with `MVM_BDD_BUNDLE=<path to .mvmpkg>` and the
-/// scenario is skipped cleanly when that is absent.
+/// the operator supplies one with `MVM_BDD_BUNDLE=<path to .mvmpkg>` plus the
+/// publisher key it was sealed under in `MVM_BDD_BUNDLE_PUBKEY`; the scenario
+/// is skipped cleanly when either is absent. `scripts/make-bundle-fixture.sh`
+/// produces both.
 pub const BUNDLE_TAG: &str = "bundle";
 
 /// Host capabilities a scenario may require, probed once by the harness.
@@ -55,8 +57,9 @@ pub struct RuntimeCaps {
     /// A usable `/dev/kvm` and a `firecracker` binary on `PATH` are both present,
     /// so a real Firecracker boot can run here.
     pub firecracker_bootable: bool,
-    /// `MVM_BDD_BUNDLE` names a readable `.mvmpkg`, so a bundle-boot scenario
-    /// has something to install.
+    /// `MVM_BDD_BUNDLE` names a readable `.mvmpkg` *and* `MVM_BDD_BUNDLE_PUBKEY`
+    /// names the publisher key it was sealed under, so a bundle scenario has
+    /// something to install and a trust anchor that admits it.
     pub bundle_fixture: bool,
     /// A `node` binary is resolvable, so the TypeScript example checkers can
     /// run at all.
@@ -151,7 +154,10 @@ impl ScenarioGate {
             Self::Pending => Some("@wip"),
             Self::NeedsLiveOptIn => Some("need MVM_BDD_LIVE (these boot a real microVM)"),
             Self::NeedsFirecracker => Some("need /dev/kvm + firecracker on PATH"),
-            Self::NeedsBundleFixture => Some("need MVM_BDD_BUNDLE to name a readable .mvmpkg"),
+            Self::NeedsBundleFixture => Some(
+                "need MVM_BDD_BUNDLE to name a readable .mvmpkg and \
+                 MVM_BDD_BUNDLE_PUBKEY its publisher key",
+            ),
             Self::NeedsNode => Some("need node on PATH (TypeScript example checkers)"),
             Self::OutsideCiLiveSubset => Some("outside the merge-queue @ci_live subset"),
         }

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -214,15 +214,28 @@ fn probe_caps() -> RuntimeCaps {
     RuntimeCaps {
         live_opted_in: std::env::var_os("MVM_BDD_LIVE").is_some(),
         firecracker_bootable: kvm_openable() && firecracker_on_path(),
-        bundle_fixture: bundle_fixture_path().is_some(),
+        bundle_fixture: bundle_fixture_path().is_some() && bundle_pubkey_path().is_some(),
         node_available: binary_on_path("node"),
     }
 }
 
-/// The operator-supplied `.mvmpkg` a bundle-boot scenario installs, when
+/// The operator-supplied `.mvmpkg` a bundle scenario installs, when
 /// `MVM_BDD_BUNDLE` names one that actually exists.
 pub(crate) fn bundle_fixture_path() -> Option<std::path::PathBuf> {
     let path = std::path::PathBuf::from(std::env::var_os("MVM_BDD_BUNDLE")?);
+    path.is_file().then_some(path)
+}
+
+/// The publisher key the fixture was sealed under (`MVM_BDD_BUNDLE_PUBKEY`),
+/// 32 raw Ed25519 bytes as `mvmctl trust add` reads them.
+///
+/// Required alongside the archive, because a bundle installs into an isolated
+/// `MVM_HOME` whose trust store starts empty and verification correctly refuses
+/// an unknown `key_id`. Without this the scenario could never have passed —
+/// which is exactly what it did, invisibly, for as long as nobody set
+/// `MVM_BDD_BUNDLE` at all.
+pub(crate) fn bundle_pubkey_path() -> Option<std::path::PathBuf> {
+    let path = std::path::PathBuf::from(std::env::var_os("MVM_BDD_BUNDLE_PUBKEY")?);
     path.is_file().then_some(path)
 }
 

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -223,15 +223,13 @@ pub(crate) fn run_mvmctl_isolated_live_home(world: &mut CliWorld, args: String) 
 /// guarantees the fixture exists before this scenario is selected.
 #[when(expr = "I install the bundle fixture")]
 fn install_bundle_fixture(world: &mut CliWorld) {
+    trust_the_fixture_publisher(world);
     let fixture = crate::bundle_fixture_path()
         .expect("`@bundle` scenarios only run when MVM_BDD_BUNDLE names a real file");
-    if world.isolated_home.is_none() {
-        world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));
-    }
     let home = world
         .isolated_home
         .as_ref()
-        .expect("isolated home is set above");
+        .expect("isolated home is set by trust_the_fixture_publisher");
     let output = mvmctl_command()
         .current_dir(workspace_root())
         .args(["bundle", "install"])
@@ -738,5 +736,75 @@ fn generated_project_contains_file(world: &mut CliWorld, file: String) {
     assert!(
         path.is_file(),
         "expected generated project to contain {file:?} at {path:?}"
+    );
+}
+
+/// Enrol the fixture's publisher key into the scenario's isolated trust store.
+///
+/// A bundle installs into a fresh `MVM_HOME`, whose trust store starts empty,
+/// and `read_and_verify_bundle` refuses an unknown `key_id` — correctly, that
+/// is claim 9. So an install scenario has to establish the trust anchor first,
+/// exactly as an operator adopting a publisher does.
+fn trust_the_fixture_publisher(world: &mut CliWorld) {
+    if world.isolated_home.is_none() {
+        world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));
+    }
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("isolated home is set above");
+    let pubkey = crate::bundle_pubkey_path()
+        .expect("`@bundle` scenarios only run when MVM_BDD_BUNDLE_PUBKEY names a real file");
+    let output = mvmctl_command()
+        .current_dir(workspace_root())
+        .args(["trust", "add"])
+        .arg(&pubkey)
+        .env("HOME", home.path())
+        .env("MVM_HOME", home.path())
+        .output()
+        .expect("failed to spawn mvmctl trust add");
+    assert!(
+        output.status.success(),
+        "enrolling the fixture publisher failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Install the fixture into a home that has *not* enrolled its publisher.
+#[when(expr = "I install the bundle fixture without trusting its publisher")]
+fn install_bundle_fixture_untrusted(world: &mut CliWorld) {
+    let fixture = crate::bundle_fixture_path()
+        .expect("`@bundle` scenarios only run when MVM_BDD_BUNDLE names a real file");
+    if world.isolated_home.is_none() {
+        world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));
+    }
+    let home = world
+        .isolated_home
+        .as_ref()
+        .expect("isolated home is set above");
+    world.last_run = Some(
+        mvmctl_command()
+            .current_dir(workspace_root())
+            .args(["bundle", "install"])
+            .arg(&fixture)
+            .env("HOME", home.path())
+            .env("MVM_HOME", home.path())
+            .output()
+            .expect("failed to spawn mvmctl"),
+    );
+}
+
+#[then(expr = "the failure names the untrusted publisher key")]
+fn failure_names_untrusted_key(world: &mut CliWorld) {
+    let run = world.last_run.as_ref().expect("a command has run");
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert!(
+        text.contains("trust store has no entry for key_id"),
+        "refusal must say the publisher is untrusted, not fail for some other \
+         reason; output was:\n{text}"
     );
 }

--- a/features/suites/s13_bundle_boot/signed_bundle_boot.feature
+++ b/features/suites/s13_bundle_boot/signed_bundle_boot.feature
@@ -6,13 +6,34 @@ Feature: Signed bundle boot on a runtime-only host
   admit, boot — with no flake, no builder VM and no network fetch of an image.
 
   Sealing a bundle is a full image build, far too slow to do inline, so the
-  archive is supplied by the operator with `MVM_BDD_BUNDLE=<path to .mvmpkg>`.
-  These scenarios boot a real Firecracker microVM, so on top of that they need
-  `MVM_BDD_LIVE`, a usable `/dev/kvm` and a `firecracker` binary; the harness
-  skips them cleanly wherever any of that is missing.
+  operator supplies the archive with `MVM_BDD_BUNDLE=<path to .mvmpkg>` and the
+  publisher key it was sealed under with `MVM_BDD_BUNDLE_PUBKEY=<path to .pub>`.
+  `scripts/make-bundle-fixture.sh` produces both.
+
+  The key is not optional bookkeeping. A scenario installs into an isolated
+  `MVM_HOME` whose trust store starts empty, and verification refuses an unknown
+  `key_id` — claim 9, working as designed. Before this suite supplied a trust
+  anchor these scenarios could not have passed even with an archive present;
+  nothing noticed, because nothing set `MVM_BDD_BUNDLE` either.
+
+  Verifying and installing an archive needs no hypervisor, so those scenarios
+  are gated on the fixture alone and run wherever one exists. Only the boot
+  additionally needs `MVM_BDD_LIVE`, a usable `/dev/kvm` and `firecracker`.
+
+  @bundle
+  Scenario: a published bundle installs by content address
+    When I install the bundle fixture
+    Then the command exits with code 0
+    And the install reports a bundle content address
+
+  @bundle
+  Scenario: a bundle from an unenrolled publisher is refused
+    When I install the bundle fixture without trusting its publisher
+    Then the command exits with code 1
+    And the failure names the untrusted publisher key
 
   @live @firecracker @bundle
-  Scenario: a published bundle installs by content address and boots
+  Scenario: an installed bundle boots by content address
     When I install the bundle fixture
     Then the command exits with code 0
     And the install reports a bundle content address

--- a/scripts/make-bundle-fixture.sh
+++ b/scripts/make-bundle-fixture.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Produce the `.mvmpkg` fixture the `@bundle` conformance scenarios install,
+# together with the publisher key it is sealed under.
+#
+# Sealing a bundle is a full image build, which is why the suite takes the
+# archive from the operator rather than building one inline. This script is the
+# supported way to make one.
+#
+#   ./scripts/make-bundle-fixture.sh [<template>] [<outdir>]
+#
+# <template> defaults to the most recently built template in ~/.mvm/templates.
+# Prints the two `export` lines to feed the suite.
+set -euo pipefail
+
+MVMCTL="${MVMCTL:-${CARGO_TARGET_DIR:-target}/debug/mvmctl}"
+[ -x "$MVMCTL" ] || { echo "no mvmctl at $MVMCTL — run: cargo build --bin mvmctl" >&2; exit 1; }
+
+TEMPLATES="$("$MVMCTL" --help >/dev/null 2>&1 && echo "${MVM_HOME:-$HOME/.mvm}/templates")"
+TEMPLATE="${1:-}"
+if [ -z "$TEMPLATE" ]; then
+    # A sealed bundle is exported from a built template slot, named by its
+    # 64-char content hash. Anything shorter in this directory is an alias.
+    TEMPLATE="$(ls -t "$TEMPLATES" 2>/dev/null | grep -E '^[0-9a-f]{64}$' | head -1 || true)"
+fi
+if [ -z "$TEMPLATE" ]; then
+    echo "no built template found in $TEMPLATES." >&2
+    echo "Build one first, e.g.: $MVMCTL machine build --flake examples/exit_code" >&2
+    exit 1
+fi
+
+OUT="${2:-${TMPDIR:-/tmp}}"
+mkdir -p "$OUT"
+PKG="$OUT/mvm-bdd-fixture.mvmpkg"
+PUB="$OUT/mvm-bdd-fixture.pub"
+
+"$MVMCTL" bundle export "$TEMPLATE" --out "$PKG"
+
+# The archive is signed by this host's signer; its public half is the trust
+# anchor a fresh MVM_HOME needs before `bundle install` will admit the archive.
+SIGNER="${MVM_HOME:-$HOME/.mvm}/keys/host-signer.pub"
+[ -f "$SIGNER" ] || { echo "no host signer public key at $SIGNER" >&2; exit 1; }
+cp "$SIGNER" "$PUB"
+
+echo
+echo "export MVM_BDD_BUNDLE=$PKG"
+echo "export MVM_BDD_BUNDLE_PUBKEY=$PUB"


### PR DESCRIPTION
The `@bundle` scenarios could not have passed. Not for want of an archive — **for want of a trust anchor.**

A bundle scenario installs into an isolated `MVM_HOME` whose trust store starts empty, and `read_and_verify_bundle` refuses an unknown `key_id`. That refusal is claim 9 working exactly as designed. But the scenario only ever ran `bundle install`, so with any archive supplied it would have failed on:

```
bundle archive failed verification: trust store has no entry for key_id e11fc77f…
```

and read as a broken bundle path rather than a missing enrolment.

Nobody noticed because the gate keys on `MVM_BDD_BUNDLE`, nobody set it, and **a scenario that never runs cannot report that it would fail.** The skip was hiding a defect, not deferring one.

## Changes

- **The fixture is a pair.** The archive plus the publisher key it was sealed under (`MVM_BDD_BUNDLE_PUBKEY`). The gate requires both and its skip reason names what is missing.
- **`scripts/make-bundle-fixture.sh`** produces both from a built template, so the archive is reproducible rather than folklore.
- **The feature is split by what each scenario actually needs.** Verifying and installing an archive needs no hypervisor; tying that to `@live @firecracker` meant it was proven nowhere. Install-by-content-address and refuse-an-unenrolled-publisher are now gated on the fixture alone and run on a hypervisor-less host. Only the boot keeps `@live @firecracker`.
- **A refusal scenario**, the cheaper half of claim 9. It asserts the failure *names the untrusted key* rather than merely being nonzero, so an install broken for an unrelated reason cannot pass as a security refusal.

## Evidence

Proven with a real 24 MB `.mvmpkg` exported from a built template:

```
Scenario: a published bundle installs by content address
 ✔ When I install the bundle fixture
 ✔ Then the command exits with code 0
 ✔ And the install reports a bundle content address
Scenario: a bundle from an unenrolled publisher is refused
 ✔ When I install the bundle fixture without trusting its publisher
 ✔ Then the command exits with code 1
 ✔ And the failure names the untrusted publisher key
```

Both pass on macOS with no `/dev/kvm`; the boot scenario skips cleanly under `need MVM_BDD_LIVE`.

`just bdd` with the fixture supplied: 240 scenarios, 232 passed, 7 failed — the same 7 that fail on main. 68 conformance unit tests, fmt, stable `clippy --workspace --all-targets -D warnings`, `check-all`, `check-conformance`, `check-honesty`, `check-nextest-groups`, `check-single-fixture-corpus` all green.