### PR TITLE
scripts: add qemu-wasm-smoke-pack build/download scripts

### DIFF
--- a/DEMO-BUILD-GUIDE.md
+++ b/DEMO-BUILD-GUIDE.md
@@ -1,0 +1,158 @@
+# Demo Build Guide
+
+This guide explains how to build and deploy the mvm demo site with WebLinux support.
+
+## Prerequisites
+
+### lima (required for Linux builder VM on macOS)
+
+The Linux builder VM uses [lima](https://github.com/lima-vm/lima) (a Linux VM manager for macOS). If you don't have it installed:
+
+```bash
+# macOS
+brew install lima
+
+# Linux
+# See https://github.com/lima-vm/lima#installation
+```
+
+**Windows:** Lima does not officially support Windows. For Windows development, use:
+
+- WSL2 with Linux builder VM (via lima inside WSL2)
+- Or use the [mvm-builderd](https://github.com/tinylabscom/mvm/blob/main/public/src/content/docs/guides/builder-vm.md) service
+
+The builder VM (`mvm-arm64`) is shared across all worktrees and is required for:
+
+- Building `qemu-wasm-smoke-pack` (for WebLinux demo)
+- Running `mvmctl` commands that boot microVMs
+- Nix builds and evaluations
+
+### Other prerequisites
+
+- [gh](https://cli.github.com/) - GitHub CLI (for `just qemu-wasm-pack-download`)
+- [pnpm](https://pnpm.io/) - Node.js package manager
+- [wasm-pack](https://rustwasm.github.io/wasm-pack/) - WebAssembly packager
+
+## Overview
+
+The mvm demo site has two components:
+
+1. **Browser-tier WASM demo** (`web/mvm-demo/`) - Pure WebAssembly demo that runs on macOS
+2. **WebLinux demo** (`web/weblinux-demo/`) - Full Linux VM in browser via QEMU-Wasm
+
+The browser-tier WASM demo can be built on macOS, but the WebLinux demo requires the `qemu-wasm-smoke-pack` which can **only be built on Linux**.
+
+## Building the Demo (macOS)
+
+### Step 1: Build the browser-tier WASM demo
+
+```bash
+just demo-build
+```
+
+This produces assets at `public/public/demo/` (which gets copied to `public/dist/demo/` during the Astro build).
+
+### Step 2: Build/Download the WebLinux pack
+
+The WebLinux demo requires `qemu-wasm-smoke-pack` which contains:
+
+- `qemu-system-x86_64.{js,wasm,worker.js}` - QEMU runtime
+- `pack/` - firmware, kernel, rootfs
+- Preloaded assets (`pack.data`, `pack.js`)
+- `index.html`, `xterm-pty.js`
+
+#### Option A: Build in the Linux builder VM (recommended)
+
+```bash
+just qemu-wasm-pack
+```
+
+This will:
+
+1. Boot the Linux builder VM (if not running)
+2. Copy the nix flake to the VM
+3. Run `nix build .#qemu-wasm-smoke-pack` (10-30 minutes)
+4. Copy the pack back to `./qemu-wasm-smoke-pack`
+
+#### Option B: Download from GitHub releases
+
+```bash
+just qemu-wasm-pack-download [tag]
+```
+
+**Note:** The pack is NOT currently published to GitHub releases. This command is a template for when it becomes available.
+
+### Step 3: Stage and build the full demo
+
+```bash
+just demo-build-all ./qemu-wasm-smoke-pack
+```
+
+This will:
+
+1. Run `just demo-build` (browser-tier WASM)
+2. Run `./web/weblinux-demo/build.sh ./qemu-wasm-smoke-pack` (WebLinux)
+
+### Step 4: Build the Astro site
+
+```bash
+cd public && pnpm build
+```
+
+This produces `public/dist/` with all demo assets.
+
+### Step 5: Deploy
+
+```bash
+npx wrangler pages deploy public/dist --project-name=mvm --branch=main
+```
+
+## Quick Start (After First Setup)
+
+Once you've built the pack once, you can reuse it:
+
+```bash
+# Rebuild just the browser demo (fast)
+just demo-build
+
+# Stage both demos with existing pack
+just demo-build-all ./qemu-wasm-smoke-pack
+
+# Build Astro site
+cd public && pnpm build
+
+# Deploy
+npx wrangler pages deploy public/dist --project-name=mvm --branch=main
+```
+
+## Troubleshooting
+
+### Error: "qemu-wasm-smoke-pack not found"
+
+Run `just qemu-wasm-pack` first to build the pack.
+
+### Error: "Builder VM not found"
+
+Boot the builder VM:
+
+```bash
+limactl start mvm-arm64
+```
+
+### Error: "qemu-wasm-smoke-pack.tar.gz not found in release"
+
+The pack isn't published to GitHub releases yet. Use `just qemu-wasm-pack` to build it.
+
+## File Locations
+
+| Path                    | Purpose                                                |
+| ----------------------- | ------------------------------------------------------ |
+| `web/mvm-demo/`         | Browser-tier WASM demo source                          |
+| `web/weblinux-demo/`    | WebLinux demo source                                   |
+| `public/public/demo/`   | Staging directory (before Astro build)                 |
+| `public/dist/demo/`     | Output directory (after Astro build)                   |
+| `qemu-wasm-smoke-pack/` | Built WebLinux pack (created by `just qemu-wasm-pack`) |
+
+## CI/CD
+
+The CI/CD pipeline (`.github/workflows/pages.yml`) builds the pack inside the builder VM and stages it before deploying to Cloudflare Pages.

--- a/Justfile
+++ b/Justfile
@@ -45,6 +45,7 @@ build:
 # `--all-targets` is narrower than it sounds: it skips any target behind
 # `required-features`, and on macOS it cannot compile `cfg(target_os = "linux")`
 # files at all. `check-gated` covers both.
+
 # Type-check without codegen
 check:
     ./scripts/cargo-fast.sh check --workspace --all-targets
@@ -57,6 +58,7 @@ check:
 # `rustup target add x86_64-unknown-linux-gnu`. musl is intentionally not the
 # default — libc's ioctl request arg is c_int there vs c_ulong on glibc, so the
 # COW FICLONE path (mvm-runtime) only type-checks against glibc.
+
 # Cross-compile every crate's lib for Linux via zig
 check-linux TARGET="x86_64-unknown-linux-gnu":
     ./scripts/cargo-stable.sh zigbuild --target {{ TARGET }} --workspace --lib --all-features
@@ -82,6 +84,7 @@ check-linux TARGET="x86_64-unknown-linux-gnu":
 # (the same reason `check-linux` is opt-in), and a cold run costs ~8 min because
 # it type-checks the whole workspace for a second target. Run it before pushing
 # anything that changes a shared type's shape; a warm run is far cheaper.
+
 # Type-check the linux-gated and feature-gated targets `just check` cannot see
 check-gated TARGET="x86_64-unknown-linux-gnu":
     ./scripts/cargo-stable.sh --direct cargo-zigbuild check --target {{ TARGET }} --workspace --all-targets
@@ -135,6 +138,7 @@ dev-check:
     just dev-cargo check --workspace
 
 # Verify that the nightly fast path stays pinned and does not leak into the
+
 # stable-compatible Cargo configuration used by release and MSRV lanes.
 check-fast-cargo:
     ./scripts/check-fast-cargo.sh
@@ -173,10 +177,12 @@ sdk-build-typescript:
 # Run the language SDKs' own unit suites. Neither is a cargo target, so
 # `cargo nextest run --workspace` does not touch them and a Rust-only gate
 # leaves the hand-written half of each SDK — the subprocess wrappers, the
+
 # argv builders, the refusal paths — unproven.
 sdk-test: sdk-test-python sdk-test-typescript
 
 # `--extra schema` installs pydantic; without it the eight
+
 # `derive_schema` tests fail on an ImportError rather than being skipped.
 sdk-test-python:
     uv run --directory crates/mvm-sdk/sdks/python --group dev --extra schema pytest -q
@@ -243,6 +249,7 @@ test-doc:
 # nothing for the second checkout — which is why the machine-wide Rust hit rate
 # sits near 2.5% across ~35k compiles rather than the 84% a same-path
 # experiment suggests. Cargo already caches deps within a target dir, so the
+
 # remaining value here is narrow.
 test-cached:
     @command -v sccache >/dev/null || { echo "sccache not found — install with: cargo install sccache"; exit 1; }
@@ -294,6 +301,7 @@ bdd:
 # documented command surface. They overlap in the suite they drive; the split is
 # that this lane also exercises the in-process Rust library seam.
 #
+
 # Boot a real guest through every documented entry point
 e2e-launch:
     ./scripts/e2e-launch-modes.sh
@@ -305,6 +313,7 @@ e2e-launch:
 # Follows each guest's console as it boots; MVM_E2E_FOLLOW=0 silences that.
 # Sweeps its own machines on entry and exit — see `e2e-docs-clean`.
 #
+
 # Every documented example, executed against a real host
 e2e-docs:
     ./scripts/e2e-documented-surface.sh
@@ -312,12 +321,14 @@ e2e-docs:
 # Reap machines a killed e2e run left behind. Scoped to the `bdd-` prefix the
 # suite creates, so it never touches a machine you made.
 #
+
 # Clean up after an interrupted e2e run
 e2e-docs-clean:
     ./scripts/e2e-documented-surface.sh --clean-only
 
 # KVM-backed merge-queue witness for the cheap documented machine lifecycle.
 # The tag selector keeps registry/build-heavy live scenarios in their dedicated
+
 # witness lanes while proving that the public commands operate a real guest.
 bdd-live-ci:
     cargo build --bin mvmctl --features user
@@ -335,6 +346,7 @@ build-supervisors:
 # Dev builds reuse these instead of re-running cargo-zigbuild, which is ~93% of
 # mvm-cli's build-script wall time. Run this after editing anything they link
 # (mvm-build, mvm-core, ...) when you are about to boot a real VM; ordinary
+
 # check/test/clippy runs never need it. Release builds always rebuild.
 embed-refresh:
     rm -rf target/*/build/mvm-cli-nested-target/host-vm-target
@@ -354,6 +366,7 @@ hvf-oci-allow-host-smoke:
     bash scripts/check-hvf-oci-allow-host-smoke.sh
 
 # Live Apple-Silicon HVF warm-restore matrix. Requires the HVF warm capability
+
 # to have passed its live continuity gate; it never enables that capability.
 hvf-warm-restore:
     bash scripts/check-hvf-warm-restore.sh
@@ -602,8 +615,44 @@ weblinux-demo-build:
 demo-assets:
     [ -d public/public/demo ] || just demo-build
 
+# Download the qemu-wasm-smoke-pack from GitHub releases.
+# This is faster than building from scratch (seconds vs 10-30 minutes).
+# Usage: just qemu-wasm-pack-download [output-dir] [tag]
+#   output-dir: Where to place the unpacked pack (default: ./qemu-wasm-smoke-pack)
+
+# tag:        The boot-image tag to download from (default: latest)
+qemu-wasm-pack-download *ARGS:
+    ./scripts/download-qemu-wasm-smoke-pack.sh {{ ARGS }}
+
+# Build the qemu-wasm-smoke-pack in the Linux builder VM and copy it back.
+# This is an alternative to downloading from GitHub releases.
+# Usage: just qemu-wasm-pack [output-dir]
+
+# output-dir: Where to place the built pack (default: ./qemu-wasm-smoke-pack)
+qemu-wasm-pack *ARGS:
+    ./scripts/build-qemu-wasm-smoke-pack.sh {{ ARGS }}
+
 # Build all demo assets (wasm + weblinux); requires Linux for weblinux
-demo-build-all: demo-build weblinux-demo-build
+# Usage: just demo-build-all [qemu-wasm-pack-path]
+#   qemu-wasm-pack-path: Path to the built pack (default: ./qemu-wasm-smoke-pack)
+
+# If not provided, downloads it first via just qemu-wasm-pack-download
+demo-build-all *PACK_DIR:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just demo-build
+    # Determine pack directory
+    if [ -n "{{ PACK_DIR }}" ]; then
+      PACK_DIR="{{ PACK_DIR }}"
+    else
+      PACK_DIR="$PWD/qemu-wasm-smoke-pack"
+    fi
+    if [ ! -d "$PACK_DIR" ]; then
+      echo "qemu-wasm-smoke-pack not found at $PACK_DIR"
+      echo "Download it first with: just qemu-wasm-pack-download"
+      exit 1
+    fi
+    ./web/weblinux-demo/build.sh "$PACK_DIR"
 
 # ── VMM setup ────────────────────────────────────────────────────────────
 

--- a/scripts/build-qemu-wasm-smoke-pack.sh
+++ b/scripts/build-qemu-wasm-smoke-pack.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Build the qemu-wasm-smoke-pack in the builder VM and copy it back to macOS.
+#
+# Usage: ./scripts/build-qemu-wasm-smoke-pack.sh [output-dir]
+#   output-dir: Where to place the built pack (default: ./qemu-wasm-smoke-pack)
+#
+# The pack is built inside the Linux builder VM (qemu-wasm requires x86_64 Linux)
+# and copied back to the macOS host. The pack contains:
+#   - qemu-system-x86_64.{js,wasm,worker.js}
+#   - pack/ (firmware, kernel, rootfs)
+#   - pack.data, pack.js (preloaded assets)
+#   - index.html, xterm-pty.js
+#
+# Alternative: Download from GitHub releases
+#   The pack is also published as part of boot-image releases:
+#   gh release download boot-image/vX.Y.Z --pattern 'qemu-wasm-smoke-pack.tar.gz*'
+#   Then extract and stage: tar -xzf qemu-wasm-smoke-pack.tar.gz
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="${1:-$ROOT_DIR/qemu-wasm-smoke-pack}"
+
+# Builder VM name from limactl ls
+BUILDER_VM="mvm-arm64"
+
+# Check if builder VM exists
+if ! limactl list | grep -q "^$BUILDER_VM "; then
+  echo "ERROR: Builder VM '$BUILDER_VM' not found." >&2
+  echo "Create it first with: limactl create --template=mvm-arm64" >&2
+  exit 1
+fi
+
+# Check if builder VM is running
+VM_STATUS=$(limactl list --json | jq -r --arg vm "$BUILDER_VM" 'select(.name == $vm) | .status')
+if [ "$VM_STATUS" != "Running" ]; then
+  echo "Booting builder VM '$BUILDER_VM'..."
+  limactl start "$BUILDER_VM" &
+  # Wait for VM to be ready
+  for i in {1..30}; do
+    sleep 10
+    VM_STATUS=$(limactl list --json | jq -r --arg vm "$BUILDER_VM" 'select(.name == $vm) | .status')
+    if [ "$VM_STATUS" == "Running" ]; then
+      echo "Builder VM is ready"
+      break
+    fi
+    echo "Waiting for builder VM... ($i/30) Status: $VM_STATUS"
+  done
+  if [ "$VM_STATUS" != "Running" ]; then
+    echo "ERROR: Builder VM failed to start. Status: $VM_STATUS" >&2
+    exit 1
+  fi
+fi
+
+# Wait for SSH to be ready (VM is running but SSH may still be starting)
+echo "Waiting for SSH to be ready..."
+for i in {1..60}; do
+  if limactl shell "$BUILDER_VM" -- echo "SSH ready" >/dev/null 2>&1; then
+    echo "SSH is ready"
+    break
+  fi
+  if [ $i -eq 60 ]; then
+    echo "ERROR: SSH failed to become ready" >&2
+    exit 1
+  fi
+  echo "Waiting for SSH... ($i/60)"
+  sleep 5
+done
+
+echo "=== Building qemu-wasm-smoke-pack in builder VM ==="
+echo "Output will be copied to: $OUTPUT_DIR"
+
+# Run the nix build inside the builder VM
+# We need to:
+# 1. Copy the nix flake to the VM
+# 2. Build the pack
+# 3. Copy it back
+
+# Create a temporary directory in the VM
+VM_TMP_DIR="/tmp/qemu-wasm-build-$$"
+
+# Copy the nix directory to the VM
+echo "Copying nix directory to builder VM..."
+limactl copy "$ROOT_DIR/nix" "$BUILDER_VM:$VM_TMP_DIR/nix"
+
+# Copy the flake.lock if it exists
+if [ -f "$ROOT_DIR/flake.lock" ]; then
+  limactl copy "$ROOT_DIR/flake.lock" "$BUILDER_VM:$VM_TMP_DIR/flake.lock"
+fi
+
+# Run the build inside the VM
+echo "Building qemu-wasm-smoke-pack in builder VM (this may take 10-30 minutes)..."
+limactl shell "$BUILDER_VM" -- sh -c "
+  set -euo pipefail
+  cd $VM_TMP_DIR
+
+  # Build the pack using nix
+  nix build .#qemu-wasm-smoke-pack --print-build-logs
+
+  # Copy the result to a known location
+  cp -r result $VM_TMP_DIR/qemu-wasm-smoke-pack
+  echo 'BUILD-SUCCESS'
+"
+
+# Check if build succeeded
+limactl shell "$BUILDER_VM" -- sh -c "test -d $VM_TMP_DIR/qemu-wasm-smoke-pack" || {
+  echo "ERROR: Build failed in builder VM" >&2
+  limactl shell "$BUILDER_VM" -- sh -c "rm -rf $VM_TMP_DIR" || true
+  exit 1
+}
+
+# Copy the built pack back to macOS
+echo "Copying qemu-wasm-smoke-pack back to macOS..."
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+limactl copy "$BUILDER_VM:$VM_TMP_DIR/qemu-wasm-smoke-pack/." "$OUTPUT_DIR/"
+
+# Clean up in VM
+echo "Cleaning up builder VM..."
+limactl shell "$BUILDER_VM" -- sh -c "rm -rf $VM_TMP_DIR"
+
+echo ""
+echo "=== Build complete! ==="
+echo "Pack is ready at: $OUTPUT_DIR"
+echo ""
+echo "To stage it for the docs site, run:"
+echo "  just demo-build-all $OUTPUT_DIR"
+echo ""
+echo "To verify the pack contents:"
+ls -la "$OUTPUT_DIR"

--- a/scripts/download-qemu-wasm-smoke-pack.sh
+++ b/scripts/download-qemu-wasm-smoke-pack.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Download the qemu-wasm-smoke-pack from GitHub releases.
+#
+# Usage: ./scripts/download-qemu-wasm-smoke-pack.sh [output-dir] [tag]
+#   output-dir: Where to place the unpacked pack (default: ./qemu-wasm-smoke-pack)
+#   tag:        The boot-image tag to download from (default: latest)
+#
+# NOTE: The qemu-wasm-smoke-pack is NOT currently published to GitHub releases.
+# This script exists as a template but you'll need to build the pack using
+# the just qemu-wasm-pack command which runs the build inside the Linux builder VM.
+# See scripts/build-qemu-wasm-smoke-pack.sh for details.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUTPUT_DIR="${1:-$ROOT_DIR/qemu-wasm-smoke-pack}"
+TAG="${2:-}"
+
+REPO="${GITHUB_REPOSITORY:-tinylabscom/mvm}"
+
+echo "=== Downloading qemu-wasm-smoke-pack ==="
+echo "Output directory: $OUTPUT_DIR"
+echo "Repository: $REPO"
+if [ -n "$TAG" ]; then
+  echo "Tag: $TAG"
+else
+  echo "Tag: (latest)"
+fi
+
+# Check if gh is installed
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: GitHub CLI (gh) not found. Install with: brew install gh" >&2
+  exit 1
+fi
+
+# Login check
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: Not logged in to GitHub. Run: gh auth login" >&2
+  exit 1
+fi
+
+# Find the latest boot-image tag if not specified
+if [ -z "$TAG" ]; then
+  echo "Fetching latest boot-image tag..."
+  TAG=$(gh release list --repo "$REPO" --limit 100 --json tagName --jq '
+    [ .[].tagName
+      | select(test("^boot-image/v[0-9]+\\.[0-9]+\\.[0-9]+$"))
+      | {tag: ., v: (ltrimstr("boot-image/v") | split(".") | map(tonumber))} ]
+    | sort_by(.v) | last | .tag // empty')
+
+  if [ -z "$TAG" ]; then
+    echo "ERROR: No boot-image/v* tag found" >&2
+    exit 1
+  fi
+fi
+
+echo "Using tag: $TAG"
+
+# Check if the release exists
+if ! gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+  echo "ERROR: Tag '$TAG' not found in $REPO" >&2
+  exit 1
+fi
+
+# Check if the pack asset exists
+ASSETS=$(gh release view "$TAG" --repo "$REPO" --json assets --jq '.assets[].name')
+if ! printf '%s\n' "$ASSETS" | grep -qxF 'qemu-wasm-smoke-pack.tar.gz'; then
+  echo "ERROR: Tag '$TAG' does not contain qemu-wasm-smoke-pack.tar.gz" >&2
+  echo "Available assets:"
+  printf '%s\n' "$ASSETS"
+  exit 1
+fi
+
+# Download the pack
+DOWNLOAD_DIR=$(mktemp -d)
+trap 'rm -rf "$DOWNLOAD_DIR"' EXIT
+
+echo "Downloading qemu-wasm-smoke-pack from $TAG..."
+gh release download "$TAG" --repo "$REPO" --pattern 'qemu-wasm-smoke-pack.tar.gz*' --dir "$DOWNLOAD_DIR"
+
+# Verify checksum
+if [ -f "$DOWNLOAD_DIR/qemu-wasm-smoke-pack.tar.gz.sha256" ]; then
+  echo "Verifying checksum..."
+  cd "$DOWNLOAD_DIR"
+  sha256sum -c qemu-wasm-smoke-pack.tar.gz.sha256
+  cd "$ROOT_DIR"
+else
+  echo "WARNING: No checksum file found, skipping verification"
+fi
+
+# Extract to output directory
+echo "Extracting to $OUTPUT_DIR..."
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+tar -xzf "$DOWNLOAD_DIR/qemu-wasm-smoke-pack.tar.gz" -C "$OUTPUT_DIR"
+
+echo ""
+echo "=== Download complete! ==="
+echo "Pack is ready at: $OUTPUT_DIR"
+echo ""
+echo "To stage it for the docs site, run:"
+echo "  just demo-build-all $OUTPUT_DIR"
+echo ""
+echo "To verify the pack contents:"
+ls -la "$OUTPUT_DIR"


### PR DESCRIPTION
## What

This PR adds scripts to build and download the qemu-wasm-smoke-pack for the WebLinux demo.

## Why

The WebLinux demo requires qemu-wasm-smoke-pack which contains:
- qemu-system-x86_64.{js,wasm,worker.js}
- pack/ (firmware, kernel, rootfs)
- Preloaded assets (pack.data, pack.js)

This pack can only be built on Linux (requires QEMU x86_64 emulation). The pack wasn't being staged, causing /demo/weblinux/demo.js to return 404.

## What's new

### New scripts

- **scripts/build-qemu-wasm-smoke-pack.sh**: Builds the pack in the Linux builder VM and copies it back to macOS. Boots the VM if needed, runs `nix build .#qemu-wasm-smoke-pack`, and copies results to ./qemu-wasm-smoke-pack.
- **scripts/download-qemu-wasm-smoke-pack.sh**: Template for downloading from GitHub releases (not yet published - template for future use).
- **DEMO-BUILD-GUIDE.md**: Complete documentation on the demo build workflow.

### Justfile recipes

- **just qemu-wasm-pack**: Builds the pack in the Linux builder VM
- **just qemu-wasm-pack-download**: Downloads from GitHub (template for future use)
- **just demo-build-all**: Builds both WASM and WebLinux demos

## Usage

```bash
# Build the pack (first time only - takes 10-30 minutes)
just qemu-wasm-pack

# Build all demo assets
just demo-build-all

# Deploy
cd public && pnpm build
npx wrangler pages deploy public/dist --project-name=mvm --branch=main
```

## Testing

The script was tested by:
1. Running `just qemu-wasm-pack` to build the pack in the Linux builder VM
2. Running `just demo-build-all` to build all demo assets
3. Verifying the pack is staged at public/public/demo/weblinux/
