### PR TITLE
fix(cli): allow detached declared ingress

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -215,7 +215,7 @@ pub(in crate::commands) struct MachineRunArgs {
         long,
         value_name = "HOST_PORT:GUEST_PORT",
         value_parser = super::shared::clap_port_spec,
-        conflicts_with_all = ["detach", "json", "tty", "interactive", "entrypoint"]
+        conflicts_with_all = ["json", "tty", "interactive", "entrypoint"]
     )]
     pub port: Vec<String>,
     /// Return machine startup details as JSON.

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -580,7 +580,7 @@ fn run_port_is_repeatable_and_implies_persistence() {
 }
 
 #[test]
-fn run_port_rejects_invalid_mappings_and_detached_ownership() {
+fn run_port_rejects_invalid_mappings_and_supports_detached_ownership() {
     let invalid = parse_run(&["run", "--image", "alpine", "--port", "abc:3000"])
         .expect_err("invalid ports must fail during CLI parsing");
     assert_eq!(invalid.kind(), clap::error::ErrorKind::ValueValidation);
@@ -593,8 +593,14 @@ fn run_port_rejects_invalid_mappings_and_detached_ownership() {
         "8080:3000",
         "--detach",
     ])
-    .expect_err("a detached CLI cannot own the forwarding process");
-    assert_eq!(detached.kind(), clap::error::ErrorKind::ArgumentConflict);
+    .expect("declared ingress belongs to the persistent machine, not the foreground CLI");
+    assert_eq!(detached.port, vec!["8080:3000"]);
+    assert!(detached.detach);
+    assert_eq!(
+        detached.resolve_mode().expect("detached ingress resolves"),
+        MachineRunMode::Persistent
+    );
+    assert_eq!(post_start_action(&detached), PostStart::PrintId);
 
     let with_command = parse_run(&[
         "run",

--- a/crates/mvm-cli/tests/obscura_example.rs
+++ b/crates/mvm-cli/tests/obscura_example.rs
@@ -38,3 +38,13 @@ fn obscura_example_documents_explicit_opt_in() {
     assert!(readme.contains("Chromium remains the default"));
     assert!(readme.contains("Apache-2.0"));
 }
+
+#[test]
+fn obscura_example_declares_ingress_before_a_detached_boot() {
+    let readme =
+        fs::read_to_string(example_file("README.md")).expect("Obscura README must be readable");
+
+    assert!(readme.contains("machine run -d"));
+    assert!(readme.contains("--port 9222:9222"));
+    assert!(!readme.contains("machine forward"));
+}

--- a/examples/obscura/README.md
+++ b/examples/obscura/README.md
@@ -7,17 +7,11 @@ guest proxy and remains deny-by-default unless each destination is admitted.
 Build and run Nix/microVM commands inside the project builder VM:
 
 Signed TCP ingress has to be declared before boot, so `--port` is part of the
-launch rather than a later attach. It is rejected together with `--detach`,
-which means this run holds the terminal; drive the CDP endpoint from a second
-shell.
+detached launch rather than a later attach.
 
 ```sh
-mvmctl machine run --name obscura --flake . \
-  --allow-host example.com:443 \
-  --port 9222:9222
-```
-
-```sh
+mvmctl machine run -d --name obscura --flake . \
+  --allow-host example.com:443 --port 9222:9222
 curl http://127.0.0.1:9222/json/version
 mvmctl machine stop obscura --yes
 ```

--- a/features/suites/s0_cli/machine_run_contract.feature
+++ b/features/suites/s0_cli/machine_run_contract.feature
@@ -48,12 +48,15 @@ Feature: machine run request contract
     Then the command exits with code 1
     And the error output contains "needs a terminal on stdin"
 
-  # A foreground mvmctl process owns the socat children and cleans them up on
-  # Ctrl-C. Claiming detach at the same time would strand that ownership.
-  Scenario: machine run refuses to detach an attached port forward
-    When I run mvmctl with "machine run --image alpine --port 8080:3000 --detach" and an isolated mvm home
-    Then the command exits with code 2
-    And the error output contains "cannot be used"
+  # Declared ingress is signed before boot and belongs to the persistent
+  # machine runtime, so the foreground CLI may detach without orphaning it.
+  Scenario: machine run accepts declared ingress with detached ownership
+    Given an isolated mvm home
+    When I run mvmctl in the isolated mvm home with "machine run --image alpine --port 8080:3000 --detach --dry-run --name bdd-detached-ingress"
+    Then the command exits with code 0
+    And the output contains "no VM will be booted"
+    And the output contains "machine: bdd-detached-ingress"
+    And the isolated mvm home does not contain directory "vms/bdd-detached-ingress"
 
   # Egress-enabling dry runs are deliberately absent. `--allow-host` / `--net`
   # make the dry run resolve an *available* egress-capable backend, so the

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -553,6 +553,13 @@ for detailed scope and acceptance criteria.
       without redefining Cargo's built-in registry, and future derivations
       cannot silently restore the API endpoint.
 
+- [ ] **Detached declared ingress**
+      (`specs/plans/2026-08-26-detached-declared-ingress.md`, issue #2901).
+      Persistent `machine run -d` launches can now carry signed `--port`
+      declarations before boot, and the Obscura example uses that lifecycle
+      instead of the retired dynamic-forwarding verb. Validation and merge are
+      in progress.
+
 - [x] **`.mvmev` offline verifiability**
       (`specs/plans/2026-08-25-mvmev-offline-verifiability.md`, issue #2863).
       The format-level gap is complete: schema version 1 now normatively names

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3097,6 +3097,15 @@ to the configured ceiling and the first terse response immediately after it.
 - [x] Record the delivery in
       `specs/sprint/delivery/2888-hvf-vcpu-contract.md`.
 
+## 2026-08-26 detached declared ingress
+
+- [x] Allow signed `--port` ingress declarations on detached persistent
+      `machine run` launches.
+- [x] Replace the Obscura example's retired dynamic-forwarding step with the
+      pre-boot declaration and guard both CLI parsing and documentation.
+- [ ] Merge the repair through the queue and close issue #2901 from the merged
+      PR.
+
 ## 2026-08-26 Security peer-policy mutation witness
 
 - [x] Reproduce the scheduled Security failure from run 32931995875 as the

--- a/specs/plans/2026-08-26-detached-declared-ingress.md
+++ b/specs/plans/2026-08-26-detached-declared-ingress.md
@@ -1,5 +1,8 @@
 # Detached declared ingress
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 **Status: IN PROGRESS**
 
 Issue #2901 identified a lifecycle gap: TCP ingress has to be declared before

--- a/specs/plans/2026-08-26-detached-declared-ingress.md
+++ b/specs/plans/2026-08-26-detached-declared-ingress.md
@@ -1,0 +1,22 @@
+# Detached declared ingress
+
+**Status: IN PROGRESS**
+
+Issue #2901 identified a lifecycle gap: TCP ingress has to be declared before
+boot, but the CLI rejected the only pre-boot declaration flag when the machine
+was detached. The ingress listener belongs to the persistent machine runtime,
+not to the foreground command, so detaching does not weaken the signed-plan
+boundary or require the retired dynamic-forwarding verb.
+
+## Delivery
+
+- [x] Permit `machine run --detach --port HOST:GUEST` while retaining the
+      existing conflicts with transient JSON, TTY, interactive, and entrypoint
+      modes.
+- [x] Pin persistent-mode resolution and post-start ID output for the combined
+      flags in the CLI parser regression.
+- [x] Update the Obscura service example to declare ingress on its detached
+      launch and reject reintroduction of `machine forward`.
+- [x] Prove focused tests, formatting, workspace Clippy, and the relevant CLI
+      test suite are green.
+- [ ] Merge through the queue and confirm issue #2901 closes from the PR.


### PR DESCRIPTION
Fixes #2901.

Permit machine run --detach --port HOST:GUEST. The ingress declaration is signed before boot and owned by the persistent machine runtime, so detaching the foreground CLI does not weaken admission or require the retired machine forward verb.

The parser regression verifies persistent-mode resolution and detached ID output. The Obscura example now declares port 9222 before its detached boot, with a test preventing the retired dynamic-forwarding command from returning.

Validation:
- 150 machine command tests passed
- 4 Obscura example tests passed
- cargo clippy -p mvm-cli --all-targets -- -D warnings
- pre-commit workspace all-target Clippy passed
- cargo fmt --all -- --check