### PR TITLE
refactor(backends): rename the *_legacy driver modules to *_process

### DIFF
--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -547,7 +547,7 @@ pub(crate) fn terminate_firecracker_pid(name: &str, pid: u32, pid_file: &Path) -
         fc_sudo_signal(pid, FcStopSignal::Terminate);
         let exited = mvm_vmm::host::process_exit::wait_for_pid_exit(
             pid as libc::pid_t,
-            Instant::now() + crate::driver::libkrun_legacy::STOP_TIMEOUT,
+            Instant::now() + crate::driver::libkrun_process::STOP_TIMEOUT,
             Some(&observer),
         );
         if exited {
@@ -566,7 +566,7 @@ pub(crate) fn terminate_firecracker_pid(name: &str, pid: u32, pid_file: &Path) -
         }
     } else {
         escalate_kill(
-            crate::driver::libkrun_legacy::STOP_TIMEOUT,
+            crate::driver::libkrun_process::STOP_TIMEOUT,
             mvm_core::poll_backoff::poll_delay,
             || crate::fc::is_firecracker_pid_running(pid),
             |signal| fc_sudo_signal(pid, signal),

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -26,7 +26,7 @@ use mvm_vmm::host::hvf_supervisor::{
 };
 use mvm_vmm::hvf_handoff::HvfHandoffRequest;
 
-use crate::driver::hvf_legacy::{
+use crate::driver::hvf_process::{
     self as hvf_backend, PID_FILE_NAME, PID_FILE_TIMEOUT, resolve_supervisor_path,
 };
 use mvm_contract::grants::CpuGrant;

--- a/crates/mvm-backends/src/driver/hvf_process.rs
+++ b/crates/mvm-backends/src/driver/hvf_process.rs
@@ -1,18 +1,15 @@
-//! `HvfBackend` — the `VmBackend` impl for the raw-HVF macOS path.
+//! Host-process mechanics for the HVF backend.
 //!
-//! Lifecycle mirrors the other detached-supervisor backend (libkrun): `start`
-//! builds an [`HvfSupervisorConfig`] from the `VmStartConfig`, spawns
-//! `mvm-hvf-supervisor` with the JSON on stdin, and waits for it to write its PID
-//! file (boot confirmed). `stop` signals that PID; `status` probes it with
-//! `kill(pid, 0)`; `list` walks `~/.mvm/vms/*/hvf.pid`; `logs` reads the captured
-//! `console.log`. The guest boots through `boot_kernel` → the unified `vmm::run`
-//! loop inside the supervisor.
+//! Not a `VmBackend` impl — the lifecycle that used to live beside these
+//! helpers moved to `mvm-runtime`'s workload runner, and the `VmmDriver` half
+//! is [`super::hvf`]. What is left here is everything the host does *around*
+//! the guest: resolve `mvm-hvf-supervisor`, wait on its PID file, enumerate the
+//! console sockets and workload disks, and answer whether this platform can run
+//! HVF at all.
 //!
-//! Transient by default (VM life = workload life): the guest runs its entrypoint
-//! and reports its exit code over the workload-exit vsock port, which ends the run;
-//! `wait` returns that code. A persistent (`-d`) VM instead runs until `stop`. With
-//! vsock + optional virtio-blk. Not yet: pause/resume/snapshot, and vsock-mediated
-//! networking/egress.
+//! The file was called `hvf_legacy` while the backend split was in progress.
+//! Nothing in it is legacy: every function has a live caller on the macOS
+//! default path.
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -30,7 +30,7 @@ use mvm_core::checkpoint::{
 };
 use mvm_vmm::host::hvf_supervisor::{HvfDisk, HvfSupervisorConfig};
 
-use crate::driver::hvf_legacy::{
+use crate::driver::hvf_process::{
     PID_FILE_NAME, PID_FILE_TIMEOUT, read_pid, resolve_supervisor_path,
 };
 

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -60,7 +60,7 @@ fn libkrun_base_bootargs(virtiofs_root: bool, has_disk: bool) -> String {
     } else {
         // Verity / initramfs boot: the initramfs PID 1 owns root/init selection,
         // so only the console base is emitted here.
-        crate::driver::libkrun_legacy::VERITY_CMDLINE.to_string()
+        crate::driver::libkrun_process::VERITY_CMDLINE.to_string()
     }
 }
 
@@ -93,7 +93,7 @@ fn relay_libkrun_supervisor_config(spec: &VmmSpec, state_dir: &Path) -> Result<S
     // kernel to a libkrun-loadable ELF and reports the format; on aarch64 it is a
     // passthrough at Raw. The driver must not diverge from the host kernel-prep.
     let (kernel, kernel_format) =
-        crate::driver::libkrun_legacy::libkrun_kernel_for_host(&kernel_path)?;
+        crate::driver::libkrun_process::libkrun_kernel_for_host(&kernel_path)?;
 
     let vcpus = u8::try_from(spec.vcpus.clamp(1, u32::from(u8::MAX))).unwrap_or(u8::MAX);
     let state_dir_str = state_dir.to_string_lossy().into_owned();
@@ -378,7 +378,7 @@ impl VmmDriver for LibkrunDriver {
         let json = serde_json::to_string(&cfg)
             .map_err(|e| anyhow!("serialize libkrun SupervisorConfig: {e}"))?;
 
-        let supervisor = crate::driver::libkrun_legacy::resolve_supervisor_path()?;
+        let supervisor = crate::driver::libkrun_process::resolve_supervisor_path()?;
         let stdout = mvm_vmm::host::console_capture::open_console_capture(&console_log)
             .map(Stdio::from)
             .unwrap_or_else(|_| Stdio::null());
@@ -398,7 +398,7 @@ impl VmmDriver for LibkrunDriver {
 
         // Poll for the PID file (boot confirmed). If the supervisor exits first,
         // surface that — its console capture carries the actionable detail.
-        let deadline = Instant::now() + crate::driver::libkrun_legacy::PID_FILE_TIMEOUT;
+        let deadline = Instant::now() + crate::driver::libkrun_process::PID_FILE_TIMEOUT;
         loop {
             if pid_file.exists() {
                 break;
@@ -416,7 +416,7 @@ impl VmmDriver for LibkrunDriver {
                 let _ = child.kill();
                 bail!(
                     "libkrun supervisor did not confirm boot within {:?}; see {}",
-                    crate::driver::libkrun_legacy::PID_FILE_TIMEOUT,
+                    crate::driver::libkrun_process::PID_FILE_TIMEOUT,
                     console_log.display()
                 );
             }
@@ -428,7 +428,7 @@ impl VmmDriver for LibkrunDriver {
         // attach / shell_exec that immediately follows doesn't race a
         // not-yet-bound socket and report the VM "not running".
         let agent_socket = vm_vsock_port_socket_at(&state_dir, GUEST_AGENT_PORT);
-        let sock_deadline = Instant::now() + crate::driver::libkrun_legacy::VSOCK_SOCKET_TIMEOUT;
+        let sock_deadline = Instant::now() + crate::driver::libkrun_process::VSOCK_SOCKET_TIMEOUT;
         while !agent_socket.exists() {
             if let Some(status) = child
                 .try_wait()
@@ -445,7 +445,7 @@ impl VmmDriver for LibkrunDriver {
                 bail!(
                     "libkrun supervisor did not bind vsock socket {} within {:?}; killed; see {}",
                     agent_socket.display(),
-                    crate::driver::libkrun_legacy::VSOCK_SOCKET_TIMEOUT,
+                    crate::driver::libkrun_process::VSOCK_SOCKET_TIMEOUT,
                     console_log.display()
                 );
             }
@@ -501,7 +501,7 @@ impl RunningVm for LibkrunRunningVm {
     }
 
     fn host_process_id(&self) -> Option<u32> {
-        crate::driver::libkrun_legacy::read_pid(&self.pid_file)
+        crate::driver::libkrun_process::read_pid(&self.pid_file)
             .and_then(|pid| u32::try_from(pid).ok())
     }
 
@@ -514,21 +514,21 @@ impl RunningVm for LibkrunRunningVm {
     fn kill(&self) -> Result<()> {
         // Arm before SIGTERM so a short-lived supervisor cannot exit between
         // signal delivery and observer registration.
-        if let Some(pid) = crate::driver::libkrun_legacy::read_pid(&self.pid_file)
-            && crate::driver::libkrun_legacy::pid_alive(pid)
+        if let Some(pid) = crate::driver::libkrun_process::read_pid(&self.pid_file)
+            && crate::driver::libkrun_process::pid_alive(pid)
         {
             let observer = mvm_vmm::host::process_exit::ProcessExitObserver::arm(pid).ok();
             // SIGTERM gives libkrun a chance to close its virtio-blk file
             // descriptors, then SIGKILL if it ignores us within the grace
             // window.
-            crate::driver::libkrun_legacy::send_signal(pid, libc::SIGTERM);
+            crate::driver::libkrun_process::send_signal(pid, libc::SIGTERM);
             let exited = mvm_vmm::host::process_exit::wait_for_pid_exit(
                 pid,
-                Instant::now() + crate::driver::libkrun_legacy::STOP_TIMEOUT,
+                Instant::now() + crate::driver::libkrun_process::STOP_TIMEOUT,
                 observer.as_ref(),
             );
             if !exited {
-                crate::driver::libkrun_legacy::send_signal(pid, libc::SIGKILL);
+                crate::driver::libkrun_process::send_signal(pid, libc::SIGKILL);
                 if !mvm_vmm::host::process_exit::wait_for_pid_exit(
                     pid,
                     Instant::now() + Duration::from_millis(500),
@@ -542,7 +542,7 @@ impl RunningVm for LibkrunRunningVm {
             }
         }
         let _ = std::fs::remove_file(&self.pid_file);
-        crate::driver::libkrun_legacy::cleanup_vsock_sockets(&self.state_dir);
+        crate::driver::libkrun_process::cleanup_vsock_sockets(&self.state_dir);
         Ok(())
     }
 
@@ -560,8 +560,8 @@ impl RunningVm for LibkrunRunningVm {
 
     fn status(&self) -> Result<VmStatus> {
         Ok(
-            match crate::driver::libkrun_legacy::read_pid(&self.pid_file) {
-                Some(pid) if crate::driver::libkrun_legacy::pid_alive(pid) => VmStatus::Running,
+            match crate::driver::libkrun_process::read_pid(&self.pid_file) {
+                Some(pid) if crate::driver::libkrun_process::pid_alive(pid) => VmStatus::Running,
                 _ => VmStatus::Stopped,
             },
         )
@@ -673,7 +673,7 @@ mod tests {
     }
 
     #[test]
-    fn carrying_a_plan_does_not_move_the_supervisor_off_its_legacy_route() {
+    fn carrying_a_plan_does_not_move_the_supervisor_onto_the_admission_route() {
         let mut spec = spec_with(KernelImage::Path("/k/Image".into()), vec![], vec![]);
         spec.plan_binding = Some(binding());
         let cfg = relay(&spec);
@@ -1039,7 +1039,7 @@ mod tests {
         let cfg = relay(&spec);
         assert_eq!(
             cfg.krun.kernel_cmdline.as_deref(),
-            Some(crate::driver::libkrun_legacy::VERITY_CMDLINE)
+            Some(crate::driver::libkrun_process::VERITY_CMDLINE)
         );
     }
 

--- a/crates/mvm-backends/src/driver/libkrun_process.rs
+++ b/crates/mvm-backends/src/driver/libkrun_process.rs
@@ -1,27 +1,18 @@
-//! libkrun backend for mvm.
+//! Host-process mechanics for the libkrun backend.
 //!
-//! Tier 2 microVM backend that runs on
-//! Linux KVM and macOS Apple Silicon. The lifecycle
-//! delegates to a per-VM `mvm-libkrun-supervisor` subprocess
-//! rather than calling libkrun in-process: `krun_start_enter` calls
-//! `exit()` on the host process when the guest powers off, so any
-//! in-process registry would tear down sibling guests. One process per
-//! VM scopes the `exit()` to that supervisor and lets the parent
-//! `mvmctl` survive a guest shutdown.
+//! libkrun's lifecycle delegates to a per-VM `mvm-libkrun-supervisor`
+//! subprocess rather than calling libkrun in-process: `krun_start_enter` calls
+//! `exit()` on the host process when the guest powers off, so an in-process
+//! registry would tear down sibling guests. One process per VM scopes that
+//! `exit()` and lets the parent `mvmctl` survive a guest shutdown.
 //!
-//! ## Lifecycle
+//! This module is the host side of that arrangement — supervisor resolution,
+//! PID-file handling, cmdline and disk assembly. The `VmmDriver` half is
+//! [`super::libkrun`].
 //!
-//! - `start` writes `~/.mvm/vms/<name>/{rootfs.ref,kernel.ref}` runtime
-//!   metadata (so `mvmctl console` can find the artifacts), serializes a
-//!   [`SupervisorConfig`], spawns `mvm-libkrun-supervisor` with the JSON
-//!   on stdin, and waits up to `PID_FILE_TIMEOUT` for the supervisor
-//!   to write its PID file. Returns once the supervisor is running or
-//!   exits with an error if the spawn fails or PID file never appears.
-//! - `stop` reads `<vm_state_dir>/libkrun.pid`, arms a host process-exit
-//!   observer before `SIGTERM`, and falls back to bounded polling plus
-//!   `SIGKILL` if the process does not exit within `STOP_TIMEOUT`.
-//! - `status` reads the PID file and probes with `kill(pid, 0)`.
-//! - `list` walks `~/.mvm/vms/*/libkrun.pid`.
+//! The file was called `libkrun_legacy` while the backend split was in
+//! progress. Nothing in it is legacy: it is the live path on Linux and on
+//! macOS 13-25.
 
 use anyhow::{Context, Result, anyhow, bail};
 use libkrun_sys::{BridgeRestartPolicy, KrunContext, SupervisorAttachConfig, SupervisorBaseConfig};

--- a/crates/mvm-backends/src/driver/mod.rs
+++ b/crates/mvm-backends/src/driver/mod.rs
@@ -7,9 +7,9 @@ pub mod hvf_restore;
 pub mod libkrun;
 pub mod qemu;
 
-pub mod hvf_legacy;
-pub mod libkrun_legacy;
-pub mod qemu_legacy;
+pub mod hvf_process;
+pub mod libkrun_process;
+pub mod qemu_process;
 
 pub use fc::FcDriver;
 pub use hvf::HvfDriver;

--- a/crates/mvm-backends/src/driver/qemu.rs
+++ b/crates/mvm-backends/src/driver/qemu.rs
@@ -28,7 +28,7 @@ use mvm_core::vm_backend::{
 };
 use mvm_net::channel::GuestService;
 
-use crate::driver::qemu_legacy::{
+use crate::driver::qemu_process::{
     self, QEMU_LOG_FILE, QEMU_PID_FILE, QemuBridgeGuestDial, QemuBridgeHostDial, QemuBridgeSpec,
 };
 use mvm_vmm::driver::spec::{KernelImage, VmmSpec, VsockDirection, VsockPort};
@@ -315,7 +315,7 @@ impl VmmDriver for QemuDriver {
     }
 
     fn is_available(&self) -> Result<bool> {
-        Ok(qemu_legacy::locate_qemu().is_ok())
+        Ok(qemu_process::locate_qemu().is_ok())
     }
 
     fn capabilities(&self) -> VmCapabilities {
@@ -392,9 +392,9 @@ impl VmmDriver for QemuDriver {
         // workload rootfs.
         let kernel = match &spec.kernel {
             KernelImage::Path(p) => p.clone(),
-            KernelImage::Bundled => qemu_legacy::resolve_workload_kernel_path(&spec.name, None)?,
+            KernelImage::Bundled => qemu_process::resolve_workload_kernel_path(&spec.name, None)?,
         };
-        let qemu_bin = qemu_legacy::locate_qemu()?;
+        let qemu_bin = qemu_process::locate_qemu()?;
 
         let state_dir = vm_state_dir(&spec.name);
         std::fs::create_dir_all(&state_dir)
@@ -409,7 +409,7 @@ impl VmmDriver for QemuDriver {
             )?,
         );
 
-        let kvm = qemu_legacy::kvm_available();
+        let kvm = qemu_process::kvm_available();
         if !kvm {
             // Loud Tier-3 banner for the unaccelerated TCG fallback — the
             // same runtime-tier signal the raw path emits.
@@ -422,7 +422,7 @@ impl VmmDriver for QemuDriver {
             ));
         }
 
-        let cid = qemu_legacy::allocate_cid(&spec.name)?;
+        let cid = qemu_process::allocate_cid(&spec.name)?;
         let pid_file = state_dir.join(QEMU_PID_FILE);
         let _ = std::fs::remove_file(&pid_file);
 
@@ -469,13 +469,13 @@ impl VmmDriver for QemuDriver {
 
         // `-daemonize` returns only after the pidfile is written, but poll
         // defensively so a slow fork doesn't race the bridge spawn below.
-        let deadline = Instant::now() + qemu_legacy::PID_FILE_TIMEOUT;
+        let deadline = Instant::now() + qemu_process::PID_FILE_TIMEOUT;
         while !pid_file.exists() {
             if Instant::now() >= deadline {
                 bail!(
                     "qemu did not write pidfile {} within {:?}",
                     pid_file.display(),
-                    qemu_legacy::PID_FILE_TIMEOUT
+                    qemu_process::PID_FILE_TIMEOUT
                 );
             }
             std::thread::sleep(Duration::from_millis(50));
@@ -487,12 +487,12 @@ impl VmmDriver for QemuDriver {
         // the pid/cid sidecars so a retry re-allocates a CID instead of
         // pinning the (possibly conflicting) one this attempt wrote.
         let bridge_spec = bridge_spec_for_vsock(cid, &state_dir, &spec.vsock);
-        if let Err(e) = qemu_legacy::spawn_vsock_bridges(&spec.name, &state_dir, &bridge_spec) {
-            if let Some(pid) = qemu_legacy::read_pid(&pid_file) {
-                qemu_legacy::send_signal(pid, libc::SIGTERM);
+        if let Err(e) = qemu_process::spawn_vsock_bridges(&spec.name, &state_dir, &bridge_spec) {
+            if let Some(pid) = qemu_process::read_pid(&pid_file) {
+                qemu_process::send_signal(pid, libc::SIGTERM);
             }
             let _ = std::fs::remove_file(&pid_file);
-            let _ = std::fs::remove_file(state_dir.join(qemu_legacy::QEMU_CID_FILE));
+            let _ = std::fs::remove_file(state_dir.join(qemu_process::QEMU_CID_FILE));
             return Err(e);
         }
 
@@ -522,7 +522,7 @@ impl VmmDriver for QemuDriver {
         // The shared agent client connects to the UNIX socket the bridge
         // binds (`vm_vsock_port_socket`); the `cid` here is the guest CID
         // the bridge dials over AF_VSOCK, surfaced for diagnostics.
-        let cid = qemu_legacy::read_cid(&id.0).unwrap_or(3);
+        let cid = qemu_process::read_cid(&id.0).unwrap_or(3);
         Ok(GuestChannelInfo::Vsock {
             cid,
             port: mvm_agentd::vsock::GUEST_AGENT_PORT,
@@ -556,31 +556,31 @@ impl RunningVm for QemuRunningVm {
         // Guard on liveness so a stale pidfile (crash without cleanup) whose
         // PID the OS has since recycled isn't signalled by mistake.
         if let Some(bridge_pid) =
-            qemu_legacy::read_pid(&self.state_dir.join(qemu_legacy::BRIDGE_PID_FILE))
-            && qemu_legacy::pid_alive(bridge_pid)
+            qemu_process::read_pid(&self.state_dir.join(qemu_process::BRIDGE_PID_FILE))
+            && qemu_process::pid_alive(bridge_pid)
         {
-            qemu_legacy::send_signal(bridge_pid, libc::SIGTERM);
+            qemu_process::send_signal(bridge_pid, libc::SIGTERM);
         }
-        let _ = std::fs::remove_file(self.state_dir.join(qemu_legacy::BRIDGE_PID_FILE));
-        qemu_legacy::cleanup_vsock_bridge_sockets(&self.state_dir);
+        let _ = std::fs::remove_file(self.state_dir.join(qemu_process::BRIDGE_PID_FILE));
+        qemu_process::cleanup_vsock_bridge_sockets(&self.state_dir);
 
         // Arm before SIGTERM so a short-lived QEMU process cannot exit between
         // signal delivery and observer registration.
-        if let Some(pid) = qemu_legacy::read_pid(&self.pid_file)
-            && qemu_legacy::pid_alive(pid)
+        if let Some(pid) = qemu_process::read_pid(&self.pid_file)
+            && qemu_process::pid_alive(pid)
         {
             let observer = mvm_vmm::host::process_exit::ProcessExitObserver::arm(pid).ok();
             // SIGTERM gives QEMU a chance to close its virtio-blk file
             // descriptors, then SIGKILL if it ignores us within the grace
             // window.
-            qemu_legacy::send_signal(pid, libc::SIGTERM);
+            qemu_process::send_signal(pid, libc::SIGTERM);
             let exited = mvm_vmm::host::process_exit::wait_for_pid_exit(
                 pid,
-                Instant::now() + qemu_legacy::STOP_TIMEOUT,
+                Instant::now() + qemu_process::STOP_TIMEOUT,
                 observer.as_ref(),
             );
             if !exited {
-                qemu_legacy::send_signal(pid, libc::SIGKILL);
+                qemu_process::send_signal(pid, libc::SIGKILL);
                 if !mvm_vmm::host::process_exit::wait_for_pid_exit(
                     pid,
                     Instant::now() + Duration::from_millis(500),
@@ -612,8 +612,8 @@ impl RunningVm for QemuRunningVm {
     }
 
     fn status(&self) -> Result<VmStatus> {
-        Ok(match qemu_legacy::read_pid(&self.pid_file) {
-            Some(pid) if qemu_legacy::pid_alive(pid) => VmStatus::Running,
+        Ok(match qemu_process::read_pid(&self.pid_file) {
+            Some(pid) if qemu_process::pid_alive(pid) => VmStatus::Running,
             _ => VmStatus::Stopped,
         })
     }
@@ -1080,7 +1080,7 @@ mod tests {
         env.set("MVM_HOME", dir.path());
 
         // Missing cache entry ⇒ a clear, named failure.
-        let err = qemu_legacy::resolve_workload_kernel_path("w", None).unwrap_err();
+        let err = qemu_process::resolve_workload_kernel_path("w", None).unwrap_err();
         assert!(
             err.to_string().contains("no bootable kernel"),
             "unexpected error: {err}"
@@ -1100,7 +1100,7 @@ mod tests {
         std::fs::create_dir_all(cached.parent().expect("cache parent")).unwrap();
         std::fs::write(&cached, b"kernel").unwrap();
         assert_eq!(
-            qemu_legacy::resolve_workload_kernel_path("w", None).unwrap(),
+            qemu_process::resolve_workload_kernel_path("w", None).unwrap(),
             cached
         );
     }

--- a/crates/mvm-backends/src/driver/qemu_process.rs
+++ b/crates/mvm-backends/src/driver/qemu_process.rs
@@ -1,48 +1,17 @@
-//! QEMU **workload** runtime backend.
+//! Host-process mechanics for the QEMU **workload** backend.
 //!
 //! The dev/test counterpart to the QEMU *builder* (`mvm-build`'s
-//! `qemu_builder`): this boots a user **workload** microVM via
-//! `qemu-system-<arch>` so a workload can run for dev/test on a host
-//! without `/dev/kvm` (TCG fallback) or where Firecracker isn't wanted.
-//! **Firecracker stays the sole production runtime**; QEMU is opt-in
-//! (`--hypervisor qemu` / `MVM_BACKEND=qemu`) and `auto_select` never
-//! picks it.
+//! `qemu_builder`): boots a user workload microVM via `qemu-system-<arch>` so a
+//! workload can run for dev/test on a host without `/dev/kvm` (TCG fallback) or
+//! where Firecracker isn't wanted. **Firecracker stays the sole production
+//! runtime**; QEMU is opt-in (`--hypervisor qemu` / `MVM_BACKEND=qemu`) and
+//! `auto_select` never picks it.
 //!
-//! The selectable launch path is the unified workload runner over
-//! [`crate::driver::QemuDriver`] — a QEMU boot attaches the universal
-//! initramfs and receives `ActivateEnvironment` over vsock exactly like
-//! Firecracker/libkrun/HVF. This raw backend remains as the driver's
-//! identity delegate and owns the shared QEMU machinery both paths use:
-//! guest-CID allocation, the AF_VSOCK↔UNIX bridge, and the pid-file
-//! lifecycle.
+//! Locating the binary, allocating a CID, PID files, and the vsock bridge
+//! subprocesses live here; the `VmmDriver` half is [`super::qemu`].
 //!
-//! ## Tier
-//!
-//! Dev tier only, outside the security claims. `AnyBackend::tier()` reports
-//! the **best-case** Tier 2 (KVM-accelerated, comparable to the
-//! microvm.nix/qemu classification); when `/dev/kvm` is absent the boot
-//! runs under TCG software emulation and `start` emits a loud Tier-3
-//! banner. The static enum tier stays
-//! Tier 2 because it's a compile-time classification consulted by the
-//! tier-sync test + `doctor`; the live KVM-vs-TCG mode is a *runtime*
-//! property surfaced through the banner and `doctor`, not the enum.
-//!
-//! ## Lifecycle
-//!
-//! - `start` boots `qemu-system` with `-daemonize -pidfile` (qemu forks
-//!   and writes its own PID file), captures the guest serial console
-//!   **write-only** to `console.log` (claim 15 — no host input fd), wires
-//!   user-mode (slirp) networking, and attaches a virtio-vsock device on
-//!   a per-VM guest CID. It then spawns a host-side AF_VSOCK↔UNIX bridge
-//!   (a detached `mvmctl` subprocess) so the shared UNIX-socket agent
-//!   client reaches the guest agent exactly as it does under
-//!   libkrun/Firecracker — QEMU's `vhost-vsock` speaks real AF_VSOCK, not
-//!   the per-port UNIX sockets those VMMs expose. The bridge is
-//!   spec-driven ([`QemuBridgeSpec`]): the runner's driver additionally
-//!   relays the guest-dialed channels (egress, broker) and captures the
-//!   workload-exit report through the same process.
-//! - `stop` SIGTERMs the qemu PID (then SIGKILL), reaps the bridge.
-//! - `status` probes the qemu PID; `list` walks `~/.mvm/vms/*/qemu.pid`.
+//! The file was called `qemu_legacy` while the backend split was in progress.
+//! Nothing in it is legacy — `qemu.rs` calls into it on every boot.
 
 use anyhow::{Context, Result, anyhow, bail};
 use mvm_core::config::{vm_state_dir, vms_dir};

--- a/crates/mvm-cli/src/commands/qemu_bridge.rs
+++ b/crates/mvm-cli/src/commands/qemu_bridge.rs
@@ -26,5 +26,5 @@ pub(in crate::commands) struct Args {
 }
 
 pub(in crate::commands) fn run(args: &Args) -> Result<()> {
-    mvm_backends::driver::qemu_legacy::run_vsock_bridge_from_spec_file(&args.spec)
+    mvm_backends::driver::qemu_process::run_vsock_bridge_from_spec_file(&args.spec)
 }

--- a/crates/mvm-runtime/src/builder_runner/inject.rs
+++ b/crates/mvm-runtime/src/builder_runner/inject.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result, bail};
 use mvm_build::rootfs_inject::{InjectBinary, build_inject_initramfs};
 use mvm_vmm::host::hvf_supervisor::{HvfDisk, HvfSupervisorConfig};
 
-use mvm_backends::driver::hvf_legacy::resolve_supervisor_path;
+use mvm_backends::driver::hvf_process::resolve_supervisor_path;
 
 /// A rootfs-injection request.
 pub struct InjectRequest<'a> {

--- a/crates/mvm-runtime/src/codesign.rs
+++ b/crates/mvm-runtime/src/codesign.rs
@@ -116,13 +116,13 @@ pub fn collect_sign_targets() -> Vec<SignTarget> {
             required: RequiredEntitlement::Virtualization,
         });
     }
-    if let Ok(p) = mvm_backends::driver::libkrun_legacy::resolve_supervisor_path() {
+    if let Ok(p) = mvm_backends::driver::libkrun_process::resolve_supervisor_path() {
         out.push(SignTarget {
             path: p,
             required: RequiredEntitlement::Hypervisor,
         });
     }
-    if let Ok(p) = mvm_backends::driver::hvf_legacy::resolve_supervisor_path() {
+    if let Ok(p) = mvm_backends::driver::hvf_process::resolve_supervisor_path() {
         out.push(SignTarget {
             path: p,
             required: RequiredEntitlement::Hypervisor,

--- a/specs/sprint/delivery/rename-legacy-driver-modules.md
+++ b/specs/sprint/delivery/rename-legacy-driver-modules.md
@@ -1,0 +1,34 @@
+# `*_legacy` driver modules were never legacy
+
+`driver/hvf_legacy.rs`, `libkrun_legacy.rs` and `qemu_legacy.rs` sat beside
+`hvf.rs` / `libkrun.rs` / `qemu.rs` and read like superseded implementations
+kept for compatibility. They are not. `qemu.rs` calls
+`qemu_legacy::locate_qemu()` on every boot; `libkrun_legacy` is the live path on
+Linux and macOS 13-25; `hvf_legacy` is on the macOS default path. 55 references
+across the workspace, all live.
+
+They are now `*_process.rs`, which is what they hold: the host side of running
+that VMM — resolve the supervisor binary, wait on a PID file, allocate a CID,
+enumerate console sockets and workload disks, spawn the vsock bridges, answer
+whether the platform supports the VMM at all. The `VmmDriver` impl stays in the
+unsuffixed sibling.
+
+## The doc headers were stale too
+
+Each opened by describing a `VmBackend` implementation — "`HvfBackend` — the
+`VmBackend` impl for the raw-HVF macOS path". There is no `HvfBackend` in the
+tree and no `impl VmBackend` in any of the three files; that lifecycle moved to
+`mvm-runtime`'s workload runner and left these behind as the process mechanics.
+The headers now describe what the modules contain, and each says explicitly that
+nothing in it is legacy, so the next sweep does not flag them again.
+
+One test name went with them:
+`carrying_a_plan_does_not_move_the_supervisor_off_its_legacy_route` →
+`..._onto_the_admission_route`. Its body already explained that "legacy route"
+meant the non-admission route.
+
+## Gates
+
+`fmt --all`, `clippy --workspace --all-targets` (zero warnings),
+`nextest --workspace` against an empty `MVM_HOME` (12,238 pass),
+`xtask check-all` (61 gates), `just check-gated`.


### PR DESCRIPTION
`driver/hvf_legacy.rs`, `libkrun_legacy.rs` and `qemu_legacy.rs` sat beside `hvf.rs` / `libkrun.rs` / `qemu.rs` and read like superseded implementations kept for compatibility. **They are not.** `qemu.rs` calls `qemu_legacy::locate_qemu()` on every boot, `libkrun_legacy` is the live path on Linux and macOS 13-25, and `hvf_legacy` is on the macOS default path — 55 live references across the workspace.

They are now `*_process.rs`, which is what they hold: the host side of running that VMM — resolve the supervisor binary, wait on a PID file, allocate a CID, enumerate console sockets and workload disks, spawn the vsock bridges, answer whether the platform supports the VMM at all. The `VmmDriver` impl stays in the unsuffixed sibling.

## The doc headers were stale in the same direction

Each opened by describing a `VmBackend` implementation — *"`HvfBackend` — the `VmBackend` impl for the raw-HVF macOS path"*. There is no `HvfBackend` anywhere in the tree and no `impl VmBackend` in any of the three files; that lifecycle moved to `mvm-runtime`'s workload runner and left these behind as the process mechanics. The headers now describe what the modules actually contain, and each states explicitly that nothing in it is legacy — so the next keyword sweep does not flag them again.

One test name went with them: `carrying_a_plan_does_not_move_the_supervisor_off_its_legacy_route` → `..._onto_the_admission_route`. Its body already explained that "legacy route" meant the non-admission route.

Pure rename plus doc corrections — no behaviour change.

## Gates

`fmt --all`, `clippy --workspace --all-targets` (zero warnings), `nextest --workspace` against an empty `MVM_HOME` (12,238 pass), `xtask check-all` (61 gates), `just check-gated`.