### PR TITLE
fix(exec): apply image environment to ad hoc commands

### DIFF
--- a/crates/mvm-agentd/src/exec_stream.rs
+++ b/crates/mvm-agentd/src/exec_stream.rs
@@ -2,9 +2,11 @@
 //! `ExecEvent` chunks via an `emit` closure as the child produces output,
 //! returning the terminal `Exit`. The wire-writing lives in the agent bin
 //! (`do_exec_streaming`); this core is closure-driven so it is unit-
-//! testable without a vsock `File`. Mirrors `process_rpc::spawn_drain` +
-//! the `handle_proc_wait` sleep-poll loop (the in-repo streaming idiom —
-//! mvm-guest has no `libc::poll` usage).
+//! testable without a vsock `File`. Commands inherit the agent environment,
+//! then apply the image's declared environment and working directory through
+//! the shared workload resolver. Mirrors `process_rpc::spawn_drain` + the
+//! `handle_proc_wait` sleep-poll loop (the in-repo streaming idiom — mvm-guest
+//! has no `libc::poll` usage).
 use crate::vsock::ExecEvent;
 use std::io::{Read, Write};
 #[cfg(unix)]
@@ -17,6 +19,30 @@ use std::time::{Duration, Instant};
 /// (was `MAX_EXEC_OUTPUT` in the agent bin).
 pub const MAX_EXEC_OUTPUT: usize = 1024 * 1024;
 const DRAIN_BUF: usize = 4096;
+
+fn resolve_exec_environment() -> crate::workload_env::WorkloadEnvironment {
+    resolve_exec_environment_from(
+        std::env::vars_os(),
+        crate::workload_env::ImageRuntimeConfig::load(),
+    )
+}
+
+fn resolve_exec_environment_from<I>(
+    vars: I,
+    image: Result<crate::workload_env::ImageRuntimeConfig, String>,
+) -> crate::workload_env::WorkloadEnvironment
+where
+    I: IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+{
+    let image = image.unwrap_or_else(|error| {
+        eprintln!("mvm-guest-agent: ignoring unreadable image runtime config: {error}");
+        crate::workload_env::ImageRuntimeConfig::default()
+    });
+    crate::workload_env::WorkloadEnvironment::builder()
+        .inherit(vars)
+        .image(&image)
+        .build()
+}
 
 fn spawn_drain<R: Read + Send + 'static>(
     mut reader: R,
@@ -96,13 +122,26 @@ pub fn stream_exec<F: FnMut(ExecEvent)>(
     command: &str,
     stdin_data: Option<&str>,
     timeout_secs: Option<u64>,
+    emit: F,
+) -> ExecEvent {
+    let environment = resolve_exec_environment();
+    stream_exec_with_environment(command, stdin_data, timeout_secs, &environment, emit)
+}
+
+fn stream_exec_with_environment<F: FnMut(ExecEvent)>(
+    command: &str,
+    stdin_data: Option<&str>,
+    timeout_secs: Option<u64>,
+    environment: &crate::workload_env::WorkloadEnvironment,
     mut emit: F,
 ) -> ExecEvent {
     let mut builder = Command::new("/bin/sh");
     builder
         .arg("-c")
         .arg(command)
-        .env("HOME", crate::guest_mount::workload_home())
+        .env_clear()
+        .envs(environment.vars())
+        .current_dir(environment.working_dir())
         .stdin(if stdin_data.is_some() {
             Stdio::piped()
         } else {
@@ -225,6 +264,73 @@ mod tests {
     use super::*;
     #[cfg(unix)]
     use libc;
+
+    fn stdout(events: &[ExecEvent]) -> Vec<u8> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                ExecEvent::Stdout { chunk } => Some(chunk.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect()
+    }
+
+    #[test]
+    fn ad_hoc_exec_resolves_a_bare_command_from_the_image_path() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().expect("temporary image bin directory");
+        let executable = temp.path().join("image-python");
+        std::fs::write(&executable, "#!/bin/sh\nprintf image-path\n")
+            .expect("write image-only executable");
+        let mut permissions = std::fs::metadata(&executable)
+            .expect("image-only executable metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&executable, permissions)
+            .expect("mark image-only executable runnable");
+
+        let image = crate::workload_env::ImageRuntimeConfig {
+            argv: Vec::new(),
+            env: vec![format!("PATH={}", temp.path().display())],
+            working_dir: None,
+        };
+        let environment = resolve_exec_environment_from(
+            [(
+                std::ffi::OsString::from("PATH"),
+                std::ffi::OsString::from("/agent/bin"),
+            )],
+            Ok(image),
+        );
+        let mut events = Vec::new();
+        let terminal =
+            stream_exec_with_environment("image-python", None, None, &environment, |event| {
+                events.push(event)
+            });
+
+        assert!(matches!(terminal, ExecEvent::Exit { code: 0 }));
+        assert_eq!(stdout(&events), b"image-path");
+    }
+
+    #[test]
+    fn unreadable_image_environment_falls_back_to_the_agent_environment() {
+        let environment = resolve_exec_environment_from(
+            [(
+                std::ffi::OsString::from("PATH"),
+                std::ffi::OsString::from("/agent/bin"),
+            )],
+            Err("malformed fixture".to_string()),
+        );
+        let vars = environment
+            .vars()
+            .map(|(key, value)| (key.to_owned(), value.to_owned()))
+            .collect::<Vec<_>>();
+
+        assert!(vars.iter().any(|(key, value)| {
+            key == std::ffi::OsStr::new("PATH") && value == std::ffi::OsStr::new("/agent/bin")
+        }));
+    }
 
     #[test]
     fn streams_stdout_then_exit_zero() {

--- a/crates/mvm-agentd/src/workload_env.rs
+++ b/crates/mvm-agentd/src/workload_env.rs
@@ -5,12 +5,12 @@
 //! rootfs at [`CONFIG_PATH`]; this module is the only place the guest reads it
 //! back, and the only place a workload environment is assembled.
 //!
-//! Both ways into a workload go through it. The entrypoint runner execs the
-//! declared argv; the interactive console starts a shell. They differ in two
-//! narrow ways — the console inherits the agent's own vars and describes a
-//! terminal — and agree on everything else, which is the point: a second
-//! resolver is exactly how `machine run --image rust:latest -it` came to land
-//! in a shell whose `PATH` was missing the image's own `/usr/local/cargo/bin`.
+//! Every way into a workload goes through it. The entrypoint runner execs the
+//! declared argv; ad-hoc exec runs a supplied command; the interactive console
+//! starts a shell. The latter two inherit the agent's own vars, and only the
+//! console describes a terminal. They agree on everything else, which is the
+//! point: a second resolver is exactly how an image command can land in an
+//! environment whose `PATH` is missing the image's own tools.
 
 use std::ffi::{CString, OsStr, OsString};
 use std::path::Path;

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -43,6 +43,13 @@ for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
 
+- [x] **Issue #2951 — ad-hoc exec honors the image environment.** Streaming
+      exec now uses the shared workload resolver, so image-declared `PATH`,
+      variables, and working directory reach `run -- <cmd>` while inherited
+      agent variables and the writable workload `HOME` retain their established
+      semantics. An unreadable image config degrades to the prior behavior. See
+      `specs/sprint/delivery/2951-ad-hoc-exec-image-environment.md`.
+
 - [x] **Issue #2887 — guest RPC refusals and SDK live-profile propagation.**
       Filesystem and process unary calls now preserve universal policy
       refusals as typed errors. The live SDK carries an explicitly selected

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3145,6 +3145,18 @@ to the configured ceiling and the first terse response immediately after it.
 - [x] Record the delivery in
       `specs/sprint/delivery/2887-guest-rpc-refusals.md`.
 
+## 2026-08-27 ad-hoc exec image environment
+
+- [x] Reproduce the bare-command failure with an executable available only on
+      the image-declared `PATH`.
+- [x] Route streaming exec through the shared image environment resolver while
+      retaining inherited agent variables and the forced writable `HOME`.
+- [x] Preserve the prior behavior when the image runtime configuration is
+      absent or unreadable.
+- [x] Retain the existing live Python service-plane scenarios as the end-to-end
+      witness and record delivery in
+      `specs/sprint/delivery/2951-ad-hoc-exec-image-environment.md`.
+
 ## Follow-up (not started) — repository-to-signed-workload generator
 
 Prompted by the same 2026-08-25 survey of a commercial enterprise

--- a/specs/plans/2026-08-27-ad-hoc-exec-image-environment.md
+++ b/specs/plans/2026-08-27-ad-hoc-exec-image-environment.md
@@ -1,0 +1,31 @@
+Backing: shipped-source
+Validation: check-sprint-append
+
+# Ad-hoc exec image environment
+
+`mvmctl run --runtime python -- python script.py` reaches the guest through
+the streaming exec path. That path inherited the guest agent's environment and
+forced only `HOME`; unlike the OCI entrypoint and interactive console paths, it
+did not read the image runtime configuration. A bare command therefore could
+not resolve an interpreter installed outside the agent's own `PATH`.
+
+The repair keeps ad-hoc exec's existing inheritance semantics, applies the
+image environment and working directory through the shared
+`WorkloadEnvironment` resolver, and then clears the child command before
+installing the resolved values. An unreadable or absent image configuration
+retains the previous agent-environment behavior rather than refusing exec.
+
+## Delivery
+
+- [x] Add a regression that executes a bare command available only on the
+      image-declared `PATH`.
+- [x] Resolve streaming exec through the existing workload-environment builder
+      with image values taking precedence over inherited agent values.
+- [x] Preserve graceful fallback when the image runtime configuration cannot
+      be read.
+- [x] Pass the focused tests and repository validation gates.
+- [x] Record the repair in the sprint, delivery note, and refactor rollup.
+
+The existing live `host.kv.v1` and `host.time.v1` scenarios remain the
+end-to-end witnesses: both launch the official Python runtime and invoke
+`python /work/fixtures/kv_roundtrip.py` by its bare image command.

--- a/specs/sprint/delivery/2951-ad-hoc-exec-image-environment.md
+++ b/specs/sprint/delivery/2951-ad-hoc-exec-image-environment.md
@@ -1,0 +1,35 @@
+# Ad-hoc exec image environment
+
+Issue #2951 exposed a split in the guest's execution contract. OCI entrypoints
+and console sessions resolved the image's declared environment, while
+streaming ad-hoc exec inherited only the guest agent environment. The official
+Python image installs its interpreter in `/usr/local/bin`, so a documented
+`run --runtime python -- python ...` launch exited 127 even though the same
+image's entrypoint could find Python.
+
+Streaming exec now uses the existing `WorkloadEnvironment` builder. Agent
+variables are inherited first, image variables override them, `HOME` remains
+forced to the writable workload home, and the image working directory is
+honored. The spawned shell receives only this resolved environment. If the
+runtime configuration is absent or unreadable, exec logs the non-sensitive
+read error and falls back to the prior inherited environment.
+
+The focused regression creates an executable that is reachable only through
+the image-declared `PATH` and proves a bare command runs. A second regression
+proves an unreadable configuration retains the agent's `PATH`. The existing
+live service-plane scenarios provide the end-to-end Python witness.
+
+Validation:
+
+- `cargo test -p mvm-agentd exec_stream::tests`
+- `cargo fmt --all -- --check`
+- `cargo check --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `cargo test --workspace` (all unit and integration targets passed; the
+  transient `mvm-cli` rustdoc artifact lookup was rerun directly and passed)
+- `cargo test -p mvm-cli --doc`
+- `cargo check -p mvm-conformance --test conformance --features bdd`
+- `cargo run -p xtask -- check-declared-backing`
+- `cargo run -p xtask -- check-sprint-append`
+- `cargo run -p xtask -- check-single-workload-env`
+- `cargo run -p xtask -- check-no-spec-refs-in-comments`


### PR DESCRIPTION
## Summary

- resolve streaming ad-hoc exec through the existing workload environment builder
- let the image override inherited agent variables and apply its working directory while retaining the forced writable workload home
- fall back to the prior inherited environment when the image runtime configuration is unreadable
- add a regression that executes a bare command available only on the image-declared `PATH`

## Validation

- `cargo test -p mvm-agentd exec_stream::tests`
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace` (all unit and integration targets passed)
- `cargo test -p mvm-cli --doc`
- `cargo check -p mvm-conformance --test conformance --features bdd`
- `cargo run -p xtask -- check-declared-backing`
- `cargo run -p xtask -- check-sprint-append`
- `cargo run -p xtask -- check-single-workload-env`
- `cargo run -p xtask -- check-no-spec-refs-in-comments`

Closes #2951
