### PR TITLE
fix(nix): fetch crates from the static CDN

### DIFF
--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -158,6 +158,7 @@
       # `/sbin/mvm-setpriv` symlink through mkGuest's package population loop.
       builderSetprivFor = pkgs:
         import (workspace + "/nix/packages/mvm-setpriv.nix") {
+          inherit pkgs;
           rustPlatform = pkgs.pkgsStatic.rustPlatform;
           lib = pkgs.lib;
           mvmSrc = workspace;

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -154,7 +154,8 @@
           pname = "mvm-runner";
           version = overlayVersion;
           src = workspace;
-          cargoLock = import (workspace + "/nix/lib/static-crates-cargo-lock.nix") {
+          cargoDeps = import (workspace + "/nix/lib/static-crates-cargo-deps.nix") {
+            inherit pkgs;
             lockFile = workspace + "/Cargo.lock";
           };
           cargoBuildFlags = [

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -86,7 +86,10 @@
   outputs =
     { self, nixpkgs, ... }:
     let
-      systems = [ "aarch64-linux" "x86_64-linux" ];
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
 
       # Workspace staging — same `MVM_WORKSPACE_PATH` env override
@@ -105,7 +108,7 @@
         (import (workspaceRoot + "/nix/lib/workspace-filter.nix") {
           inherit (nixpkgs) lib;
         })
-        { inherit workspaceRoot; };
+          { inherit workspaceRoot; };
 
       # mvmctl semver pinned to match
       # `[workspace.package].version` in the root Cargo.toml. The
@@ -126,7 +129,8 @@
       # `--bin mvm-guest-agent --bin mvm-seccomp-apply --bin mvm-verity-init`
       # flags); we just don't copy the verity-init binary into the
       # overlay's staging dir.
-      mvmGuestFor = system:
+      mvmGuestFor =
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
         in
@@ -140,7 +144,8 @@
       # Folded into mvm-agentd as a [[bin]], so we select just that
       # binary out of the mvm-agentd package; workspace Cargo.lock
       # drives the closure.
-      mvmRunnerFor = system:
+      mvmRunnerFor =
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
           staticPkgs = pkgs.pkgsStatic;
@@ -149,10 +154,15 @@
           pname = "mvm-runner";
           version = overlayVersion;
           src = workspace;
-          cargoLock = {
+          cargoLock = import (workspace + "/nix/lib/static-crates-cargo-lock.nix") {
             lockFile = workspace + "/Cargo.lock";
           };
-          cargoBuildFlags = [ "--package" "mvm-agentd" "--bin" "mvm-runner" ];
+          cargoBuildFlags = [
+            "--package"
+            "mvm-agentd"
+            "--bin"
+            "mvm-runner"
+          ];
           doCheck = false;
           meta = {
             description = "mvm function-workload entrypoint runner (plan 60 Phase 5 Slice C)";
@@ -160,7 +170,8 @@
           };
         };
 
-      mvmEgressClientFor = system:
+      mvmEgressClientFor =
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
         in
@@ -170,7 +181,8 @@
           mvmSrc = workspace;
         };
 
-      mvmAddonDnsFor = system:
+      mvmAddonDnsFor =
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
         in
@@ -180,7 +192,8 @@
           mvmSrc = workspace;
         };
 
-      mvmExitReportFor = system:
+      mvmExitReportFor =
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
         in
@@ -196,7 +209,8 @@
       # filename; built for the glibc workload rootfs (same platform as the
       # agent), not the static-musl builder target — a cdylib needs the
       # dynamic loader the rootfs provides.
-      mvmSdkCdylibFor = system:
+      mvmSdkCdylibFor =
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
         in
@@ -241,7 +255,8 @@
       # `nix/images/builder-vm/flake.nix` together.
       pinnedCryptsetupVersion = "2.8.6";
       pinnedCryptsetupSrcHash = "sha256-gAQmX9mTiF0I97Yz2+BWhR3hohAwdhOk693HQ/zO/lo=";
-      pinnedCryptsetupFor = pkgs:
+      pinnedCryptsetupFor =
+        pkgs:
         pkgs.cryptsetup.overrideAttrs (_old: {
           version = pinnedCryptsetupVersion;
           src = pkgs.fetchurl {
@@ -258,7 +273,8 @@
       # 32 MiB allocation.
       overlaySizeBytes = 16 * 1024 * 1024;
 
-      mkSdkSidecar = system:
+      mkSdkSidecar =
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
           hostsvc = mvmSdkCdylibFor system;
@@ -305,7 +321,8 @@
       # `sha256sum`-format manifest the host-side resolver verifies before it
       # offers an attachment — so a truncated or drifted artifact refuses to
       # boot instead of surfacing as an in-guest dlopen failure.
-      mkSdkSidecarImage = system:
+      mkSdkSidecarImage =
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
           tree = mkSdkSidecar system;
@@ -356,7 +373,8 @@
             echo "  VERSION: $(cat $out/VERSION)" >&2
           '';
 
-      mkRuntimeOverlay = system:
+      mkRuntimeOverlay =
+        system:
         let
           pkgs = import nixpkgs { inherit system; };
           guest = mvmGuestFor system;
@@ -373,7 +391,13 @@
               pkgs.coreutils
             ];
             passthru = {
-              inherit guest runner egressClient addonDns exitReport;
+              inherit
+                guest
+                runner
+                egressClient
+                addonDns
+                exitReport
+                ;
               sdkSidecar = mkSdkSidecar system;
               sdkSidecarImage = mkSdkSidecarImage system;
               version = overlayVersion;

--- a/nix/lib/mk-guest.nix
+++ b/nix/lib/mk-guest.nix
@@ -301,6 +301,7 @@ let
   # util-linux setpriv closure while preserving the exact privilege flags
   # emitted by the generated init script.
   setprivPkg = import ../packages/mvm-setpriv.nix {
+    inherit pkgs;
     rustPlatform = pkgs.pkgsStatic.rustPlatform;
     lib = pkgs.lib;
     inherit mvmSrc;

--- a/nix/lib/static-crates-cargo-deps.nix
+++ b/nix/lib/static-crates-cargo-deps.nix
@@ -1,0 +1,18 @@
+{ pkgs, lockFile }:
+
+let
+  cratesIoApi = "https://crates.io/api/v1/crates";
+  staticCrates = "https://static.crates.io/crates";
+  fetchStaticCrate =
+    args:
+    pkgs.fetchurl (
+      args
+      // {
+        url = builtins.replaceStrings [ cratesIoApi ] [ staticCrates ] args.url;
+      }
+    );
+  importCargoLock = pkgs.callPackage (pkgs.path + "/pkgs/build-support/rust/import-cargo-lock.nix") {
+    fetchurl = fetchStaticCrate;
+  };
+in
+importCargoLock { inherit lockFile; }

--- a/nix/lib/static-crates-cargo-lock.nix
+++ b/nix/lib/static-crates-cargo-lock.nix
@@ -1,0 +1,9 @@
+{ lockFile }:
+
+{
+  inherit lockFile;
+
+  extraRegistries = {
+    "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
+  };
+}

--- a/nix/lib/static-crates-cargo-lock.nix
+++ b/nix/lib/static-crates-cargo-lock.nix
@@ -1,9 +1,0 @@
-{ lockFile }:
-
-{
-  inherit lockFile;
-
-  extraRegistries = {
-    "https://github.com/rust-lang/crates.io-index" = "https://static.crates.io/crates";
-  };
-}

--- a/nix/packages/mvm-addon-dns.nix
+++ b/nix/packages/mvm-addon-dns.nix
@@ -14,9 +14,10 @@
 # so the crate keeps it behind that feature to hold the sealed agent's
 # default build tokio-free.
 
-{ pkgs
-, lib
-, mvmSrc
+{
+  pkgs,
+  lib,
+  mvmSrc,
 }:
 
 pkgs.rustPlatform.buildRustPackage {
@@ -25,7 +26,9 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   unpackPhase = import ./workspace-unpack.nix { inherit mvmSrc; };
 
@@ -33,13 +36,17 @@ pkgs.rustPlatform.buildRustPackage {
   # heavier members (mvm-libkrun, mvm-providers, etc.) are not in the
   # closure of this crate, so the produced artifact stays small.
   cargoBuildFlags = [
-    "--package" "mvm-agentd"
-    "--bin" "mvm-addon-dns"
-    "--features" "mvm-agentd/addons"
+    "--package"
+    "mvm-agentd"
+    "--bin"
+    "mvm-addon-dns"
+    "--features"
+    "mvm-agentd/addons"
   ];
 
   cargoTestFlags = [
-    "--package" "mvm-agentd"
+    "--package"
+    "mvm-agentd"
   ];
 
   # Tests run in the workspace's host-side `cargo test` lane; the Nix
@@ -48,8 +55,7 @@ pkgs.rustPlatform.buildRustPackage {
   doCheck = false;
 
   meta = with lib; {
-    description =
-      "mvm in-guest addon DNS — loopback-only UDP resolver for configured local-addon hostnames";
+    description = "mvm in-guest addon DNS — loopback-only UDP resolver for configured local-addon hostnames";
     homepage = "https://github.com/tinylabscom/mvm";
     license = licenses.asl20;
     platforms = platforms.linux;

--- a/nix/packages/mvm-addon-dns.nix
+++ b/nix/packages/mvm-addon-dns.nix
@@ -26,7 +26,8 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-audit-probe.nix
+++ b/nix/packages/mvm-audit-probe.nix
@@ -14,9 +14,10 @@
 # workspace, restricted to the single bin so the workspace's heavier members
 # don't enter the closure.
 
-{ pkgs
-, lib
-, mvmSrc
+{
+  pkgs,
+  lib,
+  mvmSrc,
 }:
 
 pkgs.rustPlatform.buildRustPackage {
@@ -25,15 +26,20 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   cargoBuildFlags = [
-    "--package" "mvm-agentd"
-    "--bin" "audit-probe"
+    "--package"
+    "mvm-agentd"
+    "--bin"
+    "audit-probe"
   ];
 
   cargoTestFlags = [
-    "--package" "mvm-agentd"
+    "--package"
+    "mvm-agentd"
   ];
 
   # Tests run in the workspace's host-side `cargo test` lane (the probe's
@@ -42,8 +48,7 @@ pkgs.rustPlatform.buildRustPackage {
   doCheck = false;
 
   meta = with lib; {
-    description =
-      "mvm in-guest host.audit.v1 probe — live-VM audit round-trip fixture";
+    description = "mvm in-guest host.audit.v1 probe — live-VM audit round-trip fixture";
     homepage = "https://github.com/tinylabscom/mvm";
     license = licenses.asl20;
     platforms = platforms.linux;

--- a/nix/packages/mvm-audit-probe.nix
+++ b/nix/packages/mvm-audit-probe.nix
@@ -26,7 +26,8 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-core-tpm2-clippy.nix
+++ b/nix/packages/mvm-core-tpm2-clippy.nix
@@ -4,13 +4,14 @@
 # driver, which is not part of the minimal rustPlatform toolchain used for
 # the release build.
 
-{ lib
-, stdenv
-, rustPlatform
-, pkg-config
-, clippy
-, mvmSrc
-, tpm2-tss
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  pkg-config,
+  clippy,
+  mvmSrc,
+  tpm2-tss,
 }:
 
 rustPlatform.buildRustPackage {
@@ -19,7 +20,9 @@ rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   unpackPhase = ''
     runHook preUnpack

--- a/nix/packages/mvm-core-tpm2-clippy.nix
+++ b/nix/packages/mvm-core-tpm2-clippy.nix
@@ -5,6 +5,7 @@
 # the release build.
 
 {
+  pkgs,
   lib,
   stdenv,
   rustPlatform,
@@ -20,7 +21,8 @@ rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-core-tpm2-test.nix
+++ b/nix/packages/mvm-core-tpm2-test.nix
@@ -7,6 +7,7 @@
 # full TPM2 command flow.
 
 {
+  pkgs,
   lib,
   stdenv,
   rustPlatform,
@@ -22,7 +23,8 @@ rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-core-tpm2-test.nix
+++ b/nix/packages/mvm-core-tpm2-test.nix
@@ -6,13 +6,14 @@
 # `mvm-core-tpm2` package because it must build swtpm and exercise the
 # full TPM2 command flow.
 
-{ lib
-, stdenv
-, rustPlatform
-, pkg-config
-, mvmSrc
-, tpm2-tss
-, swtpm
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  pkg-config,
+  mvmSrc,
+  tpm2-tss,
+  swtpm,
 }:
 
 rustPlatform.buildRustPackage {
@@ -21,7 +22,9 @@ rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   unpackPhase = ''
     runHook preUnpack

--- a/nix/packages/mvm-core-tpm2.nix
+++ b/nix/packages/mvm-core-tpm2.nix
@@ -4,12 +4,13 @@
 # the heavy mvmctl build-script path (which builds qemu-wasm-engine) and only
 # exercises the tss-esapi link surface inside mvm-core.
 
-{ lib
-, stdenv
-, rustPlatform
-, pkg-config
-, mvmSrc
-, tpm2-tss
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  pkg-config,
+  mvmSrc,
+  tpm2-tss,
 }:
 
 rustPlatform.buildRustPackage {
@@ -18,7 +19,9 @@ rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   unpackPhase = ''
     runHook preUnpack

--- a/nix/packages/mvm-core-tpm2.nix
+++ b/nix/packages/mvm-core-tpm2.nix
@@ -5,6 +5,7 @@
 # exercises the tss-esapi link surface inside mvm-core.
 
 {
+  pkgs,
   lib,
   stdenv,
   rustPlatform,
@@ -19,7 +20,8 @@ rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-egress-client.nix
+++ b/nix/packages/mvm-egress-client.nix
@@ -14,9 +14,10 @@
 # tokio, so the crate keeps them behind that feature to hold the sealed
 # agent's default build tokio-free.
 
-{ pkgs
-, lib
-, mvmSrc
+{
+  pkgs,
+  lib,
+  mvmSrc,
 }:
 
 pkgs.rustPlatform.buildRustPackage {
@@ -25,20 +26,26 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   unpackPhase = import ./workspace-unpack.nix { inherit mvmSrc; };
 
   # Restrict the build to the egress-client binary; the workspace's heavier members
   # are not in this crate's closure, so the artifact stays small.
   cargoBuildFlags = [
-    "--package" "mvm-agentd"
-    "--bin" "mvm-egress-client"
-    "--features" "mvm-agentd/addons"
+    "--package"
+    "mvm-agentd"
+    "--bin"
+    "mvm-egress-client"
+    "--features"
+    "mvm-agentd/addons"
   ];
 
   cargoTestFlags = [
-    "--package" "mvm-agentd"
+    "--package"
+    "mvm-agentd"
   ];
 
   # Host-side `cargo test` lane runs the tests; the Nix build stays focused on the
@@ -46,8 +53,7 @@ pkgs.rustPlatform.buildRustPackage {
   doCheck = false;
 
   meta = with lib; {
-    description =
-      "mvm in-guest egress shim — loopback SOCKS5 to the host vsock egress gateway ";
+    description = "mvm in-guest egress shim — loopback SOCKS5 to the host vsock egress gateway ";
     homepage = "https://github.com/tinylabscom/mvm";
     license = licenses.asl20;
     platforms = platforms.linux;

--- a/nix/packages/mvm-egress-client.nix
+++ b/nix/packages/mvm-egress-client.nix
@@ -26,7 +26,8 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-exit-report.nix
+++ b/nix/packages/mvm-exit-report.nix
@@ -21,7 +21,8 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-exit-report.nix
+++ b/nix/packages/mvm-exit-report.nix
@@ -9,9 +9,10 @@
 # reporter has no `do_exec`-equivalent surface and the same artifact
 # is safe for dev and prod images.
 
-{ pkgs
-, lib
-, mvmSrc
+{
+  pkgs,
+  lib,
+  mvmSrc,
 }:
 
 pkgs.rustPlatform.buildRustPackage {
@@ -20,7 +21,9 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   unpackPhase = import ./workspace-unpack.nix { inherit mvmSrc; };
 
@@ -28,12 +31,15 @@ pkgs.rustPlatform.buildRustPackage {
   # heavier members (mvm-libkrun, mvm-providers, etc.) are not in the
   # closure of this crate, so the produced artifact stays small.
   cargoBuildFlags = [
-    "--package" "mvm-agentd"
-    "--bin" "mvm-exit-report"
+    "--package"
+    "mvm-agentd"
+    "--bin"
+    "mvm-exit-report"
   ];
 
   cargoTestFlags = [
-    "--package" "mvm-agentd"
+    "--package"
+    "mvm-agentd"
   ];
 
   # Tests run in the workspace's host-side `cargo test` lane; the Nix
@@ -42,8 +48,7 @@ pkgs.rustPlatform.buildRustPackage {
   doCheck = false;
 
   meta = with lib; {
-    description =
-      "mvm in-guest exit reporter — records workload exit status before poweroff";
+    description = "mvm in-guest exit reporter — records workload exit status before poweroff";
     homepage = "https://github.com/tinylabscom/mvm";
     license = licenses.asl20;
     platforms = platforms.linux;

--- a/nix/packages/mvm-guest-agent-static.nix
+++ b/nix/packages/mvm-guest-agent-static.nix
@@ -25,7 +25,8 @@ staticPkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-guest-agent-static.nix
+++ b/nix/packages/mvm-guest-agent-static.nix
@@ -7,9 +7,10 @@
 #
 # The binary is stripped and built with LTO to keep the initramfs small.
 
-{ pkgs
-, lib
-, mvmSrc
+{
+  pkgs,
+  lib,
+  mvmSrc,
 }:
 
 let
@@ -24,17 +25,22 @@ staticPkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   # Build only the guest-agent binary; the initramfs does not need the
   # seccomp shim, verity-init, netinit, or runner.
   cargoBuildFlags = [
-    "--package" "mvm-agentd"
-    "--bin" "mvm-guest-agent"
+    "--package"
+    "mvm-agentd"
+    "--bin"
+    "mvm-guest-agent"
   ];
 
   cargoTestFlags = [
-    "--package" "mvm-agentd"
+    "--package"
+    "mvm-agentd"
   ];
 
   doCheck = false;

--- a/nix/packages/mvm-guest-agent.nix
+++ b/nix/packages/mvm-guest-agent.nix
@@ -47,7 +47,8 @@ pkgs.rustPlatform.buildRustPackage {
   # Workspace's Cargo.lock is the source of truth for every crate
   # we vendor. `buildRustPackage` vendors the closure even though
   # we only build mvm-agentd; the unused deps compile zero code.
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-guest-agent.nix
+++ b/nix/packages/mvm-guest-agent.nix
@@ -32,9 +32,10 @@
 # the guest agent's runtime profile and signed verb grant, after protocol
 # authentication; image construction does not select a handler set.
 
-{ pkgs
-, lib
-, mvmSrc
+{
+  pkgs,
+  lib,
+  mvmSrc,
 }:
 
 pkgs.rustPlatform.buildRustPackage {
@@ -46,7 +47,9 @@ pkgs.rustPlatform.buildRustPackage {
   # Workspace's Cargo.lock is the source of truth for every crate
   # we vendor. `buildRustPackage` vendors the closure even though
   # we only build mvm-agentd; the unused deps compile zero code.
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   unpackPhase = import ./workspace-unpack.nix { inherit mvmSrc; };
 
@@ -54,18 +57,25 @@ pkgs.rustPlatform.buildRustPackage {
   # has heavier members (libkrun via mvm-build, libkrun via
   # mvm-providers, etc.) that aren't in the guest closure.
   cargoBuildFlags = [
-    "--package" "mvm-agentd"
-    "--bin" "mvm-guest-agent"
-    "--bin" "mvm-seccomp-apply"
-    "--bin" "mvm-verity-init"
+    "--package"
+    "mvm-agentd"
+    "--bin"
+    "mvm-guest-agent"
+    "--bin"
+    "mvm-seccomp-apply"
+    "--bin"
+    "mvm-verity-init"
     # Guest-side network defense. Installs kernel blackhole routes
     # for `MANDATORY_DENY_RANGES` at boot from `/init` (uid 0) before
     # the main agent forks under setpriv.
-    "--bin" "mvm-guest-netinit"
+    "--bin"
+    "mvm-guest-netinit"
     # Runtime-lean OCI roots still need their static PID 1 and entrypoint
     # wrapper before the read-only runtime overlay is mounted.
-    "--bin" "mvm-oci-init"
-    "--bin" "mvm-oci-entrypoint"
+    "--bin"
+    "mvm-oci-init"
+    "--bin"
+    "mvm-oci-entrypoint"
   ];
 
   # Same selection for the `nix flake check`-equivalent test run.
@@ -73,7 +83,8 @@ pkgs.rustPlatform.buildRustPackage {
   # parsing, seccomp filter golden tests) so they run inside the
   # sandbox without privilege.
   cargoTestFlags = [
-    "--package" "mvm-agentd"
+    "--package"
+    "mvm-agentd"
   ];
 
   # Skip tests by default — they need a Linux build host and the

--- a/nix/packages/mvm-sdk-cdylib.nix
+++ b/nix/packages/mvm-sdk-cdylib.nix
@@ -23,7 +23,8 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvm-sdk-cdylib.nix
+++ b/nix/packages/mvm-sdk-cdylib.nix
@@ -11,9 +11,10 @@
 # matching `mvm-guest-agent`), not the static-musl builder-VM target — a
 # `cdylib` needs a dynamic loader, which the glibc rootfs provides.
 
-{ pkgs
-, lib
-, mvmSrc
+{
+  pkgs,
+  lib,
+  mvmSrc,
 }:
 
 pkgs.rustPlatform.buildRustPackage {
@@ -22,14 +23,17 @@ pkgs.rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   unpackPhase = import ./workspace-unpack.nix { inherit mvmSrc; };
 
   # Build only mvm-sdk's library target, which produces both the Rust `lib`
   # and the `cdylib`. The cdylib is renamed to the stable FFI filename below.
   cargoBuildFlags = [
-    "--package" "mvm-sdk"
+    "--package"
+    "mvm-sdk"
     "--lib"
   ];
 
@@ -47,8 +51,7 @@ pkgs.rustPlatform.buildRustPackage {
   '';
 
   meta = with lib; {
-    description =
-      "mvm in-guest host-services FFI — one JSON-in/JSON-out C ABI over the broker clients, loaded by every language SDK";
+    description = "mvm in-guest host-services FFI — one JSON-in/JSON-out C ABI over the broker clients, loaded by every language SDK";
     homepage = "https://github.com/tinylabscom/mvm";
     license = licenses.asl20;
     platforms = platforms.linux;

--- a/nix/packages/mvm-setpriv.nix
+++ b/nix/packages/mvm-setpriv.nix
@@ -1,13 +1,19 @@
 # Minimal static-musl privilege-drop helper used by the guest PID 1.
 
-{ rustPlatform, lib, mvmSrc }:
+{
+  rustPlatform,
+  lib,
+  mvmSrc,
+}:
 
 rustPlatform.buildRustPackage {
   pname = "mvm-setpriv";
   version = "0.18.1";
 
   src = mvmSrc;
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   unpackPhase = import ./workspace-unpack.nix { inherit mvmSrc; };
 
@@ -15,8 +21,10 @@ rustPlatform.buildRustPackage {
   # Nix's sentinel home directory in the shared build root.
   HOME = "/tmp";
   cargoBuildFlags = [
-    "--package" "mvm-agentd"
-    "--bin" "mvm-setpriv"
+    "--package"
+    "mvm-agentd"
+    "--bin"
+    "mvm-setpriv"
   ];
   doCheck = false;
 

--- a/nix/packages/mvm-setpriv.nix
+++ b/nix/packages/mvm-setpriv.nix
@@ -1,6 +1,7 @@
 # Minimal static-musl privilege-drop helper used by the guest PID 1.
 
 {
+  pkgs,
   rustPlatform,
   lib,
   mvmSrc,
@@ -11,7 +12,8 @@ rustPlatform.buildRustPackage {
   version = "0.18.1";
 
   src = mvmSrc;
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvmctl.nix
+++ b/nix/packages/mvmctl.nix
@@ -10,6 +10,7 @@
 #   need the native FFI path.
 
 {
+  pkgs,
   lib,
   stdenv,
   rustPlatform,
@@ -54,7 +55,8 @@ rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+  cargoDeps = import ../lib/static-crates-cargo-deps.nix {
+    inherit pkgs;
     lockFile = mvmSrc + "/Cargo.lock";
   };
 

--- a/nix/packages/mvmctl.nix
+++ b/nix/packages/mvmctl.nix
@@ -9,24 +9,25 @@
 #   DX but does not force a host libkrun install on systems that do not
 #   need the native FFI path.
 
-{ lib
-, stdenv
-, rustPlatform
-, pkg-config
-, cargo-zigbuild
-, curl
-, zig
-, embeddedCargo
-, embeddedRustc
-, lld
-, mvmSrc
-, libkrun ? null
-, libkrunfw ? null
-, tpm2-tss ? null
-, withBuilderVm ? true
-, withNativeLibkrun ? false
-, withTpm2 ? false
-, runTests ? true
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  pkg-config,
+  cargo-zigbuild,
+  curl,
+  zig,
+  embeddedCargo,
+  embeddedRustc,
+  lld,
+  mvmSrc,
+  libkrun ? null,
+  libkrunfw ? null,
+  tpm2-tss ? null,
+  withBuilderVm ? true,
+  withNativeLibkrun ? false,
+  withTpm2 ? false,
+  runTests ? true,
 }:
 
 assert withNativeLibkrun -> libkrun != null;
@@ -36,7 +37,7 @@ assert withTpm2 -> tpm2-tss != null;
 
 let
   featureList =
-    []
+    [ ]
     ++ lib.optionals withBuilderVm [
       "mvm-cli/builder-vm"
       "mvm-build/builder-vm"
@@ -53,7 +54,9 @@ rustPlatform.buildRustPackage {
 
   src = mvmSrc;
 
-  cargoLock.lockFile = mvmSrc + "/Cargo.lock";
+  cargoLock = import ../lib/static-crates-cargo-lock.nix {
+    lockFile = mvmSrc + "/Cargo.lock";
+  };
 
   # The `nix/` subflake imports the workspace as `path:..`; when the
   # flake itself is evaluated from a git source, that input can arrive
@@ -68,20 +71,19 @@ rustPlatform.buildRustPackage {
     runHook postUnpack
   '';
 
-  cargoBuildFlags =
-    [
-      "--package"
-      "mvmctl"
-      "--package"
-      "mvm-hostd"
-    ]
-    ++ lib.optionals (!withBuilderVm) [
-      "--no-default-features"
-    ]
-    ++ lib.optionals (featureList != [ ]) [
-      "--features"
-      (lib.concatStringsSep "," featureList)
-    ];
+  cargoBuildFlags = [
+    "--package"
+    "mvmctl"
+    "--package"
+    "mvm-hostd"
+  ]
+  ++ lib.optionals (!withBuilderVm) [
+    "--no-default-features"
+  ]
+  ++ lib.optionals (featureList != [ ]) [
+    "--features"
+    (lib.concatStringsSep "," featureList)
+  ];
 
   cargoTestFlags = [
     "--package"
@@ -102,31 +104,32 @@ rustPlatform.buildRustPackage {
   # auditable.
   auditable = !withNativeLibkrun;
 
-  nativeBuildInputs =
-    [
-      cargo-zigbuild
-      lld
-      pkg-config
-      zig
-    ]
-    ++ lib.optional withNativeLibkrun rustPlatform.bindgenHook;
+  nativeBuildInputs = [
+    cargo-zigbuild
+    lld
+    pkg-config
+    zig
+  ]
+  ++ lib.optional withNativeLibkrun rustPlatform.bindgenHook;
 
   nativeCheckInputs = [
     curl
   ];
 
-  buildInputs = lib.optionals withNativeLibkrun [
-    libkrun
-    libkrunfw
-  ]
-  ++ lib.optionals withTpm2 [
-    tpm2-tss
-  ];
+  buildInputs =
+    lib.optionals withNativeLibkrun [
+      libkrun
+      libkrunfw
+    ]
+    ++ lib.optionals withTpm2 [
+      tpm2-tss
+    ];
 
   env = {
     MVM_EMBED_CARGO = "${embeddedCargo}/bin/cargo";
     MVM_EMBED_RUSTC = "${embeddedRustc}/bin/rustc";
-  } // lib.optionalAttrs withNativeLibkrun {
+  }
+  // lib.optionalAttrs withNativeLibkrun {
     MVM_LIBKRUN_HEADER = "${lib.getDev libkrun}/include/libkrun.h";
   };
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -522,6 +522,13 @@ for detailed scope and acceptance criteria.
 
 ## In-flight plans
 
+- [ ] **Static crates registry recovery**
+      (`specs/plans/2026-08-26-static-crates-registry-fetch.md`, issue #2904).
+      The pinned Nix crate fetcher is blocked by crates.io's curl user-agent
+      policy. One shared cargo-lock helper is being applied to every repository
+      Rust derivation so checksum-verified downloads use the unaffected static
+      CDN and future derivations cannot silently restore the API endpoint.
+
 - [ ] **`.mvmev` offline verifiability**
       (`specs/plans/2026-08-25-mvmev-offline-verifiability.md`, issue #2863).
       The format-level gap is complete: schema version 1 now normatively names

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -525,9 +525,10 @@ for detailed scope and acceptance criteria.
 - [ ] **Static crates registry recovery**
       (`specs/plans/2026-08-26-static-crates-registry-fetch.md`, issue #2904).
       The pinned Nix crate fetcher is blocked by crates.io's curl user-agent
-      policy. One shared cargo-lock helper is being applied to every repository
-      Rust derivation so checksum-verified downloads use the unaffected static
-      CDN and future derivations cannot silently restore the API endpoint.
+      policy. One shared cargo-deps helper is applied to every repository Rust
+      derivation so checksum-verified downloads use the unaffected static CDN
+      without redefining Cargo's built-in registry, and future derivations
+      cannot silently restore the API endpoint.
 
 - [ ] **`.mvmev` offline verifiability**
       (`specs/plans/2026-08-25-mvmev-offline-verifiability.md`, issue #2863).

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3069,6 +3069,15 @@ to the configured ceiling and the first terse response immediately after it.
 - [x] Record the delivery in
       `specs/sprint/delivery/2870-extended-ci-recovery.md`.
 
+## 2026-08-26 static crates registry recovery
+
+- [x] Route every Nix `buildRustPackage` crate fetch through the crates.io
+      static CDN while preserving the committed `Cargo.lock` checksums.
+- [x] Guard all current and future Rust Nix derivations with one shared helper
+      and a repository-wide structural regression.
+- [ ] Restore the builder-image and Linux flake gates blocked by issue #2904,
+      then merge the repair through the queue.
+
 ## 2026-08-26 Security peer-policy mutation witness
 
 - [x] Reproduce the scheduled Security failure from run 32931995875 as the

--- a/specs/plans/2026-08-26-static-crates-registry-fetch.md
+++ b/specs/plans/2026-08-26-static-crates-registry-fetch.md
@@ -1,5 +1,8 @@
 # Static crates registry fetch
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 **Status: IN PROGRESS**
 
 Issue #2904 blocks every source-built Rust derivation used by the builder VM:

--- a/specs/plans/2026-08-26-static-crates-registry-fetch.md
+++ b/specs/plans/2026-08-26-static-crates-registry-fetch.md
@@ -13,12 +13,14 @@ checksums already committed in `Cargo.lock`.
 
 ## Delivery
 
-- [x] Add one shared `cargoLock` helper that retains the committed lockfile and
-      redirects the crates.io registry download base to `static.crates.io`.
+- [x] Add one shared `cargoDeps` helper that retains the committed lockfile and
+      overrides Nix's crate fetcher to use `static.crates.io` without defining
+      Cargo's built-in crates.io source a second time.
 - [x] Move every repository `buildRustPackage` derivation onto the helper,
       including the independently evaluated runtime-overlay flake.
 - [x] Add a structural regression that rejects a new Rust Nix derivation which
-      bypasses the helper or a helper which loses either registry endpoint.
+      bypasses the helper, loses either endpoint, or reintroduces an alternate
+      registry definition for crates.io.
 - [x] Prove the focused regression, full Nix-structure test target, formatting,
       and Clippy are green.
 - [ ] Merge the repair through the merge queue and confirm issue #2904 closes

--- a/specs/plans/2026-08-26-static-crates-registry-fetch.md
+++ b/specs/plans/2026-08-26-static-crates-registry-fetch.md
@@ -1,0 +1,22 @@
+# Static crates registry fetch
+
+**Status: IN PROGRESS**
+
+Issue #2904 blocks every source-built Rust derivation used by the builder VM:
+the pinned Nix `importCargoLock` downloads through the crates.io API endpoint,
+whose current user-agent policy rejects Nix's curl fetcher. The crate CDN serves
+the same `/<crate>/<version>/download` path and remains content-addressed by the
+checksums already committed in `Cargo.lock`.
+
+## Delivery
+
+- [x] Add one shared `cargoLock` helper that retains the committed lockfile and
+      redirects the crates.io registry download base to `static.crates.io`.
+- [x] Move every repository `buildRustPackage` derivation onto the helper,
+      including the independently evaluated runtime-overlay flake.
+- [x] Add a structural regression that rejects a new Rust Nix derivation which
+      bypasses the helper or a helper which loses either registry endpoint.
+- [x] Prove the focused regression, full Nix-structure test target, formatting,
+      and Clippy are green.
+- [ ] Merge the repair through the merge queue and confirm issue #2904 closes
+      from the merged PR.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -36,14 +36,20 @@ fn normalized_whitespace(content: &str) -> String {
 
 #[test]
 fn every_rust_derivation_uses_the_static_crates_registry() {
-    let helper = nix_dir().join("lib").join("static-crates-cargo-lock.nix");
+    let helper = nix_dir().join("lib").join("static-crates-cargo-deps.nix");
     let helper_content = fs::read_to_string(&helper)
         .unwrap_or_else(|e| panic!("static crate registry helper must be present: {e}"));
 
     assert!(
-        helper_content.contains("https://github.com/rust-lang/crates.io-index")
-            && helper_content.contains("https://static.crates.io/crates"),
-        "the cargo-lock helper must redirect the crates.io index to its static CDN"
+        helper_content.contains("https://crates.io/api/v1/crates")
+            && helper_content.contains("https://static.crates.io/crates")
+            && helper_content.contains("builtins.replaceStrings")
+            && helper_content.contains("fetchurl = fetchStaticCrate"),
+        "the cargo-deps helper must rewrite crates.io downloads to its static CDN"
+    );
+    assert!(
+        !helper_content.contains("extraRegistries"),
+        "the helper must not redefine Cargo's built-in crates.io source"
     );
 
     let mut nix_files = Vec::new();
@@ -57,7 +63,8 @@ fn every_rust_derivation_uses_the_static_crates_registry() {
         }
         rust_derivations += 1;
         assert!(
-            content.contains("static-crates-cargo-lock.nix"),
+            content.contains("cargoDeps = import")
+                && content.contains("static-crates-cargo-deps.nix"),
             "{} builds Rust without the static crates.io registry helper",
             path.display()
         );
@@ -170,7 +177,7 @@ fn host_mvmctl_package_is_source_only() {
     );
     assert!(
         content.contains("src = mvmSrc")
-            && content.contains("static-crates-cargo-lock.nix")
+            && content.contains("static-crates-cargo-deps.nix")
             && content.contains("lockFile = mvmSrc + \"/Cargo.lock\""),
         "mvmctl package must use the source checkout and committed Cargo.lock"
     );

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -76,6 +76,31 @@ fn every_rust_derivation_uses_the_static_crates_registry() {
     );
 }
 
+#[test]
+fn mvm_setpriv_imports_pass_pkgs_to_the_static_crates_helper() {
+    let mk_guest = normalized_whitespace(
+        &fs::read_to_string(nix_dir().join("lib").join("mk-guest.nix"))
+            .expect("mk-guest.nix must be readable"),
+    );
+    assert!(
+        mk_guest.contains(
+            "import ../packages/mvm-setpriv.nix { inherit pkgs; rustPlatform = pkgs.pkgsStatic.rustPlatform;"
+        ),
+        "the workload guest must pass pkgs into mvm-setpriv.nix"
+    );
+
+    let builder_flake = normalized_whitespace(
+        &fs::read_to_string(nix_dir().join("images/builder-vm/flake.nix"))
+            .expect("builder VM flake must be readable"),
+    );
+    assert!(
+        builder_flake.contains(
+            "import (workspace + \"/nix/packages/mvm-setpriv.nix\") { inherit pkgs; rustPlatform = pkgs.pkgsStatic.rustPlatform;"
+        ),
+        "the builder guest must pass pkgs into mvm-setpriv.nix"
+    );
+}
+
 fn collect_nix_files(dir: &Path, files: &mut Vec<PathBuf>) {
     for entry in
         fs::read_dir(dir).unwrap_or_else(|e| panic!("{} must be readable: {e}", dir.display()))

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -35,6 +35,54 @@ fn normalized_whitespace(content: &str) -> String {
 }
 
 #[test]
+fn every_rust_derivation_uses_the_static_crates_registry() {
+    let helper = nix_dir().join("lib").join("static-crates-cargo-lock.nix");
+    let helper_content = fs::read_to_string(&helper)
+        .unwrap_or_else(|e| panic!("static crate registry helper must be present: {e}"));
+
+    assert!(
+        helper_content.contains("https://github.com/rust-lang/crates.io-index")
+            && helper_content.contains("https://static.crates.io/crates"),
+        "the cargo-lock helper must redirect the crates.io index to its static CDN"
+    );
+
+    let mut nix_files = Vec::new();
+    collect_nix_files(&nix_dir(), &mut nix_files);
+    let mut rust_derivations = 0;
+    for path in nix_files {
+        let content = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{} must be readable: {e}", path.display()));
+        if !content.contains("rustPlatform.buildRustPackage {") {
+            continue;
+        }
+        rust_derivations += 1;
+        assert!(
+            content.contains("static-crates-cargo-lock.nix"),
+            "{} builds Rust without the static crates.io registry helper",
+            path.display()
+        );
+    }
+
+    assert!(
+        rust_derivations > 0,
+        "expected at least one Rust Nix derivation"
+    );
+}
+
+fn collect_nix_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    for entry in
+        fs::read_dir(dir).unwrap_or_else(|e| panic!("{} must be readable: {e}", dir.display()))
+    {
+        let path = entry.expect("directory entry must be readable").path();
+        if path.is_dir() {
+            collect_nix_files(&path, files);
+        } else if path.extension().and_then(|extension| extension.to_str()) == Some("nix") {
+            files.push(path);
+        }
+    }
+}
+
+#[test]
 fn flake_nix_exists_and_imports_microvm_nix() {
     let path = nix_dir().join("flake.nix");
     let content =
@@ -122,7 +170,8 @@ fn host_mvmctl_package_is_source_only() {
     );
     assert!(
         content.contains("src = mvmSrc")
-            && content.contains("cargoLock.lockFile = mvmSrc + \"/Cargo.lock\""),
+            && content.contains("static-crates-cargo-lock.nix")
+            && content.contains("lockFile = mvmSrc + \"/Cargo.lock\""),
         "mvmctl package must use the source checkout and committed Cargo.lock"
     );
     assert!(
@@ -1097,10 +1146,11 @@ fn runtime_overlay_guest_packages_use_static_musl_and_have_no_loader_bundle() {
         .join("flake.nix");
     let content = fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("nix/images/runtime-overlay/flake.nix must be present: {e}"));
-    let runtime = content
+    let normalized = normalized_whitespace(&content);
+    let runtime = normalized
         .split("mkRuntimeOverlay = system:")
         .nth(1)
-        .and_then(|tail| tail.split("\n    in\n    {").next())
+        .and_then(|tail| tail.split(" in {").next())
         .expect("runtime-overlay derivation body");
 
     assert!(
@@ -1136,9 +1186,10 @@ fn runtime_overlay_exposes_sdk_sidecar_separately() {
         .join("flake.nix");
     let content = fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("nix/images/runtime-overlay/flake.nix must be present: {e}"));
+    let normalized = normalized_whitespace(&content);
 
     assert!(
-        content.contains("mkSdkSidecar = system:"),
+        normalized.contains("mkSdkSidecar = system:"),
         "the glibc SDK FFI must have a distinct sidecar derivation"
     );
     assert!(
@@ -1168,9 +1219,10 @@ fn runtime_overlay_publishes_an_attachable_sdk_sidecar_image() {
         .join("flake.nix");
     let content = fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("nix/images/runtime-overlay/flake.nix must be present: {e}"));
+    let normalized = normalized_whitespace(&content);
 
     assert!(
-        content.contains("mkSdkSidecarImage = system:"),
+        normalized.contains("mkSdkSidecarImage = system:"),
         "the sidecar must have an ext4-image derivation, not just a directory tree"
     );
     assert!(
@@ -1341,18 +1393,19 @@ fn cryptsetup_pin_is_shared_by_builder_vm_and_runtime_overlay() {
         ("builder-vm flake", builder.as_str()),
         ("runtime-overlay flake", runtime.as_str()),
     ] {
+        let normalized = normalized_whitespace(content);
         assert!(
-            content.contains("pinnedCryptsetupVersion = \"2.8.6\""),
+            normalized.contains("pinnedCryptsetupVersion = \"2.8.6\""),
             "{name} must pin cryptsetup 2.8.6 explicitly for ADR-017 / #223"
         );
         assert!(
-            content.contains(
+            normalized.contains(
                 "pinnedCryptsetupSrcHash = \"sha256-gAQmX9mTiF0I97Yz2+BWhR3hohAwdhOk693HQ/zO/lo=\""
             ),
             "{name} must pin the cryptsetup 2.8.6 release tarball hash"
         );
         assert!(
-            content.contains("pinnedCryptsetupFor = pkgs:"),
+            normalized.contains("pinnedCryptsetupFor = pkgs:"),
             "{name} must expose a pinned cryptsetup helper instead of using raw pkgs.cryptsetup"
         );
         assert!(


### PR DESCRIPTION
Fixes #2904.

The pinned Nix importCargoLock path uses the crates.io API download endpoint, which now rejects Nix curl user agents with HTTP 403. Redirect the crates.io registry base to static.crates.io through one shared cargo-lock helper, while preserving Cargo.lock checksums.

All 13 repository buildRustPackage derivations use the helper, including the standalone runtime-overlay flake. A repository-wide structural regression prevents new Rust derivations from bypassing it. Existing runtime-overlay assertions now normalize whitespace so nixfmt-only layout changes cannot create false failures.

Validation:
- cargo test --test nix_flake_structure: 50 passed
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- nixfmt --check on every touched Nix file
- static CDN compatibility path returns HTTP 200 with the same /crate/version/download shape