### PR TITLE
perf(admission): stop syncing reconstructible caches

### DIFF
--- a/crates/mvm-hostd/src/audit/decisions.rs
+++ b/crates/mvm-hostd/src/audit/decisions.rs
@@ -26,7 +26,7 @@ use anyhow::{Context, Result};
 use ed25519_dalek::VerifyingKey;
 use mvm_contract::provenance::{DecisionId, DecisionRecord, DecisionScenario};
 
-use crate::audit::emitter::{AtomicSyncState, write_atomic, write_atomic_batched};
+use crate::audit::emitter::write_atomic_unsynced;
 use crate::supervisor::audit_file::{flock_exclusive, verify_audit_chain_entries};
 
 /// File-backed content-addressed store for one tenant's decision records.
@@ -72,24 +72,10 @@ impl DecisionStore {
     /// Verifies the content-address before writing so a corrupted or
     /// tampered record cannot enter the cache.
     pub fn put(&self, record: &DecisionRecord) -> Result<DecisionId> {
-        self.put_inner(record, None)
+        self.put_inner(record)
     }
 
-    /// Cache a decision while joining its stable-storage wait to an enclosing
-    /// admission durability batch.
-    pub(crate) fn put_batched(
-        &self,
-        record: &DecisionRecord,
-        state: &AtomicSyncState,
-    ) -> Result<DecisionId> {
-        self.put_inner(record, Some(state))
-    }
-
-    fn put_inner(
-        &self,
-        record: &DecisionRecord,
-        state: Option<&AtomicSyncState>,
-    ) -> Result<DecisionId> {
+    fn put_inner(&self, record: &DecisionRecord) -> Result<DecisionId> {
         let _guard = self.lock()?;
         if !record.verify_id() {
             anyhow::bail!("decision record id does not match its body");
@@ -98,11 +84,10 @@ impl DecisionStore {
         let path = self.path_for(&id);
         if !path.exists() {
             let bytes = serde_json::to_vec_pretty(record).context("serializing decision record")?;
-            match state {
-                Some(state) => write_atomic_batched(&path, &bytes, state),
-                None => write_atomic(&path, &bytes),
-            }
-            .context("writing decision record")?;
+            // The chain-signed `decision_record` event is authoritative and
+            // this content-addressed file can be rebuilt from it. Publish the
+            // cache atomically without extending admission's durability wait.
+            write_atomic_unsynced(&path, &bytes).context("writing decision record")?;
         }
         Ok(id)
     }

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -66,7 +66,9 @@ pub(crate) use atomic_sync::AtomicSyncState;
 use atomic_sync::atomic_sync_is_batched;
 
 mod atomic_write;
-pub(crate) use atomic_write::{write_atomic, write_atomic_batched, write_atomic_unsynced};
+#[cfg(test)]
+pub(crate) use atomic_write::write_atomic_batched;
+pub(crate) use atomic_write::{write_atomic, write_atomic_unsynced};
 
 mod session_events;
 
@@ -643,7 +645,7 @@ impl AuditEmitter {
 
         if self.decisions_enabled
             && let Some(store) = self.decision_store_for_tenant(&plan.tenant.0)
-            && let Err(e) = store.put_batched(&record, &self.atomic_sync_state)
+            && let Err(e) = store.put(&record)
         {
             tracing::warn!(
                 decision_id = %record.decision_id.0,
@@ -1325,7 +1327,7 @@ impl AuditEmitter {
             )
         })?;
         let mut emitted_id = None;
-        store.append_chained_batched(&self.atomic_sync_state, |prev| {
+        store.append_chained(|prev| {
             receipt.prev_receipt_id = prev;
             receipt.receipt_id = receipt.compute_id().context("computing receipt id")?;
             emitted_id = Some(receipt.receipt_id.clone());
@@ -1363,7 +1365,7 @@ impl AuditEmitter {
         // of the receipt id and of the signed bytes, so reading the head out
         // here and appending afterwards would let a concurrent emitter claim
         // the same parent between the two.
-        let appended = store.append_chained_batched(&self.atomic_sync_state, |prev| {
+        let appended = store.append_chained(|prev| {
             receipt.prev_receipt_id = prev;
             receipt.receipt_id = receipt.compute_id().context("computing receipt id")?;
             let signed_at = chrono::Utc::now().to_rfc3339();
@@ -1499,6 +1501,54 @@ mod tests {
         let after = dir.path().join("after.json");
         write_atomic(&after, b"after").unwrap();
         assert_eq!(std::fs::read(after).unwrap(), b"after");
+    }
+
+    #[test]
+    fn derived_caches_do_not_extend_the_admission_durability_barrier() {
+        use mvm_contract::provenance::{
+            ActorRef, AttestationBinding, DecisionCategory, DecisionOutcome, DecisionRecordBuilder,
+        };
+
+        let audit_dir = tempfile::tempdir().unwrap();
+        let decisions_dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::from_bytes(&[34; 32]);
+        let signer_pubkey = hex::encode(key.verifying_key().to_bytes());
+        let emitter = AuditEmitter::with_dir(key, audit_dir.path())
+            .unwrap()
+            .with_receipts()
+            .with_decisions_dir(decisions_dir.path());
+        let plan = fixture_plan("local", "plan-cache-durability");
+        let record = DecisionRecordBuilder::new()
+            .version(1)
+            .category(DecisionCategory::Admission)
+            .actor(ActorRef {
+                principal: "host:builder".to_string(),
+                key_id: "host-signer-1".to_string(),
+                key_role: None,
+            })
+            .reasoning("grant ceiling satisfied")
+            .outcome(DecisionOutcome::Approved)
+            .timestamp("2026-08-26T00:00:00Z".to_string())
+            .attestation(AttestationBinding {
+                plan_id: Some(plan.plan_id.0.clone()),
+                signer_pubkey,
+                ..AttestationBinding::default()
+            })
+            .build()
+            .expect("valid record");
+
+        emitter
+            .batched(|| {
+                emitter.emit_admitted(&plan, "host:test")?;
+                emitter.emit_decision_record(&plan, record)?;
+                assert_eq!(
+                    atomic_sync::deferred_path_count(&emitter.atomic_sync_state),
+                    0,
+                    "receipt and decision caches are reconstructible from the audit chain and must not add stable-storage waits to admission"
+                );
+                Ok(())
+            })
+            .expect("the audit-chain barrier remains durable");
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/emitter/atomic_sync.rs
+++ b/crates/mvm-hostd/src/audit/emitter/atomic_sync.rs
@@ -88,6 +88,16 @@ pub(super) fn defer_atomic_sync(state: &AtomicSyncState, path: &Path) -> bool {
     true
 }
 
+#[cfg(test)]
+pub(super) fn deferred_path_count(state: &AtomicSyncState) -> usize {
+    state
+        .paths
+        .lock()
+        .expect("atomic sync state poisoned")
+        .as_ref()
+        .map_or(0, HashSet::len)
+}
+
 pub(super) fn sync_path(path: &Path) -> std::io::Result<()> {
     std::fs::OpenOptions::new()
         .append(true)

--- a/crates/mvm-hostd/src/audit/emitter/atomic_write.rs
+++ b/crates/mvm-hostd/src/audit/emitter/atomic_write.rs
@@ -23,6 +23,7 @@ pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
 
 /// Atomically replace `path`, joining its stable-storage wait to `state` when
 /// the caller has an active durability batch.
+#[cfg(test)]
 pub(crate) fn write_atomic_batched(
     path: &Path,
     bytes: &[u8],

--- a/crates/mvm-hostd/src/audit/plan_persist.rs
+++ b/crates/mvm-hostd/src/audit/plan_persist.rs
@@ -14,7 +14,9 @@
 //! degrades the per-VM audit chain (lifecycle verbs will not be
 //! plan-bound) but must not block the launch — boot succeeded; the
 //! VM is running. Callers log a warn and continue, mirroring the
-//! `audit emit_*` policy in `audit_chain.rs`.
+//! `audit emit_*` policy in `audit_chain.rs`. The chain-signed admission
+//! record is the durable source of truth, so this reconstructible lifecycle
+//! cache is published atomically without adding its own pre-boot fsync.
 
 use anyhow::{Context, Result, bail};
 use mvm_core::plan::ExecutionPlan;
@@ -67,7 +69,6 @@ pub fn write_plan(vm_name: &str, plan: &ExecutionPlan) -> Result<PathBuf> {
             .with_context(|| format!("opening {} for write", tmp.display()))?;
         f.write_all(&bytes)
             .with_context(|| format!("writing plan to {}", tmp.display()))?;
-        f.sync_all().ok();
     }
     // Force-tighten in case the open()'s mode arg was honored loosely
     // under an odd umask; readers refuse loose perms below.

--- a/crates/mvm-hostd/src/audit/receipt_store.rs
+++ b/crates/mvm-hostd/src/audit/receipt_store.rs
@@ -32,9 +32,7 @@ use anyhow::{Context, Result};
 use mvm_core::receipt::SignedExecutionReceipt;
 use serde::{Deserialize, Serialize};
 
-use crate::audit::emitter::{
-    AtomicSyncState, write_atomic, write_atomic_batched, write_atomic_unsynced,
-};
+use crate::audit::emitter::write_atomic_unsynced;
 use crate::supervisor::audit_file::flock_exclusive;
 
 /// Head file content: the chain tip for one tenant's receipt store.
@@ -96,19 +94,10 @@ impl ReceiptStore {
     where
         F: FnOnce(Option<String>) -> Result<SignedExecutionReceipt>,
     {
-        self.append_chained_inner(None, build)
+        self.append_chained_inner(build)
     }
 
-    /// Append with the receipt's durability wait joined to an enclosing
-    /// admission batch. The batch still completes before admission returns.
-    pub(crate) fn append_chained_batched<F>(&self, state: &AtomicSyncState, build: F) -> Result<u64>
-    where
-        F: FnOnce(Option<String>) -> Result<SignedExecutionReceipt>,
-    {
-        self.append_chained_inner(Some(state), build)
-    }
-
-    fn append_chained_inner<F>(&self, state: Option<&AtomicSyncState>, build: F) -> Result<u64>
+    fn append_chained_inner<F>(&self, build: F) -> Result<u64>
     where
         F: FnOnce(Option<String>) -> Result<SignedExecutionReceipt>,
     {
@@ -122,10 +111,11 @@ impl ReceiptStore {
 
         let bytes =
             serde_json::to_vec_pretty(&receipt).context("serializing signed execution receipt")?;
-        match state {
-            Some(state) => write_atomic_batched(&receipt_path, &bytes, state)?,
-            None => write_atomic(&receipt_path, &bytes)?,
-        }
+        // Receipts are a reconstructible view over the durable audit chain,
+        // not a control that authorizes the workload. Keep atomic publication
+        // for concurrent readers, but do not add a second stable-storage wait
+        // to the admission boundary.
+        write_atomic_unsynced(&receipt_path, &bytes)?;
 
         head.last_receipt_id = Some(receipt.payload.receipt_id.clone());
         self.write_head(&head)?;

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -560,6 +560,15 @@ for detailed scope and acceptance criteria.
       instead of the retired dynamic-forwarding verb. Validation and merge are
       in progress.
 
+- [ ] **Admission cache durability boundary**
+      (`specs/plans/2026-08-26-admission-cache-durability.md`, issue #2900).
+      The chain-signed admission event retains the one fail-closed durability
+      barrier that gates boot. Receipt files, decision records, and per-machine
+      `plan.json` remain atomically published, permission-restricted derived
+      views, but no longer add independent stable-storage waits before launch.
+      Focused recovery, rebuild, permissions, and barrier-count tests plus
+      package Clippy are green; merge is pending.
+
 - [x] **`.mvmev` offline verifiability**
       (`specs/plans/2026-08-25-mvmev-offline-verifiability.md`, issue #2863).
       The format-level gap is complete: schema version 1 now normatively names

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,15 @@
 
 ## In progress
 
+- [ ] **Admission cache durability boundary.**
+      `specs/plans/2026-08-26-admission-cache-durability.md`.
+      Preserve the chain-signed admission record's fail-closed durability
+      barrier while removing independent pre-boot fsync waits from the
+      reconstructible receipt, decision, and per-machine plan caches. Atomic
+      publication, permissions, recovery, and rebuild behavior remain covered;
+      focused tests and package Clippy are green. Remaining: merge the repair
+      and close issue #2900 through the merged PR.
+
 - [x] **Site QEMU-WASM release artifact.**
       `specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md`.
       Move the expensive browser QEMU pack build from every Cloudflare Pages

--- a/specs/plans/2026-08-26-admission-cache-durability.md
+++ b/specs/plans/2026-08-26-admission-cache-durability.md
@@ -1,0 +1,27 @@
+# Admission cache durability boundary
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Status: IN PROGRESS**
+
+Issue #2900 measured admission spending nearly all of its time in stable-storage
+barriers. The chain-signed audit log is the authorization record and must remain
+durable before boot. Receipt files, decision files, and the per-machine
+`plan.json` are derived lifecycle views that can be reconstructed from that
+chain; they must publish atomically for readers, but they must not each add an
+independent pre-boot durability wait.
+
+## Delivery
+
+- [x] Add a regression proving receipt and decision caches contribute no paths
+      to the admission audit batch's stable-storage barrier.
+- [x] Keep the chain-signed audit event authoritative and preserve its existing
+      fail-closed durability barrier.
+- [x] Publish receipt, decision, and lifecycle-plan caches atomically without
+      independent `fsync` waits.
+- [x] Prove receipt recovery, decision rebuild, plan roundtrip and permissions,
+      the admission-barrier regression, formatting, and package Clippy are
+      green.
+- [ ] Merge the repair through the merge queue and confirm issue #2900 closes
+      from the merged PR.


### PR DESCRIPTION
Preserve the chain-signed audit record's fail-closed durability barrier while publishing receipt, decision, and per-machine plan caches atomically without independent pre-boot fsync waits.

Focused recovery, rebuild, permissions, barrier-count tests, formatting, the declared-backing invariant, package Clippy, and workspace all-target Clippy pass.

Fixes #2900