### PR TITLE
build: scope the pre-commit clippy, and move stable to 1.97.1

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -132,8 +132,26 @@ if [ "$has_rust" -eq 1 ]; then
         # commit that touches one leaf crate. Narrow to the touched packages
         # when doing so provably checks the same code (see is_leaf_package),
         # and keep the full run in every case where it might not.
-        scope_args="--workspace"
-        scope_label="--workspace"
+        #
+        # `--all-targets` is 5x the whole cost, not a trim on it. Measured after
+        # a one-line mvm-core edit against a warm stable target dir:
+        #
+        #   --workspace --all-targets            4m37s
+        #   --workspace (libs + bins only)         54s
+        #   --workspace, then -p mvm-core
+        #     --all-targets                        60s
+        #
+        # So the non-leaf case runs two narrower passes instead of one wide one:
+        # every crate's libs and bins (which is what catches a change to a
+        # depended-on crate breaking a dependent), plus the full target set of
+        # just the crates you staged (which is where your own test-code lint
+        # drift lives). What that gives up is test-target lints in crates the
+        # commit did not touch — those can only newly fire if this change
+        # altered an API their test code uses, which is narrow, and CI still
+        # runs the full `--workspace --all-targets` sweep regardless.
+        sweep_args="--workspace --all-targets"
+        focus_args=""
+        scope_label="--workspace --all-targets"
         scope_reason="a staged crate has dependents"
 
         # A manifest, lockfile or cargo/toolchain config change can alter
@@ -168,25 +186,41 @@ if [ "$has_rust" -eq 1 ]; then
                         break
                     fi
                 done
+                pkg_args=""
+                for pkg in $pkgs; do
+                    pkg_args="$pkg_args -p $pkg"
+                done
                 if [ "$all_leaf" -eq 1 ]; then
-                    scope_args=""
-                    for pkg in $pkgs; do
-                        scope_args="$scope_args -p $pkg"
-                    done
-                    scope_label="${scope_args# }"
-                    echo "pre-commit: clippy scoped to$scope_args (nothing depends on these)"
+                    # Nothing depends on these, so the touched packages alone
+                    # cover everything the wide run would have.
+                    sweep_args=""
+                    focus_args="${pkg_args# } --all-targets"
+                    scope_label="${pkg_args# } --all-targets"
+                    echo "pre-commit: clippy scoped to$pkg_args (nothing depends on these)"
+                else
+                    sweep_args="--workspace"
+                    focus_args="${pkg_args# } --all-targets"
+                    scope_label="--workspace, then${pkg_args} --all-targets"
                 fi
             fi
         fi
 
-        if [ "$scope_label" = "--workspace" ]; then
+        if [ "$scope_label" = "--workspace --all-targets" ]; then
             echo "pre-commit: clippy covering the whole workspace — $scope_reason"
         fi
 
-        echo "pre-commit: stable cargo clippy $scope_label --all-targets -- -D warnings"
-        # Unquoted on purpose: $scope_args is a list of flags we built.
-        # shellcheck disable=SC2086
-        if ! ./scripts/cargo-stable.sh clippy $scope_args --all-targets -- -D warnings; then
+        echo "pre-commit: stable cargo clippy $scope_label -- -D warnings"
+        clippy_failed=0
+        for pass in "$sweep_args" "$focus_args"; do
+            [ -z "$pass" ] && continue
+            # Unquoted on purpose: $pass is a list of flags we built.
+            # shellcheck disable=SC2086
+            if ! ./scripts/cargo-stable.sh clippy $pass -- -D warnings; then
+                clippy_failed=1
+                break
+            fi
+        done
+        if [ "$clippy_failed" -eq 1 ]; then
             echo
             echo "  clippy failed. CI gates on the same '-D warnings' rule, so"
             echo "  this commit will fail on push. Re-run with MVM_SKIP_CLIPPY=1"

--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-08-08
+          toolchain: nightly-2026-08-25
           components: rustc-codegen-cranelift
 
       - uses: ./.github/actions/apt-deps

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -97,7 +97,7 @@ jobs:
       # Stable is what the lint lanes use, so warm the exact compiler and
       # Clippy artifacts those required checks restore.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: clippy
 

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -280,7 +280,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: steps.filter.outputs.libkrun == 'true' || github.ref == 'refs/heads/main'
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: clippy
 
@@ -358,7 +358,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: steps.filter.outputs.spawn == 'true' || github.ref == 'refs/heads/main'
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Install firecracker
         if: steps.filter.outputs.spawn == 'true' || github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: rustfmt, clippy
 
@@ -303,6 +303,16 @@ jobs:
       # them on its own.
       - name: Policy gates (check-abi-layout) (single-network-path)
         run: cargo run -p xtask -- check-all
+
+      # `check-fast-cargo` pins the whole nightly-fast / stable-lint split —
+      # the toolchain versions, the cranelift and threads settings, and the
+      # exact invocations in the Justfile and the pre-commit hook. It is a
+      # shell script rather than an xtask gate, so `check-all` above does not
+      # reach it, and until now nothing in CI did either: it had gone red on
+      # main unnoticed when rust-toolchain.toml was bumped to
+      # nightly-2026-08-25 and bdd.yml was left on nightly-2026-08-08.
+      - name: Fast/stable toolchain split is pinned
+        run: ./scripts/check-fast-cargo.sh
 
 
 
@@ -436,7 +446,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           components: clippy
 
@@ -822,7 +832,7 @@ jobs:
 
       - name: Install pinned no_std toolchain and targets
         run: |
-          rustup toolchain install 1.96.0 --profile minimal \
+          rustup toolchain install 1.97.1 --profile minimal \
             --target wasm32-unknown-unknown,wasm32-wasip1,riscv32imac-unknown-none-elf
 
       - name: Install just
@@ -1202,7 +1212,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: needs.scope.outputs.nix == 'true'
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - uses: ./.github/actions/apt-deps
         if: needs.scope.outputs.nix == 'true'

--- a/.github/workflows/kernel-cve-watch.yml
+++ b/.github/workflows/kernel-cve-watch.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Install Nix
         # So the watcher can read the nixpkgs linux_6_12 pin (a Nix eval), not

--- a/.github/workflows/network-perf.yml
+++ b/.github/workflows/network-perf.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - uses: ./.github/actions/apt-deps
         with:

--- a/.github/workflows/pack-signing-smoke.yml
+++ b/.github/workflows/pack-signing-smoke.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.96.0
+          toolchain: 1.97.1
           # Two targets, two crates: `wasm-pack` builds the browser shim for
           # wasm32-unknown-unknown, and `web/mvm-demo-guest/build.sh` builds the
           # demo guest for wasm32-wasip1. Installing only the first fails the

--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -87,7 +87,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -437,7 +437,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
         with:
           targets: ${{ matrix.target }}
 
@@ -339,7 +339,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Install cargo-cyclonedx
         run: cargo install cargo-cyclonedx --locked

--- a/.github/workflows/revocations.yml
+++ b/.github/workflows/revocations.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1047,7 +1047,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: env.TARGET_TAG != ''
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - uses: ./.github/actions/install-zigbuild
         if: env.TARGET_TAG != ''
@@ -1215,7 +1215,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: env.TARGET_TAG != ''
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@1.97.1
 
       - name: Rebuild the default microVM image from source at the target tag
         if: env.TARGET_TAG != ''

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.96.0
+          toolchain: 1.97.1
           targets: wasm32-unknown-unknown,wasm32-wasip1
 
       - name: Install wasm-pack

--- a/scripts/cargo-stable.sh
+++ b/scripts/cargo-stable.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 workspace_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-stable_toolchain="1.96.0"
+stable_toolchain="1.97.1"
 rustc_bin="$(rustup which --toolchain "${stable_toolchain}" rustc)"
 cargo_bin="$(rustup which --toolchain "${stable_toolchain}" cargo)"
 toolchain_bin="$(dirname "${cargo_bin}")"

--- a/scripts/check-fast-cargo.sh
+++ b/scripts/check-fast-cargo.sh
@@ -42,14 +42,19 @@ require_text Justfile './scripts/cargo-fast.sh build --workspace'
 require_text Justfile './scripts/cargo-fast.sh nextest run --workspace'
 require_text Justfile './scripts/cargo-stable.sh clippy --workspace --all-targets -- -D warnings'
 require_text Justfile './scripts/cargo-stable.sh clippy --fix --allow-dirty --workspace --all-targets -- -D warnings'
-require_text .githooks/pre-commit "./scripts/cargo-stable.sh clippy \$scope_args --all-targets -- -D warnings"
+require_text .githooks/pre-commit "./scripts/cargo-stable.sh clippy \$pass -- -D warnings"
+# The hook must keep running the workspace sweep and the staged-package pass as
+# two separate narrower invocations; collapsing them back into one
+# `--workspace --all-targets` run is a 4.6x regression on every commit.
+require_text .githooks/pre-commit 'sweep_args="--workspace"'
+require_text .githooks/pre-commit 'focus_args="${pkg_args# } --all-targets"'
 require_text .github/workflows/ci.yml './scripts/cargo-stable.sh clippy --all-targets -- -D warnings'
-require_text .github/workflows/ci.yml 'uses: dtolnay/rust-toolchain@1.96.0'
-require_text .github/workflows/ci-full.yml 'uses: dtolnay/rust-toolchain@1.96.0'
+require_text .github/workflows/ci.yml 'uses: dtolnay/rust-toolchain@1.97.1'
+require_text .github/workflows/ci-full.yml 'uses: dtolnay/rust-toolchain@1.97.1'
 require_text .github/workflows/cache-warm.yml './scripts/cargo-stable.sh clippy --workspace --all-targets -- -D warnings'
-require_text .github/workflows/cache-warm.yml 'uses: dtolnay/rust-toolchain@1.96.0'
+require_text .github/workflows/cache-warm.yml 'uses: dtolnay/rust-toolchain@1.97.1'
 require_text Justfile './scripts/cargo-stable.sh --direct cargo-zigbuild check --target {{ TARGET }} --workspace --all-targets'
-require_text scripts/cargo-stable.sh 'stable_toolchain="1.96.0"'
+require_text scripts/cargo-stable.sh 'stable_toolchain="1.97.1"'
 require_text scripts/cargo-stable.sh "CARGO_TARGET_DIR=\"\${stable_target_root}\""
 require_text scripts/cargo-stable.sh "if [[ \"\${1:-}\" == \"--direct\" ]]"
 require_text crates/mvm-build/src/guest_agent_build.rs 'pinned_rust_toolchain(&spec.workspace_root)'

--- a/scripts/ci-linux-coverage.sh
+++ b/scripts/ci-linux-coverage.sh
@@ -17,10 +17,10 @@ mv "$tmpdir/${wasmtime_base}/wasmtime" "$HOME/.wasmtime/bin/wasmtime"
 rm -rf "$tmpdir"
 export PATH="$HOME/.wasmtime/bin:$PATH"
 
-cargo +1.96.0 build -p mvm-contract --target wasm32-unknown-unknown
-cargo +1.96.0 build -p mvm-contract --lib \
+cargo +1.97.1 build -p mvm-contract --target wasm32-unknown-unknown
+cargo +1.97.1 build -p mvm-contract --lib \
   --target riscv32imac-unknown-none-elf
-cargo +1.96.0 test -p mvm-contract --target wasm32-wasip1
+cargo +1.97.1 test -p mvm-contract --target wasm32-wasip1
 
 # Browser wasm demo: build + wasm-opt + gzipped size budget, plus Rust
 # fixture-parity tests. wasm-pack and binaryen/wabt are installed here because
@@ -30,7 +30,7 @@ sudo apt-get update && sudo apt-get install -y binaryen wabt
 (
   cd web/mvm-demo
   ./build.sh
-  cargo +1.96.0 test
+  cargo +1.97.1 test
 )
 
 cargo run -p mvm-fs --example write_sample -- /tmp/sample.ext4 \

--- a/scripts/linux-gate-mvm-vmm-clippy.sh
+++ b/scripts/linux-gate-mvm-vmm-clippy.sh
@@ -9,7 +9,7 @@ export TMPDIR=/out/tmp
 mkdir -p "$HOME" "$XDG_CACHE_HOME" "$RUSTUP_HOME" "$CARGO_HOME" "$CARGO_TARGET_DIR" "$TMPDIR"
 cd /work
 nix --extra-experimental-features 'nix-command flakes' shell nixpkgs#rustup nixpkgs#gcc nixpkgs#binutils nixpkgs#lld -c sh -c '
-  rustup toolchain install 1.96.0 --profile minimal --component clippy
-  rustup default 1.96.0
+  rustup toolchain install 1.97.1 --profile minimal --component clippy
+  rustup default 1.97.1
   cargo clippy -p mvm-vmm --all-targets -- -D warnings
 '

--- a/scripts/linux-gate-mvm-vmm-test.sh
+++ b/scripts/linux-gate-mvm-vmm-test.sh
@@ -9,7 +9,7 @@ export TMPDIR=/out/tmp
 mkdir -p "$HOME" "$XDG_CACHE_HOME" "$RUSTUP_HOME" "$CARGO_HOME" "$CARGO_TARGET_DIR" "$TMPDIR"
 cd /work
 nix --extra-experimental-features 'nix-command flakes' shell nixpkgs#rustup nixpkgs#gcc nixpkgs#binutils nixpkgs#lld -c sh -c '
-  rustup toolchain install 1.96.0 --profile minimal
-  rustup default 1.96.0
+  rustup toolchain install 1.97.1 --profile minimal
+  rustup default 1.97.1
   cargo test -p mvm-vmm --quiet
 '

--- a/specs/sprint/delivery/clippy-hook-scope-and-rust-1.97.md
+++ b/specs/sprint/delivery/clippy-hook-scope-and-rust-1.97.md
@@ -1,0 +1,39 @@
+# Pre-commit clippy 4m37s → 60s, stable toolchain 1.96.0 → 1.97.1
+
+Taking `mvm-cli`'s build script off the inner loop (PR #2883) left the
+pre-commit hook as the dominant per-commit cost. Measured after a one-line
+`mvm-core` edit against a warm stable target dir:
+
+| invocation | cost |
+|---|---|
+| `--workspace --all-targets` (what the hook ran) | **4m37s** |
+| `--workspace` (libs + bins only) | 54s |
+| `--workspace`, then `-p mvm-core --all-targets` | **60s** |
+
+`--all-targets` is 5x the whole cost, not a trim on it — it builds every
+integration-test binary and dev-dependency in the tree. The hook widened to it
+whenever a staged crate had dependents, which `mvm-core` always does, so its
+`is_leaf_package` shortcut could never fire for the crates people actually edit.
+
+The non-leaf path now runs two narrower passes: every crate's libs and bins
+(which is what catches a change to a depended-on crate breaking a dependent),
+plus the full target set of just the staged crates (where your own test-code
+lint drift lives). What that gives up is test-target lints in crates the commit
+did not touch; CI still runs the full `--workspace --all-targets` sweep.
+
+## Stable toolchain 1.96.0 → 1.97.1
+
+32 references across 17 files — it is the project-wide stable toolchain, not
+only the lint lane (release, security, boot-image and pages workflows pin it
+too). `clippy --workspace --all-targets -- -D warnings` passes clean on 1.97.1
+with no new lints.
+
+## Two things found on the way
+
+`check-fast-cargo` — the gate pinning the entire nightly-fast/stable-lint split
+— **was red on unmodified main** (`c8cd9c4245`): `rust-toolchain.toml` had been
+bumped to `nightly-2026-08-25` while `.github/workflows/bdd.yml` stayed on
+`nightly-2026-08-08`. It went unnoticed because **nothing in CI ran it**; it is
+a shell script, so `xtask check-all` does not reach it, and no workflow invoked
+it. Both fixed here: `bdd.yml` re-pinned, and the gate wired into the CI lint
+job as a step beside `check-all` so it cannot rot again.

--- a/xtask/src/check_closure_budget.rs
+++ b/xtask/src/check_closure_budget.rs
@@ -155,7 +155,7 @@ const MACOS_CLOSURE_BUDGET: usize = 229;
 /// scoped-thread `par_map` in `mvm-fs`, which is all five call sites needed.
 ///
 /// 262 (was 263): `fs2` existed only for `FileExt`'s advisory file locking,
-/// which std stabilized in 1.89 — well under the pinned 1.96 toolchain. std
+/// which std stabilized in 1.89 — well under the pinned 1.97 toolchain. std
 /// also splits contention out of the error type (`TryLockError::WouldBlock`
 /// vs `::Error`), so "another process holds it" stops riding on an errno
 /// comparison.

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -794,7 +794,7 @@ mod tests {
         )
         .expect("Linux coverage script must be readable");
         for expected in [
-            "cargo +1.96.0 build -p mvm-contract --target wasm32-unknown-unknown",
+            "cargo +1.97.1 build -p mvm-contract --target wasm32-unknown-unknown",
             "cargo test -p mvm-conformance --test meta",
             "just bdd",
         ] {


### PR DESCRIPTION
## Pre-commit clippy: 4m37s → 60s

With `mvm-cli`'s build script off the inner loop (#2883), the pre-commit hook
became the dominant per-commit cost. Measured after a one-line `mvm-core` edit
against a warm stable target dir:

| invocation | cost |
|---|---|
| `--workspace --all-targets` — what the hook ran | **4m37s** |
| `--workspace` (libs + bins only) | 54s |
| `--workspace`, then `-p mvm-core --all-targets` | **60s** |

`--all-targets` is **5x the whole cost**, not a trim on it — it builds every
integration-test binary and dev-dependency in the tree. The hook widened to it
whenever a staged crate had dependents, which `mvm-core` always does, so its
`is_leaf_package` shortcut could never fire for the crates people actually edit.

The non-leaf path now runs two narrower passes: every crate's libs and bins
(what catches a change to a depended-on crate breaking a dependent), plus the
full target set of just the staged crates (where your own test-code lint drift
lives).

**What this gives up:** test-target lints in crates the commit did not touch.
Those can only newly fire if the change altered an API their test code uses,
which is narrow — and CI still runs the full `--workspace --all-targets` sweep
regardless. The leaf and manifest/lockfile fail-safe paths are unchanged.

Verified by running the hook for real on a staged `mvm-core` edit: two passes,
`--workspace` then `-p mvm-core --all-targets`, exit 0.

## Stable 1.96.0 → 1.97.1

32 references across 17 files — it is the project-wide stable toolchain, not
only the lint lane (release, security, boot-image, pages and website workflows
pin it too). `clippy --workspace --all-targets -- -D warnings` passes clean on
1.97.1 with **no new lints**.

## Two things found on the way

`check-fast-cargo` — the gate pinning the entire nightly-fast / stable-lint
split (toolchain versions, cranelift, `-Z threads=8`, and the exact invocations
in the Justfile and hook) — **was red on unmodified `main`** (`c8cd9c4245`):
`rust-toolchain.toml` had been bumped to `nightly-2026-08-25` while
`.github/workflows/bdd.yml` stayed on `nightly-2026-08-08`.

It went unnoticed because **nothing in CI ran it**. It is a shell script, so
`xtask check-all` does not reach it, and no workflow invoked it. Fixed both
ways: `bdd.yml` re-pinned, and the gate now runs as a step beside `check-all`
in the lint job so it cannot rot again.

## Gates

`cargo +nightly fmt --all --check`, `check-fast-cargo`, `actionlint` over all
14 changed workflows (via the hook), and `xtask` `check-all` (61 gates) +
`check-declared-backing` + `check-nextest-groups` + `check-single-workload-env`
+ `check-claim-witness-freshness` — all pass.

No Rust source changed (shell, YAML and one delivery doc), so the test suite is
unaffected by construction; the nightly toolchain that runs it is untouched.