### PR TITLE
feat(admission): admit externally-signed plans from pinned fleet signers

### DIFF
--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -186,6 +186,11 @@ pub(crate) struct BootParams {
     /// The request's permission set, carried into the signed plan and — for
     /// its egress dimension — into the policy the gate enforces.
     pub(crate) grants: Option<mvm_contract::grants::Grants>,
+    /// A fleet-issued signed plan to admit instead of synthesizing one.
+    /// `Some` only when the launch request carried one; admission then
+    /// verifies it against the operator-pinned `trusted_plan_signers` and the
+    /// plan becomes the authority for sizing, grants, and teardown intent.
+    pub(crate) signed_plan: Option<mvm_core::plan::SignedExecutionPlan>,
     /// Path to an operator-authored campaign declaration, when one was asked
     /// for. Read and validated here, so a malformed declaration refuses the
     /// launch instead of producing a boot with no campaign on it.
@@ -258,6 +263,7 @@ impl LocalBackend {
             volumes: params.volumes,
             destroy_on_exit: params.transient,
             grants: params.grants.clone(),
+            signed_plan: params.signed_plan.clone(),
         };
 
         // A fresh per-launch ledger: local launches are one-shot from this
@@ -708,6 +714,7 @@ impl LocalBackend {
                 volumes,
                 transient,
                 grants: request.grants.clone(),
+                signed_plan: request.signed_plan.clone(),
                 assurance_campaign: request.assurance_campaign.clone(),
             })
             .await?;

--- a/crates/mvm-client/src/launch/request.rs
+++ b/crates/mvm-client/src/launch/request.rs
@@ -89,6 +89,15 @@ pub struct LaunchRequest {
     /// for a campaign, which is what keeps campaign discovery off the launch
     /// critical path rather than merely cheap on it.
     pub(crate) assurance_campaign: Option<std::path::PathBuf>,
+    /// A fleet-issued signed plan to admit instead of synthesizing one under
+    /// the host key. When present, the plan is the authority: the host
+    /// verifies it against the operator-pinned `trusted_plan_signers`, and
+    /// sizing, grants, and teardown intent come from the verified plan body —
+    /// `build()` refuses a request that also tries to set them. Transient
+    /// launches only: a persisted definition cannot carry the plan, so a
+    /// persistent one would silently re-admit under the host key on its next
+    /// start.
+    pub(crate) signed_plan: Option<mvm_core::plan::SignedExecutionPlan>,
 }
 
 impl LaunchRequest {
@@ -115,6 +124,7 @@ impl LaunchRequest {
             force: false,
             grants: mvm_contract::grants::Grants::default(),
             assurance_campaign: None,
+            signed_plan: None,
         }
     }
 
@@ -149,6 +159,7 @@ pub struct LaunchRequestBuilder {
     force: bool,
     grants: mvm_contract::grants::Grants,
     assurance_campaign: Option<std::path::PathBuf>,
+    signed_plan: Option<mvm_core::plan::SignedExecutionPlan>,
 }
 
 impl LaunchRequestBuilder {
@@ -271,6 +282,17 @@ impl LaunchRequestBuilder {
         self
     }
 
+    /// Admit a fleet-issued signed plan instead of synthesizing one under the
+    /// host key. The host verifies the envelope against its operator-pinned
+    /// `trusted_plan_signers` at admission; a host that pins none refuses.
+    /// Transient launches only, and mutually exclusive with request-level
+    /// grants — both enforced at `build()`.
+    #[must_use]
+    pub fn signed_plan(mut self, plan: mvm_core::plan::SignedExecutionPlan) -> Self {
+        self.signed_plan = Some(plan);
+        self
+    }
+
     /// Attach a managed volume at `guest_path`.
     #[must_use]
     pub fn volume(mut self, spec: LaunchVolumeSpec) -> Self {
@@ -355,12 +377,53 @@ impl LaunchRequestBuilder {
                 )));
             }
         }
+        // A signed plan is the launch's authority: grants are signed into it,
+        // so a request-level set would either duplicate or contradict them.
+        // And it cannot persist — a stored definition would re-admit under
+        // the host key on its next start, silently dropping the fleet's
+        // authority after the first boot.
+        if self.signed_plan.is_some() {
+            if self.mode == LifecycleMode::Persistent {
+                return Err(invalid(
+                    "a signed plan admits a transient launch only; a persisted definition \
+                     cannot carry it and would re-admit under the host key on the next start"
+                        .into(),
+                ));
+            }
+            if self.grants != mvm_contract::grants::Grants::default() {
+                return Err(invalid(
+                    "grants ride inside the signed plan; setting them on the request too \
+                     would contradict it"
+                        .into(),
+                ));
+            }
+        }
+        // Read sizing out of the envelope so the request reports what the
+        // plan authorizes. Verification happens at admission — these values
+        // only shape the request; the boot path re-derives them from the
+        // verified plan body.
+        let (cpus, memory_mib) = match &self.signed_plan {
+            Some(signed) => {
+                let plan: mvm_core::plan::ExecutionPlan = serde_json::from_slice(&signed.0.payload)
+                    .map_err(|e| {
+                        invalid(format!("the signed plan's payload does not parse: {e}"))
+                    })?;
+                let memory_mib = u32::try_from(plan.resources.mem_mib).map_err(|_| {
+                    invalid(format!(
+                        "the signed plan's memory ({} MiB) does not fit this surface",
+                        plan.resources.mem_mib
+                    ))
+                })?;
+                (plan.resources.cpus, memory_mib)
+            }
+            None => (self.cpus, self.memory_mib),
+        };
         Ok(LaunchRequest {
             name: self.name,
             mode: self.mode,
             image: self.image,
-            cpus: self.cpus,
-            memory_mib: self.memory_mib,
+            cpus,
+            memory_mib,
             backend: self.backend,
             profile: self.profile,
             ttl_seconds: self.ttl_seconds,
@@ -372,6 +435,7 @@ impl LaunchRequestBuilder {
             // grants were expressible.
             grants: (self.grants != mvm_contract::grants::Grants::default()).then_some(self.grants),
             assurance_campaign: self.assurance_campaign,
+            signed_plan: self.signed_plan,
         })
     }
 }
@@ -511,5 +575,75 @@ mod tests {
             .build()
             .unwrap_err();
         assert!(err.to_string().contains("guest path"), "got: {err}");
+    }
+
+    /// A fleet-issued plan, signed by a key the request tests never verify —
+    /// signature verification is admission's job, not the builder's.
+    fn fleet_signed_plan() -> mvm_core::plan::SignedExecutionPlan {
+        let plan = mvm_core::plan::test_support::PlanFixture::new().build();
+        mvm_core::plan::signing::sign_plan(
+            &plan,
+            &ed25519_dalek::SigningKey::from_bytes(&[42u8; 32]),
+            "fleet-prod",
+        )
+    }
+
+    #[test]
+    fn a_signed_plan_launch_derives_sizing_from_the_plan() {
+        // The plan is the authority: the request reports the plan's sizing
+        // (the fixture's 1 cpu / 128 MiB), not the builder's defaults and not
+        // anything the caller set.
+        let req = base(LifecycleMode::Transient)
+            .cpus(8)
+            .memory_mib(4096)
+            .signed_plan(fleet_signed_plan())
+            .build()
+            .expect("a transient signed-plan request builds");
+        assert!(req.signed_plan.is_some());
+        assert_eq!((req.cpus, req.memory_mib), (1, 128));
+        assert!(req.grants.is_none());
+    }
+
+    #[test]
+    fn request_grants_with_a_signed_plan_are_refused() {
+        // Grants are signed into the plan; a request-level set would either
+        // duplicate or contradict them, so the combination cannot build.
+        let err = base(LifecycleMode::Transient)
+            .cpu_millicores(500)
+            .signed_plan(fleet_signed_plan())
+            .build()
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("grants ride inside the signed plan"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn a_signed_plan_is_transient_only() {
+        // A persisted definition cannot carry the plan; without the refusal a
+        // machine's first boot would honor the fleet's signature and every
+        // later start would silently re-admit under the host key.
+        let err = base(LifecycleMode::Persistent)
+            .signed_plan(fleet_signed_plan())
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("transient"), "got: {err}");
+    }
+
+    #[test]
+    fn a_signed_plan_with_an_unparseable_payload_is_refused() {
+        let malformed =
+            mvm_core::plan::SignedExecutionPlan(mvm_core::protocol::signing::SignedPayload {
+                payload: b"not a plan".to_vec(),
+                signature: vec![0u8; 64],
+                signer_id: "fleet-prod".to_string(),
+            });
+        let err = base(LifecycleMode::Transient)
+            .signed_plan(malformed)
+            .build()
+            .unwrap_err();
+        assert!(err.to_string().contains("does not parse"), "got: {err}");
     }
 }

--- a/crates/mvm-core/src/user_config.rs
+++ b/crates/mvm-core/src/user_config.rs
@@ -79,6 +79,60 @@ pub struct MvmConfig {
     /// uncapped and contributes nothing, so this bounds the total of what was
     /// promised rather than the total of what can be consumed.
     pub host_budget_cpu_millicores: Option<u32>,
+    /// External signers whose Ed25519-signed plans this host will admit.
+    ///
+    /// Empty by default, and the default is the security posture: a host that
+    /// pins nobody refuses every externally-signed plan. Pinning an entry is
+    /// the operator delegating plan authority to a fleet control plane's
+    /// issuer key — the plan's grants are still measured against this host's
+    /// ceiling and budget, which the signer cannot widen.
+    pub trusted_plan_signers: Vec<TrustedPlanSigner>,
+}
+
+/// One external plan signer the operator has chosen to trust: the
+/// `signer_id` a `SignedExecutionPlan` envelope names, pinned to the Ed25519
+/// public key the signature must verify under.
+///
+/// The key is pinned, not looked up: the envelope's `signer_id` selects which
+/// entry verifies it, so two entries must never share an id (the first match
+/// wins, and a duplicated id would shadow the later pin).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TrustedPlanSigner {
+    /// The identifier the signed envelope carries and the verifier matches on.
+    pub signer_id: String,
+    /// The signer's Ed25519 public key, lowercase hex (64 chars, 32 bytes).
+    pub ed25519_pubkey_hex: String,
+}
+
+impl TrustedPlanSigner {
+    /// Parse the pinned public key into a verifying key.
+    ///
+    /// A malformed pin is an error, never a skipped entry: silently dropping
+    /// an unparseable pin would admit nothing the operator meant to refuse,
+    /// but surfacing it tells them the pin they wrote is not the pin in
+    /// force.
+    pub fn verifying_key(&self) -> Result<ed25519_dalek::VerifyingKey> {
+        let raw = hex::decode(&self.ed25519_pubkey_hex).with_context(|| {
+            format!(
+                "trusted plan signer {:?}: ed25519_pubkey_hex is not hex",
+                self.signer_id
+            )
+        })?;
+        let bytes: [u8; 32] = raw.try_into().map_err(|raw: Vec<u8>| {
+            anyhow::anyhow!(
+                "trusted plan signer {:?}: ed25519_pubkey_hex decodes to {} bytes, expected 32",
+                self.signer_id,
+                raw.len()
+            )
+        })?;
+        ed25519_dalek::VerifyingKey::from_bytes(&bytes).with_context(|| {
+            format!(
+                "trusted plan signer {:?}: ed25519_pubkey_hex is not a valid Ed25519 key",
+                self.signer_id
+            )
+        })
+    }
 }
 
 impl MvmConfig {
@@ -133,6 +187,20 @@ impl MvmConfig {
         }
     }
 
+    /// The host's trusted external plan signers, parsed into verifying keys.
+    ///
+    /// Read at admission, never from the plan being admitted — same trust-root
+    /// rule as the grant ceiling. An empty set is the fail-closed default:
+    /// callers must treat it as "this host admits no externally-signed plans".
+    /// A malformed pin fails the whole load rather than being skipped, so the
+    /// set in force is exactly the set the operator wrote.
+    pub fn trusted_plan_signer_keys(&self) -> Result<Vec<(String, ed25519_dalek::VerifyingKey)>> {
+        self.trusted_plan_signers
+            .iter()
+            .map(|signer| Ok((signer.signer_id.clone(), signer.verifying_key()?)))
+            .collect()
+    }
+
     /// Resolve the effective services-health timeout, honoring an
     /// `MVM_SERVICES_HEALTH_TIMEOUT_SECS` env-var override over the
     /// config field. Env-var takes precedence so a single shell
@@ -175,6 +243,10 @@ impl Default for MvmConfig {
             // a large machine while under-protecting a small one.
             host_budget_memory_mib: None,
             host_budget_cpu_millicores: None,
+            // Empty = refuse every externally-signed plan. Trusting a fleet
+            // issuer is a delegation of plan authority; it has to be written
+            // by the operator, never defaulted into.
+            trusted_plan_signers: Vec::new(),
         }
     }
 }
@@ -529,5 +601,71 @@ mod tests {
         let mut cfg = MvmConfig::default();
         let err = set_key(&mut cfg, "dev_vm_cpus", "not-a-number").unwrap_err();
         assert!(err.to_string().contains("integer"));
+    }
+
+    #[test]
+    fn trusted_plan_signers_default_empty() {
+        // Fail closed: a host that pinned nobody admits no externally-signed
+        // plan, and the empty default must survive a TOML round trip.
+        let cfg = MvmConfig::default();
+        assert!(cfg.trusted_plan_signers.is_empty());
+        assert_eq!(cfg.trusted_plan_signer_keys().unwrap(), Vec::new());
+
+        let parsed: MvmConfig = toml::from_str(&toml::to_string_pretty(&cfg).unwrap()).unwrap();
+        assert!(parsed.trusted_plan_signers.is_empty());
+    }
+
+    #[test]
+    fn trusted_plan_signers_round_trip_and_parse() {
+        let signing = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let expected = signing.verifying_key();
+        let cfg = MvmConfig {
+            trusted_plan_signers: vec![TrustedPlanSigner {
+                signer_id: "fleet-prod".to_string(),
+                ed25519_pubkey_hex: hex::encode(expected.as_bytes()),
+            }],
+            ..MvmConfig::default()
+        };
+
+        // The operator writes this into config.toml, so the persisted form is
+        // what must parse back into the same pin.
+        let parsed: MvmConfig = toml::from_str(&toml::to_string_pretty(&cfg).unwrap()).unwrap();
+        assert_eq!(parsed.trusted_plan_signers, cfg.trusted_plan_signers);
+
+        let keys = parsed.trusted_plan_signer_keys().unwrap();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].0, "fleet-prod");
+        assert_eq!(keys[0].1, expected);
+    }
+
+    #[test]
+    fn a_malformed_trusted_signer_pin_fails_the_load() {
+        // Never skip an unparseable pin: the operator believes the key they
+        // wrote is the one in force.
+        let bad_pins = [
+            "not-hex!".to_string(),
+            "ab".repeat(16), // 16 bytes — wrong length
+            "ab".repeat(64), // 64 bytes — wrong length
+        ];
+        for bad in &bad_pins {
+            let signer = TrustedPlanSigner {
+                signer_id: "fleet-prod".to_string(),
+                ed25519_pubkey_hex: bad.clone(),
+            };
+            let err = signer.verifying_key().unwrap_err();
+            assert!(
+                err.to_string().contains("fleet-prod"),
+                "the error must name the offending pin: {err:#}"
+            );
+        }
+
+        // A real key's hex parses back to that key.
+        let signing = ed25519_dalek::SigningKey::from_bytes(&[9u8; 32]);
+        let expected = signing.verifying_key();
+        let signer = TrustedPlanSigner {
+            signer_id: "fleet-prod".to_string(),
+            ed25519_pubkey_hex: hex::encode(expected.as_bytes()),
+        };
+        assert_eq!(signer.verifying_key().unwrap(), expected);
     }
 }

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -43,6 +43,16 @@
 //! `admit_for_run` takes a `Clock` and a `NonceLedger` so tests can
 //! drive the validity window + replay protection deterministically.
 //! Production callers use `SystemClock` + the host's nonce store.
+//!
+//! ## Externally-signed plans
+//!
+//! [`admit_signed_plan_for_run`] admits a plan signed by a fleet issuer the
+//! operator pinned in the host config's `trusted_plan_signers`, verifying the
+//! envelope against that set — never the host's own key — before any policy
+//! gate reads the plan body. From the content-address check onward it runs
+//! the same `finish_admission` tail as the self-signed path: the host's
+//! ceiling, budget, validity window, and replay protection apply unchanged,
+//! so the host stays the final authority over what it boots.
 
 use anyhow::{Context, Result};
 use chrono::Utc;
@@ -110,7 +120,8 @@ impl Default for InMemoryNonceLedger {
 /// input gate — decide what a workload may do by reading this plan, so a value
 /// of this type has to be a claim that the plan *was* signed, verified,
 /// window-checked and replay-checked, not merely a struct shaped like one. Both
-/// halves of that are enforced by privacy: [`admit_for_run`] is the only
+/// halves of that are enforced by privacy: `finish_admission` — the shared
+/// tail of [`admit_for_run`] and [`admit_signed_plan_for_run`] — is the only
 /// non-test code that can build one (a struct literal needs every field named,
 /// and there is no `Default` to spread from), and no accessor hands out a `&mut`
 /// or an owned field, so a caller that legitimately holds one cannot afterwards
@@ -145,7 +156,9 @@ impl AdmittedPlan {
         &self.plan_id
     }
 
-    /// The host signer whose key the plan verified under.
+    /// The signer whose key the plan verified under — this host's own signer
+    /// for a synthesized run, or the pinned external signer for a
+    /// fleet-issued one.
     #[must_use]
     pub fn signer_id(&self) -> &str {
         &self.signer_id
@@ -360,6 +373,126 @@ fn admit_plan_for_run_inner(
     let trusted: [(&str, &VerifyingKey); 1] = [(&signer_id, &signer.verifying)];
     let verified = verify_plan(&signed, &trusted).context("verifying just-signed plan")?;
 
+    finish_admission(VerifiedAdmission {
+        verified,
+        signed,
+        signer_id,
+        extensions,
+        clock,
+        ledger,
+        bundle_ctx,
+    })
+}
+
+/// Admit an externally-signed plan — one signed by a fleet issuer the
+/// operator pinned in `trusted_plan_signers`, not by this host's own key.
+///
+/// The order differs from the self-signed path in exactly the way the trust
+/// boundary dictates: the envelope is verified against the pinned signer set
+/// *first*, because every byte of it is attacker-controlled until then, and
+/// only afterwards do the host's own policy gates (extension bindings, grant
+/// ceiling, host budget) read the plan. From [`verify_plan_id`] onward both
+/// paths run the same checks through [`finish_admission`] — the host remains
+/// the final authority over what it boots, whoever signed the plan.
+///
+/// The trusted set comes from operator config and nowhere else, so a caller
+/// cannot hand admission a wider trust than the host configured. An empty set
+/// is the fail-closed default: every externally-signed plan is refused.
+///
+/// A refusal never emits an audit entry: the plan body is the only anchor a
+/// refusal entry could bind to, and until the signature verifies the body is
+/// an attacker's claim, not a fact to record.
+#[tracing::instrument(skip_all)]
+pub fn admit_signed_plan_for_run(
+    signed: &SignedExecutionPlan,
+    clock: &dyn Clock,
+    ledger: &InMemoryNonceLedger,
+    bundle_ctx: Option<&BundleAdmissionContext<'_>>,
+    posture: RunPosture,
+) -> Result<AdmittedPlan> {
+    let trusted = host_trusted_plan_signers()?;
+    if trusted.is_empty() {
+        anyhow::bail!(
+            "refusing the externally-signed plan: this host pins no trusted plan signers; \
+             set `trusted_plan_signers` in the host config.toml to admit fleet-signed plans"
+        );
+    }
+    let trusted_refs: Vec<(&str, &VerifyingKey)> =
+        trusted.iter().map(|(id, key)| (id.as_str(), key)).collect();
+    let verified =
+        verify_plan(signed, &trusted_refs).context("verifying externally-signed plan")?;
+    let signer_id = signed.0.signer_id.clone();
+
+    validate_extension_bindings(&verified)?;
+    // No extension verification context on this path: a plan that binds
+    // optional extensions is refused rather than admitted unchecked.
+    let extensions = verify_extension_packs(&verified, None)?;
+    admit_grants(&verified, &host_grant_ceiling(), posture)?;
+    admit_within_host_budget(&verified)?;
+
+    finish_admission(VerifiedAdmission {
+        verified,
+        // The caller lends the envelope; the admitted plan owns a copy so
+        // downstream consumers can re-verify without trusting this process.
+        signed: signed.clone(),
+        signer_id,
+        extensions,
+        clock,
+        ledger,
+        bundle_ctx,
+    })
+}
+
+/// The external plan signers this host trusts, from operator config.
+///
+/// Read from config rather than taken as a parameter for the same reason as
+/// the grant ceiling: admission's trust root must not be widen-able by the
+/// caller asking for admission. A malformed pin fails the whole read, so the
+/// set in force is exactly the set the operator wrote.
+fn host_trusted_plan_signers() -> Result<Vec<(String, VerifyingKey)>> {
+    mvm_core::user_config::load(None).trusted_plan_signer_keys()
+}
+
+/// Everything the shared post-verification tail of admission needs.
+///
+/// A params struct rather than seven positional arguments: `verified`,
+/// `signed`, and `signer_id` travel together from whichever path verified
+/// them, and a positional call could transpose them with nothing to catch it.
+struct VerifiedAdmission<'a> {
+    /// The plan body, already signature-verified against the trust root of
+    /// the path that produced it (the host signer, or the operator's pinned
+    /// external signer set).
+    verified: ExecutionPlan,
+    /// The envelope `verified` was decoded from, carried verbatim onto the
+    /// launch config for consumers that re-verify.
+    signed: SignedExecutionPlan,
+    /// The signer the envelope verified under — the audit chain records it.
+    signer_id: String,
+    /// Re-verified extension artifacts, empty when the plan binds none.
+    extensions: Vec<AdmittedExtension>,
+    clock: &'a dyn Clock,
+    ledger: &'a InMemoryNonceLedger,
+    bundle_ctx: Option<&'a BundleAdmissionContext<'a>>,
+}
+
+/// The checks every admitted plan passes after its signature has verified,
+/// shared by the host-signed and externally-signed paths: content-address,
+/// ingress shape, validity window, replay protection, bundle re-verify.
+///
+/// The replay insert is deliberately last but one: every check that can
+/// refuse runs before the nonce is spent, so a refused plan can be corrected
+/// and resubmitted, while an admitted one cannot be replayed.
+fn finish_admission(parts: VerifiedAdmission<'_>) -> Result<AdmittedPlan> {
+    let VerifiedAdmission {
+        verified,
+        signed,
+        signer_id,
+        extensions,
+        clock,
+        ledger,
+        bundle_ctx,
+    } = parts;
+
     // The plan_id is the content-address of the plan body — recompute it and
     // refuse a plan whose stored id doesn't match, so a run is only ever
     // admitted under an id that genuinely addresses its content.
@@ -372,7 +505,9 @@ fn admit_plan_for_run_inner(
     // Validity window — refuses plans whose now() is outside
     // [valid_from, valid_until). For freshly-synthesized plans this
     // can only fire if the host's clock changed during signing or if
-    // someone overrode the validity window in synthesis defaults.
+    // someone overrode the validity window in synthesis defaults; for an
+    // externally-signed plan it is the host's own check that the window the
+    // fleet issuer chose still holds here.
     let now = clock.now();
     check_window(&verified, now).map_err(|e| match e {
         PlanValidityError::NotYetValid { .. } | PlanValidityError::Expired { .. } => {
@@ -381,10 +516,9 @@ fn admit_plan_for_run_inner(
         other => anyhow::anyhow!("plan validity error: {other}"),
     })?;
 
-    // Replay protection: insert (signer_id, nonce). A second admit_for_run
-    // call within the validity window with the same nonce gets refused.
-    // Synthesis generates fresh nonces, so this only fires on the
-    // pathological "same plan submitted twice" case.
+    // Replay protection: insert (signer_id, nonce). A second admission with
+    // the same signer + nonce — a re-submitted fleet plan, or a synthesized
+    // plan that somehow recurred — is refused.
     {
         let mut store = ledger.inner.lock().expect("nonce store mutex poisoned");
         store
@@ -392,9 +526,9 @@ fn admit_plan_for_run_inner(
             .context("replay protection check")?;
     }
 
-    // Claim 9 — bundle re-verify at admit time. Only fires
+    // Bundle re-verify at admit time. Only fires
     // when the plan pinned a bundle; missing context with a pinned
-    // plan is operator misconfiguration (mvmctl up wasn't wired
+    // plan is operator misconfiguration (the driver wasn't wired
     // with a resolver/trust store), so we refuse rather than skip
     // silently.
     if let Some(pin) = verified.bundle.as_ref() {
@@ -2132,11 +2266,11 @@ mod tests {
             "the test constructor must stay `#[cfg(test)]` and crate-private"
         );
 
-        // 5. And `admit_for_run` is the only place that writes the literal.
+        // 5. And `finish_admission` is the only place that writes the literal.
         let literals = production_source().matches("Ok(AdmittedPlan {").count();
         assert_eq!(
             literals, 1,
-            "exactly one production construction site, inside admit_for_run"
+            "exactly one production construction site, inside finish_admission"
         );
     }
 
@@ -4973,5 +5107,243 @@ mod launch_decision_record_tests {
             Some("plan-under-launch"),
             "the attestation binding must name the launched plan"
         );
+    }
+}
+
+#[cfg(test)]
+mod signed_plan_admission_tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+    use ed25519_dalek::SigningKey;
+    use mvm_core::plan::test_support::PlanFixture;
+    use mvm_core::user_config::{MvmConfig, TrustedPlanSigner};
+    use mvm_core::util::test_env::TestEnv;
+
+    /// The fleet issuer key the tests pin — or deliberately don't.
+    fn fleet_key() -> SigningKey {
+        SigningKey::from_bytes(&[42u8; 32])
+    }
+
+    fn pin_for(signer_id: &str, key: &SigningKey) -> TrustedPlanSigner {
+        TrustedPlanSigner {
+            signer_id: signer_id.to_string(),
+            ed25519_pubkey_hex: hex::encode(key.verifying_key().as_bytes()),
+        }
+    }
+
+    /// Isolate `MVM_HOME` and write `cfg` as the host config. Admission reads
+    /// the trusted signer set (and the grant ceiling) from host config rather
+    /// than from a parameter, so a test that wants a trusting host has to
+    /// *be* one. The guard and home must both outlive the admission call.
+    fn host_with(cfg: MvmConfig) -> (TestEnv, tempfile::TempDir) {
+        let home = tempfile::tempdir().expect("scratch mvm home");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(home.path());
+        let pins = cfg.trusted_plan_signers.len();
+        mvm_core::user_config::save(&cfg, None).expect("writing the host config");
+        // Precondition, not a redundant assertion: if this fails the isolation
+        // did not hold and every check below would measure some other host.
+        assert_eq!(
+            mvm_core::user_config::load(None).trusted_plan_signers.len(),
+            pins,
+            "the isolated host must read back the pins it was configured with"
+        );
+        (env, home)
+    }
+
+    fn host_pinning(signers: Vec<TrustedPlanSigner>) -> (TestEnv, tempfile::TempDir) {
+        host_with(MvmConfig {
+            trusted_plan_signers: signers,
+            ..MvmConfig::default()
+        })
+    }
+
+    fn signed_by_fleet(plan: &ExecutionPlan) -> SignedExecutionPlan {
+        sign_plan(plan, &fleet_key(), "fleet-prod")
+    }
+
+    fn admit(signed: &SignedExecutionPlan, ledger: &InMemoryNonceLedger) -> Result<AdmittedPlan> {
+        admit_signed_plan_for_run(
+            signed,
+            &SystemClock,
+            ledger,
+            None,
+            RunPosture::without_backend(Variant::Dev),
+        )
+    }
+
+    #[test]
+    fn a_pinned_fleet_signers_plan_is_admitted() {
+        let (_env, _home) = host_pinning(vec![pin_for("fleet-prod", &fleet_key())]);
+        let plan = PlanFixture::new().tenant("fleet-tenant").build();
+        let signed = signed_by_fleet(&plan);
+
+        let admitted = admit(&signed, &InMemoryNonceLedger::new())
+            .expect("a plan signed by a pinned fleet signer admits");
+
+        assert_eq!(admitted.signer_id(), "fleet-prod");
+        assert_eq!(admitted.plan().tenant.0, "fleet-tenant");
+        // The admitted plan is content-addressed and the envelope the caller
+        // handed in is carried verbatim — not re-signed under the host key.
+        assert_eq!(admitted.plan_id(), &admitted.plan().plan_id);
+        assert_eq!(admitted.signed().0.signer_id, "fleet-prod");
+        assert_eq!(admitted.signed().0.signature, signed.0.signature);
+    }
+
+    #[test]
+    fn an_unpinned_host_refuses_every_signed_plan() {
+        // The default: no pins, no externally-signed admissions. This is the
+        // fail-closed posture a host is in before the operator delegates.
+        let (_env, _home) = host_pinning(Vec::new());
+        let signed = signed_by_fleet(&PlanFixture::new().build());
+
+        let err = admit(&signed, &InMemoryNonceLedger::new())
+            .expect_err("a host that pins nobody must refuse");
+        assert!(
+            format!("{err:#}").contains("pins no trusted plan signers"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_signer_is_refused() {
+        // The host pins a *different* fleet issuer; the envelope names one it
+        // never heard of.
+        let other = SigningKey::from_bytes(&[7u8; 32]);
+        let (_env, _home) = host_pinning(vec![pin_for("fleet-staging", &other)]);
+        let signed = signed_by_fleet(&PlanFixture::new().build());
+
+        let err = admit(&signed, &InMemoryNonceLedger::new())
+            .expect_err("an unpinned signer must be refused");
+        assert!(
+            format!("{err:#}").contains("no trusted key matched signer_id fleet-prod"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_tampered_payload_is_refused() {
+        let (_env, _home) = host_pinning(vec![pin_for("fleet-prod", &fleet_key())]);
+        let mut signed = signed_by_fleet(&PlanFixture::new().build());
+        signed.0.payload[0] ^= 0x01;
+
+        let err = admit(&signed, &InMemoryNonceLedger::new())
+            .expect_err("a tampered payload must fail signature verification");
+        assert!(
+            format!("{err:#}").contains("signature verification failed"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn an_expired_plan_is_refused() {
+        let (_env, _home) = host_pinning(vec![pin_for("fleet-prod", &fleet_key())]);
+        let now = Utc::now();
+        let plan = PlanFixture::new()
+            .validity(now - Duration::hours(2), now - Duration::hours(1))
+            .build();
+        let signed = signed_by_fleet(&plan);
+
+        let err = admit(&signed, &InMemoryNonceLedger::new())
+            .expect_err("a validly-signed but expired plan must be refused");
+        assert!(
+            format!("{err:#}").contains("plan validity window violated"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_not_yet_valid_plan_is_refused() {
+        let (_env, _home) = host_pinning(vec![pin_for("fleet-prod", &fleet_key())]);
+        let now = Utc::now();
+        let plan = PlanFixture::new()
+            .validity(now + Duration::hours(1), now + Duration::hours(2))
+            .build();
+        let signed = signed_by_fleet(&plan);
+
+        let err = admit(&signed, &InMemoryNonceLedger::new())
+            .expect_err("a plan whose window has not opened must be refused");
+        assert!(
+            format!("{err:#}").contains("plan validity window violated"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_replayed_nonce_is_refused() {
+        let (_env, _home) = host_pinning(vec![pin_for("fleet-prod", &fleet_key())]);
+        let signed = signed_by_fleet(&PlanFixture::new().build());
+        let ledger = InMemoryNonceLedger::new();
+
+        admit(&signed, &ledger).expect("the first admission succeeds");
+        let err = admit(&signed, &ledger).expect_err("the same plan admitted twice is a replay");
+        assert!(format!("{err:#}").contains("replay"), "got: {err:#}");
+    }
+
+    #[test]
+    fn a_plan_id_that_does_not_address_its_content_is_refused() {
+        use ed25519_dalek::Signer as _;
+
+        let (_env, _home) = host_pinning(vec![pin_for("fleet-prod", &fleet_key())]);
+        // sign_plan re-derives the content address, so a mismatched id cannot
+        // come through it — build the envelope by hand: a valid signature over
+        // a plan whose stored id does not address its body.
+        let plan = PlanFixture::new()
+            .plan_id("not-the-content-address")
+            .build();
+        let payload = serde_json::to_vec(&plan).expect("plan serializes");
+        let signature = fleet_key().sign(&payload);
+        let signed = SignedExecutionPlan(mvm_core::protocol::signing::SignedPayload {
+            payload,
+            signature: signature.to_bytes().to_vec(),
+            signer_id: "fleet-prod".to_string(),
+        });
+
+        let err = admit(&signed, &InMemoryNonceLedger::new())
+            .expect_err("a signed plan whose id does not address its content must be refused");
+        assert!(
+            format!("{err:#}").contains("plan_id content-address check"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_grant_over_the_host_ceiling_is_refused() {
+        // The fleet's signature does not widen host policy: the ceiling the
+        // operator configured still bounds what an externally-signed plan may
+        // ask for.
+        let (_env, _home) = host_with(MvmConfig {
+            max_cpu_millicores: Some(2000),
+            trusted_plan_signers: vec![pin_for("fleet-prod", &fleet_key())],
+            ..MvmConfig::default()
+        });
+        let plan = PlanFixture::new()
+            .grants(Some(mvm_contract::grants::Grants {
+                cpu: Some(mvm_contract::grants::CpuGrant::Share { millicores: 64_000 }),
+                ..mvm_contract::grants::Grants::default()
+            }))
+            .build();
+        let signed = signed_by_fleet(&plan);
+
+        let err = admit(&signed, &InMemoryNonceLedger::new())
+            .expect_err("a grant above the host's ceiling must not be admitted");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("ceiling"), "{msg}");
+        assert!(msg.contains("64000") && msg.contains("2000"), "{msg}");
+    }
+
+    #[test]
+    fn a_malformed_pin_refuses_admission() {
+        // A pin the operator mistyped fails the whole load — admission never
+        // runs against a silently-truncated trust set.
+        let (_env, _home) = host_pinning(vec![TrustedPlanSigner {
+            signer_id: "fleet-prod".to_string(),
+            ed25519_pubkey_hex: "not-hex".to_string(),
+        }]);
+        let signed = signed_by_fleet(&PlanFixture::new().build());
+
+        let err = admit(&signed, &InMemoryNonceLedger::new())
+            .expect_err("a malformed pin must refuse admission");
+        assert!(format!("{err:#}").contains("fleet-prod"), "got: {err:#}");
     }
 }

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -17,6 +17,12 @@
 //! facade grew a way to say it: an egress *grant* is carried, and the launch
 //! config's policy is derived from it, so the plan the boot was signed under
 //! and the policy the gate reads come from one authored value.
+//!
+//! One request shape skips synthesis: a `LocalRunRequest` carrying a
+//! `signed_plan` admits that externally-signed envelope instead — verified
+//! against the operator-pinned `trusted_plan_signers`, never re-signed under
+//! the host key — with the plan body (not the request's sizing fields) as the
+//! authority for what boots.
 
 use std::path::{Path, PathBuf};
 
@@ -75,6 +81,16 @@ pub struct LocalRunRequest {
     /// `None` keeps the pre-grant baseline: no CPU cap, no wall-clock bound,
     /// deny-all egress.
     pub grants: Option<mvm_contract::grants::Grants>,
+    /// An externally-signed plan to admit instead of synthesizing and
+    /// self-signing one — a fleet-issued plan whose signer the operator pinned
+    /// in the host config's `trusted_plan_signers`.
+    ///
+    /// When present, the plan is the authority: sizing, grants, and teardown
+    /// intent come from it (the `cpus` / `mem_mib` / `grants` /
+    /// `destroy_on_exit` fields above are not consulted), and the resolved
+    /// rootfs must hash to the plan's pinned image digest. `None` is every
+    /// ordinary local run, which synthesizes its plan as before.
+    pub signed_plan: Option<mvm_core::plan::SignedExecutionPlan>,
 }
 
 /// Admission substrate for a local run: the clock and replay ledger that drive
@@ -153,9 +169,11 @@ pub(crate) fn attach_runtime_overlay_from_cache(
 
 /// Admit `req` through the signed-plan gate and boot it on `backend`.
 ///
-/// On success the plan was signed under the host key, verified, inside its
-/// validity window, and non-replayed before the backend saw a single byte of
-/// launch config. Any failure returns with no VM created.
+/// On success the plan was either synthesized here and signed under the host
+/// key, or — when `req.signed_plan` carries a fleet-issued envelope — verified
+/// against the operator-pinned `trusted_plan_signers`; in both cases it was
+/// verified, inside its validity window, and non-replayed before the backend
+/// saw a single byte of launch config. Any failure returns with no VM created.
 pub fn admit_and_boot_local(
     backend: &AnyBackend,
     req: &LocalRunRequest,
@@ -163,6 +181,13 @@ pub fn admit_and_boot_local(
 ) -> Result<StartedMachine> {
     let sha = mvm_core::crypto::image_verify::sha256_file_cached(&req.rootfs_path)
         .with_context(|| format!("hashing rootfs at {}", req.rootfs_path.display()))?;
+
+    // An externally-signed plan takes the other admission door: verified
+    // against the operator-pinned signer set, never synthesized or re-signed
+    // under the host key.
+    if let Some(signed) = req.signed_plan.as_ref() {
+        return admit_signed_and_boot_local(backend, req, signed, &sha, ctx);
+    }
 
     // Pin the kernel into the signed plan. Deliberately the uncached digest: a
     // path+mtime-keyed cache can hand back a stale hash, which for an integrity
@@ -265,6 +290,86 @@ pub fn admit_and_boot_local(
     )
 }
 
+/// Admit an externally-signed plan through
+/// [`crate::plan_admission::admit_signed_plan_for_run`] and boot it on
+/// `backend` — the local-run tail for the fleet-issued seam.
+///
+/// The admitted plan, not the request, decides what runs: sizing, grants, and
+/// teardown intent are read from the verified plan body, and the resolved
+/// rootfs must hash to the image digest the plan pins — otherwise the host
+/// would be booting bytes the signer never authorized. The caller's
+/// `cpus`/`mem_mib`/`grants`/`destroy_on_exit` are not consulted here;
+/// `admit_and_boot_local` only routes here when `req.signed_plan` is set.
+fn admit_signed_and_boot_local(
+    backend: &AnyBackend,
+    req: &LocalRunRequest,
+    signed: &mvm_core::plan::SignedExecutionPlan,
+    rootfs_sha: &str,
+    ctx: LocalRunContext<'_>,
+) -> Result<StartedMachine> {
+    use crate::plan_admission::{RunPosture, StartAdmittedParams, start_admitted};
+
+    let posture = RunPosture::on_backend(mvm_core::plan::Variant::Dev, backend.kind());
+    let admitted = crate::plan_admission::admit_signed_plan_for_run(
+        signed, ctx.clock, ctx.ledger, None, posture,
+    )?;
+    let plan = admitted.plan();
+
+    // The plan pins the workload image by digest; the resolved rootfs must BE
+    // that image. Synthesized plans get this by construction (synthesis stamps
+    // the hash it just measured); an externally-signed plan gets it by
+    // comparison.
+    if rootfs_sha != plan.image.sha256 {
+        anyhow::bail!(
+            "the signed plan pins image sha256 {} but the resolved rootfs at {} hashes to \
+             {rootfs_sha}; refusing to boot an image the plan does not authorize",
+            plan.image.sha256,
+            req.rootfs_path.display(),
+        );
+    }
+
+    let path_string = |p: &Path| p.to_string_lossy().into_owned();
+    let mut config = VmStartConfig {
+        name: req.name.clone(),
+        rootfs_path: path_string(&req.rootfs_path),
+        kernel_path: req.kernel_path.as_deref().map(path_string),
+        verity_path: req.verity_path.as_deref().map(path_string),
+        roothash: req.roothash.clone(),
+        cpus: plan.resources.cpus,
+        memory_mib: u32::try_from(plan.resources.mem_mib)
+            .context("plan memory does not fit the launch config")?,
+        volumes: req.volumes.clone(),
+        tenant_id: Some(plan.tenant.0.clone()),
+        // The plan's egress grant projects onto the launch config's policy,
+        // exactly as a synthesized plan's does: what the gate enforces is what
+        // the plan was signed for. No grant means deny-all.
+        network_policy: match plan.grants.as_ref() {
+            Some(grants) if grants.egress.is_some() => {
+                mvm_contract::grants::projection::network_policy_from_grants(grants)
+            }
+            _ => mvm_core::network_policy::NetworkPolicy::deny_all(),
+        },
+        ..Default::default()
+    };
+    attach_runtime_overlay_from_cache(&mut config, &req.backend_name)?;
+
+    crate::audit::durability::record_admission(
+        ctx.emitter,
+        plan,
+        admitted.signer_id(),
+        crate::audit::durability::AuditDurability::BestEffort,
+    )?;
+
+    start_admitted(StartAdmittedParams {
+        backend,
+        admitted,
+        config,
+        policy_bundle: None,
+        emitter: ctx.emitter,
+        assurance: ctx.assurance,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -298,6 +403,7 @@ mod tests {
             volumes: Vec::new(),
             destroy_on_exit: false,
             grants: None,
+            signed_plan: None,
         };
 
         let started = admit_and_boot_local(
@@ -401,6 +507,7 @@ mod tests {
             }],
             destroy_on_exit: true,
             grants: None,
+            signed_plan: None,
         };
         let started = admit_and_boot_local(
             &backend,
@@ -467,6 +574,7 @@ mod tests {
             }],
             destroy_on_exit: true,
             grants: None,
+            signed_plan: None,
         };
         let err = admit_and_boot_local(
             &backend,
@@ -544,6 +652,7 @@ mod tests {
             volumes: Vec::new(),
             destroy_on_exit: false,
             grants: None,
+            signed_plan: None,
         };
         let err = admit_and_boot_local(
             &backend,
@@ -558,5 +667,137 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("hashing rootfs"));
+    }
+}
+
+#[cfg(test)]
+mod signed_boot_tests {
+    //! The fleet-issued door of the local-run seam, end to end over the
+    //! hermetic mock backend: admit an externally-signed plan and boot it —
+    //! or refuse and boot nothing.
+    use super::*;
+    use crate::plan_admission::SystemClock;
+    use ed25519_dalek::SigningKey;
+    use mvm_core::plan::test_support::PlanFixture;
+    use mvm_core::user_config::{MvmConfig, TrustedPlanSigner};
+    use mvm_core::util::test_env::TestEnv;
+
+    fn fleet_key() -> SigningKey {
+        SigningKey::from_bytes(&[42u8; 32])
+    }
+
+    /// Isolate `MVM_HOME` and write the host config; the trusted-signer set
+    /// lives in operator config, so a test that wants a trusting host has to
+    /// be one.
+    fn host_with(cfg: MvmConfig) -> (TestEnv, tempfile::TempDir) {
+        let home = tempfile::tempdir().unwrap();
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(home.path());
+        mvm_core::user_config::save(&cfg, None).unwrap();
+        (env, home)
+    }
+
+    fn pinned_host() -> (TestEnv, tempfile::TempDir) {
+        host_with(MvmConfig {
+            trusted_plan_signers: vec![TrustedPlanSigner {
+                signer_id: "fleet-prod".to_string(),
+                ed25519_pubkey_hex: hex::encode(fleet_key().verifying_key().as_bytes()),
+            }],
+            ..MvmConfig::default()
+        })
+    }
+
+    /// A request whose signed plan pins the exact bytes of `rootfs`.
+    fn signed_request(
+        name: &str,
+        rootfs: &Path,
+        plan: mvm_core::plan::ExecutionPlan,
+    ) -> LocalRunRequest {
+        LocalRunRequest {
+            name: name.to_string(),
+            rootfs_path: rootfs.to_path_buf(),
+            kernel_path: None,
+            verity_path: None,
+            roothash: None,
+            cpus: 1,
+            mem_mib: 128,
+            backend_name: "mock".into(),
+            volumes: Vec::new(),
+            destroy_on_exit: true,
+            grants: None,
+            signed_plan: Some(mvm_core::plan::sign_plan(&plan, &fleet_key(), "fleet-prod")),
+        }
+    }
+
+    fn boot(req: &LocalRunRequest) -> Result<StartedMachine> {
+        let backend = AnyBackend::from_hypervisor("mock");
+        let ledger = InMemoryNonceLedger::new();
+        admit_and_boot_local(
+            &backend,
+            req,
+            LocalRunContext {
+                clock: &SystemClock,
+                ledger: &ledger,
+                host_signer_keys_dir: None,
+                emitter: None,
+                assurance: None,
+            },
+        )
+    }
+
+    #[test]
+    fn a_fleet_signed_plan_boots_through_the_local_seam() {
+        let (_env, home) = pinned_host();
+        let rootfs = home.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"fleet workload bytes\n").unwrap();
+        let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
+
+        let mut plan = PlanFixture::new()
+            .runtime_profile("mock")
+            .tenant("fleet-tenant")
+            .build();
+        plan.image.sha256 = sha;
+        let req = signed_request("fleet-vm", &rootfs, plan);
+
+        let started = boot(&req).expect("a pinned fleet-signed plan admits and boots");
+        assert_eq!(started.vm_id.0, "fleet-vm");
+        assert_eq!(started.admitted.signer_id(), "fleet-prod");
+        assert_eq!(started.admitted.plan().tenant.0, "fleet-tenant");
+    }
+
+    #[test]
+    fn a_fleet_signed_plan_is_refused_when_the_host_pins_nobody() {
+        let (_env, home) = host_with(MvmConfig::default());
+        let rootfs = home.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"fleet workload bytes\n").unwrap();
+        let sha = mvm_core::crypto::image_verify::sha256_file(&rootfs).unwrap();
+
+        let mut plan = PlanFixture::new().runtime_profile("mock").build();
+        plan.image.sha256 = sha;
+        let req = signed_request("fleet-vm-refused", &rootfs, plan);
+
+        let err = boot(&req).expect_err("an unpinned host must refuse");
+        assert!(
+            format!("{err:#}").contains("pins no trusted plan signers"),
+            "got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_rootfs_that_is_not_the_pinned_image_is_refused() {
+        let (_env, home) = pinned_host();
+        let rootfs = home.path().join("rootfs.ext4");
+        std::fs::write(&rootfs, b"bytes the plan did not authorize\n").unwrap();
+
+        // The plan pins the fixture's digest, not this rootfs's — a validly
+        // signed plan booting different bytes must not pass.
+        let plan = PlanFixture::new().runtime_profile("mock").build();
+        let req = signed_request("fleet-vm-wrong-image", &rootfs, plan);
+
+        let err = boot(&req).expect_err("an image mismatch must refuse the boot");
+        assert!(
+            format!("{err:#}").contains("refusing to boot an image the plan does not authorize"),
+            "got: {err:#}"
+        );
     }
 }

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -740,6 +740,26 @@ default of read-only mounts unless `:rw` is explicit. `--name` is optional: when
 omitted, `machine create` auto-generates a name and prints it (mirroring
 `machine run -d`).
 
+A host can also admit plans it did not synthesize. By default every plan booted
+locally is synthesized and self-signed under the host key at admission time;
+a fleet control plane can instead sign an `ExecutionPlan` itself and have a
+host boot it, when the operator pins the fleet's issuer key in
+`~/.mvm/config/config.toml`:
+
+```toml
+[[trusted_plan_signers]]
+signer_id = "fleet-prod"              # the signer_id the plan envelope names
+ed25519_pubkey_hex = "88a4b2c1046fb3f6a1d3e5c709a2b4d6e8f0a1b3c5d7e9f1a2b4c6d8e0f2a4b6c8"
+```
+
+The list is empty by default and the default is the posture: a host that pins
+nobody refuses every externally-signed plan. Pinning a key delegates plan
+*authorship*, not host policy — the grant ceiling, host budget, validity
+window, replay protection, and content-address check above all still apply to
+an externally-signed plan unchanged, so a fleet signer cannot ask for more
+than the operator's ceiling allows. A pinned entry whose key does not parse
+fails the whole admission rather than being silently skipped.
+
 `machine start`, `machine exec`, `machine shell`, and `machine stop` require the
 named `MachineSpec` to exist first. `machine start` resolves the stored OCI
 image through the normal cache/materialization path, emits the same admission


### PR DESCRIPTION
## What

Hosts can now admit an `ExecutionPlan` signed by an external fleet control plane (e.g. MVMD), instead of only self-signing synthesized plans under the host key.

- `MvmConfig.trusted_plan_signers` (`crates/mvm-core/src/user_config.rs`): operator-pinned `signer_id` + Ed25519 public key pairs. **Empty by default — fail closed**: an unpinned host refuses every externally-signed plan. A malformed pin fails the whole load rather than being silently skipped.
- `admit_signed_plan_for_run` (`crates/mvm-hostd/src/plan_admission.rs`): verifies the envelope against the pinned set — never the host's own key — *before* any policy gate reads the plan body, then runs the identical post-verification tail as the self-signed path (extracted into a shared `finish_admission`): plan-id content-address check, validity window, nonce replay, grant ceiling, host budget. The host remains the final authority over what it boots.
- `LocalRunRequest.signed_plan` / `LaunchRequestBuilder::signed_plan` (`mvm-hostd/src/run.rs`, `mvm-client/src/launch/request.rs`): transient local launches may carry a signed plan; the plan body is the authority for sizing/grants/tenant, and the resolved rootfs must hash to the plan's pinned `image.sha256`. Persistent launches are refused (a persisted spec cannot carry the plan and would silently re-admit under the host key on next start).
- The `MvmClient` trait surface is unchanged.

## Tests

20 new tests: pinned-signer admit, unpinned-host refusal, unknown signer, tampered payload, expired / not-yet-valid window, nonce replay, plan-id mismatch, grant-over-ceiling, malformed pin, signed boot-through on the mock backend, wrong-image refusal, and request-builder validations.

Verified on macOS host with dev-env isolation: `cargo test -p mvm-core -p mvm-hostd -p mvm-client` all green; `cargo clippy -p mvm-core -p mvm-hostd -p mvm-client --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean; `xtask check-no-spec-refs-in-comments` and `check-doc-claims` clean.

Docs: `trusted_plan_signers` documented in the host config reference.