### PR TITLE
fix(http): bound idle reads so a silent peer cannot park a request forever

### DIFF
--- a/crates/mvm-http/src/client.rs
+++ b/crates/mvm-http/src/client.rs
@@ -42,6 +42,7 @@ struct Inner {
     resolver: Arc<dyn Resolve>,
     timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
+    read_idle_timeout: Option<Duration>,
     default_headers: HeaderMap,
     max_response_bytes: Option<u64>,
     user_agent: HeaderValue,
@@ -116,6 +117,7 @@ pub struct ClientBuilder {
     resolver: Option<Arc<dyn Resolve>>,
     timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
+    read_idle_timeout: Option<Duration>,
     default_headers: HeaderMap,
     max_response_bytes: Option<u64>,
     user_agent: String,
@@ -133,6 +135,7 @@ impl Default for ClientBuilder {
             resolver: None,
             timeout: None,
             connect_timeout: None,
+            read_idle_timeout: None,
             default_headers: HeaderMap::new(),
             max_response_bytes: None,
             user_agent: concat!("mvm/", env!("CARGO_PKG_VERSION")).to_string(),
@@ -165,6 +168,12 @@ impl ClientBuilder {
     }
 
     #[must_use]
+    /// Override how long a connected peer may send nothing before a read fails.
+    pub fn read_idle_timeout(mut self, d: Duration) -> Self {
+        self.read_idle_timeout = Some(d);
+        self
+    }
+
     pub fn connect_timeout(mut self, d: Duration) -> Self {
         self.connect_timeout = Some(d);
         self
@@ -223,6 +232,7 @@ impl ClientBuilder {
                 resolver: self.resolver.unwrap_or_else(|| Arc::new(SystemResolver)),
                 timeout: self.timeout,
                 connect_timeout: self.connect_timeout,
+                read_idle_timeout: self.read_idle_timeout,
                 default_headers: self.default_headers,
                 max_response_bytes: self.max_response_bytes,
                 user_agent,
@@ -648,6 +658,26 @@ async fn write_request_body(stream: &mut Stream, body: Option<RequestBody>) -> R
 /// is how an image pull came to sit in `SYN-SENT` for half an hour.
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// How long a connected peer may send nothing before the read gives up.
+///
+/// The companion to `DEFAULT_CONNECT_TIMEOUT`, and a default for the same
+/// reason: a peer that accepts and then goes silent never refuses, so an
+/// unbounded read parks in `epoll` forever. That is not hypothetical either —
+/// `mvmctl image pull` sat for five minutes consuming 0.187s of CPU, and a
+/// `machine run --image` outlived its own `--timeout 120` by 29 minutes.
+///
+/// Deliberately generous. This bounds *silence*, not slowness: a slow transfer
+/// that keeps delivering bytes re-arms the budget on every read, so only a
+/// genuinely stalled connection trips it.
+pub const DEFAULT_READ_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The per-read idle budget. An unset timeout resolves to a finite default; it
+/// must never resolve to "wait indefinitely", which is what let a silent peer
+/// consume a whole request.
+fn read_idle_budget(configured: Option<Duration>) -> Duration {
+    configured.unwrap_or(DEFAULT_READ_IDLE_TIMEOUT)
+}
+
 /// Order candidate addresses IPv4-first.
 ///
 /// The timeout above makes a dead address survivable; this makes it cheap.
@@ -691,7 +721,10 @@ async fn connect(
             Ok(tcp) => {
                 tcp.set_nodelay(true).ok();
                 if !tls_wanted {
-                    return Ok(Stream::Plain(tcp));
+                    return Ok(Stream::plain(
+                        tcp,
+                        read_idle_budget(inner.read_idle_timeout),
+                    ));
                 }
                 let server_name = rustls_pki_types::ServerName::try_from(host.to_string())
                     .map_err(|_| Error::Url(format!("invalid dns name {host}")))?;
@@ -703,7 +736,10 @@ async fn connect(
                         host: host.to_string(),
                         source,
                     })?;
-                return Ok(Stream::Tls(Box::new(tls)));
+                return Ok(Stream::tls(
+                    Box::new(tls),
+                    read_idle_budget(inner.read_idle_timeout),
+                ));
             }
             Err(e) => last = Some(e),
         }
@@ -790,7 +826,10 @@ async fn connect_via_proxy(
         crate::proxy::ProxyKind::Socks5 => socks5_connect(tcp, proxy, host, port).await?,
     };
     if !tls_wanted {
-        return Ok(Stream::Plain(tcp));
+        return Ok(Stream::plain(
+            tcp,
+            read_idle_budget(inner.read_idle_timeout),
+        ));
     }
     // TLS terminates at the destination, not the proxy: the SNI and the
     // certificate checked are the destination's, so an HTTP proxy carrying this
@@ -805,7 +844,10 @@ async fn connect_via_proxy(
             host: host.to_string(),
             source,
         })?;
-    Ok(Stream::Tls(Box::new(tls)))
+    Ok(Stream::tls(
+        Box::new(tls),
+        read_idle_budget(inner.read_idle_timeout),
+    ))
 }
 
 fn proxy_auth_header(proxy: &crate::proxy::Proxy) -> Option<String> {
@@ -1113,6 +1155,7 @@ mod tests {
             resolver: Arc::new(SystemResolver),
             timeout: None,
             connect_timeout: None,
+            read_idle_timeout: None,
             default_headers: HeaderMap::new(),
             max_response_bytes: None,
             user_agent: HeaderValue::from_static("mvm-test"),
@@ -1283,6 +1326,121 @@ mod connect_resilience_tests {
     fn an_empty_or_single_family_list_is_unchanged() {
         assert!(ipv4_first(&[]).is_empty());
         assert_eq!(ipv4_first(&[v6(1), v6(2)]), vec![v6(1), v6(2)]);
+    }
+
+    /// A server that accepts and then never answers must not hang the client.
+    ///
+    /// This is the other half of the connect regression. `DEFAULT_CONNECT_TIMEOUT`
+    /// bounds *reaching* a peer, and nothing bounded what happens after: a peer
+    /// that completes the handshake and then goes silent leaves the request
+    /// parked in `epoll` forever, because the only deadline is the optional
+    /// whole-request `timeout`, which defaults to `None`.
+    ///
+    /// Observed in production shape: `mvmctl image pull alpine:latest` sat for
+    /// five minutes consuming 0.187s of CPU — blocked, not working — and a
+    /// `machine run --image` survived 29 minutes against `--timeout 120`.
+    ///
+    /// A real listener is used rather than a reserved address because the
+    /// property under test is "accepted then silent", which a black-holed
+    /// address cannot express: that one fails at connect, which is already
+    /// bounded.
+    #[tokio::test]
+    async fn a_peer_that_accepts_then_goes_silent_does_not_hang_forever() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind a local listener");
+        let addr = listener.local_addr().expect("listener has an address");
+
+        // Accept and hold the connection open, writing nothing, forever.
+        let _accepting = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((socket, _)) = listener.accept().await {
+                held.push(socket);
+            }
+        });
+
+        let client = Client::builder()
+            .read_idle_timeout(Duration::from_millis(500))
+            .build()
+            .expect("build a client with a short idle budget");
+        let started = std::time::Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(20),
+            client.get(format!("http://{addr}/never-answers")).send(),
+        )
+        .await;
+
+        match result {
+            Err(_) => panic!(
+                "the request was still parked after 20s with no bound of its own; \
+                 a silent peer must fail, not hang (elapsed {:?})",
+                started.elapsed()
+            ),
+            Ok(Ok(_)) => panic!("a silent peer cannot produce a successful response"),
+            Ok(Err(error)) => {
+                // It must give up on its own, and say why.
+                let text = error.to_string().to_lowercase();
+                assert!(
+                    text.contains("timeout") || text.contains("timed out"),
+                    "the failure must name the timeout, not surface as some \
+                     unrelated parse or connection error: {error}"
+                );
+            }
+        }
+    }
+
+    /// The counter-test, and the reason the bound is on idle time rather than
+    /// total duration.
+    ///
+    /// A large blob pull is legitimately slow. If the budget were a whole-request
+    /// deadline, fixing the hang would have broken exactly the multi-hundred-
+    /// megabyte image pulls it exists to protect — a worse bug than the one
+    /// being fixed, and one that would only show up on big images.
+    ///
+    /// Here the transfer takes far longer than the budget in total while no
+    /// single gap between reads exceeds it. That must succeed.
+    #[tokio::test]
+    async fn a_slow_but_progressing_transfer_is_not_cut_off() {
+        const BODY: &[u8] = b"0123456789";
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind a local listener");
+        let addr = listener.local_addr().expect("listener has an address");
+
+        let _serving = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let header = format!("HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n", BODY.len());
+            let _ = socket.write_all(header.as_bytes()).await;
+            // One byte at a time, each gap under the budget, total well over it.
+            for byte in BODY {
+                tokio::time::sleep(Duration::from_millis(120)).await;
+                if socket.write_all(&[*byte]).await.is_err() {
+                    return;
+                }
+                let _ = socket.flush().await;
+            }
+        });
+
+        let client = Client::builder()
+            .read_idle_timeout(Duration::from_millis(400))
+            .build()
+            .expect("build a client with a short idle budget");
+
+        let started = std::time::Instant::now();
+        let response = client
+            .get(format!("http://{addr}/slow"))
+            .send()
+            .await
+            .expect("a slow but progressing transfer must not be cut off");
+        let body = response.bytes().await.expect("read the drip-fed body");
+
+        assert_eq!(body.as_ref(), BODY);
+        assert!(
+            started.elapsed() > Duration::from_millis(400),
+            "the transfer should have outlived the idle budget in total, or it \
+             is not exercising the distinction: {:?}",
+            started.elapsed()
+        );
     }
 
     /// **The deterministic half of the regression.** An unset timeout must

--- a/crates/mvm-http/src/conn.rs
+++ b/crates/mvm-http/src/conn.rs
@@ -2,19 +2,80 @@
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
+use tokio::time::Sleep;
 use tokio_rustls::client::TlsStream;
 
-/// A connected stream, plaintext or TLS.
+/// Plaintext or TLS.
 ///
 /// An enum rather than `Box<dyn AsyncRead + AsyncWrite>` so the hot read path
 /// stays a static dispatch and the type says exactly which two cases exist.
 #[derive(Debug)]
-pub enum Stream {
+enum Kind {
     Plain(TcpStream),
     Tls(Box<TlsStream<TcpStream>>),
+}
+
+/// A connected stream that cannot stall forever.
+///
+/// `DEFAULT_CONNECT_TIMEOUT` bounds *reaching* a peer. Nothing bounded what
+/// happened afterwards: a peer that completes the handshake and then stops
+/// sending leaves a read parked in `epoll` indefinitely, because the only other
+/// deadline is the whole-request timeout, which is `None` unless a caller sets
+/// it — and the OCI registry client does not.
+///
+/// The bound here is **idle time between reads**, not total duration. A total
+/// deadline would be the wrong instrument: a multi-hundred-megabyte blob pull is
+/// legitimately slow, and capping the whole request would break exactly the
+/// large images this is meant to keep working. What is never legitimate is a
+/// connection that yields no bytes at all for minutes.
+pub struct Stream {
+    kind: Kind,
+    idle: Duration,
+    /// Armed on the first `Pending` and cleared whenever bytes arrive, so the
+    /// budget applies per stall rather than to the transfer as a whole.
+    deadline: Option<Pin<Box<Sleep>>>,
+}
+
+impl std::fmt::Debug for Stream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Stream")
+            .field("kind", &self.kind)
+            .field("idle", &self.idle)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Stream {
+    pub fn plain(tcp: TcpStream, idle: Duration) -> Self {
+        Self {
+            kind: Kind::Plain(tcp),
+            idle,
+            deadline: None,
+        }
+    }
+
+    pub fn tls(tls: Box<TlsStream<TcpStream>>, idle: Duration) -> Self {
+        Self {
+            kind: Kind::Tls(tls),
+            idle,
+            deadline: None,
+        }
+    }
+
+    fn poll_inner_read(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match &mut self.kind {
+            Kind::Plain(s) => Pin::new(s).poll_read(cx, buf),
+            Kind::Tls(s) => Pin::new(s.as_mut()).poll_read(cx, buf),
+        }
+    }
 }
 
 impl AsyncRead for Stream {
@@ -23,9 +84,30 @@ impl AsyncRead for Stream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
-        match self.get_mut() {
-            Stream::Plain(s) => Pin::new(s).poll_read(cx, buf),
-            Stream::Tls(s) => Pin::new(s.as_mut()).poll_read(cx, buf),
+        let this = self.get_mut();
+        match this.poll_inner_read(cx, buf) {
+            Poll::Ready(result) => {
+                // Progress — including a clean EOF. Disarm so the next stall
+                // gets a fresh budget rather than inheriting a spent one.
+                this.deadline = None;
+                Poll::Ready(result)
+            }
+            Poll::Pending => {
+                let idle = this.idle;
+                let deadline = this
+                    .deadline
+                    .get_or_insert_with(|| Box::pin(tokio::time::sleep(idle)));
+                match deadline.as_mut().poll(cx) {
+                    Poll::Ready(()) => {
+                        this.deadline = None;
+                        Poll::Ready(Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            format!("read timed out: no bytes from peer for {idle:?}"),
+                        )))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 }
@@ -36,23 +118,23 @@ impl AsyncWrite for Stream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        match self.get_mut() {
-            Stream::Plain(s) => Pin::new(s).poll_write(cx, buf),
-            Stream::Tls(s) => Pin::new(s.as_mut()).poll_write(cx, buf),
+        match &mut self.get_mut().kind {
+            Kind::Plain(s) => Pin::new(s).poll_write(cx, buf),
+            Kind::Tls(s) => Pin::new(s.as_mut()).poll_write(cx, buf),
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        match self.get_mut() {
-            Stream::Plain(s) => Pin::new(s).poll_flush(cx),
-            Stream::Tls(s) => Pin::new(s.as_mut()).poll_flush(cx),
+        match &mut self.get_mut().kind {
+            Kind::Plain(s) => Pin::new(s).poll_flush(cx),
+            Kind::Tls(s) => Pin::new(s.as_mut()).poll_flush(cx),
         }
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        match self.get_mut() {
-            Stream::Plain(s) => Pin::new(s).poll_shutdown(cx),
-            Stream::Tls(s) => Pin::new(s.as_mut()).poll_shutdown(cx),
+        match &mut self.get_mut().kind {
+            Kind::Plain(s) => Pin::new(s).poll_shutdown(cx),
+            Kind::Tls(s) => Pin::new(s.as_mut()).poll_shutdown(cx),
         }
     }
 }

--- a/specs/sprint/delivery/http-read-idle-timeout.md
+++ b/specs/sprint/delivery/http-read-idle-timeout.md
@@ -1,0 +1,66 @@
+# A silent peer could park an mvm request forever
+
+Backing: shipped-source
+Validation: cargo nextest run -p mvm-http
+
+`DEFAULT_CONNECT_TIMEOUT` bounds *reaching* a peer. Nothing bounded what happened
+after the handshake. A peer that accepts and then stops sending left the read
+parked in `epoll` indefinitely, because the only other deadline is the
+whole-request `timeout`, which is `Option<Duration>` defaulting to `None` — and
+`mvm-fs`'s OCI registry client builds its client with `mvm_http::Client::new()`,
+so it never set one.
+
+Every OCI request — token, manifest, blob — was therefore unbounded after connect.
+
+## Observed
+
+On the KVM box, host load 0.04 (so not contention):
+
+```
+mvmctl machine run --name bdd-guest-hostname --image alpine --timeout 120 -- /bin/hostname
+PID 1461588  STAT Sl  WCHAN ep_poll  ELAPSED 29:21  %CPU 0.1
+threads: ep_poll, pipe_read     children: none     locks: none
+```
+
+29 minutes against `--timeout 120`. And `mvmctl image pull alpine:latest`, warm
+home, idle box: 5 minutes wall, **0.187s of CPU** — blocked, not working.
+
+This is very likely what the README pip-over-egress runs were doing when they
+exited 124 at a 900s and then a 1500s cap having produced no output. Those were
+read as "the example is slow".
+
+## Why the bound is on idle time, not total duration
+
+The obvious fix — default the whole-request `timeout` — is wrong, and wrong in a
+way that would not show up until it mattered. `deadline` wraps `send_once`, which
+covers the response body, so a total deadline would cap a multi-hundred-megabyte
+blob pull. Fixing a hang by breaking large image pulls is a worse trade, and one
+that only appears on big images.
+
+So `Stream` carries an idle budget: armed on the first `Pending`, cleared
+whenever bytes arrive. A slow transfer that keeps delivering re-arms on every
+read and is unaffected; only genuine silence trips it. Default 60s, deliberately
+generous, overridable with `Client::builder().read_idle_timeout(..)`.
+
+## Both directions are tested, and both tests are load-bearing
+
+- `a_peer_that_accepts_then_goes_silent_does_not_hang_forever` — a real listener
+  that accepts and writes nothing. Before the fix it parked the full 20s the test
+  allows; after, it fails in 0.5s naming the timeout.
+- `a_slow_but_progressing_transfer_is_not_cut_off` — a drip-fed body whose total
+  duration exceeds the budget while no single gap does. This is the counter-test
+  for the wrong fix.
+
+Mutation-verified: removing the disarm-on-progress line turns the idle bound into
+a total deadline, and the counter-test goes red while the hang test stays green.
+That is the distinction the pair exists to hold.
+
+A real listener is used rather than a reserved address because the property is
+"accepted then silent", which a black-holed address cannot express — that case
+fails at connect, which was already bounded.
+
+## Error text
+
+The read failure says `read timed out: no bytes from peer for {duration}`. The
+first draft said only "no bytes from peer", which is accurate but does not tell
+an operator what kind of failure they are looking at.


### PR DESCRIPTION
Closes #2896.

`DEFAULT_CONNECT_TIMEOUT` bounds *reaching* a peer. Nothing bounded what happened after the handshake. A peer that accepts and then stops sending left the read parked in `epoll` indefinitely — the only other deadline is the whole-request `timeout`, which defaults to `None`, and `mvm-fs`'s OCI registry client builds with `mvm_http::Client::new()`, so it never set one.

**Every OCI request — token, manifest, blob — was unbounded after connect.**

## Observed

KVM box, host load 0.04, so not contention:

```
mvmctl machine run --name bdd-guest-hostname --image alpine --timeout 120 -- /bin/hostname
PID 1461588  STAT Sl  WCHAN ep_poll  ELAPSED 29:21  %CPU 0.1
threads: ep_poll, pipe_read     children: none     locks: none
```

29 minutes against `--timeout 120`. And `image pull alpine:latest`, warm home, idle box: **5 minutes wall, 0.187s CPU** — blocked, not working.

This is very likely what the README pip-over-egress example was doing when it exited 124 at a 900s cap and then a 1500s cap with no output. That was read as "the example is slow."

## Why idle time, not total duration

The obvious fix — default the whole-request `timeout` — is wrong in a way that wouldn't surface until it mattered. That deadline wraps `send_once`, which covers the response body, so it would cap a multi-hundred-megabyte blob pull. **Fixing a hang by breaking large image pulls is the worse trade**, and it would only show up on big images.

So `Stream` carries an idle budget: armed on the first `Pending`, cleared whenever bytes arrive. A slow transfer that keeps delivering re-arms on every read; only genuine silence trips it. Default 60s, deliberately generous, overridable via `Client::builder().read_idle_timeout(..)`.

## Both directions tested, both load-bearing

- `a_peer_that_accepts_then_goes_silent_does_not_hang_forever` — real listener, accepts and writes nothing. Before the fix it parked the full 20s the test allows; after, it fails in 0.5s naming the timeout.
- `a_slow_but_progressing_transfer_is_not_cut_off` — drip-fed body whose total duration exceeds the budget while no single gap does. This is the counter-test for the wrong fix.

**Mutation-verified:** removing the disarm-on-progress line turns the idle bound into a total deadline — the counter-test goes red while the hang test stays green. That's the distinction the pair exists to hold.

A real listener is used rather than a reserved address because the property is "accepted then silent", which a black-holed address can't express — that case fails at connect, already bounded.

## Note on the error text

The read failure says `read timed out: no bytes from peer for {duration}`. My first draft said only "no bytes from peer" — accurate, but it doesn't tell an operator what kind of failure they're looking at.

## Gates

456 `mvm-http` + `mvm-fs` tests, fmt, stable `clippy --workspace --all-targets -D warnings`, `check-all` (61 gates), `check-honesty`, `check-forbidden-deps` — all green.