### PR TITLE
test(nextest): refuse to run on a nextest too old for the build layout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -4,6 +4,28 @@
 # recipe fails before running a single test with
 # `error: profile 'ci' not found`.
 
+# Refuse to run at all on a nextest too old for this toolchain's build layout.
+#
+# The pinned toolchain (rust-toolchain.toml) ships a cargo whose target
+# directory nests build artifacts as `target/debug/build/<pkg>/<hash>/out/`.
+# A nextest that predates that layout cannot associate the root package's
+# binary with its integration tests, so every one of them fails with
+# `CARGO_BIN_EXE_mvmctl is unset` — 43 test binaries, 308 tests, the entire
+# `mvmctl` CLI surface. Locally observed on 0.9.122; fine on 0.9.143.
+#
+# The reason this needs a floor rather than a note is that the failure is
+# indistinguishable from a broken working tree: the tests do not skip with a
+# warning, they fail with an error about an environment variable, which reads
+# as "my checkout is wrong" rather than "my tool is old". CI is unaffected —
+# it installs nextest through `taiki-e/install-action` with no pin and so
+# always gets a current one — which is exactly why this could rot locally for
+# a long time without a red lane anywhere.
+#
+# `required` is the oldest version verified against this layout, not a bisected
+# boundary; the true floor is somewhere between 0.9.122 and 0.9.143. Lower it
+# if someone establishes the real one.
+nextest-version = { required = "0.9.143" }
+
 [profile.default]
 # No retries, ever. A test that passes on the second attempt is a test
 # whose result carries no information, and a retry budget turns a real


### PR DESCRIPTION
A locally-installed nextest that predates this toolchain's target-directory layout silently loses the entire `mvmctl` CLI surface — **43 test binaries, 308 tests**.

## What happens

The pinned toolchain (`nightly-2026-08-25`) ships a cargo that nests build artifacts as `target/debug/build/<pkg>/<hash>/out/`. nextest 0.9.122 cannot associate the root package's binary with its integration tests under that layout, so every one of them fails with:

```
`CARGO_BIN_EXE_mvmctl` is unset
help: if this is running within a unit test, move it to an integration test
      to gain access to `CARGO_BIN_EXE_mvmctl`
```

`cargo test` runs the same binaries fine, which is what makes it confusing.

Verified against a real 0.9.122 built into a scratch prefix rather than inferred:

| nextest | `cargo nextest run -p mvmctl --tests` |
| --- | --- |
| 0.9.122 | every binary fails, `CARGO_BIN_EXE_mvmctl is unset` |
| 0.9.143 | **308 tests run, 308 passed** |

## Why a hard floor rather than a note

The shape of the failure. The tests do not skip with a warning — they fail with an error about an unset environment variable, which reads as *"my checkout is broken"* rather than *"my tool is old"*. The natural response is to go looking at the working tree, which is where I spent a while before checking versions.

`nextest-version` is enforced by nextest itself before it runs a test, so the floor holds for exactly the person who has the stale binary. Confirmed to fire on 0.9.122:

```
error: this repository requires nextest version 0.9.143, but the current version is 0.9.122
info: update nextest with cargo nextest self update, or bypass check with --override-version-check
```

## CI was never affected — and never would have caught this

`taiki-e/install-action` installs nextest unpinned, so CI always gets a current one. Every lane can stay green while a contributor's local `just test` quietly covers 308 fewer tests. That asymmetry is the reason this could rot locally for a long time with nothing red anywhere, and the reason the guard belongs in the repo config rather than in CI.

## One honest limitation

`required = "0.9.143"` is the oldest version **verified** against this layout, not a bisected boundary. The true floor is somewhere between 0.9.122 and 0.9.143. Lower it if someone establishes the real one — I chose verified-correct over guessed-precise.
