### PR TITLE
fix(bdd): probe capabilities in the home the scenarios run against

### DIFF
--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -270,6 +270,65 @@ impl ScenarioGate {
     }
 }
 
+/// Whether a version-keyed SDK sidecar cache under `sidecar_root` holds a
+/// built image.
+///
+/// Walks version and arch directories rather than hardcoding either, so a
+/// version bump cannot quietly turn this into "never available".
+///
+/// The root is an argument rather than resolved here, because the directory
+/// that decides the gate is the one the *scenarios* run against. A probe that
+/// resolves its own `MVM_HOME` reports on a home the subject never reads, and
+/// where that home happens to hold an image, the gate admits a scenario that
+/// then fails in the isolated home where it is absent.
+///
+/// Note what counts as present: the image file, not the version directory.
+/// Those two answers diverge exactly when a cache was created and never
+/// populated, which is the state that makes the distinction matter.
+pub fn sidecar_image_cached_in(sidecar_root: &std::path::Path, image_file: &str) -> bool {
+    let Ok(versions) = std::fs::read_dir(sidecar_root) else {
+        return false;
+    };
+    versions.filter_map(Result::ok).any(|version| {
+        std::fs::read_dir(version.path()).is_ok_and(|arches| {
+            arches
+                .filter_map(Result::ok)
+                .any(|arch| arch.path().join(image_file).is_file())
+        })
+    })
+}
+
+#[cfg(test)]
+mod sidecar_cache {
+    use super::sidecar_image_cached_in;
+
+    const IMAGE: &str = "sdk.ext4";
+
+    #[test]
+    fn a_missing_cache_root_is_not_cached() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert!(!sidecar_image_cached_in(&dir.path().join("absent"), IMAGE));
+    }
+
+    #[test]
+    fn a_version_directory_without_the_image_is_not_cached() {
+        // The shape that made the gate lie: the cache exists and is keyed
+        // correctly, but nothing ever wrote the image into it.
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("0.18.0").join("x86_64")).expect("create arch dir");
+        assert!(!sidecar_image_cached_in(dir.path(), IMAGE));
+    }
+
+    #[test]
+    fn an_image_under_any_version_and_arch_is_cached() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let arch = dir.path().join("9.9.9").join("aarch64");
+        std::fs::create_dir_all(&arch).expect("create arch dir");
+        std::fs::write(arch.join(IMAGE), b"image").expect("write image");
+        assert!(sidecar_image_cached_in(dir.path(), IMAGE));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -232,17 +232,29 @@ fn probe_caps() -> RuntimeCaps {
 /// built. Globbed on version rather than hardcoded so a bump does not silently
 /// turn this into "never available".
 fn sdk_sidecar_cached() -> bool {
-    let root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir()).join("sdk-sidecar");
-    let Ok(versions) = std::fs::read_dir(&root) else {
-        return false;
-    };
-    versions.filter_map(Result::ok).any(|v| {
-        std::fs::read_dir(v.path()).is_ok_and(|arches| {
-            arches
-                .filter_map(Result::ok)
-                .any(|a| a.path().join("sdk.ext4").is_file())
-        })
-    })
+    let sidecar_root = mvm_core::config::mvm_cache_dir_at(live_home())
+        .join(mvm_fs::sdk_sidecar::SDK_SIDECAR_CACHE_DIR);
+    mvm_conformance::sidecar_image_cached_in(
+        &sidecar_root,
+        mvm_fs::sdk_sidecar::SDK_SIDECAR_IMAGE_FILE,
+    )
+}
+
+/// The mvm home the live scenarios actually run against.
+///
+/// The runner exports `MVM_E2E_HOME`; it does not set `MVM_HOME`. So
+/// `mvm_core::config`'s ambient helpers resolve the *default* home inside this
+/// process, which is a different directory from the one every live step hands
+/// to `mvmctl`. A capability probe reading the default home reports on
+/// artifacts the scenario will never see: where that home happens to hold the
+/// image, the gate says "available", the scenario runs against the isolated
+/// home, and admission refuses it there — a setup gap surfacing as a product
+/// failure. Both paths are the same on a developer laptop, so this is visible
+/// only in the isolated configuration the gate exists to serve.
+fn live_home() -> std::path::PathBuf {
+    std::env::var_os("MVM_E2E_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from(mvm_core::config::mvm_home()))
 }
 
 /// Whether a prebuilt guest-binary directory was named and exists.

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -190,7 +190,18 @@ fn home_dir() -> String {
 /// Cache directory for build artifacts, images, VM runtime state:
 /// `<mvm_home>/cache`.
 pub fn mvm_cache_dir() -> String {
-    format!("{}/cache", mvm_home())
+    mvm_cache_dir_at(mvm_home()).to_string_lossy().into_owned()
+}
+
+/// Cache directory beneath an explicit mvm home: `<mvm_home>/cache`.
+///
+/// The pure variant of [`mvm_cache_dir`], for a caller holding an already
+/// resolved or isolated root rather than the one this process's `MVM_HOME`
+/// names. A harness that probes the home its subject will run against needs
+/// this: resolving its own home instead would report on a directory the
+/// subject never reads.
+pub fn mvm_cache_dir_at(mvm_home: impl AsRef<std::path::Path>) -> std::path::PathBuf {
+    mvm_home.as_ref().join("cache")
 }
 
 /// The cache directory of the *default* root (`$HOME/.mvm/cache`),
@@ -1699,6 +1710,17 @@ mod tests {
         }
 
         env.remove("MVM_HOME");
+    }
+
+    #[test]
+    fn mvm_cache_dir_at_uses_an_explicit_isolated_home() {
+        // The ambient `mvm_cache_dir()` reads this process's `MVM_HOME`. A
+        // caller probing a home it was handed — a harness checking the home
+        // its subject runs against — must not get this process's instead.
+        assert_eq!(
+            mvm_cache_dir_at("/isolated/mvm"),
+            std::path::PathBuf::from("/isolated/mvm/cache")
+        );
     }
 
     #[test]


### PR DESCRIPTION
The capability gates resolve `mvm_core::config`'s ambient helpers, which read `MVM_HOME`. The e2e runner exports `MVM_E2E_HOME` and leaves `MVM_HOME` alone, so `sdk_sidecar_cached()` read the default home while every live step ran `mvmctl` against the isolated one.

Where the default home happens to hold a built sidecar — any box a source checkout has ever built on — the gate reported "available", the two `@sdk_sidecar` scenarios ran, and admission correctly refused them in the isolated home that had no image. A setup gap surfaced as two product failures, in exactly the isolated configuration the gate exists to serve. On a laptop where both paths are the same directory it is invisible.

## Change

- New `mvm_core::config::mvm_cache_dir_at`, matching the existing `vms_dir_at` / `vm_state_dir_at` convention. `mvm_cache_dir()` now delegates to it, so there is one definition of the layout.
- The directory walk moves to `mvm_conformance::sidecar_image_cached_in`, where it is unit-testable, and the probe reuses `SDK_SIDECAR_CACHE_DIR` / `SDK_SIDECAR_IMAGE_FILE` instead of re-spelling both strings.
- `live_home()` resolves `MVM_E2E_HOME` first, falling back to the ambient home.

## Tests

Three for the walk, including the case that made the gate lie — a version directory present with no image — plus one for `mvm_cache_dir_at`.

## Evidence

Found by the Linux e2e re-run on the KVM box: 2 of 14 failures were this.