### PR TITLE
build(kernel): bump synchronized pins to 6.12.107

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -48,10 +48,10 @@ let
   # kernel — lets both of mvm's kernels track the latest point release exactly
   # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
   # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
-  kernelVersion = "6.12.106";
+  kernelVersion = "6.12.107";
   kernelSrc = pkgs.fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
-    hash = "sha256-A5JVV2HZnHYEUD9heJUeLfd+l4uSzJbRHiSEI+SO14U=";
+    hash = "sha256-pfjFvj/eLW2coU6WMWQs8fREhxQ/EQWdpzDc1YkuMHo=";
   };
   # The builder's overlay filesystem triggers a GNU tar directory-metadata
   # race while unpacking this archive. Materialize the source with bsdtar once

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.106.tar.xz";
-    hash = "sha256-A5JVV2HZnHYEUD9heJUeLfd+l4uSzJbRHiSEI+SO14U=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.107.tar.xz";
+    hash = "sha256-pfjFvj/eLW2coU6WMWQs8fREhxQ/EQWdpzDc1YkuMHo=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.106' \
+      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.107' \
       --replace-fail 'curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)' 'ln -s ${kernelSrc} $(KERNEL_TARBALL)'
     substituteInPlace patches/0008-virtio-vsock-support-dgrams.patch \
       --replace-fail 'virtio_transport_alloc_skb(&info, dgram_len, false,' \

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,12 @@ Last updated: 2026-08-28
 
 ## In progress
 
+- [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
+      `specs/plans/2026-08-28-kernel-6-12-107.md`.
+      Both kernel consumers use the kernel.org-verified archive and SRI hash;
+      structural tests and workspace Clippy are green. Linux Nix builds and
+      merge delivery remain.
+
 - [ ] **HVF machine restore dispatch — issue #2961.**
       `specs/plans/2026-08-27-hvf-machine-restore-dispatch.md`.
       The `machine` fork/restore surfaces now share the backend-origin

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,15 @@
 
 ## In progress
 
+- [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
+      `specs/plans/2026-08-28-kernel-6-12-107.md`.
+      The custom workload/builder kernel and libkrunfw firmware build now use
+      the same kernel.org-verified Linux 6.12.107 archive and SRI hash.
+      The archive digest, structural synchronization suite, sprint/plan gates,
+      and workspace Clippy are green. The macOS workspace run reaches only the
+      independently tracked #2973 failure. Linux Nix builds and merge delivery
+      remain.
+
 - [ ] **Recorded-backend pause and resume — issue #2929.**
       `specs/plans/2026-08-27-recorded-backend-pause-resume.md`.
       Existing-machine lifecycle operations resolve the VMM that owns the live

--- a/specs/plans/2026-08-28-kernel-6-12-107.md
+++ b/specs/plans/2026-08-28-kernel-6-12-107.md
@@ -1,0 +1,39 @@
+# Linux 6.12.107 kernel pin refresh
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#2971](https://github.com/tinylabscom/mvm/issues/2971)
+
+## Outcome
+
+The custom workload/builder kernel and libkrunfw firmware build consume the
+same verified Linux 6.12.107 LTS source archive. Structural coverage keeps the
+version and source hash synchronized.
+
+## Delivery checklist
+
+- [x] Verify the upstream `linux-6.12.107.tar.xz` SHA-256 against kernel.org's
+      signed checksum manifest.
+- [x] Add a red structural regression that requires both consumers to move
+      together.
+- [x] Update the custom workload/builder kernel source pin and SRI hash.
+- [x] Update the libkrunfw kernel source pin, substitution, and SRI hash.
+- [x] Pass the focused synchronization test and local pin-parity checks.
+- [x] Pass zero-warning workspace Clippy and the macOS workspace suite through
+      the single independently tracked #2973 path assertion.
+- [ ] Pass the Linux builder-VM Nix evaluation and kernel-build checks.
+- [ ] Record the completed implementation in the sprint and refactor rollup.
+- [ ] Merge the tested pull request and close #2971 through its linkage.
+
+## Source verification
+
+The upstream archive SHA-256 is
+`a5f8c5be3fde2d6d9ca14e9631642cf1f44487143f11059da730dcd5892e307a`,
+which converts to the Nix SRI hash
+`sha256-pfjFvj/eLW2coU6WMWQs8fREhxQ/EQWdpzDc1YkuMHo=`.
+
+The archive downloaded from kernel.org hashes to the same digest. The full
+macOS workspace run reached `mvm-vmm` with every earlier crate group green and
+then reproduced #2973's deterministic shortened-socket-path assertion; the
+kernel pin does not touch that path.

--- a/specs/sprint/delivery/2971-kernel-pin-6-12-107.md
+++ b/specs/sprint/delivery/2971-kernel-pin-6-12-107.md
@@ -1,0 +1,14 @@
+# Linux 6.12.107 kernel pin refresh
+
+- [x] Updated the libkrunfw firmware build and custom workload/builder kernels
+      from Linux 6.12.106 to 6.12.107.
+- [x] Verified the archive digest against kernel.org's signed SHA-256 manifest
+      and converted it to the Nix SRI hash used by both consumers.
+- [x] Updated structural parity coverage so both kernel consumers must remain
+      synchronized.
+- [x] Passed the structural suite, sprint/plan policy gates, and workspace
+      Clippy; the macOS workspace run reached only the tracked #2973 failure.
+- [ ] Record the Linux builder validation after it passes.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-08-28-kernel-6-12-107.md`.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -373,8 +373,8 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         );
     }
 
-    const KERNEL_VERSION: &str = "6.12.106";
-    const KERNEL_HASH: &str = "sha256-A5JVV2HZnHYEUD9heJUeLfd+l4uSzJbRHiSEI+SO14U=";
+    const KERNEL_VERSION: &str = "6.12.107";
+    const KERNEL_HASH: &str = "sha256-pfjFvj/eLW2coU6WMWQs8fREhxQ/EQWdpzDc1YkuMHo=";
     assert!(
         libkrunfw.contains(&format!("linux-{KERNEL_VERSION}.tar.xz"))
             && libkrunfw.contains(&format!("hash = \"{KERNEL_HASH}\""))


### PR DESCRIPTION
Closes #2971

Synchronizes the custom workload/builder kernel and libkrunfw on Linux 6.12.107 using kernel.org's signed-manifest digest. The structural contract requires both consumers to carry the same version and SRI hash.

Validation:
- kernel.org archive SHA-256 independently verified
- 56 Nix structural tests passed
- workspace Clippy passed with `-D warnings`
- sprint append and plan-name gates passed
- full macOS workspace reached only the independently tracked #2973 socket-path assertion

The PR kernel lanes build both workload and builder kernels on aarch64 and x86_64 Linux.