### PR TITLE
fix(run): stop reading stdin that nobody handed us

### DIFF
--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -310,10 +310,7 @@ fn run_entrypoint_action(args: MachineRunArgs, resolved_flake_slot: Option<Strin
 /// - a path — read that file and send it as one payload; a file has an end the
 ///   host already knows, so there is nothing to stream.
 fn resolve_entrypoint_stdin(spec: Option<&str>) -> Result<invoke::EntrypointStdin> {
-    resolve_entrypoint_stdin_with(spec, || {
-        use std::io::IsTerminal as _;
-        invoke::read_auto_stdin(std::io::stdin().is_terminal())
-    })
+    resolve_entrypoint_stdin_with(spec, invoke::read_auto_stdin)
 }
 
 /// The mapping itself, with the one arm that reads this process's own stdin
@@ -389,8 +386,7 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
             // both the transport decision and the signed plan.
             run_args.network_mode = network_mode;
             run_args.warm_pool_size = warm_pool_size;
-            use std::io::IsTerminal as _;
-            run_args.stdin = invoke::read_auto_stdin(std::io::stdin().is_terminal())?;
+            run_args.stdin = invoke::read_auto_stdin()?;
             let source = local_deployment
                 .as_ref()
                 .map(super::local_deployment_image_source)
@@ -412,7 +408,7 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
             run_args.network_mode = network_mode;
             run_args.pty = true;
             run_args.warm_pool_size = warm_pool_size;
-            run_args.stdin = invoke::read_auto_stdin(std::io::stdin().is_terminal())?;
+            run_args.stdin = invoke::read_auto_stdin()?;
             let source = local_deployment
                 .as_ref()
                 .map(super::local_deployment_image_source)

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -696,14 +696,79 @@ impl std::fmt::Display for AutoStdinError {
 }
 impl std::error::Error for AutoStdinError {}
 
-/// Read one buffered stdin payload, capped. A TTY on stdin is interactive input
-/// for the terminal, not a workload payload, so it yields empty and never blocks.
+/// What the caller's stdin is, for the purpose of the implicit payload read.
+///
+/// Three states rather than a `bool`, because "not a terminal" was doing two
+/// jobs and only one of them is "a payload is waiting".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::commands) enum AutoStdin {
+    /// A terminal. Interactive input for the person at the keyboard, never a
+    /// workload payload.
+    Terminal,
+    /// Not a terminal, and nothing readable right now — stdin was inherited
+    /// rather than redirected at us.
+    Idle,
+    /// Not a terminal and readable now: the caller handed us something.
+    Ready,
+}
+
+/// Classify the real stdin fd without consuming a byte of it.
+///
+/// A terminal is decided first: a TTY with type-ahead buffered is *readable*,
+/// and reading it would steal the person's keystrokes.
+///
+/// Otherwise `poll` with a zero timeout answers "is there something here", which
+/// is the question the implicit read actually needs. A regular file and
+/// `/dev/null` always poll readable, so redirection still works; a pipe that was
+/// merely inherited does not, so it is left alone. `POLLHUP` counts as readable
+/// because a closed pipe yields EOF immediately rather than blocking.
+fn classify_stdin() -> AutoStdin {
+    use std::io::IsTerminal as _;
+    if std::io::stdin().is_terminal() {
+        return AutoStdin::Terminal;
+    }
+    if fd_is_readable_now(libc::STDIN_FILENO) {
+        AutoStdin::Ready
+    } else {
+        AutoStdin::Idle
+    }
+}
+
+/// Whether `fd` would yield something — bytes, EOF, or an error — without
+/// waiting. Split from [`classify_stdin`] so it can be exercised against a real
+/// pipe rather than whatever the test harness happens to have on fd 0.
+fn fd_is_readable_now(fd: std::os::fd::RawFd) -> bool {
+    let mut pfd = libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    // SAFETY: `pfd` is a single initialized `pollfd` living for the whole call,
+    // and the count matches. A zero timeout cannot block. `poll` writes only
+    // `revents`.
+    let ready = unsafe { libc::poll(&mut pfd, 1, 0) };
+    ready > 0 && pfd.revents != 0
+}
+
+/// Read one buffered stdin payload, capped.
+///
+/// Only [`AutoStdin::Ready`] is read. The other two yield empty without
+/// touching the fd, which is what keeps this from blocking: an inherited pipe
+/// that nobody ever writes to or closes used to park the whole launch here in
+/// `read_to_end` — before any VM was created, with no output and no timeout.
+///
+/// One residual: a producer that writes, then holds the pipe open without
+/// closing it, polls readable and then blocks in `read_to_end` waiting for the
+/// end it was promised. That is the contract this mode has — one whole buffered
+/// payload — and truncating at whatever happened to arrive first would be worse
+/// than waiting. Callers who want a stream rather than a payload have
+/// `--stdin -`, which is a different contract with the guest.
 fn read_auto_stdin_from<R: std::io::Read>(
     mut reader: R,
-    is_tty: bool,
+    stdin: AutoStdin,
     cap: usize,
 ) -> Result<Vec<u8>, AutoStdinError> {
-    if is_tty {
+    if stdin != AutoStdin::Ready {
         return Ok(Vec::new());
     }
     // Read cap+1 so an exactly-cap payload passes and the first over-cap byte trips.
@@ -720,8 +785,8 @@ fn read_auto_stdin_from<R: std::io::Read>(
 }
 
 /// Public entry: acquire the caller's stdin payload from the real stdin fd.
-pub(in crate::commands) fn read_auto_stdin(is_tty: bool) -> anyhow::Result<Vec<u8>> {
-    read_auto_stdin_from(std::io::stdin().lock(), is_tty, MAX_STDIN_BYTES)
+pub(in crate::commands) fn read_auto_stdin() -> anyhow::Result<Vec<u8>> {
+    read_auto_stdin_from(std::io::stdin().lock(), classify_stdin(), MAX_STDIN_BYTES)
         .map_err(|e| anyhow::anyhow!(e))
 }
 
@@ -1953,34 +2018,96 @@ mod captured_tests {
 
 #[cfg(test)]
 mod auto_stdin_tests {
-    use super::{AutoStdinError, read_auto_stdin_from};
+    use super::{AutoStdin, AutoStdinError, read_auto_stdin_from};
     use std::io::Cursor;
 
     #[test]
     fn tty_stdin_yields_empty_payload() {
         // A terminal on stdin is interactive, not input: never block reading it.
-        let got = read_auto_stdin_from(Cursor::new(b"ignored" as &[u8]), true, 1024).unwrap();
+        let got = read_auto_stdin_from(Cursor::new(b"ignored" as &[u8]), AutoStdin::Terminal, 1024)
+            .unwrap();
         assert!(got.is_empty());
     }
 
     #[test]
     fn piped_stdin_under_cap_is_read_whole() {
-        let got = read_auto_stdin_from(Cursor::new(b"STDIN-RT-42" as &[u8]), false, 1024).unwrap();
+        let got =
+            read_auto_stdin_from(Cursor::new(b"STDIN-RT-42" as &[u8]), AutoStdin::Ready, 1024)
+                .unwrap();
         assert_eq!(got, b"STDIN-RT-42");
     }
 
     #[test]
     fn piped_stdin_over_cap_fails_closed() {
         let payload = vec![b'x'; 2048];
-        let err = read_auto_stdin_from(Cursor::new(&payload[..]), false, 1024).unwrap_err();
+        let err =
+            read_auto_stdin_from(Cursor::new(&payload[..]), AutoStdin::Ready, 1024).unwrap_err();
         assert!(matches!(err, AutoStdinError::TooLarge { cap: 1024 }));
     }
 
     #[test]
     fn piped_stdin_exactly_at_cap_passes() {
         let payload = vec![b'x'; 1024];
-        let got = read_auto_stdin_from(Cursor::new(&payload[..]), false, 1024).unwrap();
+        let got = read_auto_stdin_from(Cursor::new(&payload[..]), AutoStdin::Ready, 1024).unwrap();
         assert_eq!(got.len(), 1024);
+    }
+
+    /// An inherited pipe must not be touched at all. Asserted with a reader that
+    /// panics if anyone reads it, because "returned empty" and "never read" are
+    /// different facts and only the second one cannot hang.
+    #[test]
+    fn idle_stdin_is_never_read() {
+        struct Explode;
+        impl std::io::Read for Explode {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                panic!("idle stdin must not be read — this is the blocking read that hung a launch")
+            }
+        }
+        let got = read_auto_stdin_from(Explode, AutoStdin::Idle, 1024).unwrap();
+        assert!(got.is_empty());
+    }
+
+    /// The probe itself, against real pipes. The first case is the bug: a pipe
+    /// with a live writer that has sent nothing is what `ssh host 'mvmctl ...'`,
+    /// CI runners and any script hand us, and reading it parks the launch
+    /// forever before a VM is ever created.
+    #[test]
+    fn the_readiness_probe_distinguishes_an_idle_pipe_from_a_written_one() {
+        use std::io::Write as _;
+        use std::os::fd::{AsRawFd as _, FromRawFd as _};
+
+        let mut fds = [0 as libc::c_int; 2];
+        // SAFETY: `fds` is a two-element array, which is what `pipe` writes.
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0, "pipe()");
+        // SAFETY: both fds come from a successful `pipe` and are owned here.
+        let (read_end, mut write_end) = unsafe {
+            (
+                std::fs::File::from_raw_fd(fds[0]),
+                std::fs::File::from_raw_fd(fds[1]),
+            )
+        };
+        let fd = read_end.as_raw_fd();
+
+        assert!(
+            !super::fd_is_readable_now(fd),
+            "a pipe whose writer has sent nothing must not read as ready"
+        );
+
+        write_end.write_all(b"payload").unwrap();
+        assert!(
+            super::fd_is_readable_now(fd),
+            "a pipe carrying data must read as ready"
+        );
+
+        // A closed writer is EOF, which is available immediately — reading it
+        // returns empty rather than blocking, so it counts as ready.
+        let mut drain = [0u8; 7];
+        std::io::Read::read_exact(&mut { &read_end }, &mut drain).unwrap();
+        drop(write_end);
+        assert!(
+            super::fd_is_readable_now(fd),
+            "a closed writer is EOF, which is readable now"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #2903.

`mvmctl machine run` blocked forever before creating a VM whenever stdin was inherited from a non-TTY parent that never closed it. No output, no timeout, no diagnostic — just `pipe_read`:

```
PID      ETIMES  STAT  WCHAN      COMMAND
1473923     621  Sl    pipe_read  mvmctl machine run --image alpine -- /bin/true
```

621 seconds, caught on a live host. Adding `</dev/null` made the same launch take 0.89 s.

That covers `ssh host 'mvmctl ...'` without `-n`, CI runners, job supervisors, cron, and any script holding the pipe.

## Cause

`read_auto_stdin_from` guarded only on `is_terminal`, and its doc claimed it "never blocks" — true only of the TTY branch it returned early on. Every other stdin went into `read_to_end`.

"Not a terminal" was standing in for "a payload is waiting", but it also covers every stdin that was merely *inherited* rather than redirected at us. The tie was broken by waiting indefinitely: the worst available option, because the failure presents as a hung VM rather than a hung read.

## What changed

Stdin is classified before it is touched. `AutoStdin` is three states rather than a bool, because the old bool was doing two jobs and only one of them meant "read this":

- **`Terminal`** — decided first. A TTY with type-ahead buffered *is* readable, and reading it would steal the person's keystrokes.
- **`Idle`** — `poll` with a zero timeout says nothing is there. Yields empty without touching the fd.
- **`Ready`** — something is there; read it exactly as before.

A regular file and `/dev/null` always poll readable, so redirection still works, and `echo hi | mvmctl machine run` still works because that data is already in the pipe buffer. `POLLHUP` counts as ready: a closed writer is EOF, available immediately.

`read_auto_stdin` no longer takes `is_tty`; it classifies the real fd itself, which also removes the same `std::io::stdin().is_terminal()` expression from three call sites.

## One residual, documented at the function

A producer that writes and then holds the pipe open without closing it polls ready and then blocks in `read_to_end` waiting for the end it was promised. That is this mode's contract — one whole buffered payload — and truncating at whatever arrived first would be worse. Callers who want a stream have `--stdin -`, which is a different contract with the guest.

## Tests

Both mutation-checked against both legs of the fix:

- **`idle_stdin_is_never_read`** uses a reader that panics if read, because "returned empty" and "never read" are different facts and only the second one cannot hang.
- **`the_readiness_probe_distinguishes_an_idle_pipe_from_a_written_one`** drives `fd_is_readable_now` against real pipes, including the bug case: a live writer that has sent nothing.
