### PR TITLE
test(conformance): gate the workload-kernel fixture instead of panicking on it

### DIFF
--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -46,6 +46,18 @@ pub const NODE_TAG: &str = "node";
 /// produces both.
 pub const BUNDLE_TAG: &str = "bundle";
 
+/// Cucumber tag for a scenario that boots a guest from a prebuilt *workload*
+/// kernel rather than building one. The kernel is taken from
+/// `MVM_BDD_WORKLOAD_KERNEL`, or from the host's own builder-VM cache when that
+/// is unset; the scenario is skipped cleanly when neither yields a file.
+///
+/// Before this tag existed the step read the variable with `.expect(...)`, so on
+/// a host with KVM the scenario *failed* — "MVM_BDD_WORKLOAD_KERNEL must name
+/// the live workload kernel" — instead of skipping. The variable is named in no
+/// Justfile recipe, no CI lane and no document, so that failure was the only
+/// outcome it ever had, and it read as a broken volume path.
+pub const WORKLOAD_KERNEL_TAG: &str = "workload_kernel";
+
 /// Host capabilities a scenario may require, probed once by the harness.
 ///
 /// Plain data so [`scenario_should_run`] is a pure decision the harness can
@@ -64,6 +76,9 @@ pub struct RuntimeCaps {
     /// A `node` binary is resolvable, so the TypeScript example checkers can
     /// run at all.
     pub node_available: bool,
+    /// A prebuilt workload kernel is resolvable, so a scenario that boots one
+    /// has something to boot.
+    pub workload_kernel: bool,
 }
 
 /// Decide whether a scenario with `tags` should run given the host `caps`.
@@ -97,6 +112,8 @@ pub enum ScenarioGate {
     NeedsFirecracker,
     /// No `.mvmpkg` for a bundle-boot scenario to install.
     NeedsBundleFixture,
+    /// No prebuilt workload kernel could be resolved.
+    NeedsWorkloadKernel,
     /// No `node` on `PATH`, so the TypeScript example checkers cannot run.
     NeedsNode,
     /// The merge-queue lane selected only `@ci_live` scenarios, and this
@@ -127,6 +144,9 @@ pub fn scenario_gate(tags: &[String], caps: RuntimeCaps) -> ScenarioGate {
     }
     if tagged(NODE_TAG) && !caps.node_available {
         return ScenarioGate::NeedsNode;
+    }
+    if tagged(WORKLOAD_KERNEL_TAG) && !caps.workload_kernel {
+        return ScenarioGate::NeedsWorkloadKernel;
     }
     ScenarioGate::Run
 }
@@ -159,6 +179,10 @@ impl ScenarioGate {
                  MVM_BDD_BUNDLE_PUBKEY its publisher key",
             ),
             Self::NeedsNode => Some("need node on PATH (TypeScript example checkers)"),
+            Self::NeedsWorkloadKernel => Some(
+                "need a prebuilt workload kernel (MVM_BDD_WORKLOAD_KERNEL, or one \
+                 in the host builder-VM cache)",
+            ),
             Self::OutsideCiLiveSubset => Some("outside the merge-queue @ci_live subset"),
         }
     }
@@ -177,12 +201,14 @@ mod tests {
         firecracker_bootable: false,
         bundle_fixture: false,
         node_available: false,
+        workload_kernel: false,
     };
     const ALL: RuntimeCaps = RuntimeCaps {
         live_opted_in: true,
         firecracker_bootable: true,
         bundle_fixture: true,
         node_available: false,
+        workload_kernel: true,
     };
 
     #[test]
@@ -197,6 +223,25 @@ mod tests {
         ));
         assert!(scenario_should_run(
             &tags(&["live", "firecracker", "bundle"]),
+            ALL
+        ));
+    }
+
+    /// The gate this exists for: without a resolvable kernel the scenario must
+    /// skip, not fail. It failed before — the step read the env var with
+    /// `.expect(...)`, so on a KVM host the only outcome it ever had was a
+    /// panic that read as a broken volume path.
+    #[test]
+    fn workload_kernel_scenario_skips_without_a_kernel() {
+        assert!(!scenario_should_run(
+            &tags(&["live", "firecracker", "workload_kernel"]),
+            RuntimeCaps {
+                workload_kernel: false,
+                ..ALL
+            },
+        ));
+        assert!(scenario_should_run(
+            &tags(&["live", "firecracker", "workload_kernel"]),
             ALL
         ));
     }
@@ -221,6 +266,7 @@ mod tests {
                 firecracker_bootable: false,
                 bundle_fixture: false,
                 node_available: false,
+                workload_kernel: false,
             },
         ));
     }
@@ -234,6 +280,7 @@ mod tests {
                 firecracker_bootable: false,
                 bundle_fixture: false,
                 node_available: false,
+                workload_kernel: false,
             },
         ));
         assert!(scenario_should_run(&tags(&["live", "firecracker"]), ALL));
@@ -249,6 +296,7 @@ mod tests {
                 firecracker_bootable: true,
                 bundle_fixture: false,
                 node_available: false,
+                workload_kernel: false,
             },
         ));
         // Live opt-in but missing capability → skipped.
@@ -259,6 +307,7 @@ mod tests {
                 firecracker_bootable: false,
                 bundle_fixture: false,
                 node_available: false,
+                workload_kernel: false,
             },
         ));
         // Both present → runs.
@@ -276,30 +325,35 @@ mod tests {
                 firecracker_bootable: false,
                 bundle_fixture: false,
                 node_available: false,
+                workload_kernel: false,
             },
             RuntimeCaps {
                 live_opted_in: true,
                 firecracker_bootable: false,
                 bundle_fixture: false,
                 node_available: false,
+                workload_kernel: false,
             },
             RuntimeCaps {
                 live_opted_in: true,
                 firecracker_bootable: true,
                 bundle_fixture: false,
                 node_available: false,
+                workload_kernel: false,
             },
             RuntimeCaps {
                 live_opted_in: true,
                 firecracker_bootable: true,
                 bundle_fixture: true,
                 node_available: false,
+                workload_kernel: true,
             },
             RuntimeCaps {
                 live_opted_in: false,
                 firecracker_bootable: true,
                 bundle_fixture: true,
                 node_available: false,
+                workload_kernel: true,
             },
         ];
         let shapes = [
@@ -332,18 +386,21 @@ mod tests {
             firecracker_bootable: false,
             bundle_fixture: false,
             node_available: false,
+            workload_kernel: false,
         };
         let live_only = RuntimeCaps {
             live_opted_in: true,
             firecracker_bootable: false,
             bundle_fixture: false,
             node_available: false,
+            workload_kernel: false,
         };
         let bootable = RuntimeCaps {
             live_opted_in: true,
             firecracker_bootable: true,
             bundle_fixture: false,
             node_available: false,
+            workload_kernel: false,
         };
 
         assert_eq!(
@@ -394,6 +451,7 @@ mod tests {
                     firecracker_bootable: false,
                     bundle_fixture: false,
                     node_available: false,
+                    workload_kernel: false,
                 },
                 true,
             ),

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -216,6 +216,7 @@ fn probe_caps() -> RuntimeCaps {
         firecracker_bootable: kvm_openable() && firecracker_on_path(),
         bundle_fixture: bundle_fixture_path().is_some() && bundle_pubkey_path().is_some(),
         node_available: binary_on_path("node"),
+        workload_kernel: workload_kernel_path().is_some(),
     }
 }
 
@@ -237,6 +238,28 @@ pub(crate) fn bundle_fixture_path() -> Option<std::path::PathBuf> {
 pub(crate) fn bundle_pubkey_path() -> Option<std::path::PathBuf> {
     let path = std::path::PathBuf::from(std::env::var_os("MVM_BDD_BUNDLE_PUBKEY")?);
     path.is_file().then_some(path)
+}
+
+/// A prebuilt workload kernel for the block-volume scenarios.
+///
+/// `MVM_BDD_WORKLOAD_KERNEL` names one explicitly. When it is unset the host's
+/// own builder-VM cache is used — the same file the step would otherwise ask an
+/// operator to point at by hand, at the path `mvmctl` already writes it to. That
+/// default is what makes the lane runnable: the variable appears in no Justfile
+/// recipe, no CI lane and no document, so requiring it meant the scenarios ran
+/// nowhere.
+pub(crate) fn workload_kernel_path() -> Option<std::path::PathBuf> {
+    if let Some(explicit) = std::env::var_os("MVM_BDD_WORKLOAD_KERNEL") {
+        let path = std::path::PathBuf::from(explicit);
+        return path.is_file().then_some(path);
+    }
+    let cached = std::path::PathBuf::from(mvm_core::config::default_mvm_cache_dir())
+        .join("builder-vm")
+        .join(std::env::consts::ARCH)
+        .join("kernels")
+        .join("workload")
+        .join("vmlinux");
+    cached.is_file().then_some(cached)
 }
 
 /// `/dev/kvm` exists and this process can open it read-write — the mode a real

--- a/crates/mvm-conformance/tests/steps/volume.rs
+++ b/crates/mvm-conformance/tests/steps/volume.rs
@@ -43,14 +43,11 @@ fn managed_volume_path(world: &CliWorld, volume_name: &str) -> PathBuf {
 
 #[given("a cached live workload kernel")]
 fn cached_live_workload_kernel(world: &mut CliWorld) {
-    let source = PathBuf::from(
-        std::env::var_os("MVM_BDD_WORKLOAD_KERNEL")
-            .expect("MVM_BDD_WORKLOAD_KERNEL must name the live workload kernel"),
-    );
-    assert!(
-        source.is_file(),
-        "MVM_BDD_WORKLOAD_KERNEL does not name a file: {source:?}"
-    );
+    // The `@workload_kernel` gate guarantees this resolves before the scenario
+    // is selected, so reaching here without one is a harness bug, not an
+    // operator mistake.
+    let source = crate::workload_kernel_path()
+        .expect("`@workload_kernel` scenarios only run when a kernel resolves");
     let destination = isolated_home(world)
         .join("cache")
         .join("builder-vm")

--- a/features/suites/s26_volumes/volume_lifecycle.feature
+++ b/features/suites/s26_volumes/volume_lifecycle.feature
@@ -72,7 +72,7 @@ Feature: Encrypted block volume lifecycle and attachment
     Then the command exits with code 1
     And the local volume attachment lease catalog is empty
 
-  @live @firecracker
+  @live @firecracker @workload_kernel
   Scenario: a writable block volume persists guest bytes across restart
     Given an isolated mvm home
     And a cached live workload kernel
@@ -100,7 +100,7 @@ Feature: Encrypted block volume lifecycle and attachment
     When I run mvmctl in the isolated mvm home with "machine volume lock work"
     Then the command exits with code 0
 
-  @live @firecracker
+  @live @firecracker @workload_kernel
   Scenario: a read-only block attachment refuses a guest write
     Given an isolated mvm home
     And a cached live workload kernel

--- a/specs/sprint/delivery/workload-kernel-fixture-gate.md
+++ b/specs/sprint/delivery/workload-kernel-fixture-gate.md
@@ -1,0 +1,57 @@
+# The block-volume scenarios failed instead of skipping, and ran nowhere
+
+Backing: shipped-source
+Validation: cargo nextest run -p mvm-conformance --lib
+
+Two scenarios in `s26_volumes/volume_lifecycle.feature` — a writable volume
+persisting bytes across restart, and a read-only attachment refusing a guest
+write — begin with `Given a cached live workload kernel`. That step read
+`MVM_BDD_WORKLOAD_KERNEL` with `.expect(...)`.
+
+The variable is named in no Justfile recipe, no CI lane and no document. Its
+only occurrences in the entire tree were the three lines of the step that read
+it. So on a host with `/dev/kvm` the scenarios did not skip — they *failed*,
+with `MVM_BDD_WORKLOAD_KERNEL must name the live workload kernel`, and on a host
+without one they never ran at all.
+
+They have therefore never passed anywhere.
+
+## Two things wrong, not one
+
+**A missing fixture failed rather than skipped.** The harness already models
+this: `RuntimeCaps` + `ScenarioGate` turn an absent capability into a clean skip
+that lands in the run's skip tally. A bare `.expect` in a step bypasses that and
+reports a missing operator input as a red test — indistinguishable, in a log,
+from a broken volume path. This is the same defect the `@bundle` fixture had,
+in the opposite direction: that one skipped silently and hid a real gap, this
+one failed loudly and invented one.
+
+**The fixture had no default.** The step copies the kernel to
+`<isolated home>/cache/builder-vm/<arch>/kernels/workload/vmlinux` — the exact
+path `mvmctl` writes it to under the real home. So the file it demands an
+operator name by hand is, on any host that has built one, already sitting at a
+known location. `workload_kernel_path` now prefers `MVM_BDD_WORKLOAD_KERNEL` and
+falls back to the host's builder-VM cache. That default is what makes the lane
+runnable rather than merely honest.
+
+## The gate correctly objected
+
+`check-test-home-isolation` flagged the `default_mvm_cache_dir` call: reading
+the shared cache from a test is how an isolated run gets a real artifact copied
+in behind its back and passes for the wrong reason.
+
+Here the seed *is* the intent, and it cannot mask an absence assertion — these
+scenarios assert about volume bytes and write refusal, never about whether a
+kernel is cached. Declared in `SEED_SITES` with that reasoning rather than
+worked around.
+
+## Evidence
+
+`workload_kernel_scenario_skips_without_a_kernel` asserts both directions:
+skipped without a kernel, run with one. 73 conformance lib tests pass; all 61
+`xtask` gates green.
+
+Adding the capability field made the compiler reject five `RuntimeCaps`
+literals in the existing tests — the exhaustive-init check doing exactly its
+job, and the reason this file lists the field on every one rather than
+defaulting it.

--- a/xtask/src/check_test_home_isolation.rs
+++ b/xtask/src/check_test_home_isolation.rs
@@ -83,6 +83,14 @@ const SEED_SITES: &[(&str, &str)] = &[
         "xtask/src/check_test_home_isolation.rs",
         "defines the very patterns it scans for",
     ),
+    (
+        "crates/mvm-conformance/tests/conformance.rs",
+        "resolves the prebuilt workload kernel a `@workload_kernel` scenario boots. \
+         The seed is the point: the step copies that kernel into the scenario's \
+         isolated cache so a volume test does not have to build one. It cannot \
+         mask an absence assertion, because the scenarios assert about volume \
+         bytes and write refusal, never about whether a kernel is cached",
+    ),
 ];
 
 /// Symbols whose call reaches [`DEFAULT_CACHE_FN`]. A file naming any of


### PR DESCRIPTION
Two block-volume scenarios begin with `Given a cached live workload kernel`, and that step read `MVM_BDD_WORKLOAD_KERNEL` with `.expect(...)`.

That variable is named in **no Justfile recipe, no CI lane and no document** — its only occurrences in the tree were the three lines of the step reading it. So on a host with `/dev/kvm` the scenarios did not skip, they *failed*:

```
MVM_BDD_WORKLOAD_KERNEL must name the live workload kernel
```

and on a host without KVM they never ran. **They have never passed anywhere.** In a live log that failure is indistinguishable from a broken volume path, which is exactly how I first read it.

## Two things wrong

**A missing fixture failed rather than skipping.** The harness already models this — `RuntimeCaps` + `ScenarioGate` turn an absent capability into a counted skip. A bare `.expect` in a step bypasses that and reports missing operator input as a red test. This is the `@bundle` defect inverted: that one skipped silently and hid a real gap; this one failed loudly and invented one.

**The fixture had no default**, though the step copies the kernel to `<isolated home>/cache/builder-vm/<arch>/kernels/workload/vmlinux` — the exact path `mvmctl` already writes it to under the real home. The KVM box had one sitting there the whole time.

`@workload_kernel` now gates both scenarios, and `workload_kernel_path` prefers the env var but falls back to the host's builder-VM cache. That fallback is what makes the lane runnable rather than merely honest.

## The gate correctly objected

`check-test-home-isolation` flagged the `default_mvm_cache_dir` call — reading the shared cache from a test is how an isolated run gets a real artifact copied in behind its back and passes for the wrong reason.

Here the seed **is** the intent, and it cannot mask an absence assertion: these scenarios assert about volume bytes and write refusal, never about whether a kernel is cached. Declared in `SEED_SITES` with that reasoning rather than worked around.

## Context

This came out of the first valid live-BDD run on real KVM. Of 18 scenarios that looked broken on the live tier, **17 were test infrastructure** — 15 from the toolchain-orphaning fixed in #2886, and these 2. The only genuine survivor is the known SDK codegen drift.

## Evidence

`workload_kernel_scenario_skips_without_a_kernel` asserts both directions: skipped without a kernel, run with one.

Adding the capability field made the compiler reject five existing `RuntimeCaps` literals — exhaustive-init doing its job — so each is set explicitly rather than defaulted.

73 conformance lib tests, all 61 `xtask` gates, fmt and stable `clippy --workspace --all-targets -D warnings` green.