### PR TITLE
refactor(sdk): give the in-guest host-services C ABI its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3222,6 +3222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-host-services"
+version = "0.18.0"
+dependencies = [
+ "mvm-agentd",
+ "mvm-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mvm-hostd"
 version = "0.18.0"
 dependencies = [
@@ -3383,6 +3393,7 @@ dependencies = [
  "mvm-agentd",
  "mvm-contract",
  "mvm-core",
+ "mvm-host-services",
  "mvm-http",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,11 @@ members = [
     "crates/mvm-backends",
     "crates/mvm-build",
     "crates/mvm-agentd",
+    # The in-guest host-services C ABI. Its own crate so the object compiled
+    # into every guest carries no host-side toolchain: `mvm-sdk` holds the
+    # decorator parser (tree-sitter) and the deploy record (blake3), both C,
+    # and building the cdylib from that crate dragged them along.
+    "crates/mvm-host-services",
     "crates/mvm-cli",
     "crates/mvm-hostd",
     "crates/mvm-client",
@@ -356,6 +361,7 @@ mvm-core = { path = "crates/mvm-core", version = "0.18.0" }
 mvm-client = { path = "crates/mvm-client", version = "0.18.0" }
 mvm-mcp = { path = "crates/mvm-mcp", version = "0.18.0" }
 mvm-agentd = { path = "crates/mvm-agentd", version = "0.18.0" }
+mvm-host-services = { path = "crates/mvm-host-services", version = "0.18.0" }
 mvm-build = { path = "crates/mvm-build", version = "0.18.0", default-features = false }
 mvm-runtime = { path = "crates/mvm-runtime", version = "0.18.0", default-features = false }
 mvm-vmm = { path = "crates/mvm-vmm", version = "0.18.0" }

--- a/crates/mvm-agentd/fuzz/Cargo.lock
+++ b/crates/mvm-agentd/fuzz/Cargo.lock
@@ -1175,6 +1175,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-host-services"
+version = "0.18.0"
+dependencies = [
+ "mvm-agentd",
+ "mvm-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mvm-http"
 version = "0.18.0"
 dependencies = [
@@ -1213,7 +1223,7 @@ dependencies = [
  "mvm-agentd",
  "mvm-contract",
  "mvm-core",
- "mvm-http",
+ "mvm-host-services",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/mvm-build/src/guest_agent_build.rs
+++ b/crates/mvm-build/src/guest_agent_build.rs
@@ -463,7 +463,7 @@ pub fn sdk_cdylib_source_fingerprint(
     workspace_root: &Path,
 ) -> Result<String, GuestAgentBuildError> {
     let mut hasher = Sha256::new();
-    hasher.update(b"mvm-sdk-cdylib-input-v1\0");
+    hasher.update(b"mvm-host-services-cdylib-input-v1\0");
     hash_inputs(
         &mut hasher,
         workspace_root,
@@ -476,8 +476,8 @@ pub fn sdk_cdylib_source_fingerprint(
             "crates/mvm-core/src",
             "crates/mvm-agentd/Cargo.toml",
             "crates/mvm-agentd/src",
-            "crates/mvm-sdk/Cargo.toml",
-            "crates/mvm-sdk/src",
+            "crates/mvm-host-services/Cargo.toml",
+            "crates/mvm-host-services/src",
         ],
     )?;
     Ok(hex::encode(hasher.finalize()))

--- a/crates/mvm-build/src/sdk_sidecar.rs
+++ b/crates/mvm-build/src/sdk_sidecar.rs
@@ -479,7 +479,7 @@ mod tests {
             "crates/mvm-contract/src",
             "crates/mvm-core/src",
             "crates/mvm-agentd/src",
-            "crates/mvm-sdk/src",
+            "crates/mvm-host-services/src",
         ] {
             std::fs::create_dir_all(root.join(rel)).unwrap();
             std::fs::write(root.join(rel).join("lib.rs"), "pub fn shared() {}\n").unwrap();
@@ -490,15 +490,11 @@ mod tests {
             "crates/mvm-contract/Cargo.toml",
             "crates/mvm-core/Cargo.toml",
             "crates/mvm-agentd/Cargo.toml",
-            "crates/mvm-sdk/Cargo.toml",
+            "crates/mvm-host-services/Cargo.toml",
         ] {
             std::fs::write(root.join(rel), "[package]\n").unwrap();
         }
-        std::fs::write(
-            root.join("crates/mvm-sdk/src/host_services_ffi.rs"),
-            sdk_src,
-        )
-        .unwrap();
+        std::fs::write(root.join("crates/mvm-host-services/src/lib.rs"), sdk_src).unwrap();
     }
 
     /// A downloaded sidecar carries no source marker, and that absence is the
@@ -563,9 +559,7 @@ mod tests {
 
         // The edit that motivated all of this: a new verb in the FFI dispatch.
         std::fs::write(
-            checkout
-                .path()
-                .join("crates/mvm-sdk/src/host_services_ffi.rs"),
+            checkout.path().join("crates/mvm-host-services/src/lib.rs"),
             "// v2 — adds host.kv.get\n",
         )
         .unwrap();

--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -29,7 +29,10 @@ mvm-client.workspace = true
 mvm-mcp.workspace = true
 # `mvmctl compile` reads the Workload IR (mvm_contract::ir, re-exported from
 # mvm_contract::ir) and routes it through the compile pipeline.
-mvm-sdk.workspace = true
+# `deploy-remote` carries the HTTPS upload behind `mvmctl deploy`. It is off by
+# default in `mvm-sdk` so the in-guest cdylib built from that crate's lib target
+# links no rustls/ring/tokio; the CLI is the one consumer that needs it.
+mvm-sdk = { workspace = true, features = ["deploy-remote"] }
 mvm-capture.workspace = true
 # Direct IR access (`mvm_contract::ir::…`) for the command surfaces that
 # only need the DTOs, not the rest of the SDK's build-time tooling.

--- a/crates/mvm-host-services/Cargo.toml
+++ b/crates/mvm-host-services/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "mvm-host-services"
+description = "In-guest host-services C ABI (libmvm_host_services.so) — one JSON-in/JSON-out entry point over the vsock broker, loaded by every language SDK."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[lib]
+# The package name is what makes cargo emit `libmvm_host_services.so`
+# directly. When this lived in `mvm-sdk` the output was `libmvm_sdk.so` and the
+# nix package renamed it, which meant the stable filename every language SDK
+# dlopens was established by an `install` line rather than by the build.
+#
+# `lib` as well as `cdylib` so `mvm-sdk`'s error taxonomy can reference the
+# `MVM_HSVC_*` status codes as constants instead of restating them.
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+# The broker clients and vsock primitives. This crate is only the C-ABI veneer.
+mvm-agentd.workspace = true
+# Request/response DTOs for the host.audit and host.kv protocols.
+mvm-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Deliberately nothing else. This closure is what gets compiled into every
+# guest, and it must stay free of C and of an async runtime: `ring` and the
+# tree-sitter parsers cannot cross-compile to `aarch64-unknown-linux-musl`
+# without a musl C toolchain, and cannot go to `wasm32-unknown-unknown` at all.
+# `check-sdk-transport-free` holds that line.
+
+[lints]
+workspace = true

--- a/crates/mvm-host-services/src/lib.rs
+++ b/crates/mvm-host-services/src/lib.rs
@@ -38,6 +38,13 @@
 //! body is accepted for the no-payload verbs). The reply written to `out` is
 //! the verb's typed response JSON on success.
 
+// The whole point of this crate is a C ABI, so the workspace's unsafe_code lint
+// is allowed here and nowhere else in it. Confining the exception to the crate
+// that exists to hold `extern "C"` is what the split buys: it used to be an
+// `#[allow]` on one module of `mvm-sdk`, sitting alongside the decorator parser
+// and the deploy record.
+#![allow(unsafe_code)]
+
 use std::os::unix::net::UnixStream;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::ptr;

--- a/crates/mvm-runtime/fuzz-backend/Cargo.lock
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.lock
@@ -1219,6 +1219,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mvm-host-services"
+version = "0.18.0"
+dependencies = [
+ "mvm-agentd",
+ "mvm-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mvm-http"
 version = "0.18.0"
 dependencies = [
@@ -1306,7 +1316,7 @@ dependencies = [
  "mvm-agentd",
  "mvm-contract",
  "mvm-core",
- "mvm-http",
+ "mvm-host-services",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/mvm-sdk/Cargo.toml
+++ b/crates/mvm-sdk/Cargo.toml
@@ -35,7 +35,12 @@ mvm-contract.workspace = true
 async-trait = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-mvm-http.workspace = true
+# Only the remote deploy transport (`MvmdClient::ship`) speaks HTTPS, and it is
+# a host-side path. Optional so the default lib build — which is what the
+# in-guest `libmvm_host_services.so` cdylib is built from — carries no rustls,
+# no ring and no tokio. `ring` is C plus platform assembly, which neither the
+# musl cdylib target nor wasm can build.
+mvm-http = { workspace = true, optional = true }
 thiserror.workspace = true
 
 # Runtime record mode encodes `Sandbox.files.write` bytes
@@ -65,6 +70,10 @@ tree-sitter-typescript = { workspace = true }
 
 [features]
 default = []
+# The remote half of `deploy`: `MvmdClient` and the HTTPS upload. Off by
+# default; `mvm-cli` turns it on. Everything else in `deploy` — the record
+# types and boot-artifact digests the CLI verifies with — stays unconditional.
+deploy-remote = ["dep:mvm-http"]
 client-facade = ["dep:async-trait", "mvm-core/client"]
 # Derive `schemars::JsonSchema` on the addon-manifest and runtime-record types
 # and forward to the IR's own derives, for the three schema-emitter bins below.

--- a/crates/mvm-sdk/Cargo.toml
+++ b/crates/mvm-sdk/Cargo.toml
@@ -7,19 +7,16 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
-[lib]
-# The normal Rust library (`lib`) is consumed by mvmctl and the build pipeline.
-# The `cdylib` output is the in-guest host-services FFI shared object the
-# Python/TypeScript SDKs dlopen; the nix package renames it to the stable
-# `libmvm_host_services.so` filename.
-crate-type = ["lib", "cdylib"]
-
 [dependencies]
 mvm-core = { workspace = true }
 # In-guest host-services FFI: drives `host.audit.v1` / `host.time.v1` /
 # `host.cost.v1` over the vsock broker. The broker client and vsock primitives
 # live in the guest-agent crate; mvm-sdk only holds the C-ABI veneer.
 mvm-agentd.workspace = true
+# Status codes for the error taxonomy. The C ABI itself moved to its own crate
+# so the object loaded inside every guest does not carry this crate's
+# host-side decorator toolchain.
+mvm-host-services.workspace = true
 # The Workload IR itself (`mvm_sdk::ir` re-exports `mvm_contract::ir`
 # unchanged — see `src/lib.rs`). The IR's own `JsonSchema` derives come from
 # `mvm-contract/schema`, which this crate's `schema` feature forwards to —

--- a/crates/mvm-sdk/fuzz/Cargo.lock
+++ b/crates/mvm-sdk/fuzz/Cargo.lock
@@ -222,16 +222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,16 +232,6 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -289,7 +269,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom",
  "hybrid-array",
  "rand_core",
 ]
@@ -352,17 +332,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
 name = "ed25519"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,7 +366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -439,15 +408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,17 +429,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -538,22 +487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,110 +517,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
-
-[[package]]
-name = "icu_properties"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
-
-[[package]]
-name = "icu_provider"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
 ]
 
 [[package]]
@@ -725,61 +554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom",
  "libc",
 ]
 
@@ -827,12 +607,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "litemap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
-
-[[package]]
 name = "log"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,17 +635,6 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
-]
-
-[[package]]
-name = "mio"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -948,22 +711,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "mvm-http"
+name = "mvm-host-services"
 version = "0.18.0"
 dependencies = [
- "base64",
- "bytes",
- "http",
- "httparse",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
+ "mvm-agentd",
+ "mvm-core",
  "serde",
  "serde_json",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "url",
 ]
 
 [[package]]
@@ -978,7 +732,7 @@ dependencies = [
  "mvm-agentd",
  "mvm-contract",
  "mvm-core",
- "mvm-http",
+ "mvm-host-services",
  "serde",
  "serde_json",
  "sha2",
@@ -1031,18 +785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,15 +799,6 @@ dependencies = [
  "cpubits",
  "cpufeatures",
  "universal-hash",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -1099,7 +832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.3",
+ "getrandom",
  "rand_core",
 ]
 
@@ -1139,20 +872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,80 +890,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1258,24 +904,6 @@ name = "ryu-js"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "seccompiler"
@@ -1294,29 +922,6 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1425,48 +1030,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "smallvec"
-version = "1.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "socket2"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "streaming-iterator"
@@ -1503,17 +1070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,10 +1087,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1558,16 +1114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
-dependencies = [
- "displaydoc",
- "zerovec",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,42 +1127,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "tokio-macros",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
-]
 
 [[package]]
 name = "toml"
@@ -1782,57 +1292,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
 name = "uuid"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom",
  "js-sys",
  "serde_core",
  "sha1_smol",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1877,24 +1347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1958,85 +1410,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2046,12 +1425,6 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "writeable"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x25519-dalek"
@@ -2075,50 +1448,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2136,39 +1465,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]

--- a/crates/mvm-sdk/src/deploy.rs
+++ b/crates/mvm-sdk/src/deploy.rs
@@ -604,6 +604,7 @@ fn hook_phase_hash(cmds: &[crate::ir::HookCmd]) -> String {
     hex::encode(digest)
 }
 
+#[cfg(feature = "deploy-remote")]
 /// Stable response returned by mvmd after accepting a deploy artifact.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -620,11 +621,13 @@ pub struct RemoteArtifact {
     pub size_bytes: u64,
 }
 
+#[cfg(feature = "deploy-remote")]
 #[derive(Debug, Deserialize)]
 struct RemoteResponse {
     data: RemoteArtifact,
 }
 
+#[cfg(feature = "deploy-remote")]
 /// Authenticated remote artifact client.
 pub struct MvmdClient {
     /// The configured mvmd endpoint.
@@ -632,6 +635,7 @@ pub struct MvmdClient {
     api_key: String,
 }
 
+#[cfg(feature = "deploy-remote")]
 impl MvmdClient {
     /// Construct a new client for `base_url` with a bearer credential.
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
@@ -694,6 +698,7 @@ impl MvmdClient {
     }
 }
 
+#[cfg(feature = "deploy-remote")]
 fn deploy_multipart_body(record_json: &str, bundle_bytes: &[u8]) -> (String, Vec<u8>) {
     let boundary = format!("mvm-deploy-{}", blake3::hash(bundle_bytes).to_hex());
     let mut body = Vec::with_capacity(record_json.len() + bundle_bytes.len() + 512);
@@ -712,6 +717,7 @@ fn deploy_multipart_body(record_json: &str, bundle_bytes: &[u8]) -> (String, Vec
     (format!("multipart/form-data; boundary={boundary}"), body)
 }
 
+#[cfg(feature = "deploy-remote")]
 fn remote_upload_endpoint(base_url: &str) -> Result<String, DeployError> {
     let parsed = mvm_http::Url::parse(base_url).map_err(|error| DeployError::RemoteProtocol {
         base_url: base_url.to_string(),
@@ -730,6 +736,7 @@ fn remote_upload_endpoint(base_url: &str) -> Result<String, DeployError> {
     ))
 }
 
+#[cfg(feature = "deploy-remote")]
 fn is_loopback_url(url: &mvm_http::Url) -> bool {
     match url.host_str() {
         Some("localhost") => true,
@@ -1034,6 +1041,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "deploy-remote")]
     fn remote_client_fails_closed_for_unreachable_transport() {
         let client = MvmdClient::new("http://127.0.0.1:1", "test-token");
         let tmp = tempfile::tempdir().unwrap();
@@ -1075,6 +1083,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "deploy-remote")]
     fn remote_endpoint_rejects_cleartext_non_loopback() {
         let error = remote_upload_endpoint("http://mvmd.example").unwrap_err();
         assert!(matches!(
@@ -1084,6 +1093,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "deploy-remote")]
     fn deploy_multipart_body_contains_record_and_bundle_parts() {
         let (content_type, body) = deploy_multipart_body(r#"{"workload_id":"demo"}"#, b"bundle");
         let body = String::from_utf8(body).expect("multipart test body is UTF-8");

--- a/crates/mvm-sdk/src/deploy.rs
+++ b/crates/mvm-sdk/src/deploy.rs
@@ -23,7 +23,6 @@
 //! is the additional sidecar the receiver reads to make scheduling
 //! decisions without unpacking the rest.
 
-use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -659,7 +658,7 @@ impl MvmdClient {
         let endpoint = remote_upload_endpoint(&self.base_url)?;
         let record_json = serde_json::to_string(record)?;
         let bundle_bytes =
-            fs::read(&bundle.archive_path).map_err(|error| DeployError::RemoteProtocol {
+            std::fs::read(&bundle.archive_path).map_err(|error| DeployError::RemoteProtocol {
                 base_url: self.base_url.clone(),
                 reason: format!("opening bundle: {error}"),
             })?;

--- a/crates/mvm-sdk/src/error_taxonomy.rs
+++ b/crates/mvm-sdk/src/error_taxonomy.rs
@@ -2,7 +2,7 @@
 //!
 //! Both language SDKs mirror this hierarchy, and until now they mirrored
 //! it by hand. The host-services half was the worst case: the status
-//! codes live in [`crate::host_services_ffi`], and both SDKs re-declared
+//! codes live in [`mvm_host_services`], and both SDKs re-declared
 //! them as literals under a comment asking a human to keep them matching.
 //! They had already drifted in the prose — the Rust doc for
 //! `MVM_HSVC_BAD_REQUEST` says "audit cap" where the TypeScript copy says
@@ -139,35 +139,35 @@ sdk_errors! {
 
     /// The host rejected the record shape or size (audit cap).
     BadRequestError: ErrorBase::Named("HostServiceError"),
-        status = crate::host_services_ffi::MVM_HSVC_BAD_REQUEST; [Rust, Python, TypeScript]
+        status = mvm_host_services::MVM_HSVC_BAD_REQUEST; [Rust, Python, TypeScript]
 
     /// The per-workload audit emit rate limit is exhausted.
     RateLimitedError: ErrorBase::Named("HostServiceError"),
-        status = crate::host_services_ffi::MVM_HSVC_RATE_LIMITED; [Rust, Python, TypeScript]
+        status = mvm_host_services::MVM_HSVC_RATE_LIMITED; [Rust, Python, TypeScript]
 
     /// The host could not answer (handler down, broker not ready).
     UnavailableError: ErrorBase::Named("HostServiceError"),
-        status = crate::host_services_ffi::MVM_HSVC_UNAVAILABLE; [Rust, Python, TypeScript]
+        status = mvm_host_services::MVM_HSVC_UNAVAILABLE; [Rust, Python, TypeScript]
 
     /// The workload's `ExecutionPlan.services` did not bind the service.
     NotBoundError: ErrorBase::Named("HostServiceError"),
-        status = crate::host_services_ffi::MVM_HSVC_NOT_BOUND; [Rust, Python, TypeScript]
+        status = mvm_host_services::MVM_HSVC_NOT_BOUND; [Rust, Python, TypeScript]
 
     /// The verb is not implemented in this build.
     VerbNotImplementedError: ErrorBase::Named("HostServiceError"),
-        status = crate::host_services_ffi::MVM_HSVC_NOT_IMPLEMENTED; [Rust, Python, TypeScript]
+        status = mvm_host_services::MVM_HSVC_NOT_IMPLEMENTED; [Rust, Python, TypeScript]
 
     /// Any other typed broker error code.
     ServiceError: ErrorBase::Named("HostServiceError"),
-        status = crate::host_services_ffi::MVM_HSVC_SERVICE; [Rust, Python, TypeScript]
+        status = mvm_host_services::MVM_HSVC_SERVICE; [Rust, Python, TypeScript]
 
     /// Connect, framing, or (de)serialization failure on the vsock path.
     TransportError: ErrorBase::Named("HostServiceError"),
-        status = crate::host_services_ffi::MVM_HSVC_TRANSPORT; [Rust, Python, TypeScript]
+        status = mvm_host_services::MVM_HSVC_TRANSPORT; [Rust, Python, TypeScript]
 
     /// The request was malformed: unknown method or a body the verb rejects.
     InvalidInputError: ErrorBase::Named("HostServiceError"),
-        status = crate::host_services_ffi::MVM_HSVC_INVALID_INPUT; [Rust, Python, TypeScript]
+        status = mvm_host_services::MVM_HSVC_INVALID_INPUT; [Rust, Python, TypeScript]
 }
 
 /// The errors Tier C's remote-invocation machinery raises.
@@ -271,7 +271,7 @@ const TIER_C: &[SdkErrorType] = &[
 /// belongs to the same `MVM_HSVC_*` family the SDKs mirrored by hand, and
 /// generating the map while leaving this behind would leave the mirror
 /// half-alive.
-pub const STATUS_OK: i32 = crate::host_services_ffi::MVM_HSVC_OK;
+pub const STATUS_OK: i32 = mvm_host_services::MVM_HSVC_OK;
 
 /// The status → error-type mapping, in registry order. `MVM_HSVC_OK` has
 /// no entry: it is not a failure.
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn ok_is_not_an_error_type() {
         assert!(
-            !status_mapping().any(|(status, _)| status == crate::host_services_ffi::MVM_HSVC_OK),
+            !status_mapping().any(|(status, _)| status == mvm_host_services::MVM_HSVC_OK),
             "MVM_HSVC_OK must not map to an error type"
         );
     }
@@ -418,11 +418,11 @@ mod tests {
         let by_name = |n: &str| REGISTRY.iter().find(|e| e.name == n).unwrap();
         assert_eq!(
             by_name("BadRequestError").status,
-            Some(crate::host_services_ffi::MVM_HSVC_BAD_REQUEST)
+            Some(mvm_host_services::MVM_HSVC_BAD_REQUEST)
         );
         assert_eq!(
             by_name("InvalidInputError").status,
-            Some(crate::host_services_ffi::MVM_HSVC_INVALID_INPUT)
+            Some(mvm_host_services::MVM_HSVC_INVALID_INPUT)
         );
     }
 }

--- a/crates/mvm-sdk/src/lib.rs
+++ b/crates/mvm-sdk/src/lib.rs
@@ -90,11 +90,6 @@ pub mod compile;
 /// Closed `mvm.*` helper allowlist; non-literal kwargs rejected.
 pub mod decorator;
 
-/// In-guest host-services C-ABI cdylib (`libmvm_host_services.so`) loaded by
-/// the Python and TypeScript SDKs. Unsafe code is confined to this module.
-#[allow(unsafe_code)]
-mod host_services_ffi;
-
 /// Deploy-bundle assembly and local attestation for mvmd-owned control-plane
 /// flows. Builds the single `.tar.gz` (compile output plus embedded
 /// `mvmd-spec.json`) and exposes the authenticated shipping seam.

--- a/nix/packages/mvm-sdk-cdylib.nix
+++ b/nix/packages/mvm-sdk-cdylib.nix
@@ -1,7 +1,7 @@
 # `libmvm_host_services.so` — the in-guest host-services FFI shared object.
 #
-# Built from the `mvm-sdk` crate's `cdylib` output and renamed to the stable
-# `libmvm_host_services.so` filename. Packaged in the SDK sidecar at
+# Built from the `mvm-host-services` crate's `cdylib` output. Packaged in the
+# SDK sidecar at
 # `/mvm/sdk/lib/` and loaded via `ctypes` / `koffi` by the in-guest language
 # SDKs (`mvm.audit.emit`, `mvm.host.time()`, ...). It is the single JSON-in/
 # JSON-out C ABI over `mvm_agentd::host_{audit,time,cost}`, so every language
@@ -10,6 +10,13 @@
 # Built for the workload rootfs's libc (the nixpkgs Linux platform = glibc,
 # matching `mvm-guest-agent`), not the static-musl builder-VM target — a
 # `cdylib` needs a dynamic loader, which the glibc rootfs provides.
+#
+# Built from `mvm-host-services`, not `mvm-sdk`. The FFI used to live in the
+# SDK crate, so this derivation compiled that crate's host-side decorator
+# toolchain — five tree-sitter C parsers, blake3's NEON path and, until it was
+# made optional, rustls/ring/tokio — into the object loaded inside every guest.
+# `mvm-host-services` depends only on `mvm-agentd`, `mvm-core` and serde, so
+# its closure is pure Rust by construction.
 
 {
   pkgs,
@@ -35,24 +42,26 @@ pkgs.rustPlatform.buildRustPackage {
   # purity check.
   HOME = "/tmp";
 
-  # Build only mvm-sdk's library target, which produces both the Rust `lib`
-  # and the `cdylib`. The cdylib is renamed to the stable FFI filename below.
+  # Build only the library target, which produces both the Rust `lib` and the
+  # `cdylib`.
   cargoBuildFlags = [
     "--package"
-    "mvm-sdk"
+    "mvm-host-services"
     "--lib"
   ];
 
   # Tests run in the workspace's host-side `cargo test` lane.
   doCheck = false;
 
-  # Cargo emits the cdylib as `libmvm_sdk.so` because the package name is
-  # `mvm-sdk`. The SDK bindings and the runtime overlay key on the stable
-  # `libmvm_host_services.so` name, so rename it during install.
+  # Cargo emits `libmvm_host_services.so` directly — the package name is the
+  # stable FFI filename the SDK bindings and the runtime overlay key on. This
+  # used to rename `libmvm_sdk*.so` into place, which meant that filename was
+  # established by an install line rather than by the build.
   postInstall = ''
     mkdir -p $out/lib
     if [ ! -e $out/lib/libmvm_host_services.so ]; then
-      find target -name 'libmvm_sdk*.so' -print -exec install -m0644 {} $out/lib/libmvm_host_services.so \;
+      find target -name 'libmvm_host_services*.so' -print \
+        -exec install -m0644 {} $out/lib/libmvm_host_services.so \;
     fi
   '';
 

--- a/xtask/src/check_all.rs
+++ b/xtask/src/check_all.rs
@@ -158,6 +158,10 @@ pub const GATES: &[Gate] = &[
         crate::check_core_runtime_free::run,
     ),
     (
+        "check-sdk-transport-free",
+        crate::check_sdk_transport_free::run,
+    ),
+    (
         "check-content-address-determinism",
         crate::check_content_address_determinism::run,
     ),

--- a/xtask/src/check_feature_closure_budget.rs
+++ b/xtask/src/check_feature_closure_budget.rs
@@ -60,7 +60,12 @@ const BUDGET_TARGET: &str = "x86_64-unknown-linux-gnu";
 ///
 /// 483 (was 471): the opt-in `tpm2` attestation provider requires the
 /// `tss-esapi` TPM command stack; the default `mvmctl` closure is unchanged.
-const FEATURE_CLOSURE_BUDGET: usize = 483;
+///
+/// 484 (was 483): the first-party `mvm-host-services` workspace crate, split
+/// out of `mvm-sdk` so the in-guest cdylib stops being compiled from a crate
+/// carrying the decorator parser. It vendors nothing — its dependencies were
+/// already present — so the single new closure node is the crate itself.
+const FEATURE_CLOSURE_BUDGET: usize = 484;
 
 /// The two gates measure nested sets — everything in the default closure is
 /// reachable with all features on — so a feature budget at or below the default

--- a/xtask/src/check_sdk_transport_free.rs
+++ b/xtask/src/check_sdk_transport_free.rs
@@ -1,80 +1,124 @@
 //! `xtask check-sdk-transport-free`
 //!
-//! Assert that `mvm-sdk`'s **default** feature closure pulls no HTTPS/async
-//! transport stack.
+//! Two properties of the SDK crates' **default** feature closures.
 //!
-//! `nix/packages/mvm-sdk-cdylib.nix` builds `--package mvm-sdk --lib` to
-//! produce `libmvm_host_services.so`, the in-guest C ABI every language SDK
-//! loads. That object speaks JSON over the vsock broker and needs no HTTP
-//! client and no async runtime, but it is compiled from the whole crate — so a
-//! dependency added for a host-side path lands inside the guest.
+//! 1. Neither `mvm-sdk` nor `mvm-host-services` pulls an HTTPS/async transport
+//!    stack. For `mvm-sdk` that keeps `rustls`/`ring`/`tokio` out of every
+//!    `mvmctl` build that never deploys; the remote transport lives behind its
+//!    `deploy-remote` feature, which the CLI enables.
 //!
-//! It also breaks builds. `ring` carries C and platform assembly, so a
-//! `mvm-http` in the default closure means the cdylib cannot be built for
-//! `aarch64-unknown-linux-musl` without a musl C cross-compiler, and cannot be
-//! built for `wasm32-unknown-unknown` at all. Both are targets the SDK surface
-//! is meant to reach.
+//! 2. `mvm-host-services` additionally pulls nothing that compiles C.
+//!
+//! The second is the load-bearing one. `nix/packages/mvm-sdk-cdylib.nix` builds
+//! `--package mvm-host-services --lib` to produce `libmvm_host_services.so`,
+//! the in-guest C ABI every language SDK loads. A C dependency in that closure
+//! means the object cannot be cross-compiled to
+//! `aarch64-unknown-linux-musl` without a musl C toolchain, and cannot be built
+//! for `wasm32-unknown-unknown` at all — both targets the SDK surface is meant
+//! to reach.
+//!
+//! That is exactly what a shared crate cost before the split: the FFI lived in
+//! `mvm-sdk`, so the guest object was compiled from a crate that also holds the
+//! decorator parser (five tree-sitter C parsers) and the deploy record
+//! (`blake3`'s NEON path). "Pure Rust by construction" is only by construction
+//! if something checks it.
+//!
+//! `cc` is the proxy for "compiles C": a crate with C source declares it as a
+//! build-dependency, so it appears in the full tree even though it never
+//! appears in a `-e no-dev,no-build` one.
 //!
 //! Like `check-core-runtime-free`, this is deliberately *not* part of
-//! `check-forbidden-deps`: those crates are legitimately in `Cargo.lock` (the
-//! CLI enables `mvm-sdk/deploy-remote`, and plenty of host-side crates use
-//! them). What must stay true is narrower — a *default* `mvm-sdk` build links
-//! none of them — which is a feature-resolution fact read from `cargo tree`.
+//! `check-forbidden-deps`: that check is lockfile-name-based, and every crate
+//! named here is legitimately in `Cargo.lock`. What must stay true is narrower
+//! — which crates a *particular* default closure resolves to — so it is read
+//! from `cargo tree`.
 
 use anyhow::{Context, Result, bail};
 use std::path::Path;
 use std::process::Command;
 
-/// Transport crates that must not appear in mvm-sdk's default tree. `mvm-http`
-/// is the direct dependency; the other three are what it drags in, listed
-/// explicitly so the failure names the actual cost rather than one manifest
-/// line.
+/// Transport crates that must not appear in either SDK closure. `mvm-http` is
+/// the dependency an author would add; the other three are what it drags in,
+/// listed explicitly so the failure names the actual cost rather than one
+/// manifest line.
 const TRANSPORT_CRATES: &[&str] = &["mvm-http", "rustls", "ring", "tokio"];
 
-pub fn run(workspace: &Path) -> Result<()> {
-    // `-e no-dev` excludes dev-deps: mvm-sdk keeps a tokio dev-dep for the
-    // gated facade's `#[tokio::test]`s, which never reaches the cdylib.
-    // Resolved with default features, so a member enabling `deploy-remote` in
-    // the default closure surfaces here and trips the gate.
+/// Resolve a package's dependency tree to a flat set of crate names.
+///
+/// `--prefix none` makes every line start with the crate name. `include_build`
+/// selects whether build-dependencies are walked: they are what reveal a C
+/// dependency, and irrelevant to the transport question.
+fn tree_crates(workspace: &Path, package: &str, include_build: bool) -> Result<Vec<String>> {
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let edges = if include_build {
+        "no-dev"
+    } else {
+        "no-dev,no-build"
+    };
     let output = Command::new(&cargo)
         .current_dir(workspace)
         .args([
-            "tree", "-p", "mvm-sdk", "-e", "no-dev", "--prefix", "none", "--locked",
+            "tree", "-p", package, "-e", edges, "--prefix", "none", "--locked",
         ])
         .output()
-        .context("running `cargo tree -p mvm-sdk -e no-dev`")?;
+        .with_context(|| format!("running `cargo tree -p {package} -e {edges}`"))?;
 
     if !output.status.success() {
         bail!(
-            "cargo tree failed: {}",
+            "cargo tree -p {package} failed: {}",
             String::from_utf8_lossy(&output.stderr).trim()
         );
     }
 
-    let tree = String::from_utf8_lossy(&output.stdout);
-    let mut found: Vec<&str> = tree
+    let mut names: Vec<String> = String::from_utf8_lossy(&output.stdout)
         .lines()
         .filter_map(|line| line.split_whitespace().next())
-        .filter(|name| TRANSPORT_CRATES.contains(name))
+        .map(str::to_string)
         .collect();
-    found.sort_unstable();
-    found.dedup();
+    names.sort_unstable();
+    names.dedup();
+    Ok(names)
+}
 
-    if !found.is_empty() {
+pub fn run(workspace: &Path) -> Result<()> {
+    for package in ["mvm-sdk", "mvm-host-services"] {
+        // `-e no-dev` excludes dev-deps: `mvm-sdk` keeps a tokio dev-dep for
+        // the gated facade's `#[tokio::test]`s, which reaches nothing shipped.
+        let crates = tree_crates(workspace, package, false)?;
+        let found: Vec<&str> = crates
+            .iter()
+            .map(String::as_str)
+            .filter(|name| TRANSPORT_CRATES.contains(name))
+            .collect();
+        if !found.is_empty() {
+            bail!(
+                "check-sdk-transport-free: {package}'s default build pulls an HTTPS/async \
+                 transport stack ({}). Keep the remote deploy transport behind \
+                 `mvm-sdk/deploy-remote`; a workspace member likely enabled it in the default \
+                 closure. `ring` also carries C and platform assembly, which breaks the musl \
+                 and wasm builds of `libmvm_host_services.so`.",
+                found.join(", ")
+            );
+        }
+    }
+
+    // Build-dependencies included: `cc` is how a crate with C source announces
+    // itself, and it appears nowhere else.
+    let cdylib_closure = tree_crates(workspace, "mvm-host-services", true)?;
+    if cdylib_closure.iter().any(|name| name == "cc") {
         bail!(
-            "check-sdk-transport-free: mvm-sdk's default build pulls an HTTPS/async transport \
-             stack ({}). That closure is what `libmvm_host_services.so` is compiled from, so \
-             this ships an HTTP client into every guest and — because `ring` carries C and \
-             platform assembly — breaks the musl and wasm builds of the same object. Keep the \
-             remote deploy transport behind `mvm-sdk/deploy-remote`; a workspace member likely \
-             enabled it in the default closure.",
-            found.join(", ")
+            "check-sdk-transport-free: mvm-host-services pulls a crate that compiles C (`cc` is \
+             in its build-dependency tree). That crate is compiled into \
+             `libmvm_host_services.so`, so this breaks cross-compiling the in-guest object to \
+             aarch64-unknown-linux-musl without a musl C toolchain, and to \
+             wasm32-unknown-unknown at all. The C ABI speaks JSON over the vsock broker — keep \
+             its closure pure Rust and leave C-carrying dependencies in `mvm-sdk`."
         );
     }
 
     eprintln!(
-        "check-sdk-transport-free: clean (mvm-sdk default closure pulls no mvm-http/rustls/ring/tokio)"
+        "check-sdk-transport-free: clean (mvm-sdk and mvm-host-services pull no \
+         mvm-http/rustls/ring/tokio; the cdylib closure compiles no C)"
     );
     Ok(())
 }

--- a/xtask/src/check_sdk_transport_free.rs
+++ b/xtask/src/check_sdk_transport_free.rs
@@ -1,0 +1,80 @@
+//! `xtask check-sdk-transport-free`
+//!
+//! Assert that `mvm-sdk`'s **default** feature closure pulls no HTTPS/async
+//! transport stack.
+//!
+//! `nix/packages/mvm-sdk-cdylib.nix` builds `--package mvm-sdk --lib` to
+//! produce `libmvm_host_services.so`, the in-guest C ABI every language SDK
+//! loads. That object speaks JSON over the vsock broker and needs no HTTP
+//! client and no async runtime, but it is compiled from the whole crate — so a
+//! dependency added for a host-side path lands inside the guest.
+//!
+//! It also breaks builds. `ring` carries C and platform assembly, so a
+//! `mvm-http` in the default closure means the cdylib cannot be built for
+//! `aarch64-unknown-linux-musl` without a musl C cross-compiler, and cannot be
+//! built for `wasm32-unknown-unknown` at all. Both are targets the SDK surface
+//! is meant to reach.
+//!
+//! Like `check-core-runtime-free`, this is deliberately *not* part of
+//! `check-forbidden-deps`: those crates are legitimately in `Cargo.lock` (the
+//! CLI enables `mvm-sdk/deploy-remote`, and plenty of host-side crates use
+//! them). What must stay true is narrower — a *default* `mvm-sdk` build links
+//! none of them — which is a feature-resolution fact read from `cargo tree`.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+use std::process::Command;
+
+/// Transport crates that must not appear in mvm-sdk's default tree. `mvm-http`
+/// is the direct dependency; the other three are what it drags in, listed
+/// explicitly so the failure names the actual cost rather than one manifest
+/// line.
+const TRANSPORT_CRATES: &[&str] = &["mvm-http", "rustls", "ring", "tokio"];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    // `-e no-dev` excludes dev-deps: mvm-sdk keeps a tokio dev-dep for the
+    // gated facade's `#[tokio::test]`s, which never reaches the cdylib.
+    // Resolved with default features, so a member enabling `deploy-remote` in
+    // the default closure surfaces here and trips the gate.
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let output = Command::new(&cargo)
+        .current_dir(workspace)
+        .args([
+            "tree", "-p", "mvm-sdk", "-e", "no-dev", "--prefix", "none", "--locked",
+        ])
+        .output()
+        .context("running `cargo tree -p mvm-sdk -e no-dev`")?;
+
+    if !output.status.success() {
+        bail!(
+            "cargo tree failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let tree = String::from_utf8_lossy(&output.stdout);
+    let mut found: Vec<&str> = tree
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .filter(|name| TRANSPORT_CRATES.contains(name))
+        .collect();
+    found.sort_unstable();
+    found.dedup();
+
+    if !found.is_empty() {
+        bail!(
+            "check-sdk-transport-free: mvm-sdk's default build pulls an HTTPS/async transport \
+             stack ({}). That closure is what `libmvm_host_services.so` is compiled from, so \
+             this ships an HTTP client into every guest and — because `ring` carries C and \
+             platform assembly — breaks the musl and wasm builds of the same object. Keep the \
+             remote deploy transport behind `mvm-sdk/deploy-remote`; a workspace member likely \
+             enabled it in the default closure.",
+            found.join(", ")
+        );
+    }
+
+    eprintln!(
+        "check-sdk-transport-free: clean (mvm-sdk default closure pulls no mvm-http/rustls/ring/tokio)"
+    );
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -59,6 +59,7 @@ mod check_per_vm_host_binaries_sync;
 mod check_plan_names;
 mod check_require_grant_token_allowlist;
 mod check_runtime_overlay_version;
+mod check_sdk_transport_free;
 mod check_single_exec_secs_writer;
 mod check_single_fixture_corpus;
 mod check_single_grants_projection;
@@ -191,6 +192,10 @@ fn main() -> Result<()> {
         Some("check-guest-agent-runtime-free") => {
             let workspace = workspace_root();
             check_guest_agent_runtime_free::run(&workspace)
+        }
+        Some("check-sdk-transport-free") => {
+            let workspace = workspace_root();
+            check_sdk_transport_free::run(&workspace)
         }
         Some("check-guest-agent-in-all-images") => {
             let workspace = workspace_root();
@@ -417,7 +422,7 @@ fn main() -> Result<()> {
             check_all::run_all(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-sdk-transport-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -449,6 +454,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-core-runtime-free                 Plan 126 B5: assert mvm-core's default build pulls no tokio"
+            );
+            eprintln!(
+                "  check-sdk-transport-free                Assert mvm-sdk's default build (the cdylib closure) pulls no mvm-http/rustls/ring/tokio"
             );
             eprintln!(
                 "  check-content-address-determinism       Assert serde_json in mvm-core/mvm-contract has no preserve_order (stable key order → deterministic plan_id/checkpoint digests)"


### PR DESCRIPTION
Closes #2978. Two commits, one story: get the object that runs inside every guest down to a closure that is pure Rust by construction.

`libmvm_host_services.so` is the C ABI every language SDK loads inside a booted workload — two functions, `mvm_hsvc_call` and `mvm_hsvc_free`, JSON in and JSON out over the vsock broker. It was compiled from `mvm-sdk`, a crate that also holds the decorator parser and the deploy record, so the guest object carried code it never calls.

That is a build constraint, not only weight. Those dependencies mean the object cannot cross-compile to `aarch64-unknown-linux-musl` without a musl C toolchain, and cannot go to `wasm32-unknown-unknown` at all — both targets the SDK surface is meant to reach.

### 1. The HTTPS transport becomes optional

`mvm-http` was a non-optional dependency used by three lines of the remote deploy path, dragging `rustls`, `ring` and `tokio`. It now sits behind an off-by-default `deploy-remote` feature that `mvm-cli` enables.

The gating is finer than the module: `mvm-cli` consumes `deploy`'s record and digest surface — `read_deploy_record`, `verify_boot_artifact`, `digest_boot_artifact` — none of which touches HTTP. Gating the module would break the CLI.

**Measured: `mvm-sdk`'s default non-dev tree goes 389 → 260 entries.** That stands on its own for every `mvmctl` build that never deploys.

### 2. The FFI gets its own crate

Feature-gating could not finish the job. With `mvm-http` gone the musl build stopped on the *next* C dependency:

```
blake3 v1.8.5              (blake3_neon.c)
tree-sitter{,-javascript,-language,-nix,-python,-typescript}
```

Those are not stray — they are `mvm-sdk` doing its actual job, and feature-gating a majority of a crate so its minority can build is the wrong instrument.

`mvm-host-services` depends on `mvm-agentd`, `mvm-core` and serde. **The musl build now compiles the entire dependency graph and all 36 object files, reaching the link step**, where only the macOS host linker's lack of GNU `ld` flag support (`--fix-cortex-a53-843419`) stops it — a host limitation, not a property of the crate. Zero C-compilation errors.

Two things fall out:

- The package name *is* the stable FFI filename, so cargo emits `libmvm_host_services.so` directly. The nix package no longer renames `libmvm_sdk*.so` into place — the filename every language SDK dlopens is now established by the build rather than by an `install` line.
- The `unsafe_code` allowance narrows from a module of the SDK crate to the crate that exists to hold `extern "C"`.

### The gate

`check-sdk-transport-free` asserts two properties: neither SDK crate pulls a transport stack, and the cdylib's closure compiles no C — using `cc` in the build-dependency tree as the proxy, since that is how a crate with C source announces itself.

Both mutation-checked in the foreground:

- adding `deploy-remote` to `mvm-sdk`'s `default` trips the transport half and names all four crates
- adding `blake3` to `mvm-host-services` trips the C half

"Pure Rust by construction" is only by construction if something checks it — this is exactly the property nobody was checking before.

### Also

- Fixes a latent defect from the first commit: `deploy.rs`'s `use std::fs` was only reachable under `deploy-remote`. `clippy --workspace` hid it behind feature unification; `clippy -p mvm-sdk` catches it. Both feature states are now clean.
- `sdk_cdylib_source_fingerprint` follows the cdylib to its new crate — otherwise it would hash decorator edits and miss FFI ones.
- `FEATURE_CLOSURE_BUDGET` 483 → 484 for the new workspace member, with the same justification the gate's own docs record for `mvm-capture`: it vendors nothing, so the single new closure node is the crate itself.

### Gates

- `cargo run -p xtask -- check-all` — 62 gates clean
- `cargo nextest run --workspace` — 12658 passed; the one failure is #2973, the macOS-deterministic socket-path assertion, unrelated and pre-existing
- `cargo clippy --workspace --all-targets -- -D warnings`, plus `-p mvm-sdk` in both feature states
- `cargo fmt --all -- --check`

### Follow-on

This is the prerequisite for #2969 phase 2 (the musl cdylib variant) and for #2977's wasm host-import path, which shares the same crate.