### PR TITLE
ci(pages): deploy to Cloudflare Pages with COOP/COEP headers

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Deploy GitHub Pages
+name: Deploy site to Cloudflare Pages
 
 # Deploys happen when a GitHub Release is published, with manual
 # dispatch available for operator-triggered docs publishes. The
@@ -12,8 +12,7 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
+  deployments: write
 
 concurrency:
   group: pages
@@ -22,8 +21,8 @@ concurrency:
 jobs:
   deploy:
     environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      name: cloudflare-pages
+      url: ${{ steps.deployment.outputs.deployment-url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -81,14 +80,12 @@ jobs:
         working-directory: public
         run: pnpm build
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: public/dist
-
-      - name: Deploy to GitHub Pages
+      - name: Deploy to Cloudflare Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Create a Cloudflare Pages project named `mvm` (or change this).
+          command: pages deploy public/dist --project-name=mvm --branch=main
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/public/public/_headers
+++ b/public/public/_headers
@@ -1,0 +1,6 @@
+# Cross-origin isolation headers for the WebLinux browser demo.
+# QEMU-Wasm uses pthreads, which require SharedArrayBuffer; browsers only
+# expose SharedArrayBuffer in a cross-origin-isolated context.
+/demo/weblinux/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp


### PR DESCRIPTION
GitHub Pages cannot set the Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers required by SharedArrayBuffer, so the WebLinux demo fails there with `SharedArrayBuffer is not defined`.

Move deployment to Cloudflare Pages (free tier) which supports custom headers via a `_headers` file, and add the needed headers for `/demo/weblinux/*`.

Required one-time setup after merge:
1. Create a Cloudflare account and a Pages project named `mvm`.
2. Add `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` as repository secrets.
3. Trigger a workflow_dispatch run of this workflow to deploy.
4. Update DNS to point `gomicrovm.com` at Cloudflare Pages.
