### PR TITLE
test(doctor): stop asserting the host has rustup

### DIFF
--- a/crates/mvm-cli/src/doctor/toolchain.rs
+++ b/crates/mvm-cli/src/doctor/toolchain.rs
@@ -92,26 +92,21 @@ fn which_version(cmd: &str, args: &[&str]) -> Option<String> {
 mod tests {
     use super::*;
 
+    /// The success arm, against a binary at a fixed absolute path rather than
+    /// a host toolchain.
+    ///
+    /// This replaces a pair of tests that ran `rustup --version` and `cargo
+    /// --version`. Those asserted a property of the developer's machine rather
+    /// than of `check_cmd`, and failed outright for anyone whose cargo came
+    /// from a distro package or from nix — neither installs rustup. Naming an
+    /// absolute path also drops the PATH lookup, so the assertion is about the
+    /// helper and nothing else.
     #[test]
-    fn check_cmd_rustup_on_host() {
-        let c = check_cmd("rustup", "tools", &["--version"]);
-        assert!(c.ok, "rustup should be available: {}", c.info);
-        assert!(
-            c.info.contains("rustup"),
-            "expected version string, got: {}",
-            c.info
-        );
-    }
-
-    #[test]
-    fn check_cmd_cargo_on_host() {
-        let c = check_cmd("cargo", "tools", &["--version"]);
-        assert!(c.ok, "cargo should be available: {}", c.info);
-        assert!(
-            c.info.contains("cargo"),
-            "expected version string, got: {}",
-            c.info
-        );
+    fn check_cmd_reports_the_stdout_of_a_successful_command() {
+        let c = check_cmd("/bin/echo", "tools", &["mvm"]);
+        assert!(c.ok, "/bin/echo should succeed: {}", c.info);
+        assert_eq!(c.info, "mvm", "stdout is captured and trimmed");
+        assert_eq!(c.category, "tools");
     }
 
     #[test]


### PR DESCRIPTION
Follow-on to #2970, which made a spawn failure in `check_cmd` say why it failed. This removes the reason it kept failing.

`check_cmd_rustup_on_host` and `check_cmd_cargo_on_host` ran the real `rustup --version` and `cargo --version`. Both assert a property of the machine running the suite rather than of `check_cmd`, and they fail outright for a contributor whose cargo came from a distro package or from nix — neither installs rustup.

Replaced with one test against `/bin/echo` at an absolute path. It covers the same arm of `check_cmd`, drops the PATH lookup, and asserts the captured stdout exactly rather than by substring — so it also pins the trim, which neither of the tests it replaces did.

### What this does not fix

The occurrence that prompted this was a *transient* spawn failure under host memory pressure, not an absent rustup, and `/bin/echo` can fail that way too. A retry would mask it, and on a box where builds routinely exhaust memory that would hide a real signal rather than fix a test. So this removes the deterministic half of the pair's failure modes and leaves the transient half alone — #2970 means the next occurrence names its errno, which is what would let it be fixed properly rather than guessed at.

### Witness

Mutation-checked in the foreground: dropping `.trim()` from `check_cmd`'s success arm fails the new test with `left: "mvm\n" / right: "mvm"`.

### Gates

- `cargo run -p xtask -- check-all` — 61 gates clean
- `cargo nextest run -p mvm-cli` — 2034 passed
- `cargo clippy -p mvm-cli --all-targets -- -D warnings`, `cargo fmt --all -- --check`