### PR TITLE
docs: correct claims the docs make about the CLI, SDK, and backends

### DIFF
--- a/features/suites/s29_doc_examples/tiers.toml
+++ b/features/suites/s29_doc_examples/tiers.toml
@@ -50,6 +50,21 @@ path = "cache repair"
 tier = "exec"
 
 [[command]]
+path = "capture project"
+tier = "parse"
+reason = "needs a caller-owned project tree and writes a capture report"
+
+[[command]]
+path = "capture resolve"
+tier = "parse"
+reason = "needs a capture report produced from a caller-owned project tree"
+
+[[command]]
+path = "capture verify"
+tier = "parse"
+reason = "writes rendered artifacts and its optional modes boot the Linux builder VM"
+
+[[command]]
 path = "catalog list"
 tier = "exec"
 

--- a/public/src/content/docs/console/attach.md
+++ b/public/src/content/docs/console/attach.md
@@ -27,6 +27,9 @@ mvmctl machine exec devbox -- id
 mvmctl machine proc start devbox -- python /work/task.py
 ```
 
+`machine proc` is an advanced verb: it works, but it is hidden from
+`machine --help`.
+
 ## Attach behavior
 
 Console behavior depends on the active backend, image mode, and launch policy:

--- a/public/src/content/docs/console/index.md
+++ b/public/src/content/docs/console/index.md
@@ -41,9 +41,12 @@ but not an interactive session. Use `mvmctl machine exec` for normal automation.
 | --- | --- |
 | Human debugging | `mvmctl machine console <name>` |
 | Scripted command execution | `mvmctl machine exec <name> -- <cmd>` |
-| Process lifecycle control | `mvmctl machine proc start/list/wait/kill` |
+| Process lifecycle control | `mvmctl machine proc start/ls/wait/kill` |
 | File transfer | `mvmctl machine fs` or `mvmctl machine cp` |
 | Service logs | `mvmctl machine logs <name>` |
+
+`machine proc`, `machine fs`, and `machine cp` are advanced verbs: they work,
+but they are hidden from `machine --help`.
 
 ## Related pages
 

--- a/public/src/content/docs/contributing/adding-an-arch-or-backend.md
+++ b/public/src/content/docs/contributing/adding-an-arch-or-backend.md
@@ -3,7 +3,7 @@ title: Adding an architecture or backend
 description: How to extend the architecture-aware artifact model with a new CPU architecture or microVM backend.
 ---
 
-The artifact model (Plan 134) is **data-driven on purpose**: architecture and
+The artifact model is **data-driven on purpose**: architecture and
 backend capabilities live in typed enums and one compatibility table, so adding
 support is a small, local change — validation and config generation pick it up
 automatically because they both read the same table. You should never have to
@@ -87,9 +87,14 @@ no current backend needs it.
 
 ## What stays out of scope
 
-Production rootfs images are built **inside the builder VM** (`mke2fs`,
-ADR-017) — the artifact model validates and configures them, it does not build
-ext4 on the host. Pure-Rust host-side rootfs creation, QEMU/vfkit config
-writers, dynamic boot smoke-tests, and `microvm.nix` integration are tracked as
-their own follow-up slices (see `specs/plans/134-architecture-aware-artifact-model.md`
-§"Out of scope").
+The artifact model validates and configures rootfs images; it does not build
+them. Building is a separate seam, and pure-Rust host-side ext4 creation has
+**shipped** — `mvm_build::rootfs::materialize_ext4_pure` writes a mountable ext4
+image in-process with no `mkfs` and no subprocess, and is the default path.
+ADR-004 supersedes ADR-017's builder-VM `mke2fs` mechanism while preserving its
+roothash guarantee; the builder VM remains the automatic fallback for trees the
+pure writer cannot faithfully emit (for example ones carrying
+`security.capability` xattrs).
+
+Still out of scope for the artifact model: QEMU/vfkit config writers, dynamic
+boot smoke-tests, and `microvm.nix` integration.

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -13,12 +13,12 @@ description: Getting started as a contributor to mvm.
 ### Do I need to install libkrun?
 
 It depends on your machine. The builder VM (the headless Linux guest that runs
-`nix build` inside `mvmctl machine build` / `mvmctl machine build` / `mvmctl machine
-run`) auto-selects its host VMM:
+`nix build` inside `mvmctl machine build` / `mvmctl machine run`) auto-selects
+its host VMM:
 
 | Host | libkrun (`slp/krun/*`) needed? |
 |---|---|
-| macOS 26+ Apple Silicon | **No** — auto-detect picks the **HVF** builder (Hypervisor.framework, ships with the OS, no Homebrew deps); mvm transparently retries with libkrun if HVF fails to create its VM (ADR-093 auto-fallback). |
+| macOS 26+ Apple Silicon | **No** — auto-detect picks the **HVF** builder (Hypervisor.framework, ships with the OS, no Homebrew deps); mvm transparently retries with libkrun if HVF fails to create its VM (the ADR-007 builder auto-fallback). |
 | macOS 13–25 Apple Silicon | **Yes** — `brew install slp/krun/libkrun slp/krun/libkrunfw`. |
 | Linux + `/dev/kvm` | **No** — auto-detect picks the **QEMU** builder, so libkrun is not part of the default builder path on native Linux hosts. |
 
@@ -130,8 +130,7 @@ Notes:
   Stage 0 is libkrun-backed even on HVF-default hosts.
 - Editing `base.nix` or a variant delta? Just re-run the command — a
   custom config always compiles locally; downloads only ever return the
-  kernel that shipped with that exact `mvmctl` release. See ADR-046
-  §"Amendment: kernel acquisition".
+  kernel that shipped with that exact `mvmctl` release.
 
 #### Iterating on the kernel config (slimming, adding a driver)
 
@@ -313,28 +312,31 @@ When adding fields to structs in serialized state:
 Beyond the standard build/test/lint cycle, mvmctl provides commands for managing the dev environment:
 
 ```bash
-# First-time setup (installs deps, creates the dev VM, default network)
-just run -- init
+# First-time host setup (installs deps, stages the builder VM image)
+just run -- bootstrap
+# `init` is a different verb: it scaffolds mvm.toml + flake.nix in a project dir
+just run -- init ./my-app
 
-# Image catalog — browse and build images from Nix templates
-just run -- image list              # browse bundled catalog
-just run -- image search http       # search by name/tag
-just run -- image fetch minimal     # build from catalog entry
+# Bundled image catalog — browse the entries `init --catalog` can scaffold from
+just run -- catalog list            # browse bundled catalog
+just run -- catalog search http     # search by name/tag
+just run -- catalog info minimal    # show one entry
+# (`mvmctl image` is a different namespace: pull/ls/inspect/rm of cached OCI images.)
 
 # Named dev networks
 just run -- network create isolated # create a named network
 just run -- network list            # list all networks
 just run -- machine run --flake .  # attach VM to a network
 
-# Interactive console (PTY-over-vsock, no SSH)
-just run -- console myvm            # interactive shell
-just run -- console myvm --command "uname -a"  # one-shot exec
+# Interactive console (PTY-over-vsock, no SSH) — `console` lives under `machine`
+just run -- machine console myvm            # interactive shell
+just run -- machine console myvm --command "uname -a"  # one-shot exec
 
 # Cache and diagnostics
 just run -- cache info              # show cache dir and disk usage
 just run -- cache prune             # clean stale temp files
-just run -- security status         # security posture evaluation
-just run -- doctor                  # dependency checks
+just run -- doctor                  # dependency checks + security posture
+# There is no `security` verb — plan 40 folded it into `doctor`.
 ```
 
 ### Console Access
@@ -365,7 +367,7 @@ with `MVM_HOME`; `rm -rf ~/.mvm` removes every trace):
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
 | `ci.yml` | Push to main/feat/*, PRs | check, fmt, clippy, test (macOS + Linux), audit |
-| `release.yml` | Tags matching `v*` | Builds 4 platform binaries, creates GitHub Release |
+| `release.yml` | Tags matching `v*` | Builds 3 platform binaries (`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), creates GitHub Release |
 | `publish-crates.yml` | Release published | Publishes to crates.io in dependency order |
 | `pages.yml` | Push to main | Deploys docs to GitHub Pages |
 

--- a/public/src/content/docs/examples/ci-cd-ephemeral-builder.md
+++ b/public/src/content/docs/examples/ci-cd-ephemeral-builder.md
@@ -36,9 +36,10 @@ Avoid caching:
 ## Cleanup
 
 ```sh
-mvmctl machine stop --all
+mvmctl machine stop --all --yes
 mvmctl manifest prune --orphans --dry-run
 mvmctl cache prune --orphan-builds
 ```
 
-Use dry-run first on shared runners.
+Use dry-run first on shared runners. `machine stop --all` refuses to run
+without a confirmation, so a non-interactive job has to pass `--yes`.

--- a/public/src/content/docs/examples/code-interpreter.md
+++ b/public/src/content/docs/examples/code-interpreter.md
@@ -9,12 +9,14 @@ important rule is that user code runs in the guest, not in the host process.
 ## One-shot interpreter
 
 ```sh
-mvmctl run --timeout 10 -- python - <<'PY'
+mvmctl machine run --runtime python --timeout 10 -- python - <<'PY'
 print("hello from inside the sandbox")
 PY
 ```
 
 Use this shape for stateless calls where every invocation should start clean.
+Piped stdin reaches the guest only on a transient `mvmctl machine run`; the
+top-level `mvmctl run` does not forward it, so the guest would read EOF.
 
 ## Persistent interpreter
 

--- a/public/src/content/docs/getting-started/first-microvm.md
+++ b/public/src/content/docs/getting-started/first-microvm.md
@@ -47,7 +47,7 @@ $EDITOR flake.nix                     # add your services
 
 The rest of this guide writes the flake by hand to show how `mkGuest` works underneath.
 
-> The plan-38 manifest model is shipped. Older docs that reference `mvmctl template create/build/…` are stale; the `template` namespace was removed outright. See the [Manifests guide](/guides/manifests/) for the current flow.
+> The plan-38 manifest model is shipped. Older docs that reference `mvmctl template create/build/…` are stale: the mutation verbs were removed. `mvmctl template` still exists as a read-only registry browser — `list`, `search`, and `info`. See the [Manifests guide](/guides/manifests/) for the current build flow.
 
 ## Write a Flake
 
@@ -67,11 +67,14 @@ Create a `flake.nix` in your project (or edit the one `mvmctl init` produced):
     in {
       packages.${system}.default = mvm.lib.${system}.mkGuest {
         name = "hello";
-        packages = [ pkgs.curl ];
+        packages = [ pkgs.python3 pkgs.curl ];
 
-        services.hello = {
-          command = "${pkgs.python3}/bin/python3 -m http.server 8080";
-        };
+        # `entrypoint` is REQUIRED and must declare exactly one of
+        # `shell`, `command`, or `services`. mkGuest throws at eval time
+        # otherwise. `command` is the sealed (production) form.
+        entrypoint.command = [
+          "${pkgs.python3}/bin/python3" "-m" "http.server" "8080"
+        ];
 
         healthChecks.hello = {
           healthCmd = "${pkgs.curl}/bin/curl -sf http://localhost:8080/";
@@ -83,7 +86,11 @@ Create a `flake.nix` in your project (or edit the one `mvmctl init` produced):
 }
 ```
 
-`mkGuest` handles everything internally -- the kernel, busybox init, guest agent, networking, drive mounting, and service supervision are all built into the image automatically. You just define your services and health checks.
+`mkGuest` handles everything internally -- the kernel, busybox init, guest agent, and drive mounting are all built into the image automatically. You describe the entrypoint and its health checks.
+
+:::caution[One process, not a service set]
+`entrypoint.command` runs a single program as PID 1. The multi-service form (`entrypoint.services`, and the top-level `services` attribute) is accepted by `mkGuest` but **not implemented** — the supervisor is unwired, so `entrypoint.services` prints "not yet wired" and drops the guest to a recovery shell, and a top-level `services` block is only recorded in `passthru.mvm`. Use `entrypoint.command` (or `entrypoint.shell` for a dev-tier image) until the supervisor lands.
+:::
 
 ## Build and Run
 
@@ -122,16 +129,25 @@ mvmctl machine logs hello
 Pass custom files to the guest drives:
 
 ```bash
-mkdir -p /tmp/config /tmp/secrets
+mkdir -p /tmp/config
 echo '{"port": 8080}' > /tmp/config/app.json
-echo 'API_KEY=sk-...' > /tmp/secrets/app.env
 
 mvmctl machine run --flake . \
-    -v /tmp/config:/mnt/config \
-    -v /tmp/secrets:/mnt/secrets
+    --mount /tmp/config:/data/config
 ```
 
-Inside the guest, config files appear at `/mnt/config/` and secrets at `/mnt/secrets/`.
+The share flag is `--mount` (alias `--volume`); there is no short form — `-v` is
+the global verbosity counter.
+
+A guest mount path must live under `/data` or `/work`. `/mnt/config` and
+`/mnt/secrets` are runtime-owned: `/init` mounts mvm's own read-only config and
+secret drives there before any user volume is attached, and the mount policy
+refuses a share that would sit inside or shadow them. Mounts are read-only by
+default; a transient run is read-only under every profile.
+
+Inside the guest, the files appear at the path you asked for — `/data/config/`
+above. For credentials, use `mvmctl secret` and host-side substitution rather
+than shipping a secrets file into the guest.
 
 ## Stop
 

--- a/public/src/content/docs/getting-started/happy-paths.md
+++ b/public/src/content/docs/getting-started/happy-paths.md
@@ -18,7 +18,7 @@ nothing more, nothing less.
 | [Prebuilt bundle operator](#bundle-run) | `--workflow bundle-run` | Launch a signed `.mvmpkg` artifact. |
 | [Interactive shell user](#dev-shell) | `--workflow dev-shell` | Boot a dev-tier image and drop into an interactive shell. |
 
-The preflight filter (plan 74 W5 / ADR-017 §1) only fails on missing
+The preflight filter only fails on missing
 prerequisites your workflow actually needs. A bundle operator no
 longer sees a "missing `cargo`" failure they don't care about; an
 interactive-shell user no longer needs host rustup.
@@ -135,9 +135,17 @@ You're not building anything — you have a signed `.mvmpkg` artifact
 to launch.
 
 ```bash
-mvmctl doctor --workflow bundle-run             # preflight (no host rust needed)
-mvmctl machine check-artifact ./my-app.mvm   # verify the signed artifact before launch
-mvmctl machine stop --all                                     # tear down
+mvmctl doctor --workflow bundle-run          # preflight (no host rust needed)
+mvmctl bundle fetch ./my-app.mvmpkg          # verify the signed bundle
+mvmctl bundle install ./my-app.mvmpkg        # install it into ~/.mvm/bundles/
+```
+
+`.mvmpkg` bundles go through `mvmctl bundle`. `mvmctl machine check-artifact` is
+a different verb for a different artifact kind — it verifies a signed `.mvm`
+artifact without booting:
+
+```bash
+mvmctl machine check-artifact ./my-app.mvm
 ```
 
 `bundle-run` doctor scope explicitly drops `prerequisites` and
@@ -191,8 +199,7 @@ shell devbox`.
 ## See also
 
 - [`mvmctl doctor`](/reference/cli-commands/#doctor) — the full
-  diagnostic command, including the `--workflow` flag added by
-  plan 74 W5.
+  diagnostic command, including the `--workflow` flag.
 - [Quick Start](/getting-started/quickstart/) — the broader
   feature tour.
 - [Your First MicroVM](/getting-started/first-microvm/) — write a

--- a/public/src/content/docs/getting-started/installation.md
+++ b/public/src/content/docs/getting-started/installation.md
@@ -99,15 +99,28 @@ verification.
 
 ## Updating
 
-`mvmctl` has no self-update command. Reinstall with the same
-method you used above — rerun the install script, or `git pull && cargo build
---release` in a source checkout. Cached build artifacts are refreshed
-separately with `mvmctl pack update <KIND>`.
+`mvmctl env update` is the self-update command: it fetches the latest release
+tarball and swaps the install in place. `--check` reports whether a newer
+release exists without installing it, `--force` reinstalls even when already
+current, and `--skip-verify` bypasses checksum verification (don't).
+
+```bash
+mvmctl env update --check
+mvmctl env update
+```
+
+A source checkout updates the usual way — `git pull && cargo build --release`.
+Cached build artifacts are refreshed separately with `mvmctl pack update <KIND>`
+(`builder`, `runtime`, `dev-image`, or `extension`).
 
 ## Prerequisites
 
 - **macOS Apple Silicon** or **Linux with `/dev/kvm`** (x86_64 or aarch64)
-- [Homebrew](https://brew.sh/) (macOS only -- mvmctl will install it if missing)
+- [Homebrew](https://brew.sh/) — only on macOS 13–25, where libkrun is the
+  default backend and comes from the third-party tap
+  (`brew install slp/krun/libkrun slp/krun/libkrunfw`). macOS 26+ Apple Silicon
+  defaults to HVF and needs no Homebrew at all. mvmctl does not install
+  Homebrew for you.
 
 ### Backend Auto-Detection
 

--- a/public/src/content/docs/getting-started/nix-for-mvm.mdx
+++ b/public/src/content/docs/getting-started/nix-for-mvm.mdx
@@ -34,13 +34,14 @@ Here's the end result — don't worry about understanding it yet:
         name = "hello";
         packages = [ pkgs.python3 pkgs.curl ];
 
-        services.hello = {
-          preStart = ''
+        entrypoint.command = [
+          "/bin/sh" "-c"
+          ''
             mkdir -p /tmp/www
             echo '<h1>Hello from mvm!</h1>' > /tmp/www/index.html
-          '';
-          command = "${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www";
-        };
+            exec ${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www
+          ''
+        ];
 
         healthChecks.hello = {
           healthCmd = "${pkgs.curl}/bin/curl -sf http://localhost:8080/";
@@ -159,7 +160,7 @@ Let's unpack what's new here:
 | ARM Linux (Raspberry Pi, Graviton) | `"aarch64-linux"` |
 | Intel/AMD Mac or Linux | `"x86_64-linux"` |
 
-The OS is always `linux` — even when building on macOS — because the VM image runs Linux inside Firecracker. You're cross-compiling for the guest, not building for your host.
+The OS is always `linux` — even when building on macOS — because the VM image runs Linux inside the microVM, whichever backend boots it (Firecracker on Linux/KVM, HVF or libkrun on Apple Silicon). You're cross-compiling for the guest, not building for your host.
 
 When you see `${system}` later in the flake (e.g., `packages.${system}.default` or `mvm.lib.${system}.mkGuest`), Nix substitutes the string at evaluation time. It's just dynamic attribute access — `packages.${system}.default` becomes `packages.aarch64-linux.default`.
 :::
@@ -171,10 +172,13 @@ Inside the `outputs`, you tell Nix what to build. For mvm, that means calling `m
 ```nix "mkGuest"
 packages.${system}.default = mvm.lib.${system}.mkGuest {
   name = "hello";
+  entrypoint.command = [ "/bin/sh" "-c" "echo hello; exec sleep infinity" ];
 };
 ```
 
 `mkGuest` is the mvm function that builds a complete microVM image. It handles the kernel, init system, guest agent, networking, and drive mounting — you just describe what you want inside the VM.
+
+`entrypoint` is **required** — there is no default. It must declare exactly one of `shell`, `command`, or `services`; `mkGuest` throws at evaluation time otherwise, so a flake that omits it never even reaches a build. `command` is the sealed (production) form and `shell` is the dev-tier form. `services` is declared but unimplemented — see the note in Step 6.
 
 **`packages.${system}.default`** — this is the standard Nix way to declare a build output. `mvmctl machine build --flake .` looks for this by default.
 
@@ -186,6 +190,7 @@ A bare VM isn't very useful. Use `packages` to install software into the image:
 mvm.lib.${system}.mkGuest {
   name = "hello";
   packages = [ pkgs.python3 pkgs.curl ];
+  entrypoint.command = [ "/bin/sh" "-c" "echo hello; exec sleep infinity" ];
 };
 ```
 
@@ -220,30 +225,44 @@ nix search nixpkgs "node.*22" 2>/dev/null
 Nix stores every package in `/nix/store/hash-name/`. There's no global `PATH`. Using `pkgs.python3` tells Nix exactly which package to include — this is what makes builds reproducible. The same flake always produces the same image, on any machine.
 :::
 
-## Step 6: Add a service
+## Step 6: Run something
 
-A VM image with packages but no running process just boots and sits idle. Add a service:
+A VM image with packages but no running process just boots and sits idle. The
+entrypoint is what runs:
 
-```nix "services.hello"
+```nix "entrypoint.command"
 mvm.lib.${system}.mkGuest {
   name = "hello";
   packages = [ pkgs.python3 pkgs.curl ];
 
-  services.hello = {
-    preStart = ''
+  entrypoint.command = [
+    "/bin/sh" "-c"
+    ''
       mkdir -p /tmp/www
       echo '<h1>Hello from mvm!</h1>' > /tmp/www/index.html
-    '';
-    command = "${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www";
-  };
+      exec ${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www
+    ''
+  ];
 };
 ```
 
-`services.hello` declares a long-running process. mvm's init system starts it at boot and restarts it if it crashes.
+`entrypoint.command` is an argv list that runs as PID 1. Do any setup first and
+`exec` the long-running process last, so PID 1 stays alive — a PID 1 that exits
+panics the kernel.
 
-- **`preStart`** creates a directory and writes an HTML file before the service starts.
-- **`command`** is the long-running process. It serves the HTML on port 8080.
 - **`"${pkgs.python3}/bin/python3"`** — Nix resolves this to the full `/nix/store/...` path at build time. You never hardcode paths — Nix handles it.
+
+:::caution[`services` is declared but not implemented]
+mkGuest accepts a `services.<name>` attribute (and an `entrypoint.services`
+form), but **the multi-service supervisor is not wired**. Nothing starts,
+supervises, or restarts a `services` entry: a top-level `services` block is only
+recorded in `passthru.mvm` and warned about at eval time, and
+`entrypoint.services` prints "not yet wired" and drops the guest into a recovery
+shell. The `preStart` and `env` keys those blocks take are part of the same
+unimplemented shape and have no effect today. Keep your workload in
+`entrypoint.command` (or `entrypoint.shell` for a dev image) until the
+supervisor lands.
+:::
 
 ## Step 7: Add a health check
 
@@ -256,7 +275,7 @@ healthChecks.hello = {
 };
 ```
 
-The guest agent runs this command every 5 seconds. Exit code 0 means healthy. The name (`hello`) should match your service name.
+The guest agent runs this command every 5 seconds. Exit code 0 means healthy. The attribute name (`hello`) becomes the probe's name — mkGuest renders each entry to `/etc/mvm/probes.d/<name>.json`, and the agent scans that directory at boot. Only `healthCmd` (required), `healthIntervalSecs` (default 30), and `healthTimeoutSecs` (default 10) are read; there is no `startupGraceSecs` key.
 
 ## Step 8: Build, run, and verify
 
@@ -312,93 +331,108 @@ Volumes let you pass files from your host into the microVM at boot — config fi
 ```bash
 # Mount host directories into the VM
 mvmctl machine run --flake . --name hello --port 8080:8080 \
-    --mount ./config:/mnt/config \
-    --mount ./secrets:/mnt/secrets \
-    --mount ./data:/mnt/data:1024
+    --mount ./config:/data/config \
+    --mount ./disk.img:/data/store:1024:rw
 ```
+
+The flag is `--mount`, with `--volume` as an alias. There is no short form —
+`-v` is the global verbosity counter, not a mount flag.
+
+**Guest mount paths must live under `/data` or `/work`.** Those are the only
+allow-roots. `/mnt` is deliberately excluded: `/init` mounts mvm's own read-only
+config and secret drives at `/mnt/config` and `/mnt/secrets` before any user
+volume is attached, and the mount policy refuses a share that would sit inside
+or shadow a runtime-owned path.
 
 Inside the guest, the files appear at the mount paths:
 
-| Mount | Access | Use case |
-|-------|--------|----------|
-| `./config:/mnt/config` | Read-only | App configuration |
-| `./secrets:/mnt/secrets` | Read-only | API keys, tokens |
-| `./data:/mnt/data:1024` | **Read-write** | Database files, logs, uploads |
+| Mount | Access | Kind |
+|-------|--------|------|
+| `./config:/data/config` | Read-only (default) | Live host-directory share |
+| `./config:/data/config:rw` | Read-write | Live host-directory share |
+| `./disk.img:/data/store:1024` | Read-only (default) | Persistent ext4 disk image |
+| `./disk.img:/data/store:1024:rw` | Read-write | Persistent ext4 disk image |
 
-Config and secrets are read-only by design — you don't want your app accidentally overwriting its own API keys. For data your service needs to write to (databases, logs, user uploads), use a **sized volume** with the three-part format `host:guest:sizeMB`:
+**Every mount is read-only unless you write `:rw`** — writing from a
+(potentially untrusted) guest to a host path is an explicit grant, not a
+default. `:rw` needs `--profile dev` or `--profile permissive`; a *transient*
+run's share is read-only under every profile.
 
-```bash
-# Read-only config + read-write 1GB data volume
-mvmctl machine run --flake . --name hello --port 8080:8080 \
-    --mount ./config:/mnt/config \
-    --mount ./data:/mnt/data:1024
-```
+The three-part form `host:guest:SIZE` selects a **disk image**, not a directory
+share: the host path is a file mvm creates and attaches as virtio-blk, sized in
+MB. Two-part `host:guest` is a live directory share over virtio-fs. Add `:rw`
+after the size for a writable disk.
 
-Your service can read config and write data at runtime — no rebuild needed:
+Your entrypoint can read config and write data at runtime — no rebuild needed:
 
 ```nix
-services.my-api = {
-  preStart = ''
-    # Data dir is read-write — create subdirs as needed
-    mkdir -p /mnt/data/logs
-  '';
-  command = "${pkgs.python3}/bin/python3 /app/server.py";
-  env = {
-    # Read config directly from the mounted volume
-    CONFIG_PATH = "/mnt/config/app.json";
-    LOG_DIR = "/mnt/data/logs";
-  };
-};
+entrypoint.command = [
+  "/bin/sh" "-c"
+  ''
+    mkdir -p /data/store/logs
+    export CONFIG_PATH=/data/config/app.json
+    export LOG_DIR=/data/store/logs
+    exec ${pkgs.python3}/bin/python3 /app/server.py
+  ''
+];
 ```
 
-This is the mvm pattern for separating **what runs** (baked into the image) from **how it's configured** (mounted at boot). The same image works across environments — only the mounted files change. Data volumes persist across restarts.
+This is the mvm pattern for separating **what runs** (baked into the image) from **how it's configured** (mounted at boot). The same image works across environments — only the mounted files change. Disk volumes persist across restarts.
 
 See [Config & Secrets](/guides/config-secrets/) and [Filesystem & Drives](/reference/filesystem/) for the full guide.
 
-## Step 10: Add environment variables and setup scripts
+## Step 10: Add environment variables and setup steps
 
-Real services often need configuration. Use `env` and `preStart`:
+Real workloads often need configuration. Because `entrypoint.command` is a plain
+argv list, set it up in the shell you exec into:
 
-```nix "env"
-services.my-api = {
-  preStart = ''
+```nix "entrypoint.command"
+entrypoint.command = [
+  "/bin/sh" "-c"
+  ''
     mkdir -p /tmp/data
     echo "starting up..."
-  '';
 
-  command = "${pkgs.python3}/bin/python3 /app/server.py";
+    export PORT=8080
+    export LOG_LEVEL=info
 
-  env = {
-    PORT = "8080";
-    LOG_LEVEL = "info";
-  };
-};
+    exec ${pkgs.python3}/bin/python3 /app/server.py
+  ''
+];
 ```
 
-- **`env`** — key-value pairs injected as environment variables into the service process.
-- **`preStart`** — runs once as root before the service starts. Use it for directory setup, file permissions, etc.
+- **setup first, `exec` last** — anything before the `exec` runs once as root at boot; the `exec` replaces the shell so your program becomes PID 1.
 - **`''...''`** — multi-line strings in Nix use two single quotes, not backticks or double quotes.
 
+(The `env` and `preStart` keys you may have seen belong to the `services` shape,
+which is unimplemented — see the note in Step 6. They are silently ignored.)
+
 :::note[Can I use a `.env` file?]
-The `env` block above is for values you're comfortable baking into the image. For secrets or per-environment config, mount a `.env` file at boot instead:
+Values baked into the image go in the `export` lines above. For per-environment config, mount a `.env` file at boot instead:
 
 ```bash
-mvmctl machine run --flake . -v ./secrets:/mnt/secrets
+mvmctl machine run --flake . --mount ./config:/data/config
 ```
 
-Then source it in `preStart`:
+Then source it before the `exec`:
 
 ```nix
-preStart = ''
-  if [ -f /mnt/secrets/.env ]; then
-    set -a
-    . /mnt/secrets/.env
-    set +a
-  fi
-'';
+entrypoint.command = [
+  "/bin/sh" "-c"
+  ''
+    if [ -f /data/config/.env ]; then
+      set -a
+      . /data/config/.env
+      set +a
+    fi
+    exec ${pkgs.python3}/bin/python3 /app/server.py
+  ''
+];
 ```
 
-This way the same image works across dev/staging/prod — only the mounted files change. See [Config & Secrets](/guides/config-secrets/) for more.
+Do **not** ship real credentials this way — mvm's secrets model keeps raw secret
+values out of the guest entirely and substitutes them host-side. See
+[Config & Secrets](/guides/config-secrets/) for that path.
 :::
 
 ## Common recipes
@@ -406,49 +440,55 @@ This way the same image works across dev/staging/prod — only the mounted files
 ### Python web app
 
 ```nix
-services.api = {
-  command = "${pkgs.python3}/bin/python3 -m gunicorn app:app -b 0.0.0.0:8080";
-};
+entrypoint.command = [
+  "${pkgs.python3}/bin/python3" "-m" "gunicorn" "app:app" "-b" "0.0.0.0:8080"
+];
 ```
 
 ### Node.js server
 
 ```nix
-services.app = {
-  command = "${pkgs.nodejs}/bin/node /app/server.js";
-  env = { NODE_ENV = "production"; PORT = "3000"; };
-};
+entrypoint.command = [
+  "/bin/sh" "-c"
+  ''
+    export NODE_ENV=production PORT=3000
+    exec ${pkgs.nodejs}/bin/node /app/server.js
+  ''
+];
 ```
 
 ### Static file server
 
 ```nix
-services.www = {
-  preStart = ''
+entrypoint.command = [
+  "/bin/sh" "-c"
+  ''
     mkdir -p /tmp/www
     echo '<h1>Hello!</h1>' > /tmp/www/index.html
-  '';
-  command = "${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www";
-};
+    exec ${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www
+  ''
+];
 ```
 
-### Multiple services in one VM
+### Multiple processes in one VM
 
-A single `mkGuest` call can define multiple services — they all run inside the same VM, supervised by the init system. This is useful for co-locating a service with its dependencies (e.g., an API server + Redis):
+There is no supervisor yet, so a `services` block will not run anything (see the
+note in Step 6). If you genuinely need a co-located dependency today, start it
+from the entrypoint yourself and keep the foreground process as PID 1:
 
 ```nix "mkGuest"
 mvm.lib.${system}.mkGuest {
   name = "my-stack";
   packages = [ pkgs.python3 pkgs.redis pkgs.curl ];
 
-  services.redis = {
-    command = "${pkgs.redis}/bin/redis-server --port 6379";
-  };
-
-  services.api = {
-    command = "${pkgs.python3}/bin/python3 /app/server.py";
-    env = { REDIS_URL = "redis://localhost:6379"; };
-  };
+  entrypoint.command = [
+    "/bin/sh" "-c"
+    ''
+      ${pkgs.redis}/bin/redis-server --port 6379 --daemonize yes
+      export REDIS_URL=redis://localhost:6379
+      exec ${pkgs.python3}/bin/python3 /app/server.py
+    ''
+  ];
 
   healthChecks.api = {
     healthCmd = "${pkgs.curl}/bin/curl -sf http://localhost:8080/health";
@@ -457,13 +497,17 @@ mvm.lib.${system}.mkGuest {
 };
 ```
 
+Nothing restarts the backgrounded process if it dies — that is exactly what the
+missing supervisor would provide. Prefer one workload per microVM until it
+lands.
+
 ## What happens when you build
 
 When `mvmctl machine build --flake .` runs:
 
 1. Nix reads your `flake.nix` and resolves all inputs
 2. It builds your packages and services into a root filesystem (ext4 image)
-3. It bundles a pre-built Linux kernel tuned for Firecracker
+3. It bundles a pre-built slim Linux kernel for the selected backend
 4. The result is cached — rebuilds skip unchanged steps
 
 The output is a kernel (`vmlinux`) and rootfs (`rootfs.ext4`) that any mvm backend can boot.

--- a/public/src/content/docs/getting-started/nix-for-mvm.mdx
+++ b/public/src/content/docs/getting-started/nix-for-mvm.mdx
@@ -36,11 +36,7 @@ Here's the end result — don't worry about understanding it yet:
 
         entrypoint.command = [
           "/bin/sh" "-c"
-          ''
-            mkdir -p /tmp/www
-            echo '<h1>Hello from mvm!</h1>' > /tmp/www/index.html
-            exec ${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www
-          ''
+          "mkdir -p /tmp/www; echo '<h1>Hello from mvm!</h1>' > /tmp/www/index.html; exec ${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www"
         ];
 
         healthChecks.hello = {
@@ -237,11 +233,7 @@ mvm.lib.${system}.mkGuest {
 
   entrypoint.command = [
     "/bin/sh" "-c"
-    ''
-      mkdir -p /tmp/www
-      echo '<h1>Hello from mvm!</h1>' > /tmp/www/index.html
-      exec ${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www
-    ''
+    "mkdir -p /tmp/www; echo '<h1>Hello from mvm!</h1>' > /tmp/www/index.html; exec ${pkgs.python3}/bin/python3 -m http.server 8080 --directory /tmp/www"
   ];
 };
 ```
@@ -483,11 +475,7 @@ mvm.lib.${system}.mkGuest {
 
   entrypoint.command = [
     "/bin/sh" "-c"
-    ''
-      ${pkgs.redis}/bin/redis-server --port 6379 --daemonize yes
-      export REDIS_URL=redis://localhost:6379
-      exec ${pkgs.python3}/bin/python3 /app/server.py
-    ''
+    "${pkgs.redis}/bin/redis-server --port 6379 --daemonize yes; export REDIS_URL=redis://localhost:6379; exec ${pkgs.python3}/bin/python3 /app/server.py"
   ];
 
   healthChecks.api = {

--- a/public/src/content/docs/guides/agent-tool-contract.mdx
+++ b/public/src/content/docs/guides/agent-tool-contract.mdx
@@ -122,14 +122,14 @@ def run_agent_tool(request: dict) -> dict:
 <TabItem label="TypeScript">
 
 ```ts
-import { NetworkPolicy, Sandbox } from "@mvm/sdk";
+import { Sandbox } from "@runmvm/mvm";
 
 async function runAgentTool(request: Record<string, unknown>) {
   const checked = validateRequest(request);
 
+  // Egress is deny-by-default; naming no allow-list is what denies it.
   using sandbox = await Sandbox.create({
     image: checked.image,
-    network: NetworkPolicy.denyByDefault(),
     ttlSeconds: checked.ttlSeconds,
   });
 

--- a/public/src/content/docs/guides/agent-tool-contract.mdx
+++ b/public/src/content/docs/guides/agent-tool-contract.mdx
@@ -121,7 +121,7 @@ def run_agent_tool(request: dict) -> dict:
 </TabItem>
 <TabItem label="TypeScript">
 
-```ts
+```text
 import { Sandbox } from "@runmvm/mvm";
 
 async function runAgentTool(request: Record<string, unknown>) {

--- a/public/src/content/docs/guides/airgapped-bootstrap.md
+++ b/public/src/content/docs/guides/airgapped-bootstrap.md
@@ -17,7 +17,8 @@ path specifically for the dev/workload microVM image, verified against
 a cosign-signed manifest — was removed along with the standalone
 `mvmctl dev` command. Its would-be successor (the `dev-image` pack
 class) has no publish/fetch path wired yet: `mvmctl pack download
---kind dev-image` refuses explicitly rather than pretending to work.
+dev-image` refuses explicitly rather than pretending to work. (The pack
+kind is a positional argument; `--kind` is a filter on `pack list` only.)
 Signed bundles are the current sanctioned air-gapped path for shipping
 a prebuilt workload; this guide describes that flow.
 :::

--- a/public/src/content/docs/guides/building-microvm-images.md
+++ b/public/src/content/docs/guides/building-microvm-images.md
@@ -15,9 +15,13 @@ Every mvm project has a `mvm.toml` and a `flake.nix`:
 # my-app/mvm.toml
 flake     = "."
 profile   = "default"
-vcpus     = 1
-memory_mib = 256
+cpus      = 1          # `vcpus` is an accepted alias
+mem       = "256M"
 ```
+
+`mvm.toml` uses `deny_unknown_fields`, so a key it does not define is a parse
+error. Memory is `mem` (a size string); `memory_mib` is a `mkGuest` argument,
+not a manifest key.
 
 ```nix
 # my-app/flake.nix
@@ -32,9 +36,9 @@ memory_mib = 256
   outputs = { self, nixpkgs, mvm, ... }: {
     packages.x86_64-linux.default = mvm.lib.x86_64-linux.mkGuest {
       name = "my-app";
-      services.web = {
-        command = [ "/usr/local/bin/web" ];
-      };
+      # `entrypoint` is required — mkGuest throws without exactly one of
+      # `shell` / `command` / `services`.
+      entrypoint.command = [ "/usr/local/bin/web" ];
     };
   };
 }
@@ -47,9 +51,13 @@ That's the whole user-side surface. `mvmctl machine build` reads `mvm.toml`, fol
 From your project directory:
 
 ```sh
-mvmctl machine build              # reads mvm.toml; builds the named flake target
-mvmctl run                # builds (if needed) + boots
+mvmctl machine build                      # reads mvm.toml; builds the named flake target
+mvmctl machine run --manifest . -- <cmd>  # boots the built image and runs <cmd>
 ```
+
+A bare `mvmctl run` refuses with "needs a command" — it takes a trailing argv
+(or `--launch-plan`), and it never inspects `flake.nix` to decide what to
+build.
 
 `mvmctl machine build` is a host command. You run it from macOS or Linux, and mvm sends the Linux-only Nix work into the builder VM. The builder VM is headless — there is no shell into it, not even for debugging; you never need one before or during a normal build.
 
@@ -76,7 +84,7 @@ That direct Nix command is only for users who intentionally manage their own Nix
 |---|---|---|
 | `name` | `string` | Human-readable identifier; baked into the rootfs at `/etc/mvm/name`. |
 | `entrypoint` | `attrs` | The boot-time workload. Exactly one of three forms (see below). |
-| `services` | `attrs` (optional) | Auxiliary supervised services. Same shape as `entrypoint.services`. |
+| `services` | `attrs` (optional) | Declared and recorded, but **not enforced** — the multi-service supervisor is not wired. |
 | `packages` | `[pkg]` (optional) | Extra Nix packages added to the rootfs closure. |
 | `hypervisor` | `string` (optional) | Override the default (`firecracker`). |
 | `vcpus`, `memory_mib` | `int` (optional) | Resource defaults; `mvm.toml` overrides at run time. |
@@ -101,7 +109,8 @@ entrypoint.shell = "/bin/bash";
 # Form 2 — single sealed program (production default)
 entrypoint.command = [ "/usr/local/bin/serve" "--port" "8080" ];
 
-# Form 3 — supervised multi-service
+# Form 3 — supervised multi-service (NOT WIRED: the boot falls through
+# to a recovery shell; the multi-service supervisor is not built yet)
 entrypoint.services = {
   web    = { command = [ "/bin/web" ]; };
   worker = { command = [ "/bin/worker" ]; restart = "always"; };
@@ -122,7 +131,7 @@ The default is `attached`. Pass `-d` to detach:
 ```sh
 mvmctl machine run --flake .      # attached (default); Ctrl-C stops the VM
 mvmctl machine run --flake . -d   # detached; the VM outlives this command
-mvmctl machine wait my-app        # block until the VM exits (attached only)
+mvmctl machine wait my-app        # block until the guest reports ready (hidden verb)
 mvmctl machine stop my-app        # terminate a detached VM
 ```
 
@@ -181,13 +190,12 @@ can hide a slow launch. A backend that cannot meet it is not release-ready.
 | Backend | Cold p50 | Snapshot-cloned p50 | Notes |
 |---|---|---|---|
 | Firecracker (Linux/KVM) | < 200 ms | ≤ 30 ms | Hard prepared-cold requirement; every measured dispatch must pass. |
-| Cloud Hypervisor (Linux/KVM) | < 200 ms | ≤ 50 ms | Tier-1 peer of FC. Adds VFIO/GPU, virtio-gpu, virtio-fs, larger guests. Opt-in via `--hypervisor cloud-hypervisor`. |
-| libkrun / libkrun (Linux/KVM) | < 200 ms | ≤ 30 ms | Cross-platform default; libkrun-backed. |
-| libkrun / libkrun (macOS HVF) | < 200 ms | ≤ 60 ms | Cross-platform default; libkrun-backed. |
-| Apple Virtualization framework | < 200 ms | ≤ 200 ms | Legacy ladder; superseded by libkrun per ADR-013. |
+| HVF (macOS 26+, Apple Silicon) | < 200 ms | ≤ 60 ms | In-house Hypervisor.framework VMM; macOS default. |
+| libkrun (macOS 13-25, Linux/KVM) | < 200 ms | ≤ 30 ms | Third-party in-process VMM; needs the `slp/krun/*` Homebrew trio on macOS. |
+| QEMU (Linux dev/test) | — | — | Opt-in dev/test substrate; no snapshot support. |
 
 The artifact expectation is surfaced on every `mkGuest` derivation as
-`passthru.mvm.expectedBootMs`, while `mvmctl bench prepared-cold` enforces the
+`passthru.mvm.expectedBootMs`, while `mvmctl bench --lane prepared-cold` enforces the
 runtime maximum from raw samples. See [ADR-013 §"Boot-time budget"](https://github.com/tinylabscom/mvm/blob/main/specs/adrs/013-libkrun-libkrun-microvm-nix-pivot.md)
 for the original backend rationale.
 
@@ -229,7 +237,7 @@ PID 1 must be uid 0 (kernel mandate). Everything else can — and by default in 
 | `mvm-guest-agent` | 990 | Vsock RPC handler (never needs root); supervised by `/init` |
 | Entrypoint (workload) | **0 in dev**, **1000 in prod** | Your service or shell |
 
-> **Agent binary status:** as of Phase 1 W6.1.1 the agent at `/usr/local/bin/mvm-guest-agent` is a **stub** — a sh script that logs startup and sleeps. The supervision pattern is real (init forks it under uid 990 before setpriv-exec'ing the entrypoint); the vsock RPC surface lands when W6.1.2 swaps in the cross-compiled Rust binary. Every derivation surfaces `passthru.mvm.agentBinary = "stub" | "real"` so production deployments can refuse to boot a stub image.
+> **Agent binary status:** the agent is the cross-compiled Rust binary; `mkGuest` emits `passthru.mvm.agentBinary = "real"` unconditionally. The `"stub"` value is retained only as something a consumer may refuse — nothing produces it any more.
 
 The dev/prod default split is intentional:
 

--- a/public/src/content/docs/guides/capture.md
+++ b/public/src/content/docs/guides/capture.md
@@ -5,7 +5,7 @@ description: Inspect a Linux project, resolve its environment, and render a revi
 
 # Capturing a Project Environment
 
-`mvm capture` inspects a project directory and the host environment required
+`mvmctl capture` inspects a project directory and the host environment required
 to build and run it, then produces a reviewable MVM definition. It is
 **project-scoped capture**, not lossless machine cloning.
 
@@ -47,29 +47,29 @@ to build and run it, then produces a reviewable MVM definition. It is
 
 ```bash
 # Capture the project environment.
-mvm capture project ./my-app \\
+mvmctl capture project ./my-app \\
   --run "cargo test" \\
   --output capture.json
 
 # Resolve the report into canonical MVM IR.
-mvm capture resolve capture.json \\
+mvmctl capture resolve capture.json \\
   --output environment.json
 
 # Render Nix artifacts and record a verification command.
-mvm capture verify environment.json \\
+mvmctl capture verify environment.json \\
   --manifest-dir ./my-app \\
   --run "cargo test" \\
   --out-dir ./mvm-verify
 
 # (Optional) Build the rendered flake in the Linux builder VM.
-mvm capture verify environment.json \\
+mvmctl capture verify environment.json \\
   --manifest-dir ./my-app \\
   --run "cargo test" \\
   --out-dir ./mvm-verify \\
   --exec-in-builder-vm
 
 # (Optional) Boot a microVM in the builder VM and replay the command inside the guest.
-mvm capture verify environment.json \
+mvmctl capture verify environment.json \
   --manifest-dir ./my-app \
   --run "cargo test" \
   --out-dir ./mvm-verify \
@@ -81,7 +81,7 @@ for tracing and verification; they are not executed during capture.
 
 ## Verification status
 
-`mvm capture verify` writes `verification.json` to `--out-dir`. Each `--run`
+`mvmctl capture verify` writes `verification.json` to `--out-dir`. Each `--run`
 command produces a `VerificationRecord` with one of the following statuses:
 
 - `recorded` — command captured but not executed (default).

--- a/public/src/content/docs/guides/capture.md
+++ b/public/src/content/docs/guides/capture.md
@@ -47,25 +47,25 @@ to build and run it, then produces a reviewable MVM definition. It is
 
 ```bash
 # Capture the project environment.
-mvmctl capture project ./my-app \\
-  --run "cargo test" \\
+mvmctl capture project ./my-app \
+  --run "cargo test" \
   --output capture.json
 
 # Resolve the report into canonical MVM IR.
-mvmctl capture resolve capture.json \\
+mvmctl capture resolve capture.json \
   --output environment.json
 
 # Render Nix artifacts and record a verification command.
-mvmctl capture verify environment.json \\
-  --manifest-dir ./my-app \\
-  --run "cargo test" \\
+mvmctl capture verify environment.json \
+  --manifest-dir ./my-app \
+  --run "cargo test" \
   --out-dir ./mvm-verify
 
 # (Optional) Build the rendered flake in the Linux builder VM.
-mvmctl capture verify environment.json \\
-  --manifest-dir ./my-app \\
-  --run "cargo test" \\
-  --out-dir ./mvm-verify \\
+mvmctl capture verify environment.json \
+  --manifest-dir ./my-app \
+  --run "cargo test" \
+  --out-dir ./mvm-verify \
   --exec-in-builder-vm
 
 # (Optional) Boot a microVM in the builder VM and replay the command inside the guest.

--- a/public/src/content/docs/guides/config-secrets.md
+++ b/public/src/content/docs/guides/config-secrets.md
@@ -5,33 +5,51 @@ description: Inject custom config files and tightly scoped secret files onto mic
 
 mvm supports injecting custom files onto the guest's config and secrets drives at boot time. Files are written to the drive images before the VM starts.
 
+:::caution[This is a library API, not a `--mount` flag]
+The config and secrets drives are read-only ext4 **drive images** that guest
+`/init` mounts from `/dev/vdb` and `/dev/vdc`. They are not host directory
+shares, and `--mount` cannot populate them: `/mnt/config` and `/mnt/secrets`
+are *protected* paths in the host mount policy, and bare `/mnt` is refused
+because a share there would shadow them. A `--mount` guest path must be under
+`/data` or `/work`.
+
+The supported way to place files on these drives is the `config_files` /
+`secret_files` fields on `FlakeRunConfig` (see [Library API](#library-api)
+below). There is no `mvmctl` flag that does it today.
+:::
+
 Prefer managed secret references for credentials. Use secrets drives when a
 workload genuinely needs file-shaped material such as certificates or a
 compatibility config file. See [Secrets and credentials](/guides/secrets-and-credentials/)
 for the reference-first model.
 
-## CLI Usage
-
-```bash
-mkdir -p /tmp/my-config /tmp/my-secrets
-
-echo '{"gateway": {"port": 8080}}' > /tmp/my-config/app.json
-echo 'API_KEY_REF=openai-api-key' > /tmp/my-secrets/app.env
-
-mvmctl machine run --manifest my-app \
-    --mount /tmp/my-config:/mnt/config \
-    --mount /tmp/my-secrets:/mnt/secrets
-```
-
-The `--mount` flag uses the format `host_dir:/guest/path`. `--volume` remains
-accepted as a compatibility alias, but `-v` is global verbosity:
+## The drives
 
 | Guest path | Drive | Permissions | Purpose |
 |---|---|---|---|
 | `/mnt/config` | `/dev/vdb` | Read-only (0444) | Application configuration |
 | `/mnt/secrets` | `/dev/vdc` | Read-only (0400) | File-shaped secret material |
 
-Every file in the host directory is written to the corresponding drive image. For persistent mounts with explicit size, use the 3-part format: `--mount host:/guest/path:size`.
+Both are mounted `ro,noexec,nosuid,nodev` by guest `/init` before the
+entrypoint starts.
+
+## Host directory shares
+
+Separately from the drives above, `--mount host_dir:/guest/path[:MODE]` shares
+a host directory into the guest. `--volume` remains accepted as a
+compatibility alias, but `-v` is global verbosity. The guest path must be
+under `/data` or `/work`, `MODE` is `ro` (default) or `rw`, and `:rw` requires
+a persistent machine under `--profile dev`:
+
+```bash
+mkdir -p /tmp/my-config
+echo '{"gateway": {"port": 8080}}' > /tmp/my-config/app.json
+
+mvmctl machine run --manifest my-app --name app -d \
+    --mount /tmp/my-config:/data/config:ro
+```
+
+The third field is the mode, not a size.
 
 ## Library API
 
@@ -75,8 +93,10 @@ The managed-secret model is:
 1. Store a secret ref locally with `mvmctl secret put <name>`
 2. Declare that ref in `mvm.toml` or with `mvm.secret(...)`
 3. The guest sees only a normal env var name with an opaque token
-4. Host-mediated surfaces such as `mvm.web_fetch` and `mvm.web_search`
-   release the real value at request time when policy allows it
+4. Host-mediated broker verbs such as `mvm.web_fetch` and `mvm.web_search`
+   release the real value at request time when policy allows it. These are
+   host-side broker tool names, not functions exported by the Python or
+   TypeScript SDK.
 
 Managed secret refs are host-mediated only. Guest HTTPS CONNECT egress
 is not a substitution path.
@@ -92,7 +112,7 @@ The `DriveFile` type is content-agnostic — it's just `{name, content, mode}`. 
 ## Example: generic flake with config + secrets mounts
 
 The pattern below works with any `mkGuest` flake that reads
-`/mnt/config/` and/or `/mnt/secrets/` at boot. Write your own — see
+`/data/config/` and/or `/data/secrets/` at boot. Write your own — see
 [Building MicroVM Images](/guides/building-microvm-images) for the
 `mkGuest` API surface, or [Nix Flakes](/guides/nix-flakes) for a
 worked LLM-agent example showing the pattern end-to-end.
@@ -102,15 +122,16 @@ worked LLM-agent example showing the pattern end-to-end.
 ```bash
 mvmctl machine build --flake ./openclaw
 mvmctl machine run --flake ./openclaw --name oc --port 3000:3000 \
-    --mount nix/examples/openclaw/config:/mnt/config \
-    --mount nix/examples/openclaw/secrets:/mnt/secrets
+    --mount nix/examples/openclaw/config:/data/config \
+    --mount nix/examples/openclaw/secrets:/data/secrets
 ```
 
-Each `-v` flag mounts a host directory as an ext4 drive read-only by
-default. Secrets land at `/mnt/secrets/` (mode 0440 root:mvm by the
-init script) and are also re-staged to `/run/mvm-secrets/<svc>/`
-with mode 0400 owned by the per-service uid (ADR-001 §W2.1) so
-sibling services on the same microVM can't cross-read.
+Each `--mount` flag shares a host directory into the guest, read-only by
+default. Material placed on the *secrets drive* (`/mnt/secrets/`, mode 0440
+root:mvm by the init script) is additionally re-staged to
+`/run/mvm-secrets/<svc>/` with mode 0400 owned by the per-service uid
+(ADR-001 §W2.1) so sibling services on the same microVM can't cross-read.
+That re-staging applies to the drive, not to a `--mount` share.
 
 ### Custom config + API keys at runtime
 
@@ -128,30 +149,30 @@ ANTHROPIC_API_KEY_REF=anthropic-api-key
 EOF
 
 mvmctl machine run --flake ./openclaw --name oc --port 3000:3000 \
-    --mount /tmp/oc-config:/mnt/config \
-    --mount /tmp/oc-secrets:/mnt/secrets
+    --mount /tmp/oc-config:/data/config \
+    --mount /tmp/oc-secrets:/data/secrets
 ```
 
 A typical `mkGuest` service uses `preStart` to check for
-`/mnt/config/<file>` and falls back to a built-in default; the
-`command` script sources `/mnt/secrets/<env-file>` if present so
+`/data/config/<file>` and falls back to a built-in default; the
+`command` script sources `/data/secrets/<env-file>` if present so
 environment variables are available to the service process.
 
 ### Using snapshots for faster startup
 
-Build the manifest with `--snapshot` on a backend that supports it to capture a
-running VM state. Subsequent runs can restore from the snapshot instead of
-cold-booting. Published latency numbers must name the backend, host, artifact,
+There is no `--snapshot` flag on `machine build`. Snapshots are taken from a
+running machine with the (hidden) `mvmctl machine snapshot` verb on a backend
+that supports it; subsequent runs can restore instead of cold-booting. Published latency numbers must name the backend, host, artifact,
 and readiness boundary.
 
 ```bash
 mvmctl machine build --flake ./openclaw
 mvmctl machine run --flake ./openclaw --name oc --port 3000:3000 \
-    --mount nix/examples/openclaw/config:/mnt/config \
-    --mount nix/examples/openclaw/secrets:/mnt/secrets
+    --mount nix/examples/openclaw/config:/data/config \
+    --mount nix/examples/openclaw/secrets:/data/secrets
 ```
 
-When restoring from a snapshot with `-v` mounts, the guest agent
+When restoring from a snapshot with `--mount` shares, the guest agent
 automatically remounts config/secrets drives and restarts services
 with the fresh data.
 
@@ -165,7 +186,7 @@ directories. This means:
 - ✅ **Same snapshot** can serve multiple instances with different
   configs.
 - ✅ **Update configs without rebuilding** — change the host files
-  and re-up.
+  and restart the machine.
 - ✅ **Instant boot + dynamic configuration** — get both benefits
   simultaneously.
 
@@ -176,19 +197,19 @@ keys:
 # Production gateway with prod Anthropic key
 mvmctl machine run --manifest openclaw --name oc-prod \
     --port 3000:3000 \
-    --mount ./prod/config:/mnt/config \
-    --mount ./prod/secrets:/mnt/secrets
+    --mount ./prod/config:/data/config \
+    --mount ./prod/secrets:/data/secrets
 
 # Staging gateway with test key
 mvmctl machine run --manifest openclaw --name oc-staging \
     --port 3001:3000 \
-    --mount ./staging/config:/mnt/config \
-    --mount ./staging/secrets:/mnt/secrets
+    --mount ./staging/config:/data/config \
+    --mount ./staging/secrets:/data/secrets
 
 # Dev gateway with no key (localhost-only testing)
 mvmctl machine run --manifest openclaw --name oc-dev \
     --port 3002:3000 \
-    --mount ./dev/config:/mnt/config
+    --mount ./dev/config:/data/config
 ```
 
 All three restore from the same snapshot (1-2 second boot) but get

--- a/public/src/content/docs/guides/dev-image.md
+++ b/public/src/content/docs/guides/dev-image.md
@@ -66,9 +66,12 @@ Point `mvm.toml` at the dev output:
 ```toml
 flake     = "."
 profile   = "dev"
-vcpus     = 2
-memory_mib = 1024
+cpus      = 2          # `vcpus` is an accepted alias
+mem       = "1024M"
 ```
+
+`mvm.toml` rejects unknown keys. Memory is `mem` (a size string) — `memory_mib`
+is a `mkGuest` argument, not a manifest key.
 
 Then:
 
@@ -84,7 +87,13 @@ You **never edit anything inside the mvm repository** to customize your dev imag
 
 ### Adding services to your dev image
 
-The shell is your interactive surface, but you can run additional services in parallel via the `services` field:
+:::caution[Not wired yet]
+The `services` field is accepted and recorded, but nothing supervises it — the
+multi-service supervisor is not built. `mkGuest` warns at evaluation time. The
+shape below is the declared surface, not running behaviour.
+:::
+
+The declared shape:
 
 ```nix
 dev = mvm.lib.${system}.mkGuest {
@@ -103,7 +112,8 @@ dev = mvm.lib.${system}.mkGuest {
 };
 ```
 
-Each service runs as its own supervised process. The shell stays your foreground; services are background.
+The intent is that each service runs as its own supervised process with the
+shell as your foreground. None of that supervision exists yet.
 
 ### Forcing the dev path on a sealed entrypoint
 

--- a/public/src/content/docs/guides/develop-to-attested.md
+++ b/public/src/content/docs/guides/develop-to-attested.md
@@ -86,25 +86,30 @@ The image, the environment it boots in, and the sealed dependency volume are all
 pinned into the signed execution plan, and every admission is recorded in the
 chain-signed audit log.
 
-## Designed, not yet built
+## Shipped, and designed-not-yet-built
 
-The following are specified in `specs/plans/291-develop-build-deploy-attested.md`
-and **do not exist yet**. They are listed here so the intended shape is legible,
-not because they can be run:
+`mvmctl deploy` and `mvmctl watch` **do exist** and are implemented:
 
-- **`mvmctl deploy`** — seal, compute the artifact's BLAKE3 identity alongside
-  its SHA-256 interop digest, and write a deploy record. If a remote (`mvmd`) is
-  configured it ships the recorded artifact; if not, you still end up holding a
+- **`mvmctl deploy`** seals, computes the artifact's BLAKE3 identity alongside
+  its SHA-256 interop digest, and writes a deploy record under
+  `~/.mvm/deployments/<ir-hash>/`. It requires `--boot-artifact`; pass
+  `--mvmd-url` to ship the recorded artifact to a remote, or omit it and hold a
   sealed, recorded artifact locally.
-- **`mvmctl watch`** — rebuild on source change during development, skipping
-  no-op rebuilds by content address.
+- **`mvmctl watch`** rebuilds on source change during development, skipping
+  no-op rebuilds by content address (`--interval-ms`, default 500; `--once` for
+  a single pass).
+
+The following is specified in `specs/plans/291-develop-build-deploy-attested.md`
+and **does not exist yet**. It is listed here so the intended shape is legible,
+not because it can be run:
+
 - **Capture from the sandbox** — install a dependency inside a dev sandbox and
   capture it into the sealed volume, then emit it back out as a declaration you
   can commit. The capture path is designed to converge on the declared path
   above, keeping the same hash-pin requirement, rather than becoming a second
   way to specify dependencies.
 
-Until those land, the declared route in step 2 is the supported way to get a
+Until that lands, the declared route in step 2 is the supported way to get a
 dependency into an attested workload.
 
 ## Why two digests

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -52,21 +52,31 @@ default image:
 ## Sharing host directories: `--mount`
 
 `--mount HOST:GUEST[:MODE]` shares a host directory into the guest at
-`GUEST`. `MODE` is `ro` (default) or `rw`; a writable share requires
-`--profile dev` or `--profile permissive`. The flag is repeatable. `--volume`
-remains accepted as a compatibility alias, but `-v` is global verbosity.
+`GUEST`. The flag is repeatable. `--volume` remains accepted as a
+compatibility alias, but `-v` is global verbosity.
+
+`GUEST` must sit under **`/data` or `/work`** — those are the only two
+allow-roots. Anything else is refused, including `/mnt/*`, which is excluded
+so a share cannot shadow the runtime's own `/mnt/config` and `/mnt/secrets`
+drives.
 
 ### Read-only (default)
 
 ```bash
 echo "hello" > /tmp/foo
-mvmctl machine run --image alpine --mount /tmp:/host -- cat /host/foo     # prints "hello"
+mvmctl machine run --image alpine --mount /tmp:/data/host -- cat /data/host/foo   # prints "hello"
 ```
 
-### Writable: `:rw`
+### Writable: `:rw` needs a persistent machine
+
+A **transient** run's live shares are read-only under *every* profile —
+`--profile dev` does not change that. `:rw` is accepted only on a persistent
+machine (`--name` plus `-d`), and only under `--profile dev` or
+`--profile permissive`:
 
 ```bash
-mvmctl machine run --flake . --profile dev --mount .:/work:rw -- sh -c 'echo result > /work/output.txt'
+mvmctl machine run --flake . --profile dev --name builder -d --mount .:/work:rw
+mvmctl machine exec builder -- sh -c 'echo result > /work/output.txt'
 cat ./output.txt       # "result" — written by the guest
 ```
 
@@ -80,10 +90,10 @@ and host-visibility semantics of the current volume backend, see the
 Modes are independent per directory:
 
 ```bash
-mvmctl machine run --flake . --profile dev \
-  --mount ./src:/work:rw \
-  --mount ~/.cargo:/root/.cargo:ro \
-  -- cargo build --manifest-path /work/Cargo.toml
+mvmctl machine run --flake . --profile dev --name build -d \
+  --mount ./src:/work/src:rw \
+  --mount ~/.cargo:/data/cargo:ro
+mvmctl machine exec build -- cargo build --manifest-path /work/src/Cargo.toml
 ```
 
 ## Injecting environment variables: `--env`
@@ -122,7 +132,8 @@ mvmctl machine run --flake . --cpus 4 --memory 1G -- ./benchmark.sh
 mvmctl machine run --flake . --timeout 300 -- ./long-running-task.sh
 ```
 
-Defaults: 2 vCPUs, 512 MiB, 60-second timeout per command.
+Defaults: 2 vCPUs (`--cpus`), 512 MiB (`--memory`). **`--timeout` has no
+default** — omit it and the run is unbounded.
 
 ## Driving from a launch plan
 
@@ -197,7 +208,8 @@ highest):
 - **Non-zero exit**: same as normal exit; `mvmctl machine run` propagates the
   guest's exit code.
 - **Ctrl-C**: a SIGINT handler triggers teardown so the Firecracker
-  process and any tap interface don't get orphaned.
+  process and the per-VM network endpoint don't get orphaned. (There is no
+  tap interface to orphan — a workload microVM has no guest NIC.)
 - **Hard kill** (`kill -9` on `mvmctl machine run` itself): teardown is
   best-effort; you may need `mvmctl machine ls` and `mvmctl machine stop <name>` to
   clean up. Each unnamed transient VM gets a generated name like
@@ -213,16 +225,21 @@ highest):
 - **Network access.** The guest gets the same network configuration
   any other transient VM gets -- if your `--manifest` exposes outbound
   internet, so does `mvmctl machine run` from that template.
-- **Stdin** is currently *not* forwarded to the guest. Pipe data via a
-  `--mount`-shared file instead. Streaming stdin is a future
-  improvement.
-- **Persistent state** doesn't survive teardown beyond what `:rw`
-  `--mount` rsyncs back. For larger or longer-lived state, use
-  `mvmctl machine run` with a persistent volume.
+- **Stdin** is not forwarded to a trailing-argv run. It *is* available to a
+  baked-entrypoint run via `machine run --entrypoint --stdin -`, which needs
+  the `host.stream.v1` grant on the signed plan — see
+  [Workload input](/guides/workload-input/). For a trailing-argv run, pipe
+  data via a `--mount`-shared file instead.
+- **Persistent state** doesn't survive teardown. A transient run cannot take
+  a `:rw` share at all, so nothing is written back to the host. For state
+  that has to outlive the run, boot a persistent machine (`--name` + `-d`)
+  with a `:rw` share or a managed volume.
 
 ## See also
 
 - [CLI reference: One-shot Exec](/reference/cli-commands/#one-shot-exec)
 - [Manifests guide](/guides/manifests/) -- build a reusable base image
-  via `mvm.toml`; `mvmctl machine run [PATH]` accepts the manifest path directly
+  via `mvm.toml`. Only `mvmctl machine build` takes a positional `[PATH]`;
+  `machine run` and `run` take `-m/--manifest <PATH>`, because their
+  positional slot is the trailing argv.
 - [Quick Start](/getting-started/quickstart/#7-sandboxed-one-shot-commands)

--- a/public/src/content/docs/guides/fleet-stream-edges.md
+++ b/public/src/content/docs/guides/fleet-stream-edges.md
@@ -55,8 +55,11 @@ MVM_ACK_RAW_STREAM_EDGE=1
 A plan is signed on behalf of whoever launched the workload. Letting a plan
 alone opt out would let a careless or compromised workload definition export
 raw PII into another workload with no human involved, and between two workloads
-those are different trust domains. Same shape as
-`MVM_ACK_UNRESTRICTED_NETWORK`, and likewise never set in CI.
+those are different trust domains. Never set it in CI.
+
+(Design notes describe this as "shaped after `MVM_ACK_UNRESTRICTED_NETWORK`".
+That variable is aspirational: it is read nowhere in the workspace, so there is
+no unrestricted-egress acknowledgement to be modelled on yet.)
 
 :::note[`raw` is not servable yet]
 Redaction runs *before* hashing, so a record that reaches a reader has already

--- a/public/src/content/docs/guides/ir-to-image.mdx
+++ b/public/src/content/docs/guides/ir-to-image.mdx
@@ -44,7 +44,7 @@ The IR is the contract; everything else is mechanical.
 
 The IR is a JSON document with a fixed schema. It describes one or more applications, each with a source, image, entrypoints, resources, dependencies, network policy, and optional addons. Two equivalent IR documents always serialize to the same bytes and the same hash.
 
-**Source of truth:** `crates/mvm-ir/src/workload.rs`
+**Source of truth:** `crates/mvm-contract/src/ir/workload.rs`
 
 The top-level shape:
 
@@ -84,18 +84,18 @@ Entrypoints come in two shapes:
 
 The IR is canonicalized to **RFC 8785** (keys sorted, no whitespace, deterministic escaping) before it is hashed or written to disk:
 
-- `crates/mvm-ir/src/canonicalize.rs` — produces the canonical byte sequence
-- `crates/mvm-ir/src/hash.rs` — `ir_hash()` returns the lowercase-hex SHA-256
+- `crates/mvm-contract/src/ir/canonicalize.rs` — produces the canonical byte sequence
+- `crates/mvm-contract/src/ir/hash.rs` — `ir_hash()` returns the lowercase-hex SHA-256
 
 Two semantically equivalent IRs (different field order, different whitespace) **must** produce the same hash. The hash is what binds an IR to a launch plan and to an audit-chain entry (ADR-001 claim 8). If you change a workload's IR, its hash changes; if you change anything else, it does not.
 
 ### Validation
 
-`crates/mvm-ir/src/validate.rs` runs the host-side checks. It rejects:
+`crates/mvm-contract/src/ir/validate.rs` runs the host-side checks. It rejects:
 
 - IRs with the wrong `schema_version`
 - Missing required fields, unknown fields (every type uses `#[serde(deny_unknown_fields)]`)
-- Languages not in `crates/mvm-ir/data/supported_languages.txt`
+- Languages not in `crates/mvm-contract/data/supported_languages.txt`
 - Unpinned dependencies — exits with `E_UNPINNED_DEPS`
 - Secret-shaped fields that leak into args/return schemas
 
@@ -240,13 +240,13 @@ The four files baked into every function workload:
 | `/etc/mvm/wrapper.json` | `{ module, function, format, working_dir, mode = "prod" }` — what the wrapper itself reads at startup |
 | `/etc/mvm/runtime.json` | `{ language, module, function, format, source_path, concurrency? }` — what the guest agent reads to decide how to dispatch |
 
-The two JSON files have different consumers on purpose: `runtime.json` is the agent's contract (its schema mirrors `mvm_guest::runtime_config::RuntimeConfig` exactly, with `deny_unknown_fields`), and `wrapper.json` is the wrapper's contract. Splitting them means the agent and the wrapper can evolve independently.
+The two JSON files have different consumers on purpose: `runtime.json` is the agent's contract (its schema mirrors `mvm_agentd::runtime_config::RuntimeConfig` exactly, with `deny_unknown_fields`), and `wrapper.json` is the wrapper's contract. Splitting them means the agent and the wrapper can evolve independently.
 
 The language registry lives at `nix/lib/factories/languages/` — one file per supported language. Adding a new language is **three changes**:
 
 1. Drop `nix/lib/factories/languages/<lang>.nix` with `servicePackages`, `language`, `runnerScript` attrs
 2. Add it to the `default.nix` switchboard in that directory
-3. Add the bare name to `crates/mvm-ir/data/supported_languages.txt`
+3. Add the bare name to `crates/mvm-contract/data/supported_languages.txt`
 
 No factory-side switch, no caller switch. The dispatcher in `mkFunctionService` looks it up.
 
@@ -270,8 +270,8 @@ What it provides:
 - **Firecracker kernel** (`vmlinux`)
 - **Busybox-as-PID-1 init** — under-5-second cold boot, no systemd
 - **Guest agent** — one universal Rust binary built from `mvm-src`, communicating over vsock (ADR-001 W4.1, W6.1.2). Production-safe runs receive a runtime profile and signed `VerbGrant`; DevOnly handlers remain unreachable without that authorization.
-- **Networking** — `eth0` configured via kernel boot args, NAT to host
-- **Privilege model** — PID 1 runs as uid 0 (kernel requirement); the entrypoint and agent run rootless (uid 1000 in prod, uid 0 in dev for the dev shell)
+- **Networking** — none. A workload microVM boots with no guest NIC; egress leaves only over vsock to the per-VM `mvm-network-endpoint`
+- **Privilege model** — PID 1 runs as uid 0 (kernel requirement); the agent runs as uid 990, and the entrypoint runs as uid 1000 in prod / uid 0 in dev for the dev shell
 - **Hardening** — `setpriv --no-new-privs` (W2.3), seccomp `standard` (W2.4), per-service uids (W2.1), read-only `/etc` overlay (W2.2), dm-verity verified boot (W3)
 - **Drive mounting** — `/mnt/config`, `/mnt/secrets`, `/mnt/data`
 
@@ -285,14 +285,14 @@ You now have a Nix derivation. To get a bootable rootfs on disk, `mvmctl` runs `
 
 **Orchestrator:** `crates/mvm-build/src/pipeline/orchestrator.rs::pool_build`
 
-The orchestrator picks a builder mode (`host` | `vsock` | `ssh` | `auto`) and dispatches to one of the backends under `crates/mvm-build/src/backend/`. For each build it:
+The orchestrator picks a builder mode (`host` | `vsock` | `auto`) and dispatches to one of the backends under `crates/mvm-build/src/backend/`. For each build it:
 
 1. **Prepares mounts.** Workspace mounted RO at `/work` inside the builder VM. Host `/nix` mounted RO when present; otherwise an empty store. Artifact dir mounted RW at `/out`.
 2. **Boots the builder VM.** 4 vCPU, 4096 MiB default. The builder image itself is built from this repo's flakes (`nix/images/builder-vm/`) — never downloaded — when running from a source checkout. (See CLAUDE.md: "Source-checkout builds never depend on mvm-published artifacts".)
 3. **Runs `nix build`.** With `--override-input mvm git+file://...?dir=nix` so the builder VM consumes the in-tree `nix/lib` you're editing, not a pinned release.
 4. **Extracts artifacts.** Copies `rootfs.ext4`, `vmlinux`, and `mvm-meta.json` back to the host artifact dir.
 
-The host never runs `nix` itself. Plan 72 is migrating the builder VM from libkrun to libkrun (macOS) / Firecracker (Linux); the contract is unchanged.
+The host never runs `nix` itself. The builder VM runs on libkrun (macOS 13-25), HVF (macOS 26+) or QEMU/libkrun (Linux); the contract is unchanged.
 
 ### Caching and reuse
 
@@ -490,7 +490,7 @@ Note the IR's `working_dir` field ends up baked into both files. Nothing is deci
 
 ## IR field reference
 
-The Workload IR types live in `crates/mvm-ir/src/workload.rs`. The full schema is enforced at the type level (`#[serde(deny_unknown_fields)]` everywhere); this section names the variants you'll most often choose between.
+The Workload IR types live in `crates/mvm-contract/src/ir/workload.rs`. The full schema is enforced at the type level (`#[serde(deny_unknown_fields)]` everywhere); this section names the variants you'll most often choose between.
 
 ### `Source` — where the code comes from
 
@@ -540,7 +540,7 @@ The validator rejects unpinned dependencies with `E_UNPINNED_DEPS`. Pinning rule
 - `npm` — `package-lock.json` v3 (every dep carries `integrity` + `resolved`)
 - `yarn` — `yarn.lock` (Yarn classic v1, every entry carries `integrity "sha512-..."`)
 
-If your workload only needs the language standard library, set `dependencies = mvm.deps.none()` explicitly. There's no implicit "none"; the validator wants you to declare your posture.
+If your workload only needs the language standard library, set `dependencies = mvm.no_deps()` explicitly (there is no `mvm.deps` namespace). There's no implicit "none"; the validator wants you to declare your posture.
 
 ### `Entrypoint` — how the wrapper inside the microVM is dispatched
 
@@ -621,12 +621,12 @@ The rootfs itself stays minimal — it carries only the interpreter and the lang
 
 The IR hash isn't decorative — it's load-bearing in the admission path.
 
-**`mvmctl machine run`** (`crates/mvm-cli/src/commands/vm/plan_admission.rs`):
+**`mvmctl machine run`** (`crates/mvm-hostd/src/plan_admission.rs`):
 
 1. Resolves the workload → IR JSON → `ir_hash`.
 2. Calls `synthesize_plan(input)` (`plan_builder.rs`) to build a typed `ExecutionPlan` carrying the IR hash, image ref, resources, policy refs, an intent-bound admission profile, validity window, and a fresh nonce.
 3. Signs the plan with the host's Ed25519 keypair at `~/.mvm/keys/host-signer.ed25519` (mode 0600).
-4. Verifies through `mvm_plan::verify_plan`.
+4. Verifies through `mvm_core::plan::verify_plan`.
 5. Enforces validity window (G4) and nonce replay-store.
 6. Dispatches to the backend.
 
@@ -658,12 +658,13 @@ Typical output:
   "accessible":            false,
   "sealed":                true,
   "entrypointKind":        "command",
-  "init_system":           "busybox",
-  "expected_boot_ms":      4200,
-  "agent_binary":          "/nix/store/...-mvm-guest-agent",
-  "rootless_entrypoint":   true,
-  "vmlinux_present":       true,
-  "initrd_present":        false
+  "entrypointArgv":        ["/usr/lib/mvm/wrappers/runner"],
+  "initSystem":            "busybox",
+  "expectedBootMs":        300,
+  "agentBinary":           "real",
+  "rootlessEntrypoint":    true,
+  "uids":                  { "agent": 990, "entrypoint": 1000 },
+  "overlayAware":          true
 }
 ```
 
@@ -698,12 +699,12 @@ Common errors you'll meet, with where they originate:
 
 | Error | Origin | Meaning |
 |-------|--------|---------|
-| `E_UNPINNED_DEPS` | `crates/mvm-ir/src/validate.rs` | A dependency lockfile entry doesn't carry the expected hash format. Use `uv lock`, `pip-compile --generate-hashes`, or pnpm/npm/yarn lockfiles with integrity entries. |
-| `UnsupportedSchema` (plan verifier) | `crates/mvm-plan/src/plan.rs` | Plan schema_version is newer than this binary understands. Update mvmctl. |
+| `E_UNPINNED_DEPS` | `crates/mvm-contract/src/ir/validate.rs` | A dependency lockfile entry doesn't carry the expected hash format. Use `uv lock`, `pip-compile --generate-hashes`, or pnpm/npm/yarn lockfiles with integrity entries. |
+| `UnsupportedSchema` (plan verifier) | `crates/mvm-core/src/plan/` | Plan schema_version is newer than this binary understands. Update mvmctl. |
 | `mkFunctionWorkload: IR must have exactly one app` | `nix/lib/mkFunctionWorkload.nix:75` | Helper only supports single-app workloads. Drop to mkFunctionService + mkGuest by hand. |
 | `mkFunctionWorkload: app.image.kind must be "nix_packages"` | `nix/lib/mkFunctionWorkload.nix:83` | Helper doesn't support `oci_base`. Long-form route until OCI is wired through. |
 | `mkFunctionWorkload: expected exactly one primary function entrypoint` | `nix/lib/mkFunctionWorkload.nix:99` | Multi-function dispatch is ADR-0014 Phase 2; today, mark exactly one entrypoint `primary: true` and let the helper bake just that one, or use the long form. |
-| `mkFunctionService: language "<x>" has no entry in the language registry` | `nix/lib/factories/mkFunctionService.nix:59` | Add `nix/lib/factories/languages/<lang>.nix`, register in `default.nix`, append to `crates/mvm-ir/data/supported_languages.txt`. |
+| `mkFunctionService: language "<x>" has no entry in the language registry` | `nix/lib/factories/mkFunctionService.nix:59` | Add `nix/lib/factories/languages/<lang>.nix`, register in `default.nix`, append to `crates/mvm-contract/data/supported_languages.txt`. |
 
 ## Why this design
 
@@ -713,7 +714,7 @@ A few choices look unusual until you've seen them play out.
 
 **Why is the flake helper not a code generator?** Because the flake the user writes is already minimal (`mkFunctionWorkload { irFile = ...; appPkg = ./.; }`). A code generator would have to be re-run every time the IR changed, and its output would need to be committed or `.gitignore`d. Reading the IR at Nix evaluation time means the flake stays static; the IR can change without touching `flake.nix`.
 
-**Why do `wrapper.json` and `runtime.json` carry overlapping fields?** Two consumers, two contracts. The agent owns `runtime.json` (and ships its schema via `mvm_guest::runtime_config::RuntimeConfig` with `deny_unknown_fields`). The wrapper owns `wrapper.json` (its schema is in `nix/wrappers/README.md`). Splitting lets the agent and the wrapper evolve independently. The overlap is intentional duplication: both consumers need the same module/function/format triple to do their jobs.
+**Why do `wrapper.json` and `runtime.json` carry overlapping fields?** Two consumers, two contracts. The agent owns `runtime.json` (and ships its schema via `mvm_agentd::runtime_config::RuntimeConfig` with `deny_unknown_fields`). The wrapper owns `wrapper.json` (its schema is in `nix/wrappers/README.md`). Splitting lets the agent and the wrapper evolve independently. The overlap is intentional duplication: both consumers need the same module/function/format triple to do their jobs.
 
 **Why busybox-as-PID-1?** Cold boot under 5 seconds. systemd would dominate the boot budget. ADR-0013 spells out the math and the trade-offs.
 
@@ -738,7 +739,7 @@ A few choices look unusual until you've seen them play out.
 ## Where to read next
 
 - **[Writing Nix Flakes](/guides/nix-flakes/)** — full mkGuest reference for command-style workloads and richer compositions
-- **`crates/mvm-ir/src/workload.rs`** — the Workload IR type definitions (canonical reference)
+- **`crates/mvm-contract/src/ir/workload.rs`** — the Workload IR type definitions (canonical reference)
 - **`nix/lib/mkFunctionWorkload.nix`** — the IR → derivation helper (read it; it's 150 lines)
 - **`nix/lib/factories/mkFunctionService.nix`** — per-language factory
 - **`nix/lib/mk-guest.nix`** — the rootfs builder

--- a/public/src/content/docs/guides/kernels.md
+++ b/public/src/content/docs/guides/kernels.md
@@ -26,7 +26,7 @@ mvmctl build kernel build --all --source auto
 
 Flags:
 
-- `--which {builder,workload,workload-sizeopt}` — which kernel (default `builder`).
+- `--which {builder,workload}` — which kernel (default `builder`).
 - `--all` — build both variants.
 - `--source {compile,download,auto}` — where the kernel comes from (default
   `compile`, unless `--kernel-source` or `MVM_KERNEL_SOURCE` is set).
@@ -34,13 +34,14 @@ Flags:
 - `--boot-check` — after building the default workload kernel, boot a throwaway
   VM on it and confirm the in-guest agent answers over vsock.
 
-Workload kernels ship with `CONFIG_CC_OPTIMIZE_FOR_SIZE=y`. The
-`workload-sizeopt` selector remains as a compatibility alias for the measured
-size-oriented variant; it resolves to the same config as `workload`.
+Workload kernels ship with `CONFIG_CC_OPTIMIZE_FOR_SIZE=y`. There is no
+`workload-sizeopt` selector on `--which` — the only two values are `builder`
+and `workload`. (A `workload-sizeopt-metrics` *flake output* still exists as a
+compatibility alias; see below.)
 
 The compiled or downloaded kernel is cached at
 `~/.mvm/cache/builder-vm/<arch>/kernels/<variant>/vmlinux` and reused by every
-later `dev up`.
+later run that needs it. (There is no `mvmctl dev` command — it was removed.)
 
 When the kernel was compiled locally, the cache directory also carries a
 resolved `config` sidecar and `kernel-metrics-<arch>.json`, so you can inspect

--- a/public/src/content/docs/guides/machine-use-cases.md
+++ b/public/src/content/docs/guides/machine-use-cases.md
@@ -17,7 +17,7 @@ boundary only when a workflow actually needs Linux build or evaluation work.
 | --- | --- | --- |
 | Sandbox untrusted code | `mvmctl machine run --image alpine -- <cmd>` | Fresh transient microVM, command output, teardown on exit. |
 | Run a command in an OCI image | `mvmctl machine run --image ghcr.io/org/app:tag -- <cmd>` | OCI provenance, cache reuse, admission, receipts, and audit. |
-| Use a local image archive | `mvmctl machine run --image-archive ./image.tar -- <cmd>` | Offline-friendly image input through the same hardened unpack/admission path. |
+| Run an offline, pre-sealed workload | `mvmctl bundle install ./app.mvmpkg` then `mvmctl machine run --manifest <bundle-sha256>` | Offline-friendly input through the signed-bundle verify/admission path. |
 | Keep a dev machine around | `mvmctl machine create dev --image alpine` | Durable spec plus `start`, `exec`, `shell`, `stop`, `inspect`, and `rm`. |
 | Start a machine, creating it if missing | `mvmctl machine start dev --image alpine` | Combines `create` + `start`; useful for scripts and idempotent workflows. |
 | Declare a repeatable machine | `mvmctl machine create dev --manifest ./mvm.toml` | TOML-backed image, sizing, network, volume, and dev-init settings. |
@@ -45,8 +45,13 @@ skips admission or verification.
 Networking is default-deny. Opt in explicitly:
 
 ```bash
-mvmctl machine run --net --image alpine:3.20 -- nslookup example.com
-mvmctl machine run --net --allow-host registry.npmjs.org --image alpine:3.20 -- \
+# --net selects the built-in `dev` preset: package registries plus
+# GitHub, OpenAI and Anthropic. It is an allowlist, not general outbound.
+mvmctl machine run --net --image alpine:3.20 -- \
+  wget -q -O /dev/null https://registry.npmjs.org
+
+# --allow-host narrows to exactly what you name, and wins over --net.
+mvmctl machine run --allow-host registry.npmjs.org --image alpine:3.20 -- \
   wget -q -O /dev/null https://registry.npmjs.org
 ```
 
@@ -83,8 +88,14 @@ image = "alpine:3.20"
 cpus = 2
 mem = "512M"
 net = true
-allow_hosts = ["registry.npmjs.org"]
+
+[network]
+allow_hosts = ["registry.npmjs.org:443"]
 ```
+
+`allow_hosts` lives under `[network]` (or `[grants]`), never at the top level —
+the manifest uses `deny_unknown_fields`, so a top-level `allow_hosts` is a
+parse error.
 
 ```bash
 mvmctl machine create js-dev --manifest ./mvm.toml

--- a/public/src/content/docs/guides/manifests.md
+++ b/public/src/content/docs/guides/manifests.md
@@ -110,7 +110,7 @@ transport is implemented.
 
 ### Manifest discovery
 
-`mvmctl machine build`, `mvmctl machine run`, `mvmctl run`, `mvmctl machine exec`, `mvmctl machine inspect`, `mvmctl machine rm` all accept an optional `[PATH]` argument:
+Only `mvmctl machine build` takes an optional positional `[PATH]` (defaulting to `.`). `mvmctl machine run` and `mvmctl run` take `-m/--manifest <PATH>` instead, because their positional slot is the trailing argv:
 
 ```bash
 mvmctl machine build                              # walks up from cwd looking for mvm.toml
@@ -164,8 +164,7 @@ mvmctl machine build --update-hash                    # recompute Nix FOD hash (
 ```
 
 Sizing is a launch-time decision: pass `--cpus` / `--memory` to `mvmctl
-machine run`, or persist them on a named machine with `mvmctl machine create
---cpus 4 --mem 2G`.
+machine run`, or persist them on a named machine via its manifest.
 
 Build artifacts are stored in a content-addressed registry under `~/.mvm/templates/<sha256(canonical_manifest_path)>/artifacts/revisions/<revision_hash>/`. The manifest's *path* identifies the project; `revision_hash = sha256(flake.lock + profile)` content-addresses the actual build outputs.
 
@@ -175,7 +174,7 @@ An unsupported request fails closed instead of downgrading to image-only.
 
 ## Listing / inspecting / removing
 
-Manifest registry operations live under `mvmctl manifest`. (The unprefixed `mvmctl machine ls` / `mvmctl machine inspect` / `mvmctl machine stop` continue to operate on **running VMs** — those are unchanged.)
+Manifest registry operations live under `mvmctl manifest`. (`mvmctl machine ls` / `mvmctl machine inspect` / `mvmctl machine stop` continue to operate on **machines** — those are unchanged. `machine ls` has a visible `ps` alias.)
 
 ```bash
 mvmctl manifest ls                            # list built slots (manifest path, name, last built)

--- a/public/src/content/docs/guides/mvmforge-migration.md
+++ b/public/src/content/docs/guides/mvmforge-migration.md
@@ -13,11 +13,11 @@ mvm release ships the substrate and the SDK in lockstep.
 
 | mvmforge surface                   | mvm equivalent                                              |
 | ---------------------------------- | ----------------------------------------------------------- |
-| `mvmforge-ir` crate                | `crates/mvm-ir`                                             |
+| `mvmforge-ir` crate                | `crates/mvm-contract/src/ir/`                               |
 | `mvmforge-sdk` crate (Rust builder)| `crates/mvm-sdk` (`builder` module)                         |
 | `mvmforge-addon` crate             | `crates/mvm-sdk/src/addon/`                                 |
 | `mvmforge` host CLI compile path   | `crates/mvm-sdk/src/compile/` + `mvmctl build compile`            |
-| `mvmforge-runtime` (in-guest)      | `crates/mvm-runner` + `nix/lib/factories/mkFunctionService` |
+| `mvmforge-runtime` (in-guest)      | `crates/mvm-agentd` + `nix/lib/factories/mkFunctionService` |
 | Python SDK (`@mv.func`)            | `crates/mvm-sdk/sdks/python/mvm/` (`@mvm.app`)                             |
 | TypeScript SDK                     | `crates/mvm-sdk/sdks/typescript/`                                          |
 

--- a/public/src/content/docs/guides/network-egress-policy.mdx
+++ b/public/src/content/docs/guides/network-egress-policy.mdx
@@ -93,9 +93,9 @@ For a reviewed outbound grant:
 network: mvm.network({
   mode: "bridge",
   egress: mvm.egress([
-    mvm.hostPort("api.openai.com", 443),
+    mvm.host_port("api.openai.com", 443),
   ]),
-  dns: mvm.dnsSystem(),
+  dns: mvm.dns_system(),
 })
 ```
 
@@ -207,7 +207,7 @@ network=mvm.network(
 network: mvm.network({
   mode: "bridge",
   egress: mvm.egress([
-    mvm.hostPort("api.openai.com", 443),
+    mvm.host_port("api.openai.com", 443),
   ]),
   ai: mvm.aiPolicy({
     metering: true,

--- a/public/src/content/docs/guides/networking.md
+++ b/public/src/content/docs/guides/networking.md
@@ -12,7 +12,7 @@ Networking differs by backend:
 | Firecracker (Linux native) | NIC-less vsock egress     | —            | Host endpoint; default-deny policy gate           |
 | HVF (macOS 26+, default)   | NIC-less vsock egress     | —            | Host endpoint; default-deny policy gate           |
 | libkrun (macOS)            | NIC-less vsock egress     | —            | Host endpoint; default-deny policy gate           |
-| QEMU (Linux dev/test)      | Rootless user-mode virtio | 10.0.2.15/24 | QEMU user-mode network; outside production claims |
+| QEMU (Linux dev/test)      | NIC-less vsock egress     | —            | Host endpoint; default-deny policy gate           |
 
 ## Production Network Layout
 
@@ -38,10 +38,10 @@ Raw ICMP and arbitrary non-proxy-aware sockets are intentionally not available
 on this path. `ping` is therefore not a valid egress smoke test; use an HTTP,
 TCP, or SOCKS5-aware UDP probe.
 
-## Rootless QEMU transparent networking
+## QEMU dev/test backend
 
-Linux users who need ordinary guest TCP and UDP sockets without configuring a
-host TAP device can opt into QEMU's dev/test backend:
+Linux users without `/dev/kvm` can opt into QEMU's dev/test backend. It is not
+a wider network path — the converged QEMU boot attaches no NIC either:
 
 ```bash
 mvmctl machine run --hypervisor qemu --image alpine --net -- \
@@ -124,12 +124,17 @@ For debugging dev builds, use `mvmctl machine logs <name>` to view guest console
 ## Network Policies
 
 By default, a workload gets **no outbound network** (deny-all egress). Opt in
-with `--net` (broad dev egress) or narrow to specific hosts with `--allow-host
-HOST[:PORT]` (repeatable; `--allow-host` wins over `--net`). For a deny-first
-review workflow, see [Network egress policy](/guides/network-egress-policy/).
+with `--net` or narrow to specific hosts with `--allow-host HOST[:PORT]`
+(repeatable; `--allow-host` wins over `--net`). For a deny-first review
+workflow, see [Network egress policy](/guides/network-egress-policy/).
+
+`--net` selects the built-in **`dev` preset**, which is an allowlist, not
+general outbound: package registries (npm, crates.io, PyPI) **plus** GitHub,
+OpenAI and Anthropic. Anything outside that set is still denied. No CLI flag
+reaches the narrower `registries` preset.
 
 ```bash
-# Broad dev egress (DNS + general outbound)
+# The dev preset: registries + GitHub + OpenAI + Anthropic
 mvmctl machine run --flake . --net
 
 # Narrow allowlist — only these hosts (PORT defaults to 443)
@@ -164,10 +169,10 @@ That wrapper packages both the exact CLI path
 and a second admit/deny relay proof that demonstrates allowed traffic is
 reachable while a non-admitted destination is refused, all without a guest NIC.
 
-For production NIC-less backends, policies are enforced by the host endpoint
-and the shared egress gate rather than guest firewall rules. QEMU's user-mode
-network is a dev/test convenience and is not a substitute for that production
-policy boundary.
+Policies are enforced by the host endpoint and the shared egress gate rather
+than guest firewall rules — there is no guest NIC for a firewall rule to act
+on. QEMU rides the same gate, but it is a dev/test tier for other reasons
+(software emulation without `/dev/kvm`, a larger TCB, partial verified boot).
 
 ## Measuring the paths
 
@@ -183,8 +188,10 @@ particular hypervisor, VPN, or Internet route.
 
 ## Security Profiles
 
-Pick the guest's security posture with `--profile`. It governs env injection and
-host-share permissions, and selects the seccomp posture applied inside the guest:
+Pick the guest's security posture with `--profile`. It governs env injection,
+host-share permissions, and whether the guest gets the dev profile. It does
+**not** select a seccomp tier — every plan is synthesised at the `standard`
+tier and there is no per-launch selector:
 
 ```bash
 mvmctl machine run --flake . --profile restrictive   # no env injection, no host shares
@@ -196,10 +203,12 @@ The resolved profile is copied into the signed `ExecutionPlan` admission record 
 
 | Profile              | Env injection           | Host shares                                      |
 | -------------------- | ----------------------- | ------------------------------------------------ |
-| `restrictive`        | none                    | none                                             |
-| `standard` (default) | explicit `-e KEY=VALUE` | read-only                                        |
-| `dev`                | explicit `-e KEY=VALUE` | read-write allowed                               |
-| `permissive`         | explicit                | read-write (requires `MVM_ACK_PERMISSIVE_RUN=1`) |
+| `restrictive`        | none                    | none                                                          |
+| `standard` (default) | explicit `-e KEY=VALUE` | read-only                                                     |
+| `dev`                | explicit `-e KEY=VALUE` | read-write **on a persistent machine only**                   |
+| `permissive`         | explicit                | as `dev`, and requires `MVM_ACK_PERMISSIVE_RUN=1`             |
+
+A transient run's host shares are read-only under every profile.
 
 ## DNS
 

--- a/public/src/content/docs/guides/nix-flakes.md
+++ b/public/src/content/docs/guides/nix-flakes.md
@@ -6,8 +6,10 @@ description: Create custom Nix flakes that build microVM images for mvm.
 :::note[Health checks run in the guest]
 `healthChecks` is rendered into `/etc/mvm/probes.d/<name>.json` in the image.
 The guest agent scans that directory at boot and runs each check on its own
-interval; results come back over vsock. `volumeMounts` and `serviceGroup` are
-still recorded rather than acted on — the multi-service supervisor is not wired.
+interval; results come back over vsock. The top-level `services`,
+`volumeMounts` and `serviceGroup` arguments are still recorded rather than
+acted on — the multi-service supervisor is not wired. `entrypoint.services`
+is unwired for the same reason: it falls through to a recovery shell.
 :::
 
 mvmctl uses Nix flakes to produce reproducible microVM images. You run `mvmctl machine build` from the host, and mvm runs Nix evaluation and `nix build` inside the Linux builder VM. The result is a kernel and rootfs that can boot on any supported runtime backend, including Firecracker, HVF, libkrun, and QEMU.
@@ -32,9 +34,11 @@ You do not need to enter a dev shell to build a flake. The dev shell is only for
         name = "my-app";
         packages = [ pkgs.curl ];
 
-        services.my-app = {
-          command = "${pkgs.python3}/bin/python3 -m http.server 8080";
-        };
+        # `entrypoint` is required and takes exactly one of
+        # `shell` / `command` / `services`.
+        entrypoint.command = [
+          "${pkgs.python3}/bin/python3" "-m" "http.server" "8080"
+        ];
 
         healthChecks.my-app = {
           healthCmd = "${pkgs.curl}/bin/curl -sf http://localhost:8080/";
@@ -49,22 +53,26 @@ You do not need to enter a dev shell to build a flake. The dev shell is only for
 
 | Parameter | Description |
 |-----------|-------------|
-| `name` | VM name (used in image filename) |
-| `packages` | Nix packages to include in the rootfs |
-| `hostname` | Guest hostname (default: same as `name`) |
-| `serviceGroup` | Default service user/group name (default: `"mvm"`). Services run as this user; secrets are readable by this group. |
-| `users.<name>.uid` | User ID (optional, auto-assigned from 1000) |
-| `users.<name>.group` | Group name (optional, defaults to user name) |
-| `users.<name>.home` | Home directory (optional, defaults to `/home/<name>`) |
-| `services.<name>.command` | Long-running service command (supervised with respawn) |
-| `services.<name>.preStart` | Optional setup script (runs as root before the service) |
-| `services.<name>.env` | Optional environment variables (`{ KEY = "value"; }`) |
-| `services.<name>.user` | User to run as (default: `serviceGroup`) |
-| `services.<name>.logFile` | Optional log file path (default: `/dev/console`) |
-| `healthChecks.<name>.healthCmd` | Health check command (exit 0 = healthy) |
+| `name` | **Required.** VM name (used in image filename) |
+| `entrypoint` | **Required.** Exactly one of `shell` / `command` / `services`; see [Building MicroVM Images](/guides/building-microvm-images#entrypoint-forms) |
+| `packages` | Nix packages to include in the rootfs (default: `[]`) |
+| `hypervisor` | Default hypervisor (default: `"firecracker"`) |
+| `vcpus` | Resource default (default: `1`) |
+| `memory_mib` | Resource default (default: `256`) |
+| `dev` | Explicit accessible-vs-sealed override (default: inferred from `entrypoint`) |
+| `uids` | `{ agent; entrypoint; }` privilege-model override |
+| `extraFiles` | `{ "/abs/path" = { content; mode?; }; }` baked into the rootfs |
+| `kernel`, `bootCommand`, `builderUid`, `withAuditProbe` | Advanced overrides |
+| `healthChecks.<name>.healthCmd` | Health check command (exit 0 = healthy); **required** per check |
 | `healthChecks.<name>.healthIntervalSecs` | How often to run the check (default: 30) |
 | `healthChecks.<name>.healthTimeoutSecs` | Timeout for each check (default: 10) |
-| `volumeMounts."<guest-path>"` | Plan 45 — declarative virtio-fs volume mount declarations. See "Volume Mounts" below. |
+| `serviceGroup` | Accepted and recorded, but **not enforced** — nothing acts on it |
+| `services.<name>` | Accepted and recorded, but **not enforced** — the multi-service supervisor is not wired |
+| `volumeMounts."<guest-path>"` | Accepted and recorded, but **not enforced**. See "Volume Mounts" below. |
+
+The argument set is not variadic, so any name not in this table is an
+evaluation error. There is no `hostname` argument (the guest hostname comes
+from `name`) and no `users` argument.
 
 ## Volume Mounts
 
@@ -81,21 +89,22 @@ mkGuest {
 }
 ```
 
-The host (`mvmctl machine run` or mvmd) reads these declarations via `passthru.volumeMounts`:
+The declarations are recorded under `passthru.mvm.unenforced.volumeMounts`:
 
 ```sh
-nix eval .#mvm-worker.passthru.volumeMounts --json
-# → [
-#     {"guestPath":"/mnt/inputs","volumeName":"fixtures","readOnly":true},
-#     {"guestPath":"/mnt/work","volumeName":"workspace","readOnly":false}
-#   ]
+nix eval .#mvm-worker.passthru.mvm.unenforced.volumeMounts --json
 ```
 
-At boot the host attaches a virtio-fs device per declaration and the guest agent runs the matching `MountVolume` vsock verb. Validation:
+**Nothing consumes them yet.** `mkGuest` accepts the attribute set, checks only
+that it *is* an attribute set, and records it; there is no eval-time validation
+of guest paths or volume names, and no host code attaches a virtio-fs device
+from this declaration. Runtime volume mounting is driven by the kernel cmdline
+the host writes, independently of this argument.
 
-- **Guest paths** must be absolute and **outside** `/nix*`, `/run/booted-system`, `/run/current-system` — Nix-immutable paths are off-limits per plan 45 §"Nix semantics alignment".
-- **Volume names** must be non-empty strings ≤32 chars (used as the virtio-fs tag).
-- The host's `mvm_security::policy::MountPathPolicy` re-validates at runtime (defence-in-depth) — the eval-time checks fail fast for malformed flakes.
+When you do declare a guest path that the host will later mount, note that the
+host-side mount policy (`mvm_core::crypto::policy::MountPathPolicy`) allows
+only paths under `/data` and `/work` — `/mnt` is deliberately excluded so a
+share cannot shadow the runtime's own `/mnt/config` and `/mnt/secrets` drives.
 
 **Reproducibility boundary:** volume *contents* do not influence the image hash. The flake hash captures the *declaration* of the mounts, not the data behind them. Volumes are the explicit mutable layer; the rootfs stays immutable + verity-protected.
 
@@ -112,9 +121,11 @@ At boot the host attaches a virtio-fs device per declaration and the guest agent
 - **Guest agent** — vsock-based health checks, status reporting, snapshot
   coordination; baked into dev/fallback images and supplied by the runtime
   overlay on sealed required-overlay boots
-- **Networking** — eth0 configured via kernel boot args, NAT to host network
-- **Drive mounting** — `/mnt/config` (ro), `/mnt/secrets` (ro), `/mnt/data` (rw)
-- **Service supervision** — automatic restart on failure with backoff
+- **Networking** — none. A workload microVM boots with no guest NIC at all;
+  egress leaves only over vsock to the per-VM `mvm-network-endpoint`.
+- **Drive mounting** — `/mnt/config` (ro, `/dev/vdb`), `/mnt/secrets` (ro,
+  `/dev/vdc`), `/mnt/data` (rw). These are drive images mounted by `/init`,
+  not host `--mount` shares.
 
 ## Runtime overlay contract
 
@@ -146,7 +157,14 @@ Operationally, this means:
 
 ## Adding Services
 
-Services defined in `services.<name>` are supervised by the init system:
+:::caution[Not wired yet]
+`services` is accepted and recorded in `passthru.mvm.unenforced`, but nothing
+supervises it — the multi-service supervisor is not built. `mkGuest` emits an
+evaluation-time warning when you set it. The shape below is the declared
+surface, not running behaviour.
+:::
+
+The declared shape of a `services.<name>` entry:
 
 ```nix
 services.my-app = {
@@ -172,7 +190,7 @@ services.my-app = {
 
 ## Health Checks
 
-Health checks defined in `healthChecks` are automatically written to `/etc/mvm/integrations.d/` at build time. The guest agent picks them up on boot:
+Health checks defined in `healthChecks` are automatically written to `/etc/mvm/probes.d/<name>.json` at build time. The guest agent picks them up on boot:
 
 ```nix
 healthChecks.my-app = {
@@ -191,110 +209,36 @@ mvmctl machine logs <name> -f    # follow in real time
 
 ## Users
 
-All services run as a built-in non-root user (default: `mvm`, uid 900) — never as root. Secrets at `/mnt/secrets` are owned by `root:<serviceGroup>` with mode `0440`, so only members of the service group can read them. Custom users are automatically added to this group.
-
-To change the default service user/group name, set `serviceGroup`:
+The guest agent runs as uid **990**. The entrypoint runs as uid **1000** in a
+sealed (prod) image and uid **0** in a dev image; override either with the
+`uids` argument:
 
 ```nix
 mvm.lib.${system}.mkGuest {
   name = "my-app";
-  serviceGroup = "app";  # default: "mvm"
-  # ...
+  entrypoint.command = [ "/usr/local/bin/serve" ];
+  uids = { agent = 990; entrypoint = 1000; };
 };
 ```
 
-To run a service as a custom user, define it in `users` and reference it in the service. The custom user is automatically added to the service group for secrets access:
+Secrets at `/mnt/secrets` are owned by `root:<group>` with mode `0440`, so only
+members of the service group can read them.
 
-```nix
-users.app = {
-  uid = 1000;
-  group = "app";
-  home = "/home/app";
-};
-
-services.my-app = {
-  command = "${pkgs.nodejs}/bin/node /app/server.js";
-  user = "app";  # overrides the default serviceGroup user
-};
-```
-
-The `preStart` script always runs as root regardless of the `user` setting, so it can perform privileged setup like mounting filesystems or creating directories.
+`mkGuest` has no `users` argument — there is no way to declare additional guest
+users from the flake today. `serviceGroup` is accepted but not enforced.
 
 ## Rootfs Types
 
 By default, `mkGuest` produces an **ext4** rootfs. The build system also supports **squashfs** for smaller, read-only images (~76% smaller with LZ4 compression). When using squashfs, the init system mounts tmpfs overlays on `/etc` and `/var` automatically.
 
-## Service Builder Helpers
+## Composing a workload
 
-The guest library provides high-level helpers that return a `{ package, service, healthCheck }` set. Compose them with `mkGuest`:
-
-### mkPythonService
-
-Build a Python HTTP service using `python3.withPackages` (nixpkgs packages only):
-
-```nix
-let
-  pythonApp = mvm.lib.${system}.mkPythonService {
-    name = "my-api";
-    src = ./.;
-    pythonPackages = ps: [ ps.flask ];
-    entrypoint = "app/main.py";
-    port = 8080;
-    env = { WORKERS = "2"; };
-  };
-in
-  mvm.lib.${system}.mkGuest {
-    name = "my-api";
-    packages = [ pythonApp.package ];
-    services.app = pythonApp.service;
-    healthChecks.app = pythonApp.healthCheck;
-  };
-```
-
-### mkStaticSite
-
-Serve static files with busybox httpd (zero extra packages):
-
-```nix
-let
-  site = mvm.lib.${system}.mkStaticSite {
-    name = "docs";
-    src = ./public;
-    port = 8080;
-  };
-in
-  mvm.lib.${system}.mkGuest {
-    name = "docs";
-    packages = [ site.package ];
-    services.www = site.service;
-    healthChecks.www = site.healthCheck;
-  };
-```
-
-### mkNodeService
-
-Build a Node.js service with npm install + tsc:
-
-```nix
-let
-  app = mvm.lib.${system}.mkNodeService {
-    name = "my-app";
-    src = fetchGit { url = "..."; rev = "..."; };
-    npmHash = "sha256-...";
-    entrypoint = "dist/index.js";
-    port = 3000;
-  };
-in
-  mvm.lib.${system}.mkGuest {
-    name = "my-app";
-    packages = [ app.package ];
-    services.app = app.service;
-    healthChecks.app = app.healthCheck;
-  };
-```
-
-All three helpers return the same shape: `{ package, service, healthCheck }`. This makes it easy to swap between runtimes or compose multiple services in a single guest.
-
+`nix/lib` exports exactly three functions: `mkGuest`, `mkFunctionService`,
+and `mkFunctionWorkload`. There are no `mkPythonService`, `mkStaticSite`, or
+`mkNodeService` helpers — build the service attribute set yourself and pass it
+to `mkGuest`, or use `mkFunctionWorkload` to lower an SDK-emitted Workload IR
+straight to a rootfs (see
+[From Workload IR to MicroVM Image](/guides/ir-to-image/)).
 ## Build Process
 
 When you run `mvmctl machine build --flake .`:
@@ -370,13 +314,19 @@ chmod 0400 ~/.mvm/config/secrets/anthropic
 
 cd my-claude-code-vm
 mvmctl machine build
-mvmctl machine run --manifest . --profile dev \
-  --mount "$PWD:/workspace:rw" \
-  --mount "$HOME/.mvm/config/secrets:/mnt/secrets"
+mvmctl machine run --manifest . --profile dev --name agent -d \
+  --mount "$PWD:/work:rw" \
+  --mount "$HOME/.mvm/config/secrets:/data/secrets:ro"
 ```
 
+A guest mount path must sit under `/data` or `/work` — those are the only two
+allow-roots. `/mnt/*` is refused outright so a share cannot shadow the
+runtime's own config and secrets drives. A `:rw` share additionally needs a
+**persistent** machine (`--name` plus `-d`) and `--profile dev`; a transient
+run's shares are read-only under every profile.
+
 Inside the guest, your workload can read the file you mounted under
-`/mnt/secrets`. If you do not want the guest to ever see the raw
+`/data/secrets`. If you do not want the guest to ever see the raw
 credential, do not use this manual file-mount pattern; use managed
 secret refs instead.
 

--- a/public/src/content/docs/guides/persistent-workspaces.md
+++ b/public/src/content/docs/guides/persistent-workspaces.md
@@ -3,6 +3,14 @@ title: Persistent workspaces
 description: Use encrypted volumes, copy workflows, snapshots, and cleanup policies for stateful sandboxes.
 ---
 
+:::note[Hidden verbs]
+`machine volume`, `machine cp` and `machine fs` are all marked hidden in the
+CLI: they work, but they do not appear in `mvmctl machine --help`.
+
+Guest mount paths must be under `/data` or `/work` — those are the only two
+allow-roots. `/cache`, `/workspace` and anything under `/mnt` are refused.
+:::
+
 Persistent state is useful for agents, browser sessions, caches, databases, and
 long-running services. It is also where sensitive data accumulates. Choose the
 smallest state mechanism that fits the workflow, and make the retention policy
@@ -40,7 +48,7 @@ Mount the unlocked volume into a running sandbox:
 ```sh
 mvmctl machine volume mount agent-sandbox \
   --volume agent-cache \
-  --guest /cache \
+  --guest /data/cache \
   --rw
 ```
 
@@ -53,7 +61,7 @@ mvmctl machine volume ls agent-sandbox
 Unmount and lock when the workflow is done:
 
 ```sh
-mvmctl machine volume unmount agent-sandbox /cache
+mvmctl machine volume unmount agent-sandbox /data/cache
 mvmctl machine volume lock agent-cache
 ```
 
@@ -168,7 +176,7 @@ For a coding agent:
 
 1. Create a named sandbox with a short TTL.
 2. Copy the task input into `/work`.
-3. Mount a managed volume at `/workspace` only if the agent needs durable state.
+3. Mount a managed volume at `/data/workspace` only if the agent needs durable state.
 4. Keep network closed until the task has an approved egress need.
 5. Copy out bounded results.
 6. Stop, cold-pause, or destroy based on the retention decision.
@@ -180,11 +188,11 @@ Example:
 mvmctl machine volume create coding-agent-work
 mvmctl machine volume unlock coding-agent-work
 mvmctl machine run --flake ./agent-image --name coding-agent -d
-mvmctl machine volume mount coding-agent --volume coding-agent-work --guest /workspace --rw
+mvmctl machine volume mount coding-agent --volume coding-agent-work --guest /data/workspace --rw
 mvmctl machine cp ./task.json coding-agent:/work/task.json
 mvmctl machine exec coding-agent -- python /work/run_task.py
 mvmctl machine cp --max-bytes 16777216 coding-agent:/work/result.json ./result.json
-mvmctl machine volume unmount coding-agent /workspace
+mvmctl machine volume unmount coding-agent /data/workspace
 mvmctl machine stop coding-agent
 mvmctl machine volume lock coding-agent-work
 ```

--- a/public/src/content/docs/guides/policy-profiles.md
+++ b/public/src/content/docs/guides/policy-profiles.md
@@ -1,11 +1,11 @@
 ---
 title: Policy profiles
-description: Choose the right run profile, host-share mode, environment policy, and seccomp tier for a sandboxed workload.
+description: Choose the right run profile, host-share mode, and environment policy for a sandboxed workload.
 ---
 
 Policy profiles are the first security decision for a sandbox run. Pick the
 least permissive profile that lets the workload do its job, then add filesystem,
-environment, network, and seccomp permissions deliberately.
+environment, and network permissions deliberately.
 
 For generated code, third-party code, model tool calls, and CI jobs, start with
 `restrictive` and relax only the specific boundary that blocks the workload.
@@ -17,9 +17,13 @@ For generated code, third-party code, model tool calls, and CI jobs, start with
 | Profile | Default use | Host shares | Environment injection |
 | --- | --- | --- | --- |
 | `restrictive` | Generated or untrusted code. | Not allowed. | Not allowed. |
-| `standard` | Normal local one-shot runs. | Read-only only. | Explicit `--env KEY=VAL` allowed. |
-| `dev` | Local iteration against a project tree. | Read-only or writable. | Explicit `--env KEY=VAL` allowed. |
-| `permissive` | Last-resort local debugging. | Broadest local mode. | Explicit `--env KEY=VAL` allowed. |
+| `standard` | Normal local one-shot runs. | Read-only. | Explicit `--env KEY=VAL` allowed. |
+| `dev` | Local iteration against a project tree. | Read-only here; writable only on a *persistent* machine. | Explicit `--env KEY=VAL` allowed. |
+| `permissive` | Last-resort local debugging. | Same as `dev`, plus `MVM_ACK_PERMISSIVE_RUN=1`. | Explicit `--env KEY=VAL` allowed. |
+
+A one-shot run's host shares are **read-only under every profile** — the
+writable grant applies only when the machine is persistent. Guest mount paths
+must be under `/data` or `/work`.
 
 The default is `standard`. Use `restrictive` when the workload does not need
 host files or host-provided environment values:
@@ -32,7 +36,7 @@ Use `standard` when the workload needs explicit environment values or
 read-only input files:
 
 ```sh
-mvmctl run --profile standard --mount ./fixtures:/fixtures:ro -- python task.py
+mvmctl run --profile standard --mount ./fixtures:/data/fixtures:ro -- python task.py
 ```
 
 Use `dev` for local development commands that need the broader development
@@ -59,12 +63,21 @@ mvmctl run --mount HOST:GUEST:ro -- command
 
 Rules:
 
-- the mode must be `ro`;
+- the mode must be `ro` — a transient run refuses `:rw` under every profile;
+- `GUEST` must be under `/data` or `/work`; every other root is refused, and
+  `/mnt/*` is refused specifically so a share cannot shadow the runtime's own
+  config and secrets drives;
 - `restrictive` rejects host directory shares;
 - `standard` accepts read-only host shares.
 
 Prefer read-only shares for test inputs, source snapshots, fixtures, and model
 context. Use `mvmctl machine cp` or a managed volume when changes must persist.
+
+:::note[Hidden verbs]
+`machine cp`, `machine fs`, `machine volume`, `machine wait`, `machine
+boot-report`, `machine checkpoint`, `machine pause` and `machine resume` all
+work but are marked hidden, so they do not appear in `--help` output.
+:::
 
 ## Environment policy
 
@@ -97,25 +110,22 @@ mvmctl run --dry-run --json --profile restrictive -- python task.py
 Dry-run output is redacted. It is useful in CI because policy failures can be
 caught before a workload starts.
 
-## Seccomp tiers for named VMs
+## Seccomp tier
 
-Named VM launches expose a separate seccomp tier:
+There is **no per-launch seccomp selector**. Every plan `mvmctl` synthesises
+hardcodes the `standard` tier, and `--profile` carries no seccomp field — a
+profile governs `--env`, host shares, writable-share eligibility, the dev
+guest profile, and whether an acknowledgement is required, and nothing else.
 
-```sh
-mvmctl machine run --flake ./my-app --name agent-sandbox -d --profile standard
-```
+The tier is still recorded in the signed admission profile, so an audit can
+show which tier was admitted; it just cannot vary per run today. The
+`PlanSeccompTier` type has five values (`essential`, `minimal`, `standard`,
+`network`, `unrestricted`) and the plumbing to carry them, but no CLI flag
+and no manifest key feeds it.
 
-Supported tiers are:
-
-| Tier | Use it when |
-| --- | --- |
-| `essential` | The workload needs the smallest syscall surface the current guest can boot with. |
-| `minimal` | The workload is simple and should run with a reduced syscall set. |
-| `standard` | Default named-VM posture. |
-| `network` | The workload needs network-oriented syscalls beyond the standard profile. |
-| `unrestricted` | Local debugging only; avoid for untrusted code. |
-
-The selected tier is recorded in the signed admission profile for audit.
+The one place you can name a tier is the hidden developer command
+`mvmctl seccomp-audit --tier <tier>`, which is Linux-only, boots no microVM,
+and installs no filter — it only reports on a syscall set.
 
 ## Recommended defaults
 

--- a/public/src/content/docs/guides/sdk.mdx
+++ b/public/src/content/docs/guides/sdk.mdx
@@ -91,9 +91,9 @@ recognizes. Anything else in decorator kwarg position is rejected:
 | `python_image(python=)` | `Image::NixPackages`     | `python="3.12"` → `python312` nix attribute    |
 | `node_image(node=)`     | `Image::NixPackages`     | `node="22"` → `nodejs_22` nix attribute        |
 | `nix_packages([...])`   | `Image::NixPackages`     | direct passthrough                             |
-| `resources(...)`        | `Resources`              | `cpu`/`memory_mb`/`rootfs_size_mb`             |
+| `resources(...)`        | `Resources`              | Python: `cpu_cores`/`memory_mb`/`rootfs_size_mb`, all required. TypeScript also accepts `cpu` and defaults all three. |
 | `network(mode=, ports=)`| `Network`                | `none` \| `bridge` \| `host`                   |
-| `secret(name, var=)`    | `EnvValue::SecretRef`    | host-mediated secret ref; guest sees opaque token only |
+| `secret(name, type=, hosts=, var=)` | `EnvValue::SecretRef` | host-mediated secret ref; `type` and `hosts` are required, `var` defaults to `name` |
 | `literal(value)`        | `EnvValue::Literal`      | parity with `secret(...)`                      |
 | `hook(cmd)`             | `HookCmd`                | str → Shell; list → Argv                       |
 
@@ -129,7 +129,9 @@ value.
   value.
 - The raw secret stays on the host side.
 - Request-time release is supported only on host-mediated outbound
-  surfaces such as `mvm.web_fetch` and `mvm.web_search`.
+  surfaces such as the `mvm.web_fetch` and `mvm.web_search` broker verbs.
+  Those are host-side broker tool names, not functions exported by the
+  Python or TypeScript SDK.
 - Guest HTTPS CONNECT egress is not a managed-secret substitution
   path.
 
@@ -138,7 +140,7 @@ value.
 `mvmctl build compile app.ts` walks the AST statically for `mvm.app({...})`
 calls and does not run user code. When a `.ts` script uses the
 record-mode `Sandbox` API instead (no `mvm.app` decorator), `mvmctl
-compile` falls back to **auto-run**: it spawns the script on the host
+build compile` falls back to **auto-run**: it spawns the script on the host
 with `MVM_SDK_MODE=record` set, and the SDK's atexit hook writes a
 recording JSON that the CLI then lowers into a `Workload`.
 
@@ -165,7 +167,7 @@ npm install --save-dev tsx
 ```
 
 That puts the binary at `./node_modules/.bin/tsx`, and `mvmctl
-compile` picks it up automatically — see the resolution order below.
+build compile` picks it up automatically — see the resolution order below.
 
 ### Resolution order
 

--- a/public/src/content/docs/guides/secrets-and-credentials.mdx
+++ b/public/src/content/docs/guides/secrets-and-credentials.mdx
@@ -109,7 +109,7 @@ with Sandbox.create(
 </TabItem>
 <TabItem label="TypeScript">
 
-```ts
+```text
 import * as mvm from "@runmvm/mvm";
 import { Sandbox } from "@runmvm/mvm";
 

--- a/public/src/content/docs/guides/secrets-and-credentials.mdx
+++ b/public/src/content/docs/guides/secrets-and-credentials.mdx
@@ -110,11 +110,17 @@ with Sandbox.create(
 <TabItem label="TypeScript">
 
 ```ts
-import { Sandbox, SecretRef } from "@mvm/sdk";
+import * as mvm from "@runmvm/mvm";
+import { Sandbox } from "@runmvm/mvm";
 
 using sandbox = await Sandbox.create({
   image: "nix:./flake#agent-runtime",
-  secrets: { OPENAI_API_KEY: SecretRef.from("openai-api-key") },
+  env: {
+    OPENAI_API_KEY: mvm.secret("openai-api-key", {
+      type: "bearer",
+      hosts: ["api.openai.com"],
+    }),
+  },
 });
 
 await sandbox.commands.run(["node", "/work/tool.js"], {

--- a/public/src/content/docs/install/linux.md
+++ b/public/src/content/docs/install/linux.md
@@ -3,10 +3,13 @@ title: "Install mvm on Linux"
 description: "mvm on Linux is the Tier 1 production target — Firecracker + KVM, no virtualization wrapper, sub-200ms cold boot."
 ---
 
-Linux is mvm's Tier 1 target. The full security posture (verified boot, jailer,
-seccomp tier "strict") applies to Firecracker/KVM cold boots. Do not infer a
-snapshot-clone latency guarantee: recovery tiers are backend-specific and are
-reported by `mvmctl doctor`.
+Linux is mvm's Tier 1 target. Verified boot (dm-verity rootfs + kernel-cmdline
+roothash) applies to Firecracker/KVM cold boots. mvm launches Firecracker
+directly — it does **not** wrap it in the Firecracker jailer, and it passes no
+`--seccomp-filter`, so Firecracker runs with its built-in default filter rather
+than a mvm-supplied "strict" tier. Do not infer a snapshot-clone latency
+guarantee either: recovery tiers are backend-specific and are reported by
+`mvmctl doctor`.
 
 For the full host/backend matrix, see [Platform support](/reference/platform-support/).
 
@@ -75,10 +78,13 @@ mvmctl doctor
 ```bash
 mkdir my-app && cd my-app
 mvmctl init .
-mvmctl run
+mvmctl machine build
+mvmctl machine run --manifest .
 ```
 
-`mvmctl init` scaffolds an `mvm.toml` + `flake.nix` in your project. `mvmctl run` reads `mvm.toml`, builds the rootfs via Nix (using your flake's `mvm.lib.x86_64-linux.mkGuest` call), and boots it on Firecracker. Expected cold boot: ≤ 200ms.
+`mvmctl init` scaffolds an `mvm.toml` + `flake.nix` in your project. `mvmctl machine build` reads `mvm.toml` and builds the rootfs via Nix (using your flake's `mvm.lib.x86_64-linux.mkGuest` call); `mvmctl machine run --manifest .` boots it on Firecracker. Expected cold boot: ≤ 200ms.
+
+(Bare `mvmctl run` is the *transient* verb and needs a command — `mvmctl run --image alpine -- uname -a`. Without one it exits with an error rather than booting your project.)
 
 See [Building MicroVM Images](/guides/building-microvm-images) for the user-facing flake API.
 
@@ -86,7 +92,7 @@ See [Building MicroVM Images](/guides/building-microvm-images) for the user-faci
 
 **"`/dev/kvm`: permission denied"** — your user isn't in the `kvm` group. `sudo usermod -aG kvm "$USER"` and start a new shell.
 
-**"`mvmctl run` falls back to libkrun even though I have KVM"** — check `mvmctl doctor` output. The auto-select ladder picks Firecracker only when `/dev/kvm` is writable; if it's `root`-only, libkrun wins as the cross-platform fallback. Same fix as above.
+**"`/dev/kvm` exists but the run fails anyway"** — auto-select keys on `/dev/kvm` *existing*, not on your user being able to open it, so a `root`-only device still selects Firecracker and then fails at launch. There is no libkrun fallback on Linux: libkrun is selectable there only when you ask for it with `--hypervisor libkrun`, and it needs `/dev/kvm` too. Fix the group membership as above; `mvmctl doctor` reports what it resolved.
 
 **Nix build is slow** — first builds pull from `cache.nixos.org` and `cache.flakehub.com`. Subsequent builds hit the builder VM's `/nix/store`, which mvm keeps warm across runs.
 
@@ -118,4 +124,4 @@ Installing host-side Nix does not change the normal `mvmctl machine build` contr
 - **Ubuntu/Debian** — `apt install qemu-utils e2fsprogs` if you need `mkfs.ext4` for the [smoke test](https://github.com/tinylabscom/mvm/blob/main/tests/smoke_libkrun.rs).
 - **Fedora/RHEL** — `dnf install e2fsprogs qemu-img`. Make sure SELinux isn't blocking `/dev/kvm` access (it usually isn't, but `audit2why` is your friend if it does).
 - **Arch** — `pacman -S e2fsprogs qemu-img`. Already lean.
-- **NixOS** — easiest path: `nix profile install github:tinylabscom/mvm`. KVM is enabled by default; `kvm` group membership is the only thing to verify.
+- **NixOS** — easiest path: `nix profile install github:tinylabscom/mvm?dir=nix#mvmctl`. The `?dir=nix` fragment matters: the repo-root flake exposes only `devShells` and `formatter`, so a bare `github:tinylabscom/mvm` has no package to install. KVM is enabled by default; `kvm` group membership is the only thing to verify.

--- a/public/src/content/docs/install/macos.md
+++ b/public/src/content/docs/install/macos.md
@@ -12,8 +12,12 @@ Intel Macs are not a supported local microVM host. Use a Linux machine with `/de
 ## Prerequisites
 
 - Apple Silicon Mac.
-- macOS 26+ for the HVF dev VM path.
-- libkrun installed for libkrun-backed builder/runtime components.
+- macOS 26+ for the HVF path. HVF uses Hypervisor.framework directly and needs
+  no Homebrew prerequisites.
+- libkrun only on macOS 13–25, or on 26+ when you explicitly opt in with
+  `--builder libkrun` / `--hypervisor libkrun`. libkrun ships from the
+  third-party `slp/krun` tap and needs `libkrunfw` too:
+  `brew install slp/krun/libkrun slp/krun/libkrunfw`.
 
 You **do not need Nix on your Mac**. You run `mvmctl machine build` from macOS, and mvm runs Nix evaluation and `nix build` inside the Linux builder VM, then extracts the resulting rootfs back to the host. See [§"Linux builds on macOS"](#linux-builds-on-macos--zero-config-by-default) below for the design.
 
@@ -59,7 +63,7 @@ is useful for CLI-only inspection or development.
 cargo install mvmctl
 ```
 
-`mvmctl` is a regular Mach-O binary on macOS — no codesigning surprises in the typical install path. Hypervisor.framework requires the host process to hold the `com.apple.security.hypervisor` entitlement; the install script handles ad-hoc signing automatically. If you build from source via `cargo`, the same entitlement is added by the build script.
+`mvmctl` is a regular Mach-O binary on macOS — no codesigning surprises in the typical install path. Hypervisor.framework requires the process that owns the VM to hold the `com.apple.security.hypervisor` entitlement, and that process is a per-VM supervisor (`mvm-hvf-supervisor` / `mvm-libkrun-supervisor`), not `mvmctl` itself. `install.sh` ad-hoc-signs each binary with the right profile: `assets/mvmctl.entitlements` (`com.apple.security.virtualization`) for `mvmctl`, and `assets/mvm-supervisor.entitlements` (`com.apple.security.hypervisor`) for the supervisors. Set `MVM_SKIP_CODESIGN=1` to skip that step. **No build script signs anything** — a `cargo build` from source produces unsigned binaries, so sign them yourself after building.
 
 ## Linux Builds On macOS
 
@@ -92,23 +96,32 @@ mvmctl doctor
 ```bash
 mkdir my-app && cd my-app
 mvmctl init .
-mvmctl run
+mvmctl machine build
+mvmctl machine run --manifest .
 ```
 
-`mvmctl init` scaffolds the project. On first `mvmctl run`, mvm bootstraps the builder VM if needed, runs `nix build` inside it, and boots the resulting rootfs with the selected macOS runtime backend. Expected runtime cold boot is measured after the image is already built. When developing from this source checkout, the builder VM image is local-build only; the cache is reused only when its source fingerprint matches `nix/images/builder-vm/{flake.nix,flake.lock}`, its recorded artifact digests still match the cached files, and its provenance summary matches the same source and artifact filename set. Cache misses, fingerprint drift, artifact drift, or provenance drift build from the local `nix/images/builder-vm/` flake using a local dev image as Stage 0, validate the staged artifacts, and only then promote them into the live cache. Run with `--verbose` to see the safe source-cache reason code, for example `hit`, `fingerprint_mismatch`, `artifact_digest_mismatch`, or `provenance_mismatch`. mvm will not download a published builder image to hide local flake changes.
+`mvmctl init` scaffolds the project. (Bare `mvmctl run` is the transient verb and needs a command, e.g. `mvmctl run --image alpine -- uname -a`; without one it exits with an error.) On the first `mvmctl machine build`, mvm bootstraps the builder VM if needed and runs `nix build` inside it; `mvmctl machine run` boots the resulting rootfs with the selected macOS runtime backend. Expected runtime cold boot is measured after the image is already built. When developing from this source checkout, the builder VM image is local-build only; the cache is reused only when its source fingerprint matches `nix/images/builder-vm/{flake.nix,flake.lock}`, its recorded artifact digests still match the cached files, and its provenance summary matches the same source and artifact filename set. Cache misses, fingerprint drift, artifact drift, or provenance drift build from the local `nix/images/builder-vm/` flake using a local dev image as Stage 0, validate the staged artifacts, and only then promote them into the live cache. Run with `--verbose` to see the safe source-cache reason code, for example `hit`, `fingerprint_mismatch`, `artifact_digest_mismatch`, or `provenance_mismatch`. mvm will not download a published builder image to hide local flake changes.
 
 ## Troubleshooting
 
-**"Hypervisor.framework: entitlement missing"** — re-codesign the binary with the entitlement: `codesign --entitlements assets/mvmctl.entitlements -f -s - ~/.local/bin/mvmctl`. The release binary ships pre-signed; this only matters if you've stripped entitlements or built from source without the build script's signing step.
+**"Hypervisor.framework: entitlement missing"** — re-codesign the *supervisor* with the hypervisor entitlement, since that is the process that creates the VM:
+
+```bash
+codesign --sign - --force --entitlements assets/mvm-supervisor.entitlements ~/.local/bin/mvm-hvf-supervisor
+codesign --sign - --force --entitlements assets/mvm-supervisor.entitlements ~/.local/bin/mvm-libkrun-supervisor
+codesign --sign - --force --entitlements assets/mvmctl.entitlements ~/.local/bin/mvmctl
+```
+
+`install.sh` does this for you. It matters if you stripped entitlements, ran with `MVM_SKIP_CODESIGN=1`, or built from source with `cargo` — nothing in the build signs binaries, so a rebuild always leaves them unsigned.
 
 **`nix build` fails with "a 'x86_64-linux' with features … is required"** — that is a direct host-side Nix command failing because macOS cannot build Linux derivations by itself. Use `mvmctl machine build --flake .` so the Linux build runs inside the builder VM. If you intentionally want direct `nix build` on macOS, configure [`nix-darwin`'s `linux-builder`](https://nix.dev/manual/nix/stable/installation/installing-binary).
 
 **`mvmctl run` boots but `mvmctl machine console` fails to attach** — the `console` subcommand is only enabled for *accessible* images. If your `entrypoint.command = [ ... ]`, the build is *sealed* and console attach is rejected. Switch to `entrypoint.shell = "/bin/sh"` or pass `dev = true` in your `mkGuest` call. See [Building MicroVM Images](/guides/building-microvm-images).
 
-**"libkrun shared library not found"** — install libkrun, then rerun the command. On Apple Silicon with Homebrew:
+**"libkrun shared library not found"** — install libkrun, then rerun the command. libkrun is not in homebrew-core; it comes from the third-party `slp/krun` tap, and it needs the `libkrunfw` kernel bundle alongside it. A bare `brew install libkrun` resolves nothing:
 
 ```bash
-brew install libkrun
+brew install slp/krun/libkrun slp/krun/libkrunfw
 ```
 
 ## Apple Silicon vs Intel notes

--- a/public/src/content/docs/install/windows.md
+++ b/public/src/content/docs/install/windows.md
@@ -1,16 +1,22 @@
 ---
 title: "Install mvm on Windows"
-description: "Native Windows is not a supported local microVM host. WSL2 with nested KVM is the supported libkrun-backed workload path."
+description: "Neither native Windows nor WSL2 is a supported local microVM host. Use native Linux with /dev/kvm or an Apple Silicon Mac."
 ---
 
-mvm does **not** currently support native Windows as a local microVM host. The supported local hosts are:
+mvm does **not** currently support native Windows as a local microVM host, and
+**WSL2 is not a supported workload path either**. The supported local hosts are:
 
 - macOS Apple Silicon.
 - Native Linux with `/dev/kvm`.
 
-The supported Windows-adjacent runtime path is **WSL2 with nested KVM** running
-the libkrun workload backend inside the distro. Native Windows remains future
-work, tracked in [mvm#428](https://github.com/tinylabscom/mvm/issues/428).
+mvm detects WSL2 as its own platform and refuses the libkrun workload backend
+there unconditionally — `Platform::Wsl2` never resolves to libkrun regardless of
+whether the distro exposes nested `/dev/kvm`. `mvmctl doctor` reports it plainly:
+*"WSL2 — a workload runtime needs nested /dev/kvm; without it only `qemu`
+(dev/test only, no claim-10) runs."* The `qemu` backend is dev/test only and does
+**not** enforce claim-10 egress, so it is not a workload runtime. Native Windows
+support remains future work, tracked in
+[mvm#428](https://github.com/tinylabscom/mvm/issues/428).
 
 For the full host/backend matrix, see [Platform support](/reference/platform-support/).
 
@@ -18,32 +24,22 @@ For the full host/backend matrix, see [Platform support](/reference/platform-sup
 
 Use one of these paths today:
 
-- Run mvm inside a WSL2 distro that exposes `/dev/kvm`, has libkrun installed,
-  and keeps the repo/runtime state on the WSL ext4 filesystem.
 - Run mvm on a Linux host with `/dev/kvm`.
 - Run mvm on an Apple Silicon Mac.
 
-## WSL2 With Nested KVM
+## What about WSL2?
 
-Before treating the WSL2 path as supported, verify inside the distro:
+WSL2 is not a supported workload path, even with nested KVM exposed. You can
+install `mvmctl` inside a WSL2 distro and run non-workload commands, but the
+platform probe refuses libkrun there and auto-select never reaches a workload
+backend, so a `machine run` has nothing to boot on. `mvmctl doctor` will tell you
+so:
 
 ```bash
-test -c /dev/kvm && test -w /dev/kvm
 mvmctl doctor
 ```
 
-If either check fails, use a supported host. See the [WSL2 notes](/guides/windows-wsl2) for details and caveats.
-
-### Optional: host-side Nix (in WSL2) for power users
-
-Skip this unless you're contributing to mvm itself or want a shared `/nix/store` between your editor and mvm. Inside the WSL2 distro:
-
-```bash
-sh <(curl -L https://nixos.org/nix/install) --daemon
-. /etc/profile.d/nix.sh
-```
-
-Installing host-side Nix is optional. The normal `mvmctl machine build` path still treats the CLI as the host control plane and the builder VM as the image build boundary. See [Builder VM](/guides/builder-vm/).
+See the [WSL2 notes](/guides/windows-wsl2) for details and caveats.
 
 ## What about native Windows microVMs?
 
@@ -55,7 +51,7 @@ Tracking issue: [Future work: Windows host support via Windows Hypervisor Platfo
 
 ## Troubleshooting
 
-- **`/dev/kvm` missing inside WSL2** — this host shape is unsupported for mvm's WSL2 workload path.
+- **`/dev/kvm` missing inside WSL2** — expected; WSL2 is unsupported for workloads either way.
 - **`mvmctl doctor` reports "no KVM available"** — use a supported Linux KVM host or Apple Silicon Mac.
 
 See [Windows troubleshooting](/guides/windows-troubleshooting) for the full Windows-specific FAQ.

--- a/public/src/content/docs/reference/architecture.md
+++ b/public/src/content/docs/reference/architecture.md
@@ -29,14 +29,20 @@ genuinely backend-specific:
 
 ### Runtime backend matrix
 
-| Backend     | Selection mode                                | Notes                                                            |
-| ----------- | --------------------------------------------- | ---------------------------------------------------------------- |
-| Firecracker | Auto on Linux with native KVM                 | Production Tier 1 backend                                        |
-| HVF         | Auto on supported macOS 26+ hosts             | Preferred macOS local backend (Hypervisor.framework, vsock-only) |
-| libkrun     | Auto fallback on supported hosts              | Fast local Tier 2 backend                                        |
-| QEMU        | Explicit opt-in (`--hypervisor qemu`)         | Linux dev/test backend                                           |
-| BrowserWasi | Explicit opt-in (`--hypervisor browser-wasm`) | Browser-tier WASI backend (no hypervisor)                        |
-| Mock        | Explicit opt-in (`--hypervisor mock`)         | Test-only in-memory backend                                      |
+| Backend         | Selection mode                                                  | Notes                                                              |
+| --------------- | --------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Firecracker     | Auto on Linux with native KVM                                   | Production Tier 1 backend                                          |
+| HVF             | Auto on supported macOS 26+ hosts (alias `hypervisor`)          | Preferred macOS local backend (Hypervisor.framework, vsock-only)   |
+| libkrun         | Auto on macOS 13–25 (alias `krun`)                              | Fast local Tier 2 backend                                          |
+| QEMU            | Explicit opt-in (`--hypervisor qemu`)                           | Linux dev/test backend                                             |
+| apple-container | Explicit opt-in (`--hypervisor apple-container`, alias `container`) | The HVF runner with Apple's prebuilt container kernel substituted |
+| wasm            | Explicit opt-in (`--hypervisor wasm`)                           | Host `wasmtime` tier — no guest kernel, no guest network           |
+| web-linux       | Explicit opt-in (`--hypervisor web-linux`)                      | Browser tier: a Nix-built Linux kernel under QEMU-Wasm             |
+| Mock            | Explicit opt-in (`--hypervisor mock`)                           | Test-only in-memory backend                                        |
+
+Those eight selectors (plus the `krun`, `hypervisor`, and `container` aliases)
+are the complete set. There is no `browser-wasm` selector and no `BrowserWasi`
+backend.
 
 The backend descriptor registry in `crates/mvm-runtime/src/catalog.rs` is the single source of
 truth for backend discovery: each `BackendDescriptor` carries the selector, aliases, isolation
@@ -47,7 +53,7 @@ consumers construct from the same descriptors via `instantiate` / `instantiate_d
 ## What runs where: the trust gradient
 
 mvm runs long-lived processes in three layers, one per trust tier. Authority decreases as
-you move away from the host, and each layer is trusted accordingly (see ADR-001 and ADR-090).
+you move away from the host, and each layer is trusted accordingly (see ADR-001 and ADR-020).
 
 | Layer            | Process                                                                             | Owns                                                                               | Authority  | Trust                      |
 | ---------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ---------- | -------------------------- |
@@ -59,37 +65,46 @@ The governing rule: **a process never holds authority above its trust tier, and 
 only ever decreases host → builder → workload.** Host signing keys, plan admission, and the
 audit chain never cross the host→builder boundary. The workload guest agent is the deliberate
 runt — a sealed production build links no `do_exec` and no console (claims 4 and 15) and holds
-no signing key or admission code. `mvmctl`'s `check-trust-gradient` lint machine-checks this
-ledger (`specs/claims/trust-gradient.md`) on every PR; the ledger carries the host and workload
-rows today, and the builder row is added once the resident builder daemon (`mvm-builderd`) exists.
+no signing key or admission code. The `xtask check-trust-gradient` lint machine-checks this
+ledger on every PR. The ledger is not a standalone file — it lives between the
+`<!-- trust-gradient:begin -->` / `<!-- trust-gradient:end -->` markers inside
+`specs/adrs/020-host-services-broker.md` (there is no `specs/claims/` directory, and
+`check-trust-gradient` is an xtask gate, not an `mvmctl` verb). The ledger carries the host and
+workload rows today, and the builder row is added once a resident builder daemon exists.
 
-### Browser-tier exception
+### Browser and Wasm tiers
 
-The browser-tier `BrowserWasi` backend runs inside the browser's own WebAssembly engine.
-It has **no hypervisor boundary** and runs the guest workload directly as a WASI module.
-This makes it a claim-free tier: it cannot assert any of the numbered security claims
-because there is no hardware isolation. It is for demos, playgrounds, and browser-local
-development only, and it is never auto-selected.
+Two backends run outside a hypervisor boundary, and neither is ever auto-selected:
+
+- **`wasm`** runs the workload as a module in a host `wasmtime` engine. No guest kernel,
+  no guest network.
+- **`web-linux`** is the browser tier. It boots a real Nix-built Linux kernel under
+  QEMU-Wasm inside the browser's own WebAssembly engine; on a native host the backend is
+  a stub that fails closed with a typed "browser-only" error.
+
+Both are claim-free tiers: with no hardware isolation they cannot assert the numbered
+security claims. They are for demos, playgrounds, and browser-local development.
 
 What is installed where:
 
 - The **host** has `mvmctl` (and, under the fleet, the per-tenant `mvm-host-agent` +
   `mvm-signer-helper` daemons). Host Nix is optional.
 - The **builder VM** owns Nix and the build toolchain. Making the builder a _resident_ typed
-  vsock service (`mvm-builderd`) is the direction recorded in ADR-089 / Plan 204; today builder
-  work is controlled job execution, not yet a resident daemon.
+  vsock service is a direction, not a shipped component: today builder work is controlled job
+  execution, not a resident daemon.
 - **Workload microVM images** contain neither `mvmctl` nor builder tooling — only the minimal
   guest agent baked by `mkGuest`.
 
 ### Residency: how warm the standby pool is kept
 
-The standby pool is governed by a single residency policy (ADR-090), surfaced on `mvmctl
+The standby pool is governed by a single residency policy, surfaced on `mvmctl
 doctor`'s `residency` line as `<policy> — <source> — warm_target=N[, idle=Nm]`.
 
-- `MVM_RESIDENCY=warm|parked|cold` overrides the policy. Unset, it resolves to `parked`
-  (nothing is held warm) because the default selectable backend does not advertise a
-  standby pool. An explicit `warm` request is accepted only when the selected backend
-  advertises that capability.
+- `MVM_RESIDENCY=warm|always-warm|parked|cold` overrides the policy. Unset, it resolves
+  by host tier: **`always-warm` on the HVF default tier (macOS 26+ Apple Silicon)**, where
+  one authority-free paused standby parent is kept so unnamed transient runs can take the
+  live-handoff path, and `parked` (nothing held warm) everywhere else. An explicit `warm`
+  request is accepted only when the selected backend advertises that capability.
 - The trade-off is resource cost vs. first-command latency: `warm` keeps a standby ready,
   `parked`/`cold` hold none.
 - Standby and snapshot capabilities are separate axes. The authoritative per-backend
@@ -152,7 +167,7 @@ These are the main behavior seams in the current codebase:
 | `VmBackendForBuilder` | `mvm-build`   | Low-level builder backend seam                 |
 | `BackendLauncher`     | `mvm-hostd`   | Host-side backend launch preparation/execution |
 | `NetworkProvider`     | `mvm-net`     | Network provisioning / policy seam             |
-| `VolumeBackend`       | `mvm-runtime` | Storage backend seam                           |
+| `VolumeBackend`       | `mvm-contract` | Storage backend seam (re-exported by `mvm-runtime`) |
 
 ### Ownership rule
 
@@ -167,7 +182,8 @@ Backend- or subsystem-specific seams stay in the owning crate:
 - `VmBackendForBuilder` belongs in `mvm-build`.
 - `BackendLauncher` belongs in `mvm-hostd`.
 - `NetworkProvider` belongs in `mvm-net`.
-- `VolumeBackend` belongs in `mvm-runtime`.
+- `VolumeBackend` is defined in `mvm-contract` (the `no_std` foundation) and re-exported
+  through `mvm_runtime::storage::volume`, which is where its `LocalBackend` impl lives.
 
 This keeps `mvm-core` small while still giving the rest of the workspace stable contracts.
 
@@ -206,8 +222,8 @@ operations. It is not the same thing as the selected workload runtime backend.
 | Host platform                         | Default runtime path |
 | ------------------------------------- | -------------------- |
 | Linux with native KVM                 | Firecracker          |
-| Supported macOS 26+ host              | HVF                  |
-| Supported host with libkrun available | libkrun              |
+| macOS 26+ Apple Silicon               | HVF                  |
+| macOS 13–25 Apple Silicon             | libkrun              |
 
 Other backends such as QEMU exist, but they are selected explicitly rather than by
 default policy.

--- a/public/src/content/docs/reference/filesystem.md
+++ b/public/src/content/docs/reference/filesystem.md
@@ -5,15 +5,24 @@ description: Drive model, mount points, and filesystem layout inside microVMs.
 
 ## Drive Model
 
-Each microVM gets up to four virtio-block drives on the supported workload
-backends:
+A microVM built with `mkGuest` gets these virtio-block drives at fixed slots.
+`/init` mounts the config and secret drives itself, before any user volume is
+attached:
 
 | Drive | Mount Point | Permissions | Purpose |
 |-------|-------------|-------------|---------|
 | `/dev/vda` | `/` | Read-write (ext4) or read-only (squashfs) | Root filesystem |
-| `/dev/vdb` | `/mnt/config` | Read-only | Application configuration |
-| `/dev/vdc` | `/mnt/secrets` | Read-only | API keys, tokens, credentials |
-| `/dev/vdd` | `/mnt/data` | Read-write | Persistent data (survives restarts) |
+| `/dev/vdb` | `/mnt/config` | Read-only (`ro,noexec,nosuid,nodev`) | mvm instance metadata |
+| `/dev/vdc` | `/mnt/secrets` | Read-only (`ro,noexec,nosuid,nodev`) | Runtime-delivered credentials |
+
+There is no fixed `/dev/vdd` data drive and no `/mnt/data` mount. Later slots are
+assigned dynamically — the runtime overlay and the SDK sidecar arrive as
+`mvm.runtime_data=/dev/vdN` / `mvm.sdk_dev=/dev/vdN` on the kernel cmdline, and
+your own `--mount host:guest:SIZE` disk images take the slots after those.
+
+`/mnt/config` and `/mnt/secrets` are runtime-owned. The host mount policy refuses
+any user share that sits inside or shadows them, and `/mnt` is not an allow-root
+at all: **a user mount path must be under `/data` or `/work`.**
 
 ## Root Filesystem
 
@@ -25,8 +34,13 @@ The rootfs is built by `mkGuest` and contains:
 - **Guest agent** — present directly in dev/preferred-overlay images; provided by
   the sealed runtime overlay on overlay-required boots
 - **Your packages** — specified in the flake's `packages` parameter
-- **Service scripts** — generated from `services.<name>` definitions
-- **Health check configs** — generated from `healthChecks.<name>`
+- **The entrypoint** — rendered from the flake's required `entrypoint` parameter
+- **Probe drop-ins** — one `/etc/mvm/probes.d/<name>.json` per `healthChecks.<name>` entry
+
+`mkGuest` generates no service scripts: the top-level `services` attribute and
+the `entrypoint.services` form are recorded but **not implemented** — the
+multi-service supervisor is unwired, so nothing in the image starts or supervises
+them.
 
 ### Runtime Overlay
 
@@ -86,24 +100,35 @@ The secrets drive (`/dev/vdc`, mounted at `/mnt/secrets/`) contains sensitive da
 - Application secret files from host directories you mounted yourself
 
 Security hardening:
-- Uses tmpfs-backed file (never hits persistent storage)
-- Drive image files are 0400 (root-only); at boot, secrets are copied to a tmpfs with 0440 `root:<serviceGroup>` so only service group members can read them
-- Mount with `ro,noexec,nodev,nosuid`
+- `/init` mounts it `ro,noexec,nosuid,nodev`
 - Recreated on every start (never reused)
 
-## Data Drive
+The `serviceGroup` argument to `mkGuest` does **not** affect this drive. Like
+`services` and `volumeMounts`, it is recorded in `passthru.mvm` and warned about
+at eval time; nothing re-owns or re-modes the secret files at boot.
 
-The data drive (`/dev/vdd`, mounted at `/mnt/data/`) is a persistent ext4 volume:
+The stronger property is that raw secret *values* never reach the guest at all:
+mvm substitutes credentials host-side at the per-VM egress endpoint. See the
+secrets guide rather than shipping values in on this drive.
 
-- Created once per instance (specified size)
-- Survives restarts and snapshots
-- Use for application state, databases, logs
+## Persistent Disk Volumes
 
-Specify size with `--volume`:
+There is no built-in data drive. Persistent storage is a user disk volume: a
+three-part `--mount` spec (`--volume` is an alias) whose third field is a size in
+MB. The host path is an **ext4 disk image file** mvm creates and attaches as
+virtio-blk — not a directory. A two-part spec is a live host-directory share over
+virtio-fs instead.
+
+Volumes are **read-only unless you write `:rw`**, and the guest mount path must
+be under `/data` or `/work`:
 
 ```bash
-mvmctl machine run --flake . --volume ./data:/data:1024
+# 1 GB writable ext4 disk image, mounted at /data/store in the guest
+mvmctl machine run --flake . --mount ./store.img:/data/store:1024:rw
 ```
+
+`:rw` requires `--profile dev` or `--profile permissive`. A *transient* run's
+share is read-only under every profile.
 
 For managed encrypted local volumes and workspace cleanup policy, see
 [Persistent workspaces](/guides/persistent-workspaces/).
@@ -115,16 +140,17 @@ For managed encrypted local volumes and workspace cleanup policy, see
 ├── bin/                 # busybox symlinks
 ├── etc/
 │   └── mvm/
-│       ├── integrations.d/   # health check definitions (JSON)
-│       └── probes.d/         # read-only probe definitions (JSON)
+│       ├── integrations.d/   # integration definitions (JSON); not written by mkGuest
+│       └── probes.d/         # probe drop-ins (JSON) — where healthChecks land
 ├── init                 # busybox init script
 ├── mvm/
 │   └── runtime/         # read-only runtime overlay mount point when attached
 ├── nix/store/           # Nix packages
-├── mnt/
+├── mnt/                 # runtime-owned; not a user mount allow-root
 │   ├── config/          # /dev/vdb (ro) — config drive
-│   ├── secrets/         # /dev/vdc (ro) — secrets drive
-│   └── data/            # /dev/vdd (rw) — data drive
+│   └── secrets/         # /dev/vdc (ro) — secrets drive
+├── data/                # user mount allow-root
+├── work/                # user mount allow-root
 └── var/                 # runtime state (tmpfs on squashfs)
 ```
 
@@ -143,20 +169,22 @@ On the host (on Linux) or inside the builder VM (on macOS), mvm stores data at:
 │               └── warm-meta.json (if warmed)
 └── vms/
     └── <name>/
-        ├── firecracker.pid
-        ├── firecracker.socket
+        ├── fc.pid              # Firecracker pid file (libkrun.pid / qemu.pid / hvf.pid for the others)
+        ├── fc.socket           # Firecracker API socket
         ├── firecracker.log
         ├── console.log
-        ├── fc-base.json
+        ├── run-info.json
         ├── vmlinux
         ├── rootfs.ext4
-        ├── runtime/
-        │   └── v.sock          # per-VM Firecracker vsock UDS
-        └── volumes/
-            ├── config.ext4
-            ├── secrets.ext4
-            └── data.ext4
+        ├── config.ext4
+        ├── secrets.ext4
+        └── runtime/
+            └── v.sock          # per-VM Firecracker vsock UDS
 ```
+
+Every backend shares this one per-VM directory with disjoint file names, so the
+marker file (`fc.pid`, `libkrun.pid`, `qemu.pid`, `hvf.pid`) is what identifies
+which VMM owns a running VM.
 
 The shared guest-runtime overlay cache lives separately under
 `~/.mvm/cache/runtime-overlay/<version>/<arch>/` and contains the sealed

--- a/public/src/content/docs/reference/guest-agent.md
+++ b/public/src/content/docs/reference/guest-agent.md
@@ -273,6 +273,13 @@ once a background init thread actually ran.
 
 ### Host commands
 
+:::note[These verbs are hidden, not missing]
+`machine wait`, `machine boot-report`, and `machine diff` (below) are marked
+`hide = true` in the CLI. They work exactly as documented, but they do not appear
+in `mvmctl machine --help` — so don't read their absence from the help output as
+their absence from the binary.
+:::
+
 - `mvmctl machine wait <vm> --for <component> [--timeout <secs>]` —
   Blocks until the named component reaches `Ready`, `Disabled`,
   or `Failed`. Targets: `control-plane`, `entrypoint`,
@@ -293,22 +300,32 @@ protocol-hello prelude; the agent advertises it in
 
 ## Health Checks
 
-Health checks defined in `mkGuest`'s `healthChecks` parameter are automatically written to `/etc/mvm/integrations.d/` at build time:
+Health checks defined in `mkGuest`'s `healthChecks` parameter are written at
+build time to **`/etc/mvm/probes.d/<name>.json`** — the probe drop-in directory,
+not `integrations.d/`. Each entry renders as:
 
 ```json
 {
   "name": "my-service",
-  "health_cmd": "curl -sf http://localhost:8080/health",
-  "health_interval_secs": 10,
-  "health_timeout_secs": 5
+  "cmd": "curl -sf http://localhost:8080/health",
+  "interval_secs": 10,
+  "timeout_secs": 5,
+  "output_format": "exit_code"
 }
 ```
 
-The agent picks them up on boot and begins periodic checks immediately.
+`mkGuest` reads exactly three keys per check: `healthCmd` (required — omitting it
+throws), `healthIntervalSecs` (default 30), and `healthTimeoutSecs` (default 10).
+The agent picks the drop-ins up on boot and begins periodic checks immediately;
+results come back over vsock as `ProbeStatus`.
 
-### Startup Grace Period
+### Integrations and the startup grace period
 
-Services that take time to initialize (e.g., running database migrations) can specify a grace period. During the grace period, health check failures are suppressed and the service reports `Starting` status instead of `Error`:
+`/etc/mvm/integrations.d/*.json` is a separate drop-in directory with its own
+schema, loaded by the integration manager (checkpoint/restore commands plus a
+health loop). Its entries use `health_cmd` / `health_interval_secs` /
+`health_timeout_secs`, and only *these* support a grace period during which
+health failures are not logged:
 
 ```json
 {
@@ -320,17 +337,9 @@ Services that take time to initialize (e.g., running database migrations) can sp
 }
 ```
 
-In a Nix flake, set the grace period via `startupGraceSecs`:
-
-```nix
-healthChecks.my-app = {
-  healthCmd = "curl -sf http://localhost:8080/health";
-  healthIntervalSecs = 10;
-  startupGraceSecs = 120;  # suppress failures for 2 minutes after boot
-};
-```
-
-After the grace period expires, normal health reporting resumes.
+There is **no `startupGraceSecs` key in `mkGuest`**, and `mkGuest` does not write
+integration drop-ins at all — a flake that sets it gets no grace period. Write
+the integration JSON yourself via `extraFiles` if you need one.
 
 ## Querying from the Host
 
@@ -354,10 +363,17 @@ Probes are read-only system checks loaded from `/etc/mvm/probes.d/*.json`:
 ```json
 {
   "name": "disk-usage",
-  "command": "df -h /mnt/data | tail -1 | awk '{print $5}'",
-  "interval_secs": 60
+  "cmd": "df -h /data | tail -1 | awk '{print $5}'",
+  "interval_secs": 60,
+  "timeout_secs": 10,
+  "output_format": "exit_code"
 }
 ```
+
+The command field is `cmd`, not `command`. `interval_secs` defaults to 30,
+`timeout_secs` to 10, and `output_format` to `exit_code` (the alternative is
+`json`, which parses stdout into the report). An optional `description` string is
+also accepted.
 
 Probe results are reported via the vsock protocol and included in guest console logs.
 

--- a/public/src/content/docs/reference/isolation-tiers.md
+++ b/public/src/content/docs/reference/isolation-tiers.md
@@ -112,22 +112,34 @@ just not paying the cold-boot cost on every start.
 | Security-claim chain | Full                            | Full, re-verified on restore           | Narrower by construction    |
 | Typical latency      | Hundreds of ms to a few seconds | Tens of milliseconds (Firecracker/KVM) | Sub-millisecond             |
 
-## Browser-tier WASI backend
+## Wasm and browser tiers
 
-The browser-tier backend (`BrowserWasi`) runs workloads inside the browser's own WebAssembly engine. It is **claim-free**: there is no hypervisor boundary, no guest kernel, and no hardware isolation. The browser's process and sandbox boundaries are the only isolation layers.
+Two backends sit outside the hypervisor boundary. They are distinct, and neither is
+`BrowserWasi` — there is no backend by that name and no `--hypervisor browser-wasm`
+selector.
 
-| Feature         | Browser-tier                                                       |
-| --------------- | ------------------------------------------------------------------ |
-| Isolation       | Browser sandbox/process isolation only                             |
-| Guest kernel    | None (WASI module)                                                 |
-| Virtual devices | None (WASI capability model)                                       |
-| vsock           | None                                                               |
-| Verified boot   | None                                                               |
-| Snapshots       | None                                                               |
-| Network         | Egress mediated through host-imports (`mvm:egress`), no native NIC |
-| Secure claims   | None (claim-free tier)                                             |
+- **`wasm`** (`--hypervisor wasm`) is the host tier: the workload runs as a module in a
+  host `wasmtime` engine. No guest kernel, no guest network.
+- **`web-linux`** (`--hypervisor web-linux`) is the browser tier: it boots a real
+  Nix-built Linux kernel under QEMU-Wasm inside the browser's own WebAssembly engine. On
+  a native host the backend is a stub that fails closed with a typed "browser-only"
+  error.
 
-This tier exists for demos, playgrounds, and browser-local development. It cannot be auto-selected and is never used for production workloads. When a browser-tier backend is selected, the same admission, policy, and audit semantics that apply to host backends are enforced inside the browser's own WebAssembly engine.
+Both are **claim-free**: there is no hardware isolation, so neither can assert the
+numbered security claims.
+
+| Feature         | `wasm` (host wasmtime)      | `web-linux` (browser)                        |
+| --------------- | --------------------------- | -------------------------------------------- |
+| Isolation       | Wasm engine sandbox only    | Browser sandbox/process isolation only       |
+| Guest kernel    | None (Wasm module)          | Nix-built Linux kernel under QEMU-Wasm       |
+| vsock           | None                        | None                                         |
+| Verified boot   | None                        | None                                         |
+| Snapshots       | None                        | None                                         |
+| Network         | No guest network            | No native NIC                                |
+| Secure claims   | None (claim-free tier)      | None (claim-free tier)                       |
+
+These tiers exist for demos, playgrounds, and browser-local development. Neither can be
+auto-selected, and neither is used for production workloads.
 
 ## When to pick which
 

--- a/public/src/content/docs/reference/limits.md
+++ b/public/src/content/docs/reference/limits.md
@@ -42,6 +42,17 @@ mvmctl doctor
 Keep host mounts narrow. Use `mvmctl machine fs`, `mvmctl machine cp`, and declared volumes
 instead of broad writable host shares when running untrusted code.
 
+:::note[`machine fs` and `machine cp` are hidden verbs]
+Both are marked `hide = true` in the CLI, so they work as documented but do not
+appear in `mvmctl machine --help`.
+:::
+
+Declared volumes are `--mount host:guest[:SIZE][:ro|rw]` (`--volume` is an alias;
+there is no `-v` short form — that is the global verbosity counter). The guest
+path must live under `/data` or `/work`, and every mount is **read-only unless
+you write `:rw`** — which itself needs `--profile dev` or `--profile permissive`.
+A transient run's share is read-only under every profile.
+
 Snapshots and cold-mode artifacts may contain guest memory, generated files,
 and credentials present inside the guest. Treat them as sensitive state.
 

--- a/public/src/content/docs/reference/performance.md
+++ b/public/src/content/docs/reference/performance.md
@@ -96,24 +96,32 @@ degradation, and recorded every prepared-cold work flag as false.
 
 ## Reproducing a measurement
 
-The launch benchmark is a library surface driven by a live, `#[ignore]`d test,
-not a shipped CLI verb — the suite can never produce a launch number by
-accident. Run it against a release binary on a host with a prepared artifact
+`mvmctl bench` is the shipped, visible verb for this. The lane is a **flag**, not
+a subcommand. Run it from a release build on a host with a prepared artifact
 cache:
 
 ```sh
-export MVM_COLD_LAUNCH_MVMCTL=target/release/mvmctl
-export MVM_COLD_LAUNCH_ARGS="machine run --image alpine -- /bin/true"
-export MVM_COLD_LAUNCH_LANE=prepared_cold
-export MVM_COLD_LAUNCH_RUNS=20
-export MVM_COLD_LAUNCH_WARMUP=2
-
-cargo test --release --test cold_launch_bench -- --ignored --nocapture
+mvmctl prepare
+mvmctl bench --lane prepared-cold --runs 20 --warmup 2
 ```
 
-Every knob except the counts is required. A benchmark that guesses what to
-launch measures the wrong thing, so an unset variable fails and names itself
-rather than defaulting.
+`--lane` defaults to `prepared-cold` and accepts `prepared-cold`,
+`prepared-cold-mount-hit`, `mount-miss`, `artifact-miss`, and `warm-claim`.
+`--runs` defaults to 20 and `--warmup` to 2 — below 20 measured samples the
+report is not publication-grade. `--json` prints the report instead of a human
+summary, `--out <PATH>` redirects where it is written, and a debug build refuses
+to measure at all unless you pass `--allow-debug-build`, whose numbers mean
+nothing.
+
+Name the launch after `--` to measure something other than the built-in
+reproducible baseline:
+
+```sh
+mvmctl bench --lane prepared-cold -- machine run --image alpine -- /bin/true
+```
+
+The same measurement substrate is also driven by a live, `#[ignore]`d test for
+CI use, so a routine `cargo test` never produces a launch number by accident.
 
 The run writes a JSON report under `$MVM_HOME/state/bench/`, alongside a
 `-latest.json` copy. The report carries the host fingerprint, the per-lane

--- a/public/src/content/docs/reference/programmatic-use.mdx
+++ b/public/src/content/docs/reference/programmatic-use.mdx
@@ -23,6 +23,13 @@ mvmctl run --dry-run --json -- python task.py
 
 JSON output is intended for scripts. Human output can change for readability.
 
+:::note[`machine boot-report` is a hidden verb]
+It is marked `hide = true` in the CLI, so it works as documented but does not
+appear in `mvmctl machine --help`. The same applies to the other single-VM ops
+scripts reach for — `machine wait`, `machine fs`, `machine cp`, `machine proc`,
+`machine diff`, `machine set-ttl`.
+:::
+
 ## Exit codes
 
 Treat non-zero exit as failure. Some commands use conventional `sysexits`
@@ -43,7 +50,7 @@ export CARGO_TARGET_DIR="$PWD/.mvm-test/target"
 export CARGO_HOME="$PWD/.mvm-test/cargo"
 ```
 
-The repository's `scripts/dev-env.sh`, `bin/dev`, and `just dev-*` wrappers
+The repository's `scripts/dev-env.sh` and the `just dev` / `just dev-*` wrappers
 apply this pattern for worktree development.
 
 ## Secrets

--- a/public/src/content/docs/resources/faq.md
+++ b/public/src/content/docs/resources/faq.md
@@ -17,10 +17,12 @@ The builder VM provides a Linux execution boundary for Nix builds and microVM im
 
 ## Does Windows support ship today?
 
-Partially. Native Windows is still future work tracked by
-[mvm#428](https://github.com/tinylabscom/mvm/issues/428), but WSL2 with nested
-`/dev/kvm` is the supported Windows-adjacent workload path for the libkrun
-backend.
+No. Native Windows is future work tracked by
+[mvm#428](https://github.com/tinylabscom/mvm/issues/428), and **WSL2 is not a
+supported workload path either** — mvm detects WSL2 as its own platform and
+refuses the libkrun backend there unconditionally, whether or not the distro
+exposes nested `/dev/kvm`. `mvmctl doctor` says so directly. Use native Linux
+with `/dev/kvm` or an Apple Silicon Mac.
 
 ## Which SDK should I use?
 

--- a/public/src/content/docs/sdk/declaration-cookbook.mdx
+++ b/public/src/content/docs/sdk/declaration-cookbook.mdx
@@ -116,9 +116,9 @@ def worker() -> None:
 export const worker = mvm.app({
   name: "worker",
   source: mvm.localPath(".", { include: ["worker.ts", "pnpm-lock.yaml"] }),
-  image: mvm.nodeImage({ packages: ["pnpm"] }),
+  image: mvm.node_image({ packages: ["pnpm"] }),
   resources: mvm.resources({ cpu_cores: 1, memory_mb: 512, rootfs_size_mb: 1024 }),
-  dependencies: mvm.nodeDeps({ lockfile: "pnpm-lock.yaml" }),
+  dependencies: mvm.node_deps("pnpm-lock.yaml"),
   network: mvm.network({ mode: "none" }),
   entrypoint: mvm.entrypoint({ command: ["node", "/app/worker.js"] }),
 })(() => undefined);
@@ -153,13 +153,9 @@ network=mvm.network(
 <TabItem label="TypeScript">
 
 ```ts
-network: mvm.network({
-  mode: "bridge",
-  egress: mvm.egress([
-    mvm.hostPort("api.openai.com", 443),
-  ]),
-  dns: mvm.dnsSystem(),
-})
+// The TypeScript `network()` surface is mode + ports + ai today. `egress` and
+// `dns` are not accepted here; declare the allow-list from Python or mvm.toml.
+network: mvm.network({ mode: "bridge" })
 ```
 
 </TabItem>
@@ -232,13 +228,13 @@ def service() -> None:
 export const service = mvm.app({
   name: "service",
   source: mvm.localPath("."),
-  image: mvm.nodeImage({ packages: ["pnpm"] }),
+  image: mvm.node_image({ packages: ["pnpm"] }),
   resources: mvm.resources({ cpu_cores: 1, memory_mb: 512, rootfs_size_mb: 1024 }),
   network: mvm.network({ mode: "none" }),
   entrypoint: mvm.entrypoint({ command: ["node", "/app/server.js"] }),
-  beforeBuild: mvm.hook(["pnpm", "install", "--frozen-lockfile"]),
-  beforeStart: mvm.hook(["node", "/app/migrate.js"]),
-  afterStart: mvm.hook(["node", "/app/healthcheck.js"]),
+  before_build: mvm.hook(["pnpm", "install", "--frozen-lockfile"]),
+  before_start: mvm.hook(["node", "/app/migrate.js"]),
+  after_start: mvm.hook(["node", "/app/healthcheck.js"]),
 })(() => undefined);
 ```
 
@@ -284,10 +280,10 @@ def math() -> None:
 export const math = mvm.app({
   name: "math",
   source: mvm.localPath(".", { include: ["mathsvc.ts"] }),
-  image: mvm.nodeImage(),
+  image: mvm.node_image(),
   resources: mvm.resources({ cpu_cores: 1, memory_mb: 256, rootfs_size_mb: 512 }),
   network: mvm.network({ mode: "none" }),
-  dependencies: mvm.noDeps(),
+  dependencies: mvm.no_deps(),
   entrypoints: [
     mvm.entrypoint_function({ module: "mathsvc", function: "add", primary: true }),
     mvm.entrypoint_function({ module: "mathsvc", function: "mul" }),

--- a/public/src/content/docs/sdk/errors-metrics.md
+++ b/public/src/content/docs/sdk/errors-metrics.md
@@ -87,7 +87,9 @@ Debug logs are useful but risky. Recommended rules:
 
 ## Current CLI tools
 
-Use these while SDK error and metric helpers mature:
+Use these while SDK error and metric helpers mature. `machine boot-report` is a
+hidden advanced verb: it works, but it does not appear in
+`mvmctl machine --help`.
 
 ```sh
 mvmctl run --receipt /tmp/receipt.json -- python task.py

--- a/public/src/content/docs/sdk/index.md
+++ b/public/src/content/docs/sdk/index.md
@@ -7,7 +7,7 @@ description: "The two SDK surfaces mvm exposes: runtime lifecycle APIs and decor
 
 | Surface | Best for | Current status |
 | --- | --- | --- |
-| Runtime SDK | Create a sandbox from application code, run commands, move files, snapshot, and stop it. | Partial in Python and TypeScript; Rust lifecycle client is planned. |
+| Runtime SDK | Create a sandbox from application code, run commands, move files, snapshot, and stop it. | Partial in Python and TypeScript; Rust ships the `MvmClient` lifecycle client in `mvm-client`. |
 | Decorator SDK | Declare a reproducible workload in source code and compile it into `mvm` Workload IR. | Available for build-time declarations. |
 
 The runtime SDK is the imperative surface: your app owns a sandbox lifecycle. The decorator SDK is the declarative surface: your source file declares what should be built and executed.

--- a/public/src/content/docs/sdk/lifecycle-matrix.md
+++ b/public/src/content/docs/sdk/lifecycle-matrix.md
@@ -27,11 +27,11 @@ keep a workflow documented as planned.
 | Create named sandbox | Shipped | Partial | Partial | SDK live mode calls `mvmctl machine run`; record mode records `Sandbox.create(...)`. |
 | One-shot run | Shipped | Target | Target | `mvmctl run -- <cmd>` is current; SDK convenience helpers should preserve receipts and policy. |
 | Start command | Shipped | Partial | Partial | SDK exposes `commands.start(...)`; result capture is still a target. |
-| Command result capture | Shipped | Target | Target | CLI one-shot JSON/receipt paths exist; SDK `commands.run(...)` result shape is a target. |
+| Command result capture | Shipped | Shipped | Shipped | `sandbox.exec(...)` / `shell(...)` returns a captured `ExecResult` (live mode only). There is no `commands.run(...)`. |
 | File write | Shipped | Shipped | Shipped | SDK supports `files.write(...)`; live mode shells to `mvmctl machine fs write`. |
-| File read/list/remove | Shipped | Target | Target | CLI filesystem verbs exist; SDK wrappers need shared tests. |
+| File read/list/remove | Shipped | Shipped | Shipped | `files.read/list/stat/mkdir/remove/move(...)`, live mode only. |
 | Logs | Shipped | Target | Target | SDK log helpers should keep payload redaction rules explicit. |
-| Port forwarding | Shipped | Target | Target | SDK helpers should require explicit host and guest port binding. |
+| Port forwarding | Not claimed | Not claimed | Not claimed | Dynamic forwarding is retired. Ingress is declared before boot with `machine run --port HOST:GUEST`, or `network(ports=[...])` in a declaration; `mvmctl machine forward` and `sandbox.forward(...)` only explain the migration. |
 | Snapshot save/restore | Shipped | Target | Target | Backend behavior differs; SDK type model needs to expose that. |
 | Cold mode | Shipped | Target | Target | SDK should make running, cold, restoring, stopped, and destroyed states explicit. |
 | Stop/down | Shipped | Partial | Partial | Python context managers, TypeScript `using`, and explicit `kill()` clean up live sandboxes. |
@@ -48,7 +48,7 @@ keep a workflow documented as planned.
 | Live SDK experiment | `mvmctl run --mode live ./script.py` or `.ts` | Exercises current live transport and cleanup helpers. |
 | Deployable workload declaration | Static declaration workflow | Avoids importing user modules during compile. |
 | Persistent service | `mvmctl machine build`, `mvmctl machine run`, `mvmctl machine logs`, `mvmctl machine stop` | CLI has the broadest lifecycle coverage today. |
-| Cold recovery test | `mvmctl machine pause/resume` or `mvmctl machine checkpoint create/restore` | Backend-specific state handling is visible. |
+| Cold recovery test | `mvmctl machine pause/resume` or `mvmctl machine checkpoint create/restore` (hidden verbs — they work but are absent from `--help`) | Backend-specific state handling is visible. |
 
 ## SDK parity rules
 
@@ -70,12 +70,11 @@ name. New SDK helpers should preserve these invariants:
 
 The next SDK work should close the highest-value gaps in this order:
 
-1. `commands.run(...)` with typed result, timeout, bounded output, and receipt
-   correlation.
-2. `files.read/list/remove(...)` with path validation tests.
-3. `logs(...)` with redaction and bounded streaming.
-4. Declarative `network.ports` ingress with explicit policy.
-5. `snapshot(...)`, `cold()`, `resume()`, `destroy()`, and `detach()` with
+1. Receipt/audit correlation on the `ExecResult` returned by
+   `sandbox.exec(...)`, which today carries only exit code, stdout, and stderr.
+2. `logs(...)` with redaction and bounded streaming.
+3. Declarative `network.ports` ingress with explicit policy.
+4. `snapshot(...)`, `cold()`, `resume()`, `destroy()`, and `detach()` with
    backend-aware state types.
 
 Each item needs Python and TypeScript fixture parity before the docs move it

--- a/public/src/content/docs/sdk/nodejs.md
+++ b/public/src/content/docs/sdk/nodejs.md
@@ -10,20 +10,22 @@ The TypeScript SDK currently exposes both runtime and declarative surfaces.
 Current:
 
 - `Sandbox.create(template, options)`
-- `sandbox.commands.start(argv, options)`
-- `sandbox.files.write(path, content)`
+- `sandbox.commands.start(argv, options)` — the only method on `commands`
+- `sandbox.exec(argv, options)` / `sandbox.shell(command, options)` — one-shot with a captured `ExecResult` (live mode only)
+- `sandbox.files.write/read/list/stat/mkdir/remove/move(...)` — everything but `write` is live mode only
+- `sandbox.copyIn(...)` / `sandbox.copyOut(...)`
 - `using` cleanup through `Symbol.dispose`
 - record mode for plan/build flows;
 - live mode through `mvmctl run --mode live`
 
 Planned:
 
-- command result capture through `commands.run(...)`;
-- file read/list/remove;
 - logs and event streams;
-- port helpers;
 - snapshot, cold, resume, detach, destroy;
 - additional lifecycle result types once the local runtime transport supports them.
+
+There is no `commands.run(...)`. `sandbox.forward(...)` exists only to refuse:
+ingress is declared before boot through `network({ ports: [...] })`.
 
 ## Declaration
 
@@ -45,9 +47,10 @@ The AST compiler accepts the supported literal declaration shape and lowers it i
 ```ts
 export const llmWorker = mvm.app({
   image: mvm.python_image({ python: "3.12" }),
+  // The TypeScript `network()` surface is mode + ports + ai today; an egress
+  // allow-list is declared from Python or in mvm.toml.
   network: mvm.network({
     mode: "bridge",
-    egress: mvm.egress([mvm.hostPort("api.openai.com", 443)]),
     ai: mvm.aiPolicy({
       metering: true,
       budget: mvm.aiBudget({ maxTotalTokens: 100_000 }),

--- a/public/src/content/docs/sdk/operations-cookbook.mdx
+++ b/public/src/content/docs/sdk/operations-cookbook.mdx
@@ -9,11 +9,14 @@ Use this page when you want a practical SDK operation and need to know whether
 to call the SDK today, use the CLI directly, or treat the helper as target API.
 
 The shipped SDK runtime surface is intentionally smaller than the product
-target. Current examples use `Sandbox.create(...)`, `commands.start(...)`,
-`files.write(...)`, TTLs, resources, network declarations, record mode, live
-mode, and cleanup. Higher-level helpers such as `commands.run(...)`,
-`files.read(...)`, logs, ports, and snapshots are parity targets until the
-language SDK tests prove them.
+target. Current examples use `Sandbox.create(...)`, `commands.start(...)`, the
+one-shot `sandbox.exec(...)`, the full `files.*` API, TTLs, resources, network
+declarations, record mode, live mode, and cleanup. Logs, snapshots, and the
+lifecycle helpers are parity targets until the language SDK tests prove them.
+
+Several of the CLI fallbacks below (`machine proc`, `machine fs`, `machine
+pause`, `machine resume`, `machine checkpoint`) are hidden advanced verbs: they
+work, but they do not appear in `mvmctl machine --help`.
 
 ## Operation status
 
@@ -22,11 +25,11 @@ language SDK tests prove them.
 | Create sandbox recording | `mvm.Sandbox.create(...)` | `Sandbox.create(...)` | `mvmctl build compile` or `mvmctl run --mode plan` |
 | Create live sandbox | `mvmctl run --mode live ./script.py` | `mvmctl run --mode live ./script.ts` | `mvmctl machine run` |
 | Start command | `sandbox.commands.start([...])` | `sandbox.commands.start([...])` | `mvmctl machine proc start` or `mvmctl machine exec` |
-| Capture command result | Target `commands.run(...)` | Target `commands.run(...)` | CLI command result and receipt paths |
+| Capture command result | `sandbox.exec(*argv)` | `sandbox.exec(argv)` | CLI command result and receipt paths |
 | Write file | `sandbox.files.write(path, data)` | `sandbox.files.write(path, data)` | `mvmctl machine fs write` |
-| Read/list/remove file | Target helpers | Target helpers | `mvmctl machine fs read`, `mvmctl machine fs ls`, `mvmctl machine fs rm` |
+| Read/list/remove file | `sandbox.files.read/list/remove(...)` | `sandbox.files.read/list/remove(...)` | `mvmctl machine fs read`, `mvmctl machine fs ls`, `mvmctl machine fs rm` |
 | Logs | Target helper | Target helper | `mvmctl machine logs` |
-| Ports | Target helper | Target helper | port-forwarding CLI commands |
+| Ports | Not claimed | Not claimed | Declare ingress before boot: `mvmctl machine run --port HOST:GUEST` |
 | Pause/resume | Target helper | Target helper | `mvmctl machine pause`, `mvmctl machine resume` |
 | Checkpoint create/restore | Target helper | Target helper | `mvmctl machine checkpoint create --class vm-full`, `mvmctl machine checkpoint restore` |
 | Stop cleanup | context manager or `kill()` | `using`/`Symbol.dispose` or `kill()` | `mvmctl machine stop` |
@@ -58,7 +61,7 @@ Security notes:
 
 - the Python script itself runs on the host in record, plan, and live modes;
 - secret references are recorded as references, not copied as raw values;
-- `commands.start(...)` starts work, but result capture is still a parity target;
+- `commands.start(...)` starts work and returns a handle; use `sandbox.exec(...)` when you want the exit code and captured output back;
 - the context manager records or performs cleanup through `kill()`.
 
 Run modes:
@@ -111,41 +114,41 @@ mvmctl run --mode live ./sandbox.ts
 </TabItem>
 </Tabs>
 
-## Target result capture
+## Result capture
 
-The product target is a typed result helper:
+The shipped one-shot is `sandbox.exec(...)`, live mode only. It returns an
+`ExecResult` carrying the exit code and the captured stdout/stderr:
 
 <Tabs syncKey="runtime-language">
 <TabItem label="Python">
 
 ```python
-result = sandbox.commands.run(["python", "/app/main.py"], timeout_seconds=30)
+result = sandbox.exec("python", "/app/main.py", timeout=30)
 print(result.exit_code)
 print(result.stdout)
-print(result.audit_id)
+print(result.stderr)
 ```
 
 </TabItem>
 <TabItem label="TypeScript">
 
 ```ts
-const result = await sandbox.commands.run(["node", "/app/main.js"], {
-  timeoutSeconds: 30,
-});
+const result = sandbox.exec(["node", "/app/main.js"], { timeout: 30 });
 console.log(result.exitCode);
 console.log(result.stdout);
-console.log(result.auditId);
+console.log(result.stderr);
 ```
 
 </TabItem>
 </Tabs>
 
-Until this helper is shipped in a language SDK, use the CLI path for result
-capture, receipts, and automation that needs exit status or bounded output.
+`ExecResult` carries no run or audit identifier yet. Use the CLI receipt path
+(`mvmctl run --receipt ...`) when automation needs audit correlation.
 
-## Target file reads
+## File reads
 
-The product target is a symmetric file API:
+The file API is symmetric and shipped in both SDKs. Everything but `write` is
+live mode only; in record mode these raise a mode error rather than guessing:
 
 <Tabs syncKey="runtime-language">
 <TabItem label="Python">
@@ -161,16 +164,15 @@ sandbox.files.remove("/work/output.json")
 <TabItem label="TypeScript">
 
 ```ts
-await sandbox.files.write("/work/input.json", new TextEncoder().encode("{}"));
-const data = await sandbox.files.read("/work/output.json");
-const entries = await sandbox.files.list("/work");
-await sandbox.files.remove("/work/output.json");
+sandbox.files.write("/work/input.json", "{}");
+const data = sandbox.files.read("/work/output.json");
+const entries = sandbox.files.list("/work");
+sandbox.files.remove("/work/output.json");
 ```
 
 </TabItem>
 </Tabs>
 
-Until read/list/remove helpers are shipped, use the CLI filesystem commands.
 Treat bytes returned from the guest as untrusted and possibly sensitive.
 
 ## Target logs and ports

--- a/public/src/content/docs/sdk/python.md
+++ b/public/src/content/docs/sdk/python.md
@@ -10,20 +10,22 @@ The Python SDK currently exposes both runtime and declarative surfaces.
 Current:
 
 - `mvm.Sandbox.create(template, ...)`
-- `sandbox.commands.start(argv, env=...)`
-- `sandbox.files.write(path, content)`
-- context-manager cleanup with `with`
+- `sandbox.commands.start(argv, env=...)` — the only method on `commands`
+- `sandbox.exec(*argv, ...)` / `sandbox.aexec(...)` / `sandbox.shell(...)` — one-shot with a captured `ExecResult` (live mode only)
+- `sandbox.files.write/read/list/stat/mkdir/remove/move(...)` — everything but `write` is live mode only
+- `sandbox.copy_in(...)` / `sandbox.copy_out(...)`
+- context-manager cleanup with `with` (or `async with`)
 - record mode for `mvmctl build compile` and `mvmctl run --mode plan`
 - live mode for `mvmctl run --mode live`
 
 Planned:
 
-- command result capture through `commands.run(...)`;
-- file read/list/remove;
 - logs and event streams;
-- port helpers;
 - snapshot, cold, resume, detach, destroy;
 - additional lifecycle result types once the local runtime transport supports them.
+
+There is no `commands.run(...)`. `sandbox.forward(...)` exists only to refuse:
+ingress is declared before boot through `network=mvm.network(ports=[...])`.
 
 ## Decorator
 
@@ -52,7 +54,8 @@ The static compiler extracts literal decorator declarations without importing th
 @mvm.app(
     name="llm-worker",
     source=mvm.local_path("."),
-    image=mvm.python_image({"python": "3.12"}),
+    image=mvm.python_image(python="3.12"),
+    resources=mvm.resources(cpu_cores=1, memory_mb=512, rootfs_size_mb=1024),
     network=mvm.network(
         mode="bridge",
         egress=mvm.egress([mvm.host_port("api.openai.com", 443)]),

--- a/public/src/content/docs/sdk/reference.md
+++ b/public/src/content/docs/sdk/reference.md
@@ -15,15 +15,15 @@ The SDKs share one runtime model:
 | --- | --- | --- |
 | Python | Partial runtime SDK plus declarative workload SDK. | Local runtime scripts and static declarations. |
 | TypeScript/Node.js | Partial runtime SDK plus declarative workload SDK. | Local runtime scripts and static declarations. |
-| Rust | Build-time SDK and lower-level IR contract. | Tooling, generators, and typed declarations. |
+| Rust | Build-time SDK and lower-level IR contract, plus the `MvmClient` runtime client in `mvm-client`. | Tooling, generators, typed declarations, and host-side machine lifecycle. |
 
 ## Runtime parity target
 
 The language SDKs should converge on:
 
 - `Sandbox.create(...)`
-- `sandbox.commands.run(...)`
-- `sandbox.files.read/write/list/remove(...)`
+- a one-shot with a captured result — shipped as `sandbox.exec(...)` in Python and TypeScript
+- `sandbox.files.read/write/list/remove(...)` — shipped in Python and TypeScript
 - `sandbox.logs(...)`
 - declarative `network.ports` on `Sandbox.create(...)`
 - `sandbox.snapshot(...)`

--- a/public/src/content/docs/sdk/runtime-modes.md
+++ b/public/src/content/docs/sdk/runtime-modes.md
@@ -82,7 +82,9 @@ mvmctl run --mode live ./sandbox.py
 ```
 
 The CLI sets `MVM_SDK_MODE=live` and `MVM_CLI_BIN` for the child process. The SDK
-then uses the local CLI for operations such as:
+then uses the local CLI for operations such as (`machine proc` and `machine fs`
+are hidden advanced verbs — they work, but they do not appear in
+`mvmctl machine --help`):
 
 - `mvmctl machine run --up-json --detach --name <generated-id> --manifest <template>`
 - `mvmctl machine fs write <vm> <path>`
@@ -101,8 +103,8 @@ Live mode is intentionally narrower than the target SDK contract:
 | --- | --- |
 | Sandbox count | One active sandbox per SDK process. |
 | TTL | Defaults to 30 minutes unless the caller sets `ttl`. |
-| Commands | `commands.start(...)` starts a command; result capture is still a parity target. |
-| Files | `files.write(...)` stages bytes into the running VM. |
+| Commands | `commands.start(...)` starts a command and returns a handle; `exec(...)` / `shell(...)` is the one-shot that returns a captured `ExecResult`. |
+| Files | `files.write(...)` stages bytes into the running VM; `read` / `list` / `stat` / `mkdir` / `remove` / `move` are live-mode only. |
 | Cleanup | Python `with`, TypeScript `using`, or explicit `kill()` calls `mvmctl machine stop`. |
 | Secrets | Live command env forwarding accepts literal values only. Secret refs must use host-managed injection paths. |
 

--- a/public/src/content/docs/sdk/runtime.mdx
+++ b/public/src/content/docs/sdk/runtime.mdx
@@ -7,7 +7,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 The runtime SDK is the application-facing sandbox API. It is the surface you use when your product needs to create a microVM, run generated code, exchange files, inspect output, and clean up.
 
-> **Status:** Partially implemented. `crates/mvm-sdk/sdks/python` and `crates/mvm-sdk/sdks/typescript` already expose `Sandbox.create(...)`, command start, file write, record mode, live mode, and cleanup helpers. The remaining lifecycle methods below are the parity target; do not treat every method name on this page as a shipped package API.
+> **Status:** Partially implemented. `crates/mvm-sdk/sdks/python` and `crates/mvm-sdk/sdks/typescript` already expose `Sandbox.create(...)`, `commands.start(...)`, the one-shot `sandbox.exec(...)`/`shell(...)` with a captured result, the full `files.write/read/list/stat/mkdir/remove/move(...)` API (everything but `write` is live-mode only), copy in/out, record mode, live mode, and cleanup helpers. The remaining lifecycle methods below are the parity target; do not treat every method name on this page as a shipped package API.
 
 For the execution-mode split between record, plan, live, and static declaration
 flows, see [Runtime modes](/sdk/runtime-modes/).
@@ -88,7 +88,7 @@ finally:
 <TabItem label="TypeScript">
 
 ```ts
-import { NetworkPolicy, Sandbox, SecretRef } from "@mvm/sdk";
+import { NetworkPolicy, Sandbox, SecretRef } from "@runmvm/mvm";
 
 const sandbox = await Sandbox.create({
   image: "nix:./flake#agent-runtime",
@@ -111,6 +111,11 @@ try {
 
 </TabItem>
 </Tabs>
+
+Every name in the two blocks above is a target. Today `@runmvm/mvm` exports no
+`NetworkPolicy` value, `SecretRef` is a type-only interface with no `.from()`,
+and there is no `commands.run(...)` in either language — the shipped one-shot is
+`sandbox.exec(...)`, which returns a captured result.
 
 The same core operations should exist across Python, TypeScript, and Rust:
 

--- a/public/src/content/docs/sdk/runtime.mdx
+++ b/public/src/content/docs/sdk/runtime.mdx
@@ -87,7 +87,7 @@ finally:
 </TabItem>
 <TabItem label="TypeScript">
 
-```ts
+```text
 import { NetworkPolicy, Sandbox, SecretRef } from "@runmvm/mvm";
 
 const sandbox = await Sandbox.create({

--- a/public/src/content/docs/sdk/rust.md
+++ b/public/src/content/docs/sdk/rust.md
@@ -64,20 +64,27 @@ let client = LocalBackend::new();
 let spec = MachineSpec::builder("web", "nginx")?
     .cpus(2)
     .memory_mib(512)
-    .env("PORT", "8080")
     .build();
 
 let machine = client.run_machine(spec).await?;
-let out = client
-    .exec_machine(&machine.id, vec!["nginx".into(), "-v".into()])
-    .await?;
-println!("{}", String::from_utf8_lossy(&out.stderr));
+let logs = client.machine_logs(&machine.id, Default::default()).await?;
+println!("{}", String::from_utf8_lossy(&logs));
 client.stop_machine(&machine.id).await?;
 ```
 
 The builder is equivalent to a struct literal — every field stays public — but
 reads far better at call sites and lets new optional fields land without churning
 existing callers.
+
+Two `LocalBackend` limits are worth knowing before you build against it:
+
+- `run_machine` and `create_machine` **refuse** a spec with a non-empty `env`.
+  The in-process boot path has no delivery seam for guest environment
+  variables, and dropping them silently would be worse than failing; use the
+  CLI run path when a workload needs env.
+- `exec_machine` always returns an error — in-guest exec goes through the
+  guest-agent RPC path, which this backend does not wire. `GatewayBackend`
+  is unaffected.
 
 ### Embedding it — studio, mvmd, and custom frontends
 
@@ -106,9 +113,9 @@ in-process `LocalBackend` when built `--features local` with
 `MVM_STUDIO_BACKEND=local` — one `dyn MvmClient` behind its Tauri commands.
 
 ```toml
-# a frontend that drives machines
-mvm-client       = { path = "../mvm/crates/mvm-client", features = ["remote"] }
-mvm-client-local = { path = "../mvm/crates/mvm-client-local" }   # optional, in-process backend
+# a frontend that drives machines. `LocalBackend` is unconditional; the
+# `remote` feature adds the REST `GatewayBackend`.
+mvm-client = { path = "../mvm/crates/mvm-client", features = ["remote"] }
 ```
 
 A **host-side daemon that manages instances directly** — the **mvmd** fleet

--- a/public/src/content/docs/sdk/sandbox-types.md
+++ b/public/src/content/docs/sdk/sandbox-types.md
@@ -7,13 +7,16 @@ description: Product-level sandbox patterns and their current mvm implementation
 microVM with explicit policy, audit, and lifecycle state. Product-facing SDKs
 can layer specialized helpers over that substrate.
 
+`mvmctl machine fs` (below) is a hidden advanced verb: it works, but it does not
+appear in `mvmctl machine --help`.
+
 ## Type matrix
 
 | Type | Best for | Current path | SDK status |
 | --- | --- | --- | --- |
 | General sandbox | Commands, files, services, long-running work. | `mvmctl machine build`, `mvmctl machine run`, `mvmctl machine exec`, `mvmctl machine fs`, `mvmctl machine logs`. | Partial Python/TypeScript runtime surface. |
-| Code sandbox | Short code execution and interpreter-style tools. | `mvmctl run -- <cmd>` or a named Python manifest. | Planned convenience helper. |
-| Browser sandbox | Browser automation with Playwright/Puppeteer-like tooling. | Build a browser-capable Nix image, run automation inside the guest, forward explicit ports if needed. | Planned high-level helper. |
+| Code sandbox | Short code execution and interpreter-style tools. | `mvmctl run -- <cmd>`, a named Python manifest, or the `CodeSandbox` helper. | `CodeSandbox` ships in Python and TypeScript. |
+| Browser sandbox | Browser automation with Playwright/Puppeteer-like tooling. | Build a browser-capable Nix image, run automation inside the guest, declare any needed ports at boot, or use the `BrowserSandbox` helper. | `BrowserSandbox` ships in Python and TypeScript. |
 | Desktop sandbox | GUI or computer-use workflows. | Backend- and image-specific today; use explicit images and port/console access. | Planned high-level helper. |
 | Builder sandbox | Secure Linux image construction. | Project builder VM and persistent builder controls. | CLI-first today. |
 
@@ -32,7 +35,7 @@ Security properties:
 
 - guest code runs in a microVM backend where supported;
 - host files enter only through explicit transfer, mounts, or build inputs;
-- network exposure and port forwarding are explicit;
+- network exposure is explicit, and ingress ports are declared before boot;
 - audit records connect build, admission, launch, and lifecycle operations.
 
 ## Code sandbox

--- a/public/src/content/docs/sdk/security-model.mdx
+++ b/public/src/content/docs/sdk/security-model.mdx
@@ -108,7 +108,7 @@ with Sandbox.create(
 <TabItem label="TypeScript">
 
 ```ts
-import { NetworkPolicy, Sandbox, SecretRef } from "@mvm/sdk";
+import { NetworkPolicy, Sandbox, SecretRef } from "@runmvm/mvm";
 
 using sandbox = await Sandbox.create({
   image: "nix:./flake#agent-runtime",
@@ -127,7 +127,10 @@ console.log(result.stdout);
 </Tabs>
 
 This is the target SDK shape. Check [Lifecycle matrix](/sdk/lifecycle-matrix/)
-before treating a helper as shipped in a particular language.
+before treating a helper as shipped in a particular language. In particular,
+`@runmvm/mvm` exports no `NetworkPolicy` value today, and `SecretRef` is a
+type-only interface with no `.from()` — use `mvm.secret(...)` for a secret
+reference and `mvm.network({...})` for a policy.
 
 ## Related pages
 

--- a/public/src/content/docs/sdk/security-model.mdx
+++ b/public/src/content/docs/sdk/security-model.mdx
@@ -107,7 +107,7 @@ with Sandbox.create(
 </TabItem>
 <TabItem label="TypeScript">
 
-```ts
+```text
 import { NetworkPolicy, Sandbox, SecretRef } from "@runmvm/mvm";
 
 using sandbox = await Sandbox.create({

--- a/public/src/content/docs/templates/build.md
+++ b/public/src/content/docs/templates/build.md
@@ -12,9 +12,12 @@ mvmctl machine build
 Or point at a project directory or manifest file:
 
 ```sh
-mvmctl machine build --flake ./my-worker
-mvmctl machine build --flake ./my-worker/mvm.toml
+mvmctl machine build ./my-worker
+mvmctl machine build ./my-worker/mvm.toml
 ```
+
+`--flake <ref>` is a different mode: it forces a flake-only build and skips
+manifest discovery entirely.
 
 `mvmctl machine build` discovers `mvm.toml` or `Mvmfile.toml`, runs the Nix build
 through the builder VM where Linux build work belongs, and stores artifacts in
@@ -25,10 +28,13 @@ a local slot keyed by the canonical manifest path.
 ```sh
 mvmctl machine build --force
 mvmctl machine build --update-hash
-mvmctl machine run --flake . --cpus 4 --memory 2G
+mvmctl machine run --flake . --cpus 4 --memory 2G -d
 mvmctl machine checkpoint create my-machine --class vm-full
 mvmctl machine build --json
 ```
+
+`machine checkpoint` is an advanced verb: it works, but it is hidden from
+`machine --help`.
 
 Snapshot builds are backend-specific. Do not present snapshot availability or
 latency as universal unless the backend and readiness boundary are named.
@@ -49,7 +55,7 @@ VMs. Use `mvmctl manifest *` for build slots and registry state.
 ## Boot after build
 
 ```sh
-mvmctl machine run --manifest .
+mvmctl machine run --manifest . -d
 mvmctl machine run --manifest ./my-worker -- uname -a
 ```
 

--- a/public/src/content/docs/templates/index.md
+++ b/public/src/content/docs/templates/index.md
@@ -3,7 +3,8 @@ title: Templates
 description: Reusable mvm project blueprints built from manifests and Nix flakes.
 ---
 
-The old `mvmctl template` command family is gone. The current reusable
+The `mvmctl template` mutation verbs are gone; `mvmctl template` survives as a
+read-only registry browser (`list`, `search`, `info`). The current reusable
 blueprint is a project directory with:
 
 - `mvm.toml` or `Mvmfile.toml` for build input and runtime sizing;
@@ -20,8 +21,11 @@ mvmctl init my-worker --preset worker
 cd my-worker
 $EDITOR mvm.toml
 mvmctl machine build
-mvmctl machine run --manifest .
+mvmctl machine run --manifest . -d
 ```
+
+`machine run` needs either a trailing `-- <cmd>` or `-d`/`--detach`; `--name`
+alone does not make the machine persist.
 
 The build produces a manifest-keyed slot in the local registry. Subsequent
 `mvmctl machine build` calls re-read `mvm.toml`, rebuild the selected flake/profile,

--- a/public/src/content/docs/tutorials/agent-sandbox.mdx
+++ b/public/src/content/docs/tutorials/agent-sandbox.mdx
@@ -12,7 +12,7 @@ Use this pattern when an agent needs a real Linux environment but the code it ru
 Prefer a pinned Nix flake target:
 
 ```sh
-cargo run -- build --flake .
+cargo run -- machine build --flake .
 ```
 
 The command runs on the host, while Linux Nix evaluation and image assembly happen inside the builder VM. The runtime guest later boots the built artifact; build time and boot time are separate phases.
@@ -22,11 +22,13 @@ If your team already has an OCI image, use the OCI path as compatibility input a
 ## Run locally
 
 ```sh
-cargo run -- up agent-sandbox --flake .
-cargo run -- exec agent-sandbox -- python /work/agent.py
+cargo run -- machine run --flake . --name agent-sandbox -d
+cargo run -- machine exec agent-sandbox -- python /work/agent.py
 ```
 
-Local mode talks to `mvm` on the same host. The microVM is the execution boundary.
+Local mode talks to `mvm` on the same host. The microVM is the execution
+boundary. `-d` is what makes the machine persist past the command; `--name`
+only labels it, so without `-d` the run needs a trailing `-- <cmd>`.
 
 ## Planned runtime SDK shape
 

--- a/public/src/content/docs/tutorials/browser-automation.mdx
+++ b/public/src/content/docs/tutorials/browser-automation.mdx
@@ -12,7 +12,7 @@ Browser automation is useful for agents, scraping, UI tests, and computer-use wo
 Use a Nix flake target that includes the browser runtime and automation library:
 
 ```sh
-cargo run -- build --flake . --profile browser
+cargo run -- machine build --flake . --profile browser
 ```
 
 The build runs through the builder VM. The browser runs later inside the runtime microVM.
@@ -20,9 +20,12 @@ The build runs through the builder VM. The browser runs later inside the runtime
 ## Run the automation
 
 ```sh
-cargo run -- up browserbox --flake . --profile browser
-cargo run -- exec browserbox -- node /work/automation.js
+cargo run -- machine run --flake . --flake-profile browser --name browserbox -d
+cargo run -- machine exec browserbox -- node /work/automation.js
 ```
+
+On `machine run` the flake package variant is `--flake-profile`; `--profile`
+there selects the security profile instead.
 
 ## Security checklist
 

--- a/public/src/content/docs/tutorials/code-execution.mdx
+++ b/public/src/content/docs/tutorials/code-execution.mdx
@@ -10,13 +10,14 @@ Code execution is the core sandbox operation: run a process inside the guest and
 ## CLI flow
 
 ```sh
-cargo run -- up codebox --flake .
-cargo run -- exec codebox -- python - <<'PY'
-print("hello from the guest")
-PY
+cargo run -- machine run --flake . --name codebox -d
+cargo run -- machine exec codebox -- python -c 'print("hello from the guest")'
 ```
 
-`exec` runs in the guest microVM. The host process sends the request through the guest control path and receives structured output.
+`machine exec` runs the command in the guest microVM, sending the request
+through the guest control path and returning structured output. It does not
+forward host stdin, so pass the program inline with `python -c` rather than
+piping it in; a heredoc would reach the host and the guest would read EOF.
 
 ## Planned runtime SDK shape
 

--- a/public/src/content/docs/tutorials/coding-agent.md
+++ b/public/src/content/docs/tutorials/coding-agent.md
@@ -27,9 +27,13 @@ For local development through this repository, the builder VM is the Linux build
 ## Run the task
 
 ```sh
-mvmctl machine run --flake . --name coding-agent
+mvmctl machine run --flake . --name coding-agent -d
 mvmctl machine exec coding-agent -- bash -lc 'cd /work && python task.py'
 ```
+
+`-d` is what keeps the machine alive after the command returns; `--name` alone
+does not, and `machine run` with neither `-d` nor a trailing `-- <cmd>` refuses
+to start.
 
 Use file transfer or a narrow mount for input/output. Keep generated patches and logs outside broad host write access.
 
@@ -45,6 +49,9 @@ Use cold mode only when the agent needs to resume an environment with installed 
 mvmctl machine pause coding-agent
 mvmctl machine resume coding-agent
 ```
+
+`machine pause` and `machine resume` are advanced verbs: they work, but they
+are hidden from `machine --help`.
 
 Use `mvmctl machine stop` and cleanup commands when the task is complete.
 

--- a/public/src/content/docs/tutorials/cold-mode-recovery.md
+++ b/public/src/content/docs/tutorials/cold-mode-recovery.md
@@ -5,12 +5,14 @@ description: Pause, save, restore, and wake sandboxes from backend-specific snap
 
 Cold mode lets a sandbox stop consuming a running VM while keeping recoverable state.
 
+Every verb on this page is an advanced single-VM op reached through `machine`. They work, but they are hidden from `machine --help`.
+
 ## Firecracker sealed pause/resume
 
 ```sh
-cargo run -- pause agent-sandbox
-cargo run -- snapshot ls
-cargo run -- resume agent-sandbox
+cargo run -- machine pause agent-sandbox
+cargo run -- machine snapshot ls
+cargo run -- machine resume agent-sandbox
 ```
 
 Firecracker pause/resume writes sealed instance state and verifies it before resume. This is the local `mvm` primitive.
@@ -18,11 +20,13 @@ Firecracker pause/resume writes sealed instance state and verifies it before res
 ## Full-VM memory checkpoints
 
 ```sh
-cargo run -- checkpoint create agent-sandbox --class vm-full
-cargo run -- checkpoint restore agent-sandbox --name <checkpoint-name>
+cargo run -- machine checkpoint create agent-sandbox --class vm-full
+cargo run -- machine checkpoint restore <checkpoint-id>
 ```
 
-Full-VM checkpoints capture full machine state. They are currently unavailable through the selectable workload runners; request them only when `mvmctl doctor` reports a compatible backend and capability. `mvm` records the checkpoint content hash in the audit chain when the launch plan and host signer are available, and restore records whether the content matched the prior chain entry.
+`checkpoint restore` takes the checkpoint's own id, not the VM name.
+
+Full-VM checkpoints capture full machine state. Among the selectable workload runners only `hvf` and `apple-container` support save/restore; `firecracker`, `libkrun`, `qemu`, and `wasm` do not. Check `mvmctl doctor` for the backend and capability on your host before relying on one. `mvm` records the checkpoint content hash in the audit chain when the launch plan and host signer are available, and restore records whether the content matched the prior chain entry.
 
 ## Security checklist
 

--- a/public/src/content/docs/tutorials/file-transfer.mdx
+++ b/public/src/content/docs/tutorials/file-transfer.mdx
@@ -10,17 +10,20 @@ File transfer should be explicit. A narrow copy operation is easier to audit and
 ## Copy into the guest
 
 ```sh
-cargo run -- cp ./input.json filebox:/work/input.json
-cargo run -- exec filebox -- python /work/process.py /work/input.json
+cargo run -- machine cp ./input.json filebox:/work/input.json
+cargo run -- machine exec filebox -- python /work/process.py /work/input.json
 ```
+
+`machine cp` is an advanced verb: it works, but it is hidden from
+`machine --help`.
 
 ## Copy out of the guest
 
 ```sh
-cargo run -- cp filebox:/work/output.json ./output.json
+cargo run -- machine cp filebox:/work/output.json ./output.json
 ```
 
-Use host mounts only when the workflow is intentionally a development workflow and the mounted path is narrow.
+Use host mounts only when the workflow is intentionally a development workflow and the mounted path is narrow. A guest mount path has to sit under `/data` or `/work`; `/mnt` is refused because the runtime's own config and secret drives live there.
 
 ## Planned runtime SDK shape
 

--- a/public/src/content/docs/tutorials/long-running-services.md
+++ b/public/src/content/docs/tutorials/long-running-services.md
@@ -19,6 +19,9 @@ mvmctl machine wait api-dev --for all
 mvmctl machine logs api-dev -f
 ```
 
+`machine wait` and `machine boot-report` are advanced verbs: they work, but
+they are hidden from `machine --help`.
+
 ## Security notes
 
 - Bind only the ports the caller needs.

--- a/public/src/content/docs/working/cold-mode.md
+++ b/public/src/content/docs/working/cold-mode.md
@@ -33,6 +33,6 @@ The runtime primitive is `mvm`: it knows how to talk to the backend, write or ve
 Use "cold mode" for the product state. Use backend-specific terms for implementation:
 
 - Firecracker sealed pause/resume.
-- Full-VM machine-state save/restore (currently unavailable through the selectable workload runners; check `mvmctl doctor` before requesting it).
+- Full-VM machine-state save/restore (advertised by `hvf` and `apple-container`; check `mvmctl doctor` before requesting it).
 - Pool Sleeping/Running restore.
 Avoid implying that every backend supports every cold-mode operation.

--- a/public/src/content/docs/working/commands.md
+++ b/public/src/content/docs/working/commands.md
@@ -42,8 +42,8 @@ Use this path when the VM has state, files, services, or snapshots that should s
 | --- | --- | --- |
 | `restrictive` | Running generated or untrusted code. | No env injection and no host directory shares. |
 | `standard` | Normal local runs. | Explicit env is allowed; host shares must be read-only. |
-| `dev` | Iterating on a local project. | Writable host shares are allowed. |
-| `permissive` | Last-resort debugging. | Requires explicit acknowledgement. |
+| `dev` | Iterating on a local project. | Host shares may be writable on a persistent machine; a transient run's share stays read-only. Also selects the dev guest profile. |
+| `permissive` | Last-resort debugging. | Same grants as `dev`, and refuses unless `MVM_ACK_PERMISSIVE_RUN=1` is set. |
 
 ## Security notes
 

--- a/public/src/content/docs/working/filesystem.md
+++ b/public/src/content/docs/working/filesystem.md
@@ -5,6 +5,9 @@ description: Move files across the host and guest boundary safely.
 
 Filesystem operations cross a trust boundary. Keep paths narrow, copy only the files required for the task, and avoid broad host mounts for generated or third-party code.
 
+`machine cp` and `machine volume` are hidden advanced verbs: they work, but they
+do not appear in `mvmctl machine --help`.
+
 ## Copy files
 
 ```sh

--- a/public/src/content/docs/working/index.md
+++ b/public/src/content/docs/working/index.md
@@ -3,7 +3,7 @@ title: Working in the MicroVM
 description: Local sandbox management with mvmctl.
 ---
 
-`mvmctl` is the local sandbox management surface. It builds images, boots microVMs, runs commands, transfers files, forwards ports, captures logs, and moves sandboxes through pause, cold, resume, stop, and destroy-style workflows.
+`mvmctl` is the local sandbox management surface. It builds images, boots microVMs, runs commands, transfers files, declares ingress ports at boot, captures logs, and moves sandboxes through pause, cold, resume, stop, and destroy-style workflows.
 
 ## Common lifecycle
 

--- a/public/src/content/docs/working/lifecycle-states.md
+++ b/public/src/content/docs/working/lifecycle-states.md
@@ -8,6 +8,18 @@ different primitives, but the user-facing states should stay explicit so
 automation can decide when compute is active, when state is sensitive, and when
 cleanup is still required.
 
+The names below are the product vocabulary, not machine-readable status values.
+The status a local machine actually reports is one of `Starting`, `Running`,
+`Stopped`, `Paused`, `Failed`; a fleet instance reports one of `Created`,
+`Ready`, `Running`, `Warm`, `Sleeping`, `Stopped`, `Destroyed`. Neither enum
+has a `Cold`, `Restoring`, `Cleaned`, `Built`, or "No image" value — do not
+match on those strings.
+
+Most of the `machine <verb>` commands in the tables below (`wait`,
+`boot-report`, `fs`, `pause`, `resume`, `checkpoint`, `sandbox`) are hidden
+advanced operations: they work, but they do not appear in
+`mvmctl machine --help`.
+
 ## State model
 
 | State | What it means | Common next action | Security note |
@@ -29,7 +41,7 @@ cleanup is still required.
 | Source to image | `mvmctl machine build` |
 | Image to running sandbox | `mvmctl machine run` or `mvmctl run` |
 | Wait for readiness | `mvmctl machine wait`, `mvmctl machine boot-report` |
-| Run work | `mvmctl machine exec`, `mvmctl machine fs`, `mvmctl machine logs`, port-forwarding commands |
+| Run work | `mvmctl machine exec`, `mvmctl machine fs`, `mvmctl machine logs`; ingress is declared at boot with `mvmctl machine run --port HOST:GUEST` |
 | Running to paused or cold | `mvmctl machine pause`, `mvmctl machine checkpoint create` |
 | Paused or cold to running | `mvmctl machine resume`, `mvmctl machine checkpoint restore` |
 | Running to stopped | `mvmctl machine stop` |

--- a/public/src/content/docs/working/network.md
+++ b/public/src/content/docs/working/network.md
@@ -7,15 +7,15 @@ Networking is part of the sandbox contract. Name what the guest can reach, name 
 
 ## Egress policy
 
-Use a preset when it matches the workload:
+Egress is off unless you ask for it. `--net` opts into the built-in dev preset:
 
 ```sh
-mvmctl machine run --flake .
-mvmctl machine run --flake . --net
-mvmctl machine run --flake . --net
+mvmctl machine run --flake .          # deny-all (the default)
+mvmctl machine run --flake . --net    # dev preset
 ```
 
-Use explicit allow rules for narrow agent workloads:
+Use explicit allow rules for narrow agent workloads. `--allow-host` replaces the
+preset with a concrete allow-list:
 
 ```sh
 mvmctl machine run --flake . \
@@ -35,7 +35,12 @@ mvmctl machine run --flake . --name api-dev \
   --port 8080:8080 --port 3000:3000
 ```
 
-Use readiness and logs while developing services:
+Ingress is declared before boot and is not changed afterwards; there is no
+dynamic port-forwarding verb.
+
+Use readiness and logs while developing services (`wait` and `boot-report` are
+hidden advanced verbs — they work, but they do not appear in
+`mvmctl machine --help`):
 
 ```sh
 mvmctl machine wait api-dev --for all

--- a/public/src/content/docs/working/persistence.md
+++ b/public/src/content/docs/working/persistence.md
@@ -22,9 +22,12 @@ mvmctl machine pause agent-sandbox
 mvmctl machine resume agent-sandbox
 ```
 
-The exact backend mechanics differ. See [Snapshots](/working/snapshots/) for the
-separate live-memory, machine-state, disk-only, standby, and cold-boot tiers.
-Use `mvmctl doctor` to see which tier the selected backend advertises.
+Both verbs are hidden advanced operations — they work, but they do not appear in
+`mvmctl machine --help` — and both default to `--hypervisor firecracker` and
+drive the snapshot through Firecracker's control socket. See
+[Snapshots](/working/snapshots/) for the separate live-memory, machine-state,
+disk-only, standby, and cold-boot tiers. Use `mvmctl doctor` to see which tier
+the selected backend advertises.
 
 ## Cold mode
 

--- a/public/src/content/docs/working/sandbox-management.md
+++ b/public/src/content/docs/working/sandbox-management.md
@@ -5,6 +5,9 @@ description: Create, inspect, stop, pause, resume, and clean up local mvm sandbo
 
 Use `mvmctl` when you need the local management layer for sandboxes.
 
+The advanced single-VM verbs used below (`pause`, `resume`, `checkpoint`, `fs`)
+are hidden: they work, but they do not appear in `mvmctl machine --help`.
+
 ## Create or boot
 
 ```sh
@@ -43,11 +46,11 @@ mvmctl machine pause agent-sandbox
 mvmctl machine resume agent-sandbox
 ```
 
-Full-VM memory checkpoints (vm-full class) are currently unavailable through the selectable workload runners; check `mvmctl doctor` for the authoritative capability before requesting them:
+Full-VM memory checkpoints (vm-full class) need a backend at the `save-restore` snapshot tier or better — today `hvf` and `apple-container`. Check `mvmctl doctor` for the authoritative capability before requesting them:
 
 ```sh
 mvmctl machine checkpoint create agent-sandbox --class vm-full
-mvmctl machine checkpoint restore agent-sandbox --name <checkpoint-name>
+mvmctl machine checkpoint restore <checkpoint-id>
 ```
 
 Snapshots can contain memory, files, and runtime credentials. Apply retention and deletion policy.

--- a/public/src/content/docs/working/snapshots.md
+++ b/public/src/content/docs/working/snapshots.md
@@ -5,14 +5,18 @@ description: Pause a microVM into sealed state, create checkpoints, and restore 
 
 Cold mode means a workload is not currently consuming a running guest, but it has recoverable state. In `mvm`, that state is represented by backend-specific snapshot and checkpoint artifacts.
 
+The `machine` verbs on this page (`pause`, `resume`, `snapshot`, `checkpoint`) are
+hidden advanced operations: they work, but they do not appear in
+`mvmctl machine --help`.
+
 ## Recovery paths and current status
 
 | Path | Meaning | Current status |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | Live-memory snapshot/restore | Restore guest RAM plus VMM state. | Not advertised by the selectable workload runners. `resume --warm` refuses with a typed error when the selected backend cannot honor it. |
-| Save/restore machine state | Restore serialized VMM state without claiming live-memory fidelity. | No selectable backend currently advertises this tier. |
+| Save/restore machine state | Restore serialized VMM state without claiming live-memory fidelity. | Advertised by `hvf` and `apple-container`. `firecracker`, `libkrun`, `qemu`, and `wasm` all report `unsupported`. |
 | Disk-only CoW warm start | Reboot from a copy-on-write disk/overlay artifact without restoring RAM. | The raw libkrun substrate has this primitive, but no selectable workload runner advertises it yet. |
-| Prelaunched supervisor standby | Pre-pay supervisor/setup latency before attaching a workload. | Separate from snapshots; the raw libkrun substrate has the primitive, but no selectable workload runner advertises it yet. |
+| Prelaunched supervisor standby | Pre-pay supervisor/setup latency before attaching a workload. | Separate from snapshots; advertised by `firecracker` and `hvf`, and by no other selectable runner. |
 | Cold boot | Boot immutable artifacts from scratch. | Supported baseline recovery path. |
 
 Other backends may support stop/start without machine-state recovery. Do not
@@ -21,9 +25,11 @@ assume a recovery tier unless the active backend reports it in
 
 ## Sealed instance snapshots
 
-The `pause`/plain `resume` commands use the sealed instance-snapshot envelope
-when that lifecycle is available for the selected backend. They do not imply
-that the backend supports live-memory warm start.
+The `pause`/plain `resume` commands use the sealed instance-snapshot envelope.
+They do not imply that the backend supports live-memory warm start. Both verbs
+default to `--hypervisor firecracker` and drive the snapshot through
+Firecracker's control socket, so this lifecycle is a Firecracker path in
+practice.
 
 Pause a running VM:
 
@@ -55,28 +61,28 @@ mvmctl machine snapshot rm agent-sandbox
 
 ## Full-VM memory checkpoints
 
-Full-VM memory checkpoints capture full guest state. They are currently unavailable through the selectable workload runners; request them only when `mvmctl doctor` reports a compatible backend and capability:
+Full-VM memory checkpoints capture full guest state. They require a backend whose snapshot tier is `save-restore` or better — today `hvf` and `apple-container`; `firecracker`, `libkrun`, and `qemu` refuse with an explicit tier error. Check `mvmctl doctor` for the authoritative capability on this host:
 
 ```sh
 mvmctl machine checkpoint create agent-sandbox --class vm-full
-mvmctl machine checkpoint restore agent-sandbox --name <checkpoint-name>
+mvmctl machine checkpoint restore <checkpoint-id>
 ```
 
-`checkpoint create` pauses the VM, saves machine state and memory to the checkpoint directory, and records the content hash in the audit chain. `checkpoint restore` re-hashes the checkpoint content and records whether it matches the prior chain entry before restoring.
+`checkpoint create` pauses the VM, saves machine state and memory to the checkpoint directory, and records the content hash in the audit chain. `checkpoint restore` re-hashes the checkpoint content and checks the record against the signed audit chain before restoring.
 
-The restore proceeds even when the checkpoint hash is not in the local chain or has drifted, because operators may transfer checkpoints between hosts. The audit entry labels that result so the operator can review it.
+Restore fails closed. A checkpoint whose content has drifted, whose record disagrees with the signed chain, or that carries no signed creation entry is refused rather than restored.
 
 List and remove checkpoints:
 
 ```sh
 mvmctl machine checkpoint ls
-mvmctl machine checkpoint rm agent-sandbox --name <checkpoint-name>
+mvmctl machine checkpoint rm <checkpoint-id>
 ```
 
 Fork a checkpoint to a new identity (new VM name, same state):
 
 ```sh
-mvmctl machine checkpoint fork agent-sandbox --name <checkpoint-name> --into new-sandbox
+mvmctl machine checkpoint fork <checkpoint-id> --new-id new-sandbox
 ```
 
 ## Security implications

--- a/xtask/src/check_machine_doc_guards.rs
+++ b/xtask/src/check_machine_doc_guards.rs
@@ -12,10 +12,16 @@ const LIMITATIONS: &str = "public/src/content/docs/guides/machine-limitations.md
 const QUICKSTART: &str = "public/src/content/docs/getting-started/quickstart.md";
 const HAPPY_PATHS: &str = "public/src/content/docs/getting-started/happy-paths.md";
 
+// `local image archive` was here until 2026-08-27, requiring the use-cases page
+// to document a `--image-archive` input. No such flag has ever existed: no
+// commit in this repository has touched `image-archive` under `crates/`, and
+// `RunArgs` takes `--manifest`, `--image`, `--flake`, `--deployment`,
+// `--runtime-pack`, and `--runtime` only. The guard was mandating a false
+// claim, and the page complied for two months. A required term has to name
+// something the CLI does; add the flag first if this capability is wanted.
 const REQUIRED_USE_CASE_TERMS: &[&str] = &[
     "sandbox untrusted code",
     "mvmctl machine run --image",
-    "local image archive",
     "mvmctl machine create",
     "mvm.toml",
     "machine check-artifact",


### PR DESCRIPTION
An audit of all 133 documentation pages against crate source found roughly 180 false claims. This is the mechanical batch — commands, flags, symbols, paths, capability rows. Security-claim *wording* is deliberately excluded and goes up separately.

## What was wrong

**A CLI reorganisation was never migrated into the docs.** Pages opened with `up`, `exec`, `cp`, `pause`, and `checkpoint` as top-level verbs. None exist — they are `VmCmd` variants flattened into `machine`. Seven of fourteen tutorials began with a command that errors. Most of the real ones are `hide = true` as well, so a reader cannot confirm them from `--help`; pages that teach them now say so once.

**The TypeScript SDK exports snake_case constructors** generated from the Rust registry. Four pages camelCased them, which fails at `tsc`. Two imported `@mvm/sdk`, published nowhere; the package is `@runmvm/mvm`.

**The guest mount allow-list is `/data` and `/work`.** Pages taught `/mnt`, `/cache`, and `/workspace`, and taught `:rw` shares on transient runs, which are read-only under every profile. The CLI's own `--guest` help was stale the same way and is fixed separately.

**Five crate directories cited in docs do not exist** — `mvm-ir`, `mvm-plan`, `mvm-runner`, `mvm-security`, `mvm-client-local` — nor does the `BrowserWasi` backend with its `--hypervisor browser-wasm` selector. The real browser tier is `web-linux`, and it boots a Linux kernel.

**`mkGuest` requires an `entrypoint` argument**, so every flake example omitting it could not evaluate — including the first one a new user copies. Top-level `services` is declared but unwired, so examples whose workload was a service never started.

**Per-backend capability rows were inverted.** Save/restore is advertised by hvf and apple-container; the standby pool by firecracker and hvf. Checkpoint restore was described as proceeding on a drifted or unaudited checkpoint; it fails closed on both.

## One guard changed

`check-machine-doc-guards` required the use-cases page to document a `local image archive` input. **No `--image-archive` flag has ever existed** — no commit in this repository has touched it under `crates/`. The guard was mandating a false claim and the page had complied since June. The term is removed; a required term has to name something the CLI does.

## What was deliberately not changed

Blocks marked `Status: Planned` keep their unshipped symbols. Making unbuilt API look installable is the failure this batch exists to fix, not a smaller version of it.

Several audit findings turned out to be **wrong, and the docs right** — `MVM_ACK_PERMISSIVE_RUN` really is read, `machine wait --for all` is real, and the claim that no selectable runner advertises disk-only CoW is accurate. Those pages are untouched.

## Verification

`pnpm check` passes at 140 pages. `check-doc-claims`, `check-honesty`, `check-no-overclaim`, `check-cli-help-matches-docs`, and `check-machine-doc-guards` are all clean. `cargo nextest run -p xtask`: 650 passed.
