### PR TITLE
fix(sdk): say when the cached SDK sidecar predates the working tree

### DIFF
--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -446,6 +446,64 @@ pub fn guest_source_fingerprint(workspace_root: &Path) -> Result<String, GuestAg
     Ok(digest)
 }
 
+/// A content fingerprint over the inputs to `libmvm_host_services.so` — the
+/// SDK sidecar's cdylib, and the one file in that image a source change can
+/// alter.
+///
+/// Separate from [`guest_source_fingerprint`] because the input sets differ:
+/// the cdylib is `mvm-sdk`'s `[lib]` target, which the guest-binary set does
+/// not build, while the shared crates underneath it are common to both. Folding
+/// `mvm-sdk` into the guest fingerprint instead would invalidate every cached
+/// guest binary on an SDK-only edit, which is a rebuild nobody asked for.
+///
+/// The sidecar's other members — the glibc loader, `libc.so.6`, `libgcc_s.so.1`
+/// — come from nixpkgs and cannot change without the version changing, so they
+/// are deliberately not inputs here.
+pub fn sdk_cdylib_source_fingerprint(
+    workspace_root: &Path,
+) -> Result<String, GuestAgentBuildError> {
+    let mut hasher = Sha256::new();
+    hasher.update(b"mvm-sdk-cdylib-input-v1\0");
+    hash_inputs(
+        &mut hasher,
+        workspace_root,
+        &[
+            "Cargo.lock",
+            "Cargo.toml",
+            "crates/mvm-contract/Cargo.toml",
+            "crates/mvm-contract/src",
+            "crates/mvm-core/Cargo.toml",
+            "crates/mvm-core/src",
+            "crates/mvm-agentd/Cargo.toml",
+            "crates/mvm-agentd/src",
+            "crates/mvm-sdk/Cargo.toml",
+            "crates/mvm-sdk/src",
+        ],
+    )?;
+    Ok(hex::encode(hasher.finalize()))
+}
+
+/// Fold each declared input into `hasher`, failing closed on one that is
+/// missing. A fingerprint that quietly skipped an absent input would collide
+/// with the tree that still has it.
+fn hash_inputs(
+    hasher: &mut Sha256,
+    workspace_root: &Path,
+    inputs: &[&str],
+) -> Result<(), GuestAgentBuildError> {
+    for rel in inputs {
+        let path = workspace_root.join(rel);
+        if path.is_dir() {
+            hash_dir_recursive(hasher, rel, &path)?;
+        } else if path.is_file() {
+            hash_file(hasher, rel, &path)?;
+        } else {
+            return Err(GuestAgentBuildError::OutputMissing(path));
+        }
+    }
+    Ok(())
+}
+
 /// The walk itself, split out so the memo above has something to wrap and a
 /// test can measure the uncached cost directly.
 fn compute_guest_source_fingerprint(workspace_root: &Path) -> Result<String, GuestAgentBuildError> {

--- a/crates/mvm-build/src/sdk_sidecar.rs
+++ b/crates/mvm-build/src/sdk_sidecar.rs
@@ -89,6 +89,15 @@ pub enum SdkSidecarBuildError {
         /// Human-readable description of the problem.
         reason: String,
     },
+
+    /// The cdylib's source inputs could not be fingerprinted, so the cached
+    /// sidecar's provenance is unknown. Distinct from a resolve failure: the
+    /// artifact may be perfectly sound and only the *working tree* unreadable.
+    #[error("SDK sidecar source fingerprint failed: {reason}")]
+    FingerprintFailed {
+        /// Human-readable description of the problem.
+        reason: String,
+    },
 }
 
 /// Download the SDK sidecar for `version` + `arch` from the published release,
@@ -246,6 +255,76 @@ fn promote_staging(staging: &Path, artifact_dir: &Path) -> Result<(), SdkSidecar
     Ok(())
 }
 
+/// Name of the marker recording which source tree built a cached sidecar.
+///
+/// Absent on a downloaded artifact, which is correct and load-bearing: absence
+/// is how a published sidecar is told apart from a source-built one.
+pub const LOCAL_SOURCE_FINGERPRINT_FILE: &str = "SOURCE_FINGERPRINT";
+
+/// What a cached sidecar was built from, relative to the working tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SidecarProvenance {
+    /// Built from this exact source tree.
+    MatchesSource,
+    /// Built from a different revision of this source tree.
+    StaleSource,
+    /// The published artifact. It cannot carry local changes to the cdylib,
+    /// because nothing local produced it.
+    Published,
+}
+
+/// Record which source tree produced the sidecar now in the cache.
+///
+/// Nothing writes this yet — the local build path is still to come.
+/// It exists so the marker has exactly one definition rather than being
+/// invented twice, and so the reader below has a producer to name.
+pub fn record_source_fingerprint(
+    cache_root: &Path,
+    version: &str,
+    arch: GuestArch,
+    fingerprint: &str,
+) -> std::io::Result<()> {
+    let layout = SdkSidecarLayout::under(cache_root, version, &arch.to_string());
+    std::fs::create_dir_all(&layout.artifact_dir)?;
+    std::fs::write(
+        layout.artifact_dir.join(LOCAL_SOURCE_FINGERPRINT_FILE),
+        format!("{fingerprint}\n"),
+    )
+}
+
+/// Compare the cached sidecar against `workspace_root`'s cdylib sources.
+///
+/// The sidecar is the only guest artifact with no source-build path: it is
+/// fetched from the published release and cached under `<version>/<arch>`. That
+/// key does not move when someone edits the cdylib, so a contributor who adds a
+/// host-service verb keeps getting a sidecar that predates it — and finds out
+/// only from inside a booted guest, as `unknown method \`host.kv.get\``, which
+/// points at the broker rather than at the image.
+///
+/// Reporting provenance does not fix that. It makes it legible, and gives the
+/// build path a marker to write when it lands.
+pub fn cached_sidecar_provenance(
+    cache_root: &Path,
+    version: &str,
+    arch: GuestArch,
+    workspace_root: &Path,
+) -> Result<SidecarProvenance, SdkSidecarBuildError> {
+    let layout = SdkSidecarLayout::under(cache_root, version, &arch.to_string());
+    let recorded = std::fs::read_to_string(layout.artifact_dir.join(LOCAL_SOURCE_FINGERPRINT_FILE));
+    let Ok(recorded) = recorded else {
+        return Ok(SidecarProvenance::Published);
+    };
+    let expected = crate::guest_agent_build::sdk_cdylib_source_fingerprint(workspace_root)
+        .map_err(|e| SdkSidecarBuildError::FingerprintFailed {
+            reason: format!("compute SDK cdylib source fingerprint: {e}"),
+        })?;
+    Ok(if recorded.trim() == expected {
+        SidecarProvenance::MatchesSource
+    } else {
+        SidecarProvenance::StaleSource
+    })
+}
+
 /// Resolve `arch`'s sidecar from `resolver`'s cache; on a miss with a
 /// non-default cache root (a worktree-isolated `MVM_HOME`), seed that cache from
 /// the default one and retry once.
@@ -325,6 +404,116 @@ mod tests {
             },
         ];
         mvm_fs::ext4::build_image(nodes).expect("build the sidecar ext4 fixture")
+    }
+
+    /// A workspace shaped like the ones `sdk_cdylib_source_fingerprint` reads.
+    fn fake_checkout(root: &Path, sdk_src: &str) {
+        for rel in [
+            "crates/mvm-contract/src",
+            "crates/mvm-core/src",
+            "crates/mvm-agentd/src",
+            "crates/mvm-sdk/src",
+        ] {
+            std::fs::create_dir_all(root.join(rel)).unwrap();
+            std::fs::write(root.join(rel).join("lib.rs"), "pub fn shared() {}\n").unwrap();
+        }
+        for rel in [
+            "Cargo.lock",
+            "Cargo.toml",
+            "crates/mvm-contract/Cargo.toml",
+            "crates/mvm-core/Cargo.toml",
+            "crates/mvm-agentd/Cargo.toml",
+            "crates/mvm-sdk/Cargo.toml",
+        ] {
+            std::fs::write(root.join(rel), "[package]\n").unwrap();
+        }
+        std::fs::write(
+            root.join("crates/mvm-sdk/src/host_services_ffi.rs"),
+            sdk_src,
+        )
+        .unwrap();
+    }
+
+    /// A downloaded sidecar carries no source marker, and that absence is the
+    /// signal — it is how "the published artifact" is told apart from "built
+    /// here". This is the case a contributor actually hits: the cache holds a
+    /// release image that predates the verb they just wrote.
+    #[test]
+    fn a_downloaded_sidecar_reports_itself_as_published() {
+        let _env = TestEnv::new();
+        let cache = tempfile::tempdir().unwrap();
+        let checkout = tempfile::tempdir().unwrap();
+        fake_checkout(checkout.path(), "// v1\n");
+        let layout = SdkSidecarLayout::under(
+            cache.path(),
+            FIXTURE_VERSION,
+            &GuestArch::host().to_string(),
+        );
+        std::fs::create_dir_all(&layout.artifact_dir).unwrap();
+
+        assert_eq!(
+            cached_sidecar_provenance(
+                cache.path(),
+                FIXTURE_VERSION,
+                GuestArch::host(),
+                checkout.path(),
+            )
+            .unwrap(),
+            SidecarProvenance::Published,
+        );
+    }
+
+    /// A sidecar recorded against this tree is current, and an edit to the
+    /// cdylib's own sources makes it stale. Both directions, because a
+    /// provenance check that can only ever say "stale" carries no information.
+    #[test]
+    fn a_source_built_sidecar_goes_stale_when_the_cdylib_sources_change() {
+        let _env = TestEnv::new();
+        let cache = tempfile::tempdir().unwrap();
+        let checkout = tempfile::tempdir().unwrap();
+        fake_checkout(checkout.path(), "// v1\n");
+
+        let fingerprint =
+            crate::guest_agent_build::sdk_cdylib_source_fingerprint(checkout.path()).unwrap();
+        record_source_fingerprint(
+            cache.path(),
+            FIXTURE_VERSION,
+            GuestArch::host(),
+            &fingerprint,
+        )
+        .unwrap();
+
+        assert_eq!(
+            cached_sidecar_provenance(
+                cache.path(),
+                FIXTURE_VERSION,
+                GuestArch::host(),
+                checkout.path(),
+            )
+            .unwrap(),
+            SidecarProvenance::MatchesSource,
+        );
+
+        // The edit that motivated all of this: a new verb in the FFI dispatch.
+        std::fs::write(
+            checkout
+                .path()
+                .join("crates/mvm-sdk/src/host_services_ffi.rs"),
+            "// v2 — adds host.kv.get\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            cached_sidecar_provenance(
+                cache.path(),
+                FIXTURE_VERSION,
+                GuestArch::host(),
+                checkout.path(),
+            )
+            .unwrap(),
+            SidecarProvenance::StaleSource,
+            "an edit to the cdylib's sources must invalidate the cached sidecar"
+        );
     }
 
     fn append_file<W: std::io::Write>(tar: &mut tar::Builder<W>, path: &str, bytes: &[u8]) {

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -406,7 +406,10 @@ pub(crate) fn resolve_sdk_sidecar_attachment_for_host(
 
     let cache_miss =
         match mvm_runtime::sdk_sidecar::resolve_sdk_sidecar_attachment(services, &resolver, arch) {
-            Ok(resolved) => return Ok(resolved),
+            Ok(resolved) => {
+                warn_if_sidecar_predates_the_working_tree(&cache_root, version, arch);
+                return Ok(resolved);
+            }
             Err(e) => e,
         };
 
@@ -424,6 +427,67 @@ pub(crate) fn resolve_sdk_sidecar_attachment_for_host(
             mvm_build::sdk_sidecar::download_sdk_sidecar(version, arch, &cache_root)
                 .with_context(|| sdk_sidecar_download_failure_context(services, version, arch))?;
             mvm_runtime::sdk_sidecar::resolve_sdk_sidecar_attachment(services, &resolver, arch)
+        }
+    }
+}
+
+/// Say so when the cached sidecar cannot carry this checkout's cdylib changes.
+///
+/// The sidecar is the one guest artifact with no source-build path: it is
+/// downloaded and cached under `<version>/<arch>`, and that key does not move
+/// when someone edits `crates/mvm-sdk`. A contributor who adds a host-service
+/// verb therefore keeps booting guests whose `libmvm_host_services.so` predates
+/// it, and learns about it only from inside the guest, as
+/// `unknown method \`host.kv.get\`` — an error that points at the broker rather
+/// than at a stale image. That is how the `host.kv.v1` live witness came to be
+/// written but never pass.
+///
+/// A warning, not a refusal, and not an eviction. There is nothing local to
+/// rebuild from yet, so evicting would leave the guest with no cdylib at all —
+/// strictly worse than an old one for every workload that does not touch the
+/// new verb. Once the build path lands this becomes the trigger for it.
+///
+/// Silent for a release binary, which has no checkout and for which the
+/// published artifact is exactly right.
+/// Said once per process. A launch resolves the sidecar from more than one call
+/// site, and the condition is process-global — same cache, same checkout — so
+/// repeating it is noise that trains people to skip the line.
+fn warn_if_sidecar_predates_the_working_tree(
+    cache_root: &std::path::Path,
+    version: &str,
+    arch: mvm_core::arch::GuestArch,
+) {
+    static SAID: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+    let Some(workspace_root) =
+        crate::commands::runtime_overlay::runtime_overlay_source_checkout_root()
+    else {
+        return;
+    };
+    match mvm_build::sdk_sidecar::cached_sidecar_provenance(
+        cache_root,
+        version,
+        arch,
+        &workspace_root,
+    ) {
+        Ok(mvm_build::sdk_sidecar::SidecarProvenance::MatchesSource) => {}
+        Ok(_) if SAID.swap(true, std::sync::atomic::Ordering::Relaxed) => {}
+        Ok(provenance) => {
+            let origin = match provenance {
+                mvm_build::sdk_sidecar::SidecarProvenance::Published => "is the published artifact",
+                _ => "was built from a different revision of this tree",
+            };
+            ui::warn(&format!(
+                "SDK sidecar {origin}, so `libmvm_host_services.so` does not carry \
+                 changes to crates/mvm-sdk in this checkout. Host-service calls from \
+                 the guest use the verbs it shipped with; one added here answers \
+                 `unknown method`. There is no local build for this artifact yet."
+            ));
+        }
+        // Provenance is a diagnostic. Failing to compute it must not fail a
+        // launch that would otherwise proceed.
+        Err(error) => {
+            tracing::debug!(%error, "could not determine SDK sidecar provenance");
         }
     }
 }


### PR DESCRIPTION
Step 1 of #2941. This does **not** fix the staleness — it makes it legible, and builds the fingerprint the fix will need. #2941 stays open.

## The problem

The SDK sidecar is the only guest artifact with no source-build path. It is fetched from the published release and cached under `<version>/<arch>`, and that key does not move when someone edits `crates/mvm-sdk`. A contributor who adds a host-service verb keeps booting guests whose `libmvm_host_services.so` predates it — indefinitely, because the version does not change either.

They find out from inside the guest:

```
RuntimeError: host.kv.get failed status=8
  body=b'{"code":"invalid_input","message":"unknown method `host.kv.get`"}'
```

which points at the broker rather than at a fifteen-day-old image. That is how `host_kv.feature`'s `@live` scenario came to be written and never pass: `host.kv.get` entered the FFI dispatch on **2026-08-26** (#2848); the cached `sdk.ext4` on this machine was built **2026-08-11**.

Every sibling artifact honours the contributor-source rule CLAUDE.md states:

| artifact | source path | cache key |
| --- | --- | --- |
| guest binaries | `resolve_or_build_guest_binaries` | source fingerprint |
| runtime overlay | `resolve_or_build_local_runtime_overlay` | source fingerprint |
| universal initramfs | `resolve_or_build_local_initramfs` | source fingerprint |
| **SDK sidecar** | **none** | **version + arch** |

## Why not just add the build path here

I estimated this as "mostly assembly" before reading the derivation, and that was wrong. The sidecar is deliberately **glibc** — Python and Node `dlopen` it from the workload process, so it needs a dynamic loader — and its `ld-linux`, `libc.so.6` and `libgcc_s.so.1` come from nixpkgs. Cargo cannot produce them, and `mvmctl` must not shell out to host Nix. The runtime overlay avoids Nix on macOS only because its contents are static-musl binaries cargo *can* build.

The obvious shape — rebuild only the cdylib for a `*-unknown-linux-gnu` target, take the glibc runtime from the cached image, repack with the pure-Rust ext4 writer — **does not work on aarch64**. I tried it:

```
cargo zigbuild -p mvm-sdk --lib --target aarch64-unknown-linux-gnu.2.28
  error: unsupported linker arg: --fix-cortex-a53-843419
  error: could not compile `mvm-sdk` (lib)
```

rustc passes that erratum workaround on every `aarch64-unknown-linux-gnu` link and zig's linker rejects it. The workspace pins only musl targets, which is why nothing had hit this before — the guest binaries are static-musl and never take this path.

So the source build has to happen where a native glibc toolchain already exists: **inside the builder VM**, the same place every other Nix-built artifact is produced. That also fits the constraint already stated in the resolve ladder — building the sidecar must not implicitly spawn the builder VM during a launch — so it wants an explicit command, with the warning this PR adds naming it. That is the design, and it belongs in its own PR.

## What this adds

- **`sdk_cdylib_source_fingerprint`** — the cdylib's inputs. Separate from `guest_source_fingerprint` because the input sets differ: folding `mvm-sdk` into the guest fingerprint would invalidate every cached guest binary on an SDK-only edit, a rebuild nobody asked for. The sidecar's nixpkgs members are deliberately not inputs, since they cannot change without the version changing.
- **`cached_sidecar_provenance`** — `MatchesSource` / `StaleSource` / `Published`. A downloaded artifact carries no marker, and that absence is the signal rather than an oversight.
- **`record_source_fingerprint`** — no producer yet. It exists so the marker has one definition instead of being invented twice, and so the reader has a producer to name.
- **A warning at the launch path, once per process.** The resolve ladder already consulted the build-vs-download decision, but only on a cache *miss*; a hit returned with no staleness consideration at all. That was the gap.

## Warning, not refusal, not eviction

There is nothing local to rebuild from, so evicting would leave the guest with **no** cdylib at all — strictly worse than an old one for every workload that does not touch the new verb. When the build path lands, this becomes its trigger.

Silent for a release binary, which has no checkout and for which the published artifact is exactly right. Said once per process because a launch resolves the sidecar from more than one call site and the condition is process-global — repeating it trains people to skip the line.

The shape follows the aux-helper guard already in the tree, which says `...was reused from an earlier build and does NOT contain this source tree's changes... Run just embed-refresh`. That is the difference between a legible failure and `unknown method`.

## Verified

Against the real stale cache on this machine:

```
[mvm] SDK sidecar is the published artifact, so `libmvm_host_services.so` does not
      carry changes to crates/mvm-sdk in this checkout. Host-service calls from the
      guest use the verbs it shipped with; one added here answers `unknown method`.
      There is no local build for this artifact yet.
```

Fires, once, naming the consequence.

Two tests, each mutation-checked independently — one for the published case, one for source-built-then-edited — because a provenance check that can only ever say "stale" carries no information.

Gates: `xtask check-all` 61/61, clippy zero warnings, nightly fmt, `just check-gated`, 12,548 workspace tests, doctests.
