### PR TITLE
fix(doctor): report why a tool check failed to spawn

### DIFF
--- a/crates/mvm-cli/src/doctor/toolchain.rs
+++ b/crates/mvm-cli/src/doctor/toolchain.rs
@@ -23,7 +23,7 @@ pub(super) fn check_cmd(name: &'static str, category: &'static str, args: &[&str
             name,
             category,
             ok: false,
-            info: e.to_string(),
+            info: format!("{e:#}"),
         },
     }
 }
@@ -46,7 +46,7 @@ pub(super) fn check_vm_cmd(name: &'static str, category: &'static str, cmd: &'st
             name,
             category,
             ok: false,
-            info: e.to_string(),
+            info: format!("{e:#}"),
         },
     }
 }
@@ -118,5 +118,22 @@ mod tests {
     fn check_cmd_missing_tool() {
         let c = check_cmd("nonexistent-mvm-tool-xyz", "tools", &["--version"]);
         assert!(!c.ok, "nonexistent tool should fail");
+    }
+
+    #[test]
+    fn a_spawn_failure_reports_why_it_failed() {
+        let c = check_cmd("nonexistent-mvm-tool-xyz", "tools", &["--version"]);
+        assert!(
+            c.info.contains("nonexistent-mvm-tool-xyz"),
+            "expected the command to be named, got: {}",
+            c.info
+        );
+        assert!(
+            c.info.contains("os error"),
+            "a spawn failure must carry the underlying OS error, not just the \
+             context line — without it doctor reports a reason-free failure and \
+             an intermittent one cannot be told from a missing tool. got: {}",
+            c.info
+        );
     }
 }


### PR DESCRIPTION
`check_cmd` and `check_vm_cmd` built their failure line with `e.to_string()`. On an `anyhow::Error` that renders only the outermost context, so the underlying `io::Error` was discarded and every spawn failure reached the user as:

```
Failed to run: rustup --version
```

A missing tool, a permissions error, and a transient fork failure under memory pressure all produce that same reason-free line — in `mvmctl doctor` output and in test failures alike.

That is not hypothetical. `doctor::toolchain::tests::check_cmd_rustup_on_host` failed once in a ten-run loop on this box with exactly that string, and the message carries no way to tell whether rustup was absent, or whether `fork`/`exec` transiently failed on a loaded machine. rustup is installed here and the other nine runs passed, so it was the latter — but the line could not say so.

Rendering the chain with `{e:#}` keeps the context *and* the errno.

### Witness

`a_spawn_failure_reports_why_it_failed` asserts the failure line names both the command and the underlying OS error. Mutation-checked in the foreground: reverting to `e.to_string()` fails it with

```
got: Failed to run: nonexistent-mvm-tool-xyz --version
```

which is the flake's exact string, so the test pins the real defect rather than the symptom. The pre-existing `check_cmd_missing_tool` passes under that mutation — it only asserts `!ok` — which is why this needed a separate test.

### Gates

- `cargo run -p xtask -- check-all` — 61 gates clean
- `cargo nextest run -p mvm-cli` — 2035 passed
- `cargo fmt --all -- --check`, `cargo clippy -p mvm-cli --all-targets -- -D warnings`