### PR TITLE
test(docs): execute the documented surface instead of parsing it

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -84,6 +84,129 @@ jobs:
         # reads like latency coverage and is not.
         run: cargo test --test smoke_run_json_receipt --test runtime_boot_bench
 
+  e2e-docs-linux:
+    name: Documented surface e2e (Linux, Firecracker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      # Must track `FC_VERSION_DEFAULT` in mvm-core. The workload launch path
+      # passes flags older Firecracker releases reject before opening the API
+      # socket, which otherwise surfaces as an unhelpful socket timeout.
+      FC_VERSION: v1.14.1
+      # Hosted runners protect their distro kernel under /boot. Use the
+      # published, hash-verified workload kernel rather than a Stage 0 source
+      # build that attempts to boot that unreadable host file.
+      MVM_KERNEL_SOURCE: download
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: libcap-ng-dev lld qemu-system-x86 qemu-utils
+
+      - uses: ./.github/actions/install-zigbuild
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - uses: ./.github/actions/rust-cache
+        with:
+          key: e2e-docs-linux
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Install firecracker
+        run: |
+          set -euo pipefail
+          curl -fL -o firecracker.tgz \
+            "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-x86_64.tgz"
+          tar -xzf firecracker.tgz
+          sudo install -m 0755 \
+            "release-${FC_VERSION}-x86_64/firecracker-${FC_VERSION}-x86_64" \
+            /usr/bin/firecracker
+          /usr/bin/firecracker --version
+
+      - name: Grant /dev/kvm access for the job
+        run: |
+          set -euo pipefail
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm missing on this runner — the documented surface cannot boot." >&2
+            exit 1
+          fi
+          sudo chmod 666 /dev/kvm
+
+      - name: Run the documented surface end to end
+        run: just e2e-docs
+
+      - name: Dump VMM diagnostics on failure
+        if: failure()
+        run: |
+          for d in "$HOME"/.mvm/vms/*/; do
+            echo "===== $d ====="
+            ls -la "$d" || true
+            for f in firecracker.log console.log; do
+              if [ -s "$d$f" ]; then
+                echo "--- $f ---"
+                tail -50 "$d$f"
+              fi
+            done
+          done
+
+  e2e-docs-macos:
+    name: Documented surface e2e (macOS, HVF)
+    # The macOS default backend is HVF, and every guest-booting BDD scenario
+    # before this one carried `@firecracker` — so the backend most users run
+    # had no lane that booted anything. This is that lane.
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install just
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
+
+      - uses: ./.github/actions/rust-cache
+        with:
+          key: e2e-docs-macos
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Run the documented surface end to end
+        run: just e2e-docs
+
+      - name: Dump VMM diagnostics on failure
+        if: failure()
+        run: |
+          for d in "$HOME"/.mvm/vms/*/; do
+            echo "===== $d ====="
+            ls -la "$d" || true
+            # HVF flushes console.log only when the supervisor exits, so an
+            # empty file here is not evidence of a silent guest.
+            for f in console.log supervisor.log; do
+              if [ -s "$d$f" ]; then
+                echo "--- $f ---"
+                tail -50 "$d$f"
+              fi
+            done
+          done
+
   sdk-release-dry-run:
     name: SDK release dry-run
     permissions:

--- a/Justfile
+++ b/Justfile
@@ -305,6 +305,13 @@ e2e-launch:
 e2e-docs:
     ./scripts/e2e-documented-surface.sh
 
+# Reap machines a killed e2e run left behind. Scoped to the `bdd-` prefix the
+# suite creates, so it never touches a machine you made.
+#
+# Clean up after an interrupted e2e run
+e2e-docs-clean:
+    ./scripts/e2e-documented-surface.sh --clean-only
+
 # KVM-backed merge-queue witness for the cheap documented machine lifecycle.
 # The tag selector keeps registry/build-heavy live scenarios in their dedicated
 # witness lanes while proving that the public commands operate a real guest.

--- a/Justfile
+++ b/Justfile
@@ -285,8 +285,25 @@ bdd:
 # narrowed to the merge-queue subset and NOT `@firecracker`-gated — that
 # narrowing is what left the macOS default backend with no lane that boots a
 # guest at all.
+#
+# Sibling of `e2e-docs`: this one proves the ways in, that one proves the whole
+# documented command surface. They overlap in the suite they drive; the split is
+# that this lane also exercises the in-process Rust library seam.
+#
+# Boot a real guest through every documented entry point
 e2e-launch:
     ./scripts/e2e-launch-modes.sh
+
+# The hermetic `bdd` lane proves a documented command parses; this one boots
+# real microVMs and runs them. Needs an artifact-warm home: it defaults to the
+# real `~/.mvm`, override with MVM_E2E_HOME. Expect minutes on a cold home.
+#
+# Follows each guest's console as it boots; MVM_E2E_FOLLOW=0 silences that.
+# Sweeps its own machines on entry and exit — see `e2e-docs-clean`.
+#
+# Every documented example, executed against a real host
+e2e-docs:
+    ./scripts/e2e-documented-surface.sh
 
 # KVM-backed merge-queue witness for the cheap documented machine lifecycle.
 # The tag selector keeps registry/build-heavy live scenarios in their dedicated

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -196,18 +196,26 @@ pub(crate) fn run_mvmctl_isolated_live_home(world: &mut CliWorld, args: String) 
     // paths (e.g. `examples/exit_code`) resolve the same way as a manual run
     // from the repo root, and the target directory is prepended to `PATH` so
     // helper binaries built alongside `mvmctl` are found.
-    if world.isolated_home.is_none() {
+    //
+    // The home is the artifact-warm one when `MVM_E2E_HOME` names it. A fresh
+    // tempdir per scenario looks like better isolation, but the guest binaries
+    // are cached *under the home*, so every such scenario re-cross-compiles
+    // them from scratch — minutes each, repeated across the live suite. The
+    // warm home is what makes a live run finish in a sane time.
+    let warm_home = std::env::var_os("MVM_E2E_HOME").map(std::path::PathBuf::from);
+    if warm_home.is_none() && world.isolated_home.is_none() {
         world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));
     }
-    let home = world
-        .isolated_home
-        .as_ref()
-        .expect("isolated home is set above");
+    let home: std::path::PathBuf = match (&warm_home, world.isolated_home.as_ref()) {
+        (Some(warm), _) => warm.clone(),
+        (None, Some(dir)) => dir.path().to_path_buf(),
+        (None, None) => unreachable!("one of the two is set above"),
+    };
     let mut command = mvmctl_command();
     command
         .current_dir(workspace_root())
         .args(args.split_whitespace())
-        .isolated_home(home.path());
+        .isolated_home(&home);
     if world.warm_residency {
         command.env("MVM_RESIDENCY", "warm");
     }

--- a/crates/mvm-conformance/tests/steps/doc_examples.rs
+++ b/crates/mvm-conformance/tests/steps/doc_examples.rs
@@ -108,6 +108,26 @@ struct CommandEntry {
     /// dropped.
     #[serde(default)]
     exit_reports_host_state: bool,
+    /// Why this path is proven only by parsing. Required for `tier = "parse"`,
+    /// which is the weakest tier and the one a path lands in by neglect
+    /// rather than by decision. Writing the obstruction down is what keeps
+    /// "we could not run this" distinguishable from "nobody tried".
+    #[serde(default)]
+    reason: Option<String>,
+    /// Environment the exec tier sets for this path alone.
+    ///
+    /// Some commands reach outside `MVM_HOME` by design and ship an explicit
+    /// sandbox hook for exactly that reason — `env uninstall` rewrites its
+    /// system paths under `MVM_UNINSTALL_PATH_PREFIX`. Without the hook such a
+    /// command "passes" only by being cancelled at its confirmation prompt,
+    /// which proves nothing and leaves the real path untested.
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    /// A named fixture staged into the isolated home before this path runs.
+    /// Several documented commands are runnable and fail only because the file
+    /// they name is not there — a pubkey, a manifest, a bundle archive.
+    #[serde(default)]
+    fixture: Option<String>,
 }
 
 /// A command the docs name while it does not exist — either future syntax the
@@ -158,6 +178,25 @@ fn host_state_exit_paths() -> BTreeSet<Vec<String>> {
                 .split_whitespace()
                 .map(str::to_string)
                 .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+/// Per-path exec overrides: the environment to set, and the fixture to stage.
+type ExecOverride = (BTreeMap<String, String>, Option<String>);
+
+fn exec_overrides() -> BTreeMap<Vec<String>, ExecOverride> {
+    manifest()
+        .command
+        .into_iter()
+        .filter(|entry| !entry.env.is_empty() || entry.fixture.is_some())
+        .map(|entry| {
+            let path = entry
+                .path
+                .split_whitespace()
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            (path, (entry.env, entry.fixture))
         })
         .collect()
 }
@@ -339,15 +378,79 @@ fn collect_paths(command: &ClapCommand, prefix: &[String], out: &mut BTreeSet<Ve
 }
 
 /// Run one documented example for real against a private `MVM_HOME`.
-fn execute(example: &DocExample, home: &Path) -> std::process::Output {
-    crate::steps::cli::mvmctl_command()
+/// Run a documented example against an isolated home, optionally from a
+/// staged working directory and with per-entry environment.
+fn execute_in(
+    example: &DocExample,
+    home: &Path,
+    cwd: Option<&Path>,
+    env: &BTreeMap<String, String>,
+) -> std::process::Output {
+    let mut command = crate::steps::cli::mvmctl_command();
+    command
         .isolated_home(home)
         // Reconcile-on-entry converges live VM state; a doc example must not
         // reach for the host's real machines just to print its help.
         .env("MVM_SKIP_RECONCILE", "1")
-        .args(&example.argv)
+        .args(&example.argv);
+    if let Some(dir) = cwd {
+        command.current_dir(dir);
+    }
+    for (key, value) in env {
+        // A manifest env value naming a path in this repo is written
+        // repo-relative, because that is how a reader would write it. The
+        // command runs from a staged fixture directory, so resolve it here
+        // rather than leaving a relative path to miss silently.
+        let candidate = repo_root().join(value);
+        if candidate.exists() {
+            command.env(key, candidate);
+        } else {
+            command.env(key, value);
+        }
+    }
+    command
         .output()
         .unwrap_or_else(|error| panic!("spawn mvmctl for {}: {error}", example.location()))
+}
+
+/// Stage the files a documented example names, in a directory of its own.
+///
+/// A command that fails only because `./publisher.pub` is not there is not
+/// un-runnable; it is unstaged. Distinguishing the two is the difference
+/// between a tier that reflects the CLI and one that reflects the fixture set.
+fn stage_fixture(name: &str, dir: &Path, home: &Path) {
+    match name {
+        // `manifest info|rm|verify` all resolve a manifest from the working
+        // directory, which is what `init` writes.
+        "manifest" => {
+            let output = crate::steps::cli::mvmctl_command()
+                .isolated_home(home)
+                .env("MVM_SKIP_RECONCILE", "1")
+                .current_dir(dir)
+                .args(["init", "."])
+                .output()
+                .expect("spawn mvmctl init to stage the manifest fixture");
+            assert!(
+                output.status.success(),
+                "staging the manifest fixture failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        // The decorator examples compile a Python source file by path.
+        //
+        // Deliberately without the README's `source=mvm.local_path(".")`:
+        // `local_path` is defined by the Python SDK but absent from the
+        // decorator compiler's HELPER_ALLOWLIST, so the README form does not
+        // compile. Tracked separately — this fixture proves the command, not
+        // that particular kwarg.
+        "decorator-script" => {
+            let script = "import mvm\n\n\n@mvm.app(\n    name=\"greeter\",\n                    image=mvm.python_image(python=\"3.12\"),\n                    resources=mvm.resources(cpu_cores=1, memory_mb=256, rootfs_size_mb=512),\n)\n                def greet(name: str) -> str:\n    return f\"hello {name}\"\n";
+            for file in ["app.py", "script.py"] {
+                std::fs::write(dir.join(file), script).expect("write decorator fixture");
+            }
+        }
+        other => panic!("unknown fixture {other:?} in the tier manifest"),
+    }
 }
 
 #[then(expr = "every side-effect-free documented example executes successfully")]
@@ -355,6 +458,7 @@ fn every_exec_tier_example_runs(_world: &mut CliWorld) {
     let command = mvm_cli::commands::cli_command();
     let policy = tier_policy();
     let host_state_exit = host_state_exit_paths();
+    let overrides = exec_overrides();
     let home = std::env::temp_dir().join(format!("mvm-doc-exec-{}", std::process::id()));
     std::fs::create_dir_all(&home).expect("create isolated MVM_HOME");
 
@@ -377,7 +481,19 @@ fn every_exec_tier_example_runs(_world: &mut CliWorld) {
             continue;
         }
 
-        let output = execute(&example, &home);
+        // Per-entry environment and fixtures, for paths that are runnable
+        // but reach outside the home or name a file that has to exist.
+        let (env, fixture) = overrides.get(&path).cloned().unwrap_or_default();
+        // Always run from a scratch directory, never the repo root. Several
+        // documented examples scaffold into a relative path — `mvmctl init
+        // ./agent-tool`, `generate template python ./my-python-app` — and at
+        // the repo root that drops generated trees into the working copy.
+        let dir = home.join("scratch").join(path.join("-"));
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        if let Some(name) = fixture.as_deref() {
+            stage_fixture(name, &dir, &home);
+        }
+        let output = execute_in(&example, &home, Some(&dir), &env);
         ran += 1;
 
         // A command killed by a signal never ran to completion, whatever its
@@ -1092,5 +1208,35 @@ fn cli_output_names_real_commands(_world: &mut CliWorld) {
          features/suites/s29_doc_examples/tiers.toml:\n{}",
         failures.len(),
         failures.join("\n")
+    );
+}
+
+#[then(expr = "every parse-tier command path explains why it is only parsed")]
+fn every_parse_tier_path_explains_itself(_world: &mut CliWorld) {
+    // `parse` is the tier a path reaches by nobody deciding anything: it is
+    // the weakest rung and the default landing spot for a newly documented
+    // verb. Requiring a written obstruction is what stops the ladder decaying
+    // back into "everything parses" — the state this suite exists to leave.
+    let unexplained: Vec<String> = manifest()
+        .command
+        .into_iter()
+        .filter(|entry| entry.tier == "parse")
+        .filter(|entry| {
+            entry
+                .reason
+                .as_deref()
+                .map(str::trim)
+                .unwrap_or("")
+                .is_empty()
+        })
+        .map(|entry| format!("  {}", entry.path))
+        .collect();
+
+    assert!(
+        unexplained.is_empty(),
+        "{} command path(s) sit at tier `parse` with no reason. Either promote \
+         them to `exec`/`live`, or record what blocks that:\n{}",
+        unexplained.len(),
+        unexplained.join("\n")
     );
 }

--- a/crates/mvm-conformance/tests/steps/launch_e2e.rs
+++ b/crates/mvm-conformance/tests/steps/launch_e2e.rs
@@ -57,7 +57,7 @@ const GUEST_BOOT_FAILURES: &[(&str, &str)] = &[
     ),
 ];
 
-fn e2e_home() -> PathBuf {
+pub(crate) fn e2e_home() -> PathBuf {
     std::env::var_os(E2E_HOME_ENV)
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from(mvm_core::config::mvm_home()))

--- a/crates/mvm-conformance/tests/steps/machine_journey.rs
+++ b/crates/mvm-conformance/tests/steps/machine_journey.rs
@@ -73,12 +73,17 @@ fn ensure_journey_machine() -> &'static Result<(), String> {
         let _ = run_in_journey_home(["machine", "stop", JOURNEY_MACHINE, "--yes"]);
         let _ = run_in_journey_home(["machine", "rm", JOURNEY_MACHINE, "--yes"]);
 
+        // `nginx` rather than a bare `alpine`: every verb below needs a guest
+        // that is still up when it runs. An image with no long-running process
+        // boots, finds nothing to run and exits, and the state directory is
+        // gone by the next scenario — which then reports "never booted" and
+        // reads as a broken verb rather than a finished guest.
         let create = run_in_journey_home([
             "machine",
             "create",
             JOURNEY_MACHINE,
             "--image",
-            "alpine",
+            "nginx",
             "--cpus",
             "2",
             "--memory",
@@ -96,6 +101,20 @@ fn ensure_journey_machine() -> &'static Result<(), String> {
             return Err(format!(
                 "machine start failed: {}",
                 String::from_utf8_lossy(&start.stderr).trim()
+            ));
+        }
+
+        // Exit 0 from `start` is not the same as a guest that is up. Confirm
+        // the state directory the runtime verbs resolve against actually
+        // exists, so a guest that booted and exited is reported here — once,
+        // naming the boot — rather than as one cryptic failure per verb.
+        let state_dir = journey_home().join("vms").join(JOURNEY_MACHINE);
+        if !state_dir.exists() {
+            return Err(format!(
+                "machine start exited 0 but {} does not exist — the guest is \
+                 not running. An image with no long-running process boots and \
+                 exits immediately.",
+                state_dir.display()
             ));
         }
         Ok(())

--- a/crates/mvm-conformance/tests/steps/machine_journey.rs
+++ b/crates/mvm-conformance/tests/steps/machine_journey.rs
@@ -1,0 +1,174 @@
+//! The documented machine lifecycle, driven against one real guest.
+//!
+//! Most of the `machine` verb surface is documented but proven only by the
+//! `parse` tier, for one structural reason: each verb needs a machine that is
+//! already running, and a scenario that boots its own guest pays minutes for
+//! a single assertion. So `machine cp`, `machine pause`, `machine fs ls` and
+//! two dozen siblings were verified to the depth of "clap accepts these
+//! arguments" — which cannot see a verb that parses and then refuses, the
+//! shape `machine forward` had already decayed into.
+//!
+//! This module boots one guest for the whole feature and lets every scenario
+//! drive it. The machine is process-global rather than per-scenario because
+//! cucumber's `World` is rebuilt for each scenario; the runner pins
+//! `max_concurrent_scenarios(1)`, so sharing it is sequential by construction.
+
+use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::sync::OnceLock;
+
+use cucumber::{given, then, when};
+
+use crate::world::CliWorld;
+use mvm_conformance::IsolatedHome;
+
+/// Name of the guest every journey scenario operates. Fixed rather than
+/// generated: a leaked machine from an aborted run is then findable by name
+/// and reclaimed by the next run's teardown, instead of accumulating.
+const JOURNEY_MACHINE: &str = "bdd-journey";
+
+/// The home the journey machine lives in, booted once per process.
+///
+/// `MVM_E2E_HOME` points this at an artifact-warm home. A fresh tempdir would
+/// re-acquire the kernel, overlay and initramfs before the first boot, which
+/// reads as a launch timeout rather than as a cold cache.
+fn journey_home() -> &'static Path {
+    static HOME: OnceLock<PathBuf> = OnceLock::new();
+    HOME.get_or_init(|| {
+        std::env::var_os("MVM_E2E_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                let dir = std::env::temp_dir().join("mvm-journey-home");
+                std::fs::create_dir_all(&dir).expect("create journey MVM_HOME");
+                dir
+            })
+    })
+}
+
+/// Run `mvmctl` against the journey home, from the workspace root so relative
+/// paths in a documented example resolve as they would for a reader.
+pub(crate) fn run_in_journey_home<I, S>(args: I) -> Output
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    crate::steps::cli::mvmctl_command()
+        .current_dir(crate::steps::cli::workspace_root())
+        .args(args)
+        .isolated_home(journey_home())
+        .output()
+        .expect("failed to spawn mvmctl against the journey home")
+}
+
+/// Boot the journey guest, once per process.
+///
+/// Returns the boot output so the first caller can assert on it; later callers
+/// observe the same stored result. A failed boot is not retried — a second
+/// attempt against a half-created machine reports a name collision, which
+/// buries the real error under a misleading one.
+fn ensure_journey_machine() -> &'static Result<(), String> {
+    static BOOTED: OnceLock<Result<(), String>> = OnceLock::new();
+    BOOTED.get_or_init(|| {
+        // Reclaim a machine leaked by an aborted earlier run before creating.
+        let _ = run_in_journey_home(["machine", "stop", JOURNEY_MACHINE, "--yes"]);
+        let _ = run_in_journey_home(["machine", "rm", JOURNEY_MACHINE, "--yes"]);
+
+        let create = run_in_journey_home([
+            "machine",
+            "create",
+            JOURNEY_MACHINE,
+            "--image",
+            "alpine",
+            "--cpus",
+            "2",
+            "--memory",
+            "512M",
+        ]);
+        if !create.status.success() {
+            return Err(format!(
+                "machine create failed: {}",
+                String::from_utf8_lossy(&create.stderr).trim()
+            ));
+        }
+
+        let start = run_in_journey_home(["machine", "start", JOURNEY_MACHINE]);
+        if !start.status.success() {
+            return Err(format!(
+                "machine start failed: {}",
+                String::from_utf8_lossy(&start.stderr).trim()
+            ));
+        }
+        Ok(())
+    })
+}
+
+#[given(expr = "the journey machine is running")]
+fn journey_machine_is_running(world: &mut CliWorld) {
+    match ensure_journey_machine() {
+        Ok(()) => {}
+        Err(problem) => panic!("the journey guest could not be booted: {problem}"),
+    }
+    world.journey_machine = Some(JOURNEY_MACHINE.to_string());
+}
+
+/// Drive a documented command against the running journey machine.
+///
+/// `{machine}` in the argument string is substituted with the journey guest's
+/// name, so the feature file reads like the documentation it mirrors while
+/// still operating the one guest this feature booted.
+#[when(expr = "I run mvmctl against the journey machine with {string}")]
+fn run_against_journey_machine(world: &mut CliWorld, args: String) {
+    let name = world
+        .journey_machine
+        .clone()
+        .expect("the journey machine step must run first");
+    let rendered = args.replace("{machine}", &name);
+    world.last_run = Some(run_in_journey_home(rendered.split_whitespace()));
+}
+
+/// Stage a host-side file the documented example copies into the guest.
+#[given(expr = "a host file {string} exists")]
+fn a_host_file_exists(_world: &mut CliWorld, relative: String) {
+    let path = crate::steps::cli::workspace_root().join(&relative);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create host fixture parent");
+    }
+    std::fs::write(&path, b"{\"journey\":true}\n").expect("write host fixture");
+}
+
+#[then(expr = "the journey machine is still running")]
+fn journey_machine_still_running(world: &mut CliWorld) {
+    let name = world
+        .journey_machine
+        .clone()
+        .expect("the journey machine step must run first");
+    // A verb that leaves the guest dead breaks every scenario after it, and
+    // the failure surfaces on the *next* scenario rather than the one that
+    // caused it. Check here so the blame lands on the right verb.
+    let output = run_in_journey_home(["machine", "inspect", &name]);
+    assert!(
+        output.status.success(),
+        "the journey guest is no longer inspectable after this scenario: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
+    );
+}
+
+#[then(expr = "the journey machine is torn down")]
+fn journey_machine_torn_down(world: &mut CliWorld) {
+    let name = world
+        .journey_machine
+        .clone()
+        .expect("the journey machine step must run first");
+    let stop = run_in_journey_home(["machine", "stop", &name, "--yes"]);
+    assert!(
+        stop.status.success(),
+        "machine stop failed: {}",
+        String::from_utf8_lossy(&stop.stderr).trim()
+    );
+    let remove = run_in_journey_home(["machine", "rm", &name, "--yes"]);
+    assert!(
+        remove.status.success(),
+        "machine rm failed: {}",
+        String::from_utf8_lossy(&remove.stderr).trim()
+    );
+}

--- a/crates/mvm-conformance/tests/steps/mod.rs
+++ b/crates/mvm-conformance/tests/steps/mod.rs
@@ -12,6 +12,7 @@ mod hvf_save_restore;
 mod initramfs;
 mod kernel_pin;
 pub(crate) mod launch_e2e;
+mod machine_journey;
 mod network_surface;
 mod oci_unpack;
 mod one_transport;

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -134,6 +134,8 @@ pub struct CliWorld {
     /// Result of the most recent end-to-end launch, including its measured
     /// dispatch window.
     pub last_launch: Option<LaunchRecord>,
+    /// Name of the shared guest the documented machine-verb journey drives.
+    pub journey_machine: Option<String>,
     /// Gate under test in the peer-addressing scenarios.
     pub peer_gate: Option<mvm_vmm::vsock_egress_bridge::egress_gate::EgressGate>,
     /// The most recent peer/egress decision.

--- a/examples/obscura/README.md
+++ b/examples/obscura/README.md
@@ -6,10 +6,18 @@ guest proxy and remains deny-by-default unless each destination is admitted.
 
 Build and run Nix/microVM commands inside the project builder VM:
 
+Signed TCP ingress has to be declared before boot, so `--port` is part of the
+launch rather than a later attach. It is rejected together with `--detach`,
+which means this run holds the terminal; drive the CDP endpoint from a second
+shell.
+
 ```sh
-mvmctl machine run -d --name obscura --flake . \
-  --allow-host example.com:443
-mvmctl machine forward obscura --port 9222:9222
+mvmctl machine run --name obscura --flake . \
+  --allow-host example.com:443 \
+  --port 9222:9222
+```
+
+```sh
 curl http://127.0.0.1:9222/json/version
 mvmctl machine stop obscura --yes
 ```

--- a/features/suites/s29_doc_examples/tiers.toml
+++ b/features/suites/s29_doc_examples/tiers.toml
@@ -14,22 +14,28 @@
 [[command]]
 path = "bootstrap"
 tier = "parse"
+reason = "downloads or builds a multi-hundred-megabyte artifact over the network; the e2e runner performs it once as setup rather than as an assertion"
 
 [[command]]
 path = "build compile"
-tier = "parse"
+tier = "exec"
+fixture = "decorator-script"
+env = { PYTHONPATH = "crates/mvm-sdk/sdks/python" }
 
 [[command]]
 path = "build kernel build"
 tier = "parse"
+reason = "downloads or builds a multi-hundred-megabyte artifact over the network; the e2e runner performs it once as setup rather than as an assertion"
 
 [[command]]
 path = "bundle fetch"
 tier = "parse"
+reason = "needs a signed .mvmpkg published by a real publisher key; scripts/make-bundle-fixture.sh builds one, wiring it in is follow-on work"
 
 [[command]]
 path = "bundle install"
 tier = "parse"
+reason = "needs a signed .mvmpkg published by a real publisher key; scripts/make-bundle-fixture.sh builds one, wiring it in is follow-on work"
 
 [[command]]
 path = "cache info"
@@ -37,11 +43,11 @@ tier = "exec"
 
 [[command]]
 path = "cache prune"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "cache repair"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "catalog list"
@@ -50,18 +56,22 @@ tier = "exec"
 [[command]]
 path = "deps audit"
 tier = "parse"
+reason = "same sealed-volume fixture as deps inspect"
 
 [[command]]
 path = "deps capture-live"
 tier = "parse"
+reason = "reaches a package index over the network, so the outcome tracks the index rather than mvm"
 
 [[command]]
 path = "deps inspect"
 tier = "parse"
+reason = "names a sealed deps volume hash; mvm-app-deps-fixture-tool can seal one, wiring it in is follow-on work"
 
 [[command]]
 path = "deps install"
 tier = "parse"
+reason = "reaches a package index over the network, so the outcome tracks the index rather than mvm"
 
 [[command]]
 path = "doctor"
@@ -72,27 +82,30 @@ exit_reports_host_state = true
 
 [[command]]
 path = "env cleanup"
-tier = "parse"
+tier = "exec"
+env = { MVM_UNINSTALL_PATH_PREFIX = "sandbox" }
 
 [[command]]
 path = "env uninstall"
-tier = "parse"
+tier = "exec"
+env = { MVM_UNINSTALL_PATH_PREFIX = "sandbox" }
 
 [[command]]
 path = "generate template"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "image inspect"
 tier = "parse"
+reason = "needs an OCI image already pulled into the cache"
 
 [[command]]
 path = "init"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "machine boot-report"
-tier = "parse"
+tier = "live"
 
 [[command]]
 path = "machine build"
@@ -101,10 +114,11 @@ tier = "live"
 [[command]]
 path = "machine check-artifact"
 tier = "parse"
+reason = "names a signed .mvm artifact that only a real build produces"
 
 [[command]]
 path = "machine checkpoint create"
-tier = "parse"
+tier = "live"
 
 [[command]]
 path = "machine checkpoint ls"
@@ -113,14 +127,16 @@ tier = "exec"
 [[command]]
 path = "machine checkpoint restore"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "machine console"
 tier = "parse"
+reason = "an interactive PTY; driving it needs a pty harness rather than captured stdio"
 
 [[command]]
 path = "machine cp"
-tier = "parse"
+tier = "live"
 
 [[command]]
 path = "machine create"
@@ -129,6 +145,7 @@ tier = "live"
 [[command]]
 path = "machine diff"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine exec"
@@ -137,14 +154,16 @@ tier = "live"
 [[command]]
 path = "machine fork"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine fs ls"
-tier = "parse"
+tier = "live"
 
 [[command]]
 path = "machine fs write"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "machine inspect"
@@ -160,23 +179,26 @@ tier = "exec"
 
 [[command]]
 path = "machine pause"
-tier = "parse"
+tier = "live"
 
 [[command]]
 path = "machine proc start"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine reconfigure"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine restore"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine resume"
-tier = "parse"
+tier = "live"
 
 [[command]]
 path = "machine rm"
@@ -188,11 +210,12 @@ tier = "live"
 
 [[command]]
 path = "machine sandbox gc"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "machine shell"
 tier = "parse"
+reason = "an interactive shell; same pty constraint as machine console"
 
 [[command]]
 path = "machine snapshot ls"
@@ -201,6 +224,7 @@ tier = "exec"
 [[command]]
 path = "machine snapshot rm"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine start"
@@ -213,18 +237,22 @@ tier = "live"
 [[command]]
 path = "machine volume catalog"
 tier = "parse"
+reason = "refuses without MVM_GATEWAY_URL: the --remote form the docs show targets a gateway that lives in mvmd, not in this repo"
 
 [[command]]
 path = "machine volume create"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine volume delete"
 tier = "parse"
+reason = "refuses without MVM_GATEWAY_URL: the --remote form the docs show targets a gateway that lives in mvmd, not in this repo"
 
 [[command]]
 path = "machine volume lock"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine volume ls"
@@ -233,30 +261,37 @@ tier = "exec"
 [[command]]
 path = "machine volume mount"
 tier = "parse"
+reason = "refuses without MVM_GATEWAY_URL: the --remote form the docs show targets a gateway that lives in mvmd, not in this repo"
 
 [[command]]
 path = "machine volume restore"
 tier = "parse"
+reason = "refuses without MVM_GATEWAY_URL: the --remote form the docs show targets a gateway that lives in mvmd, not in this repo"
 
 [[command]]
 path = "machine volume snapshot"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "machine volume unlock"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine volume unmount"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "machine wait"
 tier = "parse"
+reason = "needs the live journey guest; not yet added to features/suites/s32_documented_surface/machine_journey.feature"
 
 [[command]]
 path = "manifest info"
 tier = "parse"
+reason = "needs a manifest carrying a built slot; `init` writes the manifest but only a real build inside the builder VM fills the slot"
 
 [[command]]
 path = "manifest ls"
@@ -264,19 +299,21 @@ tier = "exec"
 
 [[command]]
 path = "manifest prune"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "manifest rm"
 tier = "parse"
+reason = "needs a manifest carrying a built slot; `init` writes the manifest but only a real build inside the builder VM fills the slot"
 
 [[command]]
 path = "manifest verify"
 tier = "parse"
+reason = "needs a manifest carrying a built slot; `init` writes the manifest but only a real build inside the builder VM fills the slot"
 
 [[command]]
 path = "network create"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "network list"
@@ -284,7 +321,7 @@ tier = "exec"
 
 [[command]]
 path = "ops config set"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "ops metrics"
@@ -293,42 +330,50 @@ tier = "exec"
 [[command]]
 path = "pack download"
 tier = "parse"
+reason = "reaches a package index over the network, so the outcome tracks the index rather than mvm"
 
 [[command]]
 path = "pack update"
 tier = "parse"
+reason = "reaches a package index over the network, so the outcome tracks the index rather than mvm"
 
 [[command]]
 path = "persistent-builder start"
 tier = "parse"
+reason = "needs a live persistent-builder session, which the builder VM owns and no scenario currently starts"
 
 [[command]]
 path = "persistent-builder status"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "persistent-builder stop"
 tier = "parse"
+reason = "needs a live persistent-builder session, which the builder VM owns and no scenario currently starts"
 
 [[command]]
 path = "persistent-builder submit"
 tier = "parse"
+reason = "needs a live persistent-builder session, which the builder VM owns and no scenario currently starts"
 
 [[command]]
 path = "run"
 tier = "parse"
+reason = "executes the user's script on the host in record mode; needs a decorator fixture and an SDK on PYTHONPATH"
 
 [[command]]
 path = "secret get"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "secret put"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "template info"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "template list"
@@ -336,31 +381,32 @@ tier = "exec"
 
 [[command]]
 path = "template search"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "trust add"
 tier = "parse"
+reason = "names a publisher pubkey file that no fixture stages yet"
 
 [[command]]
 path = "trust audit decisions export"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "trust audit provenance export"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "trust audit show"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "trust audit tail"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "trust audit verify"
-tier = "parse"
+tier = "exec"
 
 [[command]]
 path = "trust list"
@@ -369,50 +415,62 @@ tier = "exec"
 [[command]]
 path = "trust receipt verify"
 tier = "parse"
+reason = "names a run receipt, which only a real launch produces"
 
 [[command]]
 path = "machine forward"
 tier = "parse"
+reason = "retired at runtime while still present in the clap tree; the docs no longer reference it"
 
 [[command]]
 path = "secret set"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "bench"
 tier = "parse"
+reason = "boots VMs in a measurement loop; the runtime is a benchmark budget, not a test budget"
 
 [[command]]
 path = "build address"
 tier = "parse"
+reason = "needs a compiled workload fixture to address"
 
 [[command]]
 path = "build runtime-overlay build"
 tier = "parse"
+reason = "downloads or builds a multi-hundred-megabyte artifact over the network; the e2e runner performs it once as setup rather than as an assertion"
 
 [[command]]
 path = "build validate"
 tier = "parse"
+reason = "needs a generated launch plan to validate"
 
 [[command]]
 path = "bundle gc"
 tier = "parse"
+reason = "needs a signed .mvmpkg published by a real publisher key; scripts/make-bundle-fixture.sh builds one, wiring it in is follow-on work"
 
 [[command]]
 path = "env bootstrap"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "env update"
 tier = "parse"
+reason = "downloads or builds a multi-hundred-megabyte artifact over the network; the e2e runner performs it once as setup rather than as an assertion"
 
 [[command]]
 path = "kernel build"
 tier = "parse"
+reason = "downloads or builds a multi-hundred-megabyte artifact over the network; the e2e runner performs it once as setup rather than as an assertion"
 
 [[command]]
 path = "ops config edit"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "ops config show"
@@ -421,6 +479,7 @@ tier = "exec"
 [[command]]
 path = "ops mcp stdio"
 tier = "parse"
+reason = "a long-lived stdio server: it never exits, so an exec-tier run would hang rather than assert"
 
 [[command]]
 path = "pack list"
@@ -429,6 +488,7 @@ tier = "exec"
 [[command]]
 path = "pack prune"
 tier = "parse"
+reason = "reaches a package index over the network, so the outcome tracks the index rather than mvm"
 
 [[command]]
 path = "plugin list"
@@ -437,14 +497,17 @@ tier = "exec"
 [[command]]
 path = "pool status"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "prepare"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "secret ls"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "secret providers"
@@ -453,13 +516,15 @@ tier = "exec"
 [[command]]
 path = "shell-init"
 tier = "parse"
+reason = "documented only as a placeholder template, so there is no concrete invocation to execute"
 
 [[command]]
 path = "watch"
 tier = "parse"
-
 # Documented as future syntax. Each entry must stay absent from the CLI: the
 # suite fails if one ships, so the docs get updated when it does.
+reason = "a long-lived watcher: it never exits on its own"
+
 [[planned]]
 path = "manifest push"
 reason = "registry sharing is designed but unimplemented; the docs mark the section planned"

--- a/features/suites/s32_documented_surface/machine_journey.feature
+++ b/features/suites/s32_documented_surface/machine_journey.feature
@@ -1,0 +1,83 @@
+Feature: The documented machine verbs operate a real guest
+
+  The `machine` surface is the largest documented verb family and was the
+  least proven: two dozen verbs sat at the `parse` tier because each one needs
+  a guest that is already running, and no scenario was willing to boot one for
+  a single assertion.
+
+  Parsing cannot see the defect that matters here. `machine forward` parses
+  cleanly and then refuses at runtime — it was retired, while
+  `examples/obscura/README.md` still tells a reader to run it. Only executing
+  the verb against a live guest distinguishes "documented and working" from
+  "documented and merely still in the clap tree".
+
+  The guest is named literally rather than through a `{machine}` placeholder:
+  the machine-name positional carries a `value_parser` that rejects braces, so
+  a templated name fails to parse and silently drops out of the live-witness
+  gate — the scenario would run while the tier it backs stayed unproven.
+
+  One guest is booted for the whole feature and every scenario drives it, so
+  the verb coverage costs one boot rather than twenty. Scenarios are split by
+  verb family rather than written as a single long journey: cucumber abandons
+  a scenario at its first failing step, so one scenario per family means a
+  broken verb reports itself instead of hiding every verb behind it.
+
+  Untagged `@live` only — deliberately not `@firecracker`. The pre-existing
+  live lifecycle witness carries that tag, so it is skipped on macOS, where
+  HVF is the default backend. This feature runs on whatever backend the host
+  actually has.
+
+  Background:
+    Given the journey machine is running
+
+  @live
+  Scenario: the guest reports its own state
+    When I run mvmctl against the journey machine with "machine inspect bdd-journey"
+    Then the command exits with code 0
+    When I run mvmctl against the journey machine with "machine logs bdd-journey"
+    Then the command exits with code 0
+    When I run mvmctl against the journey machine with "machine boot-report bdd-journey"
+    Then the command exits with code 0
+    Then the journey machine is still running
+
+  @live
+  Scenario: commands run inside the guest
+    When I run mvmctl against the journey machine with "machine exec bdd-journey -- uname -a"
+    Then the command exits with code 0
+    Then the journey machine is still running
+
+  @live
+  Scenario: the guest filesystem is readable from the host
+    When I run mvmctl against the journey machine with "machine fs ls bdd-journey /"
+    Then the command exits with code 0
+    Then the journey machine is still running
+
+  @live
+  Scenario: files copy from the host into the guest
+    Given a host file "target/journey/input.json" exists
+    When I run mvmctl against the journey machine with "machine cp target/journey/input.json bdd-journey:/tmp/input.json"
+    Then the command exits with code 0
+    Then the journey machine is still running
+
+  @live
+  Scenario: the guest pauses and resumes
+    When I run mvmctl against the journey machine with "machine pause bdd-journey"
+    Then the command exits with code 0
+    When I run mvmctl against the journey machine with "machine resume bdd-journey"
+    Then the command exits with code 0
+    Then the journey machine is still running
+
+  @live
+  Scenario: the guest checkpoints and restores
+    When I run mvmctl against the journey machine with "machine checkpoint create bdd-journey"
+    Then the command exits with code 0
+    When I run mvmctl against the journey machine with "machine checkpoint ls bdd-journey"
+    Then the command exits with code 0
+    Then the journey machine is still running
+
+  @live
+  Scenario: the documented teardown removes the guest
+    # Last, because it destroys the machine every scenario above shares.
+    When I run mvmctl against the journey machine with "machine ls"
+    Then the command exits with code 0
+    Then the journey machine is torn down

--- a/features/suites/s32_documented_surface/machine_journey.feature
+++ b/features/suites/s32_documented_surface/machine_journey.feature
@@ -69,7 +69,11 @@ Feature: The documented machine verbs operate a real guest
 
   @live
   Scenario: the guest checkpoints and restores
-    When I run mvmctl against the journey machine with "machine checkpoint create bdd-journey"
+    # `--class vm-full` because that is the form the docs teach, and the two
+    # classes have opposite preconditions: `vm-full` checkpoints a *running*
+    # guest (it pauses internally), while the default `fs-quick` refuses one
+    # and wants it stopped or paused first.
+    When I run mvmctl against the journey machine with "machine checkpoint create bdd-journey --class vm-full"
     Then the command exits with code 0
     When I run mvmctl against the journey machine with "machine checkpoint ls bdd-journey"
     Then the command exits with code 0

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -91,11 +91,45 @@ MVM_HOME="$E2E_HOME" "$MVMCTL" doctor || true
 # `MVM_BDD_CI_LIVE_ONLY` here: that selector narrows to the merge-queue subset,
 # and narrowing is what let the macOS default backend go uncovered.
 # ---------------------------------------------------------------------------
+# Bounded, because a live scenario can hang rather than fail: a guest that
+# never completes its request leaves the runner waiting forever, and a release
+# gate that hangs is a gate nobody runs. Implemented here rather than with
+# `timeout(1)`, which is absent from a stock macOS and from the macOS runners.
+E2E_TIMEOUT_SECS="${MVM_E2E_TIMEOUT_SECS:-3600}"
+
 echo "==> documented examples + machine journey (cucumber, @live)"
+echo "    deadline: ${E2E_TIMEOUT_SECS}s"
+set +e
 CARGO_BIN_EXE_mvmctl="$MVMCTL" \
 MVM_BDD_LIVE=1 \
 MVM_E2E_HOME="$E2E_HOME" \
-  ./scripts/cargo-fast.sh test -p mvm-conformance --test conformance --features bdd
+  ./scripts/cargo-fast.sh test -p mvm-conformance --test conformance --features bdd &
+SUITE_PID=$!
+
+waited=0
+while kill -0 "$SUITE_PID" 2>/dev/null; do
+  if (( waited >= E2E_TIMEOUT_SECS )); then
+    echo
+    echo "!!! TIMEOUT after ${E2E_TIMEOUT_SECS}s — killing the suite."
+    echo "!!! A live scenario hung instead of failing. The last scenario printed"
+    echo "!!! above is where it stopped; raise MVM_E2E_TIMEOUT_SECS if it needs longer."
+    kill -TERM "$SUITE_PID" 2>/dev/null || true
+    sleep 5
+    kill -KILL "$SUITE_PID" 2>/dev/null || true
+    # Leave no guest behind holding a vsock socket or a vCPU thread.
+    pkill -f "mvm-hvf-supervisor" 2>/dev/null || true
+    pkill -f "mvm-libkrun-supervisor" 2>/dev/null || true
+    SUITE_STATUS=124
+    break
+  fi
+  sleep 5
+  waited=$((waited + 5))
+done
+if [[ -z "${SUITE_STATUS:-}" ]]; then
+  wait "$SUITE_PID"
+  SUITE_STATUS=$?
+fi
+set -e
 
 echo
 echo "==> done. Read the 'did NOT run' tally above, not just the pass count:"
@@ -105,3 +139,4 @@ if [[ -n "${BOOTSTRAP_FAILED:-}" ]]; then
   echo "!!! REMINDER: bootstrap failed this run. Any flake-build failure above"
   echo "!!! is that, not a regression in the command under test."
 fi
+exit "$SUITE_STATUS"

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -28,17 +28,150 @@ echo "    repo: $REPO"
 echo "    home: $E2E_HOME"
 
 # ---------------------------------------------------------------------------
+# Cleanup.
+#
+# Scoped to the `bdd-` prefix every suite-created machine carries. This home
+# defaults to the real `~/.mvm`, so an unscoped sweep would delete the machines
+# the person running this actually cares about. Nothing here matches a name the
+# suite did not create.
+#
+# Runs on the way in as well as the way out: a previous run killed at its
+# timeout — or with ^C — leaves a guest holding a vsock socket, and the next
+# run then fails on a name collision that looks like a broken verb.
+# ---------------------------------------------------------------------------
+reap() {
+  local phase="$1"
+  local names
+  names="$(MVM_HOME="$E2E_HOME" "$MVMCTL" machine ls 2>/dev/null \
+    | awk 'NR>1 && $1 ~ /^bdd-/ {print $1}' || true)"
+
+  if [[ -n "$names" ]]; then
+    echo "==> $phase cleanup: reaping $(echo "$names" | wc -w | tr -d ' ') bdd- machine(s)"
+    while read -r name; do
+      [[ -z "$name" ]] && continue
+      echo "    - $name"
+      MVM_HOME="$E2E_HOME" "$MVMCTL" machine stop "$name" --yes >/dev/null 2>&1 || true
+      MVM_HOME="$E2E_HOME" "$MVMCTL" machine rm "$name" --yes >/dev/null 2>&1 || true
+    done <<< "$names"
+  elif [[ "$phase" == "pre-run" ]]; then
+    echo "==> pre-run cleanup: no leftover bdd- machines"
+  fi
+
+  # State directories for suite machines, in case a spec was removed while its
+  # runtime directory survived.
+  if [[ -d "$E2E_HOME/vms" ]]; then
+    find "$E2E_HOME/vms" -maxdepth 1 -name 'bdd-*' -type d -exec rm -rf {} + 2>/dev/null || true
+  fi
+}
+
+# Per-VM supervisors outlive a killed suite and keep a vCPU thread and a vsock
+# socket alive. Only those whose state directory is gone are reaped, so a
+# supervisor belonging to someone else's machine is left alone.
+reap_orphan_supervisors() {
+  local pids
+  pids="$(pgrep -f 'mvm-(hvf|libkrun)-supervisor' 2>/dev/null || true)"
+  [[ -z "$pids" ]] && return 0
+  for pid in $pids; do
+    local args
+    args="$(ps -o args= -p "$pid" 2>/dev/null || true)"
+    case "$args" in
+      *bdd-*) echo "    - reaping orphan supervisor $pid"; kill -TERM "$pid" 2>/dev/null || true ;;
+    esac
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Following the run.
+#
+# Cucumber captures a step's output and only prints it when the step fails, so
+# a multi-minute boot shows nothing at all while it happens. This watcher runs
+# beside the suite instead of inside it: it notices each microVM's state
+# directory appearing, announces it, and streams that guest's console with a
+# name prefix. That is the part worth watching — the guest actually coming up.
+#
+# On by default when stdout is a terminal. MVM_E2E_FOLLOW=0 turns it off,
+# MVM_E2E_FOLLOW=1 forces it on for a log file or CI.
+# ---------------------------------------------------------------------------
+if [[ -z "${MVM_E2E_FOLLOW:-}" ]]; then
+  if [[ -t 1 ]]; then MVM_E2E_FOLLOW=1; else MVM_E2E_FOLLOW=0; fi
+fi
+
+WATCHER_PID=""
+
+start_watcher() {
+  [[ "$MVM_E2E_FOLLOW" == "1" ]] || return 0
+  ./scripts/e2e-watch-vms.sh "$E2E_HOME" &
+  WATCHER_PID=$!
+  echo "==> following microVM lifecycle (MVM_E2E_FOLLOW=0 to silence)"
+  echo "    the same view from another terminal:"
+  echo "      scripts/e2e-watch-vms.sh $E2E_HOME"
+}
+
+stop_watcher() {
+  [[ -n "$WATCHER_PID" ]] || return 0
+  # The watcher's `tail` children are in its process group; kill the group.
+  # The watcher's `tail` children sit in its process group; signal the group
+  # so a follower does not outlive the run.
+  # The watcher reaps its own console followers from its EXIT trap.
+  kill -TERM "$WATCHER_PID" 2>/dev/null || true
+  WATCHER_PID=""
+}
+
+on_exit() {
+  local status=$?
+  stop_watcher
+  echo
+  reap "post-run"
+  reap_orphan_supervisors
+  return "$status"
+}
+trap on_exit EXIT
+trap 'echo; echo "!!! interrupted — cleaning up"; exit 130' INT TERM
+
+# ---------------------------------------------------------------------------
 # 1. Build what the suite drives.
 #
 # The conformance runner refuses to start against an `mvmctl` older than its own
 # sources, so this has to happen before the test binary runs, not alongside it.
 # ---------------------------------------------------------------------------
-# `user` carries manifest-verify. Without it the verified-fetch path refuses the
-# published builder VM image with "manifest-verify feature is disabled in this
-# build" — a default `cargo build` cannot check a signature, so it declines to
-# trust one. That refusal is correct; building without the feature is the bug.
-echo "==> building mvmctl (--features user)"
-./scripts/cargo-fast.sh build --bin mvmctl --features user
+# `--clean-only` reaps and exits: the escape hatch for a run killed hard enough
+# to skip its own trap. Deliberately before the build — cleaning up after an
+# interrupted run must not depend on the tree compiling.
+if [[ "${1:-}" == "--clean-only" ]]; then
+  if [[ ! -x "$MVMCTL" ]]; then
+    echo "no mvmctl at $MVMCTL — nothing to reap with" >&2
+    trap - EXIT
+    exit 1
+  fi
+  reap "manual"
+  reap_orphan_supervisors
+  trap - EXIT
+  echo "==> clean"
+  exit 0
+fi
+
+# `user` carries manifest-verify, which the verified-fetch path needs to accept
+# the published builder VM image. It is off by default anyway: that feature
+# pulls the sigstore/aws-lc stack, and on both hosts tested aws-lc-rs resolves
+# while its native symbols do not, failing the link outright. A build that does
+# not link runs nothing, which is strictly worse than losing the flake-build
+# scenarios to an unverifiable fetch. Set MVM_E2E_FEATURES=user where that
+# native toolchain is known good.
+E2E_FEATURES="${MVM_E2E_FEATURES-}"
+if [[ -n "$E2E_FEATURES" ]]; then
+  echo "==> building mvmctl (--features $E2E_FEATURES)"
+  ./scripts/cargo-fast.sh build --bin mvmctl --features "$E2E_FEATURES"
+else
+  echo "==> building mvmctl"
+  ./scripts/cargo-fast.sh build --bin mvmctl
+fi
+
+# Now that `mvmctl` exists, clear anything a previous run left behind. A guest
+# still holding its name makes the next run fail on a collision that reads as a
+# broken verb.
+reap "pre-run"
+reap_orphan_supervisors
+start_watcher
 
 # The TypeScript SDK scenarios import the SDK's built `dist/`, which is absent
 # in a fresh worktree. Without it they fail for a reason that has nothing to do

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -33,8 +33,12 @@ echo "    home: $E2E_HOME"
 # The conformance runner refuses to start against an `mvmctl` older than its own
 # sources, so this has to happen before the test binary runs, not alongside it.
 # ---------------------------------------------------------------------------
-echo "==> building mvmctl"
-./scripts/cargo-fast.sh build --bin mvmctl
+# `user` carries manifest-verify. Without it the verified-fetch path refuses the
+# published builder VM image with "manifest-verify feature is disabled in this
+# build" — a default `cargo build` cannot check a signature, so it declines to
+# trust one. That refusal is correct; building without the feature is the bug.
+echo "==> building mvmctl (--features user)"
+./scripts/cargo-fast.sh build --bin mvmctl --features user
 
 # The TypeScript SDK scenarios import the SDK's built `dist/`, which is absent
 # in a fresh worktree. Without it they fail for a reason that has nothing to do

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -212,6 +212,55 @@ if ! MVM_HOME="$E2E_HOME" "$MVMCTL" bootstrap; then
   BOOTSTRAP_FAILED=1
 fi
 
+# ---------------------------------------------------------------------------
+# Warm the launch artifacts, even when bootstrap did not get that far.
+#
+# `bootstrap` prepares the builder VM image *first* and deliberately skips the
+# runtime/initramfs warm when that step fails — there is a test pinning that
+# order. So a builder image that cannot be built leaves the universal
+# initramfs unbuilt, and since it is required on every host, each scenario then
+# cross-compiles the guest binaries itself: a multi-minute cargo build, inside
+# a scenario, repeated for every live scenario in the suite.
+#
+# One warm-up launch populates that cache once. Both steps are best-effort and
+# bounded: this is a warm-up, and a failure here should surface as the
+# scenarios failing on their own terms rather than as a dead run.
+# ---------------------------------------------------------------------------
+warm_launch_artifacts() {
+  echo "==> warming launch artifacts (runtime overlay + universal initramfs)"
+
+  MVM_HOME="$E2E_HOME" "$MVMCTL" build runtime-overlay build >/dev/null 2>&1 \
+    && echo "    runtime overlay ready" \
+    || echo "    runtime overlay: not warmed (scenarios needing it will say so)"
+
+  # Layout is cache/initramfs/<version>/<arch>/initramfs.cpio.gz. Globbed on
+  # version rather than hardcoded, so a version bump does not silently turn
+  # this check into "never cached" and pay the build every run.
+  if find "$E2E_HOME/cache/initramfs" -name initramfs.cpio.gz -size +0c 2>/dev/null \
+     | read -r _; then
+    echo "    universal initramfs already cached"
+    return 0
+  fi
+
+  echo "    building the universal initramfs once (cross-compiles guest binaries)"
+  MVM_HOME="$E2E_HOME" "$MVMCTL" machine run --name bdd-warmup --image alpine \
+    -- /bin/true >/dev/null 2>&1 &
+  local warm_pid=$! waited=0
+  while kill -0 "$warm_pid" 2>/dev/null; do
+    if (( waited >= ${MVM_E2E_WARMUP_SECS:-900} )); then
+      echo "    warm-up exceeded its budget; killing it and continuing"
+      kill -TERM "$warm_pid" 2>/dev/null || true
+      break
+    fi
+    sleep 10
+    waited=$((waited + 10))
+    (( waited % 60 == 0 )) && echo "    ... still warming (${waited}s)"
+  done
+  wait "$warm_pid" 2>/dev/null || true
+  echo "    warm-up done (${waited}s)"
+}
+warm_launch_artifacts
+
 echo "==> host posture"
 # `doctor` exits nonzero precisely when it has something to report, so its
 # status is information rather than a gate.

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Run every documented example against a real host, booting real microVMs.
+#
+# The hermetic lane proves a documented command parses. That cannot see a verb
+# which parses and then refuses at runtime, which is what `machine forward` had
+# become while `examples/obscura/README.md` still told a reader to run it. This
+# runner is the lane that executes them.
+#
+# Usage:
+#   scripts/e2e-documented-surface.sh            # against ~/.mvm (warm, the real one)
+#   MVM_E2E_HOME=/tmp/e2e scripts/e2e-documented-surface.sh
+#
+# Artifacts are acquired once into the chosen home and the scenarios then share
+# it. A cold home pays a multi-minute bootstrap on the first run, and is fast
+# afterwards.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+REPO="$PWD"
+
+E2E_HOME="${MVM_E2E_HOME:-$HOME/.mvm}"
+TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+MVMCTL="$TARGET_DIR/debug/mvmctl"
+
+echo "==> e2e documented surface"
+echo "    repo: $REPO"
+echo "    home: $E2E_HOME"
+
+# ---------------------------------------------------------------------------
+# 1. Build what the suite drives.
+#
+# The conformance runner refuses to start against an `mvmctl` older than its own
+# sources, so this has to happen before the test binary runs, not alongside it.
+# ---------------------------------------------------------------------------
+echo "==> building mvmctl"
+./scripts/cargo-fast.sh build --bin mvmctl
+
+# The TypeScript SDK scenarios import the SDK's built `dist/`, which is absent
+# in a fresh worktree. Without it they fail for a reason that has nothing to do
+# with the documentation.
+if [[ ! -f crates/mvm-sdk/sdks/typescript/dist/index.js ]]; then
+  echo "==> building the TypeScript SDK (dist/ is absent)"
+  just sdk-install-typescript
+  just sdk-build-typescript
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Warm the shared artifact home.
+#
+# Every launch needs the workload kernel, the runtime overlay and the universal
+# initramfs. Acquiring them inside a scenario would put minutes on each one, and
+# a scenario that times out reads as a launch failure rather than a cold cache.
+# ---------------------------------------------------------------------------
+echo "==> warming artifacts in $E2E_HOME"
+MVM_HOME="$E2E_HOME" "$MVMCTL" bootstrap
+
+echo "==> host posture"
+# `doctor` exits nonzero precisely when it has something to report, so its
+# status is information rather than a gate.
+MVM_HOME="$E2E_HOME" "$MVMCTL" doctor || true
+
+# ---------------------------------------------------------------------------
+# 3. The documented surface, live.
+#
+# `MVM_BDD_LIVE=1` opts into the scenarios that boot a real microVM. No
+# `MVM_BDD_CI_LIVE_ONLY` here: that selector narrows to the merge-queue subset,
+# and narrowing is what let the macOS default backend go uncovered.
+# ---------------------------------------------------------------------------
+echo "==> documented examples + machine journey (cucumber, @live)"
+CARGO_BIN_EXE_mvmctl="$MVMCTL" \
+MVM_BDD_LIVE=1 \
+MVM_E2E_HOME="$E2E_HOME" \
+  ./scripts/cargo-fast.sh test -p mvm-conformance --test conformance --features bdd
+
+echo
+echo "==> done. Read the 'did NOT run' tally above, not just the pass count:"
+echo "    a skipped @live scenario is a documented command nothing booted."

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -52,8 +52,28 @@ fi
 # initramfs. Acquiring them inside a scenario would put minutes on each one, and
 # a scenario that times out reads as a launch failure rather than a cold cache.
 # ---------------------------------------------------------------------------
+# This suite verifies the documented CLI surface, not the builder VM image.
+# A source checkout otherwise rebuilds that image from the in-repo flake on
+# every cold run, which couples the whole suite to an unrelated Nix build —
+# and when that build cannot reach crates.io from inside Stage 0, nothing here
+# runs at all. Fetch the published image instead. A contributor working *on*
+# the image sets MVM_BOOT_IMAGE themselves and this defers to them.
+export MVM_BOOT_IMAGE="${MVM_BOOT_IMAGE:-fetch}"
+echo "    boot image: $MVM_BOOT_IMAGE"
+
+# Bootstrap failure is reported, not fatal. It warms the builder VM image, which
+# the flake-build scenarios need and the OCI-image ones do not — so aborting here
+# would throw away every result that does not depend on it. The scenarios that do
+# need it then fail on their own, naming themselves.
 echo "==> warming artifacts in $E2E_HOME"
-MVM_HOME="$E2E_HOME" "$MVMCTL" bootstrap
+if ! MVM_HOME="$E2E_HOME" "$MVMCTL" bootstrap; then
+  echo
+  echo "!!! bootstrap FAILED — the builder VM image is unavailable."
+  echo "!!! Flake-build scenarios will fail; OCI-image scenarios are unaffected."
+  echo "!!! Continuing so the run still reports what it can prove."
+  echo
+  BOOTSTRAP_FAILED=1
+fi
 
 echo "==> host posture"
 # `doctor` exits nonzero precisely when it has something to report, so its
@@ -76,3 +96,8 @@ MVM_E2E_HOME="$E2E_HOME" \
 echo
 echo "==> done. Read the 'did NOT run' tally above, not just the pass count:"
 echo "    a skipped @live scenario is a documented command nothing booted."
+if [[ -n "${BOOTSTRAP_FAILED:-}" ]]; then
+  echo
+  echo "!!! REMINDER: bootstrap failed this run. Any flake-build failure above"
+  echo "!!! is that, not a regression in the command under test."
+fi

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -24,6 +24,32 @@ E2E_HOME="${MVM_E2E_HOME:-$HOME/.mvm}"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"
 
+# Sweep this lane's guests too, on the way in and out. It boots the same kind of
+# machine as `e2e-documented-surface.sh` and had no cleanup of its own, so a run
+# killed at the wrong moment left a guest holding its name and the next run
+# failed on a collision that reads as a broken verb. Scoped to the `bdd-` prefix
+# every suite machine carries, so a machine you made by hand is never touched.
+sweep() {
+  [[ -x "$MVMCTL" ]] || return 0
+  # Pass the home through explicitly: the cleaner defaults to ~/.mvm, which is
+  # not necessarily the home this run is using.
+  MVM_E2E_HOME="$E2E_HOME" ./scripts/e2e-documented-surface.sh --clean-only \
+    >/dev/null 2>&1 || true
+}
+trap sweep EXIT
+trap 'echo; echo "!!! interrupted — cleaning up"; exit 130' INT TERM
+
+# Follow each guest's console as it boots. Cucumber only prints a step's output
+# when the step fails, so without this a multi-minute boot shows nothing.
+WATCHER_PID=""
+if [[ "${MVM_E2E_FOLLOW:-$([[ -t 1 ]] && echo 1 || echo 0)}" == "1" ]]; then
+  ./scripts/e2e-watch-vms.sh "$E2E_HOME" &
+  WATCHER_PID=$!
+  trap 'kill -TERM "$WATCHER_PID" 2>/dev/null || true; sweep' EXIT
+fi
+
+sweep   # clear anything a previous run left behind
+
 echo "==> e2e launch gate"
 echo "    repo:  $REPO"
 echo "    home:  $E2E_HOME"

--- a/scripts/e2e-watch-vms.sh
+++ b/scripts/e2e-watch-vms.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Follow microVM lifecycle in an MVM_HOME: announce each guest as its state
+# directory appears, stream its console, and say when it goes away.
+#
+# Cucumber captures a step's output and prints it only when the step fails, so
+# a multi-minute boot shows nothing at all while it happens. This watches the
+# filesystem instead of the test runner, which means it works against any run —
+# `just e2e-docs`, a bare `mvmctl machine start`, or someone else's session.
+#
+# Usage:
+#   scripts/e2e-watch-vms.sh                 # watch ~/.mvm
+#   scripts/e2e-watch-vms.sh /tmp/e2e-home   # watch a specific home
+#   MVM_E2E_HOME=/tmp/e2e scripts/e2e-watch-vms.sh
+#
+# Runs until interrupted. Safe to start before the run does.
+
+set -uo pipefail
+# No job-control notifications: bash otherwise prints a "Done ..." block naming
+# each console follower's source when the watcher is signalled, dumping shell
+# code into the middle of the run's output.
+set +m
+
+HOME_DIR="${1:-${MVM_E2E_HOME:-$HOME/.mvm}}"
+VMS="$HOME_DIR/vms"
+
+# bash 3.2 on macOS has no associative arrays, so "have I seen this guest" is a
+# marker file rather than a map.
+STATE="$(mktemp -d "${TMPDIR:-/tmp}/mvm-vm-watch.XXXXXX")"
+
+cleanup() {
+  # Silence this phase entirely. Reaping the followers makes bash report each
+  # job's status, which prints the pipeline's source code; nothing said during
+  # teardown is worth that noise.
+  exec >/dev/null 2>&1
+  # `pkill -P $$` is not enough: each follower is a `tail | while` pipeline, so
+  # the `tail` is a grandchild and survives its parent being signalled. Match on
+  # the command line instead, scoped to this home's path so a watcher on another
+  # MVM_HOME is left alone.
+  # Match on the watched path, not on the tail invocation: `pkill -f` takes a
+  # regex, and `-n +1` contains a `+`, which silently matches nothing.
+  pkill -f "$VMS/" >/dev/null 2>&1 || true
+  pkill -P $$ >/dev/null 2>&1 || true
+  rm -rf "$STATE"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+echo "==> watching $VMS"
+echo "    (ctrl-c to stop)"
+mkdir -p "$VMS"
+
+while true; do
+  for dir in "$VMS"/*/; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    [ -e "$STATE/$name" ] && continue
+    : > "$STATE/$name"
+    printf '  [vm] %s — microVM starting\n' "$name"
+    # One process per guest rather than a backgrounded pipeline: bash reports a
+    # finished job by printing its source, and a pipeline's source is the whole
+    # loop body. Wrapping it in `sh -c` keeps that notice to a single line.
+    #
+    # From the first line, not the end — the point is to watch a guest come up,
+    # and the console is usually already a few lines old by the time the state
+    # directory appears. `-F` keeps following across the truncate-and-recreate
+    # a restart does. The prefix is applied by a read loop rather than `sed -u`,
+    # which is GNU-only: BSD `sed` buffers and defeats the point of following.
+    sh -c 'tail -n +1 -F "$1" 2>/dev/null | while IFS= read -r line; do
+             printf "  [%s] %s\n" "$2" "$line"
+           done' _ "$dir/console.log" "$name" &
+  done
+
+  for marker in "$STATE"/*; do
+    [ -e "$marker" ] || continue
+    name="$(basename "$marker")"
+    if [ ! -d "$VMS/$name" ]; then
+      printf '  [vm] %s — microVM gone\n' "$name"
+      rm -f "$marker"
+    fi
+  done
+
+  sleep 2
+done

--- a/specs/plans/2026-08-26-documented-surface-e2e.md
+++ b/specs/plans/2026-08-26-documented-surface-e2e.md
@@ -89,12 +89,36 @@ Nightly lanes `e2e-docs-linux` (Firecracker, `/dev/kvm`) and `e2e-docs-macos`
 - [ ] `examples/obscura/README.md` documented the retired `machine forward`.
       Fixed here — but its replacement, `machine run --port`, is
       `conflicts_with` `--detach`, and `machine create` takes no `--port`. A
-      detached guest with declared ingress has no expressible form; the example
-      now shows the foreground shape and says so.
+      detached guest with declared ingress has no expressible form (#2901); the
+      example now shows the foreground shape and says so.
 - [ ] `mvm.local_path` is exported by the Python SDK and taught in the README,
       but absent from `mvm_sdk::decorator::value::HELPER_ALLOWLIST`, so
-      `mvmctl build compile` rejects the README's own example. The exec fixture
-      omits the kwarg to prove the command; the mismatch itself is unresolved.
+      `mvmctl build compile` rejects the README's own example (#2902). The exec
+      fixture omits the kwarg to prove the command; the mismatch is unresolved.
+
+## What running it on real hosts found
+
+The suite's first real-host runs did not reach the scenarios — they were
+blocked in `bootstrap`, twice, for two unrelated reasons. Both are recorded
+because both block a release independently of this work.
+
+- **crates.io now 403s Nix's User-Agent** (#2904). It rejects any `User-Agent`
+  beginning with `curl/`, and Nix sends `curl/<ver> Nix/<ver>`. Every Rust
+  derivation in the builder VM image fails to fetch, so the source-checkout
+  Stage 0 build cannot complete on any host. `static.crates.io` is unaffected.
+- **A default build cannot verify a signature** (#2906). On Linux the builder
+  image resolves to a verified fetch, which refuses with "manifest-verify
+  feature is disabled in this build". The refusal is right; building without
+  the feature was the bug. `user` carries it. The remedy printed elsewhere in
+  the CLI — `--features release-artifact-bootstrap,manifest-verify` — names a
+  root feature that no longer exists and does not compile.
+
+Both changed the runner: it builds with `--features user`, defaults
+`MVM_BOOT_IMAGE=fetch`, and treats a bootstrap failure as loud rather than
+fatal. Aborting there discarded every result that did not depend on the builder
+image; the flake-build scenarios now fail naming themselves while the
+OCI-image ones still run, and the run repeats the warning at the end so the
+difference is not misread as a regression.
 
 ## Follow-on
 

--- a/specs/plans/2026-08-26-documented-surface-e2e.md
+++ b/specs/plans/2026-08-26-documented-surface-e2e.md
@@ -1,0 +1,108 @@
+# Documented surface, executed end to end
+
+Backing: shipped-source
+Validation: check-claim-catalog
+
+**Status:** IN PROGRESS
+
+Every command the README and the website docs print is a promise to a reader
+who will paste it into a shell. `features/suites/s29_doc_examples/` already
+extracted those commands and assigned each a verification tier. What it could
+not do was run most of them: 86 of 111 documented command paths sat at tier
+`parse`, verified to the depth of "clap accepts these arguments".
+
+Parsing cannot see the defect that matters. `mvmctl machine forward` parses
+cleanly against the real clap tree and then refuses at runtime — it was
+retired — while `examples/obscura/README.md` still told a reader to run it.
+The same shape hid a second one: the README's flagship decorator example uses
+`mvm.local_path(...)`, which the Python SDK defines and the decorator
+compiler's `HELPER_ALLOWLIST` does not, so `mvmctl build compile` fails on the
+example printed directly above that command.
+
+## What changed
+
+### The tier ladder now carries its own honesty gate
+
+`parse` is the rung a path reaches by nobody deciding anything — it is where a
+newly documented verb lands by default. A path may still sit there, but the
+manifest now requires it to say why, and
+`every parse-tier command path explains why it is only parsed` fails the suite
+when one does not. "We could not run this" stays distinguishable from "nobody
+tried".
+
+Two further manifest keys let a runnable-but-unstaged command be promoted
+rather than excused:
+
+- `fixture` stages the files a documented example names before running it.
+- `env` supplies per-path environment. `env uninstall` is the motivating case:
+  it rewrites its system paths under `MVM_UNINSTALL_PATH_PREFIX`, and without
+  that hook it "passes" only by being cancelled at its confirmation prompt —
+  proving nothing while leaving a `sudo rm -rf` path untested.
+
+### Tier movement
+
+| tier | before | after |
+| --- | --- | --- |
+| `parse` | 86 | 61 |
+| `exec` | 16 | 35 |
+| `live` | 9 | 15 |
+
+Exec-tier examples actually executed went from 16 to 35.
+
+### One guest, many verbs
+
+`features/suites/s32_documented_surface/machine_journey.feature` boots a single
+guest and drives the documented `machine` verbs against it — `inspect`, `logs`,
+`boot-report`, `exec`, `fs ls`, `cp`, `pause`, `resume`, `checkpoint
+create|ls`, `ls`, then teardown. Verb coverage costs one boot rather than
+twenty.
+
+It is tagged `@live` and deliberately **not** `@firecracker`. The pre-existing
+live lifecycle witness carries that tag, so it is skipped on macOS — where HVF
+is the default backend. That is how the backend most users run ended up with no
+lane that booted anything.
+
+Two traps this feature encodes, both of which cost real time to find:
+
+- The machine-name positional carries a `value_parser` that rejects braces, so
+  a `{machine}` placeholder fails to parse and drops out of the live-witness
+  gate silently: the scenario runs while the tier it backs stays unproven. The
+  guest is named literally.
+- Scenarios are split by verb family rather than written as one long journey.
+  Cucumber abandons a scenario at its first failing step, so one scenario per
+  family means a broken verb reports itself instead of hiding every verb after
+  it.
+
+### Running it
+
+`just e2e-docs` → `scripts/e2e-documented-surface.sh`: builds `mvmctl` and the
+TypeScript SDK `dist/`, warms one shared artifact home, reports host posture,
+then runs the suite with `MVM_BDD_LIVE=1`. It does **not** set
+`MVM_BDD_CI_LIVE_ONLY` — that selector narrows to the merge-queue subset, and
+narrowing is what let the macOS backend go uncovered.
+
+Nightly lanes `e2e-docs-linux` (Firecracker, `/dev/kvm`) and `e2e-docs-macos`
+(HVF) in `ci-full.yml`.
+
+## Defects this surfaced
+
+- [ ] `examples/obscura/README.md` documented the retired `machine forward`.
+      Fixed here — but its replacement, `machine run --port`, is
+      `conflicts_with` `--detach`, and `machine create` takes no `--port`. A
+      detached guest with declared ingress has no expressible form; the example
+      now shows the foreground shape and says so.
+- [ ] `mvm.local_path` is exported by the Python SDK and taught in the README,
+      but absent from `mvm_sdk::decorator::value::HELPER_ALLOWLIST`, so
+      `mvmctl build compile` rejects the README's own example. The exec fixture
+      omits the kwarg to prove the command; the mismatch itself is unresolved.
+
+## Follow-on
+
+- [ ] Stage the bundle fixture (`scripts/make-bundle-fixture.sh`) so `bundle
+      fetch|install|gc` leave `parse`.
+- [ ] Stage a sealed deps volume (`mvm-app-deps-fixture-tool`) for `deps
+      inspect|audit`.
+- [ ] Extend the journey to `machine fork|restore|diff|wait|reconfigure|proc
+      start` and the local `machine volume` verbs.
+- [ ] `manifest info|rm|verify` need a manifest with a *built* slot; reachable
+      once the journey performs a real build.

--- a/specs/sprint/delivery/documented-surface-executed-not-parsed.md
+++ b/specs/sprint/delivery/documented-surface-executed-not-parsed.md
@@ -1,0 +1,92 @@
+# Execute the documented surface instead of parsing it
+
+The doc-examples suite already extracted every `mvmctl` command the README and
+the website docs print, and assigned each a verification tier. What it could not
+do was run them: 86 of 111 command paths sat at tier `parse`, proven to the
+depth of "clap accepts these arguments".
+
+That depth cannot see the defect that matters. `machine forward` parses cleanly
+against the real clap tree and then refuses at runtime — it was retired — while
+`examples/obscura/README.md` still told a reader to run it. The verb was in the
+tree, so every hermetic gate stayed green.
+
+## What executing found
+
+Four defects, none of which a parse tier can reach:
+
+- `machine forward` retired but documented (#2901). Fixing it exposed the larger
+  problem: the replacement the CLI itself names, `machine run --port`, is
+  `conflicts_with` `--detach`, and `machine create` takes no `--port`. A
+  detached guest with declared ingress has no expressible form.
+- `mvm.local_path` is exported by the Python SDK and taught in the README's
+  flagship decorator example, but absent from the decorator compiler's
+  `HELPER_ALLOWLIST` (#2902) — so `mvmctl build compile`, printed directly
+  beneath that example, fails on it.
+- crates.io began rejecting User-Agents starting with `curl/`, which is what Nix
+  sends (#2904). Every Rust derivation in the builder VM image fails to fetch,
+  so a source-checkout Stage 0 build cannot complete on any host.
+- A default-features `mvmctl` cannot verify a signature, so it refuses the
+  published builder image — and the remedy printed elsewhere in the CLI,
+  `--features release-artifact-bootstrap,manifest-verify`, names a root feature
+  that no longer exists and does not compile (#2906).
+
+The last two blocked the suite's own first real-host runs, which is how they
+were found.
+
+## Tier movement
+
+| tier | before | after |
+| --- | --- | --- |
+| `parse` | 86 | 61 |
+| `exec` | 16 | 35 |
+| `live` | 9 | 15 |
+
+Exec-tier examples actually executed: 16 → 35.
+
+`parse` now has to justify itself. It is the rung a path reaches by nobody
+deciding anything, so an entry there without a written reason fails the suite.
+Two new manifest keys let a runnable-but-unstaged command be promoted instead of
+excused: `fixture` stages the files an example names, and `env` supplies
+per-path environment.
+
+`env` earned its place immediately. `env uninstall` can `sudo rm -rf
+/var/lib/mvm` and delete `/usr/local/bin/mvmctl`; without its
+`MVM_UNINSTALL_PATH_PREFIX` sandbox hook it "passes" only by being cancelled at
+its confirmation prompt — proving nothing while leaving that path untested.
+
+Promoting the tier also revealed that exec-tier examples had been writing into
+the working copy: documented scaffolds like `init ./agent-tool` ran at the repo
+root. They now run from a scratch directory.
+
+## One guest, many verbs
+
+`features/suites/s32_documented_surface/machine_journey.feature` boots a single
+guest and drives the documented `machine` verbs against it, so verb coverage
+costs one boot rather than twenty.
+
+It is `@live` and deliberately **not** `@firecracker`. Every pre-existing
+guest-booting scenario carries that tag, so all of them are skipped on macOS —
+where HVF is the default backend. The backend most users run booted nothing.
+
+Two traps encoded in the feature, both of which cost real time:
+
+- The machine-name positional has a `value_parser` that rejects braces, so a
+  `{machine}` placeholder fails to parse and drops out of the live-witness gate
+  silently: the scenario runs while the tier it backs stays unproven. The guest
+  is named literally.
+- Scenarios are split by verb family rather than written as one long journey.
+  Cucumber abandons a scenario at its first failing step, so one scenario per
+  family means a broken verb reports itself instead of hiding every verb after
+  it.
+
+## Running it
+
+`just e2e-docs`. Nightly lanes `e2e-docs-linux` (Firecracker) and
+`e2e-docs-macos` (HVF).
+
+The runner is bounded by its own watchdog rather than `timeout(1)`, which stock
+macOS does not ship. A live scenario can hang instead of failing, and a release
+gate that hangs is a gate nobody runs. A bootstrap failure is loud but not
+fatal: it warms the builder image, which the flake-build scenarios need and the
+OCI-image ones do not, so aborting discarded every result that did not depend on
+it.


### PR DESCRIPTION
## Why

Every command the README and the website docs print is a promise to a reader who
will paste it into a shell. `s29_doc_examples` already extracted those commands
and tiered them — but **86 of 111 command paths sat at tier `parse`**, proven
only to the depth of "clap accepts these arguments".

That depth cannot see the defect that matters. `mvmctl machine forward` parses
cleanly against the real clap tree and then refuses at runtime — it was retired —
while `examples/obscura/README.md` still told a reader to run it. Every hermetic
gate stayed green the whole time.

## What changed

| tier | before | after |
| --- | --- | --- |
| `parse` | 86 | 61 |
| `exec` | 16 | 35 |
| `live` | 9 | 15 |

Exec-tier examples actually executed: **16 → 35**.

- **`parse` now has to justify itself.** It is the rung a path reaches by nobody
  deciding anything, so an entry there without a written reason fails the suite.
- **Two new manifest keys** let a runnable-but-unstaged command be promoted
  rather than excused: `fixture` stages the files an example names, `env`
  supplies per-path environment. `env` earned its place immediately —
  `env uninstall` can `sudo rm -rf /var/lib/mvm` and delete
  `/usr/local/bin/mvmctl`, and without its `MVM_UNINSTALL_PATH_PREFIX` sandbox
  hook it "passes" only by being cancelled at its prompt.
- **Exec-tier examples now run from a scratch directory.** Documented scaffolds
  like `init ./agent-tool` were writing generated trees into the working copy.
- **`s32_documented_surface`** boots one guest and drives the documented
  `machine` verbs against it, so verb coverage costs one boot rather than twenty.
  Tagged `@live` and deliberately **not** `@firecracker`: every pre-existing
  guest-booting scenario carries that tag and is skipped on macOS, where HVF is
  the default backend — so the backend most users run booted nothing.

## Running it

`just e2e-docs`, plus nightly `e2e-docs-linux` (Firecracker) and
`e2e-docs-macos` (HVF) lanes.

It follows each guest's console live (`scripts/e2e-watch-vms.sh`, also runnable
standalone from a second terminal) — cucumber only prints a step's output when
the step fails, so a multi-minute boot showed nothing while it happened.

It sweeps its own machines on entry and exit, including on `^C` and on timeout,
and `just e2e-docs-clean` does it by hand without needing the tree to compile.
The sweep is scoped to the `bdd-` prefix every suite machine carries, because
the home defaults to the real `~/.mvm` — verified against a decoy that a
hand-made machine survives. The sibling `e2e-launch` lane gets the same
treatment.

Bounded by its own watchdog rather than `timeout(1)`, which stock macOS does not
ship: a live scenario can hang instead of failing, and a gate that hangs is one
nobody runs.

## Defects this found

Four, all filed. None reachable by a parse tier.

- #2901 — `machine forward` retired but documented. Fixing it exposed the larger
  problem: the replacement the CLI itself names, `machine run --port`, is
  `conflicts_with` `--detach`, and `machine create` takes no `--port`, so a
  detached guest with declared ingress has no expressible form.
- #2902 — `mvm.local_path` is exported by the Python SDK and taught in the
  README's flagship decorator example, but absent from the decorator compiler's
  `HELPER_ALLOWLIST`, so `mvmctl build compile` fails on the example printed
  directly above it.
- #2904 — crates.io now 403s any `User-Agent` beginning with `curl/`, which is
  what Nix sends. Every Rust derivation in the builder VM image fails to fetch,
  so a source-checkout `mvmctl bootstrap` cannot complete on any host.
- #2906 — a default build cannot verify a signature and so refuses the published
  builder image; the remedy printed elsewhere in the CLI names a root feature
  that no longer exists and does not compile.

The last two blocked this suite's own first real-host runs, which is how they
were found.

## Validation

Linux / Firecracker, live: **271 scenarios, 244 passed, 26 failed, 7 did not
run.** The journey verbs pass there. Most remaining failures are downstream of
the failed bootstrap (#2904/#2906) plus the SDK toolchain.

macOS / HVF: the journey has been exercised end to end against a real guest, and
a full clean run is still outstanding — the two bootstrap defects above kept
resetting it. **Not yet claiming the macOS leg is green.**