### PR TITLE
fix(web): forward terminal control keys to qemu

### DIFF
--- a/public/tests/demo-e2e.mjs
+++ b/public/tests/demo-e2e.mjs
@@ -30,6 +30,10 @@ import { loadHeaderRules, headersFor } from "../scripts/headers-config.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "../dist");
+const CTRL_C_MARKER_COMMAND =
+  "printf '\\103\\124\\122\\114\\137\\103\\137\\106\\117\\122\\127\\101\\122\\104\\105\\104\\n'";
+const CTRL_D_MARKER_COMMAND =
+  "cat; printf '\\103\\124\\122\\114\\137\\104\\137\\106\\117\\122\\127\\101\\122\\104\\105\\104\\n'";
 
 let chromium;
 try {
@@ -43,6 +47,7 @@ try {
 const mime = {
   ".html": "text/html",
   ".js": "application/javascript",
+  ".mjs": "application/javascript",
   ".css": "text/css",
   ".svg": "image/svg+xml",
   ".png": "image/png",
@@ -173,6 +178,20 @@ async function main() {
       // The demo's uname -a output includes "qemu" when running under QEMU-Wasm.
       throw new Error("guest uname did not look like the QEMU-Wasm Linux guest");
     }
+
+    // Ctrl+C must reach the serial PTY as ETX rather than becoming a browser
+    // copy shortcut. The marker command cannot execute until sleep exits.
+    await runCommand(page, "sleep 30");
+    await page.press("#command", "Control+c");
+    await runCommand(page, CTRL_C_MARKER_COMMAND);
+    await waitForLog(page, "CTRL_C_FORWARDED", 5000);
+
+    // Ctrl+D must reach the PTY as EOT. The command after `cat` only executes
+    // once cat observes EOF, and its literal marker is octal-encoded so input
+    // echo cannot satisfy the assertion.
+    await runCommand(page, CTRL_D_MARKER_COMMAND);
+    await page.press("#command", "Control+d");
+    await waitForLog(page, "CTRL_D_FORWARDED", 5000);
 
     // Stop the VM and confirm the worker tears down cleanly.
     await page.click("#stopBtn");

--- a/public/tests/weblinux-terminal-input.test.mjs
+++ b/public/tests/weblinux-terminal-input.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { terminalControlBytes } from "../../web/weblinux-demo/terminal-input.mjs";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const demoDir = path.resolve(testDir, "../../web/weblinux-demo");
+
+test("Ctrl+C maps to the terminal interrupt byte", () => {
+  assert.equal(terminalControlBytes({ key: "c", ctrlKey: true }), "\x03");
+});
+
+test("Ctrl+D maps to the terminal EOF byte", () => {
+  assert.equal(terminalControlBytes({ key: "d", ctrlKey: true }), "\x04");
+});
+
+test("unmodified, alternate, and command-key input remains browser input", () => {
+  assert.equal(terminalControlBytes({ key: "c", ctrlKey: false }), null);
+  assert.equal(terminalControlBytes({ key: "c", ctrlKey: true, altKey: true }), null);
+  assert.equal(terminalControlBytes({ key: "d", ctrlKey: true, metaKey: true }), null);
+});
+
+test("control key matching is case insensitive", () => {
+  assert.equal(terminalControlBytes({ key: "C", ctrlKey: true }), "\x03");
+  assert.equal(terminalControlBytes({ key: "D", ctrlKey: true }), "\x04");
+});
+
+test("the page, worker, and staging script carry raw terminal input end to end", () => {
+  const demo = fs.readFileSync(path.join(demoDir, "demo.js"), "utf8");
+  const worker = fs.readFileSync(path.join(demoDir, "worker.js"), "utf8");
+  const build = fs.readFileSync(path.join(demoDir, "build.sh"), "utf8");
+
+  assert.match(demo, /postMessage\(\{ type: "stdin", data: controlBytes \}\)/);
+  assert.match(worker, /inputCallback\(event\.data\.data\)/);
+  assert.match(
+    build,
+    /cp "\$SCRIPT_DIR\/terminal-input\.mjs" "\$DEST_DIR\/terminal-input\.mjs"/,
+  );
+});
+
+test("the active demo terminal forwards Ctrl+C and Ctrl+D to its worker", async () => {
+  const listeners = new Map();
+  const elements = new Map();
+  const elementIds = [
+    "status",
+    "log",
+    "runBtn",
+    "stopBtn",
+    "input-form",
+    "command",
+    "allowHost",
+  ];
+  for (const id of elementIds) {
+    const elementListeners = new Map();
+    const element = {
+      addEventListener: (type, listener) => elementListeners.set(type, listener),
+      className: "",
+      disabled: id === "command",
+      focus: () => {},
+      innerHTML: "",
+      scrollHeight: 0,
+      scrollTop: 0,
+      textContent: "",
+      value: id === "allowHost" ? "demo.mvm.local" : "",
+    };
+    elements.set(id, element);
+    listeners.set(id, elementListeners);
+  }
+
+  const workers = [];
+  class FakeWorker {
+    constructor(url) {
+      this.url = url;
+      this.messages = [];
+      workers.push(this);
+    }
+
+    postMessage(message) {
+      this.messages.push(message);
+    }
+
+    terminate() {}
+  }
+
+  globalThis.document = { getElementById: (id) => elements.get(id) };
+  globalThis.location = { search: "" };
+  globalThis.Worker = FakeWorker;
+
+  try {
+    await import(`../../web/weblinux-demo/demo.js?test=${Date.now()}`);
+    listeners.get("runBtn").get("click")();
+    const worker = workers[0];
+    worker.onmessage({ data: { type: "ready" } });
+
+    const controls = [
+      ["c", "\x03"],
+      ["d", "\x04"],
+    ];
+    for (const [key, data] of controls) {
+      let prevented = false;
+      listeners.get("command").get("keydown")({
+        altKey: false,
+        ctrlKey: true,
+        key,
+        metaKey: false,
+        preventDefault: () => {
+          prevented = true;
+        },
+      });
+      assert.equal(prevented, true);
+      assert.deepEqual(worker.messages.at(-1), { type: "stdin", data });
+    }
+  } finally {
+    delete globalThis.document;
+    delete globalThis.location;
+    delete globalThis.Worker;
+  }
+});

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-26
+Last updated: 2026-08-27
 
 ## In progress
 
@@ -643,7 +643,10 @@ for detailed scope and acceptance criteria.
       feasibility is now pinned: `ktock/qemu-wasm` 5a65998d47, Emscripten
       3.1.50, zlib/libffi/pixman/glib/xterm-pty versions are recorded, and
       `nix/packages/qemu-wasm.nix` packages the engine through the Nix
-      builder boundary. Build verification is queued for the Linux builder.
+      builder boundary. The demo terminal now forwards Ctrl+C/Ctrl+D as raw
+      ETX/EOT bytes through the Worker to the serial PTY, with focused and
+      live-browser coverage. Build verification is queued for the Linux
+      builder.
 
 - [~] **Security lane recovery — issue #2736.** The advisory finding is fixed,
       the release-artifact bootstrap source now compiles with warnings denied,

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -2608,6 +2608,9 @@ Browser-hosted demo scoped in `specs/plans/2026-08-21-weblinux-browser-demo.md`.
 - [x] 2.1 Pin and package a reproducible QEMU-Wasm engine through Nix.
       Pinned upstream revisions and added `nix/packages/qemu-wasm.nix`;
       build is queued for the Linux builder VM.
+- [x] Demo terminal input forwards Ctrl+C and Ctrl+D as raw ETX/EOT bytes
+      through the Worker to the QEMU-Wasm serial PTY, with focused input tests
+      and live-browser interruption/EOF scenarios.
 - [ ] 2.8 Boot an `mvm`-built x86_64 kernel under headless Chromium and record measurements.
 
 Workstream 1 first slice (1.1, 1.7) and the WS-2 engine packaging

--- a/specs/plans/2026-08-21-weblinux-browser-demo.md
+++ b/specs/plans/2026-08-21-weblinux-browser-demo.md
@@ -110,6 +110,9 @@ cdf057a71b07e3b52b19cbe210bdefa59250d01a9810b960f7fe1f98eed95a27  bios/kvmvapic.
   polish (ANSI color rendering, bottom-docked input, command history) and a
   CLI preview that advertises the intended
   `mvmctl machine run --hypervisor web-linux ...` surface.
+- [x] Forward Ctrl+C and Ctrl+D from the active command input to the QEMU-Wasm
+  serial PTY as raw ETX/EOT bytes. Focused browser-input tests cover both keys,
+  and the Playwright flow exercises interrupting `sleep` and closing `cat`.
 
 ### Phase 1 — Engine integration (builder VM verified)
 

--- a/web/weblinux-demo/build.sh
+++ b/web/weblinux-demo/build.sh
@@ -34,13 +34,14 @@ fi
 mkdir -p "$DEST_DIR"
 
 # Copy the pack first, then overlay the demo source files so the demo's
-# index.html, demo.js, and worker.js take precedence over any files that
-# happen to share a name in the pack.
+# index.html, demo.js, terminal-input.mjs, and worker.js take precedence over
+# any files that happen to share a name in the pack.
 cp -R "$PACK_DIR/." "$DEST_DIR/"
 chmod -R u+w "$DEST_DIR"
 rm -f "$DEST_DIR/index.html"
 cp "$SCRIPT_DIR/index.html" "$DEST_DIR/index.html"
 cp "$SCRIPT_DIR/demo.js" "$DEST_DIR/demo.js"
+cp "$SCRIPT_DIR/terminal-input.mjs" "$DEST_DIR/terminal-input.mjs"
 cp "$SCRIPT_DIR/worker.js" "$DEST_DIR/worker.js"
 
 # Cloudflare Pages rejects individual files larger than 25 MiB. The QEMU

--- a/web/weblinux-demo/demo.js
+++ b/web/weblinux-demo/demo.js
@@ -1,6 +1,8 @@
 // Main thread for the WebLinux browser demo.
 // It owns the UI and a dedicated Worker that runs the QEMU-Wasm engine.
 
+import { terminalControlBytes } from "./terminal-input.mjs";
+
 const statusEl = document.getElementById("status");
 const logEl = document.getElementById("log");
 const runBtn = document.getElementById("runBtn");
@@ -203,7 +205,7 @@ function runWorker() {
         // Allow headless tests to inject a command via ?exec=...
         const exec = new URLSearchParams(location.search).get("exec");
         if (exec) {
-          worker.postMessage({ type: "stdin", line: exec });
+          worker.postMessage({ type: "stdin", data: exec + "\r" });
         }
         break;
       case "error":
@@ -253,11 +255,15 @@ inputForm.addEventListener("submit", (event) => {
   commandEl.value = "";
   historyIndex = -1;
   savedInput = "";
-  worker.postMessage({ type: "stdin", line });
+  worker.postMessage({ type: "stdin", data: line + "\r" });
 });
 
 commandEl.addEventListener("keydown", (event) => {
-  if (event.key === "ArrowUp") {
+  const controlBytes = terminalControlBytes(event);
+  if (controlBytes && worker && !commandEl.disabled) {
+    event.preventDefault();
+    worker.postMessage({ type: "stdin", data: controlBytes });
+  } else if (event.key === "ArrowUp") {
     event.preventDefault();
     if (commandHistory.length === 0) return;
     if (historyIndex === -1) {

--- a/web/weblinux-demo/package.json
+++ b/web/weblinux-demo/package.json
@@ -1,0 +1,4 @@
+{
+  "private": true,
+  "type": "module"
+}

--- a/web/weblinux-demo/terminal-input.mjs
+++ b/web/weblinux-demo/terminal-input.mjs
@@ -1,0 +1,9 @@
+const TERMINAL_CONTROL_BYTES = new Map([
+  ["c", "\x03"],
+  ["d", "\x04"],
+]);
+
+export function terminalControlBytes(event) {
+  if (!event.ctrlKey || event.altKey || event.metaKey) return null;
+  return TERMINAL_CONTROL_BYTES.get(event.key.toLowerCase()) ?? null;
+}

--- a/web/weblinux-demo/worker.js
+++ b/web/weblinux-demo/worker.js
@@ -88,10 +88,10 @@ function createFakeTerminal() {
 
 self.onmessage = async (event) => {
   if (event.data.type === "stdin") {
-    if (inputCallback) {
-      // Send a carriage return so xterm-pty's line discipline turns it into a
-      // newline for the shell.
-      inputCallback(event.data.line + "\r");
+    if (inputCallback && typeof event.data.data === "string") {
+      // The main thread owns input encoding: submitted commands include their
+      // carriage return, while terminal controls arrive as their raw byte.
+      inputCallback(event.data.data);
     }
     return;
   }


### PR DESCRIPTION
## Summary

- forward Ctrl+C and Ctrl+D from the browser command input as raw ETX/EOT bytes
- preserve carriage-return handling for submitted command lines
- add focused input tests and live Playwright interruption/EOF scenarios

## Validation

- `node --test public/tests/weblinux-terminal-input.test.mjs`
- `pnpm --dir public check`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace` (one unrelated socket-path test flaked; exact isolated rerun passed)
- `cargo run -p xtask -- check-stubs`
- `cargo run -p xtask -- check-no-string-backend-dispatch`
- `cargo run -p xtask -- check-declared-backing`