### PR TITLE
fix(hvf): refuse unsupported multi-vCPU launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ mvmctl machine run --image python:3.12 \
 # Interactive dev shell (dev-tier images) — still transient
 mvmctl machine run --image alpine -it -- /bin/sh
 
-# Give it resources; admit specific egress only (audited; TCP/22 always refused)
-mvmctl machine run --image alpine --cpus 2 --memory 512M \
+# Give it resources; admit specific egress only (audited; TCP/22 always refused).
+# HVF currently supports exactly one guest vCPU; multi-vCPU backends may accept more.
+mvmctl machine run --image alpine --cpus 1 --memory 512M \
   --allow-host api.example.com:443 -- ./fetch
 
 # Build a Nix flake and run it transiently in one step
@@ -137,7 +138,8 @@ A persistent machine has a name and an on-disk spec: create once, start/stop/exe
 against it, reconfigure it, remove it when done.
 
 ```bash
-mvmctl machine create web --image nginx --cpus 2 --memory 512M
+# HVF currently supports exactly one guest vCPU; multi-vCPU backends may accept more.
+mvmctl machine create web --image nginx --cpus 1 --memory 512M
 mvmctl machine start web
 mvmctl machine exec  web -- nginx -v
 mvmctl machine logs  web

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -129,6 +129,13 @@ fn relay_supervisor_config_with_handoff(
     handoff: Option<&HandoffConfig>,
     exclusive_image_lock: Option<&Path>,
 ) -> Result<HvfSupervisorConfig> {
+    if spec.vcpus != 1 {
+        bail!(
+            "the hvf backend supports exactly 1 vCPU, but this launch requests {}",
+            spec.vcpus
+        );
+    }
+
     let kernel = match &spec.kernel {
         KernelImage::Path(p) => p.clone(),
         KernelImage::Bundled => {
@@ -1438,6 +1445,24 @@ mod tests {
             vec![],
         );
         assert!(relay_supervisor_config(&spec, &sample_paths()).is_err());
+    }
+
+    #[test]
+    fn relay_config_refuses_a_vcpu_count_hvf_cannot_honor() {
+        let mut spec = spec_with(
+            KernelImage::Path("/img/Image".into()),
+            vec![egress_port("/run/egress.sock")],
+            vec![],
+        );
+        spec.vcpus = 2;
+
+        let error = relay_supervisor_config(&spec, &sample_paths())
+            .expect_err("HVF must not silently reduce a multi-vCPU request");
+
+        assert_eq!(
+            error.to_string(),
+            "the hvf backend supports exactly 1 vCPU, but this launch requests 2"
+        );
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -43,6 +43,12 @@ for detailed scope and acceptance criteria.
       name plus the same validated argv contract. See
       `specs/sprint/delivery/2887-guest-rpc-refusals.md`.
 
+- [x] **Issue #2888 — HVF vCPU resource contract.** HVF now refuses any launch
+      whose requested vCPU count is not exactly one, before supervisor state is
+      written or a process is spawned. The README no longer implies that the
+      current single-vCPU backend honors a larger count. See
+      `specs/sprint/delivery/2888-hvf-vcpu-contract.md`.
+
 - [x] **Issue #2874 — scheduled Security peer-policy mutation witness.**
       `NetworkPolicy::peers()` now has a focused witness that distinguishes
       both policy variants carrying an admitted peer from the deny-all empty

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3086,6 +3086,17 @@ to the configured ceiling and the first terse response immediately after it.
 - [ ] Restore the builder-image and Linux flake gates blocked by issue #2904,
       then merge the repair through the queue.
 
+## 2026-08-26 HVF vCPU resource-contract closeout
+
+- [x] Reproduce that the HVF driver accepted a multi-vCPU `VmmSpec` even though
+      the guest could only ever observe one processor.
+- [x] Refuse every HVF launch whose requested vCPU count is not exactly one,
+      before writing supervisor state or spawning a process.
+- [x] Correct the README's backend-neutral live examples and preserve focused
+      regression coverage for the exact diagnostic.
+- [x] Record the delivery in
+      `specs/sprint/delivery/2888-hvf-vcpu-contract.md`.
+
 ## 2026-08-26 Security peer-policy mutation witness
 
 - [x] Reproduce the scheduled Security failure from run 32931995875 as the

--- a/specs/sprint/delivery/2888-hvf-vcpu-contract.md
+++ b/specs/sprint/delivery/2888-hvf-vcpu-contract.md
@@ -1,0 +1,26 @@
+# HVF refuses unsupported multi-vCPU launches
+
+Issue #2888 showed that a workload could request multiple vCPUs from the HVF
+backend, receive a successful launch, and still observe only one processor in
+the guest. The resource count reached `VmmSpec`, but the backend is single-vCPU
+by construction: its supervisor, FDT, PSCI handling, snapshots, and run loop do
+not implement SMP.
+
+The HVF driver now validates the requested count before writing supervisor
+state or spawning a process. Exactly one vCPU remains supported. Zero or more
+than one returns a clear error that names both the backend limit and the
+requested count. Other backends keep their existing multi-vCPU behavior.
+
+The README's backend-neutral examples now request one vCPU and state the HVF
+limit explicitly. This removes the false promise while leaving room for a
+future complete SMP implementation that includes secondary-vCPU lifecycle,
+PSCI `CPU_ON`, FDT CPU nodes, GIC redistributors, snapshot state, and quota
+accounting together.
+
+Validation:
+
+- a focused HVF driver regression proves a two-vCPU spec is refused with the
+  exact diagnostic;
+- the complete `mvm-backends` test suite;
+- workspace check and Clippy gates before submission;
+- the required PR and merge-group checks remain the merge gate.


### PR DESCRIPTION
HVF is single-vCPU by construction today, but the driver accepted larger VmmSpec counts and silently booted one processor. This change fails closed before supervisor state is written or a process is spawned, updates the backend-neutral README examples, and adds a focused diagnostic regression.

Verification:
- cargo test -p mvm-backends (183 passed)
- cargo check --workspace
- cargo clippy --workspace -- -D warnings
- pre-commit cargo clippy --workspace --all-targets -- -D warnings

Fixes #2888