### PR TITLE
fix(run): resolve flake builds through the slot registry

### DIFF
--- a/crates/mvm-cli/src/commands/shared/resolve.rs
+++ b/crates/mvm-cli/src/commands/shared/resolve.rs
@@ -2,9 +2,9 @@
 
 use anyhow::{Context, Result};
 
-/// One of two ways to refer to a built manifest: a legacy name (looked
-/// up in the name-keyed registry) or a manifest path that resolves to
-/// a slot hash.
+/// One of the two built workload sources accepted by `--manifest`: a
+/// manifest path that resolves to a slot hash, or a manifest selecting a
+/// pre-built wasm module.
 ///
 /// `mvmctl up` / `mvmctl exec` accept either form via their
 /// `--manifest` flag. A manifest is addressed by its path; the slot hash is
@@ -27,10 +27,12 @@ pub enum ManifestArgRef {
 
 /// Resolve a `--manifest` argument to the manifest it names.
 ///
-/// The argument is a path — a manifest file or the directory containing one.
-/// A bare name used to resolve against a name-keyed template slot; those are
-/// gone, so a non-existent path is an error here rather than a lookup failure
-/// three layers down.
+/// User-supplied arguments are paths — a manifest file or the directory
+/// containing one. The machine-run flake path also threads the strict
+/// 64-character address returned by `build_flake_to_slot` through this helper;
+/// that internal shape resolves directly against the slot registry. Every
+/// other non-existent bare argument remains a missing-path error: name-keyed
+/// template slots are gone.
 pub fn resolve_manifest_arg(arg: &str) -> Result<ManifestArgRef> {
     use mvm_core::manifest::{canonical_key_for_path, resolve_manifest_config_path};
 
@@ -72,6 +74,21 @@ pub fn resolve_manifest_arg(arg: &str) -> Result<ManifestArgRef> {
 
     let path = std::path::Path::new(arg);
     if !path.exists() {
+        if mvm_core::manifest::is_slot_hash_dirname(arg) {
+            let persisted = mvm_runtime::vm::template::lifecycle::template_load_slot(arg)
+                .with_context(|| {
+                    format!("Built slot {arg} is not present in the local registry")
+                })?;
+            if persisted.manifest_hash != arg {
+                anyhow::bail!(
+                    "Built slot {arg} records mismatched identity {}",
+                    persisted.manifest_hash
+                );
+            }
+            return Ok(ManifestArgRef::Slot {
+                slot_hash: arg.to_string(),
+            });
+        }
         anyhow::bail!(
             "Manifest path '{}' does not exist (expected a manifest file or its directory)",
             arg
@@ -329,8 +346,96 @@ pub fn resolve_effective_hypervisor(requested: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mvm_core::manifest::{MANIFEST_SCHEMA_VERSION, PersistedManifest, Provenance};
     use mvm_core::network_policy::{HostPort, NetworkPolicy, NetworkPreset};
     use mvm_core::util::test_env::TestEnv;
+
+    fn persist_flake_slot(slot_hash: &str) {
+        let now = mvm_core::time::utc_now();
+        let persisted = PersistedManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            manifest_path: "<flake-slot>/fixture".to_string(),
+            manifest_hash: slot_hash.to_string(),
+            flake_ref: "/tmp/fixture-flake".to_string(),
+            profile: "default".to_string(),
+            vcpus: 2,
+            mem_mib: 512,
+            mem_initial_mib: None,
+            data_disk_mib: 0,
+            name: None,
+            backend: "mock".to_string(),
+            provenance: Provenance::current(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        mvm_runtime::vm::template::lifecycle::template_persist_slot(&persisted)
+            .expect("persist flake slot");
+    }
+
+    #[test]
+    fn a_materialized_flake_slot_hash_resolves_through_the_registry() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(tmp.path());
+        let slot_hash = "a".repeat(64);
+        persist_flake_slot(&slot_hash);
+
+        let resolved = resolve_manifest_arg(&slot_hash).expect("built slot must resolve");
+
+        assert!(matches!(resolved, ManifestArgRef::Slot { slot_hash: got } if got == slot_hash));
+    }
+
+    #[test]
+    fn an_unknown_slot_hash_fails_closed_as_a_registry_lookup() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(tmp.path());
+        let slot_hash = "b".repeat(64);
+
+        let err = resolve_manifest_arg(&slot_hash).expect_err("unknown slot must fail");
+
+        assert!(
+            format!("{err:#}").contains("not present in the local registry"),
+            "the refusal must identify a missing registry slot: {err:#}"
+        );
+    }
+
+    #[test]
+    fn a_slot_record_with_a_mismatched_identity_fails_closed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut env = TestEnv::new();
+        env.isolate_mvm_home(tmp.path());
+        let requested = "c".repeat(64);
+        let recorded = "d".repeat(64);
+        let now = mvm_core::time::utc_now();
+        let persisted = PersistedManifest {
+            schema_version: MANIFEST_SCHEMA_VERSION,
+            manifest_path: "<flake-slot>/fixture".to_string(),
+            manifest_hash: recorded.clone(),
+            flake_ref: "/tmp/fixture-flake".to_string(),
+            profile: "default".to_string(),
+            vcpus: 2,
+            mem_mib: 512,
+            mem_initial_mib: None,
+            data_disk_mib: 0,
+            name: None,
+            backend: "mock".to_string(),
+            provenance: Provenance::current(),
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        let slot_dir = mvm_core::manifest::slot_dir(&requested);
+        persisted
+            .write_to_slot(std::path::Path::new(&slot_dir))
+            .expect("persist mismatched slot record");
+
+        let err = resolve_manifest_arg(&requested).expect_err("mismatch must fail");
+
+        assert!(
+            format!("{err:#}").contains(&format!("mismatched identity {recorded}")),
+            "the refusal must identify the recorded identity: {err:#}"
+        );
+    }
 
     /// A bare directory name is a manifest *path*, not a registry name.
     ///

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,8 +1,15 @@
 # Refactor status
 
-Last updated: 2026-08-27
+Last updated: 2026-08-28
 
 ## In progress
+
+- [ ] **Flake-built slot resolution — issue #2967.**
+      `specs/plans/2026-08-28-flake-slot-resolution.md`.
+      Strict materialized slot addresses resolve through the existing registry;
+      unknown and identity-mismatched records fail closed. Focused and workspace
+      tests, gated-target compilation, and Clippy are green; merge delivery
+      remains.
 
 - [ ] **Issue #2942 — warm-launch gate contract repair.**
       `specs/plans/2026-08-27-warm-launch-gate-contract.md`.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,13 +4,6 @@ Last updated: 2026-08-28
 
 ## In progress
 
-- [ ] **Flake-built slot resolution — issue #2967.**
-      `specs/plans/2026-08-28-flake-slot-resolution.md`.
-      Strict materialized slot addresses resolve through the existing registry;
-      unknown and identity-mismatched records fail closed. Focused and workspace
-      tests, gated-target compilation, and Clippy are green; merge delivery
-      remains.
-
 - [ ] **Audit root-history classification repair — issue #2940.**
       `specs/plans/2026-08-27-audit-root-history-classification.md`.
       Signed Merkle-root history files are excluded from lifecycle-chain
@@ -37,6 +30,13 @@ Last updated: 2026-08-28
       The README's `mvm.local_path` decorator source and the builder-pack Cargo
       feature remediation are implemented and locally green; merge-queue
       delivery remains.
+
+- [ ] **Flake-built slot resolution — issue #2967.**
+      `specs/plans/2026-08-28-flake-slot-resolution.md`.
+      Strict materialized slot addresses resolve through the existing registry;
+      unknown and identity-mismatched records fail closed. Focused and workspace
+      tests, gated-target compilation, and Clippy are green; merge delivery
+      remains.
 
 ## Completed
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,14 @@
 
 ## In progress
 
+- [ ] **Flake-built slot resolution — issue #2967.**
+      `specs/plans/2026-08-28-flake-slot-resolution.md`.
+      The shared manifest boundary now recognizes only strict, existing slot
+      addresses returned by `machine run --flake`; ordinary bare arguments
+      remain filesystem paths. Positive, unknown-slot, and mismatched-identity
+      resolver tests, workspace tests, gated-target compilation, and Clippy are
+      green; merge delivery remains.
+
 - [x] **FlowMux HTTPS live-client repair.**
       `specs/plans/2026-08-27-flowmux-https-live-client.md`.
       The seven live HTTPS egress witnesses now use the pinned multi-arch

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,14 +10,6 @@
 
 ## In progress
 
-- [ ] **Flake-built slot resolution — issue #2967.**
-      `specs/plans/2026-08-28-flake-slot-resolution.md`.
-      The shared manifest boundary now recognizes only strict, existing slot
-      addresses returned by `machine run --flake`; ordinary bare arguments
-      remain filesystem paths. Positive, unknown-slot, and mismatched-identity
-      resolver tests, workspace tests, gated-target compilation, and Clippy are
-      green; merge delivery remains.
-
 - [ ] **Audit root-history classification repair (issue #2940).**
       `specs/plans/2026-08-27-audit-root-history-classification.md`.
       The shared audit-directory classifier now excludes signed
@@ -91,6 +83,14 @@
       builder-pack download refusal names root Cargo features that exist.
       Implementation, focused tests, the full `mvm-sdk` suite, formatting, and
       package Clippy are green; merge-queue delivery remains.
+
+- [ ] **Flake-built slot resolution — issue #2967.**
+      `specs/plans/2026-08-28-flake-slot-resolution.md`.
+      The shared manifest boundary now recognizes only strict, existing slot
+      addresses returned by `machine run --flake`; ordinary bare arguments
+      remain filesystem paths. Positive, unknown-slot, and mismatched-identity
+      resolver tests, workspace tests, gated-target compilation, and Clippy are
+      green; merge delivery remains.
 
 - [x] **AI egress metering and token budgets.**
       `specs/plans/2026-08-21-ai-egress-metering-and-budget.md`.

--- a/specs/plans/2026-08-28-flake-slot-resolution.md
+++ b/specs/plans/2026-08-28-flake-slot-resolution.md
@@ -1,0 +1,21 @@
+# Flake slot resolution
+
+**Status:** IN PROGRESS
+**Issue:** #2967
+
+## Outcome
+
+`machine run --flake <ref>` must resolve the slot it just built through the
+slot registry instead of treating the slot address as a manifest filesystem
+path. Unknown or internally inconsistent slot records continue to fail closed.
+
+## Tasks
+
+- [x] Reproduce the live failure with a resolver regression that starts from a
+      materialized flake slot address.
+- [x] Resolve strict 64-character slot addresses through the existing slot
+      registry while leaving every other bare argument as a manifest path.
+- [x] Cover successful lookup, unknown-slot refusal, and mismatched-identity
+      refusal.
+- [x] Pass workspace tests, gated-target compilation, and zero-warning Clippy.
+- [ ] Open the pull request, enter the merge queue, and verify the merge.

--- a/specs/plans/2026-08-28-flake-slot-resolution.md
+++ b/specs/plans/2026-08-28-flake-slot-resolution.md
@@ -1,5 +1,8 @@
 # Flake slot resolution
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 **Status:** IN PROGRESS
 **Issue:** #2967
 


### PR DESCRIPTION
Closes #2967

## Summary
- resolve strict 64-character flake-built slot addresses through the existing slot registry
- preserve filesystem-path precedence and refuse unknown or identity-mismatched slot records
- add positive and fail-closed resolver coverage

## Validation
- cargo test --workspace --quiet
- cargo test --workspace --no-run
- just check-gated
- cargo clippy --workspace -- -D warnings
- cargo fmt --all -- --check