### PR TITLE
feat(hvf): give the guest the vCPUs it asked for, or say what it got

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,9 +506,10 @@ counts each machine's configured maximum rather than the balloon's
 current commitment. CPU is the partial half: a granted share wraps the VMM spawn in a
 systemd transient scope on Linux and the achieved tier is read back off
 `cpu.max`. On the in-house HVF VMM on macOS there is no host-level quota
-primitive, so the run loop enforces the share in-process using the vCPU
-thread's Mach CPU time; the achieved tier is read back from the scheduler's
-measured record and audited. libkrun has no in-process vCPU control, so a CPU
+primitive, so the run loop enforces the share in-process using the summed Mach
+CPU time of every vCPU thread — the sum, so the bound stays a bound on the
+machine rather than on one CPU of an SMP guest; the achieved tier is read back
+from the scheduler's measured record and audited. libkrun has no in-process vCPU control, so a CPU
 grant there stays `declared` and `--prod` refuses it. Wall clock is enforced
 by the per-VM supervisor on libkrun and HVF: the process that owns the guest
 for its whole life arms a timer from the admitted plan, and a workload that

--- a/Justfile
+++ b/Justfile
@@ -337,7 +337,8 @@ build-supervisors:
 # (mvm-build, mvm-core, ...) when you are about to boot a real VM; ordinary
 # check/test/clippy runs never need it. Release builds always rebuild.
 embed-refresh:
-    rm -rf target/*/build/mvm-cli-nested-target/host-vm-target
+    rm -rf target/*/build/mvm-cli/mvm-cli-nested-target/host-vm-target
+    rm -rf target/*/build/mvm-cli/mvm-cli-nested-target/aux-helper-target
 
 # Build the dm-verity-capable workload kernel into the local mvm cache.
 # Set MVM_KERNEL_SOURCE=download to use the hash-verified release artifact, or

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ mvmctl machine run --image python:3.12 \
 mvmctl machine run --image alpine -it -- /bin/sh
 
 # Give it resources; admit specific egress only (audited; TCP/22 always refused).
-# A request above the backend's vCPU ceiling is clamped to it, with a warning (HVF: 4).
+# A request above the backend's vCPU ceiling is clamped to it, with a warning.
 mvmctl machine run --image alpine --cpus 2 --memory 512M \
   --allow-host api.example.com:443 -- ./fetch
 
@@ -138,7 +138,7 @@ A persistent machine has a name and an on-disk spec: create once, start/stop/exe
 against it, reconfigure it, remove it when done.
 
 ```bash
-# A request above the backend's vCPU ceiling is clamped to it, with a warning (HVF: 4).
+# A request above the backend's vCPU ceiling is clamped to it, with a warning.
 mvmctl machine create web --image nginx --cpus 2 --memory 512M
 mvmctl machine start web
 mvmctl machine exec  web -- nginx -v

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ mvmctl machine run --image python:3.12 \
 mvmctl machine run --image alpine -it -- /bin/sh
 
 # Give it resources; admit specific egress only (audited; TCP/22 always refused).
-# HVF currently supports exactly one guest vCPU; multi-vCPU backends may accept more.
-mvmctl machine run --image alpine --cpus 1 --memory 512M \
+# A request above the backend's vCPU ceiling is clamped to it, with a warning (HVF: 4).
+mvmctl machine run --image alpine --cpus 2 --memory 512M \
   --allow-host api.example.com:443 -- ./fetch
 
 # Build a Nix flake and run it transiently in one step
@@ -138,8 +138,8 @@ A persistent machine has a name and an on-disk spec: create once, start/stop/exe
 against it, reconfigure it, remove it when done.
 
 ```bash
-# HVF currently supports exactly one guest vCPU; multi-vCPU backends may accept more.
-mvmctl machine create web --image nginx --cpus 1 --memory 512M
+# A request above the backend's vCPU ceiling is clamped to it, with a warning (HVF: 4).
+mvmctl machine create web --image nginx --cpus 2 --memory 512M
 mvmctl machine start web
 mvmctl machine exec  web -- nginx -v
 mvmctl machine logs  web

--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -640,6 +640,11 @@ impl VmmDriver for FcDriver {
         // authenticated identity handshake still gates admission after
         // resume, so preloading changes placement of VMM work, not authority.
         VmCapabilities {
+            // None: this driver hands `vcpu_count` to Firecracker's
+            // machine-config API unmodified and imposes no ceiling of its own.
+            // `None` says exactly that — distinct from a backend that has a
+            // limit and has not declared one, which would read as `Some(large)`.
+            max_vcpus: None,
             pause_resume: true,
             snapshots: false,
             snapshot_capability: SnapshotCapability::Unsupported,

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -232,6 +232,7 @@ fn relay_supervisor_config_with_handoff(
         kernel,
         cmdline,
         memory_mib: spec.memory_mib,
+        vcpus: spec.vcpus,
         initramfs: spec.initramfs.clone(),
         disks,
         virtiofs_root: spec

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -408,6 +408,20 @@ impl VmmDriver for HvfDriver {
         // vsock is live-proven through the unified run loop; the rest land as
         // pause/snapshot/networking are wired onto the primitive.
         VmCapabilities {
+            // Four, established by probing this backend rather than derived:
+            // 1, 2 and 4 boot and report the CPUs back through `nproc` and
+            // `/proc/cpuinfo`; 5, 6 and 8 never reach the guest agent
+            // ("connect to hvf vsock socket: Connection refused"), so the guest
+            // does not finish booting.
+            //
+            // The cause is not the device tree. The MMIO gap between
+            // `GICV3_REDIST_BASE` and `SERIAL_MMIO_BASE` fits 124 redistributor
+            // frames, and the host has 16 logical cores, so neither the address
+            // map nor the hardware explains it. Recording the measured number
+            // and saying it is unexplained beats inventing a derivation that
+            // sounds principled — if the underlying limit is a bug in the vCPU
+            // threading, a plausible-looking formula would hide it.
+            max_vcpus: Some(4),
             pause_resume: true,
             // The supervisor serializes guest RAM plus vCPU and deterministic
             // device state under an acknowledged pause, and reloads both into a

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -408,20 +408,22 @@ impl VmmDriver for HvfDriver {
         // vsock is live-proven through the unified run loop; the rest land as
         // pause/snapshot/networking are wired onto the primitive.
         VmCapabilities {
-            // Four, established by probing this backend rather than derived:
-            // 1, 2 and 4 boot and report the CPUs back through `nproc` and
-            // `/proc/cpuinfo`; 5, 6 and 8 never reach the guest agent
-            // ("connect to hvf vsock socket: Connection refused"), so the guest
-            // does not finish booting.
+            // Asked of the host, not assumed. This was a hardcoded `Some(4)`
+            // for a while: 5, 6 and 8 vCPU guests really did fail to reach the
+            // agent, and the number recorded that. The cause turned out to be a
+            // race in this backend's own vCPU creation rather than any limit —
+            // HVF hands out GIC redistributor frames in `hv_vcpu_create` order,
+            // and the creation threads were unordered, so two CPUs swapped
+            // frames and the guest could not match either to its
+            // redistributor. The suspicion written beside that constant — that
+            // a plausible-looking derivation would hide a threading bug — was
+            // right, and it was the constant that was hiding it.
             //
-            // The cause is not the device tree. The MMIO gap between
-            // `GICV3_REDIST_BASE` and `SERIAL_MMIO_BASE` fits 124 redistributor
-            // frames, and the host has 16 logical cores, so neither the address
-            // map nor the hardware explains it. Recording the measured number
-            // and saying it is unexplained beats inventing a derivation that
-            // sounds principled — if the underlying limit is a bug in the vCPU
-            // threading, a plausible-looking formula would hide it.
-            max_vcpus: Some(4),
+            // With creation ordered, 1, 2, 4, 5, 6, 8, 16 and 32 all boot and
+            // report their full count. So the ceiling comes from
+            // `hv_vm_get_max_vcpu_count` now, which answers 64 here and answers
+            // for itself on a different host.
+            max_vcpus: hvf_backend::hvf_max_vcpus(),
             pause_resume: true,
             // The supervisor serializes guest RAM plus vCPU and deterministic
             // device state under an acknowledged pause, and reloads both into a

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -129,13 +129,6 @@ fn relay_supervisor_config_with_handoff(
     handoff: Option<&HandoffConfig>,
     exclusive_image_lock: Option<&Path>,
 ) -> Result<HvfSupervisorConfig> {
-    if spec.vcpus != 1 {
-        bail!(
-            "the hvf backend supports exactly 1 vCPU, but this launch requests {}",
-            spec.vcpus
-        );
-    }
-
     let kernel = match &spec.kernel {
         KernelImage::Path(p) => p.clone(),
         KernelImage::Bundled => {
@@ -1448,22 +1441,32 @@ mod tests {
         assert!(relay_supervisor_config(&spec, &sample_paths()).is_err());
     }
 
+    /// A multi-vCPU request reaches the supervisor rather than being refused.
+    ///
+    /// This backend used to bail here, because the VMM below described one CPU
+    /// in the device tree whatever was asked for and answering a `CPU_ON` it
+    /// could not honour would hang the boot. It creates the CPUs now, so the
+    /// only correct thing to do with the count is pass it on — and passing it
+    /// on is the whole fix, since the supervisor is the process that calls
+    /// `hv_vcpu_create`.
     #[test]
-    fn relay_config_refuses_a_vcpu_count_hvf_cannot_honor() {
-        let mut spec = spec_with(
-            KernelImage::Path("/img/Image".into()),
-            vec![egress_port("/run/egress.sock")],
-            vec![],
-        );
-        spec.vcpus = 2;
+    fn relay_config_carries_a_multi_vcpu_request_to_the_supervisor() {
+        for requested in [1u32, 2, 4] {
+            let mut spec = spec_with(
+                KernelImage::Path("/img/Image".into()),
+                vec![egress_port("/run/egress.sock")],
+                vec![],
+            );
+            spec.vcpus = requested;
 
-        let error = relay_supervisor_config(&spec, &sample_paths())
-            .expect_err("HVF must not silently reduce a multi-vCPU request");
+            let config = relay_supervisor_config(&spec, &sample_paths())
+                .expect("a vCPU count this backend now honours must not be refused");
 
-        assert_eq!(
-            error.to_string(),
-            "the hvf backend supports exactly 1 vCPU, but this launch requests 2"
-        );
+            assert_eq!(
+                config.vcpus, requested,
+                "the supervisor must be told the {requested} CPUs that were asked for"
+            );
+        }
     }
 
     #[test]

--- a/crates/mvm-backends/src/driver/hvf_process.rs
+++ b/crates/mvm-backends/src/driver/hvf_process.rs
@@ -312,6 +312,46 @@ pub(crate) fn hvf_workload_support_available() -> bool {
     hvf_platform_supported() && hvf_supervisor_launch_support_available()
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[link(name = "Hypervisor", kind = "framework")]
+unsafe extern "C" {
+    /// The most vCPUs this host's hypervisor will create (macOS 11+).
+    fn hv_vm_get_max_vcpu_count(max_vcpu_count: *mut u32) -> i32;
+}
+
+/// The most vCPUs this host will let the backend create, or `None` if it will
+/// not say.
+///
+/// Asked rather than assumed. This ceiling was a hardcoded `Some(4)` derived by
+/// probing, back when a race in vCPU creation made five or more fail to boot —
+/// so the constant recorded a bug rather than a limit. With that fixed, the
+/// honest source is the host: `hv_vm_get_max_vcpu_count` reports 64 on the
+/// machine this was developed on, where guests of 1, 2, 4, 5, 6, 8, 16 and 32
+/// vCPUs all boot and report their full count back through both `nproc` and
+/// `/proc/cpuinfo`.
+///
+/// Querying also means a host smaller or larger than that one gets its own
+/// answer instead of inheriting this one's.
+pub(crate) fn hvf_max_vcpus() -> Option<u32> {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        let mut max: u32 = 0;
+        // SAFETY: `max` is a valid out-param for the documented signature. The
+        // call reads a static host property and creates nothing, so it needs
+        // neither a VM nor the hypervisor entitlement.
+        let rc = unsafe { hv_vm_get_max_vcpu_count(&mut max) };
+        // A host that will not answer, or answers zero, gets no ceiling rather
+        // than a made-up one: `None` means "never asked successfully", which is
+        // the truth, and leaves the request unclamped rather than silently
+        // reduced to a number nothing measured.
+        (rc == 0 && max > 0).then_some(max)
+    }
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    {
+        None
+    }
+}
+
 /// Probe whether HVF can actually run here. The backend's lifecycle is
 /// platform-agnostic (spawns a binary + tracks PID files), so it compiles
 /// everywhere; only this probe is macOS/Apple-silicon-specific.

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -156,6 +156,11 @@ pub fn hvf_child_restore_config(
         kernel: parent.kernel.clone(),
         cmdline: parent.cmdline.clone(),
         memory_mib: parent.memory_mib,
+        // A restored child resumes the parent's saved vCPU state, so it must
+        // come up with the parent's CPU topology. Booting a different count
+        // against a snapshot taken under another one is not a smaller machine —
+        // it is a mismatched one.
+        vcpus: parent.vcpus,
         initramfs: parent.initramfs.clone(),
         disks,
         virtiofs_root: parent.virtiofs_root.clone(),
@@ -306,6 +311,7 @@ mod tests {
             kernel: state.join("Image"),
             cmdline: Some("console=ttyAMA0 root=/dev/vda ro".into()),
             memory_mib: 512,
+            vcpus: 1,
             initramfs: None,
             disks,
             virtiofs_root: None,

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -272,6 +272,11 @@ impl VmmDriver for LibkrunDriver {
     }
 
     fn capabilities(&self) -> VmCapabilities {
+        // 255: libkrun's C API takes the count as a `u8`, and this driver
+        // already clamps to that range before the call. Declaring it here means
+        // the clamp is reported to the caller instead of happening silently one
+        // layer down.
+        //
         // libkrun does not support memory snapshots (same trade as
         // Apple Container). The mvm libkrun launch path is intentionally
         // vsock-only: the supervisor accepts only `NetworkingMode::VsockDirect`,
@@ -283,6 +288,7 @@ impl VmmDriver for LibkrunDriver {
         // admission and endpoint guards, so the runner-facing capability set
         // reports both snapshot and standby pool as unsupported.
         let mut capabilities = VmCapabilities {
+            max_vcpus: Some(u32::from(u8::MAX)),
             pause_resume: false,
             snapshots: false,
             snapshot_capability: SnapshotCapability::DiskOnly,

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1416,6 +1416,33 @@ pub fn resolve_launch(
         "admit window: admission"
     );
 
+    // Clamp the vCPU request to what this backend can actually create, and say
+    // so. Before the backend is chosen there is nothing to clamp against, and
+    // after the launch it is too late to tell anyone.
+    //
+    // Not an error. `--cpus 4` is a portable command meeting a host limit, and
+    // refusing it would make the same script succeed on Linux and fail on
+    // macOS for a reason the user cannot act on — worse, HVF's default is 2, so
+    // a hard refusal at a ceiling of 1 failed *every* launch on that backend.
+    // Silence is the other failure: a guest on one CPU while its admitted plan
+    // says four, with nothing to explain the performance.
+    if let Some(granted) =
+        mvm_core::vm_backend::clamp_vcpus(start_config.cpus, backend.capabilities().max_vcpus)
+    {
+        ui::warn(&format!(
+            "{} supports at most {granted} vCPU(s); {} requested, booting with {granted}",
+            backend.name(),
+            start_config.cpus,
+        ));
+        tracing::info!(
+            backend = backend.name(),
+            requested = start_config.cpus,
+            granted,
+            "vcpu request clamped to the backend ceiling"
+        );
+        start_config.cpus = granted;
+    }
+
     let t_overlay = std::time::Instant::now();
     crate::commands::vm::up::attach_runtime_overlay_if_cached(&mut start_config, backend.name())?;
     tracing::debug!(

--- a/crates/mvm-conformance/tests/steps/hvf_save_restore.rs
+++ b/crates/mvm-conformance/tests/steps/hvf_save_restore.rs
@@ -61,6 +61,7 @@ fn parent_config(state_dir: &std::path::Path) -> HvfSupervisorConfig {
         kernel: state_dir.join("Image"),
         cmdline: Some("console=ttyAMA0 root=/dev/vda ro".into()),
         memory_mib: 512,
+        vcpus: 1,
         initramfs: None,
         disks: vec![HvfDisk {
             path: PathBuf::from("/parent/state/rootfs.ext4"),

--- a/crates/mvm-conformance/tests/steps/launch_e2e.rs
+++ b/crates/mvm-conformance/tests/steps/launch_e2e.rs
@@ -290,8 +290,7 @@ fn guest_last_line_is(world: &mut CliWorld, expected: String) {
     let actual = record
         .stdout
         .lines()
-        .filter(|line| !line.trim().is_empty())
-        .next_back()
+        .rfind(|line| !line.trim().is_empty())
         .unwrap_or("")
         .trim();
     assert_eq!(

--- a/crates/mvm-conformance/tests/steps/launch_e2e.rs
+++ b/crates/mvm-conformance/tests/steps/launch_e2e.rs
@@ -273,6 +273,34 @@ fn guest_printed_exactly(world: &mut CliWorld, expected: String) {
     );
 }
 
+/// Assert the guest's *last* stdout line.
+///
+/// `the guest printed exactly` compares the whole of stdout, which is right
+/// when the command's output is all there is. It is wrong whenever mvm prints
+/// chrome first: a `[mvm]` warning is not a defect and not guest output, but it
+/// arrives on the same stream in the plain (non-JSON) case — deliberately, and
+/// consistently across the CLI. Verbs that emit a machine-readable envelope
+/// route chrome to stderr instead (`set_chrome_to_stderr`), so nothing is
+/// polluted there.
+///
+/// Still strict about the value: `contains` would pass "1" against "16".
+#[then(expr = "the guest's last line is {string}")]
+fn guest_last_line_is(world: &mut CliWorld, expected: String) {
+    let record = last(world);
+    let actual = record
+        .stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .next_back()
+        .unwrap_or("")
+        .trim();
+    assert_eq!(
+        actual, expected,
+        "guest's last stdout line was {actual:?}, expected {expected:?}.\n--- stdout ---\n{}",
+        record.stdout
+    );
+}
+
 #[then(expr = "the output mentions {string}")]
 fn output_mentions(world: &mut CliWorld, expected: String) {
     let record = last(world);

--- a/crates/mvm-contract/src/protocol/vm_backend.rs
+++ b/crates/mvm-contract/src/protocol/vm_backend.rs
@@ -357,11 +357,46 @@ impl VmExitStatus {
 ///
 /// Used by consumers to check what operations are available before attempting
 /// them. Recovery capabilities are deliberately part of this same value so a
+/// What a launch actually gets when it asks for `requested` vCPUs.
+///
+/// `Some(granted)` when the backend cannot honour the request in full — the
+/// caller is expected to say so and carry on with `granted`. `None` when the
+/// request is satisfiable as asked.
+///
+/// Clamping rather than refusing is the point. `--cpus 4` on a single-vCPU
+/// backend is a portable command meeting a host limit, not a malformed
+/// request; refusing it would mean a script that runs on Linux fails on macOS
+/// for a reason the user cannot act on. Silence is the other failure — a guest
+/// running on one CPU while its plan says four, with nothing to explain the
+/// performance.
+#[must_use]
+pub fn clamp_vcpus(requested: u32, max_vcpus: Option<u32>) -> Option<u32> {
+    let ceiling = max_vcpus?;
+    // A backend declaring zero has no usable answer; treat it as one rather
+    // than hand back a machine with no CPUs.
+    let ceiling = ceiling.max(1);
+    (requested > ceiling).then_some(ceiling)
+}
+
 /// caller cannot accidentally combine a snapshot tier from one backend with a
 /// standby answer from another.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VmCapabilities {
+    /// Most guest vCPUs this backend can actually create, or `None` when it
+    /// imposes no ceiling of its own.
+    ///
+    /// A request above this is **clamped and reported**, never refused: asking
+    /// for more parallelism than the host tier offers is a preference, not an
+    /// error, and failing the launch would make a portable command
+    /// backend-specific. What must not happen is the silent version — HVF
+    /// booted every guest on one CPU while its admitted plan said two, and
+    /// nothing said so.
+    ///
+    /// `None` rather than `u32::MAX` so "no ceiling" is distinguishable from a
+    /// backend that forgot to declare one.
+    #[serde(default)]
+    pub max_vcpus: Option<u32>,
     /// Can pause/resume vCPUs (Firecracker: yes, WASM: no).
     pub pause_resume: bool,
     /// Legacy coarse snapshot flag. New recovery callers should use
@@ -1292,6 +1327,41 @@ impl BackendKind {
 
 #[cfg(test)]
 mod tests {
+
+    /// A satisfiable request is left alone.
+    #[test]
+    fn a_request_within_the_ceiling_is_not_clamped() {
+        assert_eq!(super::clamp_vcpus(1, Some(1)), None);
+        assert_eq!(super::clamp_vcpus(2, Some(4)), None);
+        assert_eq!(super::clamp_vcpus(4, Some(4)), None, "equal is satisfiable");
+        assert_eq!(super::clamp_vcpus(64, None), None, "no ceiling declared");
+    }
+
+    /// Over the ceiling reports the granted count rather than refusing.
+    ///
+    /// The caller needs a value to boot with *and* something to tell the user.
+    /// Returning the granted count gives both; returning an error would make a
+    /// portable `--cpus 4` fail on one host and succeed on another for a reason
+    /// the user cannot act on.
+    #[test]
+    fn a_request_over_the_ceiling_is_granted_the_ceiling() {
+        assert_eq!(super::clamp_vcpus(4, Some(1)), Some(1));
+        assert_eq!(super::clamp_vcpus(8, Some(2)), Some(2));
+    }
+
+    /// A backend declaring zero still yields a bootable machine.
+    ///
+    /// Zero CPUs is not a smaller guest, it is not a guest. Treat a nonsense
+    /// ceiling as one rather than propagate it into the device tree.
+    #[test]
+    fn a_zero_ceiling_still_grants_one_cpu() {
+        assert_eq!(super::clamp_vcpus(4, Some(0)), Some(1));
+        assert_eq!(
+            super::clamp_vcpus(1, Some(0)),
+            None,
+            "one is already within"
+        );
+    }
     use super::*;
 
     #[test]

--- a/crates/mvm-core/src/protocol/vm_backend.rs
+++ b/crates/mvm-core/src/protocol/vm_backend.rs
@@ -29,7 +29,7 @@ pub use mvm_contract::protocol::vm_backend::{
     StandbySpec, StandbyState, StartMode, VmCapabilities, VmExitStatus, VmFile, VmId, VmInfo,
     VmNetworkInfo, VmPortMapping, VmStatus, VmVolume, VmVolumeKind, WarmArtifactIdentity,
     WarmClaimOutcome, WarmClaimRefusal, WarmClaimTiming, WarmLaunchMode, WarmPrewarmSource,
-    WarmServiceRequest, WarmServiceResponse, WarmStartError, WarmStartOutcome,
+    WarmServiceRequest, WarmServiceResponse, WarmStartError, WarmStartOutcome, clamp_vcpus,
     encode_egress_ca_cmdline, encode_secret_env_cmdline, encode_user_volumes_cmdline,
 };
 

--- a/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
@@ -379,6 +379,7 @@ fn main() -> anyhow::Result<()> {
                     .collect(),
                 cmdline: cfg.cmdline.clone(),
                 mem_mib: cfg.memory_mib,
+                vcpus: cfg.vcpus,
                 // Dev hook: `MVM_HVF_VIRTIOFS_ROOT=<dir>` boots a virtiofs root without
                 // the full run-path gate wiring, for live-mount iteration on HVF.
                 virtiofs_root: cfg.virtiofs_root.clone().or_else(|| {

--- a/crates/mvm-runtime/src/backends/hvf/boot_smoke.rs
+++ b/crates/mvm-runtime/src/backends/hvf/boot_smoke.rs
@@ -113,6 +113,19 @@ pub enum HvfError {
     BadBoot(BootFault),
     /// In-kernel GICv3 creation failed (needs macOS 15+).
     GicCreate(hv_return_t),
+    /// A vCPU's GIC redistributor frame is not where the device tree told the
+    /// guest it would be.
+    ///
+    /// Its own variant because the alternative is not a worse machine, it is a
+    /// hang: the guest matches CPUs to redistributors during IRQ init, before
+    /// the console exists, so the boot stops with nothing written anywhere.
+    /// Naming the CPU and both addresses is the difference between a five-minute
+    /// fix and a day of bisecting a silent failure.
+    RedistributorMismatch {
+        cpu: u32,
+        expected: u64,
+        actual: u64,
+    },
     /// Serialized HVF state failed structural validation.
     SnapshotState(&'static str),
 }

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -128,7 +128,57 @@ fn disk_mmio(i: usize) -> (u64, u32) {
 const PSCI_VERSION_FN: u64 = 0x8400_0000;
 const PSCI_SYSTEM_OFF: u64 = 0x8400_0008;
 const PSCI_SYSTEM_RESET: u64 = 0x8400_0009;
+/// `CPU_ON`, both calling conventions. A 64-bit guest uses the SMC64 id; the
+/// SMC32 id is accepted because a kernel may probe with it.
+const PSCI_CPU_ON_SMC64: u64 = 0xC400_0003;
+const PSCI_CPU_ON_SMC32: u64 = 0x8400_0003;
+/// `AFFINITY_INFO`, used by the kernel to poll whether a target CPU came up.
+const PSCI_AFFINITY_INFO_SMC64: u64 = 0xC400_0004;
+const PSCI_AFFINITY_INFO_SMC32: u64 = 0x8400_0004;
+
 const PSCI_NOT_SUPPORTED: u64 = (-1i64) as u64;
+/// The target CPU is not one this machine has.
+const PSCI_INVALID_PARAMETERS: u64 = (-2i64) as u64;
+/// `AFFINITY_INFO`: the queried CPU is off.
+const PSCI_AFFINITY_OFF: u64 = 1;
+
+/// Answer a PSCI `CPU_ON` for `target_mpidr`, given the CPUs this VMM created.
+///
+/// Deliberately incapable of answering `SUCCESS` while `created` is 1, and that
+/// is the whole point of the function today. Reporting success for a CPU no
+/// thread backs is strictly worse than refusing: the kernel's `cpu_up` waits on
+/// that CPU reaching its release point, and a CPU that never runs means a boot
+/// that never finishes — a hang with no console output rather than a machine
+/// with fewer CPUs than asked for.
+///
+/// `INVALID_PARAMETERS` is the defined PSCI answer for a target the
+/// implementation does not have, and Linux handles it by leaving that CPU
+/// offline and carrying on. With the device tree clamped to the CPUs this VMM
+/// creates (`effective_vcpus`), a well-behaved guest never issues the call at
+/// all; this is the answer for one that does anyway.
+fn psci_cpu_on(target_mpidr: u64, created: u32) -> u64 {
+    if target_mpidr < u64::from(created) {
+        // Reachable only once secondaries exist. Until a thread is actually
+        // waiting to be released, no caller can get here.
+        PSCI_NOT_SUPPORTED
+    } else {
+        PSCI_INVALID_PARAMETERS
+    }
+}
+
+/// Answer `AFFINITY_INFO` for `target_mpidr`.
+///
+/// A CPU this machine does not have is `INVALID_PARAMETERS`; one it does have
+/// but has not started is `OFF`. The kernel polls this after a `CPU_ON`, so
+/// answering `NOT_SUPPORTED` here would leave it unable to tell a failed
+/// bring-up from an unimplemented call.
+fn psci_affinity_info(target_mpidr: u64, created: u32) -> u64 {
+    if target_mpidr < u64::from(created) {
+        PSCI_AFFINITY_OFF
+    } else {
+        PSCI_INVALID_PARAMETERS
+    }
+}
 
 /// Raises a device SPI on the process-global in-kernel GIC — the [`IrqLine`] the
 /// vsock host-I/O thread uses to interrupt the guest off the vCPU exit path
@@ -699,6 +749,7 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
                 vsock,
                 timeout,
                 ram_size: mapped_ram_size,
+                vcpus,
                 agent_socket: channels.agent_socket,
                 substitution_socket: channels.substitution_socket,
                 egress_relay: channels.egress_relay,
@@ -750,6 +801,11 @@ struct RunInputs {
     timeout: Duration,
     /// Mapped guest RAM size in bytes (matches the host allocation).
     ram_size: usize,
+    /// vCPUs this run actually creates — already through `effective_vcpus`, and
+    /// the same number the device tree was built from. PSCI answers `CPU_ON`
+    /// and `AFFINITY_INFO` against it so the guest cannot be told a CPU exists
+    /// that no thread backs.
+    vcpus: u32,
     /// Per-VM agent RPC socket (productionized off `MVM_HVF_AGENT_SOCKET`).
     agent_socket: Option<PathBuf>,
     /// Per-VM substitution-endpoint socket (productionized off
@@ -801,6 +857,7 @@ unsafe fn run(
         vsock,
         timeout,
         ram_size,
+        vcpus,
         agent_socket,
         substitution_socket,
         egress_relay,
@@ -1202,6 +1259,19 @@ unsafe fn run(
                             match fn_id {
                                 PSCI_SYSTEM_OFF | PSCI_SYSTEM_RESET => return Ok(RunControl::Stop),
                                 PSCI_VERSION_FN => vc.set_core(CoreReg::X(0), 0x1_0000)?, // PSCI v1.0
+                                // x1 is the target MPIDR for both calls. Answered
+                                // against the CPUs this VMM actually created —
+                                // the same count the device tree was built from —
+                                // so the two can never disagree about which CPUs
+                                // exist.
+                                PSCI_CPU_ON_SMC64 | PSCI_CPU_ON_SMC32 => {
+                                    let target = vc.get_core(CoreReg::X(1))?;
+                                    vc.set_core(CoreReg::X(0), psci_cpu_on(target, vcpus))?;
+                                }
+                                PSCI_AFFINITY_INFO_SMC64 | PSCI_AFFINITY_INFO_SMC32 => {
+                                    let target = vc.get_core(CoreReg::X(1))?;
+                                    vc.set_core(CoreReg::X(0), psci_affinity_info(target, vcpus))?;
+                                }
                                 _ => vc.set_core(CoreReg::X(0), PSCI_NOT_SUPPORTED)?,
                             }
                             // HVC is completed: HVF already advanced PC. Do NOT advance.
@@ -1388,6 +1458,57 @@ mod tests {
                  this VMM creates, not the request"
             );
         }
+    }
+
+    /// `CPU_ON` must never claim success for a CPU no thread backs.
+    ///
+    /// This is the property that keeps a partial SMP implementation safe. The
+    /// kernel's `cpu_up` waits for the target to reach its release point, so
+    /// answering SUCCESS for a CPU that will never run turns "fewer CPUs than
+    /// asked for" into "boot never finishes" — a hang with no console output.
+    /// `INVALID_PARAMETERS` is the defined answer for a target the
+    /// implementation does not have, and Linux leaves that CPU offline and
+    /// carries on.
+    #[test]
+    fn cpu_on_never_reports_success_for_a_cpu_no_thread_backs() {
+        // One vCPU: every target above CPU 0 is absent.
+        for target in [1u64, 2, 7, 63] {
+            assert_eq!(
+                super::psci_cpu_on(target, 1),
+                super::PSCI_INVALID_PARAMETERS,
+                "target {target} does not exist on a 1-CPU machine"
+            );
+        }
+        // Whatever the count, success is not currently reachable — there is no
+        // secondary thread to release.
+        for created in [1u32, 2, 4] {
+            for target in 0..u64::from(created) {
+                assert_ne!(
+                    super::psci_cpu_on(target, created),
+                    0,
+                    "PSCI SUCCESS is 0 and must not be returned while no \
+                     secondary thread exists to be released"
+                );
+            }
+        }
+    }
+
+    /// `AFFINITY_INFO` distinguishes "absent" from "present but off".
+    ///
+    /// The kernel polls this after a `CPU_ON`. Answering NOT_SUPPORTED would
+    /// leave it unable to tell a failed bring-up from an unimplemented call.
+    #[test]
+    fn affinity_info_separates_an_absent_cpu_from_a_stopped_one() {
+        assert_eq!(super::psci_affinity_info(0, 1), super::PSCI_AFFINITY_OFF);
+        assert_eq!(
+            super::psci_affinity_info(1, 1),
+            super::PSCI_INVALID_PARAMETERS
+        );
+        assert_eq!(super::psci_affinity_info(3, 4), super::PSCI_AFFINITY_OFF);
+        assert_eq!(
+            super::psci_affinity_info(4, 4),
+            super::PSCI_INVALID_PARAMETERS
+        );
     }
 
     /// Until the run loop is threaded, the honest answer to any request is one.

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -67,6 +67,54 @@ fn effective_vcpus(vcpus: u32) -> u32 {
     1
 }
 
+/// The register state one vCPU starts from.
+///
+/// The primary and a secondary differ only in these values, not in how they are
+/// created, so the difference is data rather than a second code path. The
+/// primary enters at the kernel's entry point with the DTB in x0, per the arm64
+/// boot protocol. A secondary released by PSCI `CPU_ON` enters at the address
+/// that call supplied, with its context id in x0 — the kernel puts a per-CPU
+/// pointer there and reads it back on the other side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct VcpuStart {
+    /// MPIDR_EL1 affinity. Must equal the `cpu@<addr>` node's reg in the device
+    /// tree, or the CPU cannot be matched to its GIC redistributor frame.
+    pub(crate) mpidr: u64,
+    /// Where this CPU begins executing.
+    pub(crate) entry: u64,
+    /// x0 at entry: the DTB address for the primary, the PSCI context id for a
+    /// secondary.
+    pub(crate) x0: u64,
+}
+
+impl VcpuStart {
+    /// The boot CPU: entry point from the kernel image, DTB in x0.
+    pub(crate) fn primary(entry: u64, dtb_addr: u64) -> Self {
+        Self {
+            mpidr: fdt::mpidr_for_cpu(0),
+            entry,
+            x0: dtb_addr,
+        }
+    }
+}
+
+/// Put one vCPU into its architectural start state.
+///
+/// Shared by the primary and, once secondaries exist, by every CPU a PSCI
+/// `CPU_ON` releases — the two differ only in the `VcpuStart` values. x1..x3
+/// are zeroed because the arm64 boot protocol reserves them, and a secondary
+/// entering with stale register contents is a fault the guest attributes to
+/// itself.
+fn apply_vcpu_start(vcpu: &HvfVcpu, start: VcpuStart) -> Result<(), HvfError> {
+    vcpu.set_sys(SysReg::MpidrEl1, start.mpidr)
+        .and_then(|()| vcpu.set_core(CoreReg::Pc, start.entry))
+        .and_then(|()| vcpu.set_core(CoreReg::Cpsr, 0x3c5))
+        .and_then(|()| vcpu.set_core(CoreReg::X(0), start.x0))
+        .and_then(|()| vcpu.set_core(CoreReg::X(1), 0))
+        .and_then(|()| vcpu.set_core(CoreReg::X(2), 0))
+        .and_then(|()| vcpu.set_core(CoreReg::X(3), 0))
+}
+
 /// Guest RAM in bytes for `mem_mib` MiB, or the default when `mem_mib` is 0.
 /// A MiB is a multiple of the 16 KiB hypervisor page size, so the result is
 /// always page-aligned.
@@ -916,18 +964,13 @@ unsafe fn run(
         // loop (crate::vmm::run) — the same body the KVM backend uses.
         let vcpu = HvfVcpu::from_raw(vcpu_id, exit);
 
-        // MPIDR_EL1 affinity 0 must match FDT cpu@0 + the GIC redistributor frame
-        // (else gic_populate_rdist walks off the region and faults). arm64 boot
-        // protocol: x0=DTB, x1..x3=0, PC=entry, EL1h with DAIF masked.
-        let setup = vcpu
-            .set_sys(SysReg::MpidrEl1, 0)
-            .and_then(|()| vcpu.set_core(CoreReg::Pc, entry))
-            .and_then(|()| vcpu.set_core(CoreReg::Cpsr, 0x3c5))
-            .and_then(|()| vcpu.set_core(CoreReg::X(0), dtb_addr))
-            .and_then(|()| vcpu.set_core(CoreReg::X(1), 0))
-            .and_then(|()| vcpu.set_core(CoreReg::X(2), 0))
-            .and_then(|()| vcpu.set_core(CoreReg::X(3), 0));
-        if let Err(e) = setup {
+        // MPIDR_EL1 must match this CPU's `cpu@<addr>` node and hence its GIC
+        // redistributor frame (else gic_populate_rdist walks off the region and
+        // faults). arm64 boot protocol: x0 per `VcpuStart`, x1..x3=0, PC=entry,
+        // EL1h with DAIF masked. Routed through `VcpuStart` so a secondary
+        // released by PSCI takes this same path with different data rather than
+        // a second copy of it.
+        if let Err(e) = apply_vcpu_start(&vcpu, VcpuStart::primary(entry, dtb_addr)) {
             hv_vcpu_destroy(vcpu_id);
             return Err(e);
         }
@@ -1456,6 +1499,60 @@ mod tests {
                 described, 1,
                 "requested {requested}: the tree must describe the single CPU \
                  this VMM creates, not the request"
+            );
+        }
+    }
+
+    /// The primary starts per the arm64 boot protocol: DTB in x0, affinity 0.
+    #[test]
+    fn the_primary_starts_with_the_dtb_in_x0_at_affinity_zero() {
+        let start = super::VcpuStart::primary(0x8008_0000, 0x9FE0_0000);
+        assert_eq!(start.mpidr, 0, "the boot CPU is cpu@0");
+        assert_eq!(start.entry, 0x8008_0000);
+        assert_eq!(
+            start.x0, 0x9FE0_0000,
+            "arm64 boot protocol puts the DTB address in x0"
+        );
+    }
+
+    /// A secondary carries its PSCI context id in x0, not the DTB.
+    ///
+    /// `CPU_ON(target, entry, context_id)` hands the kernel a per-CPU pointer it
+    /// reads back on the other side. Passing the DTB there instead would have
+    /// the secondary dereference the device tree as its per-CPU data — a fault
+    /// the guest attributes to itself, with nothing on the host to explain it.
+    #[test]
+    fn a_secondary_starts_at_its_psci_entry_with_the_context_id_in_x0() {
+        // Built directly: the constructor lands with the code that releases
+        // secondaries. What is pinned here is the *shape* a secondary starts
+        // with, which the release path must produce.
+        let start = super::VcpuStart {
+            mpidr: mvm_vmm::vmm::fdt::mpidr_for_cpu(3),
+            entry: 0x8100_0000,
+            x0: 0xDEAD_BEEF,
+        };
+        assert_eq!(start.mpidr, 3, "cpu@3 has affinity 3");
+        assert_eq!(start.entry, 0x8100_0000, "PSCI supplies the entry point");
+        assert_eq!(start.x0, 0xDEAD_BEEF, "PSCI supplies the context id");
+    }
+
+    /// Every CPU's MPIDR matches the device tree node built for it.
+    ///
+    /// These are the two halves of one fact. If they drift, the CPU cannot be
+    /// matched to its GIC redistributor frame and IRQ init faults before any
+    /// console output — a silent hang.
+    #[test]
+    fn each_vcpu_start_agrees_with_its_device_tree_node() {
+        for index in 0..8u32 {
+            assert_eq!(
+                super::VcpuStart::primary(0, 0).mpidr,
+                mvm_vmm::vmm::fdt::mpidr_for_cpu(0),
+                "the boot cpu's start state and device tree must agree"
+            );
+            assert_eq!(
+                mvm_vmm::vmm::fdt::mpidr_for_cpu(index),
+                u64::from(index),
+                "cpu {index}: affinity is the node address"
             );
         }
     }

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -49,6 +49,24 @@ const RAM_BASE: u64 = 0x8000_0000;
 /// demo/agent boot. A builder overrides it (a `nix build` OOMs at 512 MiB).
 const DEFAULT_RAM_SIZE: usize = 0x2000_0000;
 
+/// vCPUs this VMM will actually create, for a requested `vcpus`.
+///
+/// One, always, for now: the run loop below creates a single vCPU, PSCI answers
+/// no `CPU_ON`, and the device model is reached from one thread with no
+/// synchronisation. The clamp is here — one function the DTB and the vCPU
+/// creation both read — so the tree can never describe CPUs the VMM does not
+/// create. That mismatch does not degrade; it hangs the boot waiting for a
+/// secondary that never arrives.
+///
+/// Callers must not pre-validate against this: `relay_supervisor_config`
+/// already refuses a count this backend cannot honour, so reaching here with
+/// `vcpus > 1` means the request survived that gate and the honest response is
+/// to boot the guest it can rather than describe one it cannot.
+fn effective_vcpus(vcpus: u32) -> u32 {
+    let _ = vcpus;
+    1
+}
+
 /// Guest RAM in bytes for `mem_mib` MiB, or the default when `mem_mib` is 0.
 /// A MiB is a multiple of the 16 KiB hypervisor page size, so the result is
 /// always page-aligned.
@@ -222,6 +240,13 @@ pub struct HostChannels {
     /// Guest RAM in MiB. `0` ⇒ the built-in default (512 MiB). A builder sets
     /// several GiB so `nix build` doesn't OOM.
     pub mem_mib: u32,
+    /// Guest vCPUs. `0` ⇒ 1.
+    ///
+    /// Read by exactly two things that must agree: the device tree, which tells
+    /// the guest how many CPUs exist, and the vCPU creation below. A tree that
+    /// describes more CPUs than the VMM creates hangs the boot waiting for
+    /// secondaries; fewer, and the extra vCPUs are never onlined.
+    pub vcpus: u32,
     /// When set, serve this host directory (the unpacked+injected OCI tree) to
     /// the guest as a read-only **virtiofs root** instead of a block rootfs — the
     /// Plan-223 dev-tier boot. No virtio-blk disk is attached; the default
@@ -540,6 +565,7 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
     // Validate it's an arm64 Image; we load at the fixed boot-protocol offset.
     let kernel_meta = kernel.metadata()?;
     let ram_size = ram_size_bytes(channels.mem_mib);
+    let vcpus = effective_vcpus(channels.vcpus);
     let load_off = KERNEL_LOAD_OFFSET as usize;
     let dtb_off = ram_size
         .checked_sub(FDT_MAX_SIZE as usize)
@@ -636,12 +662,7 @@ fn boot_kernel_impl(params: KernelBootUntilParams<'_>) -> Result<KernelBootResul
         initrd_bounds,
         &virtio_nodes,
         Some(&rng_seed),
-        // One, until the count reaches this process. `HvfSupervisorConfig`
-        // carries no `vcpus` field yet, so there is nothing truthful to pass —
-        // describing CPUs in the tree that no `hv_vcpu_create` backs would hang
-        // the guest waiting for secondaries that never arrive. Once the
-        // supervisor carries the admitted vCPU count, pass it through here.
-        1,
+        vcpus,
     );
     if dtb.len() > FDT_MAX_SIZE as usize {
         return Err(HvfError::BadBoot(BootFault::DtbTooLarge {
@@ -1333,6 +1354,54 @@ unsafe fn run(
 
 #[cfg(test)]
 mod tests {
+    /// The tree this VMM boots describes exactly one CPU, whatever was asked
+    /// for.
+    ///
+    /// Pinned against the literal 1 — the number of `hv_vcpu_create` calls the
+    /// run loop actually makes — and deliberately **not** against
+    /// `effective_vcpus()`. Comparing the tree to the same function that built
+    /// it is self-referential: it stays green when the clamp changes, which is
+    /// precisely the drift worth catching. A tree advertising more CPUs than
+    /// the VMM creates does not degrade to a smaller machine; the guest onlines
+    /// secondaries that never respond and the boot hangs with no console
+    /// output, reading as a VMM fault rather than a topology mismatch.
+    ///
+    /// When SMP lands this becomes the assertion that the tree matches the
+    /// spawned thread count, and it has to be updated deliberately — which is
+    /// the point.
+    #[test]
+    fn the_booted_tree_describes_exactly_the_one_cpu_the_vmm_creates() {
+        for requested in [0u32, 1, 2, 4, 64] {
+            let dtb = mvm_vmm::vmm::fdt::build_dtb(
+                "console=ttyAMA0",
+                0x8000_0000,
+                0x2000_0000,
+                None,
+                &[],
+                None,
+                super::effective_vcpus(requested),
+            );
+            let described = dtb.windows(4).filter(|w| *w == b"cpu@").count();
+            assert_eq!(
+                described, 1,
+                "requested {requested}: the tree must describe the single CPU \
+                 this VMM creates, not the request"
+            );
+        }
+    }
+
+    /// Until the run loop is threaded, the honest answer to any request is one.
+    ///
+    /// `relay_supervisor_config` refuses `vcpus > 1` before this is reached, so
+    /// this clamp is the second line rather than the first — but it is the one
+    /// that keeps the tree truthful if a caller ever bypasses that gate.
+    #[test]
+    fn a_request_beyond_what_the_vmm_supports_clamps_rather_than_lies() {
+        assert_eq!(super::effective_vcpus(0), 1, "zero is not a machine");
+        assert_eq!(super::effective_vcpus(1), 1);
+        assert_eq!(super::effective_vcpus(8), 1, "no SMP yet — see #2888");
+    }
+
     use super::*;
 
     fn arm64_image(size: usize, image_size: u64) -> Vec<u8> {

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -18,8 +18,8 @@
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use super::HvfError;
@@ -27,12 +27,13 @@ use super::HvfError;
 use super::guest_ram::HVF_PAGE_SIZE;
 use super::guest_ram::{GuestRam, page_rounded_len};
 use super::hv_impl::{HvfHandle, HvfVcpu};
-use super::snapshot::HVF_SNAPSHOT_BACKEND_KIND;
+use super::smp::{Release, SecondaryGates, VcpuStart, psci};
+use super::snapshot::{HVF_SNAPSHOT_BACKEND_KIND, HvfVcpuState};
 use super::sys::*;
 use super::vcpu::esr_ec;
 use super::{BootFault, default_bootargs, default_virtiofs_bootargs};
 use crate::vmm::device::Pl011;
-use crate::vmm::device_state::capture_device_states;
+use crate::vmm::device_state::{SnapshotDeviceState, capture_device_states};
 use crate::vmm::hv::{CoreReg, HypervisorVcpu, SysReg, VcpuHandle};
 use crate::vmm::run::{self, RunControl, RunDevice, RunOutcome};
 use crate::vmm::virtio::{DiskImage, VirtioBlk, VirtioFs};
@@ -40,7 +41,7 @@ use crate::vmm::virtio_rng::VirtioRng;
 use crate::vmm::vsock::VirtioVsock;
 use crate::vmm::{fdt, kernel_image};
 use mvm_core::vcpu_quota::VcpuQuotaRecord;
-use mvm_vmm::quota::{QuotaConfig, QuotaPolicy, ThreadCpuHandle, VcpuQuota};
+use mvm_vmm::quota::{QuotaConfig, QuotaPolicy, SummedClock, ThreadCpuHandle, VcpuQuota};
 
 /// Guest RAM base (2 GiB, per the aarch64 Linux boot convention). The GIC +
 /// PL011 sit below RAM so their accesses fault out as MMIO.
@@ -49,62 +50,27 @@ const RAM_BASE: u64 = 0x8000_0000;
 /// demo/agent boot. A builder overrides it (a `nix build` OOMs at 512 MiB).
 const DEFAULT_RAM_SIZE: usize = 0x2000_0000;
 
-/// vCPUs this VMM will actually create, for a requested `vcpus`.
+/// vCPUs this VMM will create, for a requested `vcpus`.
 ///
-/// One, always, for now: the run loop below creates a single vCPU, PSCI answers
-/// no `CPU_ON`, and the device model is reached from one thread with no
-/// synchronisation. The clamp is here — one function the DTB and the vCPU
-/// creation both read — so the tree can never describe CPUs the VMM does not
-/// create. That mismatch does not degrade; it hangs the boot waiting for a
-/// secondary that never arrives.
+/// Zero is not a machine, so it means one. Nothing else is clamped: the host's
+/// real ceiling is whatever `hv_vcpu_create` will grant, and asking for more
+/// fails the boot with that error rather than quietly handing back a smaller
+/// machine than the one that was asked for.
 ///
-/// Callers must not pre-validate against this: `relay_supervisor_config`
-/// already refuses a count this backend cannot honour, so reaching here with
-/// `vcpus > 1` means the request survived that gate and the honest response is
-/// to boot the guest it can rather than describe one it cannot.
+/// The single function the device tree and the vCPU creation both read, so the
+/// tree can never describe CPUs the VMM does not create. That mismatch does not
+/// degrade into a smaller guest; the kernel onlines secondaries that never
+/// respond and the boot hangs with no console output.
 fn effective_vcpus(vcpus: u32) -> u32 {
-    let _ = vcpus;
-    1
-}
-
-/// The register state one vCPU starts from.
-///
-/// The primary and a secondary differ only in these values, not in how they are
-/// created, so the difference is data rather than a second code path. The
-/// primary enters at the kernel's entry point with the DTB in x0, per the arm64
-/// boot protocol. A secondary released by PSCI `CPU_ON` enters at the address
-/// that call supplied, with its context id in x0 — the kernel puts a per-CPU
-/// pointer there and reads it back on the other side.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct VcpuStart {
-    /// MPIDR_EL1 affinity. Must equal the `cpu@<addr>` node's reg in the device
-    /// tree, or the CPU cannot be matched to its GIC redistributor frame.
-    pub(crate) mpidr: u64,
-    /// Where this CPU begins executing.
-    pub(crate) entry: u64,
-    /// x0 at entry: the DTB address for the primary, the PSCI context id for a
-    /// secondary.
-    pub(crate) x0: u64,
-}
-
-impl VcpuStart {
-    /// The boot CPU: entry point from the kernel image, DTB in x0.
-    pub(crate) fn primary(entry: u64, dtb_addr: u64) -> Self {
-        Self {
-            mpidr: fdt::mpidr_for_cpu(0),
-            entry,
-            x0: dtb_addr,
-        }
-    }
+    vcpus.max(1)
 }
 
 /// Put one vCPU into its architectural start state.
 ///
-/// Shared by the primary and, once secondaries exist, by every CPU a PSCI
-/// `CPU_ON` releases — the two differ only in the `VcpuStart` values. x1..x3
-/// are zeroed because the arm64 boot protocol reserves them, and a secondary
-/// entering with stale register contents is a fault the guest attributes to
-/// itself.
+/// Shared by the primary and by every CPU a PSCI `CPU_ON` releases — the two
+/// differ only in the [`VcpuStart`] values. x1..x3 are zeroed because the arm64
+/// boot protocol reserves them, and a secondary entering with stale register
+/// contents is a fault the guest attributes to itself.
 fn apply_vcpu_start(vcpu: &HvfVcpu, start: VcpuStart) -> Result<(), HvfError> {
     vcpu.set_sys(SysReg::MpidrEl1, start.mpidr)
         .and_then(|()| vcpu.set_core(CoreReg::Pc, start.entry))
@@ -184,48 +150,105 @@ const PSCI_CPU_ON_SMC32: u64 = 0x8400_0003;
 const PSCI_AFFINITY_INFO_SMC64: u64 = 0xC400_0004;
 const PSCI_AFFINITY_INFO_SMC32: u64 = 0x8400_0004;
 
-const PSCI_NOT_SUPPORTED: u64 = (-1i64) as u64;
-/// The target CPU is not one this machine has.
-const PSCI_INVALID_PARAMETERS: u64 = (-2i64) as u64;
-/// `AFFINITY_INFO`: the queried CPU is off.
-const PSCI_AFFINITY_OFF: u64 = 1;
+/// How many distinct PSCI function ids / exception classes to keep. A
+/// diagnostic sample rather than a log: the content is which kinds occurred,
+/// and a guest in a fault loop would otherwise grow the vector without bound.
+const DIAGNOSTIC_SAMPLE_LIMIT: usize = 16;
 
-/// Answer a PSCI `CPU_ON` for `target_mpidr`, given the CPUs this VMM created.
+/// Diagnostics one vCPU gathered while running.
 ///
-/// Deliberately incapable of answering `SUCCESS` while `created` is 1, and that
-/// is the whole point of the function today. Reporting success for a CPU no
-/// thread backs is strictly worse than refusing: the kernel's `cpu_up` waits on
-/// that CPU reaching its release point, and a CPU that never runs means a boot
-/// that never finishes — a hang with no console output rather than a machine
-/// with fewer CPUs than asked for.
-///
-/// `INVALID_PARAMETERS` is the defined PSCI answer for a target the
-/// implementation does not have, and Linux handles it by leaving that CPU
-/// offline and carrying on. With the device tree clamped to the CPUs this VMM
-/// creates (`effective_vcpus`), a well-behaved guest never issues the call at
-/// all; this is the answer for one that does anyway.
-fn psci_cpu_on(target_mpidr: u64, created: u32) -> u64 {
-    if target_mpidr < u64::from(created) {
-        // Reachable only once secondaries exist. Until a thread is actually
-        // waiting to be released, no caller can get here.
-        PSCI_NOT_SUPPORTED
-    } else {
-        PSCI_INVALID_PARAMETERS
+/// Per-CPU rather than shared. These are counters on the exception hot path, so
+/// a lock behind every HVC would cost more than the numbers are worth. The
+/// primary merges every CPU's set once the threads have joined, so the boot
+/// result describes the machine rather than whichever CPU happened to report.
+#[derive(Debug, Default)]
+struct CpuDiagnostics {
+    hvc_calls: usize,
+    other_exceptions: usize,
+    psci_fns: Vec<u64>,
+    other_ecs: Vec<u32>,
+}
+
+impl CpuDiagnostics {
+    /// Fold another CPU's diagnostics in. Counts add; the function-id and
+    /// exception-class lists stay sets, because "which kinds happened" is what
+    /// they answer and a secondary issuing the same PSCI call as the primary is
+    /// not new information.
+    fn merge(&mut self, other: Self) {
+        self.hvc_calls += other.hvc_calls;
+        self.other_exceptions += other.other_exceptions;
+        for fn_id in other.psci_fns {
+            if self.psci_fns.len() < DIAGNOSTIC_SAMPLE_LIMIT && !self.psci_fns.contains(&fn_id) {
+                self.psci_fns.push(fn_id);
+            }
+        }
+        for ec in other.other_ecs {
+            if self.other_ecs.len() < DIAGNOSTIC_SAMPLE_LIMIT && !self.other_ecs.contains(&ec) {
+                self.other_ecs.push(ec);
+            }
+        }
     }
 }
 
-/// Answer `AFFINITY_INFO` for `target_mpidr`.
+/// Handle one guest exception, on any vCPU.
 ///
-/// A CPU this machine does not have is `INVALID_PARAMETERS`; one it does have
-/// but has not started is `OFF`. The kernel polls this after a `CPU_ON`, so
-/// answering `NOT_SUPPORTED` here would leave it unable to tell a failed
-/// bring-up from an unimplemented call.
-fn psci_affinity_info(target_mpidr: u64, created: u32) -> u64 {
-    if target_mpidr < u64::from(created) {
-        PSCI_AFFINITY_OFF
-    } else {
-        PSCI_INVALID_PARAMETERS
+/// The same body for the boot CPU and every secondary: an HVC can come from any
+/// CPU, and PSCI in particular is issued by whichever CPU is bringing another
+/// one up. Answers come from `gates`, which is also what releases the parked
+/// threads, so the call and the thread it starts cannot disagree about which
+/// CPUs exist.
+fn handle_exception(
+    vc: &HvfVcpu,
+    esr: u64,
+    shared: &MachineShared<'_>,
+    diag: &mut CpuDiagnostics,
+) -> Result<RunControl, HvfError> {
+    if esr_ec(esr) != EC_HVC_AARCH64 {
+        let ec = esr_ec(esr);
+        diag.other_exceptions += 1;
+        if diag.other_ecs.len() < DIAGNOSTIC_SAMPLE_LIMIT && !diag.other_ecs.contains(&ec) {
+            diag.other_ecs.push(ec);
+        }
+        // Advance past the faulting instruction and keep going.
+        let pc = vc.get_core(CoreReg::Pc)?;
+        vc.set_core(CoreReg::Pc, pc + 4)?;
+        return Ok(RunControl::Continue);
     }
+
+    diag.hvc_calls += 1;
+    let fn_id = vc.get_core(CoreReg::X(0))?;
+    if diag.psci_fns.len() < DIAGNOSTIC_SAMPLE_LIMIT && !diag.psci_fns.contains(&fn_id) {
+        diag.psci_fns.push(fn_id);
+    }
+    match fn_id {
+        // Whichever CPU asks, shutting the machine down ends the whole run —
+        // PSCI SYSTEM_OFF is a machine-wide verb, not a per-CPU one. Recorded
+        // so the boot result can tell a guest that powered itself off from one
+        // the host stopped.
+        PSCI_SYSTEM_OFF | PSCI_SYSTEM_RESET => {
+            shared.guest_shutdown.store(true, Ordering::Relaxed);
+            return Ok(RunControl::Stop);
+        }
+        PSCI_VERSION_FN => vc.set_core(CoreReg::X(0), 0x1_0000)?, // PSCI v1.0
+        // x1 is the target MPIDR, x2 the entry point, x3 the context id the
+        // kernel wants handed back in x0 on the other side.
+        PSCI_CPU_ON_SMC64 | PSCI_CPU_ON_SMC32 => {
+            let target = vc.get_core(CoreReg::X(1))?;
+            let entry = vc.get_core(CoreReg::X(2))?;
+            let context_id = vc.get_core(CoreReg::X(3))?;
+            vc.set_core(
+                CoreReg::X(0),
+                shared.gates.cpu_on(target, entry, context_id),
+            )?;
+        }
+        PSCI_AFFINITY_INFO_SMC64 | PSCI_AFFINITY_INFO_SMC32 => {
+            let target = vc.get_core(CoreReg::X(1))?;
+            vc.set_core(CoreReg::X(0), shared.gates.affinity_info(target))?;
+        }
+        _ => vc.set_core(CoreReg::X(0), psci::NOT_SUPPORTED)?,
+    }
+    // HVC is completed: HVF already advanced PC. Do NOT advance.
+    Ok(RunControl::Continue)
 }
 
 /// Raises a device SPI on the process-global in-kernel GIC — the [`IrqLine`] the
@@ -891,6 +914,442 @@ struct RunInputs {
     quota_record: Option<PathBuf>,
 }
 
+/// Raise or lower a device interrupt line on the process-global in-kernel GIC.
+///
+/// The vCPU-exit-path counterpart to [`GicSpi`], which the vsock host-I/O
+/// thread uses. A free function rather than a closure per vCPU so every CPU of
+/// an SMP machine raises interrupts through the same code.
+fn set_gic_spi(intid: u32, level: bool) -> Result<(), HvfError> {
+    // SAFETY: FFI to the process-global in-kernel GIC, created before any vCPU
+    // and destroyed after all of them. `hv_gic_set_spi` is documented as
+    // callable from any thread.
+    if unsafe { hv_gic_set_spi(intid, level) } == HV_SUCCESS {
+        Ok(())
+    } else {
+        Err(HvfError::GicCreate(0))
+    }
+}
+
+/// Where a pause-time snapshot is written.
+struct SnapshotPaths {
+    request: Option<PathBuf>,
+    ram: Option<PathBuf>,
+    frame: Option<PathBuf>,
+}
+
+/// The state every vCPU of one machine shares.
+///
+/// Borrowed by each vCPU thread for the length of the run. Every field is
+/// either atomic or internally locked, because on an SMP machine each of them
+/// is read and written by several CPUs at once.
+struct MachineShared<'a> {
+    /// The parking spots PSCI `CPU_ON` releases.
+    gates: &'a SecondaryGates,
+    /// Every live vCPU's force-exit token.
+    roster: &'a Mutex<Vec<HvfHandle>>,
+    /// The supervisor's stop flag: a timeout, or a graceful stop.
+    stop: &'static AtomicBool,
+    /// The supervisor's pause request.
+    paused: &'static AtomicBool,
+    /// Set by whichever vCPU leaves its run loop first. Every other CPU reads
+    /// it as a stop, which is what turns one CPU taking `PSCI SYSTEM_OFF` into
+    /// the whole machine ending rather than the rest spinning on in a guest
+    /// that has shut itself down.
+    machine_over: &'a AtomicBool,
+    /// Set when any CPU asks to power the machine down.
+    ///
+    /// Separate from `machine_over`, which says only that the run ended. A
+    /// secondary taking `PSCI SYSTEM_OFF` ends the run through the same forced
+    /// exit a watchdog timeout uses, so without this the boot CPU reports a
+    /// clean guest shutdown as a timeout.
+    guest_shutdown: &'a AtomicBool,
+    /// The CPU-quota hold. Shared, because the quota bounds the machine and not
+    /// a thread: when it is set every vCPU parks.
+    throttle: &'a AtomicBool,
+    /// Each secondary's register state, published by that CPU while it is
+    /// parked and read by the boot CPU when it assembles a snapshot.
+    ///
+    /// It has to be published rather than collected because HVF only lets a
+    /// vCPU's registers be read from the thread that created it — the boot CPU
+    /// cannot reach into a secondary and take them. Indexed by CPU number, with
+    /// slot 0 unused; `None` means that CPU has not yet parked and published,
+    /// which is exactly the condition a capture has to wait on.
+    parked_states: &'a Mutex<Vec<Option<HvfVcpuState>>>,
+    /// Each secondary's state to resume from, for a restored machine.
+    ///
+    /// The mirror of `parked_states`, and thread-bound for the same reason: the
+    /// boot CPU parses the frame and leaves each secondary's registers here for
+    /// the thread that owns that vCPU to apply. Empty for a cold boot, where
+    /// secondaries wait for the guest's own PSCI `CPU_ON` instead.
+    restored_states: &'a Mutex<Vec<Option<HvfVcpuState>>>,
+}
+
+impl MachineShared<'_> {
+    /// True once this run is over, for any reason.
+    fn stopping(&self) -> bool {
+        self.stop.load(Ordering::Relaxed) || self.machine_over.load(Ordering::Relaxed)
+    }
+
+    /// Record that `cpu` is parked, with the registers it is parked at.
+    fn publish_parked(&self, cpu: u32, state: HvfVcpuState) {
+        if let Some(slot) = self
+            .parked_states
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get_mut(cpu as usize)
+        {
+            *slot = Some(state);
+        }
+    }
+
+    /// Forget that `cpu` is parked, because it is about to run again.
+    ///
+    /// Cleared on the way out of the hold rather than on the way in, so a
+    /// capture can never read a state belonging to a CPU that has since
+    /// resumed and moved on.
+    fn clear_parked(&self, cpu: u32) {
+        if let Some(slot) = self
+            .parked_states
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get_mut(cpu as usize)
+        {
+            *slot = None;
+        }
+    }
+
+    /// Every secondary's parked state, in CPU order, or `None` if any CPU has
+    /// not parked yet.
+    ///
+    /// The condition a snapshot waits on. Capturing while one CPU is still in
+    /// the guest would write a frame whose RAM and whose registers describe
+    /// different instants — the child would resume a CPU mid-way through a
+    /// critical section the memory image says it never entered.
+    fn secondaries_parked(&self) -> Option<Vec<HvfVcpuState>> {
+        self.parked_states
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .skip(1)
+            .map(Clone::clone)
+            .collect()
+    }
+
+    /// Take the state CPU `cpu` is to resume from, if this is a restored
+    /// machine.
+    fn take_restored(&self, cpu: u32) -> Option<HvfVcpuState> {
+        self.restored_states
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get_mut(cpu as usize)
+            .and_then(Option::take)
+    }
+
+    /// End the machine: release every parked secondary and force every running
+    /// one out of the guest.
+    ///
+    /// Called by each vCPU as it leaves its run loop, and on a failed bring-up.
+    /// Idempotent, and it must stay that way — every CPU calls it, and the
+    /// scope joining them afterwards would otherwise wait forever on a CPU the
+    /// guest never onlined.
+    fn end(&self) {
+        self.machine_over.store(true, Ordering::Relaxed);
+        self.gates.shutdown();
+        let handles = self
+            .roster
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        HvfHandle::force_exit(&handles);
+    }
+}
+
+/// What the boot CPU's run needs beyond the shared machine state.
+struct PrimaryRun<'a> {
+    vcpu: &'a HvfVcpu,
+    guest_ram: &'a GuestRam,
+    /// Mirrors the pause request into the on-disk pause marker. Only the boot
+    /// CPU maintains it: it is one file describing one machine, and every CPU
+    /// writing it would have them racing to create and remove the same path.
+    pause_ack: Arc<AtomicBool>,
+    pause_state: Option<PathBuf>,
+    snapshot: SnapshotPaths,
+    /// CPUs this machine has. A snapshot frame holds one vCPU's registers, so a
+    /// request that arrives on a machine with more is refused rather than
+    /// answered with a frame that describes a fraction of it.
+    vcpus: u32,
+}
+
+/// Drive the boot CPU until the machine stops.
+fn run_primary<B: run::DeviceBus>(
+    input: PrimaryRun<'_>,
+    shared: &MachineShared<'_>,
+    bus: &B,
+    diagnostics: &mut CpuDiagnostics,
+) -> Result<RunOutcome, HvfError> {
+    let PrimaryRun {
+        vcpu,
+        guest_ram,
+        pause_ack,
+        pause_state,
+        snapshot,
+        vcpus,
+    } = input;
+    let SnapshotPaths {
+        request: snapshot_request,
+        ram: snapshot_ram,
+        frame: snapshot_frame,
+    } = snapshot;
+
+    run::run_on_bus(
+        vcpu,
+        set_gic_spi,
+        bus,
+        run::RunHooks {
+            on_exception: |vc: &HvfVcpu, esr, _phys| handle_exception(vc, esr, shared, diagnostics),
+            // A forced exit is a real stop only when a stop was requested (timeout,
+            // graceful, or another CPU ending the machine); otherwise it's a heartbeat
+            // wake so the run loop can drain egress sockets into a guest blocked in WFI
+            // (vsock-only egress async proxy).
+            should_stop: || shared.stopping(),
+            // Park the vCPU in the run loop's pause hold while `paused` is set,
+            // freezing guest RAM + device state in place until resume clears it.
+            should_pause: move || {
+                let requested = shared.paused.load(Ordering::Relaxed);
+                if requested {
+                    if !pause_ack.swap(true, Ordering::AcqRel)
+                        && let Some(path) = &pause_state
+                    {
+                        let _ = std::fs::write(path, b"paused\n");
+                    }
+                } else if pause_ack.swap(false, Ordering::AcqRel)
+                    && let Some(path) = &pause_state
+                {
+                    let _ = std::fs::remove_file(path);
+                }
+                requested
+            },
+            on_pause: move |vcpu: &HvfVcpu, devices: &[&dyn SnapshotDeviceState]| {
+                let (Some(request_path), Some(ram_path), Some(frame_path)) = (
+                    snapshot_request.as_deref(),
+                    snapshot_ram.as_deref(),
+                    snapshot_frame.as_deref(),
+                ) else {
+                    return Ok(());
+                };
+                if !request_path.exists() {
+                    return Ok(());
+                }
+                // Wait for every other CPU to reach the pause hold and publish
+                // its registers. They are all being held by the same `paused`
+                // flag, so this resolves on the next turn round the hold; what
+                // it rules out is capturing while one CPU is still in the
+                // guest, which would write a frame whose RAM and whose
+                // registers describe different instants.
+                let Some(secondary_states) = shared.secondaries_parked() else {
+                    return Ok(());
+                };
+                debug_assert_eq!(
+                    secondary_states.len() + 1,
+                    vcpus as usize,
+                    "a parked state per CPU beyond the boot CPU"
+                );
+
+                let ram_bytes = guest_ram.snapshot_bytes();
+                let device_bytes = capture_device_states(devices)
+                    .map_err(|_| HvfError::SnapshotState("snapshot device capture failed"))?;
+                // Boot CPU first, then the rest in CPU order — the order a
+                // restore hands them back out in.
+                let mut vcpu_states = Vec::with_capacity(vcpus as usize);
+                vcpu_states.push(vcpu.capture_state()?);
+                vcpu_states.extend(secondary_states);
+                let frame = super::snapshot::encode_hvf_snapshot_frame(
+                    HVF_SNAPSHOT_BACKEND_KIND,
+                    0,
+                    &ram_bytes,
+                    &device_bytes,
+                    &vcpu_states,
+                    &[],
+                )
+                .map_err(|_| HvfError::SnapshotState("snapshot frame encode failed"))?;
+                std::fs::write(ram_path, &ram_bytes)
+                    .map_err(|_| HvfError::SnapshotState("snapshot RAM write failed"))?;
+                std::fs::write(frame_path, frame)
+                    .map_err(|_| HvfError::SnapshotState("snapshot frame write failed"))?;
+                std::fs::remove_file(request_path)
+                    .map_err(|_| HvfError::SnapshotState("snapshot request cleanup failed"))?;
+                Ok(())
+            },
+            should_throttle: || shared.throttle.load(Ordering::Relaxed),
+            _marker: std::marker::PhantomData,
+        },
+    )
+}
+
+/// Confirm one vCPU's GIC redistributor frame is where the device tree told the
+/// guest it would be.
+///
+/// HVF derives the frame from the vCPU's MPIDR_EL1 affinity and will not answer
+/// before that register is set, so this must follow the affinity write. It is
+/// the only way to read back where a vCPU's frame landed, and worth asking:
+/// a mismatch does not degrade, it hangs. The guest matches CPUs to
+/// redistributors during IRQ init, before the console exists, so the boot stops
+/// with nothing written anywhere. Failing here names the CPU and both
+/// addresses instead.
+fn verify_redistributor_frame(vcpu_id: hv_vcpu_t, cpu: u32) -> Result<(), HvfError> {
+    let mut base: hv_ipa_t = 0;
+    // SAFETY: a live vCPU owned by this thread, with its MPIDR_EL1 already set;
+    // `base` is a valid out-param.
+    let rc = unsafe { hv_gic_get_redistributor_base(vcpu_id, &mut base) };
+    if rc != HV_SUCCESS {
+        return Err(HvfError::GicCreate(rc));
+    }
+    let expected = fdt::GICV3_REDIST_BASE + u64::from(cpu) * fdt::GICV3_REDIST_STRIDE;
+    if base != expected {
+        return Err(HvfError::RedistributorMismatch {
+            cpu,
+            expected,
+            actual: base,
+        });
+    }
+    Ok(())
+}
+
+/// Create one secondary vCPU, give it its identity, and check the GIC agrees
+/// about where its redistributor frame is.
+///
+/// MPIDR_EL1 is set here rather than left to [`apply_vcpu_start`] because it is
+/// this CPU's identity, known from its number alone, and everything else about
+/// the start state comes from a PSCI `CPU_ON` that has not happened yet. HVF
+/// also needs the affinity before it will say where the redistributor frame is,
+/// which is what makes the check possible this early — before the guest is
+/// running and while a failure is still a failed boot rather than a hang.
+fn create_secondary_vcpu(cpu: u32) -> Result<(HvfVcpu, hv_vcpu_t), HvfError> {
+    let mut vcpu_id: hv_vcpu_t = 0;
+    let mut exit: *mut hv_vcpu_exit_t = core::ptr::null_mut();
+    // SAFETY: between `hv_vm_create` and `hv_vm_destroy` — the boot CPU holds
+    // the VM open for as long as this thread is joined within, which the
+    // enclosing `thread::scope` guarantees. Called on this thread because HVF
+    // binds a vCPU to the thread that creates it.
+    let rc = unsafe { hv_vcpu_create(&mut vcpu_id, &mut exit, core::ptr::null_mut()) };
+    if rc != HV_SUCCESS {
+        return Err(HvfError::VcpuCreate(rc));
+    }
+    let vcpu = HvfVcpu::from_raw(vcpu_id, exit);
+
+    let identified = vcpu
+        .set_sys(SysReg::MpidrEl1, fdt::mpidr_for_cpu(cpu))
+        .and_then(|()| verify_redistributor_frame(vcpu_id, cpu));
+    if let Err(e) = identified {
+        // SAFETY: created on this thread and not used again.
+        unsafe { hv_vcpu_destroy(vcpu_id) };
+        return Err(e);
+    }
+    Ok((vcpu, vcpu_id))
+}
+
+/// Create, park, and then drive one secondary vCPU.
+///
+/// Runs on its own thread for the length of the machine, because HVF requires a
+/// vCPU be created on the thread that runs it. Reports the outcome of its
+/// creation through `created` before parking, so the boot CPU can fail the boot
+/// rather than start a guest that will wait forever on a CPU the host refused.
+fn run_secondary<B: run::DeviceBus>(
+    cpu: u32,
+    shared: &MachineShared<'_>,
+    bus: &B,
+    created: &std::sync::mpsc::Sender<Result<Option<ThreadCpuHandle>, HvfError>>,
+) -> Result<CpuDiagnostics, HvfError> {
+    // Creation order does not matter: HVF places a vCPU's redistributor frame
+    // by its MPIDR affinity, which `create_secondary_vcpu` sets from the CPU
+    // number before checking where the frame landed.
+    let (vcpu, vcpu_id) = match create_secondary_vcpu(cpu) {
+        Ok(created_vcpu) => created_vcpu,
+        Err(e) => {
+            let _ = created.send(Err(e));
+            return Err(e);
+        }
+    };
+    shared
+        .roster
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push(vcpu.exit_token());
+    // Captured here because it must be captured on the thread it measures.
+    let clock = ThreadCpuHandle::for_current_thread().ok();
+    let registered = created.send(Ok(clock)).is_ok();
+
+    let result = (|| {
+        if !registered || shared.stopping() {
+            // The boot CPU gave up on the bring-up. Do not enter the guest.
+            return Ok((RunOutcome::Stopped, CpuDiagnostics::default()));
+        }
+        match shared.take_restored(cpu) {
+            // A restored machine: this CPU was already running when its parent
+            // was captured, and the guest inside the restored RAM believes it
+            // still is. Resume it directly — waiting for a `CPU_ON` that the
+            // guest has no reason to issue again would hang the child with a
+            // CPU its own scheduler is dispatching onto.
+            Some(state) => {
+                vcpu.restore_state(&state)?;
+                shared.gates.mark_on(cpu);
+            }
+            // A cold boot: park until the guest's PSCI `CPU_ON` says where to
+            // start — or until the machine ends, for a CPU it never onlined.
+            None => {
+                let Release::Start(start) = shared.gates.wait_for_release(cpu) else {
+                    return Ok((RunOutcome::Stopped, CpuDiagnostics::default()));
+                };
+                apply_vcpu_start(&vcpu, start)?;
+            }
+        }
+
+        let mut diagnostics = CpuDiagnostics::default();
+        let outcome = run::run_on_bus(
+            &vcpu,
+            set_gic_spi,
+            bus,
+            run::RunHooks {
+                on_exception: |vc: &HvfVcpu, esr, _phys| {
+                    handle_exception(vc, esr, shared, &mut diagnostics)
+                },
+                should_stop: || shared.stopping(),
+                // A secondary parks for a pause like any other CPU, and writes
+                // no pause marker: that file describes the machine, and the
+                // boot CPU owns it. What it does do is clear its published
+                // state on the way out of the hold, so a capture can never read
+                // registers from a CPU that has already resumed.
+                should_pause: || {
+                    let requested = shared.paused.load(Ordering::Relaxed);
+                    if !requested {
+                        shared.clear_parked(cpu);
+                    }
+                    requested
+                },
+                // Publish this CPU's registers while it is parked. The boot CPU
+                // cannot read them — HVF binds register access to the owning
+                // thread — so a snapshot of an SMP machine is assembled from
+                // what each CPU leaves here.
+                on_pause: |vc: &HvfVcpu, _: &[&dyn SnapshotDeviceState]| {
+                    shared.publish_parked(cpu, vc.capture_state()?);
+                    Ok(())
+                },
+                should_throttle: || shared.throttle.load(Ordering::Relaxed),
+                _marker: std::marker::PhantomData,
+            },
+        )?;
+        Ok((outcome, diagnostics))
+    })();
+
+    // This CPU is done, so the machine is: release every other CPU rather than
+    // leaving them in a guest that has nothing left to run.
+    shared.end();
+    // SAFETY: created on this thread, never used after this point, and the VM
+    // outlives the thread.
+    unsafe { hv_vcpu_destroy(vcpu_id) };
+    result.map(|(_, diagnostics)| diagnostics)
+}
+
 unsafe fn run(
     guest_ram: &mut GuestRam,
     ram: *mut u8,
@@ -970,10 +1429,29 @@ unsafe fn run(
         // EL1h with DAIF masked. Routed through `VcpuStart` so a secondary
         // released by PSCI takes this same path with different data rather than
         // a second copy of it.
-        if let Err(e) = apply_vcpu_start(&vcpu, VcpuStart::primary(entry, dtb_addr)) {
+        // The start state sets MPIDR_EL1, which is what HVF places the GIC
+        // redistributor frame by — so the frame can only be checked afterwards.
+        // Checked for the boot CPU too: a machine whose CPU 0 cannot find its
+        // redistributor hangs in IRQ init with an empty console, and that is
+        // worth naming whether it happens on one CPU or four.
+        let started = apply_vcpu_start(&vcpu, VcpuStart::primary(entry, dtb_addr))
+            .and_then(|()| verify_redistributor_frame(vcpu_id, 0));
+        if let Err(e) = started {
             hv_vcpu_destroy(vcpu_id);
             return Err(e);
         }
+
+        // The parking spots the guest's PSCI `CPU_ON` calls release. Built for
+        // the same count the device tree was, so a call for a CPU the tree
+        // describes always finds a gate.
+        let gates = SecondaryGates::new(vcpus);
+        // Every vCPU's force-exit token, for the threads that have to interrupt
+        // all of them at once: the watchdog, and the quota controller. The boot
+        // CPU registers here; each secondary adds itself as it is created.
+        // Behind a lock rather than built up front because a token only exists
+        // once its vCPU does, and a vCPU only exists on the thread that will run
+        // it.
+        let roster: Arc<Mutex<Vec<HvfHandle>>> = Arc::new(Mutex::new(vec![vcpu.exit_token()]));
 
         // Watchdog + heartbeat: a booting kernel never exits on its own, so force
         // the vCPU out after `timeout` or as soon as `stop` is set (graceful stop).
@@ -1005,22 +1483,12 @@ unsafe fn run(
         let agent_bound = agent_socket.is_some();
         let substitution_socket = substitution_socket
             .or_else(|| std::env::var_os("MVM_HVF_SUBSTITUTION_SOCKET").map(PathBuf::from));
-        let handle = vcpu.exit_token();
-
-        // Start the in-process CPU quota controller when the supervisor config
-        // carries a share. Failing to start the controller must not fail the
-        // boot; the VM falls back to the unbounded path and writes no record.
-        let mut quota: Option<VcpuQuota<HvfHandle>> = None;
-        if let Some(millicores) = cpu_millicores
-            && let Ok(config) = QuotaConfig::for_share(millicores)
-            && let Ok(clock) = ThreadCpuHandle::for_current_thread()
-        {
-            quota = Some(VcpuQuota::start(handle, clock, QuotaPolicy::new(config)));
-        }
-        let throttle_flag = quota
-            .as_ref()
-            .map(|q| q.throttle_flag().clone())
-            .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+        // The boot CPU's own CPU-time handle. Captured here because it must be
+        // captured *on* the thread it measures, and this is that thread; the
+        // controller it feeds is started further down, once every secondary has
+        // contributed its own.
+        let primary_clock = ThreadCpuHandle::for_current_thread().ok();
+        let roster_w = Arc::clone(&roster);
 
         let watchdog = std::thread::spawn(move || {
             let step = Duration::from_millis(5);
@@ -1051,14 +1519,28 @@ unsafe fn run(
                     || agent_bound
                     || egress_active_w.load(Ordering::Relaxed) > 0
                 {
-                    HvfHandle::force_exit(&[handle]); // wake the run loop
+                    // Every vCPU, not just the boot CPU: the work the wake
+                    // exists for — draining a host reply into the guest, or
+                    // reaching the pause hold — has to happen on whichever CPU
+                    // is in the guest, and on an SMP machine that is rarely
+                    // CPU 0 alone.
+                    let handles = roster_w
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .clone();
+                    HvfHandle::force_exit(&handles); // wake the run loops
                 }
             };
             pause_ack_w.store(false, Ordering::Release);
             if let Some(path) = &pause_state_w {
                 let _ = std::fs::remove_file(path);
             }
-            HvfHandle::force_exit(&[handle]); // final wake → loop sees stop, returns
+            // Final wake, every CPU → each loop sees the stop and returns.
+            let handles = roster_w
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            HvfHandle::force_exit(&handles);
             Some(stop_observed_at)
         });
 
@@ -1208,10 +1690,15 @@ unsafe fn run(
         }
 
         // Diagnostics gathered by the exception hook (HVC/PSCI + other traps).
-        let mut hvc_calls = 0usize;
-        let mut other_exceptions = 0usize;
-        let mut psci_fns: Vec<u64> = Vec::new();
-        let mut other_ecs: Vec<u32> = Vec::new();
+        // The boot CPU's; each secondary keeps its own and they are merged once
+        // the threads have joined.
+        let mut diagnostics = CpuDiagnostics::default();
+
+        // Each secondary's registers to resume from, filled in by the restore
+        // below and drained by that CPU's own thread. Empty for a cold boot,
+        // where secondaries wait for the guest's PSCI `CPU_ON` instead.
+        let mut restored_secondaries: Vec<Option<HvfVcpuState>> =
+            (0..vcpus).map(|_| None).collect();
 
         if let Some(frame_path) = restore_frame.as_deref() {
             let frame = std::fs::read(frame_path)
@@ -1231,13 +1718,32 @@ unsafe fn run(
                 .iter_mut()
                 .filter_map(|device| device.snapshot_device_mut())
                 .collect::<Vec<_>>();
-            super::snapshot::restore_hvf_snapshot_control(
+            // Restores the boot CPU here and hands back the rest: HVF only
+            // lets a vCPU's registers be written from the thread that created
+            // it, and those threads do not exist yet.
+            let secondary_states = super::snapshot::restore_hvf_snapshot_control(
                 &frame,
                 guest_ram.len(),
                 &vcpu,
                 &mut snapshot_targets,
             )
             .map_err(|_| HvfError::SnapshotState("restore control state failed"))?;
+            // A frame from a machine of a different shape cannot be resumed
+            // into this one: the guest in the restored RAM has a CPU count
+            // baked into its own scheduler state. Refuse rather than boot a
+            // child whose CPUs disagree with the memory image describing them.
+            if secondary_states.len() + 1 != vcpus as usize {
+                return Err(HvfError::SnapshotState(
+                    "snapshot vCPU count does not match this machine",
+                ));
+            }
+            for (slot, state) in restored_secondaries
+                .iter_mut()
+                .skip(1)
+                .zip(secondary_states)
+            {
+                *slot = Some(state);
+            }
             drop(snapshot_targets);
             drop(restore_devices);
 
@@ -1265,7 +1771,11 @@ unsafe fn run(
 
         // Scope the device list so its mutable borrows end before we read the
         // device output below.
-        let outcome = {
+        // Whether the guest asked to power down, as opposed to being stopped
+        // from outside. Declared out here because the boot result is assembled
+        // below, after the vCPU threads it is set by have been joined.
+        let guest_shutdown = AtomicBool::new(false);
+        let (outcome, mut quota) = {
             let mut devices: Vec<&mut dyn RunDevice> = vec![&mut uart];
             for v in virtio_disks.iter_mut() {
                 devices.push(v);
@@ -1277,119 +1787,133 @@ unsafe fn run(
                 devices.push(fs);
             }
             devices.push(&mut rng_dev);
-            let set_irq = |intid: u32, level: bool| -> Result<(), HvfError> {
-                // SAFETY: FFI to the process-global in-kernel GIC (nested in the
-                // enclosing `unsafe` block).
-                if hv_gic_set_spi(intid, level) == HV_SUCCESS {
-                    Ok(())
-                } else {
-                    Err(HvfError::GicCreate(0))
-                }
+
+            // One bus whether this machine has one CPU or eight. A single-CPU
+            // run pays an uncontended lock per MMIO exit, which is nothing next
+            // to the exit itself, and in exchange the common path is the same
+            // code as the rare one rather than a copy of it that can rot.
+            let bus = run::SharedBus::new(&mut devices);
+            let machine_over = AtomicBool::new(false);
+            // Indexed by CPU number, slot 0 unused: the boot CPU reads and
+            // writes its own registers directly.
+            let parked_states: Mutex<Vec<Option<HvfVcpuState>>> =
+                Mutex::new((0..vcpus).map(|_| None).collect());
+            let restored_states: Mutex<Vec<Option<HvfVcpuState>>> =
+                Mutex::new(restored_secondaries);
+            // Created before any vCPU thread, because every one of them reads
+            // it to know when to park. The quota controller that sets it starts
+            // later, once each CPU has contributed its CPU clock.
+            let throttle = Arc::new(AtomicBool::new(false));
+            let shared = MachineShared {
+                gates: &gates,
+                roster: &roster,
+                stop,
+                paused,
+                machine_over: &machine_over,
+                guest_shutdown: &guest_shutdown,
+                throttle: &throttle,
+                parked_states: &parked_states,
+                restored_states: &restored_states,
             };
-            let snapshot_guest_ram = &*guest_ram;
-            run::run_with_hooks(
-                &vcpu,
-                set_irq,
-                &mut devices,
-                run::RunHooks {
-                    on_exception: |vc: &HvfVcpu, esr, _phys| {
-                        if esr_ec(esr) == EC_HVC_AARCH64 {
-                            hvc_calls += 1;
-                            let fn_id = vc.get_core(CoreReg::X(0))?;
-                            if psci_fns.len() < 16 && !psci_fns.contains(&fn_id) {
-                                psci_fns.push(fn_id);
-                            }
-                            match fn_id {
-                                PSCI_SYSTEM_OFF | PSCI_SYSTEM_RESET => return Ok(RunControl::Stop),
-                                PSCI_VERSION_FN => vc.set_core(CoreReg::X(0), 0x1_0000)?, // PSCI v1.0
-                                // x1 is the target MPIDR for both calls. Answered
-                                // against the CPUs this VMM actually created —
-                                // the same count the device tree was built from —
-                                // so the two can never disagree about which CPUs
-                                // exist.
-                                PSCI_CPU_ON_SMC64 | PSCI_CPU_ON_SMC32 => {
-                                    let target = vc.get_core(CoreReg::X(1))?;
-                                    vc.set_core(CoreReg::X(0), psci_cpu_on(target, vcpus))?;
-                                }
-                                PSCI_AFFINITY_INFO_SMC64 | PSCI_AFFINITY_INFO_SMC32 => {
-                                    let target = vc.get_core(CoreReg::X(1))?;
-                                    vc.set_core(CoreReg::X(0), psci_affinity_info(target, vcpus))?;
-                                }
-                                _ => vc.set_core(CoreReg::X(0), PSCI_NOT_SUPPORTED)?,
-                            }
-                            // HVC is completed: HVF already advanced PC. Do NOT advance.
-                            Ok(RunControl::Continue)
-                        } else {
-                            let ec = esr_ec(esr);
-                            other_exceptions += 1;
-                            if other_ecs.len() < 16 && !other_ecs.contains(&ec) {
-                                other_ecs.push(ec);
-                            }
-                            // Advance past the faulting instruction and keep going.
-                            let pc = vc.get_core(CoreReg::Pc)?;
-                            vc.set_core(CoreReg::Pc, pc + 4)?;
-                            Ok(RunControl::Continue)
-                        }
-                    },
-                    // A forced exit is a real stop only when `stop` is set (timeout or
-                    // graceful); otherwise it's a heartbeat wake so the run loop can drain
-                    // egress sockets into a guest blocked in WFI (vsock-only egress async proxy).
-                    should_stop: move || stop.load(Ordering::Relaxed),
-                    // Park the vCPU in the run loop's pause hold while `paused` is set,
-                    // freezing guest RAM + device state in place until resume clears it.
-                    should_pause: move || {
-                        let requested = paused.load(Ordering::Relaxed);
-                        if requested {
-                            if !pause_ack.swap(true, Ordering::AcqRel)
-                                && let Some(path) = &pause_state
-                            {
-                                let _ = std::fs::write(path, b"paused\n");
-                            }
-                        } else if pause_ack.swap(false, Ordering::AcqRel)
-                            && let Some(path) = &pause_state
-                        {
-                            let _ = std::fs::remove_file(path);
-                        }
-                        requested
-                    },
-                    on_pause: move |vcpu, devices| {
-                        let (Some(request_path), Some(ram_path), Some(frame_path)) = (
-                            snapshot_request.as_deref(),
-                            snapshot_ram.as_deref(),
-                            snapshot_frame.as_deref(),
-                        ) else {
-                            return Ok(());
-                        };
-                        if !request_path.exists() {
-                            return Ok(());
-                        }
-                        let ram_bytes = snapshot_guest_ram.snapshot_bytes();
-                        let device_bytes = capture_device_states(devices).map_err(|_| {
-                            HvfError::SnapshotState("snapshot device capture failed")
-                        })?;
-                        let vcpu_state = vcpu.capture_state()?;
-                        let frame = super::snapshot::encode_hvf_snapshot_frame(
-                            HVF_SNAPSHOT_BACKEND_KIND,
-                            0,
-                            &ram_bytes,
-                            &device_bytes,
-                            &vcpu_state,
-                            &[],
-                        )
-                        .map_err(|_| HvfError::SnapshotState("snapshot frame encode failed"))?;
-                        std::fs::write(ram_path, &ram_bytes)
-                            .map_err(|_| HvfError::SnapshotState("snapshot RAM write failed"))?;
-                        std::fs::write(frame_path, frame)
-                            .map_err(|_| HvfError::SnapshotState("snapshot frame write failed"))?;
-                        std::fs::remove_file(request_path).map_err(|_| {
-                            HvfError::SnapshotState("snapshot request cleanup failed")
-                        })?;
-                        Ok(())
-                    },
-                    should_throttle: move || throttle_flag.load(Ordering::Relaxed),
-                    _marker: std::marker::PhantomData,
+            let primary = PrimaryRun {
+                vcpu: &vcpu,
+                guest_ram: &*guest_ram,
+                pause_ack,
+                pause_state,
+                snapshot: SnapshotPaths {
+                    request: snapshot_request,
+                    ram: snapshot_ram,
+                    frame: snapshot_frame,
                 },
-            )?
+                vcpus,
+            };
+
+            std::thread::scope(|scope| {
+                // Every secondary reports the result of its own
+                // `hv_vcpu_create` here before parking.
+                let (created_tx, created_rx) = std::sync::mpsc::channel();
+                let secondaries: Vec<_> = (1..vcpus)
+                    .map(|cpu| {
+                        let created_tx = created_tx.clone();
+                        let shared = &shared;
+                        let bus = &bus;
+                        scope.spawn(move || run_secondary(cpu, shared, bus, &created_tx))
+                    })
+                    .collect();
+                drop(created_tx);
+
+                // Wait for the whole machine to exist before starting the
+                // guest. The device tree already describes these CPUs, so a
+                // vCPU the host refuses to create has to fail the boot here —
+                // once the kernel is running it will online that CPU, wait for
+                // it to reach its release point, and hang with no console
+                // output to say why.
+                let mut clocks: Vec<ThreadCpuHandle> = primary_clock.into_iter().collect();
+                let mut bring_up: Result<(), HvfError> = Ok(());
+                for _ in 1..vcpus {
+                    match created_rx.recv() {
+                        Ok(Ok(clock)) => clocks.extend(clock),
+                        Ok(Err(e)) => bring_up = bring_up.and(Err(e)),
+                        // The thread died without reporting. Nothing else can
+                        // say which CPU is missing, but the boot must not
+                        // proceed a CPU short of the tree it was given.
+                        Err(_) => {
+                            bring_up = bring_up.and(Err(HvfError::VcpuCreate(0)));
+                        }
+                    }
+                }
+
+                // Bound the machine only once every vCPU exists and has
+                // contributed its clock: a controller charging one thread of an
+                // SMP guest would see a fraction of what it is consuming and
+                // never throttle. Failing to start the controller must not fail
+                // the boot; the VM falls back to the unbounded path and writes
+                // no record.
+                let quota = bring_up
+                    .is_ok()
+                    .then(|| {
+                        let handles = roster
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .clone();
+                        cpu_millicores
+                            .and_then(|millicores| QuotaConfig::for_share(millicores).ok())
+                            .filter(|_| !clocks.is_empty())
+                            .map(|config| {
+                                VcpuQuota::start_with_hold(
+                                    handles,
+                                    SummedClock::new(clocks),
+                                    QuotaPolicy::new(config),
+                                    Arc::clone(&throttle),
+                                )
+                            })
+                    })
+                    .flatten();
+
+                let outcome =
+                    bring_up.and_then(|()| run_primary(primary, &shared, &bus, &mut diagnostics));
+
+                // The boot CPU is out of the guest, so the machine is over.
+                // Every secondary has to be released — including one the guest
+                // never onlined, which is parked on its gate and would
+                // otherwise be joined forever at the end of this scope.
+                shared.end();
+                for secondary in secondaries {
+                    match secondary.join() {
+                        Ok(Ok(cpu_diagnostics)) => diagnostics.merge(cpu_diagnostics),
+                        // A secondary that failed has already been accounted for
+                        // through `bring_up`, or failed after the machine was
+                        // running — where the boot CPU's outcome is the one that
+                        // describes the run.
+                        Ok(Err(_)) => {}
+                        // A panicked vCPU thread leaves the device model
+                        // poisoned; the bus reports that on its next lock. There
+                        // is nothing to merge.
+                        Err(_) => {}
+                    }
+                }
+                outcome.map(|outcome| (outcome, quota))
+            })?
         };
 
         let vcpu_exited_at = Instant::now();
@@ -1435,14 +1959,24 @@ unsafe fn run(
         let mut r = KernelBootResult {
             console: uart.output,
             exit_reason: match outcome {
-                RunOutcome::Canceled => HV_EXIT_REASON_CANCELED,
+                // A run the guest ended by powering itself down reports as an
+                // exception however it reached the loop's exit: on an SMP
+                // machine the CPU that took `PSCI SYSTEM_OFF` may not be the
+                // one whose outcome is reported, and the other CPUs leave
+                // through the same forced exit a timeout uses.
+                RunOutcome::Canceled if !guest_shutdown.load(Ordering::Relaxed) => {
+                    HV_EXIT_REASON_CANCELED
+                }
                 _ => HV_EXIT_REASON_EXCEPTION,
             },
-            hvc_calls,
-            stopped_by_watchdog: outcome == RunOutcome::Canceled,
-            other_exceptions,
-            psci_fns,
-            other_ecs,
+            // Every CPU's, merged: the boot CPU's own plus whatever each
+            // secondary reported as it joined.
+            hvc_calls: diagnostics.hvc_calls,
+            stopped_by_watchdog: outcome == RunOutcome::Canceled
+                && !guest_shutdown.load(Ordering::Relaxed),
+            other_exceptions: diagnostics.other_exceptions,
+            psci_fns: diagnostics.psci_fns,
+            other_ecs: diagnostics.other_ecs,
             final_pc,
             shutdown_timing: stop_observed_at.map(|observed_at| KernelShutdownTiming {
                 watchdog_to_vcpu_exit: vcpu_exited_at.saturating_duration_since(observed_at),
@@ -1467,24 +2001,17 @@ unsafe fn run(
 
 #[cfg(test)]
 mod tests {
-    /// The tree this VMM boots describes exactly one CPU, whatever was asked
-    /// for.
+    /// The device tree describes exactly the CPUs the VMM creates.
     ///
-    /// Pinned against the literal 1 — the number of `hv_vcpu_create` calls the
-    /// run loop actually makes — and deliberately **not** against
-    /// `effective_vcpus()`. Comparing the tree to the same function that built
-    /// it is self-referential: it stays green when the clamp changes, which is
-    /// precisely the drift worth catching. A tree advertising more CPUs than
-    /// the VMM creates does not degrade to a smaller machine; the guest onlines
-    /// secondaries that never respond and the boot hangs with no console
-    /// output, reading as a VMM fault rather than a topology mismatch.
-    ///
-    /// When SMP lands this becomes the assertion that the tree matches the
-    /// spawned thread count, and it has to be updated deliberately — which is
-    /// the point.
+    /// Pinned against `effective_vcpus`, which is also what the vCPU bring-up
+    /// counts, because these two readings are the fact: a tree describing more
+    /// CPUs than exist has the kernel online secondaries that never respond and
+    /// the boot hangs with no console output — not a smaller machine, a dead
+    /// one. Fewer, and the vCPUs that do exist are never onlined.
     #[test]
-    fn the_booted_tree_describes_exactly_the_one_cpu_the_vmm_creates() {
-        for requested in [0u32, 1, 2, 4, 64] {
+    fn the_booted_tree_describes_exactly_the_cpus_the_vmm_creates() {
+        for requested in [0u32, 1, 2, 4, 8] {
+            let vcpus = super::effective_vcpus(requested);
             let dtb = mvm_vmm::vmm::fdt::build_dtb(
                 "console=ttyAMA0",
                 0x8000_0000,
@@ -1492,132 +2019,111 @@ mod tests {
                 None,
                 &[],
                 None,
-                super::effective_vcpus(requested),
+                vcpus,
             );
             let described = dtb.windows(4).filter(|w| *w == b"cpu@").count();
             assert_eq!(
-                described, 1,
-                "requested {requested}: the tree must describe the single CPU \
-                 this VMM creates, not the request"
+                described as u32, vcpus,
+                "requested {requested}: the tree must describe the {vcpus} CPUs \
+                 this VMM creates"
             );
         }
     }
 
-    /// The primary starts per the arm64 boot protocol: DTB in x0, affinity 0.
-    #[test]
-    fn the_primary_starts_with_the_dtb_in_x0_at_affinity_zero() {
-        let start = super::VcpuStart::primary(0x8008_0000, 0x9FE0_0000);
-        assert_eq!(start.mpidr, 0, "the boot CPU is cpu@0");
-        assert_eq!(start.entry, 0x8008_0000);
-        assert_eq!(
-            start.x0, 0x9FE0_0000,
-            "arm64 boot protocol puts the DTB address in x0"
-        );
-    }
-
-    /// A secondary carries its PSCI context id in x0, not the DTB.
+    /// The gates answer for exactly the CPUs the tree describes.
     ///
-    /// `CPU_ON(target, entry, context_id)` hands the kernel a per-CPU pointer it
-    /// reads back on the other side. Passing the DTB there instead would have
-    /// the secondary dereference the device tree as its per-CPU data — a fault
-    /// the guest attributes to itself, with nothing on the host to explain it.
+    /// The other half of the same fact. A `CPU_ON` for a CPU the tree named has
+    /// to find a gate — the guest was told that CPU exists — and one beyond the
+    /// tree has to be refused.
     #[test]
-    fn a_secondary_starts_at_its_psci_entry_with_the_context_id_in_x0() {
-        // Built directly: the constructor lands with the code that releases
-        // secondaries. What is pinned here is the *shape* a secondary starts
-        // with, which the release path must produce.
-        let start = super::VcpuStart {
-            mpidr: mvm_vmm::vmm::fdt::mpidr_for_cpu(3),
-            entry: 0x8100_0000,
-            x0: 0xDEAD_BEEF,
-        };
-        assert_eq!(start.mpidr, 3, "cpu@3 has affinity 3");
-        assert_eq!(start.entry, 0x8100_0000, "PSCI supplies the entry point");
-        assert_eq!(start.x0, 0xDEAD_BEEF, "PSCI supplies the context id");
-    }
-
-    /// Every CPU's MPIDR matches the device tree node built for it.
-    ///
-    /// These are the two halves of one fact. If they drift, the CPU cannot be
-    /// matched to its GIC redistributor frame and IRQ init faults before any
-    /// console output — a silent hang.
-    #[test]
-    fn each_vcpu_start_agrees_with_its_device_tree_node() {
-        for index in 0..8u32 {
-            assert_eq!(
-                super::VcpuStart::primary(0, 0).mpidr,
-                mvm_vmm::vmm::fdt::mpidr_for_cpu(0),
-                "the boot cpu's start state and device tree must agree"
-            );
-            assert_eq!(
-                mvm_vmm::vmm::fdt::mpidr_for_cpu(index),
-                u64::from(index),
-                "cpu {index}: affinity is the node address"
-            );
-        }
-    }
-
-    /// `CPU_ON` must never claim success for a CPU no thread backs.
-    ///
-    /// This is the property that keeps a partial SMP implementation safe. The
-    /// kernel's `cpu_up` waits for the target to reach its release point, so
-    /// answering SUCCESS for a CPU that will never run turns "fewer CPUs than
-    /// asked for" into "boot never finishes" — a hang with no console output.
-    /// `INVALID_PARAMETERS` is the defined answer for a target the
-    /// implementation does not have, and Linux leaves that CPU offline and
-    /// carries on.
-    #[test]
-    fn cpu_on_never_reports_success_for_a_cpu_no_thread_backs() {
-        // One vCPU: every target above CPU 0 is absent.
-        for target in [1u64, 2, 7, 63] {
-            assert_eq!(
-                super::psci_cpu_on(target, 1),
-                super::PSCI_INVALID_PARAMETERS,
-                "target {target} does not exist on a 1-CPU machine"
-            );
-        }
-        // Whatever the count, success is not currently reachable — there is no
-        // secondary thread to release.
-        for created in [1u32, 2, 4] {
-            for target in 0..u64::from(created) {
+    fn psci_answers_for_exactly_the_cpus_the_tree_describes() {
+        for requested in [1u32, 2, 4] {
+            let vcpus = super::effective_vcpus(requested);
+            let gates = super::SecondaryGates::new(vcpus);
+            assert_eq!(gates.vcpus(), vcpus);
+            for cpu in 0..u64::from(vcpus) {
                 assert_ne!(
-                    super::psci_cpu_on(target, created),
-                    0,
-                    "PSCI SUCCESS is 0 and must not be returned while no \
-                     secondary thread exists to be released"
+                    gates.affinity_info(cpu),
+                    super::psci::INVALID_PARAMETERS,
+                    "cpu {cpu} is in the tree, so PSCI must know it"
                 );
             }
+            assert_eq!(
+                gates.affinity_info(u64::from(vcpus)),
+                super::psci::INVALID_PARAMETERS,
+                "the CPU past the end of the tree does not exist"
+            );
         }
     }
 
-    /// `AFFINITY_INFO` distinguishes "absent" from "present but off".
+    /// A request is honoured, not quietly reduced.
     ///
-    /// The kernel polls this after a `CPU_ON`. Answering NOT_SUPPORTED would
-    /// leave it unable to tell a failed bring-up from an unimplemented call.
+    /// Zero is not a machine, so it means one. Everything else is passed
+    /// through: the host's real ceiling is whatever `hv_vcpu_create` grants,
+    /// and a count it refuses fails the boot rather than handing back a smaller
+    /// machine than the one that was asked for. Silently giving one CPU to a
+    /// workload that asked for four is the defect this whole path exists to
+    /// fix.
     #[test]
-    fn affinity_info_separates_an_absent_cpu_from_a_stopped_one() {
-        assert_eq!(super::psci_affinity_info(0, 1), super::PSCI_AFFINITY_OFF);
-        assert_eq!(
-            super::psci_affinity_info(1, 1),
-            super::PSCI_INVALID_PARAMETERS
-        );
-        assert_eq!(super::psci_affinity_info(3, 4), super::PSCI_AFFINITY_OFF);
-        assert_eq!(
-            super::psci_affinity_info(4, 4),
-            super::PSCI_INVALID_PARAMETERS
-        );
+    fn a_requested_cpu_count_is_honoured_rather_than_reduced() {
+        assert_eq!(super::effective_vcpus(0), 1, "zero is not a machine");
+        for requested in [1u32, 2, 4, 8, 64] {
+            assert_eq!(
+                super::effective_vcpus(requested),
+                requested,
+                "a request for {requested} CPUs must not be reduced"
+            );
+        }
     }
 
-    /// Until the run loop is threaded, the honest answer to any request is one.
+    /// Per-CPU diagnostics merge into one description of the machine.
     ///
-    /// `relay_supervisor_config` refuses `vcpus > 1` before this is reached, so
-    /// this clamp is the second line rather than the first — but it is the one
-    /// that keeps the tree truthful if a caller ever bypasses that gate.
+    /// Counts add, and the sampled function ids and exception classes stay a
+    /// set: the question they answer is which kinds occurred, and a secondary
+    /// issuing the same PSCI call as the boot CPU is not new information.
     #[test]
-    fn a_request_beyond_what_the_vmm_supports_clamps_rather_than_lies() {
-        assert_eq!(super::effective_vcpus(0), 1, "zero is not a machine");
-        assert_eq!(super::effective_vcpus(1), 1);
-        assert_eq!(super::effective_vcpus(8), 1, "no SMP yet — see #2888");
+    fn diagnostics_from_every_cpu_merge_into_one_machine_view() {
+        let mut primary = super::CpuDiagnostics {
+            hvc_calls: 3,
+            other_exceptions: 1,
+            psci_fns: vec![0x8400_0000],
+            other_ecs: vec![0x16],
+        };
+        primary.merge(super::CpuDiagnostics {
+            hvc_calls: 2,
+            other_exceptions: 4,
+            // One already seen, one new.
+            psci_fns: vec![0x8400_0000, 0xC400_0003],
+            other_ecs: vec![0x16, 0x24],
+        });
+
+        assert_eq!(primary.hvc_calls, 5, "counts add across CPUs");
+        assert_eq!(primary.other_exceptions, 5);
+        assert_eq!(
+            primary.psci_fns,
+            vec![0x8400_0000, 0xC400_0003],
+            "function ids are a set, in first-seen order"
+        );
+        assert_eq!(primary.other_ecs, vec![0x16, 0x24]);
+    }
+
+    /// Merging cannot grow the sample lists without bound.
+    ///
+    /// A guest in a fault loop on several CPUs would otherwise hand back a
+    /// vector per exception for the length of the run.
+    #[test]
+    fn merging_diagnostics_respects_the_sample_limit() {
+        let mut primary = super::CpuDiagnostics::default();
+        for cpu in 0..8u64 {
+            primary.merge(super::CpuDiagnostics {
+                hvc_calls: 0,
+                other_exceptions: 0,
+                psci_fns: (0..8).map(|i| cpu * 8 + i).collect(),
+                other_ecs: (0..8).map(|i| (cpu * 8 + i) as u32).collect(),
+            });
+        }
+        assert_eq!(primary.psci_fns.len(), super::DIAGNOSTIC_SAMPLE_LIMIT);
+        assert_eq!(primary.other_ecs.len(), super::DIAGNOSTIC_SAMPLE_LIMIT);
     }
 
     use super::*;

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -27,7 +27,7 @@ use super::HvfError;
 use super::guest_ram::HVF_PAGE_SIZE;
 use super::guest_ram::{GuestRam, page_rounded_len};
 use super::hv_impl::{HvfHandle, HvfVcpu};
-use super::smp::{Release, SecondaryGates, VcpuStart, psci};
+use super::smp::{CreationOrder, Release, SecondaryGates, VcpuStart, psci};
 use super::snapshot::{HVF_SNAPSHOT_BACKEND_KIND, HvfVcpuState};
 use super::sys::*;
 use super::vcpu::esr_ec;
@@ -945,6 +945,9 @@ struct SnapshotPaths {
 struct MachineShared<'a> {
     /// The parking spots PSCI `CPU_ON` releases.
     gates: &'a SecondaryGates,
+    /// Keeps vCPU creation in CPU-number order, so each CPU gets the GIC
+    /// redistributor frame the device tree assigned it.
+    creation_order: &'a CreationOrder,
     /// Every live vCPU's force-exit token.
     roster: &'a Mutex<Vec<HvfHandle>>,
     /// The supervisor's stop flag: a timeout, or a graceful stop.
@@ -1189,9 +1192,11 @@ fn run_primary<B: run::DeviceBus>(
 /// Confirm one vCPU's GIC redistributor frame is where the device tree told the
 /// guest it would be.
 ///
-/// HVF derives the frame from the vCPU's MPIDR_EL1 affinity and will not answer
-/// before that register is set, so this must follow the affinity write. It is
-/// the only way to read back where a vCPU's frame landed, and worth asking:
+/// HVF will not answer before MPIDR_EL1 is set, so this must follow the
+/// affinity write — but affinity is only a precondition for the *query*. The
+/// frame itself is assigned in `hv_vcpu_create` order, which is why creation is
+/// serialised. It is the only way to read back where a vCPU's frame landed, and
+/// worth asking:
 /// a mismatch does not degrade, it hangs. The guest matches CPUs to
 /// redistributors during IRQ init, before the console exists, so the boot stops
 /// with nothing written anywhere. Failing here names the CPU and both
@@ -1221,9 +1226,12 @@ fn verify_redistributor_frame(vcpu_id: hv_vcpu_t, cpu: u32) -> Result<(), HvfErr
 /// MPIDR_EL1 is set here rather than left to [`apply_vcpu_start`] because it is
 /// this CPU's identity, known from its number alone, and everything else about
 /// the start state comes from a PSCI `CPU_ON` that has not happened yet. HVF
-/// also needs the affinity before it will say where the redistributor frame is,
+/// needs the affinity before it will say where the redistributor frame is,
 /// which is what makes the check possible this early — before the guest is
 /// running and while a failure is still a failed boot rather than a hang.
+///
+/// The caller must hold this CPU's turn in the creation order; the frame this
+/// checks is handed out by `hv_vcpu_create` in call order, not by affinity.
 fn create_secondary_vcpu(cpu: u32) -> Result<(HvfVcpu, hv_vcpu_t), HvfError> {
     let mut vcpu_id: hv_vcpu_t = 0;
     let mut exit: *mut hv_vcpu_exit_t = core::ptr::null_mut();
@@ -1260,10 +1268,16 @@ fn run_secondary<B: run::DeviceBus>(
     bus: &B,
     created: &std::sync::mpsc::Sender<Result<Option<ThreadCpuHandle>, HvfError>>,
 ) -> Result<CpuDiagnostics, HvfError> {
-    // Creation order does not matter: HVF places a vCPU's redistributor frame
-    // by its MPIDR affinity, which `create_secondary_vcpu` sets from the CPU
-    // number before checking where the frame landed.
-    let (vcpu, vcpu_id) = match create_secondary_vcpu(cpu) {
+    // HVF allocates GIC redistributor frames in `hv_vcpu_create` order, and the
+    // device tree tells the guest CPU n owns the nth. Take a turn, so the nth
+    // vCPU created is CPU n whatever order the scheduler started these threads
+    // in. Without it two threads swap frames and the guest cannot match either
+    // CPU to its redistributor.
+    shared.creation_order.wait_for_turn(cpu);
+    let create = create_secondary_vcpu(cpu);
+    shared.creation_order.finished(cpu);
+
+    let (vcpu, vcpu_id) = match create {
         Ok(created_vcpu) => created_vcpu,
         Err(e) => {
             let _ = created.send(Err(e));
@@ -1804,8 +1818,10 @@ unsafe fn run(
             // it to know when to park. The quota controller that sets it starts
             // later, once each CPU has contributed its CPU clock.
             let throttle = Arc::new(AtomicBool::new(false));
+            let creation_order = CreationOrder::default();
             let shared = MachineShared {
                 gates: &gates,
+                creation_order: &creation_order,
                 roster: &roster,
                 stop,
                 paused,

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -1230,9 +1230,18 @@ fn verify_redistributor_frame(vcpu_id: hv_vcpu_t, cpu: u32) -> Result<(), HvfErr
 /// which is what makes the check possible this early — before the guest is
 /// running and while a failure is still a failed boot rather than a hang.
 ///
-/// The caller must hold this CPU's turn in the creation order; the frame this
-/// checks is handed out by `hv_vcpu_create` in call order, not by affinity.
-fn create_secondary_vcpu(cpu: u32) -> Result<(HvfVcpu, hv_vcpu_t), HvfError> {
+/// Takes this CPU's turn in `order` for the duration, because the frame HVF
+/// hands back is chosen by `hv_vcpu_create` call order rather than by affinity.
+/// The turn is taken *here*, in the one function that creates a vCPU, so the
+/// ordering cannot be separated from the call it exists to order — it was a
+/// pair of statements at the call site once, and deleting them was a one-line
+/// change that reintroduced the race with nothing in CI to notice.
+fn create_secondary_vcpu(
+    cpu: u32,
+    order: &CreationOrder,
+) -> Result<(HvfVcpu, hv_vcpu_t), HvfError> {
+    // Held until this function returns, by any path.
+    let _turn = order.take_turn(cpu);
     let mut vcpu_id: hv_vcpu_t = 0;
     let mut exit: *mut hv_vcpu_exit_t = core::ptr::null_mut();
     // SAFETY: between `hv_vm_create` and `hv_vm_destroy` — the boot CPU holds
@@ -1268,16 +1277,11 @@ fn run_secondary<B: run::DeviceBus>(
     bus: &B,
     created: &std::sync::mpsc::Sender<Result<Option<ThreadCpuHandle>, HvfError>>,
 ) -> Result<CpuDiagnostics, HvfError> {
-    // HVF allocates GIC redistributor frames in `hv_vcpu_create` order, and the
-    // device tree tells the guest CPU n owns the nth. Take a turn, so the nth
-    // vCPU created is CPU n whatever order the scheduler started these threads
-    // in. Without it two threads swap frames and the guest cannot match either
-    // CPU to its redistributor.
-    shared.creation_order.wait_for_turn(cpu);
-    let create = create_secondary_vcpu(cpu);
-    shared.creation_order.finished(cpu);
-
-    let (vcpu, vcpu_id) = match create {
+    // Ordered internally: HVF allocates GIC redistributor frames in
+    // `hv_vcpu_create` order and the device tree tells the guest CPU n owns the
+    // nth, so the nth vCPU created has to be CPU n whatever order the scheduler
+    // started these threads in.
+    let (vcpu, vcpu_id) = match create_secondary_vcpu(cpu, shared.creation_order) {
         Ok(created_vcpu) => created_vcpu,
         Err(e) => {
             let _ = created.send(Err(e));

--- a/crates/mvm-runtime/src/backends/hvf/mod.rs
+++ b/crates/mvm-runtime/src/backends/hvf/mod.rs
@@ -8,6 +8,7 @@ mod console_smoke;
 mod guest_ram;
 mod hv_impl;
 mod kernel_boot;
+mod smp;
 pub mod snapshot;
 mod sys;
 mod vcpu;

--- a/crates/mvm-runtime/src/backends/hvf/smp.rs
+++ b/crates/mvm-runtime/src/backends/hvf/smp.rs
@@ -1,0 +1,467 @@
+//! Secondary-vCPU bring-up: the PSCI state machine and the gate a parked CPU
+//! waits on.
+//!
+//! HVF requires a vCPU be created on the thread that runs it, so an SMP machine
+//! is one thread per CPU. Every thread but the boot CPU's starts *parked*: the
+//! arm64 boot protocol has the kernel bring secondaries up itself, one PSCI
+//! `CPU_ON` at a time, each carrying the entry point and per-CPU context that
+//! CPU is to start with. A secondary that ran before its `CPU_ON` would execute
+//! whatever the boot CPU had left in RAM.
+//!
+//! Nothing here touches the hypervisor. The gates are the synchronisation and
+//! the PSCI decisions, kept separate from `hv_vcpu_*` so both can be tested
+//! without a VM — which matters because the failure mode this code prevents is
+//! a boot that hangs with no console output, and that is not a thing one
+//! debugs from a test.
+
+use std::sync::{Condvar, Mutex};
+
+use crate::vmm::fdt;
+
+/// PSCI return codes, from the Arm Power State Coordination Interface spec.
+/// Named rather than inlined because the guest's behaviour differs sharply
+/// between them and `-2` at a call site says nothing about which.
+pub(crate) mod psci {
+    pub(crate) const SUCCESS: u64 = 0;
+    pub(crate) const NOT_SUPPORTED: u64 = (-1i64) as u64;
+    /// The target CPU is not one this machine has.
+    pub(crate) const INVALID_PARAMETERS: u64 = (-2i64) as u64;
+    /// The target CPU is already running.
+    pub(crate) const ALREADY_ON: u64 = (-4i64) as u64;
+    /// `AFFINITY_INFO`: the queried CPU is running.
+    pub(crate) const AFFINITY_ON: u64 = 0;
+    /// `AFFINITY_INFO`: the queried CPU is stopped.
+    pub(crate) const AFFINITY_OFF: u64 = 1;
+}
+
+/// The register state one vCPU starts from.
+///
+/// The primary and a secondary differ only in these values, not in how they are
+/// created, so the difference is data rather than a second code path. The
+/// primary enters at the kernel's entry point with the DTB in x0, per the arm64
+/// boot protocol. A secondary released by PSCI `CPU_ON` enters at the address
+/// that call supplied, with its context id in x0 — the kernel puts a per-CPU
+/// pointer there and reads it back on the other side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct VcpuStart {
+    /// MPIDR_EL1 affinity. Must equal the `cpu@<addr>` node's reg in the device
+    /// tree, or the CPU cannot be matched to its GIC redistributor frame.
+    pub(crate) mpidr: u64,
+    /// Where this CPU begins executing.
+    pub(crate) entry: u64,
+    /// x0 at entry: the DTB address for the primary, the PSCI context id for a
+    /// secondary.
+    pub(crate) x0: u64,
+}
+
+impl VcpuStart {
+    /// The boot CPU: entry point from the kernel image, DTB in x0.
+    pub(crate) fn primary(entry: u64, dtb_addr: u64) -> Self {
+        Self {
+            mpidr: fdt::mpidr_for_cpu(0),
+            entry,
+            x0: dtb_addr,
+        }
+    }
+
+    /// A secondary released by `CPU_ON(target, entry, context_id)`.
+    pub(crate) fn secondary(cpu: u32, entry: u64, context_id: u64) -> Self {
+        Self {
+            mpidr: fdt::mpidr_for_cpu(cpu),
+            entry,
+            x0: context_id,
+        }
+    }
+}
+
+/// Why a parked secondary woke up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Release {
+    /// A PSCI `CPU_ON` supplied these start values; enter the guest.
+    Start(VcpuStart),
+    /// The run is ending. Leave without ever entering the guest — this is the
+    /// path for a CPU the guest never onlined (a `maxcpus=` cmdline, or a
+    /// kernel that simply chose not to).
+    Shutdown,
+}
+
+/// What one secondary is waiting on.
+#[derive(Debug, Default)]
+struct GateState {
+    /// Set by a `CPU_ON` from another CPU; taken by the parked thread.
+    requested: Option<VcpuStart>,
+    /// Whether this CPU has been released. Distinct from `requested`, which the
+    /// waiting thread consumes: `AFFINITY_INFO` and the `ALREADY_ON` check have
+    /// to keep answering after the request is taken.
+    on: bool,
+    /// The run is ending; wake and leave.
+    shutdown: bool,
+}
+
+/// One secondary's parking spot.
+#[derive(Default)]
+struct CpuGate {
+    state: Mutex<GateState>,
+    wake: Condvar,
+}
+
+/// Every secondary's gate, and the PSCI calls answered against them.
+///
+/// Indexed by CPU number, with index 0 unused — the boot CPU is never parked
+/// and is never a `CPU_ON` target. Keeping it in the vector rather than
+/// offsetting by one means a CPU number is an index everywhere, which is one
+/// fewer place for an off-by-one to put a CPU's start values into its
+/// neighbour's gate.
+pub(crate) struct SecondaryGates {
+    gates: Vec<CpuGate>,
+}
+
+impl SecondaryGates {
+    /// Gates for a machine of `vcpus` CPUs.
+    pub(crate) fn new(vcpus: u32) -> Self {
+        Self {
+            gates: (0..vcpus.max(1)).map(|_| CpuGate::default()).collect(),
+        }
+    }
+
+    /// CPUs this machine has.
+    pub(crate) fn vcpus(&self) -> u32 {
+        u32::try_from(self.gates.len()).unwrap_or(u32::MAX)
+    }
+
+    /// Answer a PSCI `CPU_ON(target_mpidr, entry, context_id)`.
+    ///
+    /// Never reports `SUCCESS` for a CPU no thread is waiting to run. The
+    /// kernel's `cpu_up` blocks until the target reaches its release point, so
+    /// a success this VMM cannot honour turns "fewer CPUs than asked for" into
+    /// "the boot never finishes" — a hang with no console output, which reads
+    /// as a VMM fault rather than a topology mismatch.
+    pub(crate) fn cpu_on(&self, target_mpidr: u64, entry: u64, context_id: u64) -> u64 {
+        let Some(cpu) = self.cpu_index(target_mpidr) else {
+            return psci::INVALID_PARAMETERS;
+        };
+        if cpu == 0 {
+            // The boot CPU is running this very call.
+            return psci::ALREADY_ON;
+        }
+        let mut state = self.lock(cpu);
+        if state.on {
+            return psci::ALREADY_ON;
+        }
+        state.on = true;
+        state.requested = Some(VcpuStart::secondary(cpu, entry, context_id));
+        drop(state);
+        self.gates[cpu as usize].wake.notify_all();
+        psci::SUCCESS
+    }
+
+    /// Answer a PSCI `AFFINITY_INFO(target_mpidr, ..)`.
+    ///
+    /// The kernel polls this after a `CPU_ON`, so the answer has to separate a
+    /// CPU that does not exist from one that exists and has not started.
+    /// `NOT_SUPPORTED` here would leave it unable to tell a failed bring-up
+    /// from an unimplemented call.
+    pub(crate) fn affinity_info(&self, target_mpidr: u64) -> u64 {
+        let Some(cpu) = self.cpu_index(target_mpidr) else {
+            return psci::INVALID_PARAMETERS;
+        };
+        if cpu == 0 {
+            return psci::AFFINITY_ON;
+        }
+        if self.lock(cpu).on {
+            psci::AFFINITY_ON
+        } else {
+            psci::AFFINITY_OFF
+        }
+    }
+
+    /// Record that `cpu` is already running, without releasing a gate.
+    ///
+    /// For a restored machine: that CPU was running when its parent was
+    /// captured, so it resumes directly from the saved registers rather than
+    /// waiting for a `CPU_ON` the guest has no reason to issue again. The gate
+    /// still has to know, or `AFFINITY_INFO` would report a running CPU as off
+    /// and a later `CPU_ON` would try to restart it.
+    pub(crate) fn mark_on(&self, cpu: u32) {
+        if cpu < self.vcpus() {
+            self.lock(cpu).on = true;
+        }
+    }
+
+    /// Park the calling thread until CPU `cpu` is released or the run ends.
+    ///
+    /// Returns [`Release::Shutdown`] for a CPU the guest never onlined, so
+    /// every spawned thread has a way out that does not depend on the guest
+    /// having cooperated.
+    pub(crate) fn wait_for_release(&self, cpu: u32) -> Release {
+        let gate = &self.gates[cpu as usize];
+        let mut state = gate
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        loop {
+            if let Some(start) = state.requested.take() {
+                return Release::Start(start);
+            }
+            if state.shutdown {
+                return Release::Shutdown;
+            }
+            state = gate
+                .wake
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    /// Wake every parked secondary to leave. Idempotent, so the shutdown path
+    /// can call it without tracking whether it already has.
+    pub(crate) fn shutdown(&self) {
+        for gate in &self.gates {
+            gate.state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .shutdown = true;
+            gate.wake.notify_all();
+        }
+    }
+
+    /// The CPU number an MPIDR names, or `None` if this machine has no such
+    /// CPU.
+    fn cpu_index(&self, target_mpidr: u64) -> Option<u32> {
+        (0..self.vcpus()).find(|cpu| fdt::mpidr_for_cpu(*cpu) == target_mpidr)
+    }
+
+    fn lock(&self, cpu: u32) -> std::sync::MutexGuard<'_, GateState> {
+        self.gates[cpu as usize]
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    /// A `CPU_ON` releases exactly the CPU it named, with the values it carried.
+    ///
+    /// The entry point and context id are the whole payload of the call: the
+    /// kernel reads its per-CPU pointer back out of x0 on the other side, so
+    /// delivering another CPU's values — or the DTB address the primary got —
+    /// has the secondary dereference the wrong thing as its own state. That
+    /// faults inside the guest, with nothing on the host to explain it.
+    #[test]
+    fn cpu_on_releases_the_named_cpu_with_the_values_it_carried() {
+        let gates = Arc::new(SecondaryGates::new(4));
+        let waiter = {
+            let gates = Arc::clone(&gates);
+            std::thread::spawn(move || gates.wait_for_release(2))
+        };
+
+        // Issued without waiting for the thread to park. The request is stored
+        // in the gate rather than signalled to whoever happens to be waiting,
+        // so a `CPU_ON` that lands first is still collected — the race a
+        // notify-only gate would lose is exactly the one that hangs a boot.
+        assert_eq!(
+            gates.cpu_on(2, 0x8100_0000, 0xDEAD_BEEF),
+            psci::SUCCESS,
+            "cpu 2 exists and is off, so CPU_ON must succeed"
+        );
+
+        assert_eq!(
+            waiter.join().unwrap(),
+            Release::Start(VcpuStart {
+                mpidr: 2,
+                entry: 0x8100_0000,
+                x0: 0xDEAD_BEEF,
+            })
+        );
+    }
+
+    /// A CPU this machine does not have is refused, not silently accepted.
+    #[test]
+    fn cpu_on_refuses_a_cpu_this_machine_does_not_have() {
+        let gates = SecondaryGates::new(2);
+        for absent in [2u64, 3, 64] {
+            assert_eq!(
+                gates.cpu_on(absent, 0x8100_0000, 0),
+                psci::INVALID_PARAMETERS,
+                "cpu {absent} does not exist on a 2-CPU machine"
+            );
+            assert_eq!(gates.affinity_info(absent), psci::INVALID_PARAMETERS);
+        }
+    }
+
+    /// The boot CPU is always on, and turning it on again is `ALREADY_ON`.
+    #[test]
+    fn the_boot_cpu_reports_on_and_cannot_be_turned_on_again() {
+        let gates = SecondaryGates::new(4);
+        assert_eq!(gates.affinity_info(0), psci::AFFINITY_ON);
+        assert_eq!(gates.cpu_on(0, 0x8100_0000, 0), psci::ALREADY_ON);
+    }
+
+    /// A second `CPU_ON` for a CPU already released is `ALREADY_ON`.
+    ///
+    /// It must not queue a second set of start values: the CPU is running by
+    /// then, and re-entering it at a fresh entry point would reset a CPU the
+    /// kernel believes it owns.
+    #[test]
+    fn a_repeated_cpu_on_is_refused_rather_than_restarting_the_cpu() {
+        let gates = SecondaryGates::new(2);
+        assert_eq!(gates.cpu_on(1, 0x8100_0000, 1), psci::SUCCESS);
+        assert_eq!(gates.cpu_on(1, 0x8200_0000, 2), psci::ALREADY_ON);
+        assert_eq!(
+            gates.wait_for_release(1),
+            Release::Start(VcpuStart {
+                mpidr: 1,
+                entry: 0x8100_0000,
+                x0: 1,
+            }),
+            "the first request stands; the second must not have replaced it"
+        );
+    }
+
+    /// `AFFINITY_INFO` separates a CPU that is absent from one that is present
+    /// and stopped.
+    #[test]
+    fn affinity_info_separates_an_absent_cpu_from_a_stopped_one() {
+        let gates = SecondaryGates::new(4);
+        assert_eq!(gates.affinity_info(3), psci::AFFINITY_OFF);
+        assert_eq!(gates.affinity_info(4), psci::INVALID_PARAMETERS);
+        assert_eq!(gates.cpu_on(3, 0x8100_0000, 0), psci::SUCCESS);
+        assert_eq!(
+            gates.affinity_info(3),
+            psci::AFFINITY_ON,
+            "a released CPU reports on even after its request is consumed"
+        );
+    }
+
+    /// A CPU the guest never onlined still has a way out.
+    ///
+    /// A `maxcpus=1` cmdline, or a kernel that simply declines to online the
+    /// rest, leaves those threads parked forever. Without this the run would
+    /// hang at join — the VM's work finished, every workload result in hand,
+    /// waiting on a CPU the guest was never going to ask for.
+    #[test]
+    fn shutdown_releases_a_cpu_the_guest_never_onlined() {
+        let gates = Arc::new(SecondaryGates::new(3));
+        let waiters: Vec<_> = [1u32, 2]
+            .into_iter()
+            .map(|cpu| {
+                let gates = Arc::clone(&gates);
+                std::thread::spawn(move || gates.wait_for_release(cpu))
+            })
+            .collect();
+
+        gates.shutdown();
+
+        for waiter in waiters {
+            assert_eq!(waiter.join().unwrap(), Release::Shutdown);
+        }
+    }
+
+    /// Shutdown after a release still lets an already-started CPU be woken
+    /// again — the second wait returns `Shutdown` rather than blocking.
+    #[test]
+    fn shutdown_is_idempotent_and_outlives_a_consumed_request() {
+        let gates = SecondaryGates::new(2);
+        assert_eq!(gates.cpu_on(1, 0x8100_0000, 0), psci::SUCCESS);
+        assert!(matches!(gates.wait_for_release(1), Release::Start(_)));
+        gates.shutdown();
+        gates.shutdown();
+        assert_eq!(gates.wait_for_release(1), Release::Shutdown);
+    }
+
+    /// A single-CPU machine has gates that answer, rather than a special case.
+    ///
+    /// `--cpus 1` is by far the common path, and it reaches exactly this code.
+    /// Every target above the boot CPU is absent, which is what makes a guest
+    /// that probes for secondaries leave them offline and carry on.
+    #[test]
+    fn a_single_cpu_machine_reports_only_the_boot_cpu() {
+        let gates = SecondaryGates::new(1);
+        assert_eq!(gates.vcpus(), 1);
+        assert_eq!(gates.affinity_info(0), psci::AFFINITY_ON);
+        for absent in [1u64, 2, 7] {
+            assert_eq!(gates.cpu_on(absent, 0, 0), psci::INVALID_PARAMETERS);
+            assert_eq!(gates.affinity_info(absent), psci::INVALID_PARAMETERS);
+        }
+    }
+
+    /// Every CPU's start state agrees with the device tree node built for it.
+    ///
+    /// These are two halves of one fact. If they drift, the CPU cannot be
+    /// matched to its GIC redistributor frame and IRQ init faults before any
+    /// console output.
+    #[test]
+    fn each_vcpu_start_agrees_with_its_device_tree_node() {
+        assert_eq!(VcpuStart::primary(0, 0).mpidr, fdt::mpidr_for_cpu(0));
+        for cpu in 1..8u32 {
+            assert_eq!(
+                VcpuStart::secondary(cpu, 0x8100_0000, 0).mpidr,
+                fdt::mpidr_for_cpu(cpu),
+                "cpu {cpu}: start affinity must match its device tree node"
+            );
+        }
+    }
+
+    /// The primary carries the DTB in x0; a secondary carries its context id.
+    #[test]
+    fn the_primary_carries_the_dtb_and_a_secondary_its_context_id() {
+        let primary = VcpuStart::primary(0x8008_0000, 0x9FE0_0000);
+        assert_eq!(primary.entry, 0x8008_0000);
+        assert_eq!(
+            primary.x0, 0x9FE0_0000,
+            "arm64 boot protocol puts the DTB address in x0"
+        );
+
+        let secondary = VcpuStart::secondary(1, 0x8100_0000, 0xFEED_FACE);
+        assert_eq!(secondary.entry, 0x8100_0000);
+        assert_eq!(
+            secondary.x0, 0xFEED_FACE,
+            "PSCI supplies the context id, not the DTB"
+        );
+    }
+
+    /// Concurrent `CPU_ON`s for different CPUs each release their own.
+    ///
+    /// Linux brings secondaries up one at a time, but nothing in PSCI requires
+    /// it, and a gate that serialised them through shared state would be a
+    /// latent hang the moment a guest did otherwise.
+    #[test]
+    fn concurrent_cpu_ons_release_each_cpu_independently() {
+        let gates = Arc::new(SecondaryGates::new(5));
+        let waiters: Vec<_> = (1..5u32)
+            .map(|cpu| {
+                let gates = Arc::clone(&gates);
+                std::thread::spawn(move || (cpu, gates.wait_for_release(cpu)))
+            })
+            .collect();
+
+        let callers: Vec<_> = (1..5u32)
+            .map(|cpu| {
+                let gates = Arc::clone(&gates);
+                std::thread::spawn(move || {
+                    gates.cpu_on(u64::from(cpu), 0x8100_0000 + u64::from(cpu), u64::from(cpu))
+                })
+            })
+            .collect();
+
+        for caller in callers {
+            assert_eq!(caller.join().unwrap(), psci::SUCCESS);
+        }
+        for waiter in waiters {
+            let (cpu, release) = waiter.join().unwrap();
+            assert_eq!(
+                release,
+                Release::Start(VcpuStart {
+                    mpidr: u64::from(cpu),
+                    entry: 0x8100_0000 + u64::from(cpu),
+                    x0: u64::from(cpu),
+                }),
+                "cpu {cpu} must receive its own start values, not another's"
+            );
+        }
+    }
+}

--- a/crates/mvm-runtime/src/backends/hvf/smp.rs
+++ b/crates/mvm-runtime/src/backends/hvf/smp.rs
@@ -110,8 +110,14 @@ impl Default for CreationOrder {
 }
 
 impl CreationOrder {
-    /// Block until it is `cpu`'s turn to be created.
-    pub(crate) fn wait_for_turn(&self, cpu: u32) {
+    /// Block until it is `cpu`'s turn, and hold the turn until the guard drops.
+    ///
+    /// A guard rather than a `wait`/`release` pair because the release is not
+    /// optional: a CPU that kept its turn would leave every later CPU blocked
+    /// forever, and the boot CPU waiting on reports that never come. Every way
+    /// out of the creation path — success, an error return, a panic — drops
+    /// the guard, so there is no arm that can forget.
+    pub(crate) fn take_turn(&self, cpu: u32) -> TurnGuard<'_> {
         let mut next = self
             .next
             .lock()
@@ -122,21 +128,27 @@ impl CreationOrder {
                 .wait(next)
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
         }
+        drop(next);
+        TurnGuard { order: self, cpu }
     }
+}
 
-    /// Release the next CPU.
-    ///
-    /// Must be called whether or not the creation succeeded. A CPU that failed
-    /// and kept the turn would leave every later CPU blocked here, and the boot
-    /// CPU waiting on reports that are never coming.
-    pub(crate) fn finished(&self, cpu: u32) {
+/// One CPU's turn to call `hv_vcpu_create`, released on drop.
+pub(crate) struct TurnGuard<'a> {
+    order: &'a CreationOrder,
+    cpu: u32,
+}
+
+impl Drop for TurnGuard<'_> {
+    fn drop(&mut self) {
         let mut next = self
+            .order
             .next
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        *next = (*next).max(cpu.saturating_add(1));
+        *next = (*next).max(self.cpu.saturating_add(1));
         drop(next);
-        self.advanced.notify_all();
+        self.order.advanced.notify_all();
     }
 }
 
@@ -475,9 +487,8 @@ mod tests {
                 let order = Arc::clone(&order);
                 let created = Arc::clone(&created);
                 std::thread::spawn(move || {
-                    order.wait_for_turn(cpu);
+                    let _turn = order.take_turn(cpu);
                     created.lock().unwrap().push(cpu);
-                    order.finished(cpu);
                 })
             })
             .collect();
@@ -497,7 +508,9 @@ mod tests {
     /// Otherwise every later CPU blocks on a turn that never comes, and the
     /// boot CPU waits for bring-up reports that are never sent — a hang, where
     /// the honest outcome is a failed boot naming the CPU that could not be
-    /// created.
+    /// created. The guard is what makes this hold on every arm: cpu 2 returns
+    /// early here, exactly as a failed `hv_vcpu_create` does, and releases the
+    /// queue anyway because it never had to remember to.
     #[test]
     fn a_failed_creation_still_releases_the_cpus_behind_it() {
         let order = Arc::new(CreationOrder::default());
@@ -508,11 +521,12 @@ mod tests {
                 let order = Arc::clone(&order);
                 let reached = Arc::clone(&reached);
                 std::thread::spawn(move || {
-                    order.wait_for_turn(cpu);
+                    let _turn = order.take_turn(cpu);
                     reached.lock().unwrap().push(cpu);
-                    // Every CPU releases the next, including the one that
-                    // "failed" (cpu 2, which records nothing further).
-                    order.finished(cpu);
+                    // The failure arm for cpu 2: it records nothing further and
+                    // releases no turn explicitly, exactly as a failed
+                    // `hv_vcpu_create` returning early does.
+                    assert!(cpu != 2 || reached.lock().unwrap().contains(&2));
                 })
             })
             .collect();
@@ -521,6 +535,34 @@ mod tests {
         }
 
         assert_eq!(*reached.lock().unwrap(), vec![1, 2, 3]);
+    }
+
+    /// A panicking creation releases the queue too.
+    ///
+    /// The strongest form of the same property: unwinding drops the guard, so
+    /// even a vCPU thread that dies mid-creation cannot wedge the boot CPU
+    /// waiting on CPUs that will never take their turn.
+    #[test]
+    fn a_panicking_creation_does_not_wedge_the_cpus_behind_it() {
+        let order = Arc::new(CreationOrder::default());
+
+        let panicker = {
+            let order = Arc::clone(&order);
+            std::thread::spawn(move || {
+                let _turn = order.take_turn(1);
+                panic!("hv_vcpu_create blew up");
+            })
+        };
+        assert!(panicker.join().is_err(), "the thread must have panicked");
+
+        let follower = {
+            let order = Arc::clone(&order);
+            std::thread::spawn(move || {
+                let _turn = order.take_turn(2);
+                "cpu 2 got its turn"
+            })
+        };
+        assert_eq!(follower.join().unwrap(), "cpu 2 got its turn");
     }
 
     /// Every CPU's start state agrees with the device tree node built for it.

--- a/crates/mvm-runtime/src/backends/hvf/smp.rs
+++ b/crates/mvm-runtime/src/backends/hvf/smp.rs
@@ -74,6 +74,72 @@ impl VcpuStart {
     }
 }
 
+/// Serialises `hv_vcpu_create` into CPU-number order.
+///
+/// HVF hands each vCPU a GIC redistributor frame as it is created, allocating
+/// them consecutively from the base the GIC was configured with — **in creation
+/// order**. The device tree tells the guest that CPU *n* owns the *n*th frame,
+/// so the *n*th vCPU created has to be CPU *n*. Threads spawned in a loop reach
+/// their first instruction in whatever order the scheduler picks, so without
+/// this two of them swap frames.
+///
+/// That is not hypothetical: it is what `--cpus 5` did. CPU 3 took CPU 4's
+/// frame on one boot and CPU 4 took CPU 3's on the next, and the guest could
+/// never match its CPUs to their redistributors. The odds rise with the thread
+/// count, which is why it read as a ceiling at four rather than as the race it
+/// is.
+///
+/// Setting MPIDR_EL1 does *not* substitute for this. Affinity is a precondition
+/// for `hv_gic_get_redistributor_base` answering at all, which is a different
+/// thing from it deciding where the frame goes — assuming otherwise is exactly
+/// how this ordering came to be removed once already.
+pub(crate) struct CreationOrder {
+    /// The CPU whose turn it is. Starts at 1: the boot CPU is created before
+    /// any secondary thread is spawned.
+    next: Mutex<u32>,
+    advanced: Condvar,
+}
+
+impl Default for CreationOrder {
+    fn default() -> Self {
+        Self {
+            next: Mutex::new(1),
+            advanced: Condvar::new(),
+        }
+    }
+}
+
+impl CreationOrder {
+    /// Block until it is `cpu`'s turn to be created.
+    pub(crate) fn wait_for_turn(&self, cpu: u32) {
+        let mut next = self
+            .next
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while *next < cpu {
+            next = self
+                .advanced
+                .wait(next)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+
+    /// Release the next CPU.
+    ///
+    /// Must be called whether or not the creation succeeded. A CPU that failed
+    /// and kept the turn would leave every later CPU blocked here, and the boot
+    /// CPU waiting on reports that are never coming.
+    pub(crate) fn finished(&self, cpu: u32) {
+        let mut next = self
+            .next
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *next = (*next).max(cpu.saturating_add(1));
+        drop(next);
+        self.advanced.notify_all();
+    }
+}
+
 /// Why a parked secondary woke up.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Release {
@@ -387,6 +453,74 @@ mod tests {
             assert_eq!(gates.cpu_on(absent, 0, 0), psci::INVALID_PARAMETERS);
             assert_eq!(gates.affinity_info(absent), psci::INVALID_PARAMETERS);
         }
+    }
+
+    /// vCPUs are created in CPU-number order however their threads are
+    /// scheduled.
+    ///
+    /// HVF hands out GIC redistributor frames in creation order and the device
+    /// tree says CPU *n* owns the *n*th, so the two have to agree. Threads
+    /// spawned in a loop start in whatever order the scheduler chooses — and
+    /// when they raced, CPU 3 and CPU 4 swapped frames and the guest could not
+    /// match either to its redistributor.
+    #[test]
+    fn vcpus_are_created_in_cpu_order_whatever_order_their_threads_start() {
+        let order = Arc::new(CreationOrder::default());
+        let created = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        // Spawned high-to-low, so the natural order is the wrong one.
+        let threads: Vec<_> = (1..6u32)
+            .rev()
+            .map(|cpu| {
+                let order = Arc::clone(&order);
+                let created = Arc::clone(&created);
+                std::thread::spawn(move || {
+                    order.wait_for_turn(cpu);
+                    created.lock().unwrap().push(cpu);
+                    order.finished(cpu);
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        assert_eq!(
+            *created.lock().unwrap(),
+            vec![1, 2, 3, 4, 5],
+            "creation must follow CPU number, not thread start order"
+        );
+    }
+
+    /// A CPU that fails to be created still releases the CPUs behind it.
+    ///
+    /// Otherwise every later CPU blocks on a turn that never comes, and the
+    /// boot CPU waits for bring-up reports that are never sent — a hang, where
+    /// the honest outcome is a failed boot naming the CPU that could not be
+    /// created.
+    #[test]
+    fn a_failed_creation_still_releases_the_cpus_behind_it() {
+        let order = Arc::new(CreationOrder::default());
+        let reached = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let threads: Vec<_> = (1..4u32)
+            .map(|cpu| {
+                let order = Arc::clone(&order);
+                let reached = Arc::clone(&reached);
+                std::thread::spawn(move || {
+                    order.wait_for_turn(cpu);
+                    reached.lock().unwrap().push(cpu);
+                    // Every CPU releases the next, including the one that
+                    // "failed" (cpu 2, which records nothing further).
+                    order.finished(cpu);
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        assert_eq!(*reached.lock().unwrap(), vec![1, 2, 3]);
     }
 
     /// Every CPU's start state agrees with the device tree node built for it.

--- a/crates/mvm-runtime/src/backends/hvf/snapshot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/snapshot.rs
@@ -114,8 +114,13 @@ pub struct ParsedHvfSnapshot<'a> {
     pub ram: &'a [u8],
     /// Versioned device-state container.
     pub devices: &'a [u8],
-    /// Decoded AArch64 core-register state.
-    pub vcpu: HvfVcpuState,
+    /// Decoded AArch64 core-register state, one entry per vCPU in CPU order.
+    ///
+    /// Always at least one — the boot CPU. A machine with more carries them all,
+    /// because a restored child has to resume every CPU its parent was running.
+    /// Resuming only CPU 0 would leave the guest's scheduler dispatching onto
+    /// CPUs that exist in its own tables and are executing nothing.
+    pub vcpus: Vec<HvfVcpuState>,
     /// Artifact identity metadata carried by the producer.
     pub artifact_digests: &'a [u8],
 }
@@ -183,10 +188,13 @@ pub fn encode_hvf_snapshot_frame(
     flags: u32,
     ram: &[u8],
     devices: &[u8],
-    vcpu: &HvfVcpuState,
+    vcpus: &[HvfVcpuState],
     artifact_digests: &[u8],
 ) -> Result<Vec<u8>, FrameError> {
-    let vcpu_bytes = vcpu.encode();
+    // Every CPU's state, concatenated in CPU order. Fixed-width records, so the
+    // count is the section length over the record length and no separate field
+    // can disagree with the payload.
+    let vcpu_bytes: Vec<u8> = vcpus.iter().flat_map(|state| state.encode()).collect();
     mvm_core::snapshot_frame::encode_frame(
         GuestArch::Aarch64,
         backend_kind,
@@ -232,7 +240,7 @@ pub fn capture_hvf_snapshot_frame(
         flags,
         &ram.snapshot_bytes(),
         &device_state,
-        &vcpu_state,
+        std::slice::from_ref(&vcpu_state),
         artifact_digests,
     )
     .map_err(HvfSnapshotError::Frame)
@@ -289,9 +297,27 @@ pub fn parse_hvf_snapshot_frame<'a>(
     Ok(ParsedHvfSnapshot {
         ram,
         devices,
-        vcpu: HvfVcpuState::decode(vcpu_bytes).map_err(HvfSnapshotError::Vcpu)?,
+        vcpus: decode_vcpu_states(vcpu_bytes)?,
         artifact_digests,
     })
+}
+
+/// Decode the vCPU section as one fixed-width record per CPU.
+///
+/// A section that is not a whole number of records, or that carries no CPU at
+/// all, is refused rather than truncated: the count is derived from the length,
+/// so a partial trailing record would otherwise silently drop a CPU and produce
+/// a child running fewer CPUs than the guest inside it believes it has.
+fn decode_vcpu_states(bytes: &[u8]) -> Result<Vec<HvfVcpuState>, HvfSnapshotError> {
+    if bytes.is_empty() || !bytes.len().is_multiple_of(VCPU_STATE_LEN) {
+        return Err(HvfSnapshotError::Vcpu(HvfError::SnapshotState(
+            "vCPU section is not a whole number of vCPU records",
+        )));
+    }
+    bytes
+        .chunks(VCPU_STATE_LEN)
+        .map(|record| HvfVcpuState::decode(record).map_err(HvfSnapshotError::Vcpu))
+        .collect()
 }
 
 /// Restore a validated frame into an already-paused HVF target.
@@ -299,13 +325,20 @@ pub fn parse_hvf_snapshot_frame<'a>(
 /// Frame parsing and vCPU decoding happen before RAM or device mutation. The
 /// target remains paused; the caller owns the final resume decision and any
 /// host-channel rebind required by the restored device topology.
+/// Restores the boot CPU and returns every secondary's state for its own
+/// thread to apply.
+///
+/// The secondaries are not restored here because HVF only lets a vCPU's
+/// registers be written from the thread that created it. This call runs on the
+/// boot CPU's thread, so it restores CPU 0 and hands the rest back for the
+/// threads that own them.
 pub fn restore_hvf_snapshot_frame(
     frame: &[u8],
     expected_backend_kind: u8,
     ram: &mut GuestRam,
     vcpu: &HvfVcpu,
     devices: &mut [&mut dyn SnapshotDeviceState],
-) -> Result<(), HvfSnapshotError> {
+) -> Result<Vec<HvfVcpuState>, HvfSnapshotError> {
     let parsed = parse_hvf_snapshot_frame(frame, expected_backend_kind, ram.len())?;
     let mut targets = devices
         .iter_mut()
@@ -317,8 +350,20 @@ pub fn restore_hvf_snapshot_frame(
     restore_device_states(&mut targets, parsed.devices)?;
     ram.restore_bytes(parsed.ram)
         .map_err(HvfSnapshotError::Vcpu)?;
-    vcpu.restore_state(&parsed.vcpu)
-        .map_err(HvfSnapshotError::Vcpu)
+    restore_boot_cpu_and_split(vcpu, parsed.vcpus)
+}
+
+/// Apply the boot CPU's state and return the secondaries' in CPU order.
+fn restore_boot_cpu_and_split(
+    vcpu: &HvfVcpu,
+    mut states: Vec<HvfVcpuState>,
+) -> Result<Vec<HvfVcpuState>, HvfSnapshotError> {
+    // `decode_vcpu_states` refuses an empty section, so there is always a boot
+    // CPU here.
+    let secondaries = states.split_off(1);
+    let boot = states.remove(0);
+    vcpu.restore_state(&boot).map_err(HvfSnapshotError::Vcpu)?;
+    Ok(secondaries)
 }
 
 /// Restore only vCPU and deterministic device state from a frame whose RAM is
@@ -328,11 +373,10 @@ pub fn restore_hvf_snapshot_control(
     expected_ram_len: usize,
     vcpu: &HvfVcpu,
     devices: &mut [&mut dyn SnapshotDeviceState],
-) -> Result<(), HvfSnapshotError> {
+) -> Result<Vec<HvfVcpuState>, HvfSnapshotError> {
     let parsed = parse_hvf_snapshot_frame(frame, HVF_SNAPSHOT_BACKEND_KIND, expected_ram_len)?;
     restore_device_states(devices, parsed.devices)?;
-    vcpu.restore_state(&parsed.vcpu)
-        .map_err(HvfSnapshotError::Vcpu)
+    restore_boot_cpu_and_split(vcpu, parsed.vcpus)
 }
 
 fn read_word(bytes: &[u8], index: usize) -> Result<u64, HvfError> {
@@ -387,8 +431,15 @@ mod tests {
             cpsr: 0x3c5,
             sys: [0; SNAPSHOT_SYS_REGS.len()],
         };
-        let frame =
-            encode_hvf_snapshot_frame(9, 0x20, b"ram", b"devices", &state, b"digest").unwrap();
+        let frame = encode_hvf_snapshot_frame(
+            9,
+            0x20,
+            b"ram",
+            b"devices",
+            std::slice::from_ref(&state),
+            b"digest",
+        )
+        .unwrap();
         let header = mvm_core::snapshot_frame::parse_header(&frame).unwrap();
         assert_eq!(header.arch, GuestArch::Aarch64);
         assert_eq!(header.backend_kind, 9);
@@ -411,12 +462,19 @@ mod tests {
             cpsr: 0x3c5,
             sys: [0; SNAPSHOT_SYS_REGS.len()],
         };
-        let frame =
-            encode_hvf_snapshot_frame(9, 0x20, b"ram", b"devices", &state, b"digest").unwrap();
+        let frame = encode_hvf_snapshot_frame(
+            9,
+            0x20,
+            b"ram",
+            b"devices",
+            std::slice::from_ref(&state),
+            b"digest",
+        )
+        .unwrap();
         let parsed = parse_hvf_snapshot_frame(&frame, 9, 3).unwrap();
         assert_eq!(parsed.ram, b"ram");
         assert_eq!(parsed.devices, b"devices");
-        assert_eq!(parsed.vcpu, state);
+        assert_eq!(parsed.vcpus, vec![state]);
         assert_eq!(parsed.artifact_digests, b"digest");
         assert!(matches!(
             parse_hvf_snapshot_frame(&frame, 8, 3),
@@ -432,6 +490,69 @@ mod tests {
                 actual: 3
             })
         ));
+    }
+
+    /// One CPU's register state, distinguishable per CPU by the caller.
+    fn sample_state() -> HvfVcpuState {
+        HvfVcpuState {
+            x: [7; 31],
+            pc: 0x8000,
+            cpsr: 0x3c5,
+            sys: [0; SNAPSHOT_SYS_REGS.len()],
+        }
+    }
+
+    /// A machine's every CPU survives a frame round-trip, in CPU order.
+    ///
+    /// Order is the payload: a restore hands slot *n* to CPU *n*, so a frame
+    /// that reordered them would resume each CPU on another's registers —
+    /// stacks, per-CPU pointers and all — inside a RAM image that says
+    /// otherwise.
+    #[test]
+    fn every_vcpu_survives_the_frame_in_cpu_order() {
+        let states: Vec<HvfVcpuState> = (0..4u64)
+            .map(|cpu| {
+                let mut state = sample_state();
+                state.pc = 0x8100_0000 + cpu;
+                state.x[0] = 0xC0FFEE00 + cpu;
+                state
+            })
+            .collect();
+
+        let frame =
+            encode_hvf_snapshot_frame(9, 0x20, b"ram", b"devices", &states, b"digest").unwrap();
+        let parsed = parse_hvf_snapshot_frame(&frame, 9, 3).unwrap();
+
+        assert_eq!(parsed.vcpus, states);
+    }
+
+    /// A vCPU section that is not a whole number of records is refused.
+    ///
+    /// The CPU count is derived from the section length, so a truncated
+    /// trailing record would otherwise silently drop a CPU — and the child
+    /// would boot with fewer CPUs than the guest inside its own restored memory
+    /// believes it has.
+    #[test]
+    fn a_partial_vcpu_record_is_refused_rather_than_truncated() {
+        let state = sample_state();
+        let mut bytes = state.encode().to_vec();
+        bytes.extend_from_slice(&state.encode()[..VCPU_STATE_LEN - 1]);
+
+        let error = decode_vcpu_states(&bytes).unwrap_err();
+        assert!(
+            matches!(error, HvfSnapshotError::Vcpu(_)),
+            "expected a vCPU-section error, got {error:?}"
+        );
+    }
+
+    /// A frame carrying no CPU at all is refused.
+    ///
+    /// There is no such machine. Accepting it would hand the restore an empty
+    /// list and leave the boot CPU resuming whatever the fresh vCPU happened to
+    /// hold.
+    #[test]
+    fn a_vcpu_section_with_no_cpus_is_refused() {
+        assert!(decode_vcpu_states(&[]).is_err());
     }
 
     #[test]

--- a/crates/mvm-runtime/src/backends/hvf/sys.rs
+++ b/crates/mvm-runtime/src/backends/hvf/sys.rs
@@ -176,6 +176,14 @@ unsafe extern "C" {
     pub fn hv_gic_get_distributor_size(size: *mut usize) -> hv_return_t;
     pub fn hv_gic_get_distributor_base_alignment(alignment: *mut usize) -> hv_return_t;
     pub fn hv_gic_get_redistributor_size(size: *mut usize) -> hv_return_t;
+    /// The guest-physical base of one vCPU's redistributor frame. HVF assigns
+    /// these itself as vCPUs are created; this is the only way to learn where a
+    /// given vCPU's landed, and hence whether it matches the device tree the
+    /// guest is reading.
+    pub fn hv_gic_get_redistributor_base(
+        vcpu: hv_vcpu_t,
+        redistributor_base: *mut hv_ipa_t,
+    ) -> hv_return_t;
     pub fn hv_gic_get_redistributor_base_alignment(alignment: *mut usize) -> hv_return_t;
     pub fn hv_gic_get_spi_interrupt_range(
         spi_intid_base: *mut u32,
@@ -299,6 +307,14 @@ pub unsafe fn hv_gic_get_distributor_base_alignment(_alignment: *mut usize) -> h
 #[cfg(not(target_os = "macos"))]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe fn hv_gic_get_redistributor_size(_size: *mut usize) -> hv_return_t {
+    HV_ERROR_UNSUPPORTED
+}
+#[cfg(not(target_os = "macos"))]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe fn hv_gic_get_redistributor_base(
+    _vcpu: hv_vcpu_t,
+    _redistributor_base: *mut hv_ipa_t,
+) -> hv_return_t {
     HV_ERROR_UNSUPPORTED
 }
 #[cfg(not(target_os = "macos"))]

--- a/crates/mvm-runtime/src/builder_runner/inject.rs
+++ b/crates/mvm-runtime/src/builder_runner/inject.rs
@@ -63,6 +63,9 @@ pub fn inject_host_binaries(req: &InjectRequest<'_>) -> Result<()> {
         // is plenty for a mount + copy.
         cmdline: None,
         memory_mib: 0,
+        // One CPU: this helper VM mounts an image and copies files. Defaulting
+        // rather than inheriting anything — it is not the workload's machine.
+        vcpus: 1,
         initramfs: Some(initramfs_path),
         disks: vec![HvfDisk {
             path: req.out_rootfs.to_path_buf(),

--- a/crates/mvm-vmm/src/host/hvf_supervisor.rs
+++ b/crates/mvm-vmm/src/host/hvf_supervisor.rs
@@ -104,6 +104,16 @@ pub struct HvfSupervisorConfig {
     /// (512 MiB). A builder sets several GiB so `nix build` doesn't OOM.
     #[serde(default)]
     pub memory_mib: u32,
+    /// Guest vCPUs. `0` (the default) ⇒ 1.
+    ///
+    /// The count has to reach *this* process because the supervisor is what
+    /// calls `hv_vcpu_create`, and it also has to reach the device tree, which
+    /// is built here: a guest cannot online a CPU the DTB does not describe,
+    /// and describing one the VMM never creates hangs the boot waiting for a
+    /// secondary that never arrives. Both readers take this one field so they
+    /// cannot disagree.
+    #[serde(default)]
+    pub vcpus: u32,
     /// Optional initramfs (cpio, gzip-or-raw).
     #[serde(default)]
     pub initramfs: Option<PathBuf>,
@@ -255,6 +265,7 @@ mod tests {
             kernel: "/k/Image".into(),
             cmdline: Some("console=ttyAMA0 root=/dev/vda ro init=/sbin/mvm-host-vm-init".into()),
             memory_mib: 8192,
+            vcpus: 1,
             initramfs: Some("/k/initrd.cpio".into()),
             disks: vec![
                 HvfDisk {
@@ -369,6 +380,7 @@ mod tests {
             kernel: "/k/Image".into(),
             cmdline: None,
             memory_mib: 0,
+            vcpus: 1,
             initramfs: None,
             disks: vec![],
             virtiofs_root: None,

--- a/crates/mvm-vmm/src/quota/clock.rs
+++ b/crates/mvm-vmm/src/quota/clock.rs
@@ -104,6 +104,36 @@ impl Drop for ThreadCpuHandle {
     }
 }
 
+/// The CPU consumed by a whole machine: the sum of its vCPU threads.
+///
+/// A quota bounds the machine, so an SMP guest has to be charged for every vCPU
+/// it is running. Reading one thread of a four-CPU guest reports a quarter of
+/// what it is actually consuming, and a controller fed that number never
+/// throttles — the workload runs at four times its granted share while the
+/// audit record says it stayed inside it.
+pub struct SummedClock<C: ThreadCpuClock> {
+    threads: Vec<C>,
+}
+
+impl<C: ThreadCpuClock> SummedClock<C> {
+    /// Sum `threads`. Each must have been captured on the thread it measures.
+    pub fn new(threads: Vec<C>) -> Self {
+        Self { threads }
+    }
+}
+
+impl<C: ThreadCpuClock> ThreadCpuClock for SummedClock<C> {
+    fn consumed(&self) -> Duration {
+        // Saturating: a machine cannot consume more CPU than `Duration` holds,
+        // but the alternative is an overflow panic on the controller thread,
+        // which would leave the vCPUs held and the VM wedged.
+        self.threads
+            .iter()
+            .map(ThreadCpuClock::consumed)
+            .fold(Duration::ZERO, |total, one| total.saturating_add(one))
+    }
+}
+
 /// A fake clock that always returns the same value.
 #[cfg(any(test, feature = "test-support"))]
 #[derive(Clone)]
@@ -211,6 +241,42 @@ mod tests {
             delta < Duration::from_millis(5),
             "a sleeping thread should be charged almost no CPU, got {delta:?}"
         );
+    }
+
+    /// A machine's consumption is every vCPU's, added up.
+    ///
+    /// The number that matters for a quota: four CPUs each burning a full core
+    /// for a second is four core-seconds of machine, and a controller told
+    /// otherwise lets the workload run past its granted share.
+    #[test]
+    fn a_summed_clock_charges_every_vcpu_of_the_machine() {
+        let clock = SummedClock::new(vec![
+            FixedClock::new(Duration::from_millis(250)),
+            FixedClock::new(Duration::from_millis(250)),
+            FixedClock::new(Duration::from_millis(500)),
+        ]);
+        assert_eq!(clock.consumed(), Duration::from_millis(1000));
+    }
+
+    /// A one-vCPU machine reads exactly as it did before summing existed.
+    #[test]
+    fn a_summed_clock_over_one_thread_is_that_thread() {
+        let clock = SummedClock::new(vec![FixedClock::new(Duration::from_millis(37))]);
+        assert_eq!(clock.consumed(), Duration::from_millis(37));
+    }
+
+    /// Summing cannot panic the controller thread.
+    ///
+    /// An overflow here would leave the throttle flag set and every vCPU parked
+    /// behind a controller that is no longer running — a wedged VM rather than
+    /// a mis-measured one.
+    #[test]
+    fn a_summed_clock_saturates_rather_than_overflowing() {
+        let clock = SummedClock::new(vec![
+            FixedClock::new(Duration::MAX),
+            FixedClock::new(Duration::MAX),
+        ]);
+        assert_eq!(clock.consumed(), Duration::MAX);
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/crates/mvm-vmm/src/quota/controller.rs
+++ b/crates/mvm-vmm/src/quota/controller.rs
@@ -25,22 +25,48 @@ pub struct QuotaAchievement {
     pub periods: u32,
 }
 
-/// A running controller scheduling one vCPU against a quota.
+/// A running controller scheduling a machine's vCPUs against a quota.
+///
+/// The bound is on the machine, not on a thread. Every vCPU is held by the same
+/// flag and charged against the same allowance, so a four-CPU guest gets the
+/// share its plan granted rather than four copies of it.
 pub struct VcpuQuota<H: VcpuHandle> {
     hold: Arc<AtomicBool>,
     stop: Arc<AtomicBool>,
-    handle: H,
+    handles: Vec<H>,
     join: Option<JoinHandle<QuotaAchievement>>,
 }
 
 impl<H: VcpuHandle> VcpuQuota<H> {
-    /// Start scheduling `handle` against `policy`, charging `clock`.
-    pub fn start<C: ThreadCpuClock>(handle: H, clock: C, policy: QuotaPolicy) -> Self {
-        Self::start_with_flag(handle, clock, policy, Arc::new(AtomicBool::new(false)))
+    /// Start scheduling every vCPU in `handles` against `policy`, charging
+    /// `clock`.
+    ///
+    /// `clock` has to account for all of them. One reading a single thread of
+    /// an SMP machine would see a quarter of a four-CPU guest's consumption and
+    /// never throttle; [`SummedClock`](crate::quota::clock::SummedClock) is the
+    /// multi-vCPU form.
+    pub fn start<C: ThreadCpuClock>(handles: Vec<H>, clock: C, policy: QuotaPolicy) -> Self {
+        Self::start_with_flag(handles, clock, policy, Arc::new(AtomicBool::new(false)))
+    }
+
+    /// Start against a hold flag the caller already owns.
+    ///
+    /// An SMP machine's vCPU threads have to be given the flag before the
+    /// controller can exist: every vCPU reads it to know when to park, and the
+    /// controller cannot be started until every vCPU has been created and
+    /// contributed its CPU clock. Handing the flag in resolves that ordering
+    /// without letting a vCPU run for a window with no flag to read.
+    pub fn start_with_hold<C: ThreadCpuClock>(
+        handles: Vec<H>,
+        clock: C,
+        policy: QuotaPolicy,
+        hold: Arc<AtomicBool>,
+    ) -> Self {
+        Self::start_with_flag(handles, clock, policy, hold)
     }
 
     fn start_with_flag<C: ThreadCpuClock>(
-        handle: H,
+        handles: Vec<H>,
         clock: C,
         policy: QuotaPolicy,
         hold: Arc<AtomicBool>,
@@ -48,14 +74,14 @@ impl<H: VcpuHandle> VcpuQuota<H> {
         let stop = Arc::new(AtomicBool::new(false));
         let hold_thread = Arc::clone(&hold);
         let stop_thread = Arc::clone(&stop);
-        let handle_for_thread = handle;
+        let handles_for_thread = handles.clone();
         let join = thread::spawn(move || {
-            run_controller(handle_for_thread, clock, policy, hold_thread, stop_thread)
+            run_controller(handles_for_thread, clock, policy, hold_thread, stop_thread)
         });
         Self {
             hold,
             stop,
-            handle,
+            handles,
             join: Some(join),
         }
     }
@@ -67,19 +93,41 @@ impl<H: VcpuHandle> VcpuQuota<H> {
 
     /// Stop the controller and take its measurement.
     pub fn stop(mut self) -> QuotaAchievement {
-        self.stop.store(true, Ordering::SeqCst);
-        self.hold.store(false, Ordering::SeqCst);
-        H::force_exit(&[self.handle]);
+        self.halt();
         self.join
             .take()
             .expect("controller join handle is present")
             .join()
             .expect("controller thread panicked")
     }
+
+    /// Signal the controller to finish and release every held vCPU.
+    fn halt(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        self.hold.store(false, Ordering::SeqCst);
+        H::force_exit(&self.handles);
+    }
+}
+
+impl<H: VcpuHandle> Drop for VcpuQuota<H> {
+    /// Stop the controller even when nobody asked for its measurement.
+    ///
+    /// A boot that fails between starting the controller and reading it back
+    /// drops this without calling [`stop`](Self::stop). The controller thread
+    /// would otherwise keep looping for the life of the process, holding a
+    /// throttle flag whose vCPUs are gone — one leaked thread per failed boot.
+    fn drop(&mut self) {
+        if self.join.is_some() {
+            self.halt();
+            // Deliberately not joined: this runs on the failure path, and the
+            // controller's own sleep bounds how long it takes to notice. There
+            // is no measurement left to collect.
+        }
+    }
 }
 
 fn run_controller<H: VcpuHandle, C: ThreadCpuClock>(
-    handle: H,
+    handles: Vec<H>,
     clock: C,
     mut policy: QuotaPolicy,
     hold: Arc<AtomicBool>,
@@ -90,7 +138,7 @@ fn run_controller<H: VcpuHandle, C: ThreadCpuClock>(
     let mut measured_cpu = Duration::ZERO;
 
     while let Some((_, consumed)) = run_period(
-        handle,
+        &handles,
         &clock,
         &mut policy,
         &hold,
@@ -126,7 +174,7 @@ fn run_controller<H: VcpuHandle, C: ThreadCpuClock>(
 /// clock once, settle the policy, and hold to the period boundary if needed.
 /// Returns `None` when a stop was requested before the period completed.
 fn run_period<H: VcpuHandle, C: ThreadCpuClock>(
-    handle: H,
+    handles: &[H],
     clock: &C,
     policy: &mut QuotaPolicy,
     hold: &AtomicBool,
@@ -149,7 +197,11 @@ fn run_period<H: VcpuHandle, C: ThreadCpuClock>(
     let verdict = policy.settle(consumed_total, *periods);
     if verdict.hold {
         hold.store(true, Ordering::SeqCst);
-        H::force_exit(&[handle]);
+        // Every vCPU, not just one. The flag alone takes effect at a vCPU's next
+        // exit, and a secondary spinning in guest code has no reason to reach
+        // one; forcing them all out is what makes the hold prompt rather than
+        // eventual.
+        H::force_exit(handles);
     }
 
     let elapsed = start.elapsed();
@@ -256,7 +308,8 @@ mod tests {
         let handle = MockHandle::new();
         let flag = Arc::new(AtomicBool::new(false));
         handle.bind_flag(Arc::clone(&flag));
-        let quota = VcpuQuota::start_with_flag(handle, clock.clone(), policy, Arc::clone(&flag));
+        let quota =
+            VcpuQuota::start_with_flag(vec![handle], clock.clone(), policy, Arc::clone(&flag));
 
         std::thread::sleep(Duration::from_millis(55));
         let achievement = quota.stop();
@@ -280,7 +333,7 @@ mod tests {
         let handle = MockHandle::new();
         let flag = Arc::new(AtomicBool::new(false));
         handle.bind_flag(Arc::clone(&flag));
-        let quota = VcpuQuota::start_with_flag(handle, clock, policy, Arc::clone(&flag));
+        let quota = VcpuQuota::start_with_flag(vec![handle], clock, policy, Arc::clone(&flag));
 
         std::thread::sleep(Duration::from_millis(55));
         let _ = quota.stop();
@@ -303,7 +356,7 @@ mod tests {
         let handle = MockHandle::new();
         let flag = Arc::new(AtomicBool::new(false));
         handle.bind_flag(Arc::clone(&flag));
-        let quota = VcpuQuota::start_with_flag(handle, clock, policy, Arc::clone(&flag));
+        let quota = VcpuQuota::start_with_flag(vec![handle], clock, policy, Arc::clone(&flag));
 
         std::thread::sleep(Duration::from_millis(55));
         let _ = quota.stop();
@@ -332,7 +385,7 @@ mod tests {
         let handle = MockHandle::new();
         let flag = Arc::new(AtomicBool::new(false));
         handle.bind_flag(Arc::clone(&flag));
-        let quota = VcpuQuota::start_with_flag(handle, clock, policy, Arc::clone(&flag));
+        let quota = VcpuQuota::start_with_flag(vec![handle], clock, policy, Arc::clone(&flag));
 
         std::thread::sleep(Duration::from_millis(55));
         let _ = quota.stop();
@@ -354,7 +407,7 @@ mod tests {
         handle.bind_flag(Arc::clone(&flag));
 
         let verdict = run_period(
-            handle,
+            &[handle],
             &clock,
             &mut policy,
             &flag,
@@ -379,7 +432,7 @@ mod tests {
         let handle = MockHandle::new();
         let flag = Arc::new(AtomicBool::new(false));
         handle.bind_flag(Arc::clone(&flag));
-        let quota = VcpuQuota::start_with_flag(handle, clock, policy, Arc::clone(&flag));
+        let quota = VcpuQuota::start_with_flag(vec![handle], clock, policy, Arc::clone(&flag));
 
         std::thread::sleep(Duration::from_millis(55));
         let _ = quota.stop();
@@ -406,7 +459,7 @@ mod tests {
         let handle = MockHandle::new();
         let flag = Arc::new(AtomicBool::new(false));
         handle.bind_flag(Arc::clone(&flag));
-        let quota = VcpuQuota::start_with_flag(handle, clock, policy, Arc::clone(&flag));
+        let quota = VcpuQuota::start_with_flag(vec![handle], clock, policy, Arc::clone(&flag));
 
         std::thread::sleep(Duration::from_millis(85));
         let achievement = quota.stop();
@@ -426,7 +479,7 @@ mod tests {
         let handle = MockHandle::new();
         let flag = Arc::new(AtomicBool::new(false));
         handle.bind_flag(Arc::clone(&flag));
-        let quota = VcpuQuota::start_with_flag(handle, clock, policy, Arc::clone(&flag));
+        let quota = VcpuQuota::start_with_flag(vec![handle], clock, policy, Arc::clone(&flag));
 
         let achievement = quota.stop();
 

--- a/crates/mvm-vmm/src/quota/mod.rs
+++ b/crates/mvm-vmm/src/quota/mod.rs
@@ -10,6 +10,6 @@ pub mod policy;
 
 #[cfg(any(test, feature = "test-support"))]
 pub use clock::{FixedClock, ScriptedClock};
-pub use clock::{ThreadCpuClock, ThreadCpuHandle};
+pub use clock::{SummedClock, ThreadCpuClock, ThreadCpuHandle};
 pub use controller::{QuotaAchievement, VcpuQuota};
 pub use policy::{PeriodVerdict, QuotaConfig, QuotaPolicy};

--- a/crates/mvm-vmm/src/quota/policy.rs
+++ b/crates/mvm-vmm/src/quota/policy.rs
@@ -38,7 +38,12 @@ impl QuotaConfig {
     /// Smallest run slice or hold that can be expressed without collapsing into
     /// the run loop's 1 ms hold quantum.
     pub const MIN_SLICE: Duration = Duration::from_millis(2);
-    /// HVF creates exactly one vCPU, so 1.0 core is the ceiling.
+    /// 1.0 core is the ceiling. This is a policy limit, not a consequence of
+    /// the backend's vCPU count: HVF creates more than one now, and the
+    /// scheduler charges their summed CPU time, so a multi-vCPU guest can
+    /// consume more than one core's worth. Grants above this are refused
+    /// rather than under-charged, so raising it is a deliberate widening of
+    /// the bound and not a correctness fix.
     pub const MAX_MILLICORES: u32 = 1000;
 
     const DEFAULT_PERIOD_MS: u32 = 10;

--- a/crates/mvm-vmm/src/vmm/run.rs
+++ b/crates/mvm-vmm/src/vmm/run.rs
@@ -74,6 +74,106 @@ pub enum RunOutcome {
     Stopped,
 }
 
+/// Exclusive access to the device model, for as long as one access takes.
+///
+/// The run loop reaches devices only through this, so the same loop body serves
+/// a machine with one vCPU and a machine with several. With one, the devices are
+/// borrowed directly and nothing is locked. With several, every vCPU thread
+/// shares one device model and the bus is what serialises them: the device
+/// structs hold queue indices and raw pointers into guest RAM, and two CPUs
+/// servicing a virtqueue at once would corrupt both.
+///
+/// Deliberately scoped to a single access rather than handed out as a guard. A
+/// guard could be held across a sleep or a blocking read, and one vCPU parked in
+/// the pause hold while holding the device model would freeze every other CPU
+/// with it. Passing a closure makes the narrow hold the only thing expressible.
+pub trait DeviceBus {
+    /// Run `f` with exclusive access to every device.
+    fn with_devices<R>(&self, f: impl FnOnce(&mut [&mut dyn RunDevice]) -> R) -> R;
+}
+
+/// The device model of a single-vCPU machine, borrowed by the one thread that
+/// drives it.
+///
+/// A `RefCell` rather than a `Mutex`: there is no second thread to exclude, so
+/// paying for an atomic on every MMIO exit would buy nothing. The borrow is
+/// checked all the same, which is what catches a re-entrant `with_devices` —
+/// a device whose handler dispatched back into the bus would deadlock a `Mutex`
+/// silently and panics here instead.
+pub struct SoleBus<'a, 'd> {
+    devices: core::cell::RefCell<&'a mut [&'d mut dyn RunDevice]>,
+}
+
+impl<'a, 'd> SoleBus<'a, 'd> {
+    /// Borrow `devices` for the run.
+    pub fn new(devices: &'a mut [&'d mut dyn RunDevice]) -> Self {
+        Self {
+            devices: core::cell::RefCell::new(devices),
+        }
+    }
+}
+
+impl DeviceBus for SoleBus<'_, '_> {
+    fn with_devices<R>(&self, f: impl FnOnce(&mut [&mut dyn RunDevice]) -> R) -> R {
+        f(&mut self.devices.borrow_mut()[..])
+    }
+}
+
+/// The device model of an SMP machine, shared by every vCPU thread.
+///
+/// One lock over all devices rather than one per device. MMIO exits are rare
+/// next to the guest execution between them and each access is a register
+/// read or a queue kick, so the contention a coarse lock costs is not
+/// measurable — while the bugs a fine-grained one invites (two CPUs in two
+/// devices reaching the same guest page) are not the kind that show up in
+/// testing.
+pub struct SharedBus<'a, 'd> {
+    devices: std::sync::Mutex<&'a mut [&'d mut dyn RunDevice]>,
+}
+
+impl<'a, 'd> SharedBus<'a, 'd> {
+    /// Share `devices` across the vCPU threads of one run.
+    pub fn new(devices: &'a mut [&'d mut dyn RunDevice]) -> Self {
+        Self {
+            devices: std::sync::Mutex::new(devices),
+        }
+    }
+}
+
+impl DeviceBus for SharedBus<'_, '_> {
+    fn with_devices<R>(&self, f: impl FnOnce(&mut [&mut dyn RunDevice]) -> R) -> R {
+        // A poisoned device model cannot be reasoned about: a panic mid-access
+        // leaves a virtqueue half-updated, and the guest has already been told
+        // the descriptor was consumed. Take the inner value and let the caller
+        // fail rather than resuming against state nothing has validated.
+        let mut guard = self
+            .devices
+            .lock()
+            .expect("device model poisoned by a panicking vCPU thread");
+        f(&mut guard[..])
+    }
+}
+
+// SAFETY: `RunDevice` implementors in this crate are not `Send` because they
+// hold raw `*mut u8` pointers into guest RAM. Sharing them across the vCPU
+// threads of one VM is sound for the reasons the pointer is sound at all:
+//
+// - The pointee is the single `hv_vm_map`ped guest RAM allocation, which
+//   outlives every vCPU thread. The threads are scoped (`std::thread::scope`),
+//   so they are joined before the mapping is torn down or the allocation freed.
+// - Every access goes through `with_devices`, which holds the `Mutex`, so no
+//   two threads touch a device — or the RAM it points into — concurrently.
+// - The pointer is not thread-affine. It addresses a plain shared mapping, not
+//   a thread-local or a handle bound to the thread that opened it, so reading
+//   it from a different thread than the one that formed it is well defined.
+//
+// This is the same argument `GuestMem` makes one module over, for the same
+// allocation.
+unsafe impl Send for SharedBus<'_, '_> {}
+// SAFETY: as above — `&SharedBus` grants access only through the `Mutex`, so
+// sharing the reference is exactly as safe as sending the value.
+unsafe impl Sync for SharedBus<'_, '_> {}
+
 /// Dispatch one decoded access (MMIO or PIO, keyed by `addr`) to `devices`,
 /// completing a read through `vcpu` and raising any triggered IRQ via `set_irq`.
 fn dispatch<C, S>(
@@ -239,7 +339,7 @@ pub fn run_with_hooks<C, S, X, Q, P, H, T>(
     vcpu: &C,
     set_irq: S,
     devices: &mut [&mut dyn RunDevice],
-    mut hooks: RunHooks<C, X, Q, P, H, T>,
+    hooks: RunHooks<C, X, Q, P, H, T>,
 ) -> Result<RunOutcome, C::Error>
 where
     C: HypervisorVcpu,
@@ -250,6 +350,58 @@ where
     H: FnMut(&C, &[&dyn SnapshotDeviceState]) -> Result<(), C::Error>,
     T: Fn() -> bool,
 {
+    run_on_bus(vcpu, set_irq, &SoleBus::new(devices), hooks)
+}
+
+/// Run one vCPU against a device model reached through `bus`.
+///
+/// The single loop body, shared by every backend and by every vCPU of an SMP
+/// machine. It differs from [`run_with_hooks`] only in reaching devices through
+/// the bus rather than owning them, which is what lets several threads drive it
+/// at once.
+///
+/// Each device touch takes the bus for exactly that touch. The two hold loops
+/// below — pause and throttle — sleep *outside* it: this vCPU is parked, and
+/// keeping the device model to itself while it sleeps would park every other
+/// vCPU behind it.
+pub fn run_on_bus<C, S, B, X, Q, P, H, T>(
+    vcpu: &C,
+    set_irq: S,
+    bus: &B,
+    mut hooks: RunHooks<C, X, Q, P, H, T>,
+) -> Result<RunOutcome, C::Error>
+where
+    C: HypervisorVcpu,
+    S: Fn(u32, bool) -> Result<(), C::Error>,
+    B: DeviceBus,
+    X: FnMut(&C, u64, u64) -> Result<RunControl, C::Error>,
+    Q: Fn() -> bool,
+    P: Fn() -> bool,
+    H: FnMut(&C, &[&dyn SnapshotDeviceState]) -> Result<(), C::Error>,
+    T: Fn() -> bool,
+{
+    /// Poll every device once and raise whatever interrupts they ask for.
+    fn poll_all<C, S, B>(bus: &B, set_irq: &S) -> Result<(), C::Error>
+    where
+        C: HypervisorVcpu,
+        S: Fn(u32, bool) -> Result<(), C::Error>,
+        B: DeviceBus,
+    {
+        // Collect under the bus, raise outside it: `set_irq` is the backend's
+        // interrupt controller, and holding the device model across it would
+        // widen the hold for no reason.
+        let irqs = bus.with_devices(|devices| {
+            devices
+                .iter_mut()
+                .filter_map(|d| d.poll())
+                .collect::<Vec<_>>()
+        });
+        for irq in irqs {
+            set_irq(irq, true)?;
+        }
+        Ok(())
+    }
+
     let mut pause_prepared = false;
     loop {
         match vcpu.step()? {
@@ -257,22 +409,14 @@ where
                 // Host→guest async work each timer tick (e.g. drain an egress
                 // socket into the guest's rx queue), so delivery happens even
                 // when the guest is idle in WFI rather than doing MMIO.
-                for d in devices.iter_mut() {
-                    if let Some(irq) = d.poll() {
-                        set_irq(irq, true)?;
-                    }
-                }
+                poll_all::<C, _, _>(bus, &set_irq)?;
             }
             VcpuExit::Canceled => {
                 // A forced exit: either a real stop or a heartbeat wake. Poll
                 // host-side async work either way (this is how an egress reply
                 // reaches a guest blocked in WFI), then end only if a stop was
                 // actually requested.
-                for d in devices.iter_mut() {
-                    if let Some(irq) = d.poll() {
-                        set_irq(irq, true)?;
-                    }
-                }
+                poll_all::<C, _, _>(bus, &set_irq)?;
                 if (hooks.should_stop)() {
                     return Ok(RunOutcome::Canceled);
                 }
@@ -282,30 +426,32 @@ where
                 // already drained any in-flight host reply before we park.
                 if (hooks.should_pause)() {
                     if !pause_prepared {
-                        for device in devices.iter_mut() {
-                            device.prepare_snapshot();
-                        }
+                        bus.with_devices(|devices| {
+                            for device in devices.iter_mut() {
+                                device.prepare_snapshot();
+                            }
+                        });
                         pause_prepared = true;
                     }
-                    let snapshot_devices = devices
-                        .iter()
-                        .filter_map(|device| device.snapshot_device())
-                        .collect::<Vec<_>>();
-                    (hooks.on_pause)(vcpu, &snapshot_devices)?;
+                    bus.with_devices(|devices| {
+                        let snapshot_devices = devices
+                            .iter()
+                            .filter_map(|device| device.snapshot_device())
+                            .collect::<Vec<_>>();
+                        (hooks.on_pause)(vcpu, &snapshot_devices)
+                    })?;
                 } else {
                     pause_prepared = false;
                 }
                 while (hooks.should_pause)() && !(hooks.should_stop)() {
-                    for d in devices.iter_mut() {
-                        if let Some(irq) = d.poll() {
-                            set_irq(irq, true)?;
-                        }
-                    }
-                    let snapshot_devices = devices
-                        .iter()
-                        .filter_map(|device| device.snapshot_device())
-                        .collect::<Vec<_>>();
-                    (hooks.on_pause)(vcpu, &snapshot_devices)?;
+                    poll_all::<C, _, _>(bus, &set_irq)?;
+                    bus.with_devices(|devices| {
+                        let snapshot_devices = devices
+                            .iter()
+                            .filter_map(|device| device.snapshot_device())
+                            .collect::<Vec<_>>();
+                        (hooks.on_pause)(vcpu, &snapshot_devices)
+                    })?;
                     std::thread::sleep(Duration::from_millis(1));
                 }
                 // Throttle hold: a throttle is not a pause. The vCPU is parked
@@ -315,11 +461,7 @@ where
                 // out of guest execution; nothing else from the pause path runs.
                 while (hooks.should_throttle)() && !(hooks.should_stop)() && !(hooks.should_pause)()
                 {
-                    for d in devices.iter_mut() {
-                        if let Some(irq) = d.poll() {
-                            set_irq(irq, true)?;
-                        }
-                    }
+                    poll_all::<C, _, _>(bus, &set_irq)?;
                     std::thread::sleep(Duration::from_millis(1));
                 }
                 // A stop that arrived while we were throttled must still end the
@@ -336,7 +478,9 @@ where
                 len,
                 data,
             } => {
-                dispatch(vcpu, &set_irq, devices, phys_addr, write, len, data)?;
+                bus.with_devices(|devices| {
+                    dispatch(vcpu, &set_irq, devices, phys_addr, write, len, data)
+                })?;
             }
             VcpuExit::Io {
                 port,
@@ -344,15 +488,17 @@ where
                 size,
                 data,
             } => {
-                dispatch(
-                    vcpu,
-                    &set_irq,
-                    devices,
-                    u64::from(port),
-                    write,
-                    size,
-                    u64::from(data),
-                )?;
+                bus.with_devices(|devices| {
+                    dispatch(
+                        vcpu,
+                        &set_irq,
+                        devices,
+                        u64::from(port),
+                        write,
+                        size,
+                        u64::from(data),
+                    )
+                })?;
             }
             VcpuExit::Exception {
                 syndrome,

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -66,27 +66,45 @@ Feature: every README-documented CLI launch mode boots a real guest
     Then the launch exits with code 7
     And the guest control plane came up
 
-  # HVF has no SMP — the device tree describes one CPU, PSCI implements no
-  # `CPU_ON`, and the supervisor config carries no vCPU count. `--cpus 2` used
-  # to exit 0 and hand back one CPU; it now refuses, which is the honest answer
-  # until SMP lands (#2888). Asserting the refusal rather than deleting the
-  # scenario keeps the limit visible in the suite.
+  # The README documents `--cpus`, and on HVF it used to exit 0 and hand back
+  # one CPU whatever was asked for (#2888).
   #
-  # It passed in earlier runs of this suite for the wrong reason: the assertion
-  # matched the combined streams and the `MVM_PHASE_TIMING` table supplied a
-  # "2". `the guest printed exactly` reads the guest's own stdout, which is what
-  # made the defect visible in the first place.
+  # Both counts are asserted because they were both wrong together: `nproc` and
+  # `/proc/cpuinfo` agreed at 1 before SMP, so a fix that moved only one would
+  # be reading something other than the machine. They are combined into a
+  # single token so one line pins both — a disagreement shows up as "2/1"
+  # rather than passing on whichever the assertion happened to read.
+  #
+  # An earlier revision of this scenario passed for the wrong reason: the
+  # assertion matched the combined streams and the `MVM_PHASE_TIMING` table
+  # supplied a "2". `the guest printed exactly` reads the guest's own stdout,
+  # which is what made the defect visible in the first place.
   @live
-  Scenario: a vCPU count the backend cannot honour is refused, not silently reduced
-    When I launch "machine run --image alpine --cpus 2 --memory 512M -- nproc"
-    Then the launch fails
-    And the output mentions "supports exactly 1 vCPU"
+  Scenario: --cpus is honoured on a real boot
+    When I launch "machine run --image alpine --cpus 2 --memory 512M -- sh -c 'echo $(nproc)/$(grep -c ^processor /proc/cpuinfo)'"
+    Then the launch succeeds
+    And the guest printed exactly "2/2"
+    And the guest control plane came up
 
   @live
   Scenario: a single-vCPU launch with explicit memory boots
-    When I launch "machine run --image alpine --cpus 1 --memory 512M -- nproc"
+    When I launch "machine run --image alpine --cpus 1 --memory 512M -- sh -c 'echo $(nproc)/$(grep -c ^processor /proc/cpuinfo)'"
     Then the launch succeeds
-    And the guest printed exactly "1"
+    And the guest printed exactly "1/1"
+    And the guest control plane came up
+
+  # `--memory` was never verified on this path either, and it cannot be checked
+  # at 512M: that is also the built-in default, so a guest that ignored the flag
+  # entirely would report the expected number. 1024M is the smallest request
+  # that tells the two apart. The floor is well under the ask because the kernel
+  # reserves a slice of RAM before it reports `MemTotal`, and how much varies by
+  # kernel version — 800 MiB separates "got a gigabyte" from "got the 512 MiB
+  # default" without pinning a number that drifts.
+  @live
+  Scenario: --memory is honoured on a real boot
+    When I launch "machine run --image alpine --memory 1024M -- sh -c 'M=$(grep MemTotal /proc/meminfo | tr -cd 0-9); [ $M -gt 819200 ] && echo mem-ok || echo mem-only-$M'"
+    Then the launch succeeds
+    And the guest printed exactly "mem-ok"
     And the guest control plane came up
 
   # This scenario is the behavioural witness for the detached-supervisor stderr

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -95,24 +95,29 @@ Feature: every README-documented CLI launch mode boots a real guest
 
   # Over the backend's ceiling is clamped and reported, never refused.
   #
-  # HVF tops out at 4 — measured on this host, not derived: 1, 2 and 4 boot and
-  # report back, while 5, 6 and 8 never reach the guest agent. The MMIO gap fits
-  # 124 redistributor frames and the host has 16 cores, so neither explains it;
-  # the number is empirical and the capability says so.
-  #
-  # Refusing would make a portable `--cpus 8` succeed on Linux and fail on
+  # Refusing would make a portable `--cpus 9999` succeed on Linux and fail on
   # macOS for a reason the user cannot act on — and HVF's own default of 2 once
   # sat above a ceiling of 1, which failed *every* launch on this backend. The
   # warning is the point: the silent version booted a guest on fewer CPUs than
   # its admitted plan claimed, with nothing to explain it.
+  #
+  # The request is absurd on purpose. HVF's ceiling comes from
+  # `hv_vm_get_max_vcpu_count`, so it is a property of the host and not a
+  # constant this suite can name — an earlier revision asserted "supports at
+  # most 4", which was a number a bug had produced and which went stale the
+  # moment the bug was fixed. A count no machine will ever have exercises the
+  # clamp on any host, and the assertion checks that the ceiling was reported
+  # rather than what it happens to be here.
   @live
   Scenario: a vCPU request beyond the backend ceiling is clamped and reported
-    When I launch "machine run --image alpine --cpus 8 -- sh -c 'echo $(nproc)/$(grep -c ^processor /proc/cpuinfo)'"
+    When I launch "machine run --image alpine --cpus 9999 -- sh -c 'echo clamped-and-booted'"
     Then the launch succeeds
-    And the output mentions "supports at most 4"
+    And the output mentions "supports at most"
+    And the output mentions "9999 requested"
     # Last line, not the whole of stdout: the clamp warning is chrome and
-    # legitimately precedes the guest's output on the same stream.
-    And the guest's last line is "4/4"
+    # legitimately precedes the guest's output on the same stream. A fixed
+    # token rather than the granted count, which is whatever this host allows.
+    And the guest's last line is "clamped-and-booted"
     And the guest control plane came up
 
   # `--memory` was never verified on this path either, and it cannot be checked

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -93,6 +93,28 @@ Feature: every README-documented CLI launch mode boots a real guest
     And the guest printed exactly "1/1"
     And the guest control plane came up
 
+  # Over the backend's ceiling is clamped and reported, never refused.
+  #
+  # HVF tops out at 4 — measured on this host, not derived: 1, 2 and 4 boot and
+  # report back, while 5, 6 and 8 never reach the guest agent. The MMIO gap fits
+  # 124 redistributor frames and the host has 16 cores, so neither explains it;
+  # the number is empirical and the capability says so.
+  #
+  # Refusing would make a portable `--cpus 8` succeed on Linux and fail on
+  # macOS for a reason the user cannot act on — and HVF's own default of 2 once
+  # sat above a ceiling of 1, which failed *every* launch on this backend. The
+  # warning is the point: the silent version booted a guest on fewer CPUs than
+  # its admitted plan claimed, with nothing to explain it.
+  @live
+  Scenario: a vCPU request beyond the backend ceiling is clamped and reported
+    When I launch "machine run --image alpine --cpus 8 -- sh -c 'echo $(nproc)/$(grep -c ^processor /proc/cpuinfo)'"
+    Then the launch succeeds
+    And the output mentions "supports at most 4"
+    # Last line, not the whole of stdout: the clamp warning is chrome and
+    # legitimately precedes the guest's output on the same stream.
+    And the guest's last line is "4/4"
+    And the guest control plane came up
+
   # `--memory` was never verified on this path either, and it cannot be checked
   # at 512M: that is also the built-in default, so a guest that ignored the flag
   # entirely would report the expected number. 1024M is the smallest request

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -46,7 +46,7 @@ export MVM_EMBED_NO_CACHE="e2e-$(date +%s)"
 
 # Floor on scenarios that must actually execute. See the assertion after the
 # cucumber run for why a count, not just an exit status.
-MIN_SCENARIOS=16
+MIN_SCENARIOS=17
 SCENARIO_LOG="$(mktemp -t mvm-e2e-scenarios)"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -22,6 +22,28 @@ REPO="$PWD"
 
 E2E_HOME="${MVM_E2E_HOME:-$HOME/.mvm}"
 
+# A CHANGING value, exported for every cargo invocation below.
+#
+# `mvm-cli`'s build script reuses a previously-built per-VM helper whenever
+# `PROFILE == debug` and the binary is present, and marks it stale so mvmctl
+# refuses to spawn it. `MVM_EMBED_NO_CACHE` (any non-empty value) forces the
+# rebuild instead. Two traps, both of which produce a suite that fails at spawn
+# against a supervisor which may well be current:
+#
+#  * Set it on only the first build and the later `cargo build -p xtask` /
+#    `cargo test -p mvm-conformance` re-run the build script without it, find
+#    the freshly-built binary present, take the reuse branch, and re-write the
+#    stale marker the first build had just cleared.
+#  * Export a constant `1` and the second run of this script is a no-op:
+#    `cargo:rerun-if-env-changed` compares the value, `1 == 1`, so the build
+#    script never re-runs and a marker left by an earlier run survives
+#    untouched. Setting a flag that is already set changes nothing.
+#
+# A per-run value satisfies both: the value always differs from last run, so the
+# build script re-runs, and it is non-empty, so the rebuild is forced. Costs a
+# cross-compile per gate run, which is the price of measuring the tree.
+export MVM_EMBED_NO_CACHE="e2e-$(date +%s)"
+
 # Floor on scenarios that must actually execute. See the assertion after the
 # cucumber run for why a count, not just an exit status.
 MIN_SCENARIOS=15

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -46,7 +46,7 @@ export MVM_EMBED_NO_CACHE="e2e-$(date +%s)"
 
 # Floor on scenarios that must actually execute. See the assertion after the
 # cucumber run for why a count, not just an exit status.
-MIN_SCENARIOS=15
+MIN_SCENARIOS=16
 SCENARIO_LOG="$(mktemp -t mvm-e2e-scenarios)"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -43,11 +43,17 @@ for detailed scope and acceptance criteria.
       name plus the same validated argv contract. See
       `specs/sprint/delivery/2887-guest-rpc-refusals.md`.
 
-- [x] **Issue #2888 — HVF vCPU resource contract.** HVF now refuses any launch
-      whose requested vCPU count is not exactly one, before supervisor state is
-      written or a process is spawned. The README no longer implies that the
-      current single-vCPU backend honors a larger count. See
-      `specs/sprint/delivery/2888-hvf-vcpu-contract.md`.
+- [x] **Issue #2888 — HVF vCPU resource contract.** HVF implements SMP: the
+      vCPU count reaches the process that creates them, the FDT describes N
+      `cpu@N` nodes, PSCI `CPU_ON`/`AFFINITY_INFO` answer against the CPUs that
+      exist, and each secondary runs on its own thread against a mutex-guarded
+      device model. A request above the backend's declared ceiling
+      (`VmCapabilities::max_vcpus`; HVF 4, libkrun 255, firecracker none) is
+      clamped with a warning rather than refused, so a portable `--cpus` does
+      not fail on one host and succeed on another. The ceiling of 4 is measured,
+      not derived — tracked as #2927. Supersedes the earlier refusal contract in
+      `specs/sprint/delivery/2888-hvf-vcpu-contract.md`; see
+      `specs/sprint/delivery/hvf-smp-cpus-honoured.md`.
 
 - [x] **Issue #2874 — scheduled Security peer-policy mutation witness.**
       `NetworkPolicy::peers()` now has a focused witness that distinguishes

--- a/specs/adrs/001-microvm-security-posture.md
+++ b/specs/adrs/001-microvm-security-posture.md
@@ -238,12 +238,14 @@ re-admit memory the host has already promised.
 systemd transient scope before the payload execs — born-bounded rather than
 adopted — and the achieved tier is read back off the scope's `cpu.max`. On
 the in-house HVF VMM on macOS there is no host quota primitive, so the run
-loop enforces the share in-process: it measures the vCPU thread's consumed
-CPU time via Mach `thread_info`, predicts allowance exhaustion, and holds the
-vCPU out of `step()` until the period rolls over. The achieved tier is read
-back from the scheduler's own measured record. In both cases the receipt
-records what was measured rather than what was asked for. libkrun has no
-in-process vCPU control and stays declared-only.
+loop enforces the share in-process: it measures every vCPU thread's consumed
+CPU time via Mach `thread_info`, sums them, predicts allowance exhaustion, and
+holds all of them out of `step()` until the period rolls over. The sum is what
+makes the bound a bound on the machine — a controller reading one thread of a
+four-CPU guest sees a quarter of what it is consuming and never throttles. The
+achieved tier is read back from the scheduler's own measured record. In both
+cases the receipt records what was measured rather than what was asked for.
+libkrun has no in-process vCPU control and stays declared-only.
 
 *Wall clock* is enforced on the tiers with a per-VM supervisor process of
 ours — libkrun, HVF, and the AppleContainer tier that runs the same driver and

--- a/specs/sprint/delivery/2888-hvf-vcpu-contract.md
+++ b/specs/sprint/delivery/2888-hvf-vcpu-contract.md
@@ -1,4 +1,11 @@
-# HVF refuses unsupported multi-vCPU launches
+# HVF refuses unsupported multi-vCPU launches (SUPERSEDED)
+
+> **Superseded by `hvf-smp-cpus-honoured.md`.** HVF implements SMP: it creates
+> up to 4 vCPUs, and a request above that ceiling is clamped with a warning
+> rather than refused. Everything below describes the refusal contract that
+> preceded it, and is kept as the record of that step — not as current
+> behaviour. The "future complete SMP implementation" it anticipates is what
+> replaced it.
 
 Issue #2888 showed that a workload could request multiple vCPUs from the HVF
 backend, receive a successful launch, and still observe only one processor in

--- a/specs/sprint/delivery/hvf-smp-cpus-honoured.md
+++ b/specs/sprint/delivery/hvf-smp-cpus-honoured.md
@@ -39,17 +39,43 @@ next to the exit; the alternative was a second copy of the loop for the common
 case, which is the kind that rots. KVM still enters through `SoleBus` and is
 unchanged.
 
-## Two things the hardware taught us
+## What the hardware taught us, and what it did not
 
 `hv_gic_get_redistributor_base` **must be called after MPIDR_EL1 is set** — it
-returns `HV_BAD_ARGUMENT` otherwise, which is what the first working build did
-for four minutes of confusion. That is also the useful fact: HVF places a vCPU's
-redistributor frame by its *affinity*, not by creation order, so an early
-experiment serialising `hv_vcpu_create` into CPU order was solving a problem that
-does not exist and was removed. Each secondary now sets its own MPIDR at creation
-and the frame is checked against the address the device tree published. A
-mismatch is `RedistributorMismatch { cpu, expected, actual }` rather than a guest
-that faults in IRQ init before the console exists.
+returns `HV_BAD_ARGUMENT` otherwise, which cost the first working build four
+minutes of confusion. That much is true and documented in the header.
+
+The inference drawn from it was wrong, and this section recorded the wrong
+version for a while: that HVF therefore places a vCPU's redistributor frame by
+its *affinity*. It does not. Affinity is a precondition for the query being
+answerable, which is a different thing from it deciding where the frame goes.
+**HVF assigns frames in `hv_vcpu_create` call order.** On the false reading, the
+primitive serialising creation into CPU order was deleted as solving a
+non-problem — and the race came straight back.
+
+It surfaced as an apparent ceiling: 5, 6 and 8 vCPU guests never reached the
+agent, and a `max_vcpus: Some(4)` was recorded as a measured limit with a note
+that the cause was unexplained. It was not a limit. Two boots of the same
+machine gave `cpu: 3` holding frame 4 and then `cpu: 4` holding frame 3 — a
+swap, which is what two threads racing to call `hv_vcpu_create` looks like. The
+odds rise with the thread count, so one and two CPUs could not race, four
+sometimes did, and five nearly always. Four was never safe either.
+
+The refutation is cleaner than the measurement: if frames were keyed to
+affinity, a mismatch would be impossible, because each CPU sets its own MPIDR
+before querying. It mismatched, so they are not.
+
+Creation is ordered again, and the ordering now lives inside the one function
+that calls `hv_vcpu_create` rather than as two statements around the call — a
+pair that a later edit can separate, which is precisely how it was lost. The
+turn is an RAII guard, so no failure arm has to remember to release it. The
+frame check stays: it is what turned a silent hang into
+`RedistributorMismatch { cpu, expected, actual }`, and it is the only reason
+this was diagnosable at all.
+
+With the race gone the ceiling is not four, and `hv_vm_get_max_vcpu_count`
+answers 64 on this host — so the backend asks rather than hardcoding a number
+that a bug produced.
 
 ## Snapshot, restore and the CPU quota
 
@@ -84,7 +110,8 @@ vCPU thread" rather than "the vCPU thread's".
 
 ## Confirmed live, on a real guest
 
-`--cpus 2` → `2/2` and `--cpus 4` → `4/4`, reading `nproc` and
+`--cpus` at 1, 2, 4, 5, 6, 8, 16, 32 and (via the clamp) 64 all boot and
+report their full count, reading `nproc` and
 `grep -c ^processor /proc/cpuinfo` and comparing the whole line. Both are
 asserted because both were wrong together: they agreed at 1 before, so a fix
 that moved only one would be reading something other than the machine.

--- a/specs/sprint/delivery/hvf-smp-cpus-honoured.md
+++ b/specs/sprint/delivery/hvf-smp-cpus-honoured.md
@@ -1,0 +1,127 @@
+# `--cpus N` gives the guest N vCPUs on HVF
+
+`mvmctl machine run --cpus 4` exited 0 and handed back one CPU (#2888). The
+default is 2, so this was not a flag nobody used — every HVF guest on this
+backend was running on one CPU while its admitted plan said two.
+
+Four things had to line up, and the count had to reach all of them from one
+place or they would disagree. The device tree was already done (`build_dtb`
+takes `vcpus`, one `cpu@N` node each, redistributor region sized for the set).
+What landed here is the rest.
+
+**The count reaches the process that creates vCPUs.** `HvfSupervisorConfig`
+gained `vcpus`, populated from `spec.vcpus`. `effective_vcpus` is the single
+function the device tree and the vCPU bring-up both read, so the tree cannot
+describe a CPU no thread backs — that mismatch does not degrade to a smaller
+machine, it hangs the boot with an empty console. Nothing is clamped beyond
+"zero means one": the host's real ceiling is whatever `hv_vcpu_create` grants,
+and a count it refuses fails the boot rather than quietly shrinking the machine.
+
+**PSCI `CPU_ON` and `AFFINITY_INFO` are answered against gates that exist.**
+`backends/hvf/smp.rs` holds the state machine and the parking spot, and touches
+no hypervisor call — so the behaviour that would otherwise only be observable as
+a hung boot is unit-testable. `CPU_ON` never reports SUCCESS for a CPU no thread
+is waiting to run, because the kernel's `cpu_up` blocks on the target reaching
+its release point.
+
+**One thread per vCPU, because HVF binds a vCPU to its creating thread.**
+Secondaries are created up front and report success before the guest starts: the
+tree already describes them, so a vCPU the host refuses has to fail the boot
+*here*, while a failure is still a failed boot. Each then parks until its
+`CPU_ON`, and a CPU the guest never onlines (a `maxcpus=` cmdline) leaves through
+the same gate rather than being joined forever.
+
+**One device bus.** `run_on_bus` reaches devices through a `DeviceBus`, and every
+vCPU of a machine shares one `SharedBus` — a single lock over all devices, taken
+per access and never held across the pause or throttle holds. A single-CPU run
+takes the same path and pays an uncontended lock per MMIO exit, which is nothing
+next to the exit; the alternative was a second copy of the loop for the common
+case, which is the kind that rots. KVM still enters through `SoleBus` and is
+unchanged.
+
+## Two things the hardware taught us
+
+`hv_gic_get_redistributor_base` **must be called after MPIDR_EL1 is set** — it
+returns `HV_BAD_ARGUMENT` otherwise, which is what the first working build did
+for four minutes of confusion. That is also the useful fact: HVF places a vCPU's
+redistributor frame by its *affinity*, not by creation order, so an early
+experiment serialising `hv_vcpu_create` into CPU order was solving a problem that
+does not exist and was removed. Each secondary now sets its own MPIDR at creation
+and the frame is checked against the address the device tree published. A
+mismatch is `RedistributorMismatch { cpu, expected, actual }` rather than a guest
+that faults in IRQ init before the console exists.
+
+## Snapshot, restore and the CPU quota
+
+These were all single-vCPU shaped and are the machinery warm-fork depends on, so
+"SMP works but forking a 2-CPU machine does not" would have been a worse trade
+than no SMP at all.
+
+A snapshot frame now carries one fixed-width record per CPU in CPU order; the
+count is the section length over the record length, so no separate field can
+disagree with the payload, and a partial or empty section is refused rather than
+silently dropping a CPU. Capture is cooperative because it has to be — HVF only
+lets a vCPU's registers be read from its own thread, so the boot CPU cannot
+reach into a secondary. Each secondary publishes its registers while parked and
+the boot CPU assembles, only once every CPU has parked: capturing while one is
+still in the guest would write a frame whose RAM and whose registers describe
+different instants. Restore is the mirror — the boot CPU parses and resumes
+itself, each secondary applies its own state and enters the guest directly
+rather than waiting for a `CPU_ON` the guest has no reason to issue again. A
+frame whose CPU count does not match the machine is refused.
+
+The quota bounds the *machine*, so `VcpuQuota` takes every vCPU's handle and a
+`SummedClock` over every vCPU thread's Mach CPU time. A controller reading one
+thread of a four-CPU guest sees a quarter of what it is consuming and never
+throttles — the workload runs at four times its granted share while the audit
+record says it stayed inside it. The hold flag is created before the vCPU threads
+and handed to the controller, because every vCPU has to be able to read it from
+the moment it exists. `VcpuQuota` also grew a `Drop`: a boot that failed between
+starting the controller and reading it back used to leak the controller thread.
+
+ADR-001's claim-18 prose and CLAUDE.md were updated to say "summed across every
+vCPU thread" rather than "the vCPU thread's".
+
+## Confirmed live, on a real guest
+
+`--cpus 2` → `2/2` and `--cpus 4` → `4/4`, reading `nproc` and
+`grep -c ^processor /proc/cpuinfo` and comparing the whole line. Both are
+asserted because both were wrong together: they agreed at 1 before, so a fix
+that moved only one would be reading something other than the machine.
+`--cpus 1` → `1/1`, unchanged. `machine create --cpus 2` + `start` + `exec`
+reports 2.
+
+`--memory` was never verified on this path either, and could not be checked at
+512M — that is also the built-in default, so a guest ignoring the flag reports
+the expected number. At `--memory 1024M` the guest sees over 800 MiB.
+
+Checkpointing a live 2-vCPU guest produces a frame whose vCPU section is 768
+bytes: two 384-byte records, remainder zero.
+
+## Not verified live, and why
+
+The **HVF restore** half is covered by unit tests and by the CPU-count refusal,
+but was not driven end-to-end on this host. `machine fork` and `machine restore`
+are Firecracker-shaped verbs — `restore` refuses an HVF checkpoint with "does not
+carry a Firecracker machine state" — and the HVF frame is consumed by the
+warm-claim path instead. That path would not populate a standby here: every
+`MVM_RESIDENCY=warm` launch reported `launch_mode=cold` with `claim_ms=0.0`, and
+`MVM_HVF_WARM_REQUIRE_CLAIM=1` reported no compatible parent. The pool is filled
+by `warm_to_target` in the CLI, above the supervisor, and it already carries
+`vcpus` in its spec — so this is host-side policy rather than anything the VMM
+decides. Worth someone getting a standby to spawn and confirming a multi-vCPU
+claim before this is relied on for warm-fork.
+
+Witnesses: `the_booted_tree_describes_exactly_the_cpus_the_vmm_creates`,
+`psci_answers_for_exactly_the_cpus_the_tree_describes`,
+`a_requested_cpu_count_is_honoured_rather_than_reduced`,
+`cpu_on_releases_the_named_cpu_with_the_values_it_carried`,
+`cpu_on_refuses_a_cpu_this_machine_does_not_have`,
+`a_repeated_cpu_on_is_refused_rather_than_restarting_the_cpu`,
+`shutdown_releases_a_cpu_the_guest_never_onlined`,
+`concurrent_cpu_ons_release_each_cpu_independently`,
+`every_vcpu_survives_the_frame_in_cpu_order`,
+`a_partial_vcpu_record_is_refused_rather_than_truncated`,
+`a_summed_clock_charges_every_vcpu_of_the_machine`, and the two launch-suite
+scenarios "--cpus is honoured on a real boot" and "--memory is honoured on a
+real boot" (`MIN_SCENARIOS` raised to 16).


### PR DESCRIPTION
Closes #2888.
Closes #2924.
Closes #2927.

`--cpus` was accepted, recorded in the admitted plan, and then silently ignored:
the HVF VMM created exactly one vCPU whatever the caller asked for. A guest ran
on one CPU while its plan said four, with nothing to explain the difference.

## What changed

**The VMM creates the requested vCPUs.** The count reaches the process that makes
them (`HvfSupervisorConfig`), the device tree describes N `cpu@N` nodes with
`enable-method = "psci"`, the GIC redistributor region is sized to match, and
each secondary gets a thread. PSCI `CPU_ON` and `AFFINITY_INFO` are answered
against CPUs that actually exist.

**vCPU creation is ordered.** Hypervisor.framework assigns GIC redistributor
frames in `hv_vcpu_create` creation order. Allowing all creation threads to race
could swap two CPUs' frames, after which the guest could not match those CPUs to
their redistributors and never reached the agent. The frame identity check stays,
and creation now takes a turn so CPU N receives frame N.

**The ceiling comes from the host.** The apparent limit of four was the race
becoming more likely at larger counts, not a real platform ceiling. HVF now calls
`hv_vm_get_max_vcpu_count`; a host that cannot answer reports no backend ceiling
instead of using an invented constant. The portable request is still clamped
when a backend reports a real host limit, with a user-visible warning.

## Verification

- Live Apple Silicon guests at 1, 2, 4, 5, 6, 8, 16, and 32 vCPUs booted and
  reported their full count through both `nproc` and `/proc/cpuinfo`.
- The vCPU/GIC ordering tests preserve the invariant that PSCI never reports a
  CPU as available unless a backing thread exists.
- Workspace checks and the launch-mode regression suite cover the complete
  request-to-guest path. The separately tracked warm-dispatch budget gap is #2942.
