### PR TITLE
docs(backends): warn at the libkrun capability fields that they are overwritten

### DIFF
--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -291,6 +291,10 @@ impl VmmDriver for LibkrunDriver {
             max_vcpus: Some(u32::from(u8::MAX)),
             pause_resume: false,
             snapshots: false,
+            // Both of the next two are overwritten below — see the
+            // reassignment after this literal. They describe the raw libkrun
+            // substrate, not what the selectable runner advertises. Quoting
+            // either value from here is wrong, and has been more than once.
             snapshot_capability: SnapshotCapability::DiskOnly,
             standby_pool: true,
             vsock: true,
@@ -322,6 +326,10 @@ impl VmmDriver for LibkrunDriver {
             resource_controls: ResourceControls::for_backend(BackendKind::Libkrun),
             ..VmCapabilities::default()
         };
+        // The runner-facing answer, and the one every caller sees. The
+        // substrate has the primitives; this runner does not route them
+        // through its admission and endpoint guards, so it advertises
+        // neither.
         capabilities.snapshot_capability = SnapshotCapability::Unsupported;
         capabilities.standby_pool = false;
         capabilities


### PR DESCRIPTION
`capabilities()` builds a `VmCapabilities` literal advertising `DiskOnly` and `standby_pool: true`, then reassigns both to unsupported about thirty lines later, before returning.

The prose above the literal already said so. Three separate readers still quoted the literal values — twice producing a confidently wrong answer about which backends advertise a warm-start tier, and once nearly turning a *correct* documentation sentence into a false one during a docs audit.

A comment above a thirty-line struct is not where someone reading a field looks. This puts the warning on the two fields themselves, and says at the reassignment which answer callers actually see.

No behaviour change.

## Verification

`cargo fmt --all --check` and `cargo clippy -p mvm-backends --all-targets -- -D warnings` pass.
