### PR TITLE
Fix Cloudflare Pages release lookup

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           set -euo pipefail
           BOOT_TAG="$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
-            --json tagName --jq -r '
+            --json tagName --jq '
               [ .[].tagName
                 | select(test("^boot-image/v[0-9]+\\.[0-9]+\\.[0-9]+$"))
                 | {tag: ., v: (ltrimstr("boot-image/v") | split(".") | map(tonumber))} ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,7 +392,7 @@ jobs:
           # The strict N.N.N match also drops anything that is not a plain
           # release tag rather than trying to order it.
           BOOT_TAG="$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
-            --json tagName --jq -r '
+            --json tagName --jq '
               [ .[].tagName
                 | select(test("^boot-image/v[0-9]+\\.[0-9]+\\.[0-9]+$"))
                 | {tag: ., v: (ltrimstr("boot-image/v") | split(".") | map(tonumber))} ]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-26
+Last updated: 2026-08-27
 
 ## In progress
 
@@ -18,8 +18,10 @@ Last updated: 2026-08-26
       Cloudflare Pages consumes the signed, checksummed release artifact while
       retaining the current revision's demo shell. Its oversized WASM module is
       staged as an explicitly decompressed gzip payload so it fits Cloudflare's
-      per-file limit. Workflow contracts, actionlint, workspace
-      tests/check/doctests, and Clippy are green.
+      per-file limit. GitHub CLI receives the semantic-version filter directly
+      through `--jq` in both consuming workflows, with a regression contract
+      against the unsupported standalone jq `-r` flag. Workflow contracts,
+      actionlint, and Clippy are green.
 
 - [x] **AI egress metering and token budgets** —
       `specs/plans/2026-08-21-ai-egress-metering-and-budget.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -26,8 +26,10 @@
       latest semantic-versioned pack and verifies its keyless release identity
       and checksum before staging the current demo shell. The staged QEMU WASM
       is explicitly gzip-compressed below Cloudflare Pages' per-file limit and
-      decompressed by the browser worker. Workflow contracts, actionlint,
-      workspace tests/check/doctests, and Clippy are green.
+      decompressed by the browser worker. The Pages and CLI release lookups now
+      pass their semantic-version filter directly to GitHub CLI's `--jq`
+      option; a 28-test workflow contract suite prevents the invalid standalone
+      jq `-r` flag from returning. Actionlint and Clippy are green.
 
 - [ ] **SDK surface contract repairs for issues #2902 and #2906.**
       `specs/plans/2026-08-26-sdk-surface-contract-repairs.md`.

--- a/specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md
+++ b/specs/plans/2026-08-26-site-qemu-wasm-release-artifact.md
@@ -22,6 +22,9 @@ JavaScript shell remains sourced from the deploying revision.
 - [x] Compress the staged QEMU WebAssembly module below Cloudflare Pages'
       25 MiB per-file limit and explicitly decompress it in the browser worker.
 - [x] Ignore Wrangler's repository-local cache and account metadata.
+- [x] Pass the semantic-version filter directly to GitHub CLI's `--jq` option
+      in both Pages and CLI release lookups, with a regression contract that
+      rejects the unsupported standalone jq `-r` flag.
 - [x] Pass the focused release-assets suite, actionlint, workspace tests,
       workspace check, and Clippy with warnings denied.
 

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -576,6 +576,23 @@ fn pages_workflow_installs_every_wasm_target_used_by_the_demo() {
 }
 
 #[test]
+fn release_lookups_pass_the_filter_directly_to_gh_jq() {
+    for (name, workflow) in [
+        ("pages.yml", pages_workflow()),
+        ("release.yml", release_workflow()),
+    ] {
+        assert!(
+            workflow.contains("--json tagName --jq '"),
+            "{name} must pass its semantic-version filter directly to gh --jq"
+        );
+        assert!(
+            !workflow.contains("--json tagName --jq -r"),
+            "{name} must pass the filter directly to gh --jq; -r is a standalone jq flag"
+        );
+    }
+}
+
+#[test]
 fn qemu_wasm_site_pack_is_built_once_on_the_boot_image_train() {
     let boot_image = boot_image_workflow();
     let pages = pages_workflow();


### PR DESCRIPTION
## Summary

- pass the semantic-version filter directly to GitHub CLI's --jq option
- repair the same invalid lookup in the CLI release workflow
- add workflow regression coverage and update delivery tracking

## Validation

- cargo test --test release_assets (28 passed)
- actionlint .github/workflows/pages.yml .github/workflows/release.yml
- cargo clippy --workspace -- -D warnings
- cargo run -p xtask -- check-sprint-append
- pre-commit formatting, Clippy, and actionlint gates