### PR TITLE
Build the site QEMU-WASM pack on boot-image tags

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -56,17 +56,38 @@ jobs:
       - name: Install binaryen (wasm-opt)
         run: sudo apt-get update && sudo apt-get install -y binaryen
 
-      - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-        with:
-          determinate: false
-          extra-conf: |
-            extra-system-paths = /usr/bin
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
 
-      - name: Build weblinux demo assets
+      - name: Download verified WebLinux runtime pack
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_IDENTITY_REGEXP: "^https://github.com/${{ github.repository }}/.github/workflows/release-boot-image.yml@refs/tags/boot-image/v.*$"
+          COSIGN_OIDC_ISSUER: "https://token.actions.githubusercontent.com"
         run: |
-          nix build ./nix#qemu-wasm-smoke-pack
-          ./web/weblinux-demo/build.sh result
+          set -euo pipefail
+          BOOT_TAG="$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
+            --json tagName --jq -r '
+              [ .[].tagName
+                | select(test("^boot-image/v[0-9]+\\.[0-9]+\\.[0-9]+$"))
+                | {tag: ., v: (ltrimstr("boot-image/v") | split(".") | map(tonumber))} ]
+              | sort_by(.v) | last | .tag // empty')"
+          if [ -z "${BOOT_TAG}" ]; then
+            echo "::error::no boot-image/v* release contains the WebLinux runtime pack" >&2
+            exit 1
+          fi
+          gh release download "${BOOT_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern 'qemu-wasm-smoke-pack.tar.gz*'
+          cosign verify-blob \
+            --bundle qemu-wasm-smoke-pack.tar.gz.sha256.bundle \
+            --certificate-identity-regexp "${COSIGN_IDENTITY_REGEXP}" \
+            --certificate-oidc-issuer "${COSIGN_OIDC_ISSUER}" \
+            qemu-wasm-smoke-pack.tar.gz.sha256
+          sha256sum -c qemu-wasm-smoke-pack.tar.gz.sha256
+          mkdir qemu-wasm-smoke-pack
+          tar -xzf qemu-wasm-smoke-pack.tar.gz -C qemu-wasm-smoke-pack
+          ./web/weblinux-demo/build.sh qemu-wasm-smoke-pack
 
       - name: Build wasm demo
         working-directory: web/mvm-demo

--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -735,9 +735,41 @@ jobs:
             staging/default-microvm-${{ matrix.arch }}.sbom.txt
             staging/default-microvm-${{ matrix.arch }}-checksums-sha256.txt
 
+  # Browser QEMU is an immutable runtime pack, not a website build input. Build
+  # it on the boot-image release cadence so a docs-only publish only downloads
+  # and verifies these bytes instead of compiling QEMU through Emscripten again.
+  qemu-wasm-site-pack:
+    if: ${{ github.event_name == 'push' || github.event.inputs.dry_run == 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Build QEMU-WASM browser pack
+        run: |
+          set -euo pipefail
+          nix build ./nix#qemu-wasm-smoke-pack
+          mkdir -p staging
+          tar -C result -czf staging/qemu-wasm-smoke-pack.tar.gz .
+          (
+            cd staging
+            sha256sum qemu-wasm-smoke-pack.tar.gz \
+              > qemu-wasm-smoke-pack.tar.gz.sha256
+          )
+
+      - name: Upload QEMU-WASM browser pack
+        uses: actions/upload-artifact@v7
+        with:
+          name: qemu-wasm-site-pack
+          path: |
+            staging/qemu-wasm-smoke-pack.tar.gz
+            staging/qemu-wasm-smoke-pack.tar.gz.sha256
+
   publish-boot-image:
-    needs: [builder-vm-image, runtime-overlay-image, sdk-sidecar-image, default-microvm]
-    # `!cancelled()` rather than plain success: the four image jobs are
+    needs: [builder-vm-image, runtime-overlay-image, sdk-sidecar-image, default-microvm, qemu-wasm-site-pack]
+    # `!cancelled()` rather than plain success: the five image jobs are
     # independent artifacts and one arch's Nix build failing must not strand
     # the others, exactly as it does not strand the binary release next door.
     # It reaches this job so the completeness check below can name every
@@ -788,6 +820,7 @@ jobs:
           for blob in \
             artifacts/runtime-overlay-*.tar.gz \
             artifacts/sdk-sidecar-*.tar.gz \
+            artifacts/qemu-wasm-smoke-pack.tar.gz.sha256 \
             artifacts/builder-vm-*-checksums-sha256.txt \
             artifacts/default-microvm-*-checksums-sha256.txt; do
             cosign sign-blob \
@@ -824,6 +857,11 @@ jobs:
               [ -s "artifacts/${f}" ] || missing+=("${f}")
             done
           done
+          for f in \
+            qemu-wasm-smoke-pack.tar.gz \
+            qemu-wasm-smoke-pack.tar.gz.sha256; do
+            [ -s "artifacts/${f}" ] || missing+=("${f}")
+          done
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::boot image release is incomplete — refusing to publish. Missing: ${missing[*]}" >&2
             echo "Re-run the failed image job(s); the successful ones are already uploaded as run artifacts." >&2
@@ -857,6 +895,9 @@ jobs:
             artifacts/sdk-sidecar-*.tar.gz
             artifacts/sdk-sidecar-*.tar.gz.sha256
             artifacts/sdk-sidecar-*.tar.gz.bundle
+            artifacts/qemu-wasm-smoke-pack.tar.gz
+            artifacts/qemu-wasm-smoke-pack.tar.gz.sha256
+            artifacts/qemu-wasm-smoke-pack.tar.gz.sha256.bundle
             artifacts/default-microvm-vmlinux-*
             artifacts/default-microvm-rootfs-*
             artifacts/default-microvm-meta-*

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ nix/images/dev-prebuilt/
 # Worktree-local dev env (use .envrc.example as template)
 /.envrc
 /.codex/
+/.wrangler/
 /.codex-transfer/
 /.mvm-test/
 # Ad-hoc parallel-session isolation dirs (MVM_CACHE_DIR / MVM_DATA_DIR pointed

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -7,8 +7,10 @@ Last updated: 2026-08-26
       `specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md`.
       The browser QEMU pack now builds on the `boot-image/v*` release cadence;
       Cloudflare Pages consumes the signed, checksummed release artifact while
-      retaining the current revision's demo shell. Workflow contracts,
-      actionlint, workspace tests/check/doctests, and Clippy are green.
+      retaining the current revision's demo shell. Its oversized WASM module is
+      staged as an explicitly decompressed gzip payload so it fits Cloudflare's
+      per-file limit. Workflow contracts, actionlint, workspace
+      tests/check/doctests, and Clippy are green.
 
 - [x] **AI egress metering and token budgets** —
       `specs/plans/2026-08-21-ai-egress-metering-and-budget.md`.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -3,6 +3,13 @@
 Last updated: 2026-08-26
 ## Completed
 
+- [x] **Site QEMU-WASM release artifact** —
+      `specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md`.
+      The browser QEMU pack now builds on the `boot-image/v*` release cadence;
+      Cloudflare Pages consumes the signed, checksummed release artifact while
+      retaining the current revision's demo shell. Workflow contracts,
+      actionlint, workspace tests/check/doctests, and Clippy are green.
+
 - [x] **AI egress metering and token budgets** —
       `specs/plans/2026-08-21-ai-egress-metering-and-budget.md`.
       Provider-reported token counts (OpenAI + Anthropic) at the host

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -15,8 +15,10 @@
       Move the expensive browser QEMU pack build from every Cloudflare Pages
       deployment to the `boot-image/v*` release train. Pages downloads the
       latest semantic-versioned pack and verifies its keyless release identity
-      and checksum before staging the current demo shell. Workflow contracts,
-      actionlint, workspace tests/check/doctests, and Clippy are green.
+      and checksum before staging the current demo shell. The staged QEMU WASM
+      is explicitly gzip-compressed below Cloudflare Pages' per-file limit and
+      decompressed by the browser worker. Workflow contracts, actionlint,
+      workspace tests/check/doctests, and Clippy are green.
 
 - [x] **AI egress metering and token budgets.**
       `specs/plans/2026-08-21-ai-egress-metering-and-budget.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,14 @@
 
 ## In progress
 
+- [x] **Site QEMU-WASM release artifact.**
+      `specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md`.
+      Move the expensive browser QEMU pack build from every Cloudflare Pages
+      deployment to the `boot-image/v*` release train. Pages downloads the
+      latest semantic-versioned pack and verifies its keyless release identity
+      and checksum before staging the current demo shell. Workflow contracts,
+      actionlint, workspace tests/check/doctests, and Clippy are green.
+
 - [x] **AI egress metering and token budgets.**
       `specs/plans/2026-08-21-ai-egress-metering-and-budget.md`.
       Provider-reported token counts at the host substitution endpoint,

--- a/specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md
+++ b/specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md
@@ -19,6 +19,8 @@ JavaScript shell remains sourced from the deploying revision.
       and safe staging through the existing WebLinux demo script.
 - [x] Add a workflow contract test that prevents Pages from rebuilding QEMU or
       accepting an unsigned pack.
+- [x] Compress the staged QEMU WebAssembly module below Cloudflare Pages'
+      25 MiB per-file limit and explicitly decompress it in the browser worker.
 - [x] Pass the focused release-assets suite, actionlint, workspace tests,
       workspace check, and Clippy with warnings denied.
 
@@ -31,3 +33,5 @@ JavaScript shell remains sourced from the deploying revision.
   fallback build or unsigned compatibility path.
 - The archive is produced from the tagged Nix derivation and is never rebuilt
   from an unrelated site revision.
+- The worker decompresses the staged gzip payload into `Module.wasmBinary`
+  before Emscripten starts, independent of CDN content-encoding behavior.

--- a/specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md
+++ b/specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md
@@ -1,0 +1,33 @@
+# Site QEMU-WASM release artifact
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+## Goal
+
+Keep Cloudflare Pages deployments fast by building the immutable QEMU-WASM
+runtime pack on the `boot-image/v*` release cadence, then downloading and
+verifying that pack during each site deployment. The website's HTML and
+JavaScript shell remains sourced from the deploying revision.
+
+## Tasks
+
+- [x] Add a `qemu-wasm-site-pack` job to the boot-image workflow and publish
+      its archive, checksum, and keyless-signature bundle.
+- [x] Replace the Pages workflow's Nix/QEMU build with latest-semver boot-image
+      asset selection, release-identity verification, checksum verification,
+      and safe staging through the existing WebLinux demo script.
+- [x] Add a workflow contract test that prevents Pages from rebuilding QEMU or
+      accepting an unsigned pack.
+- [x] Pass the focused release-assets suite, actionlint, workspace tests,
+      workspace check, and Clippy with warnings denied.
+
+## Security invariants
+
+- Site deployment verifies the checksum manifest against the
+  `release-boot-image.yml@refs/tags/boot-image/v*` keyless identity before
+  trusting the archive digest.
+- A missing, unsigned, or digest-mismatched pack fails deployment; there is no
+  fallback build or unsigned compatibility path.
+- The archive is produced from the tagged Nix derivation and is never rebuilt
+  from an unrelated site revision.

--- a/specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md
+++ b/specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md
@@ -21,6 +21,7 @@ JavaScript shell remains sourced from the deploying revision.
       accepting an unsigned pack.
 - [x] Compress the staged QEMU WebAssembly module below Cloudflare Pages'
       25 MiB per-file limit and explicitly decompress it in the browser worker.
+- [x] Ignore Wrangler's repository-local cache and account metadata.
 - [x] Pass the focused release-assets suite, actionlint, workspace tests,
       workspace check, and Clippy with warnings denied.
 

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -630,6 +630,24 @@ fn qemu_wasm_site_pack_is_built_once_on_the_boot_image_train() {
     );
 }
 
+#[test]
+fn weblinux_qemu_module_is_staged_below_the_pages_file_limit() {
+    let build =
+        fs::read_to_string("web/weblinux-demo/build.sh").expect("read WebLinux build script");
+    let worker = fs::read_to_string("web/weblinux-demo/worker.js").expect("read WebLinux worker");
+
+    assert!(
+        build.contains("gzip -9 -n \"$DEST_DIR/qemu-system-x86_64.wasm\""),
+        "the oversized QEMU-WASM module must be compressed while staging"
+    );
+    assert!(
+        worker.contains("qemu-system-x86_64.wasm.gz")
+            && worker.contains("new DecompressionStream(\"gzip\")")
+            && worker.contains("self.Module.wasmBinary = await loadCompressedWasm()"),
+        "the worker must explicitly decompress the staged module before Emscripten starts"
+    );
+}
+
 /// The compiled-in boot image tag must name the release the workflow creates.
 ///
 /// The tag is spliced straight into a download URL, so a drift between the two

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -112,8 +112,12 @@ fn the_release_job_attaches_the_sdk_sidecar_assets() {
         boot_image.contains("  sdk-sidecar-image:"),
         "release-boot-image.yml must define the sdk-sidecar-image job"
     );
+    let publish_needs = job_block(&boot_image, "publish-boot-image")
+        .lines()
+        .find(|line| line.trim_start().starts_with("needs:"))
+        .expect("the boot image publish job must declare its dependencies");
     assert!(
-        boot_image.contains("sdk-sidecar-image, default-microvm]"),
+        publish_needs.contains("sdk-sidecar-image"),
         "the boot image publish job must declare the sdk-sidecar-image job in its needs"
     );
     // Both releases attach it for now: the download side still composes its URL
@@ -568,6 +572,61 @@ fn pages_workflow_installs_every_wasm_target_used_by_the_demo() {
     assert!(
         workflow.contains("targets: wasm32-unknown-unknown, wasm32-wasip1"),
         "pages.yml must install both the browser and guest WASM targets"
+    );
+}
+
+#[test]
+fn qemu_wasm_site_pack_is_built_once_on_the_boot_image_train() {
+    let boot_image = boot_image_workflow();
+    let pages = pages_workflow();
+    let publish_needs = job_block(&boot_image, "publish-boot-image")
+        .lines()
+        .find(|line| line.trim_start().starts_with("needs:"))
+        .expect("the boot image publish job must declare its dependencies");
+
+    assert!(
+        boot_image.contains("\n  qemu-wasm-site-pack:\n"),
+        "release-boot-image.yml must build the browser QEMU pack on the boot-image tag"
+    );
+    assert!(
+        boot_image.contains("nix build ./nix#qemu-wasm-smoke-pack"),
+        "the boot-image workflow must build the QEMU-WASM pack from the tagged tree"
+    );
+    assert!(
+        publish_needs.contains("qemu-wasm-site-pack"),
+        "the boot-image release must wait for the QEMU-WASM pack before publishing"
+    );
+    for asset in [
+        "qemu-wasm-smoke-pack.tar.gz",
+        "qemu-wasm-smoke-pack.tar.gz.sha256",
+        "qemu-wasm-smoke-pack.tar.gz.sha256.bundle",
+    ] {
+        assert!(
+            boot_image.contains(asset),
+            "the boot-image release must publish {asset} for site deployments"
+        );
+        assert!(
+            pages.contains(asset),
+            "pages.yml must download and verify {asset} instead of rebuilding QEMU"
+        );
+    }
+    assert!(
+        !pages.contains("nix build ./nix#qemu-wasm-smoke-pack"),
+        "site deployment must not rebuild the tagged QEMU-WASM pack"
+    );
+    assert!(
+        !pages.contains("nix-installer-action"),
+        "site deployment no longer needs Nix once the QEMU-WASM pack is released"
+    );
+    assert!(
+        pages.contains("cosign verify-blob")
+            && pages.contains("release-boot-image.yml@refs/tags/boot-image/v.*")
+            && pages.contains("sha256sum -c qemu-wasm-smoke-pack.tar.gz.sha256"),
+        "site deployment must verify the tag-built pack's release identity"
+    );
+    assert!(
+        pages.contains("./web/weblinux-demo/build.sh qemu-wasm-smoke-pack"),
+        "site deployment must stage the verified pack with the current demo shell"
     );
 }
 

--- a/web/weblinux-demo/build.sh
+++ b/web/weblinux-demo/build.sh
@@ -43,6 +43,13 @@ cp "$SCRIPT_DIR/index.html" "$DEST_DIR/index.html"
 cp "$SCRIPT_DIR/demo.js" "$DEST_DIR/demo.js"
 cp "$SCRIPT_DIR/worker.js" "$DEST_DIR/worker.js"
 
+# Cloudflare Pages rejects individual files larger than 25 MiB. The QEMU
+# module is larger uncompressed but comfortably fits once gzipped. Keep the
+# compressed suffix because the worker deliberately decompresses it before
+# handing the bytes to Emscripten; this does not depend on CDN content-encoding
+# behavior.
+gzip -9 -n "$DEST_DIR/qemu-system-x86_64.wasm"
+
 # The standalone index.html is also kept in the destination so the demo can
 # be served directly (e.g. with web/weblinux-demo/serve.py) without Astro.
 # Astro's src/pages/demo/weblinux.astro renders the same HTML with COOP/COEP

--- a/web/weblinux-demo/worker.js
+++ b/web/weblinux-demo/worker.js
@@ -41,6 +41,20 @@ function postError(error) {
   console.error("DEMO-RESULT: ERROR", error);
 }
 
+async function loadCompressedWasm() {
+  if (typeof DecompressionStream !== "function") {
+    throw new Error("this browser does not support gzip decompression streams");
+  }
+
+  const response = await fetch(`${baseUrl}qemu-system-x86_64.wasm.gz`);
+  if (!response.ok || !response.body) {
+    throw new Error(`failed to load compressed QEMU-WASM module (${response.status})`);
+  }
+
+  const decompressed = response.body.pipeThrough(new DecompressionStream("gzip"));
+  return new Response(decompressed).arrayBuffer();
+}
+
 // Minimal xterm.js-shaped object that lets xterm-pty's Master route output to
 // the UI and accept injected input from the main thread.
 function createFakeTerminal() {
@@ -154,6 +168,9 @@ self.onmessage = async (event) => {
         streamOps.poll = (stream, _timeout) => oldPoll.call(streamOps, stream, 0);
       }
     }, 10);
+
+    postStatus("loading engine");
+    self.Module.wasmBinary = await loadCompressedWasm();
 
     postStatus("initializing engine");
     const engineModule = await import(`${baseUrl}qemu-system-x86_64.js`);


### PR DESCRIPTION
## Summary

- build and publish the browser QEMU-WASM runtime pack on `boot-image/v*` releases
- download and verify the signed pack during Pages deployments instead of rebuilding QEMU with Nix
- gzip the 44.4 MiB QEMU module below Cloudflare Pages’ 25 MiB file limit and explicitly decompress it in the worker
- retain the current revision’s WebLinux demo shell and add workflow contract coverage
- ignore Wrangler’s repository-local cache and account metadata

## Validation

- `cargo test --test release_assets` (27 passed)
- `actionlint .github/workflows/pages.yml .github/workflows/release-boot-image.yml`
- `node --check web/weblinux-demo/worker.js`
- `git check-ignore -v .wrangler/cache/pages.json`
- pre-commit workspace Clippy/check gates
- live Cloudflare Playwright boot: `Status: ready`, `DEMO-RESULT: READY`, `crossOriginIsolated: true`, no browser errors