### PR TITLE
test: stop two local-environment faults from faking test failures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -695,6 +695,19 @@ rust = "1.91.1"
 zig = "0.13.0"
 cargo-zigbuild = "0.23.0"
 
+# Developer tooling that is NOT vendored or pinned by rust-toolchain.toml, so a
+# contributor's machine can silently drift below what the workspace needs.
+#
+# nextest: the pinned nightly cargo emits test binaries under
+# `target/debug/build/<pkg>/<hash>/out/` rather than `target/debug/deps/`.
+# A nextest older than this does not export `CARGO_BIN_EXE_<name>` for that
+# layout, and `assert_cmd`'s fallback — pop one dir, expect `deps` — then looks
+# for `mvmctl` in the wrong place. Every one of the 111 root-package CLI
+# integration tests fails with "CARGO_BIN_EXE_mvmctl is unset", which reads as
+# broken code rather than a stale tool. `scripts/require-nextest.sh` turns that
+# into one actionable line. This is a known-good floor, not a bisected minimum.
+nextest-min = "0.9.143"
+
 # Per-arch musl target. build.rs picks the entry for CARGO_CFG_TARGET_ARCH
 # (the arch mvmctl is built for == the arch of the guest it boots, since the
 # local builder/Stage 0 VM is always same-arch as the host). Plan 164.

--- a/Justfile
+++ b/Justfile
@@ -202,6 +202,7 @@ sdk-test-typescript: sdk-install-typescript
 test:
     #!/usr/bin/env bash
     set -euo pipefail
+    ./scripts/require-nextest.sh
     mkdir -p target/nextest
     ./scripts/cargo-fast.sh nextest run --workspace 2>&1 | tee target/nextest/last-run.log
 
@@ -250,10 +251,12 @@ test-cached:
 
 # Test a single crate
 test-crate CRATE:
+    ./scripts/require-nextest.sh
     ./scripts/cargo-fast.sh nextest run -p {{ CRATE }}
 
 # Run tests matching a filter expression
 test-filter FILTER:
+    ./scripts/require-nextest.sh
     ./scripts/cargo-fast.sh nextest run --workspace -E 'test({{ FILTER }})'
 
 # Run tests under the `ci` profile: no retries, slow-test warnings, and a
@@ -261,6 +264,7 @@ test-filter FILTER:
 
 # only (no captured test output — see .config/nextest.toml).
 test-ci:
+    ./scripts/require-nextest.sh
     ./scripts/cargo-fast.sh nextest run --workspace --profile ci
 
 # Run tests with cargo test (fallback if nextest not installed)

--- a/scripts/require-nextest.sh
+++ b/scripts/require-nextest.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Refuse to run the suite under a cargo-nextest too old for this workspace's
+# cargo. The floor lives in Cargo.toml's `[workspace.metadata.mvm.toolchain]`
+# as `nextest-min`, beside the other tool pins.
+#
+# Why this guard earns its keep: the failure it catches does not look like a
+# tooling problem. Under an old nextest every root-package CLI integration test
+# fails with "CARGO_BIN_EXE_mvmctl is unset", which reads as 111 broken tests
+# rather than one stale binary — and it is invisible in CI, where the runner
+# installs a current nextest every time.
+set -euo pipefail
+
+workspace_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+required="$(sed -n 's/^nextest-min = "\([^"]*\)"$/\1/p' "${workspace_root}/Cargo.toml")"
+if [[ -z "${required}" ]]; then
+  echo "require-nextest: no nextest-min in Cargo.toml [workspace.metadata.mvm.toolchain]" >&2
+  exit 1
+fi
+
+if ! command -v cargo-nextest >/dev/null 2>&1; then
+  echo "require-nextest: cargo-nextest not installed. Install with:" >&2
+  echo "    cargo install cargo-nextest --locked" >&2
+  exit 1
+fi
+
+# `cargo-nextest 0.9.143 (60fa45f63 2026-08-04)` -> `0.9.143`
+found="$(cargo nextest --version | head -1 | awk '{print $2}')"
+if [[ -z "${found}" ]]; then
+  echo "require-nextest: could not parse 'cargo nextest --version'" >&2
+  exit 1
+fi
+
+# `sort -V` puts the lower version first; if that is not the floor, we are below it.
+if [[ "$(printf '%s\n%s\n' "${required}" "${found}" | sort -V | head -1)" != "${required}" ]]; then
+  cat >&2 <<EOF
+require-nextest: cargo-nextest ${found} is older than the required ${required}.
+
+  This workspace's pinned nightly cargo emits test binaries under
+  target/debug/build/<pkg>/<hash>/out/ instead of target/debug/deps/. An older
+  nextest does not export CARGO_BIN_EXE_<name> for that layout, so every
+  root-package CLI integration test fails with:
+
+      CARGO_BIN_EXE_mvmctl is unset
+
+  Those failures are the tool, not your code. Fix with:
+
+      cargo install cargo-nextest --locked
+EOF
+  exit 1
+fi

--- a/specs/sprint/delivery/nextest-floor-and-nested-checkout-scan.md
+++ b/specs/sprint/delivery/nextest-floor-and-nested-checkout-scan.md
@@ -1,0 +1,46 @@
+# Local test gate: 111 phantom failures, and a gate that scanned other checkouts
+
+Two local-environment faults that made `just test` report failures that were
+not in the code. Both were invisible in CI, which is what let them persist.
+
+## 111 CLI tests "failing" under nextest
+
+Every root-package CLI integration test failed with
+`CARGO_BIN_EXE_mvmctl is unset` — 111 tests across 22 files — while
+`cargo test --test <same>` passed. So the entire root CLI suite was gating
+nothing under `just test`.
+
+The pinned nightly cargo emits test binaries under
+`target/debug/build/<pkg>/<hash>/out/` rather than `target/debug/deps/`.
+`assert_cmd::Command::cargo_bin` first reads `CARGO_BIN_EXE_<name>` from the
+environment, then falls back to popping one directory and expecting `deps`.
+Under the new layout the fallback looks for `mvmctl` inside `.../out/` and
+finds nothing; `cargo test` survives only because cargo exports the variable
+into the child environment, and cargo-nextest 0.9.122 (2026-01) does not.
+
+Not a code fault, and not fixable in the tests: it is a stale tool. Updating to
+0.9.143 takes the suite from 111 failures to 0.
+
+Guarded by `nextest-min` in `Cargo.toml`'s
+`[workspace.metadata.mvm.toolchain]` plus `scripts/require-nextest.sh`, wired
+into `test`, `test-ci`, `test-crate` and `test-filter`. The guard matters more
+than the version bump: 111 red tests read as broken code, and CI never sees it
+because the runner installs a current nextest every time — so local is red
+while CI is green, which is the worst way for this to present. `0.9.143` is a
+known-good floor, not a bisected minimum.
+
+## A gate that walked into another checkout
+
+`test_support_source_owners_match_the_targeted_ci_lane` failed with 34 paths
+under `.claude/worktrees/site-isolation-headers/` — a gitignored worktree
+belonging to another session, nested inside the repo.
+
+The 12 source-scanning gates walk the filesystem rather than `git ls-files`,
+and `fs_walk`'s skip list covered only `target`, `.git` and `node_modules`. So
+any nested checkout got scanned and reported as findings in this tree.
+
+`fs_walk::walk_files` now refuses to descend into a directory containing a
+`.git` entry — a file for a linked worktree, a directory for a clone. The root
+being scanned is never tested, so a normal run is unaffected. Verified both
+ways: with the `.git` marker present the gate is green, and with it removed the
+same tree turns the gate red, so the skip is what does the work.

--- a/xtask/src/fs_walk.rs
+++ b/xtask/src/fs_walk.rs
@@ -13,6 +13,25 @@ use std::path::{Path, PathBuf};
 /// Directories never worth descending into: build output and VCS metadata.
 const SKIP_DIRS: [&str; 3] = ["target", ".git", "node_modules"];
 
+/// Whether `dir` is the root of a *different* checkout, and so not ours to scan.
+///
+/// A linked worktree carries a `.git` **file** (pointing at the real gitdir), a
+/// clone carries a `.git` directory; either way, the presence of a `.git` entry
+/// in a subdirectory means everything beneath it belongs to another checkout.
+///
+/// Gates walk the filesystem rather than `git ls-files`, so without this they
+/// descend into gitignored worktrees a contributor happens to have nested
+/// inside the repo and report that tree's files as findings. Observed on
+/// 2026-08-26: a worktree at `.claude/worktrees/<name>/` — gitignored, another
+/// session's — made `test_support_source_owners_match_the_targeted_ci_lane`
+/// fail with 34 paths that were all copies of files the gate already allows.
+///
+/// The root being scanned is never tested here; only directories we are about
+/// to descend into, so a normal run over the repo root is unaffected.
+fn is_nested_checkout(dir: &Path) -> bool {
+    dir.join(".git").exists()
+}
+
 /// Visit every file under `dir`, recursively, in sorted order.
 ///
 /// A missing `dir` is not an error — a gate that scans an optional tree
@@ -32,7 +51,7 @@ pub fn walk_files(dir: &Path, f: &mut dyn FnMut(&Path)) -> Result<()> {
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or_default();
-            if SKIP_DIRS.contains(&name) {
+            if SKIP_DIRS.contains(&name) || is_nested_checkout(&path) {
                 continue;
             }
             walk_files(&path, f)?;
@@ -94,6 +113,49 @@ mod tests {
             names,
             vec!["a.rs".to_string(), "b.rs".to_string(), "c.rs".to_string()]
         );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A gitignored worktree nested inside the repo belongs to another checkout;
+    /// scanning it reports that tree's files as if they were ours.
+    #[test]
+    fn walk_does_not_descend_into_a_nested_worktree() {
+        let tmp = std::env::temp_dir().join(format!("xtask-fs-nested-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("crates")).unwrap();
+        std::fs::create_dir_all(tmp.join("nested/crates")).unwrap();
+        std::fs::write(tmp.join("crates/ours.rs"), "ours").unwrap();
+        // A linked worktree's `.git` is a file, not a directory.
+        std::fs::write(tmp.join("nested/.git"), "gitdir: /elsewhere").unwrap();
+        std::fs::write(tmp.join("nested/crates/theirs.rs"), "theirs").unwrap();
+
+        let mut names: Vec<String> = Vec::new();
+        walk_files(&tmp, &mut |p| {
+            names.push(p.file_name().unwrap().to_string_lossy().into_owned());
+        })
+        .unwrap();
+
+        assert_eq!(names, vec!["ours.rs".to_string()], "{names:?}");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The same rule must not stop the walk at the repo root, which also has
+    /// a `.git`.
+    #[test]
+    fn walk_still_scans_the_root_even_though_it_is_a_checkout() {
+        let tmp = std::env::temp_dir().join(format!("xtask-fs-root-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("crates")).unwrap();
+        std::fs::create_dir_all(tmp.join(".git")).unwrap();
+        std::fs::write(tmp.join("crates/ours.rs"), "ours").unwrap();
+
+        let mut names: Vec<String> = Vec::new();
+        walk_files(&tmp, &mut |p| {
+            names.push(p.file_name().unwrap().to_string_lossy().into_owned());
+        })
+        .unwrap();
+
+        assert_eq!(names, vec!["ours.rs".to_string()], "{names:?}");
         let _ = std::fs::remove_dir_all(&tmp);
     }
 


### PR DESCRIPTION
Two faults that made `just test` report failures that were not in the code.
Both were invisible in CI, which is what let them persist.

## 1. 111 CLI tests "failing" under nextest

Every root-package CLI integration test failed with `CARGO_BIN_EXE_mvmctl is
unset` — **111 tests across 22 files** — while `cargo test --test <the same
test>` passed. The entire root CLI suite was gating nothing under `just test`.

**Cause.** The pinned nightly cargo emits test binaries under
`target/debug/build/<pkg>/<hash>/out/` rather than `target/debug/deps/`.
`assert_cmd::Command::cargo_bin` reads `CARGO_BIN_EXE_<name>` from the
environment, and otherwise falls back to popping one directory and expecting
`deps` — so under the new layout it looks for `mvmctl` inside `.../out/` and
finds nothing. `cargo test` survives because cargo exports the variable into
the child environment. **cargo-nextest 0.9.122 (2026-01) does not.**

Updating to 0.9.143 takes the suite from **111 failures to 0**.

Nothing in the tests is wrong, so nothing in the tests changes. What is added
is a floor: `nextest-min` in `Cargo.toml` beside the other tool pins, plus
`scripts/require-nextest.sh` wired into `test`, `test-ci`, `test-crate` and
`test-filter`.

**The guard is the point, not the version bump.** 111 red tests read as broken
code, not a stale binary — and CI never sees it, because the runner installs a
current nextest every time. So local goes red while CI stays green, which is
the worst way for this to present. `0.9.143` is a known-good floor, not a
bisected minimum.

Guard verified on all three paths: below-floor fails with an actionable
message, at-floor passes, above-floor passes.

## 2. A gate that walked into another checkout

`test_support_source_owners_match_the_targeted_ci_lane` failed with 34 paths
under `.claude/worktrees/<name>/` — a **gitignored worktree belonging to
another session**, nested inside the repo.

The 12 source-scanning gates walk the filesystem rather than `git ls-files`,
and `fs_walk`'s skip list covered only `target`, `.git` and `node_modules`, so
any nested checkout was scanned and its files reported as findings here.

`fs_walk::walk_files` now refuses to descend into a directory containing a
`.git` entry — a *file* for a linked worktree, a *directory* for a clone. The
root being scanned is never tested, so a normal run over the repo root is
unaffected.

Verified both ways: with the `.git` marker present the gate is green; with it
removed the same tree turns the gate red. So the skip is what does the work,
rather than the gate passing by accident.

## Gates

`cargo +nightly fmt --all --check`, stable `clippy --workspace --all-targets -D
warnings` (via the hook), full `cargo nextest run --workspace` — **12,548 tests,
0 failures** — and `xtask` `check-all` (61 gates) + `check-declared-backing` +
`check-nextest-groups`.

`check-fast-cargo` fails on this branch for a reason that predates it and is
unrelated: `bdd.yml` still pins `nightly-2026-08-08` while `rust-toolchain.toml`
is on `nightly-2026-08-25`. That is fixed by #2891, which is already in the
merge queue.