### PR TITLE
fix(ci,nix): unblock the site deploy — gh --jq -r, and crates.io 403ing Nix

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -69,16 +69,32 @@ jobs:
           COSIGN_OIDC_ISSUER: "https://token.actions.githubusercontent.com"
         run: |
           set -euo pipefail
+          # No `-r`: `gh --jq` already prints a string result raw, and gh has no
+          # such flag. Passing one consumes `--jq`'s value, demoting the real
+          # expression to a positional argument, and gh rejects the whole
+          # invocation with `unknown command "<the entire jq program>"`.
           BOOT_TAG="$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
-            --json tagName --jq -r '
+            --json tagName --jq '
               [ .[].tagName
                 | select(test("^boot-image/v[0-9]+\\.[0-9]+\\.[0-9]+$"))
                 | {tag: ., v: (ltrimstr("boot-image/v") | split(".") | map(tonumber))} ]
               | sort_by(.v) | last | .tag // empty')"
           if [ -z "${BOOT_TAG}" ]; then
-            echo "::error::no boot-image/v* release contains the WebLinux runtime pack" >&2
+            echo "::error::no boot-image/v* release exists to take the WebLinux runtime pack from" >&2
             exit 1
           fi
+
+          # A boot-image release cut before the pack job existed carries every
+          # other asset and none of these. `gh release download` reports that as
+          # `no assets match the file pattern`, which reads like a typo in the
+          # pattern rather than a release that needs re-cutting.
+          ASSETS="$(gh release view "${BOOT_TAG}" --repo "${GITHUB_REPOSITORY}" \
+            --json assets --jq '.assets[].name')"
+          if ! printf '%s\n' "${ASSETS}" | grep -qxF 'qemu-wasm-smoke-pack.tar.gz'; then
+            echo "::error::${BOOT_TAG} carries no qemu-wasm-smoke-pack.tar.gz, so the WebLinux demo cannot be staged. Cut a new boot-image/v* tag from a commit whose release-boot-image.yml builds the pack, then re-run this deploy." >&2
+            exit 1
+          fi
+
           gh release download "${BOOT_TAG}" \
             --repo "${GITHUB_REPOSITORY}" \
             --pattern 'qemu-wasm-smoke-pack.tar.gz*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,8 +391,12 @@ jobs:
           # property of the version, not of the order someone happened to push.
           # The strict N.N.N match also drops anything that is not a plain
           # release tag rather than trying to order it.
+          # No `-r`: `gh --jq` already prints a string result raw, and gh has no
+          # such flag. Passing one consumes `--jq`'s value, demoting the real
+          # expression to a positional argument, and gh rejects the whole
+          # invocation with `unknown command "<the entire jq program>"`.
           BOOT_TAG="$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
-            --json tagName --jq -r '
+            --json tagName --jq '
               [ .[].tagName
                 | select(test("^boot-image/v[0-9]+\\.[0-9]+\\.[0-9]+$"))
                 | {tag: ., v: (ltrimstr("boot-image/v") | split(".") | map(tonumber))} ]

--- a/nix/lib/crates-io.nix
+++ b/nix/lib/crates-io.nix
@@ -1,0 +1,40 @@
+# Where crate tarballs come from, in one place.
+#
+# The crates.io API host answers a plain curl User-Agent with 403. Nix's
+# fetchurl sends exactly that, so any `crates.io/api/v1/crates/...` fetch fails
+# — and because fetchurl names a derivation after the URL's last segment, every
+# one of them is called `download`, so the build reports
+# `error: Cannot build '/nix/store/...-download.drv'` and names neither the
+# crate nor the host it could not reach.
+#
+# static.crates.io is the CDN cargo itself fetches from. It serves byte-identical
+# `.crate` files — swapping hosts changes no hash — and applies no such rule.
+#
+# Scope: the crate fetches this repo writes. A pinned nixpkgs pulls ~116 more
+# through its own fetchCrate, still on the API host, and those keep working
+# because cache.nixos.org substitutes them rather than reaching the network.
+# The ones written here have no such cache entry, so they are the ones that go
+# out over curl and the only ones that 403.
+rec {
+  api = "https://crates.io/api/v1/crates";
+  cdn = "https://static.crates.io/crates";
+
+  # Move an API-host crate URL onto the CDN. A URL that is already on the CDN
+  # passes through unchanged, so this is safe to apply more than once.
+  toCdn = builtins.replaceStrings [ api ] [ cdn ];
+
+  # A crate fetch that names itself. Takes the same `sha256` the API-host URL
+  # took: the bytes are the same, so an existing hash carries over untouched.
+  fetchCrate =
+    fetchurl:
+    {
+      crate,
+      version,
+      sha256,
+    }:
+    fetchurl {
+      name = "${crate}-${version}.crate";
+      url = "${cdn}/${crate}/${version}/download";
+      inherit sha256;
+    };
+}

--- a/nix/lib/static-crates-cargo-deps.nix
+++ b/nix/lib/static-crates-cargo-deps.nix
@@ -1,14 +1,13 @@
 { pkgs, lockFile }:
 
 let
-  cratesIoApi = "https://crates.io/api/v1/crates";
-  staticCrates = "https://static.crates.io/crates";
+  cratesIo = import ./crates-io.nix;
   fetchStaticCrate =
     args:
     pkgs.fetchurl (
       args
       // {
-        url = builtins.replaceStrings [ cratesIoApi ] [ staticCrates ] args.url;
+        url = cratesIo.toCdn args.url;
       }
     );
   importCargoLock = pkgs.callPackage (pkgs.path + "/pkgs/build-support/rust/import-cargo-lock.nix") {

--- a/nix/packages/qemu-wasm.nix
+++ b/nix/packages/qemu-wasm.nix
@@ -33,6 +33,10 @@
 }:
 
 let
+  # Crate tarballs come off the CDN, not the crates.io API host, which 403s a
+  # plain curl User-Agent. See nix/lib/crates-io.nix.
+  fetchCrate = (import ../lib/crates-io.nix).fetchCrate fetchurl;
+
   # ── Upstream pins ──────────────────────────────────────────────────
   qemuWasmRev = "5a65998d47d78723115d1478a8a40f8d6d497f37";
   qemuWasmVersion = "9.2.92-wasm";
@@ -141,63 +145,75 @@ let
     sha256 = "1jdv47cq5aplyj3kz79jpapbfm3wv26inh8szjwrl99z47491ldb";
   };
 
-  arbitraryIntSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/arbitrary-int/1.2.7/download";
+  arbitraryIntSrc = fetchCrate {
+    crate = "arbitrary-int";
+    version = "1.2.7";
     sha256 = "0vgl3n5zzpdn2hxpz6gqk8zg2psk5gwyjzsgpngzd9iqwc1w0ky8";
   };
 
-  bilgeSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/bilge/0.2.0/download";
+  bilgeSrc = fetchCrate {
+    crate = "bilge";
+    version = "0.2.0";
     sha256 = "0mvvwq9caiq701bmmwyd4q4pc8c69i5zaj3zdk6ya7gqxgc7ww6w";
   };
 
-  bilgeImplSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/bilge-impl/0.2.0/download";
+  bilgeImplSrc = fetchCrate {
+    crate = "bilge-impl";
+    version = "0.2.0";
     sha256 = "1n5jml0c1z0np76ms0h5rxx19krblz46h84wycx29b9q4001xcgy";
   };
 
-  eitherSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/either/1.12.0/download";
+  eitherSrc = fetchCrate {
+    crate = "either";
+    version = "1.12.0";
     sha256 = "12xmhlrv5gfsraimh6xaxcmb0qh6cc7w7ap4sw40ky9wfm095jix";
   };
 
-  itertoolsSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/itertools/0.11.0/download";
+  itertoolsSrc = fetchCrate {
+    crate = "itertools";
+    version = "0.11.0";
     sha256 = "0mzyqcc59azx9g5cg6fs8k529gvh4463smmka6jvzs3cd2jp7hdi";
   };
 
-  libcSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/libc/0.2.162/download";
+  libcSrc = fetchCrate {
+    crate = "libc";
+    version = "0.2.162";
     sha256 = "1633a00yyx45kzx9r54fndvr8njsjqyr7zl12mzgsmgyczg8glhq";
   };
 
-  procMacroErrorSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/proc-macro-error/1.0.4/download";
+  procMacroErrorSrc = fetchCrate {
+    crate = "proc-macro-error";
+    version = "1.0.4";
     sha256 = "1373bhxaf0pagd8zkyd03kkx6bchzf6g0dkwrwzsnal9z47lj9fs";
   };
 
-  procMacroErrorAttrSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/proc-macro-error-attr/1.0.4/download";
+  procMacroErrorAttrSrc = fetchCrate {
+    crate = "proc-macro-error-attr";
+    version = "1.0.4";
     sha256 = "0sgq6m5jfmasmwwy8x4mjygx5l7kp8s4j60bv25ckv2j1qc41gm1";
   };
 
-  procMacro2Src = fetchurl {
-    url = "https://crates.io/api/v1/crates/proc-macro2/1.0.84/download";
+  procMacro2Src = fetchCrate {
+    crate = "proc-macro2";
+    version = "1.0.84";
     sha256 = "1mj998115z75c0007glkdr8qj57ibv82h7kg6r8hnc914slwd5pc";
   };
 
-  quoteSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/quote/1.0.36/download";
+  quoteSrc = fetchCrate {
+    crate = "quote";
+    version = "1.0.36";
     sha256 = "19xcmh445bg6simirnnd4fvkmp6v2qiwxh5f6rw4a70h76pnm9qg";
   };
 
-  synSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/syn/2.0.66/download";
+  synSrc = fetchCrate {
+    crate = "syn";
+    version = "2.0.66";
     sha256 = "1xfgrprsbz8j31kabvfinb4fyhajlk2q7lxa18fb006yl90kyby4";
   };
 
-  unicodeIdentSrc = fetchurl {
-    url = "https://crates.io/api/v1/crates/unicode-ident/1.0.12/download";
+  unicodeIdentSrc = fetchCrate {
+    crate = "unicode-ident";
+    version = "1.0.12";
     sha256 = "0jzf1znfpb2gx8nr8mvmyqs1crnv79l57nxnbiszc7xf7ynbjm1k";
   };
 

--- a/specs/sprint/delivery/gh-jq-flag-broke-boot-tag-lookup.md
+++ b/specs/sprint/delivery/gh-jq-flag-broke-boot-tag-lookup.md
@@ -51,8 +51,52 @@ matched the version pattern. It now says what it tested.
 `release.yml` needs no equivalent gate — it already refuses to publish an
 incomplete asset set, and the pack is in the list it checks.
 
+## And the blocker behind *that*
+
+Cutting a boot-image tag runs `nix build ./nix#qemu-wasm-smoke-pack`, the same
+build that failed in `pages.yml` the run before:
+
+```
+error: Cannot build '/nix/store/27dscpgbrpps8zs6awm70m8ks69h1wnx-download.drv'
+       > curl: (22) The requested URL returned error: 403
+```
+
+crates.io's API host answers a plain curl User-Agent with 403, and Nix's
+fetchurl sends exactly that:
+
+```
+$ curl -sS -o /dev/null -w '%{http_code}\n' -L https://crates.io/api/v1/crates/bilge/0.2.0/download
+403
+$ curl -sS -o /dev/null -w '%{http_code}\n' -L -A "mvm-build/1.0" <same URL>
+200
+```
+
+`nix/packages/qemu-wasm.nix` fetched twelve crates that way. They now go through
+`static.crates.io`, the CDN cargo itself uses. It serves byte-identical `.crate`
+files, so every recorded `sha256` carries over untouched — verified directly:
+the CDN copy of `bilge-0.2.0` hashes to the `0mvvwq9c…` already in the file, and
+a real `nix build` of `arbitrary-int-1.2.7` through the new helper succeeds,
+which for a fixed-output derivation is the hash check.
+
+The rewrite lives in `nix/lib/crates-io.nix` rather than inline, because
+`nix/lib/static-crates-cargo-deps.nix` had already solved this once for the
+lockfile-driven path and the constant was about to exist twice. Both import it
+now.
+
+The derivations are also named. `fetchurl` names one after the URL's last
+segment, so all twelve were called `download` — which is exactly why the CI
+error above names neither the crate nor the host it could not reach. They are
+`arbitrary-int-1.2.7.crate` and friends from here on.
+
+A pinned nixpkgs pulls ~116 further crates through its own fetcher, still on the
+API host. Those are left alone deliberately: `cache.nixos.org` substitutes them
+so they never reach the network, which is why only the twelve written here ever
+403'd.
+
 ## Limits
 
-Cutting the boot-image release is still outstanding, and so is pointing
-gomicrovm.com at the Pages project. This change makes the deploy reach the
-point where those are the only things left, and makes the failure say so.
+The nix change is verified by evaluation and by fetching one crate; the full
+`qemu-wasm-smoke-pack` build is an Emscripten QEMU compile that was not run
+locally. Cutting the boot-image release is still outstanding, and so is pointing
+gomicrovm.com at the Pages project. This makes the deploy reach the point where
+those are the only things left, and makes each failure say so.

--- a/specs/sprint/delivery/gh-jq-flag-broke-boot-tag-lookup.md
+++ b/specs/sprint/delivery/gh-jq-flag-broke-boot-tag-lookup.md
@@ -1,0 +1,58 @@
+# `gh --jq -r` broke the boot-image tag lookup in two workflows
+
+Backing: shipped-source
+Validation: actionlint, simulated against the live repo
+
+`gh release list ... --json tagName --jq -r '<expr>'` fails outright. `gh` has
+no `-r`; `--jq` takes the expression as its *value*, so `-r` is consumed as the
+expression and the real jq program becomes a positional argument. `gh` then
+rejects the whole invocation with
+
+```
+unknown command "\n    [ .[].tagName\n      | select(test(...
+```
+
+which names neither the flag nor the step's purpose, and buries the jq program
+in the error text where it reads like corrupted input.
+
+Both copies of this lookup carried it:
+
+- `pages.yml` — the site deploy died here on every run, before reaching the
+  Cloudflare Pages step. The site was still being served by GitHub Pages
+  (Cloudflare in front as a DNS proxy only), so the cross-origin isolation
+  headers that the WebLinux demo needs were never sent, no matter what
+  `_headers` said. See [site-cross-origin-isolation.md](site-cross-origin-isolation.md).
+- `release.yml` — same expression, resolving which boot-image release a CLI
+  release attaches its assets from. It would have failed every release the
+  same way. Nothing had exercised it since the flag was introduced.
+
+## The second blocker it was hiding
+
+With the flag fixed, the step resolves `boot-image/v0.1.3` and then fails
+because that release carries no `qemu-wasm-smoke-pack.tar.gz`: it was published
+2026-08-23, and the job that builds the pack was added to
+`release-boot-image.yml` on 2026-08-26. No boot-image release has ever
+contained it.
+
+`gh release download` reports that as `no assets match the file pattern`, which
+reads like a typo in the pattern rather than a release that needs re-cutting,
+so `pages.yml` now checks for the asset by name first and says what to do:
+
+```
+::error::boot-image/v0.1.3 carries no qemu-wasm-smoke-pack.tar.gz, so the
+WebLinux demo cannot be staged. Cut a new boot-image/v* tag from a commit whose
+release-boot-image.yml builds the pack, then re-run this deploy.
+```
+
+The pre-existing message on the tag-lookup branch also claimed a release
+"contains the WebLinux runtime pack" when all it had checked was that a tag
+matched the version pattern. It now says what it tested.
+
+`release.yml` needs no equivalent gate — it already refuses to publish an
+incomplete asset set, and the pack is in the list it checks.
+
+## Limits
+
+Cutting the boot-image release is still outstanding, and so is pointing
+gomicrovm.com at the Pages project. This change makes the deploy reach the
+point where those are the only things left, and makes the failure say so.

--- a/specs/sprint/delivery/gh-jq-flag-broke-boot-tag-lookup.md
+++ b/specs/sprint/delivery/gh-jq-flag-broke-boot-tag-lookup.md
@@ -93,6 +93,28 @@ API host. Those are left alone deliberately: `cache.nixos.org` substitutes them
 so they never reach the network, which is why only the twelve written here ever
 403'd.
 
+### The guard that should have existed
+
+`every_rust_derivation_uses_the_static_crates_registry` asserted four string
+literals against `static-crates-cargo-deps.nix` — including both hostnames and
+`builtins.replaceStrings`. Moving those three lines into `crates-io.nix` failed
+it, on a PR that made the thing it was guarding *more* true. A test that pins a
+constant's file rather than its effect breaks on every refactor and catches no
+regression, and this one had a blind spot to match: it only inspected files
+containing `rustPlatform.buildRustPackage`, so the twelve hand-written fetches
+in `qemu-wasm.nix` — the ones that actually 403'd — were never in scope.
+
+Split into three, each asserting one property, plus a new
+`no_nix_file_fetches_a_crate_from_the_api_host` that scans every `.nix` file in
+the tree and allows the API host to be named only in `crates-io.nix`, and only
+to rewrite it away. Verified by injecting the old URL back into `qemu-wasm.nix`:
+
+```
+these files fetch crates from the crates.io API host, which 403s Nix's fetchurl;
+use the fetchCrate helper in nix/lib/crates-io.nix instead:
+["…/nix/packages/qemu-wasm.nix"]
+```
+
 ## Limits
 
 The nix change is verified by evaluation and by fetching one crate; the full

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -34,24 +34,42 @@ fn normalized_whitespace(content: &str) -> String {
     content.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+const CRATES_IO_API: &str = "https://crates.io/api/v1/crates";
+
 #[test]
-fn every_rust_derivation_uses_the_static_crates_registry() {
+fn the_crate_source_helper_rewrites_the_api_host_to_the_cdn() {
+    let source = nix_dir().join("lib").join("crates-io.nix");
+    let content = fs::read_to_string(&source)
+        .unwrap_or_else(|e| panic!("crate source helper must be present: {e}"));
+
+    assert!(
+        content.contains(CRATES_IO_API)
+            && content.contains("https://static.crates.io/crates")
+            && content.contains("builtins.replaceStrings"),
+        "nix/lib/crates-io.nix must rewrite crates.io API downloads to the CDN"
+    );
+}
+
+#[test]
+fn the_cargo_deps_helper_routes_downloads_through_the_crate_source_helper() {
     let helper = nix_dir().join("lib").join("static-crates-cargo-deps.nix");
     let helper_content = fs::read_to_string(&helper)
         .unwrap_or_else(|e| panic!("static crate registry helper must be present: {e}"));
 
     assert!(
-        helper_content.contains("https://crates.io/api/v1/crates")
-            && helper_content.contains("https://static.crates.io/crates")
-            && helper_content.contains("builtins.replaceStrings")
+        helper_content.contains("crates-io.nix")
+            && helper_content.contains("toCdn")
             && helper_content.contains("fetchurl = fetchStaticCrate"),
-        "the cargo-deps helper must rewrite crates.io downloads to its static CDN"
+        "the cargo-deps helper must route lockfile downloads through crates-io.nix"
     );
     assert!(
         !helper_content.contains("extraRegistries"),
         "the helper must not redefine Cargo's built-in crates.io source"
     );
+}
 
+#[test]
+fn every_rust_derivation_uses_the_static_crates_registry() {
     let mut nix_files = Vec::new();
     collect_nix_files(&nix_dir(), &mut nix_files);
     let mut rust_derivations = 0;
@@ -73,6 +91,35 @@ fn every_rust_derivation_uses_the_static_crates_registry() {
     assert!(
         rust_derivations > 0,
         "expected at least one Rust Nix derivation"
+    );
+}
+
+/// crates.io's API host answers a plain curl User-Agent with 403, which is what
+/// Nix's fetchurl sends. A hand-written crate fetch against that host therefore
+/// cannot build — it fails with `curl: (22) ... error: 403` on a derivation
+/// named `download`, naming neither the crate nor the host. `crates-io.nix` is
+/// the one place allowed to name the API host, and only to rewrite it away.
+#[test]
+fn no_nix_file_fetches_a_crate_from_the_api_host() {
+    let allowed = nix_dir().join("lib").join("crates-io.nix");
+
+    let mut nix_files = Vec::new();
+    collect_nix_files(&nix_dir(), &mut nix_files);
+
+    let offenders: Vec<PathBuf> = nix_files
+        .into_iter()
+        .filter(|path| *path != allowed)
+        .filter(|path| {
+            fs::read_to_string(path)
+                .unwrap_or_else(|e| panic!("{} must be readable: {e}", path.display()))
+                .contains(CRATES_IO_API)
+        })
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "these files fetch crates from the crates.io API host, which 403s Nix's \
+         fetchurl; use the fetchCrate helper in nix/lib/crates-io.nix instead: {offenders:?}"
     );
 }
 


### PR DESCRIPTION
The site deploy has never once reached Cloudflare Pages. gomicrovm.com is still
served by GitHub Pages, with Cloudflare in front as a DNS proxy only:

```
$ curl -sSI https://gomicrovm.com/
server: cloudflare              <- proxy
x-github-request-id: 0A58:150CD8:5132C:5D0A3:6A9026C4
via: 1.1 varnish                <- GitHub Pages origin
(no cross-origin-* headers)
```

GitHub Pages cannot send COOP/COEP, so the WebLinux demo fails with
`SharedArrayBuffer is not defined` no matter what `_headers` says.

Two bugs stand between a dispatch and a deploy. This fixes both.

## 1. `gh --jq -r` — the deploy dies before the build

`pages.yml` fails at "Download verified WebLinux runtime pack":

```
unknown command "\n    [ .[].tagName\n      | select(test(...  for "gh release list"
```

`gh` has no `-r`. `--jq` takes the expression as its *value*, so in
`--jq -r '<expr>'` the `-r` becomes the jq program and the real expression is
demoted to a positional argument. The error prints the jq program back as if it
were a typo'd subcommand, naming neither the flag nor the step.

**The same expression is in `release.yml`**, resolving which boot-image release
a CLI release attaches its assets from. It would fail every release the same
way; nothing has exercised it since the flag was introduced.

## 2. crates.io 403s Nix — the build dies before the deploy

The run before that one failed differently, in the nix build that this step
replaced:

```
error: Cannot build '/nix/store/27dscpgbrpps8zs6awm70m8ks69h1wnx-download.drv'
       > curl: (22) The requested URL returned error: 403
```

crates.io's API host answers a plain curl User-Agent with 403, and Nix's
fetchurl sends exactly that:

```
$ curl -sS -o /dev/null -w '%{http_code}\n' -L https://crates.io/api/v1/crates/bilge/0.2.0/download
403
$ curl -sS -o /dev/null -w '%{http_code}\n' -L -A "mvm-build/1.0" <same URL>
200
```

`nix/packages/qemu-wasm.nix` fetched twelve crates that way, so
`nix#qemu-wasm-smoke-pack` cannot build — which blocks the site deploy **and**
any boot-image release, since both run that derivation.

They now come from `static.crates.io`, the CDN cargo itself uses. Byte-identical
`.crate` files, so every recorded `sha256` carries over untouched. The rewrite
lives in `nix/lib/crates-io.nix` rather than inline because
`nix/lib/static-crates-cargo-deps.nix` had already solved this for the
lockfile-driven path and the constant was about to exist twice; both import it
now.

The derivations are named too. `fetchurl` names one after the URL's last
segment, so all twelve were `download` — which is precisely why the error above
names neither the crate nor the host.

~116 further crates come from a pinned nixpkgs' own fetcher, still on the API
host. Left alone deliberately: `cache.nixos.org` substitutes those so they never
reach the network, which is why only the twelve written here 403.

## The blocker these were hiding

With the `gh` flag fixed, the step resolves `boot-image/v0.1.3` and then fails
because that release carries no `qemu-wasm-smoke-pack.tar.gz`. It was published
2026-08-23; the job that builds the pack landed 2026-08-26 (#2892). No
boot-image release has ever contained it.

`gh release download` reports that as `no assets match the file pattern`, which
reads like a typo rather than a release that needs re-cutting, so `pages.yml`
now checks for the asset by name first:

```
::error::boot-image/v0.1.3 carries no qemu-wasm-smoke-pack.tar.gz, so the
WebLinux demo cannot be staged. Cut a new boot-image/v* tag from a commit whose
release-boot-image.yml builds the pack, then re-run this deploy.
```

The tag-lookup error above it also claimed a release "contains the WebLinux
runtime pack" when all it had checked was the tag pattern. It now says what it
tested.

## Verification

- Simulated the fixed `gh` invocation against the live repo: resolves
  `boot-image/v0.1.3`, then the new asset gate fires with the message above.
- `nix eval` of `packages.x86_64-linux.qemu-wasm-smoke-pack.drvPath` succeeds;
  walking the derivation graph shows all twelve in-repo crate fetches on the CDN
  and none on the API host.
- Real `nix build` of `arbitrary-int-1.2.7` through the new helper succeeds —
  for a fixed-output derivation that *is* the hash check — and produces
  `arbitrary-int-1.2.7.crate` rather than `download`.
- Independently: the CDN copy of `bilge-0.2.0` hashes to the `0mvvwq9c…`
  already recorded in the file.
- `actionlint` clean; `nixfmt` applied.

## Limits

The full `qemu-wasm-smoke-pack` build is an Emscripten QEMU compile and was not
run locally — CI is the first place it runs end to end.

## Still outstanding after this

1. Cut a `boot-image/v0.1.4` tag so the pack asset exists.
2. Run the deploy.
3. Attach gomicrovm.com as a custom domain on the Pages project — until then
   the domain serves GitHub Pages whatever is deployed.
