### PR TITLE
feat(image): record the guest's libc in the image sidecar

### DIFF
--- a/crates/mvm-build/src/builder_vm.rs
+++ b/crates/mvm-build/src/builder_vm.rs
@@ -27,6 +27,8 @@ use std::path::{Path, PathBuf};
 
 use mvm_core::build_env::ShellEnvironment;
 use serde::{Deserialize, Serialize};
+
+use crate::guest_libc::GuestLibc;
 use thiserror::Error;
 
 /// Pinned Nix-bearing OCI image. Bumped deliberately; the per-bump
@@ -279,6 +281,20 @@ pub struct GuestSidecar {
     /// non-git flake input), which a Nix build cannot invent.
     #[serde(default)]
     pub generator_rev: String,
+    /// The C library this rootfs is built against, read off its dynamic loader
+    /// while the tree was still a directory.
+    ///
+    /// Load-bearing for the same reason as [`Self::entrypoint_argv`]: nothing
+    /// on the host opens the ext4 once it exists, so a host-side decision that
+    /// depends on the guest's libc can only be made from what was recorded
+    /// here. The SDK host-services cdylib is such a decision — it is built for
+    /// one libc, and a process under the other cannot load it at all.
+    ///
+    /// [`GuestLibc::Unknown`] covers both a sidecar written before this field
+    /// existed and a tree whose loader was unrecognisable. Neither is a
+    /// permissive default: a caller gating on this must refuse, not guess.
+    #[serde(default)]
+    pub libc: GuestLibc,
 }
 
 impl GuestSidecar {
@@ -367,6 +383,9 @@ impl GuestSidecar {
             built_at: String::new(),
             protocol_version: 0,
             generator_rev: String::new(),
+            // Read off the unpacked tree by the caller that still has it;
+            // this constructor has only a name. `with_libc` records it.
+            libc: GuestLibc::Unknown,
         }
     }
 
@@ -375,6 +394,15 @@ impl GuestSidecar {
     #[must_use]
     pub fn with_entrypoint_argv(mut self, argv: Vec<String>) -> Self {
         self.entrypoint_argv = argv;
+        self
+    }
+
+    /// Record the libc detected on the unpacked rootfs, for the same reason as
+    /// [`Self::with_entrypoint_argv`]: it is observable only while the tree is
+    /// a directory, and needed after it is not.
+    #[must_use]
+    pub fn with_libc(mut self, libc: GuestLibc) -> Self {
+        self.libc = libc;
         self
     }
 
@@ -1399,6 +1427,7 @@ mod tests {
             built_at: String::new(),
             protocol_version: 0,
             generator_rev: String::new(),
+            libc: GuestLibc::Glibc,
         }
     }
 

--- a/crates/mvm-build/src/guest_libc.rs
+++ b/crates/mvm-build/src/guest_libc.rs
@@ -1,0 +1,179 @@
+//! Which libc a materialized guest rootfs carries.
+//!
+//! The host can read the unpacked tree only while it is still a directory.
+//! Once it is an ext4 blob nothing on the host opens it again, so anything
+//! admission needs to know about the guest's C library has to be observed
+//! here and recorded in the sidecar.
+//!
+//! What needs it: `libmvm_host_services.so`, the C-ABI shim every language SDK
+//! loads, is built against one libc. A musl process cannot `dlopen` a
+//! glibc-linked object — it fails resolving glibc-only symbols such as
+//! `_dl_find_object` — and shipping a second loader alongside does not help,
+//! because the process doing the loading already has one.
+
+use std::path::Path;
+
+/// The C library a guest rootfs is built against.
+///
+/// [`GuestLibc::Unknown`] is not a neutral default. It means the tree carried
+/// no loader this code recognises, or carried more than one, and a caller
+/// gating on it must treat that as *unknown*, never as safe — the same
+/// convention the sidecar's `entrypoint_argv` follows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GuestLibc {
+    /// GNU libc. Loader is `ld-linux-<arch>.so.<n>`.
+    Glibc,
+    /// musl libc, as used by Alpine. Loader is `ld-musl-<arch>.so.1`.
+    Musl,
+    /// No recognised loader, or more than one.
+    #[default]
+    Unknown,
+}
+
+impl GuestLibc {
+    /// The value as it appears in the sidecar and in operator-facing text.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Glibc => "glibc",
+            Self::Musl => "musl",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Directories a dynamic loader lives in, relative to the rootfs.
+const LOADER_DIRS: [&str; 2] = ["lib", "lib64"];
+
+/// Identify the libc of an unpacked rootfs by looking for its dynamic loader.
+///
+/// Matching is by file name prefix rather than by a fixed set of full paths, so
+/// this holds across architectures without enumerating them:
+/// `ld-musl-aarch64.so.1` and `ld-linux-x86-64.so.2` are both recognised by
+/// their stem.
+///
+/// Entries are matched by name and never followed. On Alpine the loader is a
+/// symlink to `libc.musl-<arch>.so.1`, and `Path::exists` on a dangling link
+/// would report the loader absent when the name is right there in the
+/// directory.
+///
+/// Finding both families is reported as [`GuestLibc::Unknown`] rather than
+/// picking one: an image carrying two loaders gives no basis for choosing which
+/// one a workload's interpreter will use.
+pub fn detect_guest_libc(root: &Path) -> GuestLibc {
+    let mut saw_musl = false;
+    let mut saw_glibc = false;
+
+    for dir in LOADER_DIRS {
+        let Ok(entries) = std::fs::read_dir(root.join(dir)) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if name.starts_with("ld-musl-") {
+                saw_musl = true;
+            } else if name.starts_with("ld-linux-") {
+                saw_glibc = true;
+            }
+        }
+    }
+
+    match (saw_glibc, saw_musl) {
+        (true, false) => GuestLibc::Glibc,
+        (false, true) => GuestLibc::Musl,
+        _ => GuestLibc::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a rootfs tree carrying `names` in `lib/`.
+    fn rootfs_with(names: &[&str]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("lib")).unwrap();
+        for name in names {
+            std::fs::write(dir.path().join("lib").join(name), b"").unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn an_alpine_style_tree_is_musl() {
+        let dir = rootfs_with(&["ld-musl-aarch64.so.1", "libc.musl-aarch64.so.1"]);
+        assert_eq!(detect_guest_libc(dir.path()), GuestLibc::Musl);
+    }
+
+    #[test]
+    fn a_glibc_tree_is_glibc() {
+        let dir = rootfs_with(&["ld-linux-aarch64.so.1", "libc.so.6"]);
+        assert_eq!(detect_guest_libc(dir.path()), GuestLibc::Glibc);
+    }
+
+    /// The x86-64 glibc loader lives in `lib64`, not `lib`, so a detector that
+    /// only scanned `lib` would call a perfectly ordinary image unknown.
+    #[test]
+    fn the_glibc_loader_is_found_in_lib64_too() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("lib64")).unwrap();
+        std::fs::write(dir.path().join("lib64/ld-linux-x86-64.so.2"), b"").unwrap();
+        assert_eq!(detect_guest_libc(dir.path()), GuestLibc::Glibc);
+    }
+
+    /// A dangling loader symlink still names the libc. Alpine ships exactly
+    /// this shape, so following links here would misreport real images.
+    #[test]
+    fn a_dangling_loader_symlink_still_identifies_the_libc() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("lib")).unwrap();
+        std::os::unix::fs::symlink(
+            "libc.musl-aarch64.so.1",
+            dir.path().join("lib/ld-musl-aarch64.so.1"),
+        )
+        .unwrap();
+        assert!(!dir.path().join("lib/ld-musl-aarch64.so.1").exists());
+        assert_eq!(detect_guest_libc(dir.path()), GuestLibc::Musl);
+    }
+
+    #[test]
+    fn a_tree_with_no_loader_is_unknown() {
+        let dir = rootfs_with(&["libz.so.1"]);
+        assert_eq!(detect_guest_libc(dir.path()), GuestLibc::Unknown);
+    }
+
+    /// Two loaders give no basis for picking one, so this reports unknown and
+    /// lets the caller refuse rather than guessing.
+    #[test]
+    fn a_tree_carrying_both_loaders_is_unknown() {
+        let dir = rootfs_with(&["ld-musl-aarch64.so.1", "ld-linux-aarch64.so.1"]);
+        assert_eq!(detect_guest_libc(dir.path()), GuestLibc::Unknown);
+    }
+
+    #[test]
+    fn a_missing_tree_is_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            detect_guest_libc(&dir.path().join("nope")),
+            GuestLibc::Unknown
+        );
+    }
+
+    #[test]
+    fn unknown_is_the_default() {
+        assert_eq!(GuestLibc::default(), GuestLibc::Unknown);
+    }
+
+    #[test]
+    fn the_wire_form_is_lowercase() {
+        let json = serde_json::to_string(&GuestLibc::Musl).unwrap();
+        assert_eq!(json, "\"musl\"");
+        assert_eq!(
+            serde_json::from_str::<GuestLibc>("\"glibc\"").unwrap(),
+            GuestLibc::Glibc
+        );
+    }
+}

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -48,6 +48,9 @@ pub mod egress_readiness;
 /// Extract an FC-loadable ELF `vmlinux` from a published x86_64 bzImage.
 pub mod firecracker;
 pub mod guest_elf;
+/// Which libc a materialized guest rootfs carries, observed while the tree is
+/// still a directory the host can read.
+pub mod guest_libc;
 /// Config contract for the `mvm-hvf-supervisor` per-VM host process (raw HVF
 /// macOS backend, raw HVF backend). Shared by `mvm_runtime::backends::hvf` (writer) + the bin.
 /// Universal initramfs build + cache resolution.

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -135,17 +135,37 @@ pub fn inject_and_materialize(request: InjectAndMaterializeRequest<'_>) -> Resul
     let rootfs_dir = output
         .parent()
         .ok_or_else(|| anyhow::anyhow!("rootfs path has no parent dir: {}", output.display()))?;
-    // Always runtime-lean: the overlay is the single source of the guest
-    // binaries, so an injected rootfs never carries a copy of them.
-    crate::builder_vm::GuestSidecar::for_oci_run(label, sealed, true)
-        // The same argv baked into `etc/mvm/image-runtime.json` above, put where
-        // the host can still read it: once this tree is an ext4 blob nothing on
-        // the host opens it, and admission has to know what the image runs before
-        // it decides whether anything may drive its stdin.
-        .with_entrypoint_argv(entrypoint.map(|e| e.argv.clone()).unwrap_or_default())
+    oci_run_sidecar(unpacked_root, label, sealed, entrypoint)
         .write_to_dir(rootfs_dir)
         .with_context(|| format!("write OCI sidecar in {}", rootfs_dir.display()))?;
     Ok(())
+}
+
+/// Build the sidecar describing a materialized OCI run rootfs.
+///
+/// Both recorded facts are things the host can establish only while
+/// `unpacked_root` is still a directory: once this tree is an ext4 blob nothing
+/// on the host opens it again. The argv is what admission needs to know an
+/// image runs before deciding whether anything may drive its stdin; the libc is
+/// what decides whether the SDK host-services cdylib can load in this image at
+/// all.
+///
+/// Reading the libc after `inject_mvm_runtime` is deliberate and safe: the
+/// injected guest binaries are statically linked and land in `usr/local/bin`,
+/// so they add no dynamic loader to `lib` or `lib64` and cannot change the
+/// verdict.
+///
+/// Always runtime-lean: the overlay is the single source of the guest binaries,
+/// so an injected rootfs never carries a copy of them.
+fn oci_run_sidecar(
+    unpacked_root: &Path,
+    label: &str,
+    sealed: bool,
+    entrypoint: Option<&ImageRuntimeConfig>,
+) -> crate::builder_vm::GuestSidecar {
+    crate::builder_vm::GuestSidecar::for_oci_run(label, sealed, true)
+        .with_entrypoint_argv(entrypoint.map(|e| e.argv.clone()).unwrap_or_default())
+        .with_libc(crate::guest_libc::detect_guest_libc(unpacked_root))
 }
 
 /// Materialize the admitted top-level guest volume roots into every sealed OCI
@@ -521,6 +541,64 @@ pub fn resolve_guest_runtime_identity(cache_root: &Path) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build an unpacked-rootfs tree whose `lib/` carries `loader`.
+    fn tree_with_loader(loader: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("lib")).unwrap();
+        std::fs::write(dir.path().join("lib").join(loader), b"").unwrap();
+        dir
+    }
+
+    #[test]
+    fn the_sidecar_records_the_libc_of_the_tree_it_describes() {
+        let musl = tree_with_loader("ld-musl-aarch64.so.1");
+        assert_eq!(
+            oci_run_sidecar(musl.path(), "alpine:3", false, None).libc,
+            crate::guest_libc::GuestLibc::Musl
+        );
+
+        let glibc = tree_with_loader("ld-linux-aarch64.so.1");
+        assert_eq!(
+            oci_run_sidecar(glibc.path(), "debian:12", false, None).libc,
+            crate::guest_libc::GuestLibc::Glibc
+        );
+    }
+
+    /// An image whose loader we cannot identify must not be recorded as either
+    /// libc. A caller gating on this refuses on unknown, so mislabelling here
+    /// would turn a refusal into a mismatched load.
+    #[test]
+    fn a_tree_with_no_recognisable_loader_records_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            oci_run_sidecar(dir.path(), "scratch", false, None).libc,
+            crate::guest_libc::GuestLibc::Unknown
+        );
+    }
+
+    /// A sidecar written before the field existed must deserialize as unknown,
+    /// not as a libc that happens to sort first.
+    #[test]
+    fn a_sidecar_predating_the_libc_field_reads_as_unknown() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut json: serde_json::Value = serde_json::to_value(
+            crate::builder_vm::GuestSidecar::for_oci_run("old", false, true),
+        )
+        .unwrap();
+        json.as_object_mut().unwrap().remove("libc");
+        assert!(!json.as_object().unwrap().contains_key("libc"));
+        std::fs::write(
+            crate::builder_vm::GuestSidecar::path_in(dir.path()),
+            serde_json::to_string(&json).unwrap(),
+        )
+        .unwrap();
+
+        let read = crate::builder_vm::GuestSidecar::read_from_dir(dir.path())
+            .unwrap()
+            .unwrap();
+        assert_eq!(read.libc, crate::guest_libc::GuestLibc::Unknown);
+    }
 
     #[test]
     fn sealed_oci_tree_contains_volume_mount_roots() {

--- a/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint/revert.rs
@@ -1240,6 +1240,7 @@ mod tests {
             built_at: String::new(),
             protocol_version: 0,
             generator_rev: String::new(),
+            libc: mvm_build::guest_libc::GuestLibc::Glibc,
         };
         sidecar.write_to_dir(tmp.path()).unwrap();
 


### PR DESCRIPTION
First half of #2969, and the half that lands without the musl build existing.

The SDK host-services cdylib is built for one libc. A process under the other cannot load it — a musl guest fails resolving glibc-only symbols such as `_dl_find_object` — and shipping a second loader alongside does not help, because the process doing the loading already has one. Every runtime in the built-in catalog is Alpine, so today that combination is reachable by default and fails with a relocation error from inside the guest.

Deciding this host-side needs to know which libc a guest carries, and that is readable only while the unpacked tree is still a directory: once it is an ext4 blob nothing on the host opens it again. So observe it during materialization and record it in `mvm-meta.json`.

That sidecar is already where facts of exactly this shape live. `entrypoint_argv` is recorded for the same reason, and its own doc comment states the rule this field follows:

> the host has no way to read inside a materialized ext4, so this is the only place admission can learn what a workload will run before it runs it […] a caller gating on it must treat empty as *unknown*, never as safe.

`GuestLibc::Unknown` is that convention, and covers both a sidecar written before this field existed and a tree whose loader was unrecognisable.

### Detection

Matching is on the dynamic loader's name prefix, so it holds across architectures without enumerating them (`ld-musl-aarch64.so.1`, `ld-linux-x86-64.so.2`), and it scans `lib64` as well as `lib` — the x86-64 glibc loader lives only in the former.

Entries are matched by name and never followed. Alpine's `ld-musl-<arch>.so.1` is a symlink to `libc.musl-<arch>.so.1`, and `Path::exists` on a dangling link would report the loader absent when the name is right there in the directory.

A tree carrying both families reports `Unknown` rather than resolving to either: two loaders give no basis for choosing which one an interpreter will use, and a caller that refuses on unknown is the correct outcome there.

### Scope

**No caller gates on this yet** — that is the next change, and it is what turns today's relocation error into a legible host-side refusal. This one only records the fact.

Reading the field after `inject_mvm_runtime` is deliberate and safe: the injected guest binaries are statically linked and land in `usr/local/bin`, so they add no loader to `lib` or `lib64` and cannot change the verdict.

`inject_and_materialize` itself is not unit-testable (`resolve_guest_binaries` triggers a real guest cross-compile), so the sidecar construction is extracted into `oci_run_sidecar`, which is.

### Witnesses

Nine tests on detection, three on the wiring and the serde convention. Both new behaviours mutation-checked in the foreground:

- dropping `.with_libc(…)` fails `the_sidecar_records_the_libc_of_the_tree_it_describes`
- dropping `#[serde(default)]` fails `a_sidecar_predating_the_libc_field_reads_as_unknown`

### Gates

- `cargo run -p xtask -- check-all` — 61 gates clean
- `cargo nextest run --workspace` — 12659 passed, 2 pre-existing failures unrelated to this change: the macOS-deterministic socket-path assertion filed as #2973, and a parallel-load flake in `mvm-hostd`'s audit-chain restart test. Neither test references `GuestSidecar`, `guest_libc` or `mvm_build`, and `mvm-vmm` does not depend on `mvm-build`.
- `cargo clippy -p mvm-build --all-targets -- -D warnings`, `cargo fmt --all -- --check`

Refs #2969.