### PR TITLE
test(security): witness peer policy bindings

### DIFF
--- a/crates/mvm-contract/src/policy/network_policy.rs
+++ b/crates/mvm-contract/src/policy/network_policy.rs
@@ -716,6 +716,7 @@ mod tests {
     use alloc::vec;
 
     use super::*;
+    use crate::peer::{PeerBinding, PeerName};
 
     #[test]
     fn host_port_parse() {
@@ -1003,6 +1004,25 @@ mod tests {
         ]);
         let rules = policy.resolve_rules().unwrap();
         assert_eq!(rules.len(), 2);
+    }
+
+    #[test]
+    fn policy_peers_returns_attached_bindings_for_every_shape() {
+        let peer = PeerBinding {
+            name: PeerName::parse("database.mvm.peer").expect("valid peer name"),
+            port: 5432,
+            host_addr: "127.0.0.1".into(),
+            host_port: 34567,
+        };
+
+        for policy in [
+            NetworkPolicy::deny_all().with_peers(vec![peer.clone()]),
+            NetworkPolicy::allow_list(vec![HostPort::new("example.com", 443)])
+                .with_peers(vec![peer.clone()]),
+        ] {
+            assert_eq!(policy.peers(), core::slice::from_ref(&peer));
+        }
+        assert!(NetworkPolicy::deny_all().peers().is_empty());
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,6 +17,15 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
+- [x] **Issue #2874 — scheduled Security peer-policy mutation witness.**
+      `NetworkPolicy::peers()` now has a focused witness that distinguishes
+      both policy variants carrying an admitted peer from the deny-all empty
+      default. The exact surviving empty-slice mutant from Security run
+      32931995875 is caught; the second generated replacement is unviable.
+      Issue #2875 remains open as the scheduled-evidence tracker until the next
+      scheduled Security run records the repaired lane. See
+      `specs/sprint/delivery/2874-security-peer-policy-witness.md`.
+
 - [x] **Issues #2841 and #2842 — scheduled security evidence is executable.**
       Sealed-production policy witnesses now follow the refactored agent
       modules and the `mvm-contract` source of truth. A contributor-checkout

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3059,6 +3059,19 @@ to the configured ceiling and the first terse response immediately after it.
 - [x] Record the delivery in
       `specs/sprint/delivery/2870-extended-ci-recovery.md`.
 
+## 2026-08-26 Security peer-policy mutation witness
+
+- [x] Reproduce the scheduled Security failure from run 32931995875 as the
+      empty-slice replacement of `NetworkPolicy::peers()`.
+- [x] Add a focused witness for attached peer bindings on preset and explicit
+      allow-list policies while preserving the deny-all empty default.
+- [x] Prove the exact mutation surface: one replacement caught and the other
+      generated replacement unviable.
+- [x] Keep issues #2874 and #2875 open while the repair lands and fresh
+      scheduled evidence is collected.
+- [x] Record the delivery in
+      `specs/sprint/delivery/2874-security-peer-policy-witness.md`.
+
 ## Follow-up (not started) — repository-to-signed-workload generator
 
 Prompted by the same 2026-08-25 survey of a commercial enterprise

--- a/specs/sprint/delivery/2874-security-peer-policy-witness.md
+++ b/specs/sprint/delivery/2874-security-peer-policy-witness.md
@@ -1,0 +1,24 @@
+# Security peer-policy mutation witness
+
+Issue #2874 reported the failed scheduled Security run 32931995875. Its only
+red job was the `mvm-contract` mutation shard: replacing
+`NetworkPolicy::peers()` with an always-empty slice survived, so the claim-10
+peer-policy accessor lacked a direct witness.
+
+The focused test now attaches one validated peer binding to both policy shapes
+and requires the accessor to return that exact binding. It separately preserves
+the deny-all empty default. This distinguishes the real stored policy from the
+surviving fail-closed-looking replacement without weakening the mutation
+baseline.
+
+Validation:
+
+- focused `mvm-contract` peer-policy test: green;
+- exact `NetworkPolicy::peers` mutation selection: two generated mutants,
+  one caught and one unviable;
+- the repository's static mutation-surface gate, contract suite, check, and
+  Clippy run before the repair branch is submitted.
+
+Issue #2875 is the independent scheduled-evidence tracker. It remains open
+until scheduled Security history contains the repaired witness; manual evidence
+does not replace that cadence assertion.


### PR DESCRIPTION
Addresses the scheduled Security failure reported in #2874 while leaving the issue open for scheduled evidence.

- adds a focused witness for attached peer bindings on both NetworkPolicy shapes
- proves the exact surviving empty-slice mutant is caught
- records the required sprint and refactor delivery state

Validation: mvm-contract tests (961 passed), cargo check, clippy with warnings denied, static mutation-witness gate, and exact cargo-mutants selection (one caught, one unviable).

#2875 remains open until scheduled Security history contains the repaired witness.