### PR TITLE
fix(sdk): align documented surface contracts

### DIFF
--- a/crates/mvm-cli/src/commands/pack/download.rs
+++ b/crates/mvm-cli/src/commands/pack/download.rs
@@ -176,9 +176,36 @@ pub(in crate::commands) mod builder {
     ) -> Result<PromotedBuilderPack> {
         anyhow::bail!(
             "builder pack download requires an mvmctl built with --features \
-             release-artifact-bootstrap,manifest-verify (end-user release binaries carry \
+             user,release-artifact-bootstrap (end-user release binaries carry \
              this by default); this binary was built without it, so it cannot fetch a \
              published pack"
+        );
+    }
+}
+
+#[cfg(all(
+    test,
+    not(all(
+        feature = "release-artifact-bootstrap",
+        feature = "builder-vm",
+        feature = "manifest-verify"
+    ))
+))]
+mod tests {
+    #[test]
+    fn download_refusal_names_root_features_that_exist() {
+        let error = match super::builder::fetch_and_promote(None) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("a build without the release feature must refuse"),
+        };
+
+        assert!(
+            error.contains("--features user,release-artifact-bootstrap"),
+            "the remediation must compile against the root package: {error}"
+        );
+        assert!(
+            !error.contains("release-artifact-bootstrap,manifest-verify"),
+            "the remediation must not name the removed root feature: {error}"
         );
     }
 }

--- a/crates/mvm-sdk/src/decorator/python.rs
+++ b/crates/mvm-sdk/src/decorator/python.rs
@@ -538,6 +538,85 @@ def greet(name: str) -> str:
     }
 
     #[test]
+    fn documented_local_path_source_lowers_to_the_workload_ir() {
+        let src = r#"
+import mvm
+
+@mvm.app(
+    name="greeter",
+    source=mvm.local_path(
+        ".",
+        include=["src/**", "pyproject.toml"],
+        exclude=["target/**"],
+    ),
+    image=mvm.python_image(python="3.12"),
+    resources=mvm.resources(cpu=1, memory_mb=256, rootfs_size_mb=512),
+)
+def greet(name: str) -> str:
+    return f"hello {name}"
+"#;
+
+        let (workload, _) = parse_str(src).expect("the documented local_path helper must parse");
+        match &workload.apps[0].source {
+            crate::ir::Source::LocalPath {
+                path,
+                include,
+                exclude,
+            } => {
+                assert_eq!(path, ".");
+                assert_eq!(include, &["src/**", "pyproject.toml"]);
+                assert_eq!(exclude, &["target/**"]);
+            }
+            other => panic!("expected local_path source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn local_path_requires_a_path() {
+        let src = r#"
+import mvm
+
+@mvm.app(
+    source=mvm.local_path(),
+    image=mvm.python_image(python="3.12"),
+)
+def greet(): pass
+"#;
+
+        let error = parse_str(src).expect_err("a local source without a path must fail");
+        assert!(
+            matches!(
+                error,
+                ParseError::HelperMissingKwarg {
+                    ref helper,
+                    kwarg: "path",
+                    ..
+                } if helper == "mvm.local_path"
+            ),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn local_path_rejects_non_string_include_entries() {
+        let src = r#"
+import mvm
+
+@mvm.app(
+    source=mvm.local_path(".", include=["src/**", 7]),
+    image=mvm.python_image(python="3.12"),
+)
+def greet(): pass
+"#;
+
+        let error = parse_str(src).expect_err("include entries must be strings");
+        let rendered = error.to_string();
+        assert!(rendered.contains("mvm.local_path"), "{rendered}");
+        assert!(rendered.contains("include"), "{rendered}");
+        assert!(rendered.contains("expected string element"), "{rendered}");
+    }
+
+    #[test]
     fn name_kwarg_overrides_function_name() {
         let src = r#"
 import mvm

--- a/crates/mvm-sdk/src/decorator/value.rs
+++ b/crates/mvm-sdk/src/decorator/value.rs
@@ -22,9 +22,9 @@ use super::ParseError;
 /// kwarg-value position. Anything outside this set is rejected with
 /// [`ParseError::UnknownHelper`].
 ///
-/// Documented surface: `mvm.python_image`, `mvm.node_image`,
-/// `mvm.nix_packages`, `mvm.resources`, `mvm.network`, `mvm.secret`,
-/// `mvm.literal`, `mvm.hook`, `mvm.addons.database`,
+/// Documented surface: `mvm.local_path`, `mvm.python_image`,
+/// `mvm.node_image`, `mvm.nix_packages`, `mvm.resources`, `mvm.network`,
+/// `mvm.secret`, `mvm.literal`, `mvm.hook`, `mvm.addons.database`,
 /// `mvm.addons.service`. The list lives in code so adding a helper
 /// is a reviewed code change rather than a config update.
 ///
@@ -32,6 +32,7 @@ use super::ParseError;
 /// a TypeScript `app({...})` import becomes `mvm.app` before lookup)
 /// so the allowlist is a single source of truth.
 pub const HELPER_ALLOWLIST: &[&str] = &[
+    "mvm.local_path",
     "mvm.python_image",
     "mvm.node_image",
     "mvm.nix_packages",
@@ -175,7 +176,8 @@ pub fn lower_to_workload(
                     detail: format!("expected string list, got element {other:?}"),
                 }),
             })
-            .collect::<Result<Vec<_>, _>>()?,
+            .collect::<Result<Vec<_>, _>>()?
+            .into(),
         Some(other) => {
             return Err(ParseError::HelperBadKwarg {
                 path: path.to_path_buf(),
@@ -185,7 +187,29 @@ pub fn lower_to_workload(
                 detail: format!("expected string list, got {other:?}"),
             });
         }
-        None => vec!["**".to_string()],
+        None => None,
+    };
+
+    let source = match kwargs.remove("source") {
+        Some(value) => {
+            let mut source = helper_to_source(value, path, decorator_line)?;
+            if let Some(include) = include {
+                let Source::LocalPath {
+                    include: source_include,
+                    ..
+                } = &mut source
+                else {
+                    unreachable!("mvm.local_path always lowers to a local source")
+                };
+                *source_include = include;
+            }
+            source
+        }
+        None => Source::LocalPath {
+            path: ".".to_string(),
+            include: include.unwrap_or_else(|| vec!["**".to_string()]),
+            exclude: vec![],
+        },
     };
 
     // `addons` lowering deferred — Phase 4 ships with the IR field
@@ -219,11 +243,7 @@ pub fn lower_to_workload(
 
     let app = App {
         name: workload_id.clone(),
-        source: Source::LocalPath {
-            path: ".".to_string(),
-            include,
-            exclude: vec![],
-        },
+        source,
         image,
         entrypoints: vec![Entrypoint::Function {
             language: language.to_string(),
@@ -257,6 +277,92 @@ pub fn lower_to_workload(
         volumes: vec![],
         extensions: BTreeMap::new(),
     })
+}
+
+fn helper_to_source(v: Value, path: &Path, line: usize) -> Result<Source, ParseError> {
+    let Value::Helper {
+        name,
+        mut kwargs,
+        positional,
+    } = v
+    else {
+        return Err(ParseError::HelperBadKwarg {
+            path: path.to_path_buf(),
+            line,
+            helper: "mvm.app".to_string(),
+            kwarg: "source".to_string(),
+            detail: format!("expected mvm.local_path(...), got {v:?}"),
+        });
+    };
+    if name != "mvm.local_path" {
+        return Err(ParseError::HelperBadKwarg {
+            path: path.to_path_buf(),
+            line,
+            helper: "mvm.app".to_string(),
+            kwarg: "source".to_string(),
+            detail: format!("expected mvm.local_path(...), got {name}(...)"),
+        });
+    }
+
+    let source_path = match positional.as_slice() {
+        [Value::Str(value)] => value.clone(),
+        [] => {
+            pop_string_kwarg(&mut kwargs, "path").ok_or_else(|| ParseError::HelperMissingKwarg {
+                path: path.to_path_buf(),
+                line,
+                helper: "mvm.local_path".to_string(),
+                kwarg: "path",
+            })?
+        }
+        other => {
+            return Err(ParseError::HelperBadKwarg {
+                path: path.to_path_buf(),
+                line,
+                helper: "mvm.local_path".to_string(),
+                kwarg: "path".to_string(),
+                detail: format!("expected one string path, got {other:?}"),
+            });
+        }
+    };
+
+    let include =
+        strict_string_list_kwarg(&mut kwargs, "include", vec!["**".to_string()], path, line)?;
+    let exclude = strict_string_list_kwarg(&mut kwargs, "exclude", vec![], path, line)?;
+    if let Some((kwarg, value)) = kwargs.into_iter().next() {
+        return Err(ParseError::HelperBadKwarg {
+            path: path.to_path_buf(),
+            line,
+            helper: "mvm.local_path".to_string(),
+            kwarg,
+            detail: format!("unrecognized kwarg with value {value:?}"),
+        });
+    }
+
+    Ok(Source::LocalPath {
+        path: source_path,
+        include,
+        exclude,
+    })
+}
+
+fn strict_string_list_kwarg(
+    kwargs: &mut BTreeMap<String, Value>,
+    name: &str,
+    default: Vec<String>,
+    path: &Path,
+    line: usize,
+) -> Result<Vec<String>, ParseError> {
+    match kwargs.remove(name) {
+        Some(Value::List(items)) => list_of_strings(&items, path, line, "mvm.local_path", name),
+        Some(other) => Err(ParseError::HelperBadKwarg {
+            path: path.to_path_buf(),
+            line,
+            helper: "mvm.local_path".to_string(),
+            kwarg: name.to_string(),
+            detail: format!("expected string list, got {other:?}"),
+        }),
+        None => Ok(default),
+    }
 }
 
 fn helper_to_image(v: Value, path: &Path, line: usize) -> Result<Image, ParseError> {

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,15 @@
 # Refactor status
 
 Last updated: 2026-08-26
+
+## In progress
+
+- [ ] **SDK surface contract repairs — issues #2902 and #2906.**
+      `specs/plans/2026-08-26-sdk-surface-contract-repairs.md`.
+      The README's `mvm.local_path` decorator source and the builder-pack Cargo
+      feature remediation are implemented and locally green; merge-queue
+      delivery remains.
+
 ## Completed
 
 - [x] **Site QEMU-WASM release artifact** —

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -20,6 +20,14 @@
       decompressed by the browser worker. Workflow contracts, actionlint,
       workspace tests/check/doctests, and Clippy are green.
 
+- [ ] **SDK surface contract repairs for issues #2902 and #2906.**
+      `specs/plans/2026-08-26-sdk-surface-contract-repairs.md`.
+      The documented `mvm.local_path` decorator source now lowers to the shared
+      workload IR with strict path/include/exclude validation, and the
+      builder-pack download refusal names root Cargo features that exist.
+      Implementation, focused tests, the full `mvm-sdk` suite, formatting, and
+      package Clippy are green; merge-queue delivery remains.
+
 - [x] **AI egress metering and token budgets.**
       `specs/plans/2026-08-21-ai-egress-metering-and-budget.md`.
       Provider-reported token counts at the host substitution endpoint,

--- a/specs/plans/2026-08-26-sdk-surface-contract-repairs.md
+++ b/specs/plans/2026-08-26-sdk-surface-contract-repairs.md
@@ -1,0 +1,35 @@
+# SDK surface contract repairs
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+## Status
+
+In progress. Implementation and local verification are complete; merge-queue
+delivery remains.
+
+## Scope
+
+Two documented recovery paths had drifted from their executable surfaces:
+
+- the README's Python decorator used `source=mvm.local_path(".")`, but the
+  static compiler rejected that exported SDK helper before lowering; and
+- the builder-pack download refusal recommended the removed root Cargo feature
+  `manifest-verify`, so following the error could not compile.
+
+The repair keeps the public SDK and compiler aligned. `mvm.local_path` is now a
+strictly lowered source helper with typed path, include, and exclude handling;
+malformed inputs fail at the decorator boundary. The download refusal names the
+existing root feature aggregation, `user,release-artifact-bootstrap`.
+
+## Tasks
+
+- [x] Reproduce the documented decorator failure with the exact helper shape.
+- [x] Add `mvm.local_path` to the shared allowlist and lower its source fields.
+- [x] Add negative coverage for a missing path and malformed include entries.
+- [x] Correct the builder-pack remediation and pin it with a unit test.
+- [x] Pass the full `mvm-sdk` suite, focused `mvm-cli` test, formatting, and
+      package Clippy with warnings denied.
+- [ ] Merge the repair PR and verify issues #2902 and #2906 close through the
+      merge commit.
+


### PR DESCRIPTION
## Summary

- accept the documented `mvm.local_path(...)` decorator helper and lower path/include/exclude into the shared workload IR
- reject malformed local-path inputs at the static compiler boundary
- correct the builder-pack download remediation to use root Cargo features that exist
- record the issue closeout in the plan, sprint, and refactor rollup

## Verification

- `cargo test -p mvm-sdk` (287 unit tests plus integration and doctests)
- `cargo test -p mvm-cli download_refusal_names_root_features_that_exist -- --nocapture`
- `cargo clippy -p mvm-sdk -p mvm-cli -- -D warnings`
- pre-commit: `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

Fixes #2902
Fixes #2906