### PR TITLE
perf(kernel): stop hashing the workload kernel twice on every boot

### DIFF
--- a/crates/mvm-build/src/kernel_fetch.rs
+++ b/crates/mvm-build/src/kernel_fetch.rs
@@ -135,7 +135,14 @@ fn verify_cached_kernel(kernel: &Path) -> Result<VerifiedKernel, KernelFetchErro
         }
     };
 
-    let actual = compute_file_sha256(kernel)?;
+    // Through the size+mtime-keyed digest cache, not a raw re-read. This check
+    // runs on every kernel resolve, so on an unchanged cached kernel it was
+    // re-reading the whole image once per launch to recompute a digest that
+    // cannot have changed. The rootfs pin backing claim 8 already reads its
+    // (far larger) image through this same cache for the same reason; any
+    // rewrite of the file moves its size or mtime and forces a re-hash, so a
+    // stale digest cannot be adopted here either.
+    let actual = mvm_core::crypto::image_verify::sha256_file_cached(kernel)?;
     if actual != expected {
         evict_kernel(kernel);
         return Err(KernelFetchError::HashMismatch { expected, actual });
@@ -143,13 +150,29 @@ fn verify_cached_kernel(kernel: &Path) -> Result<VerifiedKernel, KernelFetchErro
     Ok(VerifiedKernel(kernel.to_path_buf()))
 }
 
-/// Remove a rejected kernel, its sidecar, and its optional resolved config.
-/// Removing only part of the entry can leave stale capability metadata beside
-/// the replacement, or let a poisoned artifact be re-adopted.
+/// Every file that belongs to a cached kernel entry, in deletion order.
+///
+/// One definition because a kernel is evicted from more than one place, and a
+/// caller that lists the set itself drifts: removing only part of the entry can
+/// leave stale capability metadata beside the replacement, or let a poisoned
+/// artifact be re-adopted under a digest nothing re-derived.
+#[must_use]
+pub fn kernel_entry_files(kernel: &Path) -> Vec<PathBuf> {
+    vec![
+        kernel.to_path_buf(),
+        kernel_digest_sidecar(kernel),
+        kernel.with_file_name("config"),
+        // Keyed on the evicted file's size+mtime, so an orphan can be served to
+        // a replacement that happens to land on the same pair.
+        mvm_core::crypto::image_verify::sha256_cache_path(kernel),
+    ]
+}
+
+/// Remove a rejected kernel and everything else in its entry, best-effort.
 fn evict_kernel(kernel: &Path) {
-    let _ = std::fs::remove_file(kernel);
-    let _ = std::fs::remove_file(kernel_digest_sidecar(kernel));
-    let _ = std::fs::remove_file(kernel.with_file_name("config"));
+    for path in kernel_entry_files(kernel) {
+        let _ = std::fs::remove_file(path);
+    }
 }
 
 /// How a kernel pin resolves to a concrete `vmlinux` for a given backend.
@@ -368,6 +391,59 @@ mod tests {
                 KernelResolution::Cached(v) => assert_eq!(v.path(), kernel),
                 other => panic!("expected a verified hit, got {other:?}"),
             }
+        }
+
+        /// This check runs on every kernel resolve, so on an unchanged cached
+        /// kernel it must not re-read the whole image to recompute a digest
+        /// that cannot have changed. Asserted by the shared digest cache being
+        /// warm afterwards: a raw re-read leaves no entry behind.
+        #[test]
+        fn serving_a_pinned_kernel_leaves_its_digest_cache_warm() {
+            use mvm_core::crypto::image_verify::{DigestSource, sha256_file_cached_with_source};
+
+            let _env = env_guard();
+            let dir = tempfile::tempdir().unwrap();
+            let kernel = staged(dir.path(), b"kernel bytes", true);
+
+            assert!(matches!(
+                resolve_kernel(dir.path(), "aarch64", "workload", true),
+                KernelResolution::Cached(_)
+            ));
+
+            let (_, source) = sha256_file_cached_with_source(&kernel).unwrap();
+            assert_eq!(
+                source,
+                DigestSource::Sidecar,
+                "the pin check must digest through the shared cache, not re-read the image"
+            );
+        }
+
+        /// The digest cache is keyed on the evicted file's size+mtime, so an
+        /// orphan left behind can be served to a replacement that lands on the
+        /// same pair — vouching for bytes nothing re-derived.
+        #[test]
+        fn evicting_a_kernel_removes_its_digest_cache() {
+            let _env = env_guard();
+            let dir = tempfile::tempdir().unwrap();
+            let kernel = staged(dir.path(), b"kernel bytes", true);
+            // Warm the cache, then corrupt the pin so the next resolve evicts.
+            assert!(matches!(
+                resolve_kernel(dir.path(), "aarch64", "workload", true),
+                KernelResolution::Cached(_)
+            ));
+            let cache = mvm_core::crypto::image_verify::sha256_cache_path(&kernel);
+            assert!(cache.is_file(), "cache must be warm before the eviction");
+            std::fs::write(kernel_digest_sidecar(&kernel), "0".repeat(64)).unwrap();
+
+            assert!(!matches!(
+                resolve_kernel(dir.path(), "aarch64", "workload", true),
+                KernelResolution::Cached(_)
+            ));
+            assert!(!kernel.exists(), "the rejected kernel must be gone");
+            assert!(
+                !cache.exists(),
+                "its digest cache must go with it, not outlive the bytes it names"
+            );
         }
 
         #[test]

--- a/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/default_microvm.rs
@@ -195,11 +195,7 @@ pub(crate) fn assert_workload_kernel_supports_verity(kernel_path: &str) -> Resul
 }
 
 pub(super) fn evict_incompatible_workload_kernel(kernel: &std::path::Path) -> Result<()> {
-    for path in [
-        kernel.to_path_buf(),
-        mvm_build::kernel_fetch::kernel_digest_sidecar(kernel),
-        kernel.with_file_name("config"),
-    ] {
+    for path in mvm_build::kernel_fetch::kernel_entry_files(kernel) {
         match std::fs::remove_file(&path) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}

--- a/crates/mvm-core/src/crypto/image_verify.rs
+++ b/crates/mvm-core/src/crypto/image_verify.rs
@@ -449,7 +449,7 @@ pub fn sha256_file_cached_with_source(path: &Path) -> io::Result<(String, Digest
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_nanos());
 
-    let sidecar = sha256_sidecar_path(path);
+    let sidecar = sha256_cache_path(path);
     if let Some(mtime) = mtime_nanos
         && let Ok(contents) = fs::read_to_string(&sidecar)
         && let Some(hex) = parse_sha256_sidecar(&contents, size, mtime)
@@ -464,7 +464,13 @@ pub fn sha256_file_cached_with_source(path: &Path) -> io::Result<(String, Digest
     Ok((hex, DigestSource::Hashed(size)))
 }
 
-fn sha256_sidecar_path(path: &Path) -> std::path::PathBuf {
+/// Where [`sha256_file_cached`] keeps `path`'s digest.
+///
+/// Public because whoever *deletes* an artifact has to delete this beside it.
+/// The entry is keyed on the file's size+mtime, so an orphaned sidecar can be
+/// served to a replacement that lands on the same pair.
+#[must_use]
+pub fn sha256_cache_path(path: &Path) -> std::path::PathBuf {
     let mut s = path.as_os_str().to_os_string();
     s.push(".sha256cache");
     std::path::PathBuf::from(s)
@@ -503,7 +509,7 @@ mod tests {
         f.write_all(b"hello").expect("write");
         f.flush().expect("flush");
         let p = f.path().to_path_buf();
-        let sidecar = sha256_sidecar_path(&p);
+        let sidecar = sha256_cache_path(&p);
 
         let direct = sha256_file(&p).expect("direct hash");
         // First cached call computes + writes the sidecar.
@@ -537,7 +543,7 @@ mod tests {
         f.write_all(body).expect("write");
         f.flush().expect("flush");
         let p = f.path().to_path_buf();
-        let sidecar = sha256_sidecar_path(&p);
+        let sidecar = sha256_cache_path(&p);
         let _ = fs::remove_file(&sidecar);
 
         let (miss, miss_source) = sha256_file_cached_with_source(&p).expect("cached miss");

--- a/crates/mvm-vmm/src/host/fc_kernel.rs
+++ b/crates/mvm-vmm/src/host/fc_kernel.rs
@@ -111,14 +111,22 @@ pub fn ensure_fc_loadable_kernel(path: &Path) -> Result<PathBuf> {
 
 /// Identifies the exact `vmlinux` an extracted ELF came from.
 ///
-/// Filesystems exposed through a builder or shared-volume boundary may report
-/// timestamps at one-second resolution. A same-sized kernel replacement can
-/// therefore retain the same `(length, mtime)` pair and must not reuse an ELF
-/// extracted from the previous bytes. Hashing is deliberate here: serving a
-/// stale kernel would cross the verified-kernel seam, while the caller invokes
-/// this only during kernel preparation.
+/// The stamp is the kernel's content digest, so replacing `vmlinux` — a
+/// rebuild, a re-fetch — never reuses an ELF extracted from the previous bytes.
+/// Serving a stale kernel would cross the verified-kernel seam.
+///
+/// The digest is obtained through the shared size+mtime-keyed cache rather than
+/// by re-reading the image. The caller that resolved this kernel just verified
+/// the same bytes against their recorded pin through that same cache, so an
+/// unconditional read here was hashing one multi-MB image twice per boot to
+/// reach a value already computed. The two now share one entry and one hash per
+/// kernel change. What that trades away is the one case a raw re-read still
+/// caught: a same-sized replacement landing on a byte-identical mtime, which a
+/// filesystem reporting timestamps at one-second resolution can produce. The
+/// pin backing the kernel is keyed the same way, so on such a filesystem both
+/// go stale together rather than one silently covering for the other.
 fn source_stamp(path: &Path) -> Result<String> {
-    mvm_core::crypto::image_verify::sha256_file(path)
+    mvm_core::crypto::image_verify::sha256_file_cached(path)
         .with_context(|| format!("hash kernel {} for extracted-ELF cache", path.display()))
 }
 
@@ -362,6 +370,30 @@ mod tests {
 
         let got = ensure_fc_loadable_kernel(&kpath).unwrap();
         assert_eq!(std::fs::read(&got).unwrap(), real);
+    }
+
+    /// The stamp is the same content digest the kernel's own pin is checked
+    /// against, so preparing a kernel for boot must go through the shared
+    /// digest cache rather than re-reading the image. Asserted by the cache
+    /// being warm afterwards: a raw re-read leaves no entry behind, so a boot
+    /// path that stopped using the cache would re-read the whole image on every
+    /// launch and nothing else here would notice.
+    #[test]
+    fn preparing_a_kernel_leaves_the_shared_digest_cache_warm() {
+        use mvm_core::crypto::image_verify::{DigestSource, sha256_file_cached_with_source};
+
+        let dir = tempfile::tempdir().unwrap();
+        let kpath = dir.path().join("vmlinux");
+        std::fs::write(&kpath, fake_bzimage(&fake_vmlinux_tagged(0x99))).unwrap();
+
+        ensure_fc_loadable_kernel(&kpath).unwrap();
+
+        let (_, source) = sha256_file_cached_with_source(&kpath).unwrap();
+        assert_eq!(
+            source,
+            DigestSource::Sidecar,
+            "kernel preparation must digest through the shared cache, not a raw re-read"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Every launch read the whole `vmlinux` twice to compute the same SHA-256:

- `kernel_fetch::verify_cached_kernel` checks the cached kernel against its recorded `vmlinux.sha256` pin on every resolve.
- `fc_kernel::source_stamp` computes the same digest to key the extracted-ELF cache against `vmlinux.elf.src`.

The two sidecars hold identical values, computed microseconds apart in one process. On a 4.3 MB x86_64 workload kernel that is 8.6 MB re-read per boot for a value neither pass can have changed.

Confirmed under `strace` on a live Firecracker host — one launch, two full passes over the same file:

```
fd=5  vmlinux -> 4310016 bytes in 67 reads   (verify_cached_kernel)
fd=11 vmlinux ->       4 bytes               (ELF-magic probe)
fd=11 vmlinux ->      60 bytes               (arm64 Image probe)
fd=11 vmlinux -> 4244480 bytes in 66 reads   (source_stamp)
```

## What changed

Both now go through the shared size+mtime-keyed digest cache (`sha256_file_cached`), which the rootfs pin backing claim 8 already uses on a far larger image for the same reason. They share one entry, so steady state is zero reads and a kernel change costs one hash instead of two.

The tradeoff is the one case an unconditional re-read still caught: a same-sized replacement landing on a byte-identical mtime, which a filesystem reporting timestamps at one-second resolution can produce. Both the pin and the stamp are keyed the same way, so on such a filesystem they go stale together rather than one silently covering for the other. This is the residual the rootfs pin already accepts and documents.

The kernel entry file set also moves to one definition, `kernel_fetch::kernel_entry_files`, and gains the digest cache. It was listed separately in the CLI's incompatible-kernel eviction, and an orphaned cache entry can be served to a replacement that lands on the same size+mtime pair.

## Why `prepared_cold` could not produce a number

The lane forbids `artifact_hash`, and on any host whose cached kernel is a compressed bzImage it failed with `lane prepared_cold forbids artifact_hash but the launch performed it`. `source_stamp` is the only one of the two passes the work-flag gate can see — `verify_cached_kernel` hashed via `mvm_fs::overlay::compute_file_sha256`, which does not report bytes — so the lane refused on one 4.3 MB read while the other stayed invisible.

A host whose `vmlinux` is already an ELF returns before extraction and never reaches `source_stamp`, which is why the published 2026-08-19 row recorded the flag as false. The lane was not universally unreachable; it was unreachable wherever the kernel ships compressed.

## Measured

Verified on the Hetzner box against the recorded baseline:

| | before | after |
| --- | ---: | ---: |
| bytes read from `vmlinux` per launch | 8,554,560 | **64** |
| `work.artifact_bytes_hashed` in the launch sample | 4,310,016 | **0** |

The 64 remaining bytes are the two cheap probes `ensure_fc_loadable_kernel` does before the stamp — a 4-byte ELF-magic read and a 60-byte arm64 `Image` header read. Both full 4.3 MB hash passes are gone. In their place the shared `vmlinux.sha256cache` sidecar is read three times at 93 bytes each, once per consumer.

**`artifact_bytes_hashed` is now `0`, which is exactly what the `prepared_cold` lane's forbidden-work gate checks.** The lane refused to produce a number on this host before; that blocker is measured as cleared, not argued.

Side effect worth noting: `backend_start_ms` moved 141.0 / 142.2 ms → 127.3 / 127.5 / 127.7 ms across three warm runs. Since the lane's budget is `backend_start + vsock_wait`, that is ~14 ms more headroom under the 200 ms ceiling. Caveat: the measured binary carries three sibling commits from the same investigation (#2907, #2908, #2909), so treat that total as combined; the two rows in the table above are mechanically attributable to this change.

## Tests

Three added, each mutation-checked in the foreground — mutation applied, confirmed red, restored:

| Test | Mutation that turns it red |
| --- | --- |
| `serving_a_pinned_kernel_leaves_its_digest_cache_warm` | pin reverts to a raw re-read |
| `evicting_a_kernel_removes_its_digest_cache` | pin reverts to a raw re-read |
| `preparing_a_kernel_leaves_the_shared_digest_cache_warm` | stamp reverts to a raw re-read |

The existing stamp-binding tests from the extracted-ELF fix still pass unchanged — a rebuilt or replaced kernel is still not served from the previous extraction.

Gates: `xtask check-all` 61/61, `cargo clippy --workspace --all-targets` zero warnings, nightly `cargo fmt --all --check`, `just check-gated`, full workspace tests + 43 CLI test binaries + doctests.

## Siblings

Split out of the same investigation, independently reviewable: #2909 (nothing pinned the booting kernel), #2907 (source fingerprint computed 6× per launch), #2908 (`machine run` hung forever on inherited stdin). Attribution of the `admit_ms` figures across them is noted in #2907.

## Two things worth flagging

**A load-sensitive flake in the audit fsync batch.** Under heavy machine load, `admission_emits_policy_resolved_for_default_local_default_refs` intermittently fails with `syncing batched audit entries before the action they authorize`. It passed 12/12 in isolation, 10/10 on a quiet machine, and 6/6 on a clean `origin/main` control worktree. This diff does not touch the audit sync path, but the control samples are small enough that I won't claim pre-existence outright.

**`cargo nextest` cannot run the root package's CLI integration tests locally** — all 43 fail with `CARGO_BIN_EXE_mvmctl is unset`, persisting after `cargo clean -p mvmctl`, because the test binaries land under `target/debug/build/mvmctl/*/out/`. `cargo test -p mvmctl --tests` runs them fine, which is how they were verified. Unrelated to this diff, but it means a local `just test` is not covering them.
