### PR TITLE
fix(conformance): stop HOME isolation from hiding the Rust toolchain

### DIFF
--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -413,3 +413,173 @@ mod tests {
         );
     }
 }
+
+/// Point a command at an isolated `HOME` without orphaning the Rust toolchain.
+///
+/// Scenarios replace `HOME` so a run cannot touch the developer's real
+/// `~/.mvm`. But `rustup` locates its toolchains through `$HOME/.rustup` unless
+/// `RUSTUP_HOME` says otherwise, so replacing `HOME` alone also hides every
+/// installed toolchain and target from any command that compiles something.
+///
+/// On a source checkout that is not a subtle degradation. `mvmctl` cross-compiles
+/// the embedded host-vm binaries to musl, and under a bare isolated `HOME` that
+/// build either fails with
+///
+/// ```text
+/// error[E0463]: can't find crate for `core`
+///   = note: the `x86_64-unknown-linux-musl` target may not be installed
+/// ```
+///
+/// — which reads as a missing target on a host where the target *is* installed —
+/// or silently downloads a fresh toolchain into the throwaway directory, once per
+/// scenario, for as long as the suite runs.
+///
+/// So the state isolation is kept and the toolchain locators are passed through.
+/// `MVM_HOME` still points at the temporary directory; only rustup's and cargo's
+/// own roots survive, and neither is state the suite is trying to isolate.
+pub trait IsolatedHome {
+    /// Point this command at `home` for state, keeping the toolchain visible.
+    fn isolated_home(&mut self, home: impl AsRef<std::path::Path>) -> &mut Self;
+}
+
+impl IsolatedHome for std::process::Command {
+    fn isolated_home(&mut self, home: impl AsRef<std::path::Path>) -> &mut Self {
+        let home = home.as_ref();
+        self.env("HOME", home).env("MVM_HOME", home);
+        for (var, dir) in [("RUSTUP_HOME", ".rustup"), ("CARGO_HOME", ".cargo")] {
+            if let Some(value) = toolchain_root(var, dir) {
+                self.env(var, value);
+            }
+        }
+        self
+    }
+}
+
+/// Resolve a toolchain root: an explicit override wins, otherwise the directory
+/// under the *real* home, and only when it actually exists — passing a path that
+/// is not there would replace one confusing failure with another.
+fn toolchain_root(var: &str, dir: &str) -> Option<std::path::PathBuf> {
+    if let Some(explicit) = std::env::var_os(var) {
+        let path = std::path::PathBuf::from(explicit);
+        return path.is_dir().then_some(path);
+    }
+    let real_home = std::env::var_os("HOME")?;
+    let path = std::path::PathBuf::from(real_home).join(dir);
+    path.is_dir().then_some(path)
+}
+
+#[cfg(test)]
+mod isolate_home_tests {
+    use super::*;
+
+    /// The isolation itself must survive the fix: both state vars still point at
+    /// the scenario's directory, or the suite starts writing to the real `~/.mvm`.
+    #[test]
+    fn isolates_both_state_variables() {
+        let dir = std::env::temp_dir().join("mvm-isolate-home-test");
+        let mut command = std::process::Command::new("true");
+        command.isolated_home(&dir);
+
+        let vars: std::collections::BTreeMap<_, _> = command
+            .get_envs()
+            .filter_map(|(k, v)| Some((k.to_str()?.to_string(), v?.to_str()?.to_string())))
+            .collect();
+
+        assert_eq!(vars.get("HOME").map(String::as_str), dir.to_str());
+        assert_eq!(vars.get("MVM_HOME").map(String::as_str), dir.to_str());
+    }
+
+    /// The point of the change: a toolchain root that exists is handed through,
+    /// so a compiling command can still find the installed targets.
+    #[test]
+    fn passes_an_existing_toolchain_root_through() {
+        let real = std::env::temp_dir().join("mvm-isolate-home-rustup");
+        std::fs::create_dir_all(&real).expect("create fake RUSTUP_HOME");
+        // Safety: single-threaded test process; the var is restored below.
+        let previous = std::env::var_os("RUSTUP_HOME");
+        unsafe { std::env::set_var("RUSTUP_HOME", &real) };
+
+        let mut command = std::process::Command::new("true");
+        command.isolated_home(std::env::temp_dir());
+        let passed = command
+            .get_envs()
+            .any(|(k, v)| k == "RUSTUP_HOME" && v.map(|v| v == real.as_os_str()) == Some(true));
+
+        match previous {
+            Some(value) => unsafe { std::env::set_var("RUSTUP_HOME", value) },
+            None => unsafe { std::env::remove_var("RUSTUP_HOME") },
+        }
+        assert!(passed, "an existing RUSTUP_HOME must reach the child");
+    }
+
+    /// A root that does not exist is not forwarded: pointing rustup at a missing
+    /// directory trades one misleading failure for another.
+    #[test]
+    fn does_not_forward_a_missing_root() {
+        let previous = std::env::var_os("RUSTUP_HOME");
+        unsafe { std::env::set_var("RUSTUP_HOME", "/definitely/not/a/real/rustup/root") };
+
+        let mut command = std::process::Command::new("true");
+        command.isolated_home(std::env::temp_dir());
+        let forwarded = command.get_envs().any(|(k, _)| k == "RUSTUP_HOME");
+
+        match previous {
+            Some(value) => unsafe { std::env::set_var("RUSTUP_HOME", value) },
+            None => unsafe { std::env::remove_var("RUSTUP_HOME") },
+        }
+        assert!(!forwarded, "a missing root must not be forwarded");
+    }
+
+    /// No step may replace `HOME` by hand.
+    ///
+    /// `IsolatedHome::isolated_home` exists because replacing `HOME` alone hides
+    /// the Rust toolchain from any command that compiles something — on a source
+    /// checkout the embedded host-vm binaries then fail to cross-compile with
+    /// "the `x86_64-unknown-linux-musl` target may not be installed", on a host
+    /// where it is installed. That failure reads as a broken product, and it cost
+    /// a ninety-minute live run to find. A raw `.env("HOME", …)` reintroduces it
+    /// silently, so the rule is mechanical rather than remembered.
+    #[test]
+    fn no_step_sets_home_without_the_isolation_helper() {
+        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
+        let mut offenders = Vec::new();
+        let mut scanned = 0usize;
+
+        let mut stack = vec![dir.clone()];
+        while let Some(current) = stack.pop() {
+            for entry in std::fs::read_dir(&current).into_iter().flatten().flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().is_some_and(|e| e == "rs") {
+                    scanned += 1;
+                    let text = std::fs::read_to_string(&path).unwrap_or_default();
+                    for (number, line) in text.lines().enumerate() {
+                        if line.contains(r#".env("HOME""#) {
+                            offenders.push(format!(
+                                "  {}:{}",
+                                path.file_name().unwrap_or_default().to_string_lossy(),
+                                number + 1
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        assert!(
+            scanned > 5,
+            "scanned only {scanned} step file(s) — the walk went blind, so this \
+             test would pass without checking anything"
+        );
+        assert!(
+            offenders.is_empty(),
+            "{} site(s) set HOME directly; use `command.isolated_home(path)` so the \
+             Rust toolchain stays visible to the child:\n{}",
+            offenders.len(),
+            offenders.join("\n")
+        );
+    }
+}

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -11,6 +11,7 @@ use tokio::task::spawn_blocking;
 use tokio::time::timeout;
 
 use crate::world::CliWorld;
+use mvm_conformance::IsolatedHome;
 
 /// Build an `mvmctl` subprocess with the same binary discovery the rest of
 /// the conformance suite uses, plus the target directory on `PATH` so helper
@@ -102,8 +103,7 @@ fn run_mvmctl_isolated_home(world: &mut CliWorld, args: String) {
     let mut cmd = mvmctl_command();
     let output = cmd
         .args(args.split_whitespace())
-        .env("HOME", home.path())
-        .env("MVM_HOME", home.path())
+        .isolated_home(home.path())
         .output()
         .expect("failed to spawn mvmctl");
     world.last_run = Some(output);
@@ -123,9 +123,7 @@ fn run_mvmctl_in_isolated_home(world: &mut CliWorld, args: String) {
         .as_ref()
         .expect("`Given an isolated mvm home` must run before this step");
     let mut cmd = mvmctl_command();
-    cmd.args(args.split_whitespace())
-        .env("HOME", home.path())
-        .env("MVM_HOME", home.path());
+    cmd.args(args.split_whitespace()).isolated_home(home.path());
     if world.kernel_reacquisition_must_fail {
         cmd.env("MVM_KERNEL_SOURCE", "download")
             .env("MVM_UPDATE_DOWNLOAD_URL", "http://127.0.0.1:9");
@@ -209,8 +207,7 @@ pub(crate) fn run_mvmctl_isolated_live_home(world: &mut CliWorld, args: String) 
     command
         .current_dir(workspace_root())
         .args(args.split_whitespace())
-        .env("HOME", home.path())
-        .env("MVM_HOME", home.path());
+        .isolated_home(home.path());
     if world.warm_residency {
         command.env("MVM_RESIDENCY", "warm");
     }
@@ -234,8 +231,7 @@ fn install_bundle_fixture(world: &mut CliWorld) {
         .current_dir(workspace_root())
         .args(["bundle", "install"])
         .arg(&fixture)
-        .env("HOME", home.path())
-        .env("MVM_HOME", home.path())
+        .isolated_home(home.path())
         .output()
         .expect("failed to spawn mvmctl");
     // `Installed bundle <sha> (N artifacts, publisher key_id=...)`
@@ -276,8 +272,7 @@ fn boot_installed_bundle(world: &mut CliWorld, args: String) {
         .current_dir(workspace_root())
         .args(["machine", "run", "--manifest", &sha])
         .args(args.split_whitespace())
-        .env("HOME", home.path())
-        .env("MVM_HOME", home.path())
+        .isolated_home(home.path())
         .output()
         .expect("failed to spawn mvmctl");
     world.last_run = Some(output);
@@ -718,8 +713,7 @@ fn generate_project_from_template(world: &mut CliWorld, name: String) {
             &project_dir.to_string_lossy(),
         ])
         .env("MVM_TEMPLATE_REGISTRY", registry_url)
-        .env("HOME", &home_path)
-        .env("MVM_HOME", &home_path)
+        .isolated_home(&home_path)
         .env("MVM_SKIP_RECONCILE", "1")
         .output()
         .expect("failed to spawn mvmctl");
@@ -759,8 +753,7 @@ fn trust_the_fixture_publisher(world: &mut CliWorld) {
         .current_dir(workspace_root())
         .args(["trust", "add"])
         .arg(&pubkey)
-        .env("HOME", home.path())
-        .env("MVM_HOME", home.path())
+        .isolated_home(home.path())
         .output()
         .expect("failed to spawn mvmctl trust add");
     assert!(
@@ -787,8 +780,7 @@ fn install_bundle_fixture_untrusted(world: &mut CliWorld) {
             .current_dir(workspace_root())
             .args(["bundle", "install"])
             .arg(&fixture)
-            .env("HOME", home.path())
-            .env("MVM_HOME", home.path())
+            .isolated_home(home.path())
             .output()
             .expect("failed to spawn mvmctl"),
     );

--- a/crates/mvm-conformance/tests/steps/doc_examples.rs
+++ b/crates/mvm-conformance/tests/steps/doc_examples.rs
@@ -25,6 +25,7 @@ use mvm_conformance::doc_examples::{
 };
 
 use crate::world::CliWorld;
+use mvm_conformance::IsolatedHome;
 
 /// Repo root — two levels above this crate's manifest dir, resolved at compile
 /// time so the run does not depend on the process working directory.
@@ -340,8 +341,7 @@ fn collect_paths(command: &ClapCommand, prefix: &[String], out: &mut BTreeSet<Ve
 /// Run one documented example for real against a private `MVM_HOME`.
 fn execute(example: &DocExample, home: &Path) -> std::process::Output {
     crate::steps::cli::mvmctl_command()
-        .env("HOME", home)
-        .env("MVM_HOME", home)
+        .isolated_home(home)
         // Reconcile-on-entry converges live VM state; a doc example must not
         // reach for the host's real machines just to print its help.
         .env("MVM_SKIP_RECONCILE", "1")

--- a/crates/mvm-conformance/tests/steps/readme_contract.rs
+++ b/crates/mvm-conformance/tests/steps/readme_contract.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 
 use crate::steps::cli::mvmctl_command;
 use crate::world::CliWorld;
+use mvm_conformance::IsolatedHome;
 
 /// Repo root — two levels above this crate's manifest dir, resolved at compile
 /// time so the run is independent of the process working directory.
@@ -42,9 +43,7 @@ fn spawn_mvmctl(args: &str, home: Option<PathBuf>) -> std::process::Output {
     if let Some(home) = home {
         // Reconcile-on-entry converges live-VM state; disable it so a refusal
         // guard runs against a clean slate with no host side effects.
-        cmd.env("HOME", &home)
-            .env("MVM_HOME", &home)
-            .env("MVM_SKIP_RECONCILE", "1");
+        cmd.isolated_home(&home).env("MVM_SKIP_RECONCILE", "1");
     }
     cmd.args(args.split_whitespace())
         .output()

--- a/crates/mvm-conformance/tests/steps/volume.rs
+++ b/crates/mvm-conformance/tests/steps/volume.rs
@@ -18,6 +18,7 @@ use mvm_runtime::vm::volume_registry::LocalVolumeCatalog;
 use crate::world::CliWorld;
 
 use super::cli::{mvmctl_command, workspace_root};
+use mvm_conformance::IsolatedHome;
 
 fn isolated_home(world: &CliWorld) -> &Path {
     world
@@ -210,8 +211,7 @@ fn execute_machine_shell(world: &mut CliWorld, script: String, machine: String) 
     let output = mvmctl_command()
         .current_dir(workspace_root())
         .args(["machine", "exec", &machine, "--", "/bin/sh", "-c", &script])
-        .env("HOME", home)
-        .env("MVM_HOME", home)
+        .isolated_home(home)
         .output()
         .expect("execute command in live volume machine");
     world.last_run = Some(output);
@@ -229,8 +229,7 @@ fn attempt_direct_start(world: &mut CliWorld, machine: String, backend: String) 
     let output = mvmctl_command()
         .current_dir(workspace_root())
         .args(["machine", "start", &machine, "--hypervisor", &backend])
-        .env("HOME", home)
-        .env("MVM_HOME", home)
+        .isolated_home(home)
         .env("MVM_DIRECT_BOOT", "1")
         .env("MVM_KERNEL_PATH", &kernel)
         .env("MVM_ROOTFS_PATH", &rootfs)

--- a/specs/sprint/delivery/bdd-home-isolation-orphans-toolchain.md
+++ b/specs/sprint/delivery/bdd-home-isolation-orphans-toolchain.md
@@ -1,0 +1,68 @@
+# The BDD suite's HOME isolation was hiding the Rust toolchain
+
+Backing: shipped-source
+Validation: cargo nextest run -p mvm-conformance --lib
+
+Every conformance step that spawns `mvmctl` replaces `HOME` so a run cannot
+touch the developer's real `~/.mvm`. That isolation is correct and gated
+(`xtask check-test-home-isolation`). What nobody accounted for is that `rustup`
+locates its toolchains through `$HOME/.rustup` unless `RUSTUP_HOME` says
+otherwise — so replacing `HOME` also hid every installed toolchain and target
+from any spawned command that compiles.
+
+On a source checkout `mvmctl` cross-compiles the embedded host-vm binaries to
+musl. Under a bare isolated `HOME` that build fails with:
+
+```
+error[E0463]: can't find crate for `core`
+  = note: the `x86_64-unknown-linux-musl` target may not be installed
+```
+
+on a host where the target *is* installed — or silently downloads a fresh
+toolchain into the scenario's temporary directory, which is then deleted, once
+per scenario, for as long as the suite runs.
+
+## How it was found, and the wrong turn on the way
+
+A live run on the KVM box crawled: 192 scenarios at 57 minutes, 196 at 90.
+Four scenarios in thirty-three minutes.
+
+The first diagnosis was wrong in the direction that matters. Reproducing
+`HOME=$(mktemp -d) rustup target list --installed` showed rustup syncing a
+channel, which looked like the answer — but the run's own log contained zero
+occurrences of `syncing channel updates`, so the evidence did not support the
+claim. The mechanism was only established by a controlled comparison:
+
+| Environment | Resolves musl std to |
+| --- | --- |
+| real `HOME` | `/root/.rustup/…`, `libcore` present |
+| `HOME` replaced | downloads 6 components into `/tmp/tmp.XXXX/.rustup` |
+| `HOME` replaced, `RUSTUP_HOME`/`CARGO_HOME` preserved | `/root/.rustup/…` |
+
+## The fix
+
+`IsolatedHome::isolated_home` replaces the hand-written
+`.env("HOME", …).env("MVM_HOME", …)` pair at all 12 sites. `MVM_HOME` still
+points at the scenario's directory — the isolation the suite wants is
+unchanged; only rustup's and cargo's own roots survive, and neither is state
+the suite is isolating. A root that does not exist is *not* forwarded, since
+pointing rustup at a missing directory trades one misleading failure for
+another.
+
+`check-single-home` correctly flagged the `$HOME` read. It is exempted for the
+`HomeRead` rule only, with the reason: this reads the real home to locate
+rustup, not to locate mvm state.
+
+## Guard
+
+`no_step_sets_home_without_the_isolation_helper` fails on any raw
+`.env("HOME"` under `tests/`, naming file and line. It lives in the **lib**
+target, not with the steps: the cucumber target is `harness = false`, so a
+`#[test]` there is never executed — the first version of this guard was written
+in `steps/mod.rs` and would have silently never run.
+
+It also asserts it scanned more than five files, because a walk that returns
+nothing passes a "no offenders" assertion perfectly.
+
+Mutation-verified: reintroducing one raw site turns it red naming `cli.rs:106`;
+restoring turns it green.

--- a/xtask/src/check_single_home.rs
+++ b/xtask/src/check_single_home.rs
@@ -61,6 +61,14 @@ const ALL_RULES: &[Rule] = &[
 /// narrowest rule class that the file legitimately needs.
 const EXEMPTIONS: &[(&str, &[Rule], &str)] = &[
     (
+        "crates/mvm-conformance/src/lib.rs",
+        &[Rule::HomeRead],
+        "locates rustup's and cargo's own roots, not mvm state: a scenario replaces \
+         HOME to isolate ~/.mvm, which also hides the installed Rust toolchain from \
+         any command that compiles, so the real $HOME is read to pass RUSTUP_HOME / \
+         CARGO_HOME through",
+    ),
+    (
         "crates/mvm-core/src/config.rs",
         ALL_RULES,
         "the single legitimate resolver: owns the MVM_HOME | $HOME/.mvm derivation and the child layout",


### PR DESCRIPTION
Every conformance step that spawns `mvmctl` replaces `HOME` so a run cannot touch the developer's real `~/.mvm`. That isolation is correct and gated.

But **`rustup` locates its toolchains through `$HOME/.rustup`** unless `RUSTUP_HOME` says otherwise — so replacing `HOME` also hid every installed toolchain and target from any spawned command that compiles something.

On a source checkout `mvmctl` cross-compiles the embedded host-vm binaries to musl. Under a bare isolated `HOME` that build either fails with

```
error[E0463]: can't find crate for `core`
  = note: the `x86_64-unknown-linux-musl` target may not be installed
```

on a host where the target **is** installed — a message that reads as a broken product — or silently downloads a fresh toolchain into the scenario's temp directory, which is then deleted, **once per scenario, for as long as the suite runs.**

A live run on the KVM box managed **four scenarios in thirty-three minutes** before this was found.

## The wrong turn on the way, since it shaped the fix

My first diagnosis was unsupported. Reproducing `HOME=$(mktemp -d) rustup target list --installed` showed rustup syncing a channel, which looked like the answer — but the run's own log had **zero** occurrences of `syncing channel updates`. I'd have shipped a root cause the evidence didn't back.

The mechanism was only established by controlled comparison:

| Environment | Resolves musl std to |
| --- | --- |
| real `HOME` | `/root/.rustup/…`, `libcore` present |
| `HOME` replaced | **downloads 6 components** into `/tmp/tmp.XXXX/.rustup` |
| `HOME` replaced + `RUSTUP_HOME`/`CARGO_HOME` preserved | `/root/.rustup/…` |

## The fix

`IsolatedHome::isolated_home` replaces the hand-written `.env("HOME", …).env("MVM_HOME", …)` pair at all 12 sites. `MVM_HOME` still points at the scenario's directory — the isolation the suite wants is unchanged; only rustup's and cargo's own roots survive, and neither is state the suite is isolating.

A root that does **not** exist is not forwarded: pointing rustup at a missing directory trades one misleading failure for another.

`check-single-home` correctly flagged the `$HOME` read; exempted for the `HomeRead` rule only, with the reason recorded inline.

## Guard

`no_step_sets_home_without_the_isolation_helper` fails on any raw `.env("HOME"` under `tests/`, naming file and line.

It lives in the **lib** target, not with the steps. The cucumber target is `harness = false`, so a `#[test]` there is never executed — my first version of this guard was in `steps/mod.rs` and would have silently never run. It also asserts it scanned more than five files, because a walk that returns nothing satisfies a "no offenders" assertion perfectly.

Mutation-verified: one reintroduced raw site turns it red at `cli.rs:106`; restoring turns it green.

## Gates

fmt, stable `clippy --workspace --all-targets -D warnings`, `check-all` (61 gates), `check-conformance`, `check-honesty`, `check-test-home-isolation`, `check-single-home`, `check-nextest-groups`, 72 conformance lib tests — all green.