### PR TITLE
fix(admission): pin the booting kernel into every CLI-signed plan

### DIFF
--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -1012,6 +1012,7 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
         vm_name: p.child_vm_name,
         backend_name: &effective_hypervisor,
         rootfs_path: p.instance_rootfs,
+        kernel_path: Some(std::path::Path::new(&vmlinux_path)),
         precomputed_image_sha256: None,
         boot_artifact_identity: None,
         cpus,

--- a/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/fork_vm_full.rs
@@ -380,6 +380,11 @@ fn admit_forked_child(p: &AdmitForkedChildParams<'_>) -> Result<AdmittedForkChil
             vm_name: p.child_vm_name,
             backend_name: p.backend_kind.as_str(),
             rootfs_path: &rootfs_blob,
+            // A fork resumes a saved VM state rather than booting a kernel of
+            // its own, so this admission has no kernel to name. Deliberately
+            // not the parent's: a child admitted under an environment it did
+            // not itself load would record a pin nothing here verified.
+            kernel_path: None,
             precomputed_image_sha256: recorded_sha,
             boot_artifact_identity: None,
             cpus: user_cfg.default_cpus,

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -805,6 +805,7 @@ pub(in crate::commands) fn run_secure_with_source(
     let oci_provenance: OciProvenanceSink = std::rc::Rc::new(std::cell::RefCell::new(None));
     let provenance_for_admit = std::rc::Rc::clone(&oci_provenance);
     let admit = move |rootfs: &std::path::Path,
+                      kernel: Option<&std::path::Path>,
                       vm_name: &str|
           -> Result<Option<crate::exec::SessionAuditSubstrate>> {
         let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::default();
@@ -812,6 +813,7 @@ pub(in crate::commands) fn run_secure_with_source(
             network_mode: admit_network_mode,
             tenant: "local",
             vm_name,
+            kernel_path: kernel,
             backend_name: &admit_backend,
             rootfs_path: rootfs,
             precomputed_image_sha256: None,

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -143,6 +143,8 @@ struct EntrypointAdmission {
 
 struct EntrypointAdmissionParams<'a> {
     rootfs: &'a std::path::Path,
+    /// The kernel this boot loads, pinned into the plan alongside the image.
+    kernel_path: Option<&'a std::path::Path>,
     vm_name: &'a str,
     backend_name: &'a str,
     cpus: u32,
@@ -159,11 +161,13 @@ struct EntrypointAdmissionParams<'a> {
 impl<'a> EntrypointAdmissionParams<'a> {
     fn builder(
         rootfs: &'a std::path::Path,
+        kernel_path: Option<&'a std::path::Path>,
         vm_name: &'a str,
         backend_name: &'a str,
     ) -> EntrypointAdmissionParamsBuilder<'a> {
         EntrypointAdmissionParamsBuilder {
             rootfs,
+            kernel_path,
             vm_name,
             backend_name,
             cpus: 1,
@@ -179,6 +183,7 @@ impl<'a> EntrypointAdmissionParams<'a> {
 
 struct EntrypointAdmissionParamsBuilder<'a> {
     rootfs: &'a std::path::Path,
+    kernel_path: Option<&'a std::path::Path>,
     vm_name: &'a str,
     backend_name: &'a str,
     cpus: u32,
@@ -232,6 +237,7 @@ impl<'a> EntrypointAdmissionParamsBuilder<'a> {
     fn build(self) -> EntrypointAdmissionParams<'a> {
         EntrypointAdmissionParams {
             rootfs: self.rootfs,
+            kernel_path: self.kernel_path,
             vm_name: self.vm_name,
             backend_name: self.backend_name,
             cpus: self.cpus,
@@ -267,6 +273,7 @@ fn admit_entrypoint_boot(
         vm_name: params.vm_name,
         backend_name: params.backend_name,
         rootfs_path: params.rootfs,
+        kernel_path: params.kernel_path,
         precomputed_image_sha256: None,
         boot_artifact_identity: None,
         cpus: params.cpus,
@@ -447,10 +454,11 @@ pub(in crate::commands) fn run_entrypoint(call: EntrypointCall) -> Result<()> {
         std::rc::Rc::new(std::cell::RefCell::new(None));
     let ctx_sink = std::rc::Rc::clone(&admit_ctx);
     let admit = move |rootfs: &std::path::Path,
+                      kernel: Option<&std::path::Path>,
                       vm_name: &str|
           -> Result<Option<crate::exec::SessionAuditSubstrate>> {
         let admitted = admit_entrypoint_boot(
-            EntrypointAdmissionParams::builder(rootfs, vm_name, &admit_backend)
+            EntrypointAdmissionParams::builder(rootfs, kernel, vm_name, &admit_backend)
                 .cpus(cpus)
                 .mem_mib(mem)
                 .lowered_secrets(&lowered_secrets)
@@ -1579,7 +1587,7 @@ mod stdin_grant_tests {
         ) -> anyhow::Result<Option<super::EntrypointAdmission>> {
             let lowered = super::super::managed_secrets::LoweredPlanSecrets::default();
             admit_entrypoint_boot(
-                EntrypointAdmissionParams::builder(&self.rootfs, vm, "firecracker")
+                EntrypointAdmissionParams::builder(&self.rootfs, None, vm, "firecracker")
                     .lowered_secrets(&lowered)
                     .stream_stdin(stream_stdin)
                     .build(),
@@ -2008,7 +2016,7 @@ mod tests {
 
         let lowered_secrets = LoweredPlanSecrets::default();
         let admitted = admit_entrypoint_boot(
-            EntrypointAdmissionParams::builder(&rootfs, "invoke-proof-sealed", "firecracker")
+            EntrypointAdmissionParams::builder(&rootfs, None, "invoke-proof-sealed", "firecracker")
                 .cpus(1)
                 .mem_mib(256)
                 .lowered_secrets(&lowered_secrets)
@@ -2065,7 +2073,7 @@ mod tests {
         let policy = NetworkPolicy::allow_list(vec![HostPort::new("127.0.0.1", 443)]);
         let lowered_secrets = LoweredPlanSecrets::default();
         let admitted = admit_entrypoint_boot(
-            EntrypointAdmissionParams::builder(&rootfs, "invoke-proof-allow", "firecracker")
+            EntrypointAdmissionParams::builder(&rootfs, None, "invoke-proof-allow", "firecracker")
                 .cpus(1)
                 .mem_mib(256)
                 .lowered_secrets(&lowered_secrets)

--- a/crates/mvm-cli/src/commands/vm/session.rs
+++ b/crates/mvm-cli/src/commands/vm/session.rs
@@ -1010,6 +1010,7 @@ fn cmd_start(args: StartArgs) -> Result<()> {
     let admit_ctx: Rc<RefCell<Option<super::up::AdmissionContext>>> = Rc::new(RefCell::new(None));
     let ctx_sink = Rc::clone(&admit_ctx);
     let admit = move |rootfs: &std::path::Path,
+                      kernel: Option<&std::path::Path>,
                       vm_name: &str|
           -> Result<Option<crate::exec::SessionAuditSubstrate>> {
         let ledger = mvm_hostd::plan_admission::InMemoryNonceLedger::default();
@@ -1017,6 +1018,7 @@ fn cmd_start(args: StartArgs) -> Result<()> {
             network_mode: crate::commands::machine::preflight_network(),
             tenant: "local",
             vm_name,
+            kernel_path: kernel,
             backend_name: &admit_backend,
             rootfs_path: rootfs,
             precomputed_image_sha256: None,

--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -37,6 +37,16 @@ pub(in crate::commands::vm) struct AdmitPlanForBootParams<'a> {
     pub vm_name: &'a str,
     pub backend_name: &'a str,
     pub rootfs_path: &'a std::path::Path,
+    /// The kernel this launch will boot, pinned into the plan's
+    /// `EnvironmentRef` and re-checked by the admitted-environment gate.
+    ///
+    /// `None` only for backends that carry their own kernel (libkrun's
+    /// bundled image, the mock). For everything else this must be the same
+    /// path handed to the backend: the image digest says what the workload
+    /// *is* and says nothing about what confines it, so a plan that names the
+    /// image but not the kernel admits a workload onto whatever kernel the
+    /// host happened to have cached.
+    pub kernel_path: Option<&'a std::path::Path>,
     /// Skip re-hashing `rootfs_path` and admit with this sha256 instead.
     /// Only sound when a fail-closed integrity check re-hashes the same
     /// bytes before boot (the checkpoint fork path: `verify_content`
@@ -357,6 +367,18 @@ pub(in crate::commands::vm) fn admit_plan_for_boot_with_ingress(
         None => (None, None, None),
     };
 
+    // Pin the kernel alongside the image. Through the shared digest cache, the
+    // same way `image_sha256` above is derived — a pin that re-read the whole
+    // kernel would put a multi-MB read back on every launch to reproduce a
+    // value the kernel's own cache check just computed from the same bytes.
+    let kernel_sha256 = p
+        .kernel_path
+        .map(|kernel| {
+            mvm_core::crypto::image_verify::sha256_file_cached(kernel)
+                .with_context(|| format!("hashing kernel at {} for the plan pin", kernel.display()))
+        })
+        .transpose()?;
+
     let generated_network_policy_bundle =
         generated_policy_bundle_for_network_policy(p.tenant, p.vm_name, &p.network_policy)?;
     let generated_policy_ref = generated_network_policy_bundle
@@ -369,7 +391,7 @@ pub(in crate::commands::vm) fn admit_plan_for_boot_with_ingress(
         // signature covers it.
         grants: p.grants.clone(),
         stream_edges: Vec::new(),
-        kernel_sha256: None,
+        kernel_sha256: kernel_sha256.as_deref(),
         network_mode: p.network_mode,
         ingress,
         vm_name: p.vm_name,
@@ -921,6 +943,25 @@ pub(super) fn enforce_shares_if(
     Ok(())
 }
 
+/// Refuse to boot if the kernel about to be loaded is not the one the verified
+/// `ExecutionPlan` pinned. No-op when admission was skipped.
+///
+/// The sibling of [`enforce_shares_if`], called at the same point for the same
+/// reason: `mvmctl` admits its plan and then starts the backend itself rather
+/// than going through `start_admitted`, so every gate that path runs has to be
+/// run here too or it does not run at all. The admitted-environment gate was
+/// the one nobody called.
+pub(super) fn enforce_kernel_if(
+    ctx: &Option<AdmissionContext>,
+    kernel_path: Option<&std::path::Path>,
+) -> Result<()> {
+    if let Some(ctx) = ctx {
+        mvm_hostd::plan_admission::enforce_admitted_environment(kernel_path, ctx.admitted.plan())
+            .context("admission kernel check")?;
+    }
+    Ok(())
+}
+
 /// Emit `plan.failed` against the supplied admission context. No-op
 /// when admission was skipped. `class` is a short grep-friendly tag
 /// (e.g. `backend-start`, `snapshot-restore`); `err` becomes the
@@ -1149,6 +1190,123 @@ mod admit_plan_tests {
         assert!(sibling_deploy_boot_artifact(&unrelated).unwrap().is_none());
     }
 
+    /// A minimal admission that really runs — signs, verifies, burns a nonce.
+    /// Callers override only the fields their assertion is about.
+    fn pinning_params<'a>(
+        rootfs: &'a std::path::Path,
+        ledger: &'a InMemoryNonceLedger,
+    ) -> AdmitPlanForBootParams<'a> {
+        AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
+            tenant: "local",
+            vm_name: "vm-pinned",
+            backend_name: "firecracker",
+            rootfs_path: rootfs,
+            kernel_path: None,
+            precomputed_image_sha256: None,
+            boot_artifact_identity: None,
+            cpus: 2,
+            mem_mib: 512,
+            seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+            secret_release: mvm_core::plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
+            no_supervisor: false,
+            ledger,
+            keys_dir: None,
+            audit_dir: None,
+            policy_dir: None,
+            bundle_pin: None,
+            deps_volume: None,
+            shares: Vec::new(),
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+            network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+            agent_verb_override: vec![],
+            restrict_agent_verbs: true,
+            services: Vec::new(),
+            grants: None,
+            backend_kind: None,
+            entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
+        }
+    }
+
+    /// The image digest says what the workload *is* and nothing about what
+    /// confines it, so a plan that names the image but not the kernel admits a
+    /// workload onto whatever kernel the host happened to have cached. This is
+    /// the assertion that would have caught `kernel_sha256: None` sitting on
+    /// the CLI's only admission seam.
+    #[test]
+    fn the_booting_kernel_is_pinned_into_the_signed_plan() {
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path(), b"hello rootfs");
+        let kernel = rootfs_dir.path().join("vmlinux");
+        std::fs::write(&kernel, b"workload-kernel-bytes").unwrap();
+        let expected = mvm_core::crypto::image_verify::sha256_file(&kernel).unwrap();
+        let ledger = InMemoryNonceLedger::new();
+
+        let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            kernel_path: Some(kernel.as_path()),
+            keys_dir: Some(keys_dir.path()),
+            audit_dir: Some(audit_dir.path()),
+            ..pinning_params(&rootfs, &ledger)
+        })
+        .expect("admission")
+        .expect("Some when admission ran");
+
+        let environment = ctx
+            .admitted
+            .plan()
+            .environment
+            .as_ref()
+            .expect("a launch that boots a kernel must pin it");
+        assert_eq!(environment.kernel_sha256, expected);
+
+        // And the pin is what the enforcement gate compares against, so the
+        // kernel that was admitted is admitted onto itself rather than the pin
+        // being a value nothing ever reads.
+        mvm_hostd::plan_admission::enforce_admitted_environment(
+            Some(kernel.as_path()),
+            ctx.admitted.plan(),
+        )
+        .expect("the pinned kernel must pass its own gate");
+    }
+
+    /// A kernel swapped between admission and boot is refused. Same plan, same
+    /// image, a different confinement — the substitution the pin exists to make
+    /// visible.
+    #[test]
+    fn a_kernel_swapped_after_admission_is_refused() {
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path(), b"hello rootfs");
+        let kernel = rootfs_dir.path().join("vmlinux");
+        std::fs::write(&kernel, b"workload-kernel-bytes").unwrap();
+        let ledger = InMemoryNonceLedger::new();
+
+        let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            kernel_path: Some(kernel.as_path()),
+            keys_dir: Some(keys_dir.path()),
+            audit_dir: Some(audit_dir.path()),
+            ..pinning_params(&rootfs, &ledger)
+        })
+        .expect("admission")
+        .expect("Some when admission ran");
+
+        std::fs::write(&kernel, b"a-general-purpose-kernel-with-user-ns").unwrap();
+
+        let err = mvm_hostd::plan_admission::enforce_admitted_environment(
+            Some(kernel.as_path()),
+            ctx.admitted.plan(),
+        )
+        .expect_err("a kernel swapped after admission must be refused");
+        assert!(
+            format!("{err:#}").contains("admitted-environment mismatch"),
+            "error must name the mismatch, got: {err:#}"
+        );
+    }
+
     #[test]
     fn no_supervisor_short_circuits_to_none() {
         // The escape hatch must skip admission entirely — no host
@@ -1162,6 +1320,7 @@ mod admit_plan_tests {
             vm_name: "vm-skip",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 2,
@@ -1204,6 +1363,7 @@ mod admit_plan_tests {
             vm_name: "vm-happy",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: Some(&boot_artifact),
             cpus: 2,
@@ -1267,6 +1427,7 @@ mod admit_plan_tests {
             vm_name: "vm-missing",
             backend_name: "firecracker",
             rootfs_path: std::path::Path::new("/nonexistent/rootfs.ext4"),
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 1,
@@ -1346,6 +1507,7 @@ mod admit_plan_tests {
                 vm_name: "vm-transport",
                 backend_name: "firecracker",
                 rootfs_path: &rootfs,
+                kernel_path: None,
                 precomputed_image_sha256: None,
                 boot_artifact_identity: None,
                 cpus: 1,
@@ -1398,6 +1560,7 @@ mod admit_plan_tests {
             vm_name: "vm-1",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 1,
@@ -1430,6 +1593,7 @@ mod admit_plan_tests {
             vm_name: "vm-2",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 1,
@@ -1487,6 +1651,7 @@ mod admit_plan_tests {
             vm_name: "vm-boot-posture",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 1,
@@ -1566,6 +1731,7 @@ mod admit_plan_tests {
             vm_name: "vm-local-default",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 1,
@@ -1623,6 +1789,7 @@ mod admit_plan_tests {
             vm_name: "vm-allow-list",
             backend_name: "libkrun",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 1,
@@ -1687,6 +1854,7 @@ mod admit_plan_tests {
             vm_name: "vm-unrestricted",
             backend_name: "hvf",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 1,
@@ -1778,6 +1946,7 @@ mod admit_plan_tests {
             vm_name: "vm-non-shell-granted",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             cpus: 1,
             mem_mib: 128,
@@ -1839,6 +2008,7 @@ mod admit_plan_tests {
             vm_name: "vm-shell-ungranted",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             cpus: 1,
             mem_mib: 128,
@@ -1890,6 +2060,7 @@ mod admit_plan_tests {
             vm_name: "vm-shell-granted",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             cpus: 1,
             mem_mib: 128,
@@ -1949,6 +2120,7 @@ mod admit_plan_tests {
             vm_name: "vm-entrypoint-unknown",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             cpus: 1,
             mem_mib: 128,
@@ -2004,6 +2176,7 @@ mod admit_plan_tests {
             vm_name: "vm-entrypoint-unknown-ungranted",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             cpus: 1,
             mem_mib: 128,
@@ -2052,6 +2225,7 @@ mod admit_plan_tests {
             vm_name: "vm-dev-shell",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             cpus: 1,
             mem_mib: 128,
@@ -2252,6 +2426,7 @@ allow_hosts = ["localhost:8443"]
             vm_name: "vm-granted",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 4,
@@ -2419,6 +2594,7 @@ allow_hosts = ["localhost:8443"]
             vm_name: "vm-over-ceiling",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 4,
@@ -2481,6 +2657,7 @@ allow_hosts = ["localhost:8443"]
             vm_name: "vm-ungranted",
             backend_name: "firecracker",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 2,

--- a/crates/mvm-cli/src/commands/vm/up/grants_report.rs
+++ b/crates/mvm-cli/src/commands/vm/up/grants_report.rs
@@ -123,6 +123,7 @@ mod tests {
             vm_name,
             backend_name: "libkrun",
             rootfs_path: &rootfs,
+            kernel_path: None,
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus: 2,

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -19,7 +19,7 @@ use crate::commands::vm::readiness::record_vm_readiness;
 
 use super::admission::{
     AdmitPlanForBootParams, admit_plan_for_boot_with_ingress, attach_guest_boot_config,
-    emit_failed_if, emit_launched_if, enforce_shares_if, guest_profile_for_boot,
+    emit_failed_if, emit_launched_if, enforce_kernel_if, enforce_shares_if, guest_profile_for_boot,
 };
 use super::policy::shares_from_volume_cfg;
 use super::runtime_source::{
@@ -226,6 +226,7 @@ pub(in crate::commands) fn start_persistent_oci_machine(
             vm_name: name,
             backend_name,
             rootfs_path,
+            kernel_path: Some(std::path::Path::new(&kernel_path)),
             precomputed_image_sha256: None,
             boot_artifact_identity: None,
             cpus,
@@ -306,6 +307,16 @@ pub(in crate::commands) fn start_persistent_oci_machine(
         }
     }
     enforce_shares_if(&admission, &start_config.volumes)?;
+    // Against the config the backend is about to be handed, not the local the
+    // plan was synthesized from — that is what makes this a check rather than a
+    // restatement of what admission already believed.
+    enforce_kernel_if(
+        &admission,
+        start_config
+            .kernel_path
+            .as_deref()
+            .map(std::path::Path::new),
+    )?;
     // VMM selection + workload-support check + start move behind the facade; the
     // admission gate (above) and the launched/failed emits stay here.
     if let Err(err) = mvm_client::start_prepared(backend_name, &start_config) {

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1665,7 +1665,14 @@ pub fn resolve_launch(
     // snapshot restore is unavailable for workload admission.
     let t_admission = std::time::Instant::now();
     if let Some(admit_fn) = admit
-        && let Some(sub) = admit_fn(std::path::Path::new(&image.rootfs), &vm_name)?
+        && let Some(sub) = admit_fn(
+            std::path::Path::new(&image.rootfs),
+            start_config
+                .kernel_path
+                .as_deref()
+                .map(std::path::Path::new),
+            &vm_name,
+        )?
     {
         start_config.tenant_id = Some(sub.tenant_id);
         start_config.plan_json = Some(sub.plan_json);
@@ -2222,12 +2229,18 @@ pub struct SessionAuditSubstrate {
     pub config_files: Vec<mvm_core::vm_backend::VmFile>,
 }
 
-/// Admission callback: given the resolved rootfs + the generated vm_name (both
-/// known only inside `boot_session_vm`), produce the audit substrate, or `None`
-/// when the workload declares no secrets. Lives in the caller so admission stays
-/// in the command layer; `boot_session_vm` just applies the result.
-pub type SessionAdmit<'a> =
-    dyn Fn(&std::path::Path, &str) -> Result<Option<SessionAuditSubstrate>> + 'a;
+/// Admission callback: given the resolved rootfs, the kernel that will be
+/// booted, and the generated vm_name (all known only inside `boot_session_vm`),
+/// produce the audit substrate, or `None` when the workload declares no
+/// secrets. Lives in the caller so admission stays in the command layer;
+/// `boot_session_vm` just applies the result.
+///
+/// The kernel rides along for the same reason the rootfs does. A plan that
+/// names the image but not the kernel pins what the workload *is* and nothing
+/// about what confines it, so the callback cannot bind the environment it was
+/// admitted onto unless it is told which kernel that is.
+pub type SessionAdmit<'a> = dyn Fn(&std::path::Path, Option<&std::path::Path>, &str) -> Result<Option<SessionAuditSubstrate>>
+    + 'a;
 
 pub fn boot_session_vm(
     env: &str,
@@ -2305,7 +2318,14 @@ pub fn boot_session_vm(
     // bypasses the endpoint-spawn path. `None` admit ⇒ unchanged legacy path.
     let mut admitted_workload = false;
     if let Some(admit_fn) = admit
-        && let Some(sub) = admit_fn(std::path::Path::new(&rootfs), &vm_name)?
+        && let Some(sub) = admit_fn(
+            std::path::Path::new(&rootfs),
+            start_config
+                .kernel_path
+                .as_deref()
+                .map(std::path::Path::new),
+            &vm_name,
+        )?
     {
         start_config.tenant_id = Some(sub.tenant_id);
         start_config.plan_json = Some(sub.plan_json);

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1504,26 +1504,37 @@ impl<'a> Default for AdmitAndStartParamsBuilder<'a> {
 /// Fail-closed in both directions. A plan that pins a kernel and a launch
 /// config that supplies none is a refusal, not a pass — otherwise dropping the
 /// kernel path would be a way to skip the check.
-fn enforce_admitted_environment(config: &VmStartConfig, plan: &ExecutionPlan) -> Result<()> {
+/// Takes the kernel path rather than the whole [`VmStartConfig`] so the two
+/// admission seams can share one gate. `mvmctl` synthesizes and admits its plan
+/// without ever building a `VmStartConfig`, so a config-shaped signature meant
+/// the CLI — the seam that ships — could not call this at all.
+pub fn enforce_admitted_environment(
+    kernel_path: Option<&std::path::Path>,
+    plan: &ExecutionPlan,
+) -> Result<()> {
     let Some(environment) = plan.environment.as_ref() else {
         // No environment pinned. Plans predating the field, and backends that
         // boot their own bundled kernel, land here.
         return Ok(());
     };
-    let Some(kernel_path) = config.kernel_path.as_deref() else {
+    let Some(kernel_path) = kernel_path else {
         anyhow::bail!(
             "plan pins kernel {} but the launch config supplies no kernel path",
             environment.kernel_sha256
         );
     };
-    let actual = mvm_core::crypto::image_verify::sha256_file(std::path::Path::new(kernel_path))
-        .with_context(|| {
-            format!("hashing kernel at {kernel_path} for admitted-environment check")
+    let actual =
+        mvm_core::crypto::image_verify::sha256_file_cached(kernel_path).with_context(|| {
+            format!(
+                "hashing kernel at {} for admitted-environment check",
+                kernel_path.display()
+            )
         })?;
     if actual != environment.kernel_sha256 {
         anyhow::bail!(
-            "admitted-environment mismatch: plan pins kernel {} but {kernel_path} hashes to {actual}",
-            environment.kernel_sha256
+            "admitted-environment mismatch: plan pins kernel {} but {} hashes to {actual}",
+            environment.kernel_sha256,
+            kernel_path.display()
         );
     }
     Ok(())
@@ -1583,7 +1594,10 @@ fn run_post_admission_gates(
     if let Err(e) = enforce_admitted_shares(&config.volumes, admitted.plan()) {
         return Err(("admitted-shares", e));
     }
-    if let Err(e) = enforce_admitted_environment(&config, admitted.plan()) {
+    if let Err(e) = enforce_admitted_environment(
+        config.kernel_path.as_deref().map(std::path::Path::new),
+        admitted.plan(),
+    ) {
         return Err(("admitted-environment", e));
     }
     if let Err(e) = enforce_sdk_sidecar_attachment(&config.volumes, admitted.plan()) {
@@ -1966,13 +1980,6 @@ mod admitted_environment_tests {
         plan
     }
 
-    fn config_with_kernel(kernel: Option<&std::path::Path>) -> VmStartConfig {
-        VmStartConfig {
-            kernel_path: kernel.map(|k| k.display().to_string()),
-            ..VmStartConfig::default()
-        }
-    }
-
     fn write_kernel(dir: &std::path::Path, bytes: &[u8]) -> std::path::PathBuf {
         let p = dir.join("vmlinux");
         std::fs::write(&p, bytes).expect("write kernel fixture");
@@ -1985,11 +1992,8 @@ mod admitted_environment_tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let kernel = write_kernel(tmp.path(), b"workload-kernel");
         let sha = mvm_core::crypto::image_verify::sha256_file(&kernel).expect("hash");
-        enforce_admitted_environment(
-            &config_with_kernel(Some(&kernel)),
-            &plan_pinning(Some(&sha)),
-        )
-        .expect("matching kernel must be admitted");
+        enforce_admitted_environment(Some(kernel.as_path()), &plan_pinning(Some(&sha)))
+            .expect("matching kernel must be admitted");
     }
 
     /// A different kernel than the plan pinned is refused: same plan, same
@@ -2002,11 +2006,8 @@ mod admitted_environment_tests {
         let sha = mvm_core::crypto::image_verify::sha256_file(&kernel).expect("hash");
         std::fs::write(&kernel, b"a-general-purpose-kernel").expect("swap kernel");
 
-        let err = enforce_admitted_environment(
-            &config_with_kernel(Some(&kernel)),
-            &plan_pinning(Some(&sha)),
-        )
-        .expect_err("a substituted kernel must be refused");
+        let err = enforce_admitted_environment(Some(kernel.as_path()), &plan_pinning(Some(&sha)))
+            .expect_err("a substituted kernel must be refused");
         let msg = format!("{err:#}");
         assert!(
             msg.contains("admitted-environment mismatch"),
@@ -2017,11 +2018,8 @@ mod admitted_environment_tests {
     /// Dropping the kernel path must not be a way around the pin.
     #[test]
     fn pinned_plan_with_no_kernel_path_is_refused() {
-        let err = enforce_admitted_environment(
-            &config_with_kernel(None),
-            &plan_pinning(Some(&"a".repeat(64))),
-        )
-        .expect_err("a pinned plan with no kernel path must be refused");
+        let err = enforce_admitted_environment(None, &plan_pinning(Some(&"a".repeat(64))))
+            .expect_err("a pinned plan with no kernel path must be refused");
         assert!(format!("{err:#}").contains("supplies no kernel path"));
     }
 
@@ -2031,9 +2029,9 @@ mod admitted_environment_tests {
     fn unpinned_plan_is_unaffected() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let kernel = write_kernel(tmp.path(), b"whatever");
-        enforce_admitted_environment(&config_with_kernel(Some(&kernel)), &plan_pinning(None))
+        enforce_admitted_environment(Some(kernel.as_path()), &plan_pinning(None))
             .expect("an unpinned plan must be unaffected");
-        enforce_admitted_environment(&config_with_kernel(None), &plan_pinning(None))
+        enforce_admitted_environment(None, &plan_pinning(None))
             .expect("an unpinned plan with no kernel must be unaffected");
     }
 }


### PR DESCRIPTION
Closes #2894.

`EnvironmentRef` exists because the image digest says what the workload *is* and nothing about what confines it — [#2103](https://github.com/tinylabscom/mvm/pull/2103) added it precisely because *"a kernel with `CONFIG_USER_NS` enabled lets the guest become uid 0 in a user namespace, which the workload kernel is built to prevent."*

The CLI never recorded it. `admission.rs` hardcoded `kernel_sha256: None`, so `synthesize_plan` left `plan.environment` unset, so `enforce_admitted_environment` took its first early return and checked nothing — on every `mvmctl` launch, across all six boot paths sharing that seam: transient run, persistent `--image`, invoke, sessions, checkpoint restore, fork.

Not a case of having no kernel to pin. The same call chain resolves a **verified** workload kernel and boots the guest with it (`machine/lifecycle.rs` → `up::resolve_kernel_pin_path` → `kernel_fetch::resolve_kernel`). The path was in hand and dropped at synthesis.

## The second half of the gap

Even with the pin set, the CLI **could not have called the gate**. `enforce_admitted_environment` took a `&VmStartConfig`, which `mvmctl` never builds: it admits its plan and then starts the backend itself rather than going through `start_admitted`, so a gate living only inside `run_post_admission_gates` does not run for the binary that ships. The CLI already re-calls `enforce_shares_if` for claim 1 next to `backend.start()`; the environment gate was the one nobody added.

This is worth knowing generally: **there are two admission seams and only one of them runs the post-admission gates.** A gate added to `run_post_admission_gates` protects mvmd and `mvm-client`, not `mvmctl`.

## What changed

`AdmitPlanForBootParams` now carries the kernel, and the digest goes into the plan. Making it a **required** field rather than an `Option` with a default is deliberate: every call site had to state what it boots. That is how the fork path's answer turned out to be an honest `None` rather than an oversight — a fork resumes saved VM state instead of loading a kernel, and pinning the parent's would record an environment the child never verified.

`enforce_admitted_environment` now takes the kernel path instead of a whole `VmStartConfig`, so both seams can share one gate. `oci_persist` runs it against the config the backend is about to receive — a check, not a restatement of what admission already believed.

`SessionAdmit` gains the kernel alongside the rootfs, for the reason its own doc gives for the rootfs: both are known only inside `boot_session_vm`, and a callback that is not told which kernel it got cannot bind the environment it was admitted onto.

The digest comes from the shared size+mtime cache, the same way `image_sha256` beside it already does, so the pin adds no read to a launch.

## Tests

Both mutation-checked — restoring `kernel_sha256: None` turns both red:

- `the_booting_kernel_is_pinned_into_the_signed_plan` — asserts the digest lands in the signed plan, then feeds it back through the real gate so the pin is not a value nothing reads.
- `a_kernel_swapped_after_admission_is_refused` — same plan, same image, different kernel: the substitution the pin exists to make visible.

## Worth deciding separately

ADR-001's claim-8 row names no witness for the environment pin, so nothing would have gone red when `kernel_sha256: None` was introduced, and nothing would go red if it came back. Adding one is a maintainer call rather than something to slip into this PR.
