### PR TITLE
fix(cli): take the default vCPU count from the selected backend

### DIFF
--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -635,7 +635,7 @@ fn machine_run_spec(
         peer: Vec::new(),
         ai: None,
         ports: args.port.clone(),
-        cpus: args.run.cpus,
+        cpus: crate::exec::effective_cpus(args.run.cpus, args.run.hypervisor.as_deref()),
         memory: args.run.memory.clone(),
         mem_initial: None,
         profile,

--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -329,7 +329,7 @@ fn run_entrypoint_action(args: MachineRunArgs, resolved_flake_slot: Option<Strin
         source,
         stdin,
         timeout: args.run.timeout.unwrap_or(30),
-        cpus: args.run.cpus,
+        cpus: crate::exec::effective_cpus(args.run.cpus, args.run.hypervisor.as_deref()),
         memory_mib,
         from_workload_ir: args.from_workload_ir.clone(),
         agent_verb_override: args.run.agent_verb.clone(),

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -482,7 +482,9 @@ fn transient_run_without_argv_is_rejected_at_dispatch() {
 #[test]
 fn run_defaults_match_the_lower_level_runner() {
     let args = parse_run(&["run", "--image", "alpine", "--", "true"]).expect("parse");
-    assert_eq!(args.run.cpus, 2);
+    // Unspecified: the selected backend's `default_vcpus` decides at launch,
+    // so parsing must not bake a count in here.
+    assert_eq!(args.run.cpus, None);
     assert_eq!(args.run.memory, "512M");
     assert_eq!(
         args.run.profile,
@@ -524,7 +526,7 @@ fn run_accepts_passthrough_flags() {
         "-a",
     ])
     .expect("parse");
-    assert_eq!(args.run.cpus, 4);
+    assert_eq!(args.run.cpus, Some(4));
     assert_eq!(args.run.memory, "1G");
     assert_eq!(args.run.profile, RunProfile::Dev);
     assert_eq!(args.run.mounts, vec!["/host:/work:rw"]);
@@ -3011,11 +3013,11 @@ fn cpus_and_cpu_limit_are_independent_controls() {
         "500",
     ])
     .expect("both flags parse together");
-    assert_eq!(args.run.cpus, 4);
+    assert_eq!(args.run.cpus, Some(4));
     assert_eq!(args.run.cpu_limit, Some(500));
 
     let only_cpus = parse_run(&["run", "--image", "alpine", "--cpus", "4"]).expect("parses");
-    assert_eq!(only_cpus.run.cpus, 4);
+    assert_eq!(only_cpus.run.cpus, Some(4));
     assert_eq!(
         only_cpus.run.cpu_limit, None,
         "--cpus must not imply a share"
@@ -3025,8 +3027,8 @@ fn cpus_and_cpu_limit_are_independent_controls() {
         parse_run(&["run", "--image", "alpine", "--cpu-limit", "500"]).expect("parses");
     assert_eq!(only_limit.run.cpu_limit, Some(500));
     assert_eq!(
-        only_limit.run.cpus, 2,
-        "--cpu-limit must not move the vCPU count off its default"
+        only_limit.run.cpus, None,
+        "--cpu-limit must not turn an unspecified vCPU count into a request"
     );
 }
 

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -1957,7 +1957,7 @@ mod tests {
         let shape = |name: Option<&'static str>| crate::exec::LaunchShape {
             name,
             image: &image,
-            cpus: 2,
+            cpus: Some(2),
             memory_mib: 1024,
             mem_initial_mib: None,
             dir_shares: &[],
@@ -2294,7 +2294,7 @@ fn resolve_warm_launch(req: &WarmRequest) -> Result<crate::exec::ResolvedLaunch>
     let shape = crate::exec::LaunchShape {
         name: None,
         image: &image,
-        cpus: req.cpus,
+        cpus: Some(req.cpus),
         memory_mib: req.memory_mib,
         mem_initial_mib: None,
         dir_shares: &[],

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -3385,7 +3385,7 @@ fn run_transient_default_manifest_argv_only() {
                 ..
             }) => {
                 assert!(manifest.is_none());
-                assert_eq!(cpus, 2);
+                assert_eq!(cpus, None, "unspecified until the backend resolves it");
                 assert_eq!(memory, "512M");
                 assert!(volume.is_empty());
                 assert!(env.is_empty());
@@ -3468,7 +3468,7 @@ fn run_default_profile_argv_only() {
                 assert_eq!(image.as_deref(), Some("alpine:latest"));
                 assert!(!net, "deny-all by default");
                 assert!(allow_host.is_empty());
-                assert_eq!(cpus, 2);
+                assert_eq!(cpus, None, "unspecified until the backend resolves it");
                 assert_eq!(memory, "512M");
                 assert_eq!(profile, exec::RunProfile::Standard);
                 assert!(volume.is_empty());
@@ -4026,7 +4026,7 @@ fn run_transient_with_manifest_and_resources() {
                 ..
             }) => {
                 assert_eq!(manifest.as_deref(), Some("my-tpl"));
-                assert_eq!(cpus, 4);
+                assert_eq!(cpus, Some(4));
                 assert_eq!(memory, "1G");
                 assert_eq!(argv, vec!["/bin/true".to_string()]);
             }

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -42,9 +42,9 @@ pub(in crate::commands) struct Args {
     /// Internal (not a CLI flag): optional foreground transient VM identity.
     #[arg(skip)]
     pub vm_name: Option<String>,
-    /// vCPU cores (default: 2)
-    #[arg(long, default_value = "2")]
-    pub cpus: u32,
+    /// vCPU cores; default is the backend's (HVF 1, else 2)
+    #[arg(long)]
+    pub cpus: Option<u32>,
     /// Memory (supports human-readable: 512M, 1G, …)
     #[arg(long, default_value = "512M")]
     pub memory: String,
@@ -272,9 +272,9 @@ pub(in crate::commands) struct RunArgs {
     /// Bind a peer route this workload may dial (repeatable).
     #[arg(long = "peer", value_name = "NAME:PORT=ADDR:PORT")]
     pub peer: Vec<String>,
-    /// Set how many vCPUs the guest sees (not a host CPU share).
-    #[arg(long, default_value = "2")]
-    pub cpus: u32,
+    /// vCPUs the guest sees; default is the backend's (HVF 1, else 2)
+    #[arg(long)]
+    pub cpus: Option<u32>,
     /// Cap host CPU time in millicores (1500 = 1.5 cores); not `--cpus`.
     #[arg(long = "cpu-limit", value_name = "MILLICORES")]
     pub cpu_limit: Option<u32>,
@@ -576,7 +576,7 @@ impl Default for RunArgs {
             net: false,
             allow_host: Vec::new(),
             peer: Vec::new(),
-            cpus: 2,
+            cpus: None,
             cpu_limit: None,
             grants_file: None,
             memory: "512M".to_string(),
@@ -783,7 +783,12 @@ pub(in crate::commands) fn run_secure_with_source(
     let receipt_backend = admit_backend.clone();
     let admit_network_mode = args.network_mode;
     let admit_grants = resolved_grants.plan_grants.clone();
-    let admit_cpus = args.cpus;
+    // The plan records what will actually boot, not what the caller typed. An
+    // unspecified count resolves through the backend already selected above, so
+    // the signed plan and the launch cannot disagree about vCPUs.
+    let admit_cpus = args
+        .cpus
+        .unwrap_or_else(|| admit_backend_kind.default_vcpus());
     let admit_mem_mib = u64::from(parse_human_size(&args.memory).context("Invalid --memory")?);
     let admit_network_policy = network_policy.clone();
     let admit_agent_verb = args.agent_verb.clone();
@@ -1496,7 +1501,9 @@ impl ReceiptInput {
         Ok(Self {
             manifest: args.manifest.clone(),
             image: args.image.clone(),
-            cpus: args.cpus,
+            // The receipt is signed over what the run actually used, so an
+            // unspecified count resolves the same way the launch resolves it.
+            cpus: crate::exec::effective_cpus(args.cpus, args.hypervisor.as_deref()),
             memory: args.memory.clone(),
             profile: args
                 .profile

--- a/crates/mvm-cli/src/commands/vm/exec/preflight.rs
+++ b/crates/mvm-cli/src/commands/vm/exec/preflight.rs
@@ -180,7 +180,7 @@ impl RunPreflightSummary {
                 timeout_secs: receipt_input.timeout_secs,
             },
             resources: RunPreflightResources {
-                cpus: args.cpus,
+                cpus: crate::exec::effective_cpus(args.cpus, args.hypervisor.as_deref()),
                 memory: args.memory.clone(),
                 memory_mib,
                 timeout_secs: args.timeout.unwrap_or(60),

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -190,7 +190,11 @@ pub struct LaunchShape<'a> {
     /// Explicit VM name, or `None` to generate a throwaway one.
     pub name: Option<&'a str>,
     pub image: &'a ImageSource,
-    pub cpus: u32,
+    /// `None` means the caller did not ask, and the selected backend's
+    /// [`mvm_core::vm_backend::BackendKind::default_vcpus`] decides. An
+    /// explicit count passes through unchanged, so a backend that cannot run
+    /// it still refuses rather than being silently corrected.
+    pub cpus: Option<u32>,
     pub memory_mib: u32,
     pub mem_initial_mib: Option<u32>,
     pub dir_shares: &'a [DirShareSpec],
@@ -208,7 +212,8 @@ pub struct ExecRequest {
     /// throwaway name.
     pub name: Option<String>,
     pub image: ImageSource,
-    pub cpus: u32,
+    /// `None` = unspecified; the selected backend's `default_vcpus` decides.
+    pub cpus: Option<u32>,
     pub memory_mib: u32,
     /// Opt into virtio-balloon. `None` keeps the legacy "commit
     /// memory_mib at boot" behaviour; `Some(n)` commits only `n` MiB
@@ -1205,6 +1210,7 @@ fn build_start_config(
     vm_name: &str,
     resolved: &ResolvedImage,
     boot: &BootStrategy,
+    cpus: u32,
 ) -> VmStartConfig {
     // Pre-open console data sockets for interactive PTY runs against
     // non-sealed images. OCI/dev images can carry verity sidecars and still be
@@ -1246,7 +1252,7 @@ fn build_start_config(
         revision_hash: resolved.revision.clone(),
         flake_ref: resolved.flake_ref.clone(),
         profile: resolved.profile.clone(),
-        cpus: shape.cpus,
+        cpus,
         memory_mib: shape.memory_mib,
         mem_initial_mib: shape.mem_initial_mib,
         ports: Vec::new(),
@@ -1341,6 +1347,23 @@ pub struct ResolvedLaunch {
 /// what makes the config claim-eligible. A warm spawn passes `None`: a factory
 /// parent carries no workload authority, and the spawn drops the tenant and
 /// plan from the config it is handed anyway.
+/// The vCPU count a launch will actually boot with.
+///
+/// `requested` is what the caller asked for, if anything. With nothing asked,
+/// the answer is the selected backend's own default — HVF runs exactly one
+/// vCPU, so a fixed default made every unqualified launch on the macOS default
+/// backend refuse. Shared by the launch path and the preflight summaries so the
+/// number a dry run prints is the number a real run boots.
+pub(crate) fn effective_cpus(requested: Option<u32>, hypervisor: Option<&str>) -> u32 {
+    if let Some(n) = requested {
+        return n;
+    }
+    let kind = hypervisor
+        .and_then(mvm_core::vm_backend::BackendKind::from_label)
+        .unwrap_or_else(|| mvm_runtime::backend::AnyBackend::auto_select().kind());
+    kind.default_vcpus()
+}
+
 pub fn resolve_launch(
     shape: &LaunchShape<'_>,
     admit: Option<&SessionAdmit<'_>>,
@@ -1352,6 +1375,11 @@ pub fn resolve_launch(
         shape.network_policy,
         shape.hypervisor,
     )?;
+
+    // The vCPU count the caller left unspecified is the selected backend's
+    // own default — HVF runs exactly one, so a fixed default made every bare
+    // launch on the macOS default backend refuse.
+    let cpus = shape.cpus.unwrap_or_else(|| backend.kind().default_vcpus());
 
     // Resolve image artifacts: either a named template or a pre-built pair.
     // For templates, also probe for a pre-built snapshot so we can skip the
@@ -1383,7 +1411,7 @@ pub fn resolve_launch(
     // spans account for roughly half the window, so the rest needs naming
     // before any of it can be acted on.
     let t_build = std::time::Instant::now();
-    let mut start_config = build_start_config(shape, &vm_name, &image, &boot);
+    let mut start_config = build_start_config(shape, &vm_name, &image, &boot, cpus);
     tracing::debug!(
         ms = t_build.elapsed().as_secs_f64() * 1000.0,
         "admit window: build_start_config"
@@ -1476,7 +1504,7 @@ mod tests {
         let shape = LaunchShape {
             name: Some("wasm-test"),
             image: &image,
-            cpus: 1,
+            cpus: Some(1),
             memory_mib: 64,
             mem_initial_mib: None,
             dir_shares: &[],
@@ -1623,7 +1651,7 @@ mod tests {
             name: Some("named-vm".into()),
             warm_pool_size: 3,
             image: ImageSource::Template("t".into()),
-            cpus: 4,
+            cpus: Some(4),
             memory_mib: 2048,
             mem_initial_mib: Some(512),
             dir_shares: vec![share.clone()],
@@ -1642,7 +1670,7 @@ mod tests {
 
         assert_eq!(shape.name, Some("named-vm"));
         assert!(matches!(shape.image, ImageSource::Template(n) if n == "t"));
-        assert_eq!(shape.cpus, 4);
+        assert_eq!(shape.cpus, Some(4));
         assert_eq!(shape.memory_mib, 2048);
         assert_eq!(shape.mem_initial_mib, Some(512));
         assert_eq!(shape.dir_shares.len(), 1);
@@ -1692,7 +1720,7 @@ mod tests {
         let shape = LaunchShape {
             name: None,
             image: &image,
-            cpus: 2,
+            cpus: Some(2),
             memory_mib: 1024,
             mem_initial_mib: None,
             dir_shares: &[],
@@ -1724,6 +1752,8 @@ mod tests {
             "the verity sidecar beside the rootfs must reach the config"
         );
         assert_eq!(resolved.start_config.roothash.as_deref(), Some(ROOTHASH));
+        // The shape asked for 2, so the resolved config carries 2 — an
+        // explicit request passes through the backend default untouched.
         assert_eq!(resolved.start_config.cpus, 2);
         assert_eq!(resolved.start_config.memory_mib, 1024);
         assert!(
@@ -1767,7 +1797,7 @@ mod tests {
             name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
-            cpus: 1,
+            cpus: Some(1),
             memory_mib: 256,
             mem_initial_mib: None,
             // Live shares are attached by the guest activation path.
@@ -1793,7 +1823,7 @@ mod tests {
             name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
-            cpus: 1,
+            cpus: Some(1),
             memory_mib: 256,
             mem_initial_mib: None,
             // Live shares are attached by the guest activation path.
@@ -1827,7 +1857,7 @@ mod tests {
             name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
-            cpus: 1,
+            cpus: Some(1),
             memory_mib: 256,
             mem_initial_mib: None,
             // Live shares are attached by the guest activation path.
@@ -1876,7 +1906,7 @@ mod tests {
             name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
-            cpus: 1,
+            cpus: Some(1),
             memory_mib: 256,
             mem_initial_mib: None,
             // Live shares are attached by the guest activation path.
@@ -1909,7 +1939,7 @@ mod tests {
             name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
-            cpus: 1,
+            cpus: Some(1),
             memory_mib: 256,
             mem_initial_mib: None,
             // Live shares are attached by the guest activation path.
@@ -1957,7 +1987,7 @@ mod tests {
             name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
-            cpus: 1,
+            cpus: Some(1),
             memory_mib: 256,
             mem_initial_mib: None,
             dir_shares: Vec::new(),

--- a/crates/mvm-cli/src/exec/guest_run.rs
+++ b/crates/mvm-cli/src/exec/guest_run.rs
@@ -210,7 +210,7 @@ mod tests {
             name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
-            cpus: 1,
+            cpus: Some(1),
             memory_mib: 256,
             mem_initial_mib: None,
             // Live shares are attached by the guest activation path.
@@ -240,7 +240,7 @@ mod tests {
             name: None,
             warm_pool_size: 0,
             image: ImageSource::Template("t".into()),
-            cpus: 1,
+            cpus: Some(1),
             memory_mib: 256,
             mem_initial_mib: None,
             // Live shares are attached by the guest activation path.

--- a/crates/mvm-cli/src/exec/session.rs
+++ b/crates/mvm-cli/src/exec/session.rs
@@ -186,7 +186,7 @@ pub fn dispatch_in_session(
         name: None,
         warm_pool_size: 0,
         image: ImageSource::Template(String::new()),
-        cpus: 0,
+        cpus: Some(0),
         memory_mib: 0,
         mem_initial_mib: None,
         dir_shares: vec![],

--- a/crates/mvm-contract/src/protocol/vm_backend.rs
+++ b/crates/mvm-contract/src/protocol/vm_backend.rs
@@ -1261,6 +1261,28 @@ impl BackendKind {
         }
     }
 
+    /// How many vCPUs to boot when the caller did not ask for a count.
+    ///
+    /// Not a maximum: it is the number a bare `mvmctl machine run` gets. HVF is
+    /// the reason this is per-backend rather than one constant — it runs
+    /// exactly one vCPU (`fdt.rs` emits a single `cpu@0` and PSCI implements no
+    /// `CPU_ON`), so any other default makes the macOS default backend refuse
+    /// every unqualified launch. An explicit `--cpus 2` on HVF still fails in
+    /// the driver; this only decides what "unspecified" means.
+    #[must_use]
+    pub const fn default_vcpus(self) -> u32 {
+        match self {
+            Self::Hvf => 1,
+            Self::Firecracker
+            | Self::Libkrun
+            | Self::Qemu
+            | Self::Mock
+            | Self::Wasm
+            | Self::WebLinux
+            | Self::AppleContainer => 2,
+        }
+    }
+
     /// The inverse of [`as_str`](Self::as_str).
     ///
     /// A plan names its backend as a string, so somewhere a label has to
@@ -2152,6 +2174,37 @@ mod tests {
     /// conjunction: any missing isolation layer means not a microVM. With
     /// a disjunction, a container that only clears the host-hypervisor
     /// layer reports as hardware-isolated and the banner never fires.
+    /// The macOS default backend runs exactly one vCPU, so an unqualified
+    /// launch must default to one. A fixed default of 2 made every bare
+    /// `mvmctl machine run` refuse on HVF once the driver started rejecting
+    /// unsupported counts instead of silently ignoring them.
+    #[test]
+    fn hvf_defaults_to_the_single_vcpu_it_can_actually_run() {
+        assert_eq!(BackendKind::Hvf.default_vcpus(), 1);
+    }
+
+    /// Every backend has to answer, so a new variant is a compile error here
+    /// rather than a launch that refuses in the driver.
+    #[test]
+    fn every_backend_declares_a_bootable_default_vcpu_count() {
+        for kind in [
+            BackendKind::Firecracker,
+            BackendKind::Libkrun,
+            BackendKind::Qemu,
+            BackendKind::Mock,
+            BackendKind::Hvf,
+            BackendKind::Wasm,
+            BackendKind::WebLinux,
+            BackendKind::AppleContainer,
+        ] {
+            assert!(
+                kind.default_vcpus() >= 1,
+                "{} must boot at least one vCPU",
+                kind.as_str()
+            );
+        }
+    }
+
     #[test]
     fn is_microvm_requires_every_isolation_layer() {
         assert!(LayerCoverage::all_layers().is_microvm());


### PR DESCRIPTION
`mvmctl machine run --image alpine -- sh -c 'echo hi'` fails on macOS today:

```
Error: starting transient microVM
Caused by: the hvf backend supports exactly 1 vCPU, but this launch requests 2
```

Nobody asked for 2. `--cpus` carried `default_value = "2"`, and #2899 had just turned the HVF vCPU mismatch from a silent ignore into a hard refusal — correct on its own, but it made a fixed default fatal on the macOS default backend. The primary documented command fails on a bare invocation; `--cpus 1` works.

Reproduces on plain `main` at `efa77021c5`.

## The fix

`BackendKind::default_vcpus()` — an exhaustive match, so a new backend is a compile error here rather than a launch that refuses in the driver. HVF answers 1 because that is all it runs (`fdt.rs` emits a single `cpu@0`, PSCI implements no `CPU_ON`); everything else answers 2.

`--cpus` becomes `Option<u32>`: `None` = "unspecified, ask the backend", `Some(n)` passes through untouched. **`--cpus 2` on HVF still refuses loudly** — #2899's behaviour is preserved exactly, and only the meaning of *unspecified* changed.

Resolution happens where the backend is already known:

- `resolve_launch`, for the boot itself
- the signed `ExecutionPlan` (`admit_cpus`) via the already-selected `admit_backend_kind`, so the plan records what will actually boot
- the signed run receipt (`ReceiptInput`) and the preflight summaries, through a shared `effective_cpus` helper — so the number a dry run prints is the number a real run boots

## Verified live, not just in CI

Bare invocation prints its output; `--cpus 2` on HVF still fails with the #2899 message. Both run on a real macOS/HVF host.

## Gates

`fmt --all`, `clippy --workspace --all-targets` (zero warnings), `nextest --workspace` against an empty `MVM_HOME` (12,240 pass), the test-support lane (3,839 pass), `xtask check-all` (61 gates), `just check-gated`.

The test-support lane was the only one that caught two `LaunchShape` fixtures in `pool.rs` — that file's tests compile only under `--features test-support`.

## Follow-up, not in this PR

Making `--cpus 4` *mean* something on HVF is #2888: `HvfSupervisorConfig` has no `vcpus` field, `fdt.rs` emits one hardcoded `cpu@0`, and PSCI implements no `CPU_ON`. That needs all three plus per-vCPU threads and GIC sizing — a feature, not a fix.