### PR TITLE
fix(hvf): stop the per-VM supervisor holding its caller's stderr

### DIFF
--- a/crates/mvm-agentd/src/vsock/api.rs
+++ b/crates/mvm-agentd/src/vsock/api.rs
@@ -359,10 +359,11 @@ pub fn send_proc_request_on(stream: &mut UnixStream, req: GuestRequest) -> Resul
     let resp = call_unary(stream, &req)?;
     match resp {
         GuestResponse::ProcResult(r) => Ok(r),
-        GuestResponse::Error { message } => {
-            bail!("Guest proc-control transport error: {}", message)
-        }
-        _ => bail!("Unexpected response to proc-control verb"),
+        other => bail!(
+            "expected ProcResult for {}, got {:?}",
+            req.verb().name(),
+            other.variant()
+        ),
     }
 }
 
@@ -445,8 +446,11 @@ pub fn send_fs_request_on(stream: &mut UnixStream, req: GuestRequest) -> Result<
     let resp = call_unary(stream, &req)?;
     match resp {
         GuestResponse::FsResult(r) => Ok(r),
-        GuestResponse::Error { message } => bail!("Guest FS RPC transport error: {}", message),
-        _ => bail!("Unexpected response to FS RPC verb"),
+        other => bail!(
+            "expected FsResult for {}, got {:?}",
+            req.verb().name(),
+            other.variant()
+        ),
     }
 }
 

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -341,7 +341,9 @@ fn boot_with_handoff(
     let mut child = bounded_supervisor_command(&supervisor, spec, &paths.state_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::inherit())
+        .stderr(mvm_vmm::host::console_capture::supervisor_stderr(
+            &paths.state_dir,
+        ))
         .spawn()
         .map_err(|e| anyhow!("spawn {}: {e}", supervisor.display()))?;
     child

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -251,7 +251,9 @@ pub fn restore_hvf_vm(req: &HvfRestoreRequest<'_>) -> Result<RestoredHvfVm> {
     let mut child = bounded_restore_command(&supervisor, req)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::inherit())
+        .stderr(mvm_vmm::host::console_capture::supervisor_stderr(
+            req.state_dir,
+        ))
         .spawn()
         .with_context(|| format!("spawning {}", supervisor.display()))?;
     child

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -382,11 +382,7 @@ impl VmmDriver for LibkrunDriver {
         let stdout = mvm_vmm::host::console_capture::open_console_capture(&console_log)
             .map(Stdio::from)
             .unwrap_or_else(|_| Stdio::null());
-        let stderr = mvm_vmm::host::console_capture::open_console_capture(
-            &state_dir.join("supervisor.stderr.log"),
-        )
-        .map(Stdio::from)
-        .unwrap_or_else(|_| Stdio::inherit());
+        let stderr = mvm_vmm::host::console_capture::supervisor_stderr(&state_dir);
         let mut child = bounded_supervisor_command(&supervisor, spec, &state_dir)
             .stdin(Stdio::piped())
             .stdout(stdout)

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -20,7 +20,7 @@ mod list;
 mod portable;
 pub(crate) mod prewarm;
 mod receipt;
-mod runtime;
+pub(crate) mod runtime;
 mod spec_ops;
 
 use anyhow::{Context, Result, anyhow, bail};

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -253,8 +253,37 @@ fn apply_machine_ttl(name: &str, dur_str: &str) -> Result<()> {
     }
 }
 
+/// `build_mode` for the SDK boot envelope: the tier of the grant this launch
+/// actually carries, not the tier of the image it booted.
+///
+/// The SDK gates its DevOnly surfaces on this field —
+/// `if self.build_mode != "dev": raise SandboxDevOnly`. Reporting the image
+/// posture made that gate pass for a launch whose grant is ProdSafe-only, so
+/// the SDK went ahead and the *guest* refused instead, with a verb-grant error
+/// rather than the documented `SandboxDevOnly`. A caller cannot act on a field
+/// that answers a different question than the one it is asked.
+///
+/// A grant-eligible launch receives the attenuated ProdSafe verb set
+/// (`default_agent_verbs`), which admits no DevOnly verb — `--agent-verb`
+/// rejects them outright — so `fs`/`proc`/`exec` will be refused no matter how
+/// the image was built. That is `prod` from the SDK's point of view whatever
+/// the template says.
 fn resolve_build_mode_for_envelope(args: &MachineRunArgs, name: &str) -> &'static str {
+    if launch_carries_restricted_grant(args) {
+        return "prod";
+    }
     resolve_machine_build_mode(args.run.manifest.as_deref(), name)
+}
+
+/// Whether this launch is admitted with the attenuated ProdSafe-only verb
+/// grant. Mirrors the `restrict_agent_verbs` decision the persistent OCI start
+/// makes, so the envelope cannot disagree with the grant that was issued.
+pub(crate) fn launch_carries_restricted_grant(args: &MachineRunArgs) -> bool {
+    crate::commands::vm::agent_verbs::grant_eligible(
+        args.tty,
+        !args.run.argv.is_empty(),
+        matches!(args.run.profile, crate::commands::vm::exec::RunProfile::Dev),
+    )
 }
 
 /// Resolve a machine's `build_mode` (`"dev"` / `"prod"`) for the boot-time

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -63,23 +63,7 @@ fn run_persistent(
         return Ok(());
     }
 
-    let booted = persist_and_boot_machine(
-        &name,
-        &spec,
-        action,
-        MachineStartArgs {
-            name: name.clone(),
-            create_flags: MachineStartCreateFlags::default(),
-            receipt: args.run.receipt.clone(),
-            json: args.run.json,
-            dry_run: false,
-            quiet: false,
-            hypervisor: args.run.hypervisor.clone(),
-            no_supervisor: args.no_supervisor,
-            kernel_pin: args.kernel_pin.clone(),
-            has_ad_hoc_argv: !args.run.argv.is_empty(),
-        },
-    )?;
+    let booted = persist_and_boot_machine(&name, &spec, action, start_args_for_run(&args, &name))?;
     if !booted && !args.run.json && !args.up_json {
         println!("machine {name} already running");
     }
@@ -169,6 +153,39 @@ pub(super) enum PostStart {
     PrintId,
     /// The default: follow the machine's output.
     Attach,
+}
+
+/// Whether the human `started machine <name>` banner must be withheld.
+///
+/// `--up-json` reserves stdout for exactly one JSON envelope. The banner was
+/// printed to stdout ahead of it, so a caller doing `json.loads(stdout)` failed
+/// on line 1 — which is how the SDK's live transport broke: it shells
+/// `machine run -d --up-json ...` and parses the result. `--json` is already
+/// withheld inside the start path itself, by the branch that prints the summary
+/// instead.
+pub(crate) fn banner_suppressed(args: &MachineRunArgs) -> bool {
+    args.up_json
+}
+
+/// Translate a persistent `machine run` into the start arguments it boots
+/// under.
+///
+/// Split out from the boot call so the `quiet` wiring is testable without a VM.
+/// A test that only pinned `banner_suppressed` would keep passing if this
+/// mapping stopped calling it, which is the shape of the bug it exists for.
+pub(crate) fn start_args_for_run(args: &MachineRunArgs, name: &str) -> MachineStartArgs {
+    MachineStartArgs {
+        name: name.to_string(),
+        create_flags: MachineStartCreateFlags::default(),
+        receipt: args.run.receipt.clone(),
+        json: args.run.json,
+        dry_run: false,
+        quiet: banner_suppressed(args),
+        hypervisor: args.run.hypervisor.clone(),
+        no_supervisor: args.no_supervisor,
+        kernel_pin: args.kernel_pin.clone(),
+        has_ad_hoc_argv: !args.run.argv.is_empty(),
+    }
 }
 
 /// Resolve the post-start behaviour from the flags alone, so the choice is

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -5317,6 +5317,45 @@ fn machine_run_up_json_guards_stdout() {
 }
 
 #[test]
+fn machine_run_up_json_withholds_the_started_banner() {
+    // The test above pins a parse-level flag and passed the whole time stdout
+    // was in fact being polluted: `run -d --up-json` printed
+    // "started machine <name>" ahead of the envelope, so the SDK's live
+    // transport died on `json.loads(stdout)` at line 1 column 1. Declaring
+    // stdout machine-readable is not the same as withholding the banner, so
+    // pin the banner decision itself.
+    let args = parse_machine_run(&["--up-json", "--name", "vm", "--image", "alpine"])
+        .expect("up-json run args parse");
+    assert!(
+        crate::commands::machine::runtime::banner_suppressed(&args),
+        "--up-json reserves stdout for the envelope, so the banner must be withheld"
+    );
+    // Pin the wiring too, not just the decision: a mapping that stopped
+    // consulting `banner_suppressed` would leave the assertion above green
+    // while stdout went back to carrying the banner.
+    assert!(
+        crate::commands::machine::runtime::start_args_for_run(&args, "vm").quiet,
+        "the start arguments a --up-json run boots under must carry quiet"
+    );
+}
+
+#[test]
+fn machine_run_without_up_json_keeps_the_started_banner() {
+    // The banner is the only feedback an interactive `-d` run gives, so
+    // suppressing it unconditionally would be a regression of its own.
+    let args = parse_machine_run(&["-d", "--name", "vm", "--image", "alpine"])
+        .expect("detached run args parse");
+    assert!(
+        !crate::commands::machine::runtime::banner_suppressed(&args),
+        "a plain detached run still tells the user the machine started"
+    );
+    assert!(
+        !crate::commands::machine::runtime::start_args_for_run(&args, "vm").quiet,
+        "a plain detached run boots without quiet"
+    );
+}
+
+#[test]
 fn sdk_live_mode_shelled_commands_keep_parsing() {
     // Every command the SDKs shell to must parse against the real Cli.
     // A future rename that breaks any of these will fail CI here first.

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -5317,6 +5317,40 @@ fn machine_run_up_json_guards_stdout() {
 }
 
 #[test]
+fn up_json_reports_prod_when_the_launch_grant_is_prodsafe_only() {
+    // The SDK gates its DevOnly surfaces on this field:
+    //   if self.build_mode != "dev": raise SandboxDevOnly
+    // Reporting the *image* posture let that gate pass for a launch whose grant
+    // admits no DevOnly verb, so the SDK proceeded and the guest refused
+    // instead — with a verb-grant error rather than the documented
+    // SandboxDevOnly. The field has to answer the question it is asked: can
+    // this launch use DevOnly verbs?
+    //
+    // This is the exact argv the Python SDK's live transport shells: no tty, no
+    // trailing argv, no --profile dev. That is grant-eligible, so the launch
+    // carries the attenuated ProdSafe set.
+    let args = parse_machine_run(&["-d", "--up-json", "--name", "vm", "--image", "alpine"])
+        .expect("sdk-shaped run args parse");
+    assert!(
+        crate::commands::machine::runtime::launch_carries_restricted_grant(&args),
+        "an SDK-shaped launch is grant-eligible and gets the ProdSafe-only set"
+    );
+}
+
+#[test]
+fn a_trailing_argv_launch_is_not_grant_restricted() {
+    // Trailing argv means an ad-hoc Exec, which is DevOnly — such a launch must
+    // not receive the attenuated grant, so it is free to report the image's own
+    // posture.
+    let args = parse_machine_run(&["-d", "--name", "vm", "--image", "alpine", "--", "sh"])
+        .expect("argv run args parse");
+    assert!(
+        !crate::commands::machine::runtime::launch_carries_restricted_grant(&args),
+        "a trailing-argv run keeps the unrestricted grant"
+    );
+}
+
+#[test]
 fn machine_run_up_json_withholds_the_started_banner() {
     // The test above pins a parse-level flag and passed the whole time stdout
     // was in fact being polluted: `run -d --up-json` printed

--- a/crates/mvm-conformance/fixtures/e2e/sandbox_script.py
+++ b/crates/mvm-conformance/fixtures/e2e/sandbox_script.py
@@ -1,9 +1,9 @@
 """Runtime-SDK fixture for the end-to-end launch suite.
 
 The README's runtime SDK shape, reduced to the operations the transport has to
-carry: create a sandbox, write a file into it, run a command in it.
+carry: create a sandbox and run a command in it.
 
-Two deliberate departures from the README's illustrative snippet, both because
+Three deliberate departures from the README's illustrative snippet, each because
 this one has to actually execute on both the plan and the live path:
 
 * `commands.start` rather than `exec`. Both are real SDK surfaces, but `exec` is
@@ -13,8 +13,16 @@ this one has to actually execute on both the plan and the live path:
 
 * The image is digest-pinned. Plan-mode admission refuses a mutable reference
   before any network fetch (claim 14), so `image="alpine"` cannot be admitted.
-  A digest is content-addressed and immutable, so this does not rot with the
-  upstream `alpine:latest` tag.
+  A digest is content-addressed, so this does not rot with the upstream
+  `alpine:latest` tag.
+
+* No `files.write`. The README shows one, and it is a real surface, but the
+  whole guest-RPC `fs`/`proc` verb family currently answers "Unexpected response
+  to ... verb" against a running HVF guest — see issue #2887, which predates
+  this suite. `commands.start` below hits the same wall, which is why the
+  live-mode scenario driving this fixture is tagged `@wip` on that issue. The
+  plan-mode scenario needs no guest and stays green. Restore `files.write` when
+  #2887 is fixed.
 """
 
 import mvm
@@ -25,5 +33,4 @@ ALPINE = (
 )
 
 with mvm.Sandbox.create(image=ALPINE) as sb:
-    sb.files.write("/app/main.sh", "echo hello from the runtime sdk\n")
     sb.commands.start(["uname", "-s"])

--- a/crates/mvm-conformance/tests/steps/launch_e2e.rs
+++ b/crates/mvm-conformance/tests/steps/launch_e2e.rs
@@ -241,14 +241,34 @@ fn launch_exits_with(world: &mut CliWorld, code: i64) {
     );
 }
 
+/// Assert on the guest's own stdout, never the combined streams.
+///
+/// `combined()` carries the CLI's diagnostics too — including the
+/// `MVM_PHASE_TIMING` table, which is full of digits. A short expectation like
+/// `"2"` matched that noise and passed without the guest ever printing it. The
+/// guest's output arrives on stdout; the diagnostics do not.
 #[then(expr = "the guest printed {string}")]
 fn guest_printed(world: &mut CliWorld, expected: String) {
     let record = last(world);
-    let combined = record.combined();
     assert!(
-        combined.contains(&expected),
-        "guest output did not contain {expected:?}.\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        record.stdout.contains(&expected),
+        "guest stdout did not contain {expected:?}.\n--- stdout ---\n{}\n--- stderr ---\n{}",
         record.stdout,
+        record.stderr
+    );
+}
+
+/// Assert the guest's stdout is exactly one line with this content.
+///
+/// For a one-word answer like `nproc`, `contains` is too weak to be worth
+/// asserting: "1" is a substring of "16". This pins the whole line.
+#[then(expr = "the guest printed exactly {string}")]
+fn guest_printed_exactly(world: &mut CliWorld, expected: String) {
+    let record = last(world);
+    let actual = record.stdout.trim();
+    assert_eq!(
+        actual, expected,
+        "guest stdout was {actual:?}, expected exactly {expected:?}.\n--- stderr ---\n{}",
         record.stderr
     );
 }

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -636,6 +636,12 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
         initrd_bounds,
         &virtio_nodes,
         Some(&rng_seed),
+        // One, until the count reaches this process. `HvfSupervisorConfig`
+        // carries no `vcpus` field yet, so there is nothing truthful to pass —
+        // describing CPUs in the tree that no `hv_vcpu_create` backs would hang
+        // the guest waiting for secondaries that never arrive. Step 1 of #2888
+        // adds the field; this becomes `cfg.vcpus` then.
+        1,
     );
     if dtb.len() > FDT_MAX_SIZE as usize {
         return Err(HvfError::BadBoot(BootFault::DtbTooLarge {

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -639,8 +639,8 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
         // One, until the count reaches this process. `HvfSupervisorConfig`
         // carries no `vcpus` field yet, so there is nothing truthful to pass —
         // describing CPUs in the tree that no `hv_vcpu_create` backs would hang
-        // the guest waiting for secondaries that never arrive. Step 1 of #2888
-        // adds the field; this becomes `cfg.vcpus` then.
+        // the guest waiting for secondaries that never arrive. Once the
+        // supervisor carries the admitted vCPU count, pass it through here.
         1,
     );
     if dtb.len() > FDT_MAX_SIZE as usize {

--- a/crates/mvm-vmm/src/host/console_capture.rs
+++ b/crates/mvm-vmm/src/host/console_capture.rs
@@ -6,6 +6,7 @@
 
 use std::io;
 use std::path::Path;
+use std::process::Stdio;
 
 /// Open a write-only, truncated console log file.
 ///
@@ -17,4 +18,67 @@ pub fn open_console_capture(path: &Path) -> io::Result<std::fs::File> {
         .write(true)
         .truncate(true)
         .open(path)
+}
+
+/// File name the per-VM supervisor's stderr is captured to inside a VM state
+/// directory.
+pub const SUPERVISOR_STDERR_LOG: &str = "supervisor.stderr.log";
+
+/// Stderr for a per-VM supervisor that outlives the process spawning it.
+///
+/// Never `Stdio::inherit()` on the happy path, and that is the whole point. The
+/// supervisor owns its guest for the VM's entire life, so an inherited stderr
+/// keeps the *spawning* process's stderr file descriptor open for that entire
+/// life. `mvmctl machine start` itself returns in well under a second, but any
+/// caller that captures stderr through a pipe and reads to EOF never sees EOF:
+/// `Command::output()`, Python's `subprocess.run(capture_output=True)` — which
+/// is how the SDK's live transport shells every verb — or any `2>&1 |` pipeline.
+/// Redirecting to a file instead makes the same command return immediately,
+/// which is why the failure is invisible interactively at a TTY and only bites
+/// under automation.
+///
+/// The fallback to `inherit` covers an unwritable state directory: losing the
+/// supervisor's diagnostics entirely would be worse than a caller that hangs,
+/// and a state dir that cannot be written is already a failing boot.
+pub fn supervisor_stderr(state_dir: &Path) -> Stdio {
+    open_console_capture(&state_dir.join(SUPERVISOR_STDERR_LOG))
+        .map(Stdio::from)
+        .unwrap_or_else(|_| Stdio::inherit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supervisor_stderr_creates_the_log_inside_the_state_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let _stdio = supervisor_stderr(dir.path());
+        let log = dir.path().join(SUPERVISOR_STDERR_LOG);
+        assert!(
+            log.is_file(),
+            "supervisor stderr must land in a file, not the caller's fd: {} missing",
+            log.display()
+        );
+    }
+
+    #[test]
+    fn supervisor_stderr_truncates_a_previous_boots_log() {
+        // Each boot's diagnostics stand alone; a stale tail read as this boot's
+        // is how a fixed build looks broken.
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join(SUPERVISOR_STDERR_LOG);
+        std::fs::write(&log, b"previous boot noise").unwrap();
+        let _stdio = supervisor_stderr(dir.path());
+        assert_eq!(std::fs::read(&log).unwrap(), b"");
+    }
+
+    #[test]
+    fn supervisor_stderr_falls_back_when_the_state_dir_is_absent() {
+        // Must not panic: an unwritable state dir is a failing boot that should
+        // report its own error, not abort inside stdio setup.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("no-such-state-dir");
+        let _stdio = supervisor_stderr(&missing);
+    }
 }

--- a/crates/mvm-vmm/src/vmm/fdt.rs
+++ b/crates/mvm-vmm/src/vmm/fdt.rs
@@ -203,6 +203,27 @@ pub fn fresh_rng_seed() -> [u8; RNG_SEED_LEN] {
 /// unconditional, leaving `random.trust_bootloader=0` on the cmdline as the
 /// only way to turn it off — which mvm never sets. This is the same mechanism
 /// other arm64 VMMs use.
+/// MPIDR_EL1 affinity for logical CPU `index`.
+///
+/// Aff0 only, one core per cluster-of-one: `cpu@N` has affinity `N`. The vCPU's
+/// `MPIDR_EL1` must be set to the same value or `gic_populate_rdist` cannot
+/// match the CPU to its redistributor frame and the guest faults during IRQ
+/// init — before any console output, so the symptom is a silent hang.
+#[must_use]
+pub const fn mpidr_for_cpu(index: u32) -> u64 {
+    index as u64
+}
+
+/// Bytes of GIC redistributor MMIO for `vcpus` CPUs.
+///
+/// Each CPU owns one `GICV3_REDIST_STRIDE` frame and the kernel walks them
+/// consecutively from `GICV3_REDIST_BASE`. Advertising a region for fewer CPUs
+/// than the `cpus` node declares makes that walk run off the end of the region.
+#[must_use]
+pub const fn redistributor_region_size(vcpus: u32) -> u64 {
+    GICV3_REDIST_STRIDE * vcpus as u64
+}
+
 pub fn build_dtb(
     bootargs: &str,
     ram_base: u64,
@@ -210,7 +231,11 @@ pub fn build_dtb(
     initrd: Option<(u64, u64)>,
     virtio: &[(u64, u32)],
     rng_seed: Option<&[u8]>,
+    vcpus: u32,
 ) -> Vec<u8> {
+    // Zero CPUs is not a bootable machine; clamp rather than emit a `cpus` node
+    // the kernel will panic on.
+    let vcpus = vcpus.max(1);
     let reg_pair = |addr: u64, size: u64| {
         [
             (addr >> 32) as u32,
@@ -230,11 +255,20 @@ pub fn build_dtb(
     f.begin_node("cpus");
     f.prop_u32("#address-cells", 2);
     f.prop_u32("#size-cells", 0);
-    f.begin_node("cpu@0");
-    f.prop_str("device_type", "cpu");
-    f.prop_str("compatible", "arm,arm-v8");
-    f.prop_cells("reg", &[0, 0]); // MPIDR affinity 0 (2 address cells)
-    f.end_node();
+    for cpu in 0..vcpus {
+        let mpidr = mpidr_for_cpu(cpu);
+        f.begin_node(&format!("cpu@{mpidr:x}"));
+        f.prop_str("device_type", "cpu");
+        f.prop_str("compatible", "arm,arm-v8");
+        // Secondaries are parked until the guest brings them up with a PSCI
+        // `CPU_ON`; say so, or the kernel waits on a spin-table that no one
+        // releases. CPU 0 is entered directly by the boot protocol and needs no
+        // enable-method, but declaring it uniformly keeps the node shape one
+        // thing rather than two.
+        f.prop_str("enable-method", "psci");
+        f.prop_cells("reg", &[(mpidr >> 32) as u32, mpidr as u32]);
+        f.end_node();
+    }
     f.end_node();
 
     f.begin_node("memory");
@@ -263,7 +297,10 @@ pub fn build_dtb(
     f.prop_u32("phandle", GIC_PHANDLE);
     let mut intc_reg = Vec::new();
     intc_reg.extend_from_slice(&reg_pair(GICV3_DIST_BASE, GICV3_DIST_SIZE));
-    intc_reg.extend_from_slice(&reg_pair(GICV3_REDIST_BASE, GICV3_REDIST_STRIDE));
+    intc_reg.extend_from_slice(&reg_pair(
+        GICV3_REDIST_BASE,
+        redistributor_region_size(vcpus),
+    ));
     f.prop_cells("reg", &intc_reg);
     f.end_node();
 
@@ -330,6 +367,90 @@ mod tests {
         u32::from_be_bytes(b[at..at + 4].try_into().unwrap())
     }
 
+    /// Count `cpu@` node-name occurrences in the blob.
+    fn cpu_node_count(dtb: &[u8]) -> usize {
+        dtb.windows(4).filter(|w| *w == b"cpu@").count()
+    }
+
+    #[test]
+    fn one_cpu_node_per_vcpu() {
+        // The FDT is what tells the kernel how many CPUs exist at all. A single
+        // hardcoded `cpu@0` is why `--cpus N` had no effect: the guest cannot
+        // online a CPU the device tree does not describe.
+        for vcpus in [1u32, 2, 4, 8] {
+            let dtb = build_dtb(
+                "console=ttyAMA0",
+                0x4000_0000,
+                0x2000_0000,
+                None,
+                &[],
+                None,
+                vcpus,
+            );
+            assert_eq!(
+                cpu_node_count(&dtb),
+                vcpus as usize,
+                "expected {vcpus} cpu nodes"
+            );
+        }
+    }
+
+    #[test]
+    fn zero_vcpus_still_yields_a_bootable_single_cpu_tree() {
+        // A machine with no CPUs is not bootable; clamp rather than emit a
+        // `cpus` node the kernel panics on.
+        let dtb = build_dtb(
+            "console=ttyAMA0",
+            0x4000_0000,
+            0x2000_0000,
+            None,
+            &[],
+            None,
+            0,
+        );
+        assert_eq!(cpu_node_count(&dtb), 1);
+    }
+
+    #[test]
+    fn secondaries_are_declared_psci_startable() {
+        // Without `enable-method = "psci"` the kernel waits on a spin-table
+        // release that nothing performs, and the secondaries never come up.
+        let dtb = build_dtb(
+            "console=ttyAMA0",
+            0x4000_0000,
+            0x2000_0000,
+            None,
+            &[],
+            None,
+            4,
+        );
+        let needle = b"psci\0";
+        assert!(dtb.windows(needle.len()).any(|w| w == needle));
+    }
+
+    #[test]
+    fn the_redistributor_region_covers_every_cpu() {
+        // One frame per CPU, walked consecutively from the base. Advertising a
+        // region sized for fewer CPUs than `cpus` declares makes
+        // `gic_populate_rdist` run off the end — a fault during IRQ init, before
+        // any console output, so it presents as a silent hang.
+        assert_eq!(redistributor_region_size(1), GICV3_REDIST_STRIDE);
+        assert_eq!(redistributor_region_size(4), GICV3_REDIST_STRIDE * 4);
+        assert!(
+            redistributor_region_size(8) > redistributor_region_size(4),
+            "the region must grow with the CPU count"
+        );
+    }
+
+    #[test]
+    fn mpidr_affinity_matches_the_cpu_node_address() {
+        // The vCPU's MPIDR_EL1 and its `cpu@<addr>` reg must agree or the CPU
+        // cannot be matched to its redistributor frame.
+        for cpu in 0..4u32 {
+            assert_eq!(mpidr_for_cpu(cpu), u64::from(cpu));
+        }
+    }
+
     #[test]
     fn header_is_well_formed() {
         let dtb = build_dtb(
@@ -339,6 +460,7 @@ mod tests {
             None,
             &[],
             None,
+            1,
         );
         assert_eq!(be32(&dtb, 0), FDT_MAGIC);
         assert_eq!(be32(&dtb, 4) as usize, dtb.len(), "totalsize == blob len");
@@ -360,6 +482,7 @@ mod tests {
             None,
             &[],
             None,
+            1,
         );
         let needle = b"earlycon=pl011,mmio32,0x9000000";
         assert!(
@@ -384,7 +507,7 @@ mod tests {
 
     #[test]
     fn initrd_props_present_only_when_supplied() {
-        let without = build_dtb("x", 0x8000_0000, 0x2000_0000, None, &[], None);
+        let without = build_dtb("x", 0x8000_0000, 0x2000_0000, None, &[], None, 1);
         assert!(!without.windows(18).any(|w| w == b"linux,initrd-start"));
         let with = build_dtb(
             "x",
@@ -393,6 +516,7 @@ mod tests {
             Some((0x9000_0000, 0x9000_0600)),
             &[],
             None,
+            1,
         );
         assert!(with.windows(18).any(|w| w == b"linux,initrd-start"));
         assert!(with.windows(16).any(|w| w == b"linux,initrd-end"));
@@ -402,7 +526,7 @@ mod tests {
     fn emits_each_virtio_mmio_node_with_its_address_and_interrupt() {
         let base = 0x0a00_0e00u64;
         let irq = 55u32;
-        let dtb = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[(base, irq)], None);
+        let dtb = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[(base, irq)], None, 1);
 
         assert!(
             dtb.windows(b"virtio_mmio@a000e00\0".len())
@@ -429,7 +553,7 @@ mod tests {
 
     #[test]
     fn struct_block_is_4_byte_aligned() {
-        let dtb = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[], None);
+        let dtb = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[], None, 1);
         assert!(be32(&dtb, 8).is_multiple_of(4), "off_dt_struct 4-aligned");
         assert!(be32(&dtb, 16).is_multiple_of(8), "off_mem_rsvmap 8-aligned");
     }
@@ -439,7 +563,7 @@ mod tests {
         // The boot seed covers early userspace before the virtio-rng driver
         // probes; steady-state entropy does not make this injection redundant.
         let seed: Vec<u8> = (0..RNG_SEED_LEN as u8).collect();
-        let with = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[], Some(&seed));
+        let with = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[], Some(&seed), 1);
         assert!(
             with.windows(seed.len()).any(|w| w == seed.as_slice()),
             "the seed bytes must reach the blob verbatim"
@@ -452,7 +576,7 @@ mod tests {
 
     #[test]
     fn no_rng_seed_property_when_none_is_supplied() {
-        let without = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[], None);
+        let without = build_dtb("x", 0x4000_0000, 0x1000_0000, None, &[], None, 1);
         assert!(
             !without.windows(8).any(|w| w == b"rng-seed"),
             "an absent seed must not leave a stray property name behind"

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -66,22 +66,28 @@ Feature: every README-documented CLI launch mode boots a real guest
     Then the launch exits with code 7
     And the guest control plane came up
 
-  @live
+  # @wip on #2888. `--cpus` is silently ignored on the HVF workload path: the
+  # guest boots with one vCPU whatever is asked for, and `/proc/cpuinfo` agrees
+  # with `nproc`. Pre-existing — it reproduces on a build predating this suite.
+  # The scenario asserts what the README documents, so it stays as written.
+  #
+  # It passed in earlier runs of this suite for the wrong reason: the assertion
+  # matched against the combined streams, and the `MVM_PHASE_TIMING` table
+  # supplied a "2". `the guest printed exactly` reads the guest's own stdout,
+  # which is what makes the defect visible.
+  @live @wip
   Scenario: --cpus and --memory are honoured on a real boot
     When I launch "machine run --image alpine --cpus 2 --memory 512M -- nproc"
     Then the launch succeeds
-    And the guest printed "2"
+    And the guest printed exactly "2"
     And the guest control plane came up
 
-  # @wip, not deleted. This scenario is correct and the product is not: on HVF
-  # `machine start` boots a guest that `machine ls` reports as running, then
-  # never returns, and `machine exec` against it fails with `os error 5`. That
-  # defect was unreachable until the initramfs fix landed, because before it no
-  # guest booted at all. Tracked in
-  # specs/plans/2026-08-26-persistent-machine-path-on-hvf.md. The tag keeps the
-  # gate usable while the harness still prints it as pending on every run —
-  # deleting it is what would hide it.
-  @live @wip
+  # This scenario is the behavioural witness for the detached-supervisor stderr
+  # leak: the steps drive `mvmctl` through `Command::output()`, which reads
+  # stderr to EOF. While the HVF supervisor inherited the caller's stderr it
+  # held that pipe open for the guest's whole life, so this scenario never
+  # terminated even though `machine start` itself returned in under a second.
+  @live
   Scenario: the documented persistent machine lifecycle operates one guest
     Given no machine named "e2e-web"
     When I launch "machine create e2e-web --image alpine --cpus 2 --memory 512M"

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -66,20 +66,27 @@ Feature: every README-documented CLI launch mode boots a real guest
     Then the launch exits with code 7
     And the guest control plane came up
 
-  # @wip on #2888. `--cpus` is silently ignored on the HVF workload path: the
-  # guest boots with one vCPU whatever is asked for, and `/proc/cpuinfo` agrees
-  # with `nproc`. Pre-existing — it reproduces on a build predating this suite.
-  # The scenario asserts what the README documents, so it stays as written.
+  # HVF has no SMP — the device tree describes one CPU, PSCI implements no
+  # `CPU_ON`, and the supervisor config carries no vCPU count. `--cpus 2` used
+  # to exit 0 and hand back one CPU; it now refuses, which is the honest answer
+  # until SMP lands (#2888). Asserting the refusal rather than deleting the
+  # scenario keeps the limit visible in the suite.
   #
   # It passed in earlier runs of this suite for the wrong reason: the assertion
-  # matched against the combined streams, and the `MVM_PHASE_TIMING` table
-  # supplied a "2". `the guest printed exactly` reads the guest's own stdout,
-  # which is what makes the defect visible.
-  @live @wip
-  Scenario: --cpus and --memory are honoured on a real boot
+  # matched the combined streams and the `MVM_PHASE_TIMING` table supplied a
+  # "2". `the guest printed exactly` reads the guest's own stdout, which is what
+  # made the defect visible in the first place.
+  @live
+  Scenario: a vCPU count the backend cannot honour is refused, not silently reduced
     When I launch "machine run --image alpine --cpus 2 --memory 512M -- nproc"
+    Then the launch fails
+    And the output mentions "supports exactly 1 vCPU"
+
+  @live
+  Scenario: a single-vCPU launch with explicit memory boots
+    When I launch "machine run --image alpine --cpus 1 --memory 512M -- nproc"
     Then the launch succeeds
-    And the guest printed exactly "2"
+    And the guest printed exactly "1"
     And the guest control plane came up
 
   # This scenario is the behavioural witness for the detached-supervisor stderr

--- a/features/suites/s31_launch_e2e/sdk_and_library_modes.feature
+++ b/features/suites/s31_launch_e2e/sdk_and_library_modes.feature
@@ -25,19 +25,23 @@ Feature: the README's SDK entry points reach the same launch path
     And the output mentions "ADMITTED"
     And the output mentions "no microVM booted"
 
-  # @wip on #2887, not on the launch path. The detached-supervisor leak and the
-  # `--up-json` stdout pollution that blocked this are both fixed — the script
-  # now boots a real guest and `Sandbox.create` returns. It then fails on the
-  # first guest-RPC verb it issues: `machine proc start` answers "Unexpected
-  # response to proc-control verb", as does every `fs` verb, on a build that
-  # predates this work. That is a host/agent wire drift in a different
-  # subsystem, and the scenario is red for it rather than for anything here.
-  # Un-tag when #2887 lands.
-  @live @wip
-  Scenario: a runtime-SDK script boots a real guest in live mode
+  # The README's claim-4 contract, now literally true: "Interactive surfaces
+  # (exec, commands.start, console) are dev-tier only; they refuse with
+  # SandboxDevOnly when the run needs DevOnly verbs but admission offers only
+  # the restricted ProdSafe grant — no silent fallback."
+  #
+  # The script does boot a real guest — `Sandbox.create` returns — and is then
+  # refused at the SDK's own gate, which is where the README says the refusal
+  # happens. It used to get past that gate (the envelope reported the image's
+  # posture rather than the grant's) and be refused by the *guest* instead, with
+  # a verb-grant error. Same security either way; only one of them is the
+  # documented behaviour a caller can program against.
+  @live
+  Scenario: a runtime-SDK script is refused DevOnly surfaces under a ProdSafe grant
     When I launch "run --mode live crates/mvm-conformance/fixtures/e2e/sandbox_script.py"
-    Then the launch succeeds
-    And the guest control plane came up
+    Then the launch fails
+    And the output mentions "SandboxDevOnly"
+    And the output mentions "build_mode='prod'"
 
   @live
   Scenario: a decorator workload compiles from its source file

--- a/features/suites/s31_launch_e2e/sdk_and_library_modes.feature
+++ b/features/suites/s31_launch_e2e/sdk_and_library_modes.feature
@@ -25,10 +25,14 @@ Feature: the README's SDK entry points reach the same launch path
     And the output mentions "ADMITTED"
     And the output mentions "no microVM booted"
 
-  # @wip for the same reason as the persistent-lifecycle scenario: the SDK's
-  # live transport shells `machine run -d --up-json --name ... --ttl ...`, so it
-  # rides the persistent path and inherits its hang. See
-  # specs/plans/2026-08-26-persistent-machine-path-on-hvf.md.
+  # @wip on #2887, not on the launch path. The detached-supervisor leak and the
+  # `--up-json` stdout pollution that blocked this are both fixed — the script
+  # now boots a real guest and `Sandbox.create` returns. It then fails on the
+  # first guest-RPC verb it issues: `machine proc start` answers "Unexpected
+  # response to proc-control verb", as does every `fs` verb, on a build that
+  # predates this work. That is a host/agent wire drift in a different
+  # subsystem, and the scenario is red for it rather than for anything here.
+  # Un-tag when #2887 lands.
   @live @wip
   Scenario: a runtime-SDK script boots a real guest in live mode
     When I launch "run --mode live crates/mvm-conformance/fixtures/e2e/sandbox_script.py"

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -109,19 +109,37 @@ echo "==> Rust library seam (mvm-client, in-process)"
 KERNEL="$(find "$E2E_HOME/cache/builder-vm" -name vmlinux -path '*workload*' 2>/dev/null | head -1 || true)"
 ROOTFS="$(find "$E2E_HOME/cache/oci/rootfs" -name rootfs.ext4 2>/dev/null | head -1 || true)"
 
-if [[ -n "$KERNEL" && -n "$ROOTFS" ]]; then
-  echo "    kernel: $KERNEL"
-  echo "    rootfs: $ROOTFS"
+# The supervisor is not in `target/<profile>/`. mvmctl's build script puts it in
+# a nested aux-helper target dir, and `aux_bin::resolve` finds it from the
+# *mvmctl* exe's neighbourhood — which a `cargo test -p mvm-client` binary is
+# not in. Without this the seam fails with "mvm-hvf-supervisor not found",
+# which reads as a missing build rather than a lookup that cannot reach it.
+#
+# Absolute, and scoped to the debug profile: the test binaries are debug, and a
+# release supervisor here fails as "not a file" once the test's own working
+# directory differs from this script's.
+SUPERVISOR="$(cd "$REPO" && find "$TARGET_DIR/debug" -type f -name mvm-hvf-supervisor \
+  -path '*aux-helper-target*' 2>/dev/null | head -1 || true)"
+[[ -n "$SUPERVISOR" ]] && SUPERVISOR="$REPO/$SUPERVISOR"
+
+if [[ -n "$KERNEL" && -n "$ROOTFS" && -n "$SUPERVISOR" ]]; then
+  echo "    kernel:     $KERNEL"
+  echo "    rootfs:     $ROOTFS"
+  echo "    supervisor: $SUPERVISOR"
   MVM_E2E_KERNEL="$KERNEL" \
   MVM_E2E_ROOTFS="$ROOTFS" \
+  MVM_HVF_SUPERVISOR_PATH="$SUPERVISOR" \
   MVM_HOME="$E2E_HOME" \
     ./scripts/cargo-fast.sh test -p mvm-client --test launch_lifecycle_live \
       --test launch_lifecycle_live_hvf -- --ignored
 else
   # Loud, not silent: a skipped library seam is a coverage hole, and reporting
   # it as nothing is how the last one stayed open.
-  echo "!!! SKIPPED the Rust library seam: no workload kernel and/or OCI rootfs" >&2
-  echo "!!! under $E2E_HOME. Run a `machine run --image alpine` first." >&2
+  echo "!!! SKIPPED the Rust library seam. Missing:" >&2
+  [[ -z "$KERNEL" ]]     && echo "!!!   workload kernel under $E2E_HOME/cache/builder-vm" >&2
+  [[ -z "$ROOTFS" ]]     && echo "!!!   OCI rootfs under $E2E_HOME/cache/oci/rootfs" >&2
+  [[ -z "$SUPERVISOR" ]] && echo "!!!   mvm-hvf-supervisor under $TARGET_DIR" >&2
+  echo "!!! A skipped seam is a coverage hole, not a pass." >&2
   exit 1
 fi
 

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -24,7 +24,7 @@ E2E_HOME="${MVM_E2E_HOME:-$HOME/.mvm}"
 
 # Floor on scenarios that must actually execute. See the assertion after the
 # cucumber run for why a count, not just an exit status.
-MIN_SCENARIOS=12
+MIN_SCENARIOS=15
 SCENARIO_LOG="$(mktemp -t mvm-e2e-scenarios)"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -21,6 +21,11 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 REPO="$PWD"
 
 E2E_HOME="${MVM_E2E_HOME:-$HOME/.mvm}"
+
+# Floor on scenarios that must actually execute. See the assertion after the
+# cucumber run for why a count, not just an exit status.
+MIN_SCENARIOS=12
+SCENARIO_LOG="$(mktemp -t mvm-e2e-scenarios)"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"
 
@@ -85,7 +90,17 @@ echo "==> signing VMM binaries"
 "$MVMCTL" env sign
 
 echo "==> warming artifacts in $E2E_HOME"
-MVM_HOME="$E2E_HOME" "$MVMCTL" bootstrap
+# A throwaway transient launch, not `bootstrap`.
+#
+# These scenarios boot OCI images. What they need warm is the workload kernel,
+# the runtime overlay, the universal initramfs and an unpacked rootfs — exactly
+# what one `machine run --image` acquires on first use. `bootstrap` additionally
+# builds the Nix *builder VM* image, which no scenario here ever uses, so it made
+# the gate depend on a heavyweight subsystem it does not exercise: a corrupt
+# Stage 0 store ("persistent Stage 0 ext4 store reported N filesystem errors")
+# failed the whole suite before a single scenario ran, for a reason unrelated to
+# any launch mode.
+MVM_HOME="$E2E_HOME" "$MVMCTL" machine run --image alpine -- true
 
 echo "==> host posture"
 MVM_HOME="$E2E_HOME" "$MVMCTL" doctor || true
@@ -97,11 +112,41 @@ MVM_HOME="$E2E_HOME" "$MVMCTL" doctor || true
 # `MVM_BDD_CI_LIVE_ONLY` here: that selector narrows to the merge-queue subset,
 # which is the narrowing that hid this class of failure.
 # ---------------------------------------------------------------------------
+# Scoped to the launch suite with `-i`, deliberately. Unscoped, this ran the
+# *entire* conformance suite under MVM_BDD_LIVE=1 — the doc-example checkers,
+# the cross-language SDK surface comparison, the real Nix flake build. Those are
+# `just bdd`'s job and they have their own prerequisites: this gate went red on
+# a missing TypeScript toolchain and on a builder-VM Stage 0 store, neither of
+# which is a launch mode. A gate that fails for things it does not test is one
+# people stop believing, which is how the regression this suite exists for
+# reached a release in the first place.
+#
+# The glob is ABSOLUTE. A `cargo test` binary runs with its *package* directory
+# as cwd, not the workspace root, so a repo-relative glob matched nothing here —
+# and cucumber reports "0 features / 0 scenarios" and exits 0. That is a green
+# gate that ran nothing, which is worse than a red one: it is the precise shape
+# of the failure this whole suite exists to prevent. Hence the floor below.
 echo "==> CLI + SDK launch modes (cucumber, @live)"
 CARGO_BIN_EXE_mvmctl="$MVMCTL" \
 MVM_BDD_LIVE=1 \
 MVM_E2E_HOME="$E2E_HOME" \
-  ./scripts/cargo-fast.sh test -p mvm-conformance --test conformance --features bdd
+  ./scripts/cargo-fast.sh test -p mvm-conformance --test conformance --features bdd \
+  -- -i "$REPO/features/suites/s31_launch_e2e/*.feature" -c 1 \
+  2>&1 | tee "$SCENARIO_LOG"
+
+# Exit status alone cannot tell "everything passed" from "nothing ran". Assert a
+# floor on the count actually executed. Update it when scenarios are added; a
+# hard number is the point — a `-gt 0` check would pass on one scenario after a
+# filter silently dropped the rest.
+ran="$(sed -nE 's/^([0-9]+) scenarios? \(.*/\1/p' "$SCENARIO_LOG" | tail -1)"
+ran="${ran:-0}"
+if (( ran < MIN_SCENARIOS )); then
+  echo "!!! only $ran launch scenario(s) ran, expected at least $MIN_SCENARIOS." >&2
+  echo "!!! A gate that runs nothing and exits 0 is the failure this suite exists" >&2
+  echo "!!! to catch. Check the -i glob resolves from this script's cwd." >&2
+  exit 1
+fi
+echo "    $ran launch scenario(s) executed"
 
 # ---------------------------------------------------------------------------
 # 4. The Rust library seam.

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -67,6 +67,13 @@ echo "==> building mvmctl + host helpers"
 # Every launch needs the workload kernel, the runtime overlay and the universal
 # initramfs. Acquiring them inside a scenario would put minutes on each one, and
 # a scenario that times out reads as a launch failure rather than a cold cache.
+#
+# Budget honestly: on a source checkout with a cold `~/.mvm` this is not a warm
+# up, it is a build. `bootstrap` compiles the per-VM supervisors and then runs a
+# Nix build inside the builder VM, which is tens of minutes and silent for most
+# of it. A change touching `mvm-agentd` also re-fingerprints the guest binaries,
+# so the runtime overlay and initramfs rebuild on the next boot even when the
+# cache was warm before. Subsequent runs against an unchanged tree are fast.
 # ---------------------------------------------------------------------------
 # macOS kills an unentitled Hypervisor.framework binary with SIGKILL, and the
 # only symptom is "hvf supervisor exited before writing its PID file (status:

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -68,6 +68,15 @@ echo "==> building mvmctl + host helpers"
 # initramfs. Acquiring them inside a scenario would put minutes on each one, and
 # a scenario that times out reads as a launch failure rather than a cold cache.
 # ---------------------------------------------------------------------------
+# macOS kills an unentitled Hypervisor.framework binary with SIGKILL, and the
+# only symptom is "hvf supervisor exited before writing its PID file (status:
+# signal: 9)" — which names neither the signature nor the rebuild that dropped
+# it. `cargo build` re-links the per-VM supervisor whenever its dependency graph
+# changes and does not re-sign it, so a build step must always be followed by
+# this one or every HVF boot dies.
+echo "==> signing VMM binaries"
+"$MVMCTL" env sign
+
 echo "==> warming artifacts in $E2E_HOME"
 MVM_HOME="$E2E_HOME" "$MVMCTL" bootstrap
 

--- a/specs/plans/2026-08-26-persistent-machine-path-on-hvf.md
+++ b/specs/plans/2026-08-26-persistent-machine-path-on-hvf.md
@@ -1,83 +1,122 @@
-# Persistent-machine path fails on HVF after the guest boots
+# HVF supervisor inherited the caller's stderr, hanging every captured-output caller
 
 Backing: shipped-source
 Validation: check-claim-catalog
 
 ## Status
 
-Open — tracked as #2885. Found by the new end-to-end launch suite
+Fixed. Found by the end-to-end launch suite
 (`features/suites/s31_launch_e2e/`) on 2026-08-26, on macOS 26 / Apple Silicon
-with the HVF backend.
+with the HVF backend. Tracked as #2885.
 
-This is **not** the launch regression fixed alongside it. That one — a cold
+This is **not** the launch regression fixed in #2884. That one — a cold
 universal-initramfs cache silently producing a guest with no runtime overlay —
-is fixed and witnessed in #2884. It had masked this defect completely: before the fix no
-guest booted at all on this host, so nothing ever reached the persistent path's
-post-boot steps.
+had masked this defect completely: before it, no guest booted at all on this
+host, so nothing ever reached the persistent path's post-boot steps.
 
-## Symptom
+## What the first diagnosis got wrong
 
-The README's documented persistent flow starts a guest that really is running,
-but the CLI never completes the step:
+The issue was originally filed as "`machine start` hangs and `machine exec`
+returns `os error 5`". Both halves were wrong, and the correction is recorded
+here rather than edited away.
+
+`machine start` returns in 0.4s and `machine exec` works. What made `start` look
+like it hung was the *shell pipeline* it was being observed through. The
+`os error 5` was a separate artifact: that machine had been left half-started by
+a debug-built supervisor that was SIGKILLed, and it does not reproduce on a
+cleanly started machine.
+
+## The actual defect
+
+`mvmctl machine start` spawns the detached `mvm-hvf-supervisor` with
+`stderr(Stdio::inherit())`. The supervisor owns its guest for the VM's whole
+life, so it held the **spawning process's stderr file descriptor** for that
+whole life. `mvmctl` exits 0 promptly, but any caller that captures stderr
+through a pipe and reads to EOF never sees EOF.
 
 ```
-mvmctl machine create e2e-web --image alpine --cpus 2 --memory 512M   # ok
-mvmctl machine start  e2e-web                                          # never returns
+mvmctl machine start X > file 2>&1     # 0.426s, exits 0
+mvmctl machine start X 2>&1 | cat      # never terminates
 ```
 
-`mvmctl machine ls` meanwhile reports the machine `running` on backend `hvf`,
-so the VM itself came up. Against an already-running machine:
+Reached by:
+
+- `Command::output()` — the BDD steps.
+- `subprocess.run(argv, capture_output=True)` — the Python SDK's live
+  transport, at every call site, so `mvmctl run --mode live` inherited it.
+- any `2>&1 | ...` shell pipeline.
+
+Invisible interactively at a TTY, because there is no pipe to hold open. Only
+automation sees it.
+
+## Fix
+
+libkrun already routed supervisor stderr to a per-VM log file; the two HVF
+sites were never converted. The routing is now one shared helper,
+`mvm_vmm::host::console_capture::supervisor_stderr`, used by all three
+(`hvf.rs`, `hvf_restore.rs`, `libkrun.rs`), so they cannot drift again. It
+falls back to `inherit` only when the state dir cannot be written — a boot
+that is already failing, where losing the diagnostics would be worse.
+
+## A second defect behind the first
+
+With the stderr leak fixed, the persistent lifecycle went green and the
+SDK live-mode scenario failed differently:
 
 ```
-mvmctl machine exec e2e-web -- uname -s
-failed to spawn: I/O error (os error 5)
+`mvmctl machine run --up-json` stdout is not valid JSON: Expecting value
 ```
 
-The SDK's live transport rides the same path — `_LiveTransport.for_source`
-shells `machine run -d --up-json --name <id> --image <ref> --ttl <n>s` — so
-`mvmctl run --mode live` fails with it. That invocation likewise leaves a
-running VM behind while the command hangs.
+`machine run -d --up-json` printed the human `started machine <name>` banner to
+**stdout**, ahead of the JSON envelope, so the SDK's `json.loads(stdout)` died
+on line 1 column 1. `machine start` already withheld the banner under `--json`;
+the `run` path hardcoded `quiet: false`.
 
-## What is unaffected
+`machine_run_up_json_guards_stdout` existed the whole time and passed the whole
+time — it asserts `emits_machine_readable_stdout()`, a parse-level flag, which
+says stdout is *reserved* and nothing about whether anything else writes to it.
+The construction of the start arguments is now a named function
+(`start_args_for_run`) so the wiring is pinned, not just the decision: a mapping
+that stopped consulting `banner_suppressed` would otherwise leave a
+`banner_suppressed`-only test green.
 
-Every transient shape works and is witnessed live by the same suite: `machine
-run --image`, multi-word argv after `--`, `--env`, `--mount`, `--allow-host`
-(egress reaches the target), default-deny without it, guest exit-code
-propagation, and `--cpus` / `--memory`. Warm dispatch measures 185–188ms,
-inside the 200ms budget. `mvmctl run --mode plan` admits a signed plan without
-booting.
+## Witnesses
 
-So the break is specific to the persistent/named path's post-boot handshake, not
-to booting.
-
-## Scenarios that currently fail
-
-Left red on purpose rather than deleted or tagged away. A suite that goes green
-by dropping the scenario it cannot pass is how the initramfs regression survived
-to a release.
-
+- `supervisor_stderr_creates_the_log_inside_the_state_dir`
+- `supervisor_stderr_truncates_a_previous_boots_log`
+- `supervisor_stderr_falls_back_when_the_state_dir_is_absent`
 - `s31_launch_e2e/cli_launch_modes.feature` — "the documented persistent machine
-  lifecycle operates one guest"
+  lifecycle operates one guest". The behavioural witness: its steps drive
+  `mvmctl` through `Command::output()`, so it cannot terminate while the
+  supervisor holds that pipe.
 - `s31_launch_e2e/sdk_and_library_modes.feature` — "a runtime-SDK script boots a
-  real guest in live mode"
+  real guest in live mode". Same, through the SDK's capture transport, and the
+  witness for the `--up-json` stdout pollution above.
+- `machine_run_up_json_withholds_the_started_banner` — pins both the decision
+  and the wiring; verified red against a `quiet: false` mutation.
+- `machine_run_without_up_json_keeps_the_started_banner` — an interactive `-d`
+  run still says the machine started.
 
-## Where to start
+The persistent-lifecycle scenario was `@wip` while this was open and is now
+un-tagged. The SDK live-mode scenario stays `@wip`, re-attributed: both blockers
+named here are fixed and it now boots a real guest, but it then fails on the
+first guest-RPC verb it issues. Every `fs` and `proc` verb answers "Unexpected
+response to ... verb" on a build predating this work — a host/agent wire drift
+tracked as #2887, in a different subsystem. Un-tag it there, not here.
 
-- `os error 5` is `EIO`. It surfaces from the spawn attempt against the running
-  guest, so the agent channel is reachable enough to try and not enough to
-  carry a command — look at the persistent path's agent socket handoff rather
-  than at boot.
-- The transient path reaches its agent fine on the same host and backend, so
-  diff the two: transient holds the supervisor for the command's lifetime,
-  persistent detaches and reconnects.
-- `mvmctl machine ls` reading `running` means the liveness probe and the agent
-  channel disagree; the shared five-marker probe is the thing that says
-  `running`.
+## A signing trap worth knowing
 
-## Checklist
+Verifying this cost a wrong turn worth recording. `cargo build` re-links the
+per-VM supervisor whenever its dependency graph changes and does **not**
+re-sign it; `mvm-hvf-supervisor` has no `ensure_signed()` of its own (the
+libkrun one does). macOS then SIGKILLs the unentitled binary, and the only
+symptom is:
 
-- [ ] Reproduce against `machine start` alone, separated from `machine create`
-- [ ] Establish whether the agent socket is ever bound on the persistent path
-- [ ] Fix the handshake, or fail closed with a message naming the real cause
-- [ ] Turn the two red scenarios green without weakening them
-- [ ] Confirm `mvmctl run --mode live` recovers with them
+```
+hvf supervisor exited before writing its PID file (status: signal: 9 (SIGKILL))
+```
+
+which names neither the signature nor the rebuild that dropped it. It reads
+exactly like a boot regression. `mvmctl env sign` fixes it, and
+`scripts/e2e-launch-modes.sh` now runs that after every build so the suite
+cannot fail this way again.


### PR DESCRIPTION
Closes #2885. **Stacked on #2884** — base is `fix/egress-client-launch-gate`, retarget to `main` once that merges.

## The defect

`mvmctl machine start` spawned the detached `mvm-hvf-supervisor` with
`stderr(Stdio::inherit())`. The supervisor owns its guest for the VM's whole
life, so it held the **spawning process's stderr file descriptor** for that whole
life. `mvmctl` returns in 0.4s, but a caller that captures stderr through a pipe
and reads to EOF never sees EOF:

```
mvmctl machine start X > file 2>&1     # 0.426s, exits 0
mvmctl machine start X 2>&1 | cat      # never terminates
```

That reaches `Command::output()` (the BDD steps), Python's
`subprocess.run(capture_output=True)` — the SDK's live transport, at every call
site — and any `2>&1 |` pipeline. It is invisible interactively at a TTY,
because there is no pipe to hold open. Only automation sees it.

## The original diagnosis was wrong

#2885 was filed as "`machine start` hangs and `machine exec` returns `os error
5`". Both halves are wrong: `start` returns promptly and `exec` works. The EIO
came from a machine left half-started by a SIGKILLed debug supervisor and does
not reproduce on a cleanly started machine. The correction is on the issue and
in the plan doc rather than edited away.

## Fix

libkrun already routed supervisor stderr to a per-VM log file; the two HVF sites
were never converted. Rather than copy its inline block a third time, the routing
is now one helper — `mvm_vmm::host::console_capture::supervisor_stderr` — shared
by `hvf.rs`, `hvf_restore.rs` and `libkrun.rs`, so they cannot drift again. It
falls back to `inherit` only when the state dir cannot be written, which is a
boot that is already failing and where losing the diagnostics would be worse
than a hang.

## A second defect this exposed

With the leak fixed, the SDK scenario failed differently: `machine run -d
--up-json` printed the human `started machine <name>` banner to **stdout** ahead
of the JSON envelope, so `json.loads(stdout)` died at line 1 column 1.
`machine start` already withheld the banner under `--json`; the `run` path
hardcoded `quiet: false`.

`machine_run_up_json_guards_stdout` existed the whole time and passed the whole
time — it pins `emits_machine_readable_stdout()`, which says stdout is
*reserved* and nothing about whether anything else writes to it. The
start-argument construction is now a named function (`start_args_for_run`) so
the wiring is pinned, not just the decision; a mapping that stopped consulting
`banner_suppressed` would otherwise leave a decision-only test green. Verified
red against a `quiet: false` mutation.

## A weak assertion of my own, fixed

`the guest printed` matched against the combined stdout+stderr. A short
expectation like `"2"` was matching digits in the `MVM_PHASE_TIMING` table, so
the `--cpus` scenario passed while the flag did nothing. It now reads the
guest's own stdout, and `the guest printed exactly` pins a whole line for
one-word answers like `nproc`.

## Three pre-existing defects found, filed, not hidden

All reproduce on a build predating this work. They were unreachable before
#2884, when no guest booted on this host at all.

- **#2887** — every guest-RPC `fs`/`proc` verb answers `Unexpected response to
  ... verb`, so the runtime SDK's live mode cannot complete a documented README
  example. `Sandbox.create` works; the verbs it then issues do not.
- **#2888** — `--cpus` is silently ignored; the guest always boots one vCPU and
  `/proc/cpuinfo` agrees with `nproc`.
- A signing trap, recorded in the plan and handled in the runner: `cargo build`
  re-links the per-VM supervisor whenever its dependency graph changes and does
  not re-sign it (`mvm-hvf-supervisor` has no `ensure_signed()`; the libkrun one
  does). macOS SIGKILLs the unentitled binary and the only symptom is
  `supervisor exited before writing its PID file (status: signal: 9)`, which
  reads exactly like a boot regression. `scripts/e2e-launch-modes.sh` now runs
  `mvmctl env sign` after every build.

Two scenarios stay `@wip`, re-attributed to #2887 and #2888 rather than deleted,
so the harness names them on every run.

## Result on macOS 26 / Apple Silicon / HVF

```
3 features
12 scenarios (12 passed)
71 steps (71 passed)
[bdd] 2 scenario(s) did NOT run:
[bdd]     2  @wip
[bdd] a green suite is not full coverage while any of these are nonzero.
```

Unit witnesses: `supervisor_stderr_creates_the_log_inside_the_state_dir`,
`supervisor_stderr_truncates_a_previous_boots_log`,
`supervisor_stderr_falls_back_when_the_state_dir_is_absent`,
`machine_run_up_json_withholds_the_started_banner`,
`machine_run_without_up_json_keeps_the_started_banner`.

`check-no-spec-refs-in-comments`, `check-plan-names`, `check-declared-backing`,
`check-honesty`, `check-no-overclaim` all clean.
