### PR TITLE
ci: deploy Cloudflare Pages on version tags and add just pages-deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,13 +1,16 @@
 name: Deploy site to Cloudflare Pages
 
-# Deploys happen when a GitHub Release is published, with manual
-# dispatch available for operator-triggered docs publishes. The
-# previous `push: branches: [main] paths: [public/**]` trigger was
-# dropped in the ecosystem-wide CI cost reduction (no push-to-branch
-# triggers anywhere).
+# Deploys happen when a GitHub Release is published or a version tag is
+# pushed, with manual dispatch available for operator-triggered docs
+# publishes. The previous `push: branches: [main] paths: [public/**]`
+# trigger was dropped in the ecosystem-wide CI cost reduction (no
+# push-to-branch triggers anywhere).
 on:
   release:
     types: [published]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -83,12 +83,28 @@ jobs:
         working-directory: public
         run: pnpm build
 
+      - name: Verify cross-origin isolation headers are staged
+        run: |
+          if [ ! -f public/dist/_headers ]; then
+            echo "ERROR: public/dist/_headers is missing; Cloudflare Pages will not send COOP/COEP headers." >&2
+            exit 1
+          fi
+          echo "OK: public/dist/_headers present"
+
+      - name: Ensure Cloudflare Pages project exists
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create mvm --production-branch=main
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
       - name: Deploy to Cloudflare Pages
         id: deployment
         uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # Create a Cloudflare Pages project named `mvm` (or change this).
           command: pages deploy public/dist --project-name=mvm --branch=main
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/Justfile
+++ b/Justfile
@@ -529,18 +529,21 @@ docs-dev: demo-assets
 docs-build: demo-assets
     cd public && pnpm build
 
-# Publish the docs site to GitHub Pages (dispatches pages.yml on main)
+# Publish the docs site to Cloudflare Pages (dispatches pages.yml on main)
 docs-publish:
-    # `pages.yml` is workflow_dispatch-only on purpose — the old
-    # `push: branches:[main] paths:[public/**]` trigger was dropped in the CI
-    # cost reduction — so a docs change reaches the site only when someone asks
-    # for it. That is why this recipe exists: otherwise publishing is an
-    # undocumented `gh workflow run` you have to already know about.
+    # `pages.yml` runs automatically when a release is published or a `v*`
+    # tag is pushed; this recipe exists for operator-triggered docs publishes.
+    # The old `push: branches:[main] paths:[public/**]` trigger was dropped in
+    # the CI cost reduction — so a docs-only change reaches the site only when
+    # someone asks for it or a release/tag fires.
     #
     # `--ref main`, never the current branch: Pages serves what is on main, and
     # dispatching from a branch would publish something nobody has merged.
     gh workflow run pages.yml --ref main
     @echo "Dispatched pages.yml on main. Watch it with: gh run watch \$(gh run list --workflow=pages.yml --limit 1 --json databaseId --jq '.[0].databaseId')"
+
+# Alias for `docs-publish` using the Cloudflare Pages deployment name.
+pages-deploy: docs-publish
 
 # Build the browser-tier microVM demo assets (wasm core + guest + fixtures)
 demo-build:

--- a/specs/notes/2026-08-26-cloudflare-pages-domain-setup.md
+++ b/specs/notes/2026-08-26-cloudflare-pages-domain-setup.md
@@ -47,6 +47,8 @@ The workflow deploys with:
 wrangler pages deploy public/dist --project-name=mvm --branch=main
 ```
 
+The workflow also runs `wrangler pages project create mvm --production-branch=main` before deploying. That step is allowed to fail (for example, when the project already exists), so a missing project is created automatically on the first run.
+
 ## Custom domain setup
 
 Cloudflare Pages custom domains work best when Cloudflare is also the authoritative DNS provider for the zone. The registrar (iwantmyname) can keep the registration; only the nameservers need to point at Cloudflare.
@@ -168,8 +170,24 @@ If you also need to send email:
 
 ## Troubleshooting
 
-- **Deployment fails with "Could not find the project"**: create the `mvm` Pages project first; the workflow does not auto-create it.
+- **Deployment fails with "Could not find the project"**: the workflow now tries to create the `mvm` project automatically. If this still fails, make sure the API token has `Cloudflare Pages:Edit` permission for the account.
 - **Secrets missing**: ensure `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are set at the repository level, not just environment level.
 - **Custom domain shows "Invalid"**: confirm the zone is active on Cloudflare and the nameservers at iwantmyname match exactly.
-- **SharedArrayBuffer still missing**: verify `public/public/_headers` is present in the built output and the request path starts with `/demo/weblinux/`.
-- **Email not arriving**: verify the destination address is verified in Cloudflare Email Routing, and that the MX records point to Cloudflare (check with `dig gomicrovm.com MX`).
+- **SharedArrayBuffer still missing**:
+  - Check that the deployed response carries the headers:
+    ```bash
+    curl -I https://gomicrovm.com/demo/weblinux/
+    ```
+    You should see `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`.
+  - If the headers are missing, the build did not include `public/dist/_headers`. The workflow now fails fast if that file is missing.
+  - Make sure you are testing the deployed Cloudflare Pages URL, not a local `demo.mvm.local` dev server (Astro dev does not send COOP/COEP headers; use the production URL or the local `web/weblinux-demo/serve.py` helper).
+- **Email not arriving**:
+  - In Cloudflare Email Routing, verify the destination address (e.g., `gomicrovm@ari.io`). An unverified destination causes Cloudflare to silently drop messages.
+  - Check the zone overview: the zone status must be **Active** (not **Pending**) for Email Routing to work.
+  - Confirm the required DNS records are live:
+    ```bash
+    dig gomicrovm.com MX
+    dig gomicrovm.com TXT
+    ```
+    You should see MX records pointing to Cloudflare inbound servers and an SPF TXT record including `_spf.mx.cloudflare.net`.
+  - Make sure the catch-all rule action is set to **Send to an email** (not **Drop**) and a verified destination is selected.

--- a/specs/notes/2026-08-26-cloudflare-pages-domain-setup.md
+++ b/specs/notes/2026-08-26-cloudflare-pages-domain-setup.md
@@ -60,7 +60,7 @@ In the Cloudflare dashboard:
 3. Cloudflare will provide two nameservers, for example:
    - `bob.ns.cloudflare.com`
    - `lara.ns.cloudflare.com`
-   (The exact pair is assigned per-zone; copy the values from the Cloudflare setup page.)
+     (The exact pair is assigned per-zone; copy the values from the Cloudflare setup page.)
 
 ### 2. Update nameservers at iwantmyname
 
@@ -95,6 +95,71 @@ Look for:
 
 Also verify the demo works in a browser: open `https://gomicrovm.com/demo/weblinux/` and confirm `SharedArrayBuffer` is available (no console error).
 
+## Email setup
+
+Because Cloudflare is now the authoritative DNS provider for `gomicrovm.com`, all mail-related DNS records are managed in the Cloudflare dashboard.
+
+### Receiving email with Cloudflare Email Routing (free)
+
+Cloudflare Email Routing is a free, receive-only forwarding service. It is the simplest option for addresses like `hello@gomicrovm.com`.
+
+1. In the Cloudflare dashboard, select the `gomicrovm.com` zone → **Email** → **Email Routing**.
+2. Click **Get started** and choose **Catch-all address** or individual routes.
+3. Add a destination address you already own (e.g., your personal Gmail). Cloudflare will send a verification email; click the link to confirm.
+4. Add custom addresses:
+   - `hello@gomicrovm.com` → `your-address@gmail.com`
+   - `support@gomicrovm.com` → `your-address@gmail.com`
+   - Or enable a catch-all so any `@gomicrovm.com` address forwards to your inbox.
+5. Cloudflare automatically adds the required DNS records:
+   - **MX records** pointing to Cloudflare's inbound mail servers.
+   - **SPF TXT record** (`v=spf1 include:_spf.mx.cloudflare.net ~all`) to authorize Cloudflare to receive mail for the domain.
+
+Wait for DNS propagation (usually minutes), then send a test message to `hello@gomicrovm.com` and confirm it arrives in the destination inbox.
+
+**Limitations:** Email Routing only forwards incoming mail. You cannot send mail `From: hello@gomicrovm.com` through Cloudflare.
+
+### Sending email from the domain
+
+To send mail as `@gomicrovm.com`, use a transactional email provider and add their DNS records to Cloudflare. Good options:
+
+- **Resend** (developer-friendly, free tier)
+- **Postmark**
+- **AWS SES**
+- **Mailgun**
+- **SendGrid**
+
+Each provider will give you records to add. Typically you need:
+
+- **SPF TXT record** at the root:
+
+  ```
+  v=spf1 include:_spf.mx.cloudflare.net include:mailprovider.com ~all
+  ```
+
+  Replace `mailprovider.com` with the provider's SPF include (e.g., `include:amazonses.com`, `include:resend.com`). If you are not using Cloudflare Email Routing, omit `include:_spf.mx.cloudflare.net`.
+
+- **DKIM CNAME records** (usually 3) provided by the sending service.
+
+- **DMARC TXT record** at `_dmarc.gomicrovm.com`:
+  ```
+  v=DMARC1; p=quarantine; rua=mailto:dmarc-reports@example.com; pct=100
+  ```
+  Start with `p=none` while testing, then move to `p=quarantine` or `p=reject` once mail flows correctly. Provide a real address for aggregate reports, or use a free DMARC reporting service.
+
+### Recommended minimal setup
+
+If you only need to receive email at `gomicrovm.com`:
+
+1. Use Cloudflare Email Routing.
+2. Let it manage MX and SPF automatically.
+
+If you also need to send email:
+
+1. Keep Cloudflare Email Routing for inbound mail.
+2. Add the sending provider's SPF include to the existing SPF record.
+3. Add the provider's DKIM records.
+4. Add a DMARC record at `_dmarc.gomicrovm.com`.
+
 ## Triggering a deployment
 
 - Automatic: publish a GitHub Release or push a `v*` tag.
@@ -106,4 +171,5 @@ Also verify the demo works in a browser: open `https://gomicrovm.com/demo/weblin
 - **Deployment fails with "Could not find the project"**: create the `mvm` Pages project first; the workflow does not auto-create it.
 - **Secrets missing**: ensure `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are set at the repository level, not just environment level.
 - **Custom domain shows "Invalid"**: confirm the zone is active on Cloudflare and the nameservers at iwantmyname match exactly.
-- **SharedArrayBuffer still missing**: verify `public/public/_headers` is present in the built output and that the request path starts with `/demo/weblinux/`.
+- **SharedArrayBuffer still missing**: verify `public/public/_headers` is present in the built output and the request path starts with `/demo/weblinux/`.
+- **Email not arriving**: verify the destination address is verified in Cloudflare Email Routing, and that the MX records point to Cloudflare (check with `dig gomicrovm.com MX`).

--- a/specs/notes/2026-08-26-cloudflare-pages-domain-setup.md
+++ b/specs/notes/2026-08-26-cloudflare-pages-domain-setup.md
@@ -1,0 +1,109 @@
+# Cloudflare Pages domain setup for gomicrovm.com
+
+This note records how the public site (`public/`, Astro) is hosted on Cloudflare Pages and how the custom domain `gomicrovm.com` is wired up from the iwantmyname registrar.
+
+## Current state
+
+- The site is deployed by `.github/workflows/pages.yml` to Cloudflare Pages project `mvm`.
+- The workflow triggers on:
+  - GitHub Release `published`
+  - Push of a `v*` tag
+  - Manual `workflow_dispatch`
+- A manual dispatch can be triggered from the repo with:
+
+```bash
+just pages-deploy
+# or the older alias
+just docs-publish
+```
+
+## Required GitHub secrets
+
+The workflow reads two repository secrets:
+
+- `CLOUDFLARE_API_TOKEN` — Cloudflare API token with `Cloudflare Pages:Edit` and `Zone:Read` permissions for the account/zone.
+- `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account ID.
+
+Set them with the GitHub CLI:
+
+```bash
+gh secret set CLOUDFLARE_API_TOKEN --repo tinylabscom/mvm
+gh secret set CLOUDFLARE_ACCOUNT_ID --repo tinylabscom/mvm --body "<account-id>"
+```
+
+## Cloudflare Pages project
+
+Project name: `mvm`
+
+Create it through the Cloudflare dashboard (Pages & Workers → Create a project → Upload assets), or with Wrangler once authenticated:
+
+```bash
+npx wrangler pages project create mvm --production-branch=main
+```
+
+The workflow deploys with:
+
+```bash
+wrangler pages deploy public/dist --project-name=mvm --branch=main
+```
+
+## Custom domain setup
+
+Cloudflare Pages custom domains work best when Cloudflare is also the authoritative DNS provider for the zone. The registrar (iwantmyname) can keep the registration; only the nameservers need to point at Cloudflare.
+
+### 1. Add the zone to Cloudflare
+
+In the Cloudflare dashboard:
+
+1. Add site → enter `gomicrovm.com`.
+2. Choose the free/pro plan.
+3. Cloudflare will provide two nameservers, for example:
+   - `bob.ns.cloudflare.com`
+   - `lara.ns.cloudflare.com`
+   (The exact pair is assigned per-zone; copy the values from the Cloudflare setup page.)
+
+### 2. Update nameservers at iwantmyname
+
+1. Log in to <https://iwantmyname.com>.
+2. Go to **Domain Management** → select `gomicrovm.com`.
+3. Open the **Nameservers** section.
+4. Replace the current nameservers with the two Cloudflare nameservers from step 1.
+5. Save. DNS propagation usually takes a few minutes to a few hours.
+
+### 3. Add the custom domain in Pages
+
+1. In Cloudflare dashboard, go to **Pages** → `mvm` project → **Custom domains**.
+2. Click **Set up a custom domain**.
+3. Enter `gomicrovm.com` and confirm.
+4. Cloudflare will automatically add the required CNAME/A/AAAA records to the `gomicrovm.com` zone because it is authoritative.
+
+If you prefer to keep iwantmyname as the authoritative DNS provider (not recommended for Pages), add a CNAME record for `gomicrovm.com` pointing at `mvm.pages.dev`. Note that CNAME at the zone apex is not valid per RFC and may not be supported by iwantmyname; use Cloudflare nameservers for the root domain instead.
+
+### 4. Verify
+
+Once DNS propagates:
+
+```bash
+curl -I https://gomicrovm.com
+```
+
+Look for:
+
+- HTTP 200
+- `report-to` / `nel` headers from Cloudflare
+- `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp` on `/demo/weblinux/*` paths (from `public/public/_headers`)
+
+Also verify the demo works in a browser: open `https://gomicrovm.com/demo/weblinux/` and confirm `SharedArrayBuffer` is available (no console error).
+
+## Triggering a deployment
+
+- Automatic: publish a GitHub Release or push a `v*` tag.
+- Manual: `just pages-deploy` from the repo root.
+- Watch the run: `gh run watch $(gh run list --workflow=pages.yml --limit 1 --json databaseId --jq '.[0].databaseId')`
+
+## Troubleshooting
+
+- **Deployment fails with "Could not find the project"**: create the `mvm` Pages project first; the workflow does not auto-create it.
+- **Secrets missing**: ensure `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are set at the repository level, not just environment level.
+- **Custom domain shows "Invalid"**: confirm the zone is active on Cloudflare and the nameservers at iwantmyname match exactly.
+- **SharedArrayBuffer still missing**: verify `public/public/_headers` is present in the built output and that the request path starts with `/demo/weblinux/`.


### PR DESCRIPTION
### Changes

- Trigger `.github/workflows/pages.yml` on pushes to `v*` tags, so tag-based releases redeploy the site automatically.
- Update the `docs-publish` recipe comment to reflect that the target is now Cloudflare Pages and that the workflow also fires on releases and tags.
- Add `pages-deploy` as a clearer alias for `docs-publish`.
- Add `specs/notes/2026-08-26-cloudflare-pages-domain-setup.md`, a runbook for:
  - Creating the Cloudflare Pages `mvm` project.
  - Setting `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repository secrets.
  - Updating iwantmyname nameservers to point `gomicrovm.com` at Cloudflare.
  - Verifying the custom domain and cross-origin-isolation headers.

### Manual follow-up required

- [ ] Create the `mvm` Cloudflare Pages project (or run `npx wrangler pages project create mvm --production-branch=main` with a token that has Pages edit permission).
- [ ] Set the two repository secrets via `gh secret set` or the GitHub UI.
- [ ] Add `gomicrovm.com` as a custom domain in the Pages project.
- [ ] Replace the nameservers for `gomicrovm.com` at iwantmyname with the Cloudflare-assigned pair.
- [ ] Verify `https://gomicrovm.com/demo/weblinux/` loads with `SharedArrayBuffer` available.