### PR TITLE
build(kernel): bump synchronized pins to Linux 6.12.106

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -48,10 +48,10 @@ let
   # kernel — lets both of mvm's kernels track the latest point release exactly
   # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
   # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
-  kernelVersion = "6.12.105";
+  kernelVersion = "6.12.106";
   kernelSrc = pkgs.fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
-    hash = "sha256-6zaAHhGVKbE1E8NFncIOKjL3BTYp86q7Y+pQGk2I9j0=";
+    hash = "sha256-A5JVV2HZnHYEUD9heJUeLfd+l4uSzJbRHiSEI+SO14U=";
   };
   # The builder's overlay filesystem triggers a GNU tar directory-metadata
   # race while unpacking this archive. Materialize the source with bsdtar once

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.105.tar.xz";
-    hash = "sha256-6zaAHhGVKbE1E8NFncIOKjL3BTYp86q7Y+pQGk2I9j0=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.106.tar.xz";
+    hash = "sha256-A5JVV2HZnHYEUD9heJUeLfd+l4uSzJbRHiSEI+SO14U=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.105' \
+      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.106' \
       --replace-fail 'curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)' 'ln -s ${kernelSrc} $(KERNEL_TARBALL)'
     substituteInPlace patches/0008-virtio-vsock-support-dgrams.patch \
       --replace-fail 'virtio_transport_alloc_skb(&info, dgram_len, false,' \

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,12 @@ Last updated: 2026-08-27
 
 ## In progress
 
+- [ ] **Linux 6.12.106 synchronized kernel pin — issue #2931.**
+      `specs/plans/2026-08-27-kernel-6-12-106.md`.
+      Both kernel consumers use the kernel.org-verified archive and SRI hash;
+      local synchronization, freshness, workspace, and Clippy gates are green.
+      Linux Nix PR checks and merge delivery remain.
+
 - [ ] **SDK surface contract repairs — issues #2902 and #2906.**
       `specs/plans/2026-08-26-sdk-surface-contract-repairs.md`.
       The README's `mvm.local_path` decorator source and the builder-pack Cargo

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,14 @@
 
 ## In progress
 
+- [ ] **Linux 6.12.106 synchronized kernel pin — issue #2931.**
+      `specs/plans/2026-08-27-kernel-6-12-106.md`.
+      The custom workload/builder kernel and libkrunfw firmware build now use
+      the same kernel.org-verified Linux 6.12.106 archive and SRI hash.
+      Structural synchronization and freshness tests, workspace check/tests,
+      and zero-warning Clippy are green. Remaining: pass the PR's Linux Nix
+      evaluation/build gates, merge it, and close #2931 through the PR link.
+
 - [ ] **Admission cache durability boundary.**
       `specs/plans/2026-08-26-admission-cache-durability.md`.
       Preserve the chain-signed admission record's fail-closed durability

--- a/specs/plans/2026-08-27-kernel-6-12-106.md
+++ b/specs/plans/2026-08-27-kernel-6-12-106.md
@@ -1,0 +1,31 @@
+# Linux 6.12.106 kernel pin refresh
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#2931](https://github.com/tinylabscom/mvm/issues/2931)
+
+## Outcome
+
+The custom workload/builder kernel and libkrunfw firmware build consume the
+same verified Linux 6.12.106 LTS source archive. Structural coverage keeps the
+version and source hash synchronized.
+
+## Delivery checklist
+
+- [x] Verify the upstream `linux-6.12.106.tar.xz` SHA-256 against kernel.org's
+      signed checksum manifest.
+- [x] Update the custom workload/builder kernel source pin and SRI hash.
+- [x] Update the libkrunfw kernel source pin, substitution, and SRI hash.
+- [x] Pass the focused synchronization test and kernel freshness check.
+- [x] Pass workspace check/tests and zero-warning Clippy.
+- [ ] Pass the PR's Linux Nix evaluation and kernel-build checks.
+- [x] Record the implementation closeout in the sprint and refactor rollup.
+- [ ] Merge the tested pull request and close #2931 through its linkage.
+
+## Source verification
+
+The upstream archive SHA-256 is
+`0392555761d99c7604503f6178951e2df77e978b92cc96d11e248423e48ed785`,
+which converts to the Nix SRI hash
+`sha256-A5JVV2HZnHYEUD9heJUeLfd+l4uSzJbRHiSEI+SO14U=`.

--- a/specs/sprint/delivery/2931-kernel-pin-6-12-106.md
+++ b/specs/sprint/delivery/2931-kernel-pin-6-12-106.md
@@ -1,0 +1,10 @@
+# Linux 6.12.106 kernel pin refresh
+
+- [x] Updated the libkrunfw firmware build and custom workload/builder kernels
+      from Linux 6.12.105 to 6.12.106.
+- [x] Verified the archive digest against kernel.org's signed SHA-256 manifest
+      and converted it to the Nix SRI hash used by both consumers.
+- [x] Updated structural parity coverage so both kernel consumers must remain
+      synchronized.
+
+Owning plan: `specs/plans/2026-08-27-kernel-6-12-106.md`.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -373,8 +373,8 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         );
     }
 
-    const KERNEL_VERSION: &str = "6.12.105";
-    const KERNEL_HASH: &str = "sha256-6zaAHhGVKbE1E8NFncIOKjL3BTYp86q7Y+pQGk2I9j0=";
+    const KERNEL_VERSION: &str = "6.12.106";
+    const KERNEL_HASH: &str = "sha256-A5JVV2HZnHYEUD9heJUeLfd+l4uSzJbRHiSEI+SO14U=";
     assert!(
         libkrunfw.contains(&format!("linux-{KERNEL_VERSION}.tar.xz"))
             && libkrunfw.contains(&format!("hash = \"{KERNEL_HASH}\""))


### PR DESCRIPTION
## Summary

- bump the custom workload/builder kernel from Linux 6.12.105 to 6.12.106
- keep libkrunfw on the same verified Linux source archive and Nix SRI hash
- update structural synchronization coverage and delivery tracking

The upstream kernel.org SHA-256 is `0392555761d99c7604503f6178951e2df77e978b92cc96d11e248423e48ed785`, represented for Nix as `sha256-A5JVV2HZnHYEUD9heJUeLfd+l4uSzJbRHiSEI+SO14U=`.

## Validation

- `cargo test --test nix_flake_structure native_vmm_recipes_are_source_built_and_pinned`
- `cargo run -q -p xtask -- check-kernel-pin-freshness --quiet`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- pre-commit stable workspace/mvmctl Clippy gate

Linux Nix evaluation and kernel builds remain merge-required PR checks.

Closes #2931
