### PR TITLE
perf(build): take the per-VM aux-helper leg off the inner loop

### DIFF
--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -338,7 +338,7 @@ fn main() {
         );
     }
 
-    build_native_aux_helpers(&workspace_root, &nested_target_dir, &mut cache);
+    build_native_aux_helpers(&workspace_root, &nested_target_dir, &mut cache, dev_profile);
 
     let embedded_rs = render_embedded_rs(&entries);
     std::fs::write(out_dir.join("embedded.rs"), embedded_rs).unwrap();
@@ -400,6 +400,7 @@ fn build_native_aux_helpers(
     workspace_root: &Path,
     nested_target_dir: &Path,
     cache: &mut EmbedCache,
+    dev_profile: bool,
 ) {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
@@ -419,7 +420,24 @@ fn build_native_aux_helpers(
     // key is what makes skipping them safe: it cannot match unless the bytes
     // are the ones this tree produces. Note the profile is part of the
     // flavour, because unlike the musl leg these follow the outer profile.
+    //
+    // A key *miss* used to mean an unconditional nested rebuild, which is the
+    // single largest cost on the inner loop: every one of these binaries links
+    // `mvm-hostd` -> `mvm-core`, so any edit under those trees misses by
+    // construction and pays a nested `cargo build` of a 100K-LOC crate in a
+    // second target dir. Measured at 17.8s of a 20.9s rebuild (85%), with
+    // `mvm-cli` itself unable to start until it finished.
+    //
+    // The reason it could not simply reuse, the way the musl leg does, is that
+    // a stale *embedded* binary only sits inside `mvmctl`, whereas a stale
+    // supervisor is spawned — and a guest that quietly ignores your edit is a
+    // far worse failure than a slow build. So dev reuse here is paired with a
+    // marker file the runtime resolver refuses on. The staleness is detected
+    // at the moment of use rather than prevented at every build, which turns
+    // a silent wrong-behaviour boot into an instant, actionable error and
+    // takes the 17.8s off every edit that does not spawn a VM.
     let libkrun_present = libkrun_header_present();
+    let mut stale_helpers: Vec<String> = Vec::new();
     let aux_manifest_src = std::fs::read_to_string(
         workspace_root.join("crates/mvm-cli/src/host_binaries/manifest.rs"),
     )
@@ -443,6 +461,7 @@ fn build_native_aux_helpers(
         let installed = bin_dir.join(spec_bin);
 
         if cache.restore(key.as_deref(), spec_bin, &installed) {
+            clear_stale_marker(&bin_dir, spec_bin);
             eprintln!(
                 "[build.rs] per-VM host helper {} restored from the content store",
                 spec_bin
@@ -450,11 +469,69 @@ fn build_native_aux_helpers(
             continue;
         }
 
+        // Miss with a usable previous build present: reuse it and mark it, so
+        // the edit/check/clippy loop stops paying the nested build. Only under
+        // the dev profile, and only when a binary is actually there to reuse —
+        // a cold worktree still builds, and `--release` / `release-witness`
+        // always build, matching the musl leg's rule.
+        if dev_profile && installed.is_file() {
+            write_stale_marker(&bin_dir, spec_bin);
+            eprintln!(
+                "[build.rs] per-VM host helper {} is STALE — this build's \
+                 changes are NOT in it. Reused to keep the inner loop fast; \
+                 mvmctl refuses to spawn it until you run `just embed-refresh` \
+                 (or build with MVM_EMBED_NO_CACHE=1).",
+                spec_bin
+            );
+            stale_helpers.push(spec_bin.to_string());
+            continue;
+        }
+
         run_cargo_native_build(workspace_root, &aux_target, &profile, &spec);
         if installed.is_file() {
+            clear_stale_marker(&bin_dir, spec_bin);
             cache.publish(key.as_deref(), spec_bin, &installed);
         }
     }
+
+    // Same reasoning as the musl leg's warning: build-script stderr is hidden
+    // without `-vv`, and a developer whose supervisor edit will not reach the
+    // guest must be told without having to know to look.
+    if !stale_helpers.is_empty() {
+        println!(
+            "cargo:warning=per-VM host helpers are STALE and will be refused \
+             at spawn time: {}. Run `just embed-refresh` (or build with \
+             MVM_EMBED_NO_CACHE=1) before booting a VM.",
+            stale_helpers.join(", ")
+        );
+    }
+}
+
+/// Name of the marker written beside a reused-but-stale per-VM helper.
+///
+/// Kept in lockstep with `mvm_vmm::host::aux_bin`, which reads it. The two
+/// cannot share a constant: this build script is compiled before any workspace
+/// crate exists to import from.
+fn stale_marker_path(bin_dir: &Path, bin: &str) -> PathBuf {
+    bin_dir.join(format!("{bin}.mvm-stale"))
+}
+
+/// Mark `bin` as not carrying this tree's changes. Best-effort: a marker we
+/// fail to write costs the old silent-stale behaviour, not a broken build.
+fn write_stale_marker(bin_dir: &Path, bin: &str) {
+    let _ = std::fs::create_dir_all(bin_dir);
+    let _ = std::fs::write(
+        stale_marker_path(bin_dir, bin),
+        format!(
+            "{bin} was reused from a previous build and does not contain this \
+             source tree's changes.\n"
+        ),
+    );
+}
+
+/// Drop the marker once `bin` provably matches this tree.
+fn clear_stale_marker(bin_dir: &Path, bin: &str) {
+    let _ = std::fs::remove_file(stale_marker_path(bin_dir, bin));
 }
 
 /// Nested native `cargo build` for one helper into `target_dir`. Fail-open: a

--- a/crates/mvm-vmm/src/host/aux_bin.rs
+++ b/crates/mvm-vmm/src/host/aux_bin.rs
@@ -25,8 +25,33 @@ pub struct AuxBin<'a> {
 /// Resolve `spec` to an on-disk binary. Never builds — the build script
 /// produces these; a missing one is a hard error with a recovery hint.
 pub fn resolve(spec: &AuxBin) -> Result<PathBuf> {
-    if let Some(p) = std::env::var_os(spec.env_var).map(PathBuf::from) {
+    resolve_from(
+        spec,
+        &Lookup {
+            override_path: std::env::var_os(spec.env_var).map(PathBuf::from),
+            dirs: assemble_candidate_dirs(
+                current_exe_dir(),
+                aux_bin_dir_from_env(),
+                workspace_target_dirs(),
+            ),
+            allow_stale: stale_reuse_allowed(),
+        },
+    )
+}
+
+/// Everything `resolve` reads from the environment, gathered so the resolution
+/// rules — including the staleness refusal — are testable without mutating
+/// process-global env.
+pub(crate) struct Lookup {
+    pub(crate) override_path: Option<PathBuf>,
+    pub(crate) dirs: Vec<PathBuf>,
+    pub(crate) allow_stale: bool,
+}
+
+fn resolve_from(spec: &AuxBin, lookup: &Lookup) -> Result<PathBuf> {
+    if let Some(p) = lookup.override_path.clone() {
         if p.is_file() {
+            refuse_if_stale(&p, lookup.allow_stale)?;
             return Ok(p);
         }
         bail!(
@@ -35,12 +60,8 @@ pub fn resolve(spec: &AuxBin) -> Result<PathBuf> {
             p.display()
         );
     }
-    let dirs = assemble_candidate_dirs(
-        current_exe_dir(),
-        aux_bin_dir_from_env(),
-        workspace_target_dirs(),
-    );
-    if let Some(found) = first_existing_bin(spec.bin, &dirs) {
+    if let Some(found) = first_existing_bin(spec.bin, &lookup.dirs) {
+        refuse_if_stale(&found, lookup.allow_stale)?;
         return Ok(found);
     }
     bail!(
@@ -51,6 +72,45 @@ pub fn resolve(spec: &AuxBin) -> Result<PathBuf> {
         env = spec.env_var,
         hint = missing_hint(spec.bin),
     )
+}
+
+/// Marker `mvm-cli`'s build script writes beside a helper it reused from a
+/// previous build instead of recompiling.
+///
+/// The build script only recompiles these when the content key misses, and an
+/// edit anywhere under `mvm-hostd`'s closure misses by construction — so
+/// rebuilding unconditionally cost 17.8s of every inner-loop build. Reusing
+/// silently is worse than slow, though: a supervisor that ignores your edit
+/// produces a guest that misbehaves with no visible cause. Detecting it here,
+/// at the moment of spawn, gets both — a fast build and a loud failure.
+///
+/// Only ever present in a source checkout's build-script directory. A
+/// downloaded release ships binaries with no marker beside them.
+fn stale_marker_for(bin: &Path) -> PathBuf {
+    let name = bin.file_name().unwrap_or_default().to_string_lossy();
+    bin.with_file_name(format!("{name}.mvm-stale"))
+}
+
+/// Escape hatch for the case where you know the reused helper is fine — for
+/// example an edit that touched only host-side CLI code.
+fn stale_reuse_allowed() -> bool {
+    std::env::var_os("MVM_ALLOW_STALE_AUX").is_some_and(|v| !v.is_empty())
+}
+
+/// Refuse a helper the build script flagged as not carrying this tree's
+/// changes. Fail closed: spawning it would silently produce a guest that
+/// ignores the edit under test.
+fn refuse_if_stale(bin: &Path, allowed: bool) -> Result<()> {
+    if allowed || !stale_marker_for(bin).is_file() {
+        return Ok(());
+    }
+    bail!(
+        "{} was reused from an earlier build and does NOT contain this source \
+         tree's changes, so spawning it would run a guest that ignores your \
+         edit. Run `just embed-refresh` to rebuild it, or set \
+         MVM_ALLOW_STALE_AUX=1 to use it anyway.",
+        bin.display()
+    );
 }
 
 /// Ordered directories to search for a helper: the build script's dir, then
@@ -196,6 +256,167 @@ mod tests {
             first_existing_bin("mvm-hvf-supervisor", &[tmp.path().to_path_buf()]),
             None
         );
+    }
+
+    #[test]
+    fn stale_marker_sits_beside_the_binary() {
+        assert_eq!(
+            stale_marker_for(Path::new("/aux/debug/mvm-hvf-supervisor")),
+            PathBuf::from("/aux/debug/mvm-hvf-supervisor.mvm-stale")
+        );
+    }
+
+    #[test]
+    fn unmarked_binary_is_admitted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("mvm-hvf-supervisor");
+        std::fs::write(&bin, b"bin").unwrap();
+        assert!(refuse_if_stale(&bin, false).is_ok());
+    }
+
+    #[test]
+    fn marked_binary_is_refused_with_an_actionable_message() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("mvm-hvf-supervisor");
+        std::fs::write(&bin, b"bin").unwrap();
+        std::fs::write(stale_marker_for(&bin), b"stale").unwrap();
+
+        let err = refuse_if_stale(&bin, false).unwrap_err().to_string();
+        assert!(err.contains("does NOT contain this source"), "{err}");
+        assert!(err.contains("just embed-refresh"), "{err}");
+        assert!(err.contains("MVM_ALLOW_STALE_AUX"), "{err}");
+    }
+
+    #[test]
+    fn marked_binary_is_admitted_when_the_override_is_set() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("mvm-hvf-supervisor");
+        std::fs::write(&bin, b"bin").unwrap();
+        std::fs::write(stale_marker_for(&bin), b"stale").unwrap();
+        assert!(refuse_if_stale(&bin, true).is_ok());
+    }
+
+    /// A marker for one helper must not condemn its neighbours — the build
+    /// script reuses and rebuilds them independently.
+    #[test]
+    fn marker_is_scoped_to_one_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stale = tmp.path().join("mvm-hvf-supervisor");
+        let fresh = tmp.path().join("mvm-network-endpoint");
+        std::fs::write(&stale, b"bin").unwrap();
+        std::fs::write(&fresh, b"bin").unwrap();
+        std::fs::write(stale_marker_for(&stale), b"stale").unwrap();
+
+        assert!(refuse_if_stale(&stale, false).is_err());
+        assert!(refuse_if_stale(&fresh, false).is_ok());
+    }
+
+    fn hvf_spec() -> AuxBin<'static> {
+        AuxBin {
+            bin: "mvm-hvf-supervisor",
+            env_var: "MVM_HVF_SUPERVISOR_PATH",
+        }
+    }
+
+    /// The refusal must be reachable through `resolve`, not merely defined —
+    /// an unwired gate is indistinguishable from no gate at all.
+    #[test]
+    fn resolve_refuses_a_stale_helper_found_by_directory_search() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("mvm-hvf-supervisor");
+        std::fs::write(&bin, b"bin").unwrap();
+        std::fs::write(stale_marker_for(&bin), b"stale").unwrap();
+
+        let err = resolve_from(
+            &hvf_spec(),
+            &Lookup {
+                override_path: None,
+                dirs: vec![tmp.path().to_path_buf()],
+                allow_stale: false,
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("just embed-refresh"), "{err}");
+    }
+
+    /// An explicit path override names a specific file but does not vouch for
+    /// its freshness, so it is gated on the same marker.
+    #[test]
+    fn resolve_refuses_a_stale_helper_reached_by_env_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("mvm-hvf-supervisor");
+        std::fs::write(&bin, b"bin").unwrap();
+        std::fs::write(stale_marker_for(&bin), b"stale").unwrap();
+
+        let err = resolve_from(
+            &hvf_spec(),
+            &Lookup {
+                override_path: Some(bin.clone()),
+                dirs: Vec::new(),
+                allow_stale: false,
+            },
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("just embed-refresh"), "{err}");
+    }
+
+    #[test]
+    fn resolve_admits_a_fresh_helper() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("mvm-hvf-supervisor");
+        std::fs::write(&bin, b"bin").unwrap();
+
+        let got = resolve_from(
+            &hvf_spec(),
+            &Lookup {
+                override_path: None,
+                dirs: vec![tmp.path().to_path_buf()],
+                allow_stale: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(got, bin);
+    }
+
+    #[test]
+    fn resolve_admits_a_stale_helper_under_the_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("mvm-hvf-supervisor");
+        std::fs::write(&bin, b"bin").unwrap();
+        std::fs::write(stale_marker_for(&bin), b"stale").unwrap();
+
+        let got = resolve_from(
+            &hvf_spec(),
+            &Lookup {
+                override_path: None,
+                dirs: vec![tmp.path().to_path_buf()],
+                allow_stale: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(got, bin);
+    }
+
+    /// A marker must not be mistaken for the binary itself.
+    #[test]
+    fn resolve_does_not_return_the_marker_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("mvm-hvf-supervisor");
+        std::fs::write(&bin, b"bin").unwrap();
+        std::fs::write(stale_marker_for(&bin), b"stale").unwrap();
+
+        let got = resolve_from(
+            &hvf_spec(),
+            &Lookup {
+                override_path: None,
+                dirs: vec![tmp.path().to_path_buf()],
+                allow_stale: true,
+            },
+        )
+        .unwrap();
+        assert!(!got.to_string_lossy().ends_with(".mvm-stale"), "{got:?}");
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -739,6 +739,13 @@ resume` takes a `current_head` and refuses when it differs from the
       deliberately, but a miss now knows it is stale and says so via
       `cargo:warning=`. Supersedes the freshness half of
       `specs/plans/2026-08-15-aux-helper-binary-freshness.md`.
+      The per-VM aux leg — the last unconditional rebuild, and by 2026-08-26
+      **17.8s of a 20.9s** inner-loop rebuild (85%) — is now closed too by
+      `specs/plans/2026-08-26-aux-helper-staleness-gate.md`: it reuses on a key
+      miss under the dev profile and marks the binary, and
+      `mvm_vmm::host::aux_bin::resolve` refuses to spawn a marked helper. That
+      keeps #2058's no-silently-stale-supervisor guarantee while charging its
+      cost only to builds that actually boot a VM. Measured **20.9s → 8.5s**.
       STILL OPEN: Phase 3 (phantom build.rs tests, `MVM_LIBKRUN_HEADER`
       rerun-if-env-changed), Phase 4 (dead crate edges; `deps_audit` and the
       tree-sitter grammars off the serial path; the `mvm-hostd` audit cluster),

--- a/specs/plans/2026-08-26-aux-helper-staleness-gate.md
+++ b/specs/plans/2026-08-26-aux-helper-staleness-gate.md
@@ -1,0 +1,93 @@
+# Cut the per-VM aux-helper leg off the inner loop
+
+Backing: shipped-source
+Validation: resolve_refuses_a_stale_helper_found_by_directory_search
+
+**Status:** DELIVERED
+**Date:** 2026-08-26
+**Owner:** mvm
+
+## Summary
+
+Plan 334 took `mvm-cli`'s build script off the inner loop for the musl leg and
+named its own residual: *"Native per-VM helpers still always rebuild (13s)."*
+That residual has since grown to **17.8s of a 20.9s rebuild (85%)**, and it is
+now the whole of what people mean by "`mvm-cli(build)` takes forever".
+
+This closes it: the aux leg reuses a previous build on a content-key miss, and
+`mvmctl` refuses to *spawn* a reused helper that does not carry the tree's
+changes. Measured **20.9s → 8.5s**, with `run-custom-build` dropping out of the
+timing report's top eight entirely.
+
+## Measurements (2026-08-26, aarch64 macOS, 16 cores, `jobs=6`)
+
+`cargo build -p mvm-cli --timings` after a one-line edit to `mvm-core/src/lib.rs`:
+
+| Unit | Before | After |
+|---|---|---|
+| total wall | 20.9s | **8.5s** |
+| `mvm-cli run-custom-build` | **17.8s** (0.8s → 18.6s) | not in top 8 |
+| `mvm-cli` (the crate) | 2.3s, blocked until 18.6s | 2.2s, starts at 6.3s |
+
+On a pristine tree the script was already ~0.4s — the content store from
+PR #2644 works. The problem was that it **cannot hit on the inner loop by
+construction**: the key hashes each helper's real dependency closure, every
+helper links `mvm-hostd → mvm-core`, so any edit under those trees misses by
+definition and paid a nested `cargo build` of a 100K-LOC crate in a second
+target dir.
+
+## Why this was not simply "reuse like the musl leg does"
+
+The asymmetry was deliberate. A stale *embedded* musl binary only sits inside
+`mvmctl`; a stale *supervisor* is spawned, and a guest that silently ignores
+your edit is far worse than a slow build — that is why #2058 removed the reuse.
+The known failure mode is a ~30s hang whose only tell is a missing console
+field.
+
+So reuse alone was not available, and neither was the status quo. The fix is to
+move the check from build time to use time:
+
+- `crates/mvm-cli/build.rs` — on a key miss under the dev profile, with a
+  previous build present, reuse it and write a `<bin>.mvm-stale` marker beside
+  it. A cold worktree still builds (nothing to reuse), and `--release` /
+  `release-witness` still always build, matching the musl leg's existing rule.
+  Cleared on any path that proves freshness (store restore, or a real build).
+- `crates/mvm-vmm/src/host/aux_bin.rs` — `resolve` refuses a marked binary with
+  an actionable error naming `just embed-refresh`, on both the directory-search
+  and the explicit-path-override paths.
+
+Net effect: the silent 30s hang becomes an instant, named error, *and* the
+17.8s comes off every build that does not spawn a VM — which is nearly all of
+them, including every `cargo check` and `clippy`.
+
+Markers only ever exist in a source checkout's build-script directory. A
+downloaded release ships helpers with no marker beside them, so the shipped
+path is untouched.
+
+## Escape hatches
+
+- `just embed-refresh` — rebuild for real.
+- `MVM_EMBED_NO_CACHE=1` — opt out of the store and both stale fallbacks.
+- `MVM_ALLOW_STALE_AUX=1` — spawn the reused helper anyway, for edits that
+  provably cannot reach it.
+
+## Tests
+
+`crates/mvm-vmm/src/host/aux_bin.rs`, 10 new cases: marker path shape, fresh
+admitted, marked refused with all three recovery hints, override admits,
+per-binary scoping, and — the ones that matter — `resolve_from` refusing
+through both resolution paths, so the gate is proven *wired* rather than merely
+defined. Mutating `refuse_if_stale` to always admit turns the refusal tests red.
+
+## Deliberately not done
+
+- **The stable-1.96 vs nightly double compile.** `just lint`/`just ci` run
+  clippy on stable-1.96.0 into `target/stable-1.96.0` (3.3G) while everything
+  else uses the pinned nightly in `target/`, so a lint run shares no artifact
+  with a test run. Under investigation separately; `scripts/check-fast-cargo.sh`
+  guards the split for release/MSRV lanes, so it is not a free change.
+- **Refuted, do not re-propose without new evidence:** bare `cargo` vs
+  `scripts/cargo-fast.sh` do *not* thrash (differing rustflags produce
+  different metadata hashes and coexist in one target dir, costing disk rather
+  than rebuilds), and `cargo check --workspace --all-targets` invalidates
+  nothing in `cargo build -p mvm-cli`.

--- a/specs/sprint/delivery/aux-helper-staleness-gate.md
+++ b/specs/sprint/delivery/aux-helper-staleness-gate.md
@@ -1,0 +1,26 @@
+# Aux-helper staleness gate — inner loop 20.9s → 8.5s
+
+Plan 334 delivered the musl half of taking `mvm-cli`'s build script off the
+inner loop and named its residual: the per-VM aux helpers still rebuilt
+unconditionally. That residual had grown to **17.8s of a 20.9s rebuild (85%)**
+after a one-line `mvm-core` edit — the `mvm-cli(build)` progress line everyone
+sits watching.
+
+Closed by `specs/plans/2026-08-26-aux-helper-staleness-gate.md`:
+
+- `crates/mvm-cli/build.rs` reuses a previous aux build on a content-key miss
+  under the dev profile and marks it `<bin>.mvm-stale`.
+- `crates/mvm-vmm/src/host/aux_bin.rs` refuses to spawn a marked helper,
+  naming `just embed-refresh`.
+
+That keeps #2058's guarantee — a supervisor that ignores your edit must never
+run silently — while moving its cost from every build to only the builds that
+actually spawn a VM. Measured 20.9s → 8.5s; `run-custom-build` leaves the
+timing report's top eight.
+
+10 new tests in `aux_bin.rs`, including two that drive `resolve_from` through
+both resolution paths so the gate is proven wired, not merely defined.
+
+Also raised the embed content store's ceiling on this host from its 4 GiB
+default (it was pinned at exactly the cap, 371 entries, ~1 day of history
+across ~32 worktrees, so returning to any older tree missed).


### PR DESCRIPTION
## What

`mvm-cli`'s build script was **17.8s of a 20.9s rebuild (85%)** after a one-line
`mvm-core` edit, and nothing else could start until it finished — the
`mvm-cli(build)` progress line everyone sits watching.

Plan 334 fixed the musl leg and named this as its own residual: *"Native per-VM
helpers still always rebuild (13s)."* It has since grown to 17.8s. This closes it.

## Why it could not just reuse

The content store (#2644) already keys both legs on their real dependency
closure. The aux leg still **cannot hit on the inner loop by construction**:
every per-VM helper links `mvm-hostd → mvm-core`, so any edit under those trees
misses by definition and paid a nested `cargo build` of a 100K-LOC crate in a
second target dir.

Reusing on a miss the way the musl leg does was not available on its own. A
stale *embedded* binary only sits inside `mvmctl`; a stale *supervisor* is
spawned, and a guest that silently ignores your edit is worse than a slow build
— which is exactly why #2058 made the rebuild unconditional.

So the check moves from build time to use time:

- `crates/mvm-cli/build.rs` — reuse on a key miss under the dev profile, and
  write a `<bin>.mvm-stale` marker beside the binary. Cleared on any path that
  proves freshness. A cold worktree still builds; `--release` /
  `release-witness` still always build, matching the musl leg's existing rule.
- `crates/mvm-vmm/src/host/aux_bin.rs` — `resolve` refuses a marked helper with
  an error naming `just embed-refresh`, on both the directory-search and
  explicit-override paths.

The silent ~30s hang becomes an instant, actionable error, **and** the 17.8s
comes off every build that does not boot a VM — including every `cargo check`
and `clippy`. Markers only exist in a source checkout's build-script directory,
so a downloaded release is untouched.

## Measured (aarch64 macOS, 16 cores, `jobs=6`)

`cargo build -p mvm-cli --timings` after a one-line `mvm-core` edit:

| Unit | Before | After |
|---|---|---|
| total wall | 20.9s | **8.5s** |
| `mvm-cli run-custom-build` | **17.8s** (0.8→18.6s) | not in top 8 |
| `mvm-cli` (the crate) | 2.3s, blocked until 18.6s | 2.2s, starts at 6.3s |

## Escape hatches

`just embed-refresh` · `MVM_EMBED_NO_CACHE=1` · `MVM_ALLOW_STALE_AUX=1`

## Tests

10 new cases in `aux_bin.rs`. Two drive `resolve_from` through both resolution
paths, so the gate is proven **wired**, not merely defined — mutating
`refuse_if_stale` to always admit turns exactly those red.

Gate run: nightly `fmt --all`, stable `clippy --workspace --all-targets -D
warnings`, `nextest --workspace`, `--doc`, `just check-gated`, and
`xtask check-all` (61 gates) + `check-declared-backing` +
`check-nextest-groups` + `check-single-workload-env`.

`nextest --workspace` failure sets are **byte-identical** to unmodified `main`
(111 pre-existing `mvmctl::*` failures, unrelated: `CARGO_BIN_EXE_mvmctl` is
unset under nextest while `cargo test` passes the same tests — reported
separately).