### PR TITLE
fix(rpc): preserve guest policy refusals

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ Run a Sandbox script as an admission-only plan check or against a real VM:
 
 ```bash
 mvmctl run --mode plan ./script.py     # synthesize + sign + admit, no boot
-mvmctl run --mode live ./script.py     # boot a real microVM and execute
+mvmctl run --mode live --profile dev ./script.py  # explicitly enable dev-only Sandbox verbs
 ```
 
 Interactive surfaces (`exec`, `commands.start`, `console`) are **dev-tier only**;

--- a/crates/mvm-agentd/src/vsock/api.rs
+++ b/crates/mvm-agentd/src/vsock/api.rs
@@ -356,7 +356,7 @@ pub fn send_proc_request_on(stream: &mut UnixStream, req: GuestRequest) -> Resul
             | GuestRequest::ProcKill { .. }
     ));
     require_capabilities(stream, &[GuestCapability::ProcessRpc])?;
-    let resp = send_request(stream, &req)?;
+    let resp = call_unary(stream, &req)?;
     match resp {
         GuestResponse::ProcResult(r) => Ok(r),
         GuestResponse::Error { message } => {
@@ -442,7 +442,7 @@ pub fn send_fs_request(instance_dir: &str, req: GuestRequest) -> Result<FsResult
 /// over this for callers that still pass an instance dir (mvmd, mock).
 pub fn send_fs_request_on(stream: &mut UnixStream, req: GuestRequest) -> Result<FsResult> {
     require_capabilities(stream, &[GuestCapability::FilesystemRpc])?;
-    let resp = send_request(stream, &req)?;
+    let resp = call_unary(stream, &req)?;
     match resp {
         GuestResponse::FsResult(r) => Ok(r),
         GuestResponse::Error { message } => bail!("Guest FS RPC transport error: {}", message),
@@ -491,6 +491,82 @@ pub fn mount_volume_on(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn serve_unary_response(
+        mut guest: UnixStream,
+        capability: GuestCapability,
+        expected_verb: &'static str,
+        response: GuestResponse,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let hello: GuestRequest = read_frame(&mut guest).unwrap();
+            assert!(matches!(hello, GuestRequest::ProtocolHello { .. }));
+            write_frame(
+                &mut guest,
+                &GuestResponse::ProtocolHelloAck {
+                    agent_protocol_version: PROTOCOL_VERSION,
+                    min_supported_version: MIN_SUPPORTED_PROTOCOL_VERSION,
+                    agent_version: env!("CARGO_PKG_VERSION").to_string(),
+                    capabilities: vec![capability],
+                },
+            )
+            .unwrap();
+
+            let request: GuestRequest = read_frame(&mut guest).unwrap();
+            assert_eq!(request.kind_name(), expected_verb);
+            write_frame(&mut guest, &response).unwrap();
+        })
+    }
+
+    #[test]
+    fn fs_rpc_surfaces_a_verb_grant_refusal() {
+        let (mut host, guest) = UnixStream::pair().unwrap();
+        let server = serve_unary_response(
+            guest,
+            GuestCapability::FilesystemRpc,
+            "fs-read",
+            GuestResponse::VerbNotAuthorized {
+                verb: "fs-read".to_string(),
+            },
+        );
+
+        let error = send_fs_request_on(
+            &mut host,
+            GuestRequest::FsRead {
+                path: "/tmp/data".to_string(),
+                offset: None,
+                length: 16,
+                follow_symlinks: false,
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("verb fs-read not authorized"));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn proc_rpc_surfaces_an_agent_profile_refusal() {
+        let (mut host, guest) = UnixStream::pair().unwrap();
+        let server = serve_unary_response(
+            guest,
+            GuestCapability::ProcessRpc,
+            "proc-list",
+            GuestResponse::UnsupportedInProfile {
+                profile: mvm_core::security::AgentProfile::SealedProd,
+                verb: "proc-list".to_string(),
+            },
+        );
+
+        let error = send_proc_request_on(&mut host, GuestRequest::ProcList).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("verb proc-list unsupported in agent profile SealedProd")
+        );
+        server.join().unwrap();
+    }
 
     #[test]
     fn workload_is_primed_reflects_marker_presence() {

--- a/crates/mvm-cli/src/commands/vm/run_plan.rs
+++ b/crates/mvm-cli/src/commands/vm/run_plan.rs
@@ -102,6 +102,9 @@ pub(in crate::commands) fn dispatch_sdk_mode(
 ///   We pass our own absolute path (resolved via
 ///   [`std::env::current_exe`]) so a `cargo run -- run --mode
 ///   live` flow finds the same `mvmctl` it invoked through.
+/// - `MVM_SDK_RUN_PROFILE=<profile>` — the explicit security profile
+///   selected on this outer command. The language SDK validates it and
+///   passes it to the nested `machine run`.
 /// - Inherited stdio + env — the SDK prints its own output;
 ///   nothing is captured here.
 ///
@@ -144,6 +147,7 @@ fn run_live_mode(args: &RunArgs) -> Result<()> {
         .arg(&script)
         .env(mvm_sdk::env::MVM_SDK_MODE_ENV, "live")
         .env(mvm_sdk::env::MVM_CLI_BIN_ENV, &mvmctl_bin)
+        .env(mvm_sdk::env::MVM_SDK_RUN_PROFILE_ENV, args.profile.as_str())
         .status()
         .with_context(|| {
             format!(
@@ -640,5 +644,10 @@ mod tests {
         args.argv = vec!["./foo.py".to_string()];
         let p = extract_script_arg(&args).expect("one positional");
         assert_eq!(p, PathBuf::from("./foo.py"));
+    }
+
+    #[test]
+    fn live_profile_env_name_is_owned_by_the_sdk_registry() {
+        assert_eq!(mvm_sdk::env::MVM_SDK_RUN_PROFILE_ENV, "MVM_SDK_RUN_PROFILE");
     }
 }

--- a/crates/mvm-conformance/tests/steps/sdk.rs
+++ b/crates/mvm-conformance/tests/steps/sdk.rs
@@ -229,6 +229,9 @@ fn run_live_fixture(
     if language.eq_ignore_ascii_case("python") {
         command.env("PYTHONPATH", repo_root().join("crates/mvm-sdk/sdks/python"));
     }
+    if build_mode == "dev" {
+        command.env(mvm_sdk::env::MVM_SDK_RUN_PROFILE_ENV, "dev");
+    }
     let output = command
         .current_dir(repo_root())
         .arg(&script)

--- a/crates/mvm-sdk/sdks/python/README.md
+++ b/crates/mvm-sdk/sdks/python/README.md
@@ -175,6 +175,7 @@ When changing the Python SDK in this repo:
 ```sh
 cargo build -p mvm-cli
 export MVM_CLI_BIN="$PWD/target/debug/mvmctl"
+export MVM_SDK_RUN_PROFILE=dev  # explicit opt-in for files/process verbs
 uv venv
 . .venv/bin/activate
 uv pip install -e sdks/python

--- a/crates/mvm-sdk/sdks/python/mvm/__init__.py
+++ b/crates/mvm-sdk/sdks/python/mvm/__init__.py
@@ -98,7 +98,11 @@ from mvm._helpers import (
 # defined and read by `_sandbox`, but never re-exported here — which is
 # the whole of the 'absent from Python' divergence the TypeScript SDK
 # recorded against them.
-from mvm._env import MVM_SDK_MODE_ENV, MVM_SDK_OUT_PATH_ENV
+from mvm._env import (
+    MVM_SDK_MODE_ENV,
+    MVM_SDK_OUT_PATH_ENV,
+    MVM_SDK_RUN_PROFILE_ENV,
+)
 from mvm._machine import (
     MVM_MACHINE_MAX_OUTPUT_ENV,
     MVM_MACHINE_TIMEOUT_ENV,
@@ -150,6 +154,7 @@ __all__ = [
     "MVM_MACHINE_TIMEOUT_ENV",
     "MVM_SDK_MODE_ENV",
     "MVM_SDK_OUT_PATH_ENV",
+    "MVM_SDK_RUN_PROFILE_ENV",
     "SCHEMA_VERSION",
     "BadRequestError",
     "BrowserSandbox",

--- a/crates/mvm-sdk/sdks/python/mvm/_env/__init__.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_env/__init__.py
@@ -11,6 +11,7 @@ from mvm._env.vars import (
     MVM_MACHINE_TIMEOUT_ENV,
     MVM_SDK_MODE_ENV,
     MVM_SDK_OUT_PATH_ENV,
+    MVM_SDK_RUN_PROFILE_ENV,
 )
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "MVM_MACHINE_TIMEOUT_ENV",
     "MVM_SDK_MODE_ENV",
     "MVM_SDK_OUT_PATH_ENV",
+    "MVM_SDK_RUN_PROFILE_ENV",
 ]

--- a/crates/mvm-sdk/sdks/python/mvm/_env/vars.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_env/vars.py
@@ -8,6 +8,10 @@ MVM_CLI_BIN_ENV = "MVM_CLI_BIN"
 #: Selects the SDK's execution mode (for example `live` or `record`).
 MVM_SDK_MODE_ENV = "MVM_SDK_MODE"
 
+#: Carries an explicitly selected security profile from `mvmctl run`
+#: into the live SDK's nested `mvmctl machine run` invocation.
+MVM_SDK_RUN_PROFILE_ENV = "MVM_SDK_RUN_PROFILE"
+
 #: When set, the SDK writes its wire-shape recording JSON to this
 #: path on exit, so a caller need not parse stdout.
 MVM_SDK_OUT_PATH_ENV = "MVM_SDK_OUT_PATH"
@@ -25,6 +29,7 @@ MVM_MACHINE_MAX_OUTPUT_ENV = "MVM_MACHINE_MAX_OUTPUT_BYTES"
 __all__ = [
     "MVM_CLI_BIN_ENV",
     "MVM_SDK_MODE_ENV",
+    "MVM_SDK_RUN_PROFILE_ENV",
     "MVM_SDK_OUT_PATH_ENV",
     "MVM_MACHINE_TIMEOUT_ENV",
     "MVM_MACHINE_MAX_OUTPUT_ENV",

--- a/crates/mvm-sdk/sdks/python/mvm/_sandbox.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_sandbox.py
@@ -75,7 +75,11 @@ from mvm._cli import MVM_CLI_BIN_ENV, cli_resolution_hint, resolve_cli_bin
 from mvm._dsl import literal as _literal_value
 # Owned by the Rust registry (crates/mvm-sdk/src/env.rs), generated into
 # `_env/vars.py`. Re-exported from this module for existing importers.
-from mvm._env.vars import MVM_SDK_MODE_ENV, MVM_SDK_OUT_PATH_ENV
+from mvm._env.vars import (
+    MVM_SDK_MODE_ENV,
+    MVM_SDK_OUT_PATH_ENV,
+    MVM_SDK_RUN_PROFILE_ENV,
+)
 from mvm._runtime.runtime import (
     RuntimeFsEntry,
     RuntimeFsStat,
@@ -84,6 +88,7 @@ from mvm._runtime.runtime import (
 __all__ = [
     "DEFAULT_TTL_SECONDS",
     "MVM_CLI_BIN_ENV",
+    "MVM_SDK_RUN_PROFILE_ENV",
     "ExecResult",
     "FsEntry",
     "FsStat",
@@ -762,6 +767,15 @@ class _LiveTransport:
         if not ports:
             argv.append("-d")
         argv.extend(["--up-json", "--name", vm_id])
+        profile = os.environ.get(MVM_SDK_RUN_PROFILE_ENV)
+        if profile is not None:
+            profile = profile.strip().lower()
+            if profile not in {"restrictive", "standard", "dev", "permissive"}:
+                raise SandboxModeError(
+                    f"{MVM_SDK_RUN_PROFILE_ENV}={profile!r} is invalid — expected one of: "
+                    "restrictive, standard, dev, permissive"
+                )
+            argv.extend(["--profile", profile])
         argv.extend(["--manifest" if source_kind == "manifest" else "--image", source])
         argv.extend(create_args)
         argv.extend(["--ttl", f"{ttl_seconds}s"])

--- a/crates/mvm-sdk/sdks/python/tests/test_sandbox_live.py
+++ b/crates/mvm-sdk/sdks/python/tests/test_sandbox_live.py
@@ -41,10 +41,12 @@ def _isolate() -> None:
     mvm.reset_recording()
     os.environ.pop("MVM_SDK_MODE", None)
     os.environ.pop("MVM_CLI_BIN", None)
+    os.environ.pop("MVM_SDK_RUN_PROFILE", None)
     yield
     mvm.reset_recording()
     os.environ.pop("MVM_SDK_MODE", None)
     os.environ.pop("MVM_CLI_BIN", None)
+    os.environ.pop("MVM_SDK_RUN_PROFILE", None)
 
 
 def _write_fixture_mvmctl(
@@ -231,6 +233,48 @@ def test_sandbox_create_live_parses_envelope_and_records_vm(
     assert calls[0].startswith("machine run -d --up-json --name ")
     assert "--manifest python-3.12" in calls[0]
     assert "--ttl" in calls[0]
+
+
+def test_sandbox_create_live_propagates_an_explicit_dev_profile(
+    tmp_path: Path,
+) -> None:
+    script = _write_fixture_mvmctl(
+        tmp_path,
+        up_envelope={
+            "schema_version": 1,
+            "vm_id": "sb-dev-vm",
+            "build_mode": "dev",
+        },
+    )
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+    os.environ[mvm.MVM_SDK_RUN_PROFILE_ENV] = "dev"
+
+    mvm.Sandbox.create("python-3.12", workload_id="testwid")
+
+    call = _read_fixture_log(tmp_path)[0]
+    assert "--profile dev" in call
+
+
+def test_sandbox_create_live_rejects_an_unknown_profile_before_boot(
+    tmp_path: Path,
+) -> None:
+    script = _write_fixture_mvmctl(
+        tmp_path,
+        up_envelope={
+            "schema_version": 1,
+            "vm_id": "unused",
+            "build_mode": "dev",
+        },
+    )
+    os.environ["MVM_SDK_MODE"] = "live"
+    os.environ["MVM_CLI_BIN"] = str(script)
+    os.environ[mvm.MVM_SDK_RUN_PROFILE_ENV] = "unknown"
+
+    with pytest.raises(mvm.SandboxModeError, match="MVM_SDK_RUN_PROFILE"):
+        mvm.Sandbox.create("python-3.12")
+
+    assert _read_fixture_log(tmp_path) == []
 
 
 def test_live_image_boot_lowers_literal_env_allowlist_and_command(tmp_path: Path) -> None:

--- a/crates/mvm-sdk/sdks/typescript/README.md
+++ b/crates/mvm-sdk/sdks/typescript/README.md
@@ -195,6 +195,7 @@ When changing the TypeScript SDK in this repo:
 ```sh
 cargo build -p mvm-cli
 export MVM_CLI_BIN="$PWD/target/debug/mvmctl"
+export MVM_SDK_RUN_PROFILE=dev  # explicit opt-in for files/process verbs
 just sdk-install-typescript
 just sdk-build-typescript
 ```

--- a/crates/mvm-sdk/sdks/typescript/src/_env/vars.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/_env/vars.ts
@@ -11,6 +11,12 @@ export const MVM_CLI_BIN_ENV = "MVM_CLI_BIN";
 export const MVM_SDK_MODE_ENV = "MVM_SDK_MODE";
 
 /**
+ * Carries an explicitly selected security profile from `mvmctl run`
+ * into the live SDK's nested `mvmctl machine run` invocation.
+ */
+export const MVM_SDK_RUN_PROFILE_ENV = "MVM_SDK_RUN_PROFILE";
+
+/**
  * When set, the SDK writes its wire-shape recording JSON to this
  * path on exit, so a caller need not parse stdout.
  */

--- a/crates/mvm-sdk/sdks/typescript/src/_sandbox.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/_sandbox.ts
@@ -190,8 +190,8 @@ export const DEFAULT_TTL_SECONDS = 1800;
 
 // Owned by the Rust registry (crates/mvm-sdk/src/env.rs) and generated
 // into `_env/vars.ts`.
-export { MVM_SDK_MODE_ENV, MVM_SDK_OUT_PATH_ENV } from "./_env/vars.js";
-import { MVM_SDK_MODE_ENV, MVM_SDK_OUT_PATH_ENV } from "./_env/vars.js";
+export { MVM_SDK_MODE_ENV, MVM_SDK_OUT_PATH_ENV, MVM_SDK_RUN_PROFILE_ENV } from "./_env/vars.js";
+import { MVM_SDK_MODE_ENV, MVM_SDK_OUT_PATH_ENV, MVM_SDK_RUN_PROFILE_ENV } from "./_env/vars.js";
 
 
 let recording: RuntimeRecordingWire | null = null;
@@ -552,10 +552,25 @@ export class LiveTransport {
 
     const argv = ["machine", "run"];
     if (opts.ports.length === 0) argv.push("-d");
+    const rawProfile = process.env[MVM_SDK_RUN_PROFILE_ENV];
+    const profile = rawProfile?.trim().toLowerCase();
+    if (
+      profile !== undefined &&
+      profile !== "restrictive" &&
+      profile !== "standard" &&
+      profile !== "dev" &&
+      profile !== "permissive"
+    ) {
+      throw new SandboxModeError(
+        `${MVM_SDK_RUN_PROFILE_ENV}=${JSON.stringify(profile)} is invalid — expected one of: ` +
+          "restrictive, standard, dev, permissive",
+      );
+    }
     argv.push(
       "--up-json",
       "--name",
       vmId,
+      ...(profile === undefined ? [] : ["--profile", profile]),
       opts.source.kind === "manifest" ? "--manifest" : "--image",
       opts.source.value,
       ...opts.createArgs,

--- a/crates/mvm-sdk/sdks/typescript/src/index.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/index.ts
@@ -96,6 +96,7 @@ export {
   MVM_CLI_BIN_ENV,
   MVM_SDK_MODE_ENV,
   MVM_SDK_OUT_PATH_ENV,
+  MVM_SDK_RUN_PROFILE_ENV,
   RecordingNotActiveError,
   Sandbox,
   SandboxDevOnly,

--- a/crates/mvm-sdk/sdks/typescript/tests/sandbox_live.test.ts
+++ b/crates/mvm-sdk/sdks/typescript/tests/sandbox_live.test.ts
@@ -138,12 +138,14 @@ beforeEach(() => {
   mvm.resetRecording();
   delete process.env.MVM_SDK_MODE;
   delete process.env.MVM_CLI_BIN;
+  delete process.env.MVM_SDK_RUN_PROFILE;
 });
 
 afterEach(() => {
   mvm.resetRecording();
   delete process.env.MVM_SDK_MODE;
   delete process.env.MVM_CLI_BIN;
+  delete process.env.MVM_SDK_RUN_PROFILE;
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -320,6 +322,31 @@ describe("Sandbox.create (live mode)", () => {
     expect(calls[0]).toMatch(/^machine run -d --up-json --name /);
     expect(calls[0]).toContain("--manifest python-3.12");
     expect(calls[0]).toContain("--ttl");
+  });
+
+  it("propagates an explicit dev profile", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: { schema_version: 1, vm_id: "sb-dev-vm", build_mode: "dev" },
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+    process.env[mvm.MVM_SDK_RUN_PROFILE_ENV] = "dev";
+
+    mvm.Sandbox.create("python-3.12", { workloadId: "testwid" });
+
+    expect(readFixtureLog()[0]).toContain("--profile dev");
+  });
+
+  it("rejects an unknown profile before boot", () => {
+    const script = writeFixtureMvmctl({
+      upEnvelope: { schema_version: 1, vm_id: "unused", build_mode: "dev" },
+    });
+    process.env.MVM_SDK_MODE = "live";
+    process.env.MVM_CLI_BIN = script;
+    process.env[mvm.MVM_SDK_RUN_PROFILE_ENV] = "unknown";
+
+    expect(() => mvm.Sandbox.create("python-3.12")).toThrow(/MVM_SDK_RUN_PROFILE/);
+    expect(readFixtureLog()).toEqual([]);
   });
 
   it("lowers an image, literal env, allowlist, and boot command", () => {

--- a/crates/mvm-sdk/src/env.rs
+++ b/crates/mvm-sdk/src/env.rs
@@ -98,6 +98,10 @@ sdk_env_vars! {
     /// Selects the SDK's execution mode (for example `live` or `record`).
     MVM_SDK_MODE_ENV = "MVM_SDK_MODE", [Rust, Python, TypeScript];
 
+    /// Carries an explicitly selected security profile from `mvmctl run`
+    /// into the live SDK's nested `mvmctl machine run` invocation.
+    MVM_SDK_RUN_PROFILE_ENV = "MVM_SDK_RUN_PROFILE", [Rust, Python, TypeScript];
+
     /// When set, the SDK writes its wire-shape recording JSON to this
     /// path on exit, so a caller need not parse stdout.
     MVM_SDK_OUT_PATH_ENV = "MVM_SDK_OUT_PATH", [Rust, Python, TypeScript];
@@ -135,6 +139,10 @@ mod tests {
         };
         assert_eq!(by_ident("MVM_CLI_BIN_ENV").name, MVM_CLI_BIN_ENV);
         assert_eq!(by_ident("MVM_SDK_MODE_ENV").name, MVM_SDK_MODE_ENV);
+        assert_eq!(
+            by_ident("MVM_SDK_RUN_PROFILE_ENV").name,
+            MVM_SDK_RUN_PROFILE_ENV
+        );
         assert_eq!(by_ident("MVM_SDK_OUT_PATH_ENV").name, MVM_SDK_OUT_PATH_ENV);
         assert_eq!(
             by_ident("MVM_MACHINE_TIMEOUT_ENV").name,
@@ -190,11 +198,12 @@ mod tests {
             [
                 "MVM_CLI_BIN_ENV",
                 "MVM_SDK_MODE_ENV",
+                "MVM_SDK_RUN_PROFILE_ENV",
                 "MVM_SDK_OUT_PATH_ENV",
                 "MVM_MACHINE_TIMEOUT_ENV",
                 "MVM_MACHINE_MAX_OUTPUT_ENV"
             ]
         );
-        assert_eq!(exported_to(Surface::Python).count(), 5);
+        assert_eq!(exported_to(Surface::Python).count(), 6);
     }
 }

--- a/features/suites/s27_sdk/fixtures/live_session.jsonl
+++ b/features/suites/s27_sdk/fixtures/live_session.jsonl
@@ -1,4 +1,4 @@
-["machine", "run", "-d", "--up-json", "--name", "<vm-name>", "--manifest", "python-3.12", "--ttl", "1800s"]
+["machine", "run", "-d", "--up-json", "--name", "<vm-name>", "--profile", "dev", "--manifest", "python-3.12", "--ttl", "1800s"]
 ["machine", "proc", "start", "sdk-bdd-vm", "--", "python", "-c", "print('ok')"]
 ["machine", "proc", "wait", "sdk-bdd-vm", "ptok-bdd"]
 ["machine", "fs", "write", "sdk-bdd-vm", "/app/hello.txt", "--mode", "420"]

--- a/schema/sdk-env-v0.json
+++ b/schema/sdk-env-v0.json
@@ -29,6 +29,16 @@
       ]
     },
     {
+      "doc": "Carries an explicitly selected security profile from `mvmctl run` into the live SDK's nested `mvmctl machine run` invocation.",
+      "ident": "MVM_SDK_RUN_PROFILE_ENV",
+      "name": "MVM_SDK_RUN_PROFILE",
+      "surfaces": [
+        "rust",
+        "python",
+        "typescript"
+      ]
+    },
+    {
       "doc": "When set, the SDK writes its wire-shape recording JSON to this path on exit, so a caller need not parse stdout.",
       "ident": "MVM_SDK_OUT_PATH_ENV",
       "name": "MVM_SDK_OUT_PATH",

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -17,6 +17,14 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
+- [x] **Issue #2887 — guest RPC refusals and SDK live-profile propagation.**
+      Filesystem and process unary calls now preserve universal policy
+      refusals as typed errors. The live SDK carries an explicitly selected
+      dev profile into its nested machine launch while an omitted profile
+      remains standard, and Python/TypeScript share one generated environment
+      name plus the same validated argv contract. See
+      `specs/sprint/delivery/2887-guest-rpc-refusals.md`.
+
 - [x] **Issue #2874 — scheduled Security peer-policy mutation witness.**
       `NetworkPolicy::peers()` now has a focused witness that distinguishes
       both policy variants carrying an admitted peer from the deny-all empty

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3072,6 +3072,17 @@ to the configured ceiling and the first terse response immediately after it.
 - [x] Record the delivery in
       `specs/sprint/delivery/2874-security-peer-policy-witness.md`.
 
+## 2026-08-26 guest RPC refusal and SDK profile closeout
+
+- [x] Preserve `VerbNotAuthorized` and `UnsupportedInProfile` as typed errors
+      for filesystem and process unary RPCs.
+- [x] Propagate an explicit live SDK dev profile through the Rust-owned
+      environment contract without weakening the standard default.
+- [x] Keep Python and TypeScript validation and argv lowering in parity, with
+      focused language and Rust tests.
+- [x] Record the delivery in
+      `specs/sprint/delivery/2887-guest-rpc-refusals.md`.
+
 ## Follow-up (not started) — repository-to-signed-workload generator
 
 Prompted by the same 2026-08-25 survey of a commercial enterprise

--- a/specs/plans/336-sdk-parity-and-bdd-coverage.md
+++ b/specs/plans/336-sdk-parity-and-bdd-coverage.md
@@ -258,3 +258,14 @@ cover fork/exec plus a first write plus one poll.
 - [x] F3. Python + TypeScript suites green
 - [x] F4. `specs/REFACTOR-STATUS.md` rollup updated
 - [x] F5. Delivery note under `specs/sprint/delivery/`
+
+### WS-J — post-landing guest RPC refusal repair
+
+- [x] J1. Route filesystem and process unary calls through the shared response
+      contract so universal policy refusals remain typed errors.
+- [x] J2. Preserve the standard-profile default while propagating an explicit
+      `mvmctl run --mode live --profile dev` choice into the nested SDK launch.
+- [x] J3. Keep Python and TypeScript profile validation, live argv, and refusal
+      behavior in parity, including the generated environment-name registry.
+- [x] J4. Record the issue closeout in
+      `specs/sprint/delivery/2887-guest-rpc-refusals.md`.

--- a/specs/sprint/delivery/2887-guest-rpc-refusals.md
+++ b/specs/sprint/delivery/2887-guest-rpc-refusals.md
@@ -1,0 +1,33 @@
+# 2887 — Guest RPC refusal handling and explicit SDK dev profile
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+## What shipped
+
+Filesystem and process RPC helpers now use the shared unary-response contract.
+Valid universal refusals such as `VerbNotAuthorized` and
+`UnsupportedInProfile` therefore remain typed errors instead of being reported
+as an unmatched response variant.
+
+The runtime SDK's live transport also carries an explicitly selected outer run
+profile into its nested `machine run`. `mvmctl run --mode live --profile dev`
+sets the Rust-owned `MVM_SDK_RUN_PROFILE` contract, and both language SDKs
+validate and lower it to `machine run --profile dev`. A direct SDK launch with
+no profile remains on the CLI's secure standard default; unknown values fail
+before a VM is booted.
+
+The Python and TypeScript live fixtures now exercise the explicit dev profile,
+produce the same golden argv, and retain the sealed-machine refusal witness.
+
+## Verification
+
+- `cargo test -p mvm-agentd rpc_surfaces_`: 2 passed
+- `cargo test -p mvm-sdk env::tests`: 5 passed
+- `cargo check -p mvm-cli`: passed
+- Python live Sandbox suite: 58 passed
+- TypeScript SDK suite: 151 passed
+- SDK BDD live argv scenarios passed in both languages; the reviewed surface
+  divergence check passed after verifying the generated root export in both
+  built artifacts
+- generated SDK environment bindings refreshed from the Rust registry


### PR DESCRIPTION
## Summary
- preserve universal guest policy refusals as typed filesystem/process RPC errors
- propagate an explicit live SDK run profile without weakening the standard default
- keep Python and TypeScript argv, exports, generated env bindings, and BDD witnesses in parity

## Verification
- workspace clippy with all targets and warnings denied
- focused Rust RPC and SDK registry tests
- cargo check -p mvm-cli
- Python live SDK: 58 passed
- TypeScript SDK: 151 passed
- SDK live argv scenarios passed for both languages

Fixes #2887