### PR TITLE
fix(site): isolate the whole site so the embedded demo gets SharedArrayBuffer

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -108,3 +108,14 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy public/dist --project-name=mvm --branch=main
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      # `_headers` is inert unless the host reads it, so the only proof that
+      # this deployment is cross-origin isolated — and therefore that the
+      # WebLinux demo has a SharedArrayBuffer — is the wire. Checked against
+      # the deployment URL rather than the production domain: this step can
+      # only speak for what it just published. Whether users reach it is a DNS
+      # question, which "Site isolation watch" answers on its own schedule.
+      - name: Verify the deployment is cross-origin isolated
+        env:
+          DEPLOYMENT_URL: ${{ steps.deployment.outputs.deployment-url }}
+        run: ./scripts/check-site-isolation-headers.sh "$DEPLOYMENT_URL"

--- a/.github/workflows/site-isolation-watch.yml
+++ b/.github/workflows/site-isolation-watch.yml
@@ -1,0 +1,103 @@
+name: Site isolation watch
+
+# Checks that the live site sends the cross-origin isolation headers the
+# WebLinux demo needs, on a schedule that nothing in the repo has to trigger.
+#
+# Every other gate here reasons about the tree. This one exists because the
+# tree was right and the site was still broken: `public/public/_headers` is a
+# Cloudflare Pages file, GitHub Pages ignores it silently, and the deploy was
+# moved to Cloudflare Pages behind one-time setup (a Pages project, two
+# secrets, a DNS change) that a merged PR cannot perform. The demo has been
+# failing with "SharedArrayBuffer is not defined" ever since, with a correct
+# config in the tree and a green Website lane.
+#
+# The deploy job checks the deployment URL it just published, which cannot see
+# this: DNS pointing somewhere else is invisible from inside a successful
+# deploy. So this asks the question users ask — fetch the production domain,
+# read the headers off the wire — and it runs on a cron because the deploy is
+# release-triggered and may not run for weeks.
+#
+# Failure opens or updates one tracking issue; a clean run closes it. That is
+# the enforcement surface, not a merge block: no PR can regress this and no PR
+# can fix it.
+
+on:
+  schedule:
+    - cron: "23 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write # opens/updates/closes the tracking issue
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Check live cross-origin isolation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      # No URL argument: the script reads the domain out of the site config, so
+      # a domain move cannot leave this watching the old one and passing.
+      - name: Check the production domain
+        id: check
+        run: |
+          set -uo pipefail
+          ./scripts/check-site-isolation-headers.sh 2>&1 | tee report.txt
+          echo "status=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Open, update, or close the tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          STATUS: ${{ steps.check.outputs.status }}
+          TITLE: "Live site is not cross-origin isolated"
+        run: |
+          set -euo pipefail
+
+          EXISTING=$(gh issue list --repo "$REPO" --state open \
+            --search "\"$TITLE\" in:title" --json number --jq '.[0].number // empty')
+
+          if [ "$STATUS" = "0" ]; then
+            if [ -n "$EXISTING" ]; then
+              printf 'The live site is cross-origin isolated again ([run](%s)) — closing.\n' \
+                "$RUN_URL" > body.md
+              gh issue comment "$EXISTING" --repo "$REPO" --body-file body.md
+              gh issue close "$EXISTING" --repo "$REPO"
+            fi
+            exit 0
+          fi
+
+          # Backticks below are markdown, not command substitution.
+          # shellcheck disable=SC2016
+          {
+            printf 'The WebLinux demo on the live site fails with '
+            printf '`SharedArrayBuffer is not defined`.\n\n'
+            printf 'Run: %s\n\n' "$RUN_URL"
+            printf '```\n'
+            cat report.txt
+            printf '```\n\n'
+            printf 'SharedArrayBuffer is exposed only to a cross-origin-isolated document, '
+            printf 'and isolation does not propagate upward from a frame — so the landing '
+            printf 'page, which embeds the demo in an iframe, has to send the headers too, '
+            printf 'not just the demo document.\n\n'
+            printf 'The headers are declared in `public/public/_headers`, which only '
+            printf 'Cloudflare Pages reads. If the report above says GitHub Pages served '
+            printf 'the response, the config is fine and the deployment is not: finish the '
+            printf 'cutover in `.github/workflows/pages.yml` (Pages project, '
+            printf '`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`, DNS).\n'
+          } > body.md
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$REPO" --body-file body.md
+          else
+            gh issue create --repo "$REPO" --title "$TITLE" --body-file body.md
+          fi
+
+          exit 1

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -79,6 +79,10 @@ jobs:
         working-directory: public
         run: pnpm check:perf
 
+      - name: Check cross-origin isolation headers
+        working-directory: public
+        run: pnpm check:headers
+
       - name: Build
         working-directory: public
         run: pnpm build

--- a/Justfile
+++ b/Justfile
@@ -545,6 +545,14 @@ docs-publish:
 # Alias for `docs-publish` using the Cloudflare Pages deployment name.
 pages-deploy: docs-publish
 
+# Check the live site sends the cross-origin isolation headers the demo needs
+docs-check-live-headers url="":
+    # No argument checks the domain in public/astro.config.mjs; pass a URL to
+    # check a preview deployment instead. `pnpm check:headers` gates the
+    # `_headers` config — this one gates what the host actually sends, which is
+    # a different question and the one that has been answered wrong.
+    ./scripts/check-site-isolation-headers.sh {{ url }}
+
 # Build the browser-tier microVM demo assets (wasm core + guest + fixtures)
 demo-build:
     ./web/mvm-demo/build.sh

--- a/public/package.json
+++ b/public/package.json
@@ -12,7 +12,8 @@
     "check:tokens": "node scripts/check-no-hardcoded-hex.mjs",
     "check:samples": "node scripts/check-sample-provenance.mjs",
     "check:perf": "node scripts/check-perf-provenance.mjs",
-    "check": "pnpm check:tokens && pnpm check:samples && pnpm check:perf && pnpm build"
+    "check:headers": "node scripts/check-isolation-headers.mjs",
+    "check": "pnpm check:tokens && pnpm check:samples && pnpm check:perf && pnpm check:headers && pnpm build"
   },
   "dependencies": {
     "@astrojs/react": "^4.4.2",

--- a/public/public/_headers
+++ b/public/public/_headers
@@ -1,6 +1,17 @@
 # Cross-origin isolation headers for the WebLinux browser demo.
 # QEMU-Wasm uses pthreads, which require SharedArrayBuffer; browsers only
 # expose SharedArrayBuffer in a cross-origin-isolated context.
-/demo/weblinux/*
+#
+# The scope is the whole site, not just /demo/weblinux/*, because the landing
+# page embeds the demo in an iframe (DemoTeaser.tsx). Isolation does not
+# propagate upward from a frame: a frame is cross-origin isolated only if the
+# top-level document is isolated too, so headers on the demo path alone leave
+# the embedded copy without SharedArrayBuffer.
+#
+# require-corp site-wide means every cross-origin subresource must carry CORP
+# or CORS headers or the browser blocks it. The site loads none today (external
+# origins appear only as link targets and a form action), so this is free; a
+# future third-party embed has to opt in explicitly.
+/*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp

--- a/public/scripts/check-isolation-headers.mjs
+++ b/public/scripts/check-isolation-headers.mjs
@@ -1,0 +1,59 @@
+// The WebLinux demo boots QEMU-Wasm, which uses pthreads and therefore needs
+// SharedArrayBuffer. Browsers expose SharedArrayBuffer only to a
+// cross-origin-isolated document, and isolation does not propagate upward from
+// a frame: a page that embeds the demo in an iframe must itself be isolated or
+// the embedded copy fails with "SharedArrayBuffer is not defined" while the
+// standalone demo page works fine.
+//
+// That is exactly how it shipped once, so this gate reads the embed out of the
+// component rather than trusting a hand-kept list: whatever page embeds the
+// demo, and the demo document itself, must both resolve to COOP/COEP under the
+// deployed `_headers`.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { loadHeaderRules, isolationGaps } from "./headers-config.mjs";
+
+const publicDir = join(import.meta.dirname, "..", "public");
+const teaserPath = join(import.meta.dirname, "..", "src/components/landing/DemoTeaser.tsx");
+
+const failures = [];
+const fail = (m) => failures.push(m);
+
+let rules;
+try {
+  rules = loadHeaderRules(publicDir);
+} catch (err) {
+  console.error(`check:headers FAILED\n  - ${err.message}`);
+  process.exit(1);
+}
+
+// The landing page is the top-level document a visitor loads; it is isolated
+// only if `_headers` says so.
+const required = new Map([["/", "landing page"]]);
+
+const teaser = readFileSync(teaserPath, "utf8");
+const embed = teaser.match(/<iframe[\s\S]*?src=\{`\$\{base\}([^`?]*)/);
+if (embed === null) {
+  fail(`could not find the demo iframe src in ${teaserPath}; this gate has drifted`);
+} else {
+  required.set(embed[1], "embedded demo document");
+}
+
+for (const [pathname, label] of required) {
+  for (const gap of isolationGaps(rules, pathname)) {
+    fail(`${pathname} (${label}) is missing ${gap}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error("check:headers FAILED");
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error(
+    "\nFix public/public/_headers so every document above resolves to\n" +
+      "  Cross-Origin-Opener-Policy: same-origin\n" +
+      "  Cross-Origin-Embedder-Policy: require-corp",
+  );
+  process.exit(1);
+}
+
+console.log(`check:headers OK (${[...required.keys()].join(", ")} are cross-origin isolated)`);

--- a/public/scripts/headers-config.mjs
+++ b/public/scripts/headers-config.mjs
@@ -1,0 +1,86 @@
+// Parser for the Cloudflare Pages `_headers` file that carries the deployed
+// site's response headers.
+//
+// It is shared rather than duplicated because two consumers need to agree on
+// what the deployed site will send: the static gate that checks the file
+// declares cross-origin isolation everywhere it is needed, and the browser
+// smoke test, which serves these headers instead of inventing its own. A
+// harness that stamps its own policy proves nothing about the deployment.
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// `_headers` path patterns use `*` as a splat that spans path separators and
+// `:name` as a single-segment placeholder.
+export function patternToRegExp(pattern) {
+  let source = "";
+  for (let i = 0; i < pattern.length; i += 1) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      source += ".*";
+    } else if (ch === ":") {
+      while (i + 1 < pattern.length && /[A-Za-z0-9_]/.test(pattern[i + 1])) i += 1;
+      source += "[^/]+";
+    } else {
+      source += ch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  return new RegExp(`^${source}$`);
+}
+
+// A rule is an unindented path pattern followed by indented `Name: value`
+// lines. Returns them in file order.
+export function parseHeaders(text) {
+  const rules = [];
+  let current = null;
+  for (const raw of text.split("\n")) {
+    // `#` starts a comment only at the head of a line; a header value may
+    // legitimately contain one.
+    if (raw.trim().startsWith("#")) continue;
+    const line = raw.replace(/\s+$/, "");
+    if (line.trim() === "") continue;
+    if (!/^\s/.test(line)) {
+      current = { path: line.trim(), pattern: patternToRegExp(line.trim()), headers: {} };
+      rules.push(current);
+      continue;
+    }
+    const sep = line.indexOf(":");
+    if (current === null || sep === -1) continue;
+    current.headers[line.slice(0, sep).trim()] = line.slice(sep + 1).trim();
+  }
+  return rules;
+}
+
+export function loadHeaderRules(root) {
+  const file = join(root, "_headers");
+  if (!existsSync(file)) {
+    throw new Error(`${file} not found`);
+  }
+  return parseHeaders(readFileSync(file, "utf8"));
+}
+
+// Every matching rule applies; a later rule wins on a repeated header name.
+export function headersFor(rules, pathname) {
+  const merged = {};
+  for (const rule of rules) {
+    if (rule.pattern.test(pathname)) Object.assign(merged, rule.headers);
+  }
+  return merged;
+}
+
+// The two headers a document needs to be cross-origin isolated, which is the
+// only context in which browsers expose SharedArrayBuffer.
+export const ISOLATION_HEADERS = {
+  "Cross-Origin-Opener-Policy": "same-origin",
+  "Cross-Origin-Embedder-Policy": "require-corp",
+};
+
+// Returns the header names that are missing or wrong for `pathname`.
+export function isolationGaps(rules, pathname) {
+  const resolved = {};
+  for (const [name, value] of Object.entries(headersFor(rules, pathname))) {
+    resolved[name.toLowerCase()] = value;
+  }
+  return Object.entries(ISOLATION_HEADERS)
+    .filter(([name, want]) => resolved[name.toLowerCase()] !== want)
+    .map(([name, want]) => `${name}: ${want} (got ${resolved[name.toLowerCase()] ?? "nothing"})`);
+}

--- a/public/tests/demo-e2e.mjs
+++ b/public/tests/demo-e2e.mjs
@@ -3,9 +3,10 @@
  * Smoke test for the WebLinux browser demo and the static site.
  *
  * This script starts a tiny static server from the built `public/dist`
- * directory (with COOP/COEP headers required by SharedArrayBuffer) and uses
- * Playwright to visit the landing page and drive the /demo/weblinux page
- * through run, shell interaction, and stop.
+ * directory, serving the response headers the deployed site's `_headers` file
+ * declares, and uses Playwright to visit the landing page, confirm both it and
+ * the demo it embeds are cross-origin isolated, and drive the /demo/weblinux
+ * page through run, shell interaction, and stop.
  *
  * Prerequisites: Playwright must be installed in a discoverable Node scope.
  *   cd public && pnpm add -D playwright
@@ -20,6 +21,12 @@ import http from "node:http";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+// The deployed site's response headers come from a `_headers` file that
+// Cloudflare Pages reads at the site root. This harness serves that same file
+// instead of stamping COOP/COEP on every response: a hard-coded blanket policy
+// passes under a config that would not isolate the real site, which is how the
+// landing page's embedded demo shipped without SharedArrayBuffer.
+import { loadHeaderRules, headersFor } from "../scripts/headers-config.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "../dist");
@@ -49,22 +56,51 @@ const mime = {
   ".woff": "font/woff",
 };
 
-function startServer(port) {
+function startServer(port, rules) {
   return new Promise((resolve) => {
     const server = http.createServer((req, res) => {
-      let file = path.join(ROOT, decodeURIComponent(req.url.split("?")[0]));
+      const pathname = decodeURIComponent(req.url.split("?")[0]);
+      let file = path.join(ROOT, pathname);
       if (file.endsWith("/")) file += "index.html";
       if (!fs.existsSync(file)) file = path.join(ROOT, "index.html");
       const ext = path.extname(file);
       res.writeHead(200, {
         "Content-Type": mime[ext] || "application/octet-stream",
-        "Cross-Origin-Opener-Policy": "same-origin",
-        "Cross-Origin-Embedder-Policy": "require-corp",
+        ...headersFor(rules, pathname),
       });
       fs.createReadStream(file).pipe(res);
     });
     server.listen(port, () => resolve(server));
   });
+}
+
+// SharedArrayBuffer exists only in a cross-origin-isolated context, and
+// isolation does not propagate upward from a frame: an embedded demo is
+// isolated only when the document embedding it is isolated too. Accepts a Page
+// or a Frame — both expose evaluate().
+async function assertIsolated(context, label) {
+  const state = await context.evaluate(() => ({
+    isolated: globalThis.crossOriginIsolated === true,
+    sharedArrayBuffer: typeof SharedArrayBuffer !== "undefined",
+  }));
+  if (!state.isolated || !state.sharedArrayBuffer) {
+    throw new Error(
+      `${label} is not cross-origin isolated (crossOriginIsolated=${state.isolated}, ` +
+        `SharedArrayBuffer=${state.sharedArrayBuffer}); widen the COOP/COEP scope in ` +
+        `public/public/_headers`,
+    );
+  }
+}
+
+async function openEmbeddedDemo(page, timeoutMs = 30000) {
+  await page.click("button:has-text('Run demo')");
+  const element = await page.waitForSelector("iframe[title='mvm WebLinux demo']", {
+    timeout: timeoutMs,
+  });
+  const frame = await element.contentFrame();
+  if (!frame) throw new Error("the demo iframe exposed no content frame");
+  await frame.waitForLoadState("domcontentloaded");
+  return frame;
 }
 
 async function runCommand(page, cmd) {
@@ -88,7 +124,17 @@ async function main() {
     throw new Error(`Built dist not found at ${ROOT}; run 'just docs-build' first.`);
   }
 
-  const server = await startServer(8788);
+  // Built from public/public/_headers. Without it the harness would serve an
+  // unisolated site and every assertion below would fail for the wrong reason,
+  // so treat a missing file as a broken build rather than an empty ruleset.
+  let rules;
+  try {
+    rules = loadHeaderRules(ROOT);
+  } catch (err) {
+    throw new Error(`${err.message}; rebuild the site with 'just docs-build'`);
+  }
+
+  const server = await startServer(8788, rules);
   const browser = await chromium.launch();
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
 
@@ -103,6 +149,16 @@ async function main() {
     // Smoke-check the landing page first.
     await page.goto("http://localhost:8788/", { waitUntil: "networkidle" });
     await page.waitForTimeout(500);
+    await assertIsolated(page, "landing page");
+
+    // Open the demo the way a landing-page visitor does. The frame inherits
+    // isolation from this document, so it is the direct witness that the
+    // embedded copy can allocate a SharedArrayBuffer. Close it again rather
+    // than letting the autorun boot run alongside the standalone drive below.
+    const embedded = await openEmbeddedDemo(page);
+    await assertIsolated(embedded, "embedded demo iframe");
+    await page.click("button[aria-label='Close demo']");
+    await page.waitForTimeout(250);
 
     // Open the WebLinux demo with autorun so the engine starts immediately.
     await page.goto("http://localhost:8788/demo/weblinux/?autorun=1", { waitUntil: "networkidle" });

--- a/scripts/check-site-isolation-headers.sh
+++ b/scripts/check-site-isolation-headers.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Asserts a *deployed* site actually sends the cross-origin isolation headers
+# the WebLinux demo needs. QEMU-Wasm uses pthreads, so it needs
+# SharedArrayBuffer, which browsers expose only to a cross-origin-isolated
+# document — and isolation does not propagate upward from a frame, so the page
+# embedding the demo has to be isolated too, not just the demo document.
+#
+# This checks the wire, not the repo, because the repo has been right while the
+# wire was wrong: `public/public/_headers` is a Cloudflare Pages file that
+# GitHub Pages silently ignores, so a correct config served by the wrong host —
+# or by the right host behind DNS that still points at the old one — produces
+# exactly the shipped-and-broken state, with nothing in the tree to show for
+# it. `pnpm check:headers` gates the config; this gates the deployment.
+#
+# Usage: check-site-isolation-headers.sh [base-url] [path ...]
+# The base URL defaults to the site config's own domain, and the paths to the
+# landing page and the demo document.
+set -euo pipefail
+
+readonly WANT_COOP="same-origin"
+readonly WANT_COEP="require-corp"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+
+# One source of truth for the domain: a copy pinned here would keep passing
+# against the old one after a domain move.
+site_url_from_config() {
+  local config="$REPO_ROOT/public/astro.config.mjs" url
+  url=$(sed -n 's/^[[:space:]]*site:[[:space:]]*"\([^"]*\)".*/\1/p' "$config" | head -n 1)
+  if [[ -z "$url" ]]; then
+    echo "could not read the site URL from $config" >&2
+    return 1
+  fi
+  printf '%s' "$url"
+}
+
+# Header names are case-insensitive on the wire; take the last occurrence and
+# strip the name, surrounding whitespace, and the trailing CR.
+header_value() {
+  local headers="$1" name="$2"
+  printf '%s\n' "$headers" |
+    grep -i "^${name}:" |
+    tail -n 1 |
+    sed -e 's/^[^:]*:[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
+
+# A just-published deployment can take a moment to become reachable, and a
+# transient fetch failure must not be reported as a missing header.
+fetch_headers() {
+  local url="$1" attempt response
+  for attempt in 1 2 3 4 5; do
+    if response=$(curl --silent --show-error --location --fail --max-time 30 --head "$url"); then
+      printf '%s' "$response"
+      return 0
+    fi
+    if [[ "$attempt" -lt 5 ]]; then
+      sleep $((attempt * 5))
+    fi
+  done
+  return 1
+}
+
+check_url() {
+  local url="$1" headers got_coop got_coep ok=1
+
+  if ! headers=$(fetch_headers "$url"); then
+    echo "FAIL $url — could not fetch" >&2
+    return 1
+  fi
+
+  got_coop=$(header_value "$headers" "cross-origin-opener-policy")
+  got_coep=$(header_value "$headers" "cross-origin-embedder-policy")
+
+  if [[ "$got_coop" != "$WANT_COOP" ]]; then
+    echo "FAIL $url — Cross-Origin-Opener-Policy: want '$WANT_COOP', got '${got_coop:-nothing}'" >&2
+    ok=0
+  fi
+  if [[ "$got_coep" != "$WANT_COEP" ]]; then
+    echo "FAIL $url — Cross-Origin-Embedder-Policy: want '$WANT_COEP', got '${got_coep:-nothing}'" >&2
+    ok=0
+  fi
+
+  if [[ "$ok" -eq 1 ]]; then
+    echo "ok   $url — cross-origin isolated"
+    return 0
+  fi
+
+  # A response served by GitHub Pages explains the whole failure, so say so
+  # rather than leaving someone to re-read a `_headers` file that is correct.
+  if printf '%s\n' "$headers" | grep -qi '^x-github-request-id:'; then
+    echo "     ...served by GitHub Pages, which cannot set these headers at all." >&2
+    echo "     The site must be served by Cloudflare Pages (.github/workflows/pages.yml)." >&2
+  fi
+  return 1
+}
+
+main() {
+  local base_url
+  if [[ $# -ge 1 ]]; then
+    base_url="${1%/}"
+    shift
+  else
+    base_url="$(site_url_from_config)"
+    base_url="${base_url%/}"
+  fi
+
+  local paths=("$@")
+  if [[ ${#paths[@]} -eq 0 ]]; then
+    paths=("/" "/demo/weblinux/")
+  fi
+
+  local failures=0 path
+  for path in "${paths[@]}"; do
+    check_url "${base_url}${path}" || failures=$((failures + 1))
+  done
+
+  if [[ "$failures" -gt 0 ]]; then
+    echo >&2
+    echo "$failures document(s) are not cross-origin isolated; the WebLinux demo will" >&2
+    echo "fail with 'SharedArrayBuffer is not defined'." >&2
+    return 1
+  fi
+
+  echo "all checked documents are cross-origin isolated"
+}
+
+main "$@"

--- a/specs/sprint/delivery/site-cross-origin-isolation.md
+++ b/specs/sprint/delivery/site-cross-origin-isolation.md
@@ -1,0 +1,98 @@
+# The demo on the homepage had no SharedArrayBuffer
+
+Backing: shipped-source
+Validation: pnpm check:headers, check-site-isolation-headers.sh, demo-e2e.mjs
+
+The WebLinux demo embedded on the landing page fails in the browser with
+
+```
+DEMO-RESULT: ERROR SharedArrayBuffer is not defined
+```
+
+QEMU-Wasm uses pthreads, so it needs `SharedArrayBuffer`, which browsers
+expose only to a cross-origin-isolated document. Two independent things
+were preventing that, and each is sufficient on its own.
+
+## The scope was wrong
+
+`public/public/_headers` declared COOP/COEP for `/demo/weblinux/*` only.
+The landing page embeds the demo as an iframe (`DemoTeaser.tsx`), and
+isolation does not propagate upward from a frame: a frame is isolated only
+when the top-level document is isolated too. So the standalone demo page
+would have worked and the embedded copy — the one nearly every visitor
+reaches — could not.
+
+The scope is now `/*`. `require-corp` site-wide means every cross-origin
+subresource needs CORP or CORS headers; the site loads none today (external
+origins appear only as link targets and a form action), so this costs
+nothing now and makes a future third-party embed opt in explicitly.
+
+## The headers were never sent at all
+
+`_headers` is a Cloudflare Pages file. gomicrovm.com is still served by
+GitHub Pages, which ignores it — the responses carry
+`x-github-request-id` and Fastly's `via: 1.1 varnish` behind Cloudflare's
+DNS proxy. #2880 moved the deploy to Cloudflare Pages precisely because
+GitHub Pages cannot set these headers, but it listed one-time setup a
+merged PR cannot perform (create the Pages project, add
+`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`, repoint DNS), and
+`pages.yml` triggers only on `release: published` and manual dispatch. So
+the config landed, the lane stayed green, and the site kept serving no
+isolation headers.
+
+**That setup is still outstanding.** Nothing here can finish it; the watch
+below is what makes it visible until someone does.
+
+## Why the existing test could not catch either half
+
+`public/tests/demo-e2e.mjs` starts a static server that stamped
+COOP/COEP on *every* response. Its environment was strictly more permissive
+than production, so it passed under a config that isolates nothing, and it
+would have passed just as happily against a deployment serving no headers
+at all. A harness that invents its own policy tests the harness.
+
+It now parses `_headers` out of the built `dist` and serves exactly the
+rules the deployed site declares, via a parser shared with the static gate
+(`public/scripts/headers-config.mjs`) so the two cannot drift. It then
+asserts `crossOriginIsolated` on the landing page, opens the demo the way a
+visitor does, and asserts it on the frame — the direct witness for the
+reported failure. Reverted to the old scope, it fails with
+`landing page is not cross-origin isolated (crossOriginIsolated=false,
+SharedArrayBuffer=false)`.
+
+## Three gates, three different questions
+
+The two halves fail independently, so one gate cannot cover both.
+
+- `pnpm check:headers` (`public/scripts/check-isolation-headers.mjs`, wired
+  into `website.yml`) asks **is the config right**. It reads the iframe
+  `src` out of `DemoTeaser.tsx` rather than keeping a list, so whatever
+  page embeds the demo — and the demo document itself — must both resolve
+  to COOP/COEP. It needs no network and runs on every PR touching
+  `public/**`.
+- `scripts/check-site-isolation-headers.sh`, run from `pages.yml` after the
+  deploy, asks **did what we just published come out isolated**. It checks
+  the deployment URL, which is all a deploy step can speak for.
+- `site-isolation-watch.yml` asks **does the site users load actually send
+  the headers**. This is the question the other two structurally cannot
+  answer: a correct config, correctly deployed, still reaches nobody while
+  DNS points at the old host. It is a cron rather than a trigger on
+  anything in the repo because no commit can cause or fix this, and it
+  opens/updates/closes one tracking issue in the house style. Run against
+  production today it fails, and names the cause:
+
+  ```
+  FAIL https://gomicrovm.com/ — Cross-Origin-Opener-Policy: want 'same-origin', got 'nothing'
+       ...served by GitHub Pages, which cannot set these headers at all.
+  ```
+
+The shell script and the watch both read the domain from
+`public/astro.config.mjs` rather than pinning a copy, so a domain move
+cannot leave them checking the old one and passing.
+
+## Limits
+
+The wire check reads response headers; it does not run a browser, so it
+confirms the precondition for `SharedArrayBuffer` rather than the demo
+booting. `demo-e2e.mjs` covers the boot, but only against a local server —
+there is no lane that drives a real browser against the deployed site.


### PR DESCRIPTION
The WebLinux demo on the landing page fails in the browser with:

```
[demo] sending allowHost: demo.mvm.local
[worker] allowHost received: demo.mvm.local
DEMO-RESULT: ERROR SharedArrayBuffer is not defined
```

QEMU-Wasm uses pthreads, so it needs `SharedArrayBuffer`, which browsers
expose only to a cross-origin-isolated document. Two independent things were
preventing that, and each is sufficient on its own.

## The scope was wrong

`public/public/_headers` declared COOP/COEP for `/demo/weblinux/*` only. The
landing page embeds the demo as an iframe (`DemoTeaser.tsx:91`), and isolation
does not propagate upward from a frame: a frame is isolated only when the
top-level document is isolated too. So the standalone demo page worked and the
embedded copy — the one nearly every visitor reaches — could not.

Widened to `/*`. `require-corp` site-wide means every cross-origin subresource
needs CORP or CORS headers; the built site loads none today (external origins
appear only as link targets and a Formspree form action), so this costs
nothing now and makes a future third-party embed opt in explicitly.

## The headers were never sent at all

`_headers` is a Cloudflare Pages file. gomicrovm.com is still served by GitHub
Pages, which ignores it:

```
$ curl -sSI https://gomicrovm.com/demo/weblinux/
server: cloudflare              <- DNS proxy only
x-github-request-id: 2882:11D58B:...
via: 1.1 varnish
(no cross-origin-* headers)
```

The deploy was moved to Cloudflare Pages precisely because GitHub Pages cannot
set these headers, but that change listed one-time setup a merged PR cannot
perform — create the Pages project, add `CLOUDFLARE_API_TOKEN` +
`CLOUDFLARE_ACCOUNT_ID`, repoint DNS — and `pages.yml` triggers only on
`release: published` and manual dispatch.

**That setup is still outstanding and this PR cannot do it.** The watch below
is what keeps it visible until someone does.

## Why the existing test could not catch either half

`public/tests/demo-e2e.mjs` started a static server that stamped COOP/COEP on
*every* response. Its environment was strictly more permissive than
production, so it passed under a config that isolates nothing, and would have
passed just as happily against a deployment serving no headers at all.

It now parses `_headers` out of the built `dist` and serves exactly the rules
the deployed site declares, then asserts `crossOriginIsolated` on the landing
page, opens the demo the way a visitor does, and asserts it on the frame.

## Three gates, three different questions

| Gate | Question | Trigger |
| --- | --- | --- |
| `pnpm check:headers` | is the config right? | every PR touching `public/**` |
| `check-site-isolation-headers.sh` in `pages.yml` | did what we just published come out isolated? | after each deploy |
| `site-isolation-watch.yml` | does the site users load actually send the headers? | daily cron |

The third is the one the other two structurally cannot answer: a correct
config, correctly deployed, still reaches nobody while DNS points at the old
host. It is a cron rather than a trigger on anything in the repo because no
commit can cause or fix it, and it opens/updates/closes one tracking issue in
the same style as `security-lane-watch.yml`.

`check:headers` reads the iframe `src` out of `DemoTeaser.tsx` rather than
keeping a hand-maintained path list, and the shell script reads the domain
from `public/astro.config.mjs`, so neither can drift into passing against the
wrong target.

## Verification

- `check:headers` passes on the new config and fails on the old one, naming
  `/` as the missing document.
- `check-site-isolation-headers.sh` fails against production today and
  identifies the cause ("served by GitHub Pages, which cannot set these
  headers at all"), and passes against a locally served isolated site.
- `demo-e2e.mjs` gets through both new isolation assertions in a real browser
  against a fresh `pnpm build`, and — rebuilt with the old narrow scope —
  fails with `landing page is not cross-origin isolated
  (crossOriginIsolated=false, SharedArrayBuffer=false)`.
- `actionlint`, `shellcheck`, `shfmt`, `cargo nextest run -p xtask` (648
  passed), `check-workflow-paths`, `check-declared-backing`,
  `check-sprint-append`, `check-honesty`, `check-no-overclaim`,
  `check-witness-citations`, `check-no-spec-refs-in-comments` all clean.

## Limits

The wire check reads response headers; it does not run a browser, so it
confirms the precondition for `SharedArrayBuffer` rather than the demo
booting. `demo-e2e.mjs` covers the boot, but only against a local server —
there is no lane driving a real browser against the deployed site.
