### PR TITLE
fix(guest): mount devpts so an interactive console can open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3117,6 +3117,7 @@ dependencies = [
  "mvm-sdk",
  "mvm-vmm",
  "mvmctl",
+ "nix 0.29.0",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/crates/mvm-agentd/src/guest_bootstrap.rs
+++ b/crates/mvm-agentd/src/guest_bootstrap.rs
@@ -101,6 +101,7 @@ fn report_read_only_skips() {
 pub fn provision_guest_environment() -> Result<(), EgressClientMissing> {
     provision_hostname();
     ensure_runtime_dirs();
+    provision_pty_devices();
     provision_workload_identity();
     mount_mediated_tools();
     provision_egress_ca();
@@ -113,6 +114,35 @@ pub fn provision_guest_environment() -> Result<(), EgressClientMissing> {
     }
     report_read_only_skips();
     Ok(())
+}
+
+/// Make `/dev` complete enough for a shell.
+///
+/// Two gaps, both from the same cause: devtmpfs creates device nodes and
+/// nothing else, and this guest runs no udev, no mdev and no
+/// systemd-tmpfiles to fill in the rest.
+///
+/// Without the `devpts` mount `openpty(3)` has no slave filesystem to
+/// allocate from, so `machine run -it` and `machine console` fail with
+/// "openpty() failed" — a message that names the call and not the missing
+/// mount. Without the `/dev/fd` family bash process substitution fails with
+/// "/dev/fd/63: No such file or directory".
+///
+/// Both are loud on failure and neither is fatal: a non-interactive workload
+/// needs neither, and refusing to boot over a PTY it will never open would
+/// turn a degraded shell into a dead machine. Reported directly rather than
+/// through [`note_optional_step`] because both land on devtmpfs — a read-only
+/// image root is not an explanation here, so the failure is real either way.
+fn provision_pty_devices() {
+    if let Err(e) = crate::guest_mount::mount_pty_filesystem() {
+        eprintln!(
+            "mvm-guest-init: devpts not mounted at /dev/pts ({e}); \
+             interactive console sessions will fail at openpty()"
+        );
+    }
+    for failure in crate::guest_mount::link_dev_fd_family() {
+        eprintln!("mvm-guest-init: /dev symlink not created: {failure}");
+    }
 }
 
 /// Give the workload a home it owns and a name for its uid.

--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -535,6 +535,104 @@ pub fn ensure_workload_home() -> Result<()> {
     Ok(())
 }
 
+/// Where the pseudo-terminal slave filesystem is mounted.
+pub const DEVPTS_MOUNT_POINT: &str = "/dev/pts";
+
+/// Standard tty-group layout for the slave nodes `devpts` hands out.
+///
+/// `gid=5` is the `tty` group and `mode=0620` is what every distro's
+/// `/etc/fstab` uses; a shell that wants `mesg y` needs both.
+pub const DEVPTS_OPTIONS: &str = "mode=0620,gid=5";
+
+/// Symlinks the guest needs under `/dev` that no filesystem provides.
+///
+/// devtmpfs creates device *nodes*; the `/dev/fd` family are symlinks into
+/// `/proc/self/fd` that udev or systemd-tmpfiles would normally lay down, and
+/// this guest runs neither. Without them bash process substitution
+/// (`< <(...)`) fails with "/dev/fd/63: No such file or directory" and
+/// anything opening `/dev/stdout` by name fails the same way.
+pub const DEV_FD_SYMLINKS: &[(&str, &str)] = &[
+    ("/proc/self/fd", "/dev/fd"),
+    ("/proc/self/fd/0", "/dev/stdin"),
+    ("/proc/self/fd/1", "/dev/stdout"),
+    ("/proc/self/fd/2", "/dev/stderr"),
+];
+
+/// Mount the pseudo-terminal slave filesystem an interactive console needs.
+///
+/// `openpty(3)` opens `/dev/ptmx` and then the slave the kernel allocated for
+/// it at `/dev/pts/N`. devtmpfs supplies the `ptmx` node but not the slave
+/// filesystem, so with `/dev/pts` an empty directory every `ConsoleOpen`
+/// request — `machine run -it`, `machine console` — dies at `openpty()`, and
+/// the caller is told only "openpty() failed".
+///
+/// Runs after the pivot, so the mount lands on the `/dev` the workload will
+/// actually see, and before the privilege drop, which is the last moment root
+/// is available to make it. The slave node is owned by whoever opened the
+/// master, so the unprivileged workload still gets a usable PTY.
+#[cfg(target_os = "linux")]
+pub fn mount_pty_filesystem() -> Result<()> {
+    if devpts_is_mounted(&std::fs::read_to_string("/proc/mounts").unwrap_or_default()) {
+        // A shared-kernel container runtime mounted it for the namespace and
+        // took CAP_SYS_ADMIN away afterwards; mounting again would fail for a
+        // reason that is not a defect.
+        return Ok(());
+    }
+    ensure_dir(DEVPTS_MOUNT_POINT)?;
+    mount(
+        "devpts",
+        DEVPTS_MOUNT_POINT,
+        "devpts",
+        libc::MS_NOSUID | libc::MS_NOEXEC,
+        DEVPTS_OPTIONS,
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn mount_pty_filesystem() -> Result<()> {
+    Ok(())
+}
+
+/// Whether `/proc/mounts` already shows a `devpts` at [`DEVPTS_MOUNT_POINT`].
+///
+/// Split from the mount so the container arm is testable without a guest:
+/// that arm is the only one a host test can never reach through the syscall.
+#[must_use]
+#[cfg(any(target_os = "linux", test))]
+pub(crate) fn devpts_is_mounted(mounts: &str) -> bool {
+    mounts.lines().any(|line| {
+        let mut fields = line.split_whitespace();
+        let (Some(_dev), Some(target), Some(fstype)) =
+            (fields.next(), fields.next(), fields.next())
+        else {
+            return false;
+        };
+        target == DEVPTS_MOUNT_POINT && fstype == "devpts"
+    })
+}
+
+/// Lay down the [`DEV_FD_SYMLINKS`], reporting each one that could not be made.
+///
+/// Best-effort by construction: `/dev` is devtmpfs and writable on every guest
+/// that reaches here, but an image that already ships one of these gets an
+/// `AlreadyExists` that is the desired end state rather than a failure.
+pub fn link_dev_fd_family() -> Vec<String> {
+    let mut failures = Vec::new();
+    for (target, link) in DEV_FD_SYMLINKS {
+        if Path::new(link).exists() {
+            continue;
+        }
+        // `AlreadyExists` lost the race with something else creating it, which
+        // is the desired end state and not a failure.
+        if let Err(e) = std::os::unix::fs::symlink(target, link)
+            && e.kind() != std::io::ErrorKind::AlreadyExists
+        {
+            failures.push(format!("{link} -> {target}: {e}"));
+        }
+    }
+    failures
+}
+
 /// Lay a writable tmpfs over the workload's home.
 ///
 /// Every workload root is mounted read-only, so the baked-in home is an empty
@@ -1580,6 +1678,168 @@ mod tests {
         assert!(
             body.contains("uid={WORKLOAD_UID}"),
             "the workload must own its home: {body}"
+        );
+    }
+
+    /// `openpty(3)` needs the slave filesystem, not just the `ptmx` node.
+    ///
+    /// devtmpfs gives `/dev/ptmx` and the empty `/dev/pts` directory the image
+    /// happens to ship, which together look like a working PTY setup and are
+    /// not one: every `ConsoleOpen` fails at `openpty()` with no indication
+    /// that a mount is missing. `mount_pty_filesystem` must therefore mount
+    /// `devpts` — creating the directory is what the broken version did.
+    #[test]
+    fn the_pty_filesystem_is_mounted_not_merely_created() {
+        let src = include_str!("guest_mount.rs");
+        let body = src
+            .split("pub fn mount_pty_filesystem")
+            .nth(1)
+            .expect("mount_pty_filesystem must exist")
+            .split("\n#[cfg(not(target_os = \"linux\"))]")
+            .next()
+            .expect("the Linux arm is delimited by the non-Linux one");
+        assert!(
+            body.contains("mount(") && body.contains("\"devpts\""),
+            "a PTY comes from a devpts mount, not from mkdir: {body}"
+        );
+        let created = body
+            .find("ensure_dir(DEVPTS_MOUNT_POINT)")
+            .expect("the mount point must be created before it is mounted onto");
+        let mounted = body.find("mount(").expect("checked above");
+        assert!(created < mounted, "ensure_dir must precede the mount");
+    }
+
+    /// The tty-group layout the slave nodes are handed out with.
+    #[test]
+    fn devpts_uses_the_standard_tty_group_layout() {
+        assert_eq!(DEVPTS_MOUNT_POINT, "/dev/pts");
+        assert!(DEVPTS_OPTIONS.contains("mode=0620"));
+        assert!(DEVPTS_OPTIONS.contains("gid=5"));
+    }
+
+    /// A container runtime already mounted it, and took away the capability
+    /// to mount it again. Skipping is correct there and only there.
+    #[test]
+    fn an_existing_devpts_mount_is_recognised_and_not_remounted() {
+        let mounted = "\
+devtmpfs /dev devtmpfs rw,nosuid,relatime 0 0
+devpts /dev/pts devpts rw,nosuid,noexec,relatime,mode=620,gid=5 0 0
+";
+        assert!(devpts_is_mounted(mounted));
+    }
+
+    /// The empty directory is exactly the state that produced the bug, so a
+    /// probe that cannot tell it from a mount would skip the fix forever.
+    #[test]
+    fn a_dev_pts_directory_without_a_mount_is_not_a_mount() {
+        // devtmpfs carries /dev/pts as a plain directory: nothing in
+        // /proc/mounts names it, which is what this must report.
+        let unmounted = "\
+devtmpfs /dev devtmpfs rw,nosuid,relatime 0 0
+tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0
+";
+        assert!(!devpts_is_mounted(unmounted));
+        // A devpts mounted somewhere else is not this mount either.
+        let elsewhere = "devpts /mnt/root/dev/pts devpts rw,relatime 0 0\n";
+        assert!(!devpts_is_mounted(elsewhere));
+        // Nor is some other filesystem sitting on the mount point.
+        let wrong_fs = "tmpfs /dev/pts tmpfs rw,relatime 0 0\n";
+        assert!(!devpts_is_mounted(wrong_fs));
+    }
+
+    /// The `/dev/fd` family points into `/proc/self/fd` and nowhere else.
+    #[test]
+    fn the_dev_fd_family_resolves_through_proc_self_fd() {
+        let links: Vec<&str> = DEV_FD_SYMLINKS.iter().map(|(_, link)| *link).collect();
+        assert_eq!(
+            links,
+            ["/dev/fd", "/dev/stdin", "/dev/stdout", "/dev/stderr"]
+        );
+        for (target, link) in DEV_FD_SYMLINKS {
+            assert!(
+                target.starts_with("/proc/self/fd"),
+                "{link} must resolve through /proc/self/fd, not {target}"
+            );
+        }
+    }
+
+    // The two tests below assert how `guest_bootstrap` wires this module's
+    // mount into the boot path. They live here rather than beside that code
+    // because `mvm_agentd::guest_bootstrap` is `cfg(target_os = "linux")`, so
+    // its own test module is invisible on the macOS hosts most of this is
+    // developed on — which is where the missing mount would have been caught.
+    // Both read source text and need no guest.
+
+    /// The PTY mount has to be one of the provisioning steps, not something a
+    /// single init does on its way past.
+    ///
+    /// It shipped missing entirely — `ensure_runtime_dirs` created `/dev/pts`
+    /// and nothing ever mounted onto it — so `machine run -it` failed at
+    /// `openpty()` on every OCI image. `guest_bootstrap` exists so a step
+    /// cannot be quietly lost; this is that guarantee for this step.
+    #[test]
+    fn the_pty_filesystem_is_provisioned_before_the_workload_identity() {
+        let steps = provisioning_steps();
+        let dirs = steps
+            .iter()
+            .position(|s| s == "ensure_runtime_dirs()")
+            .expect("the runtime directories must still be created");
+        let pty = steps
+            .iter()
+            .position(|s| s == "provision_pty_devices()")
+            .expect(
+                "devpts must be mounted during provisioning, or every \
+                 interactive console fails at openpty()",
+            );
+        assert!(
+            dirs < pty,
+            "/dev/pts must exist before devpts is mounted onto it: {steps:?}"
+        );
+    }
+
+    /// The calls `provision_guest_environment` actually makes, in order.
+    ///
+    /// Comment lines are dropped first. A plain substring search over the
+    /// function body matches `// provision_pty_devices();` just as happily as
+    /// the call, so commenting the step out — the exact shape of losing it —
+    /// left the test green.
+    fn provisioning_steps() -> Vec<String> {
+        let src = include_str!("guest_bootstrap.rs");
+        let body = src
+            .split("pub fn provision_guest_environment")
+            .nth(1)
+            .expect("provision_guest_environment must exist")
+            .split("\n}")
+            .next()
+            .expect("the function body ends at the first closing brace");
+        body.lines()
+            .map(str::trim)
+            .filter(|line| !line.starts_with("//"))
+            .filter_map(|line| line.strip_suffix(';'))
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Provisioning runs between the pivot and the privilege drop, and both
+    /// bounds matter: before the pivot the mount lands on a `/dev` the
+    /// workload never sees, and after the drop there is no CAP_SYS_ADMIN left
+    /// to mount with.
+    #[test]
+    fn provisioning_runs_after_the_pivot_and_before_the_privilege_drop() {
+        let init = include_str!("bin/mvm-guest-agent/init.rs");
+        let pivot = init
+            .find("pivot_to_root(")
+            .expect("activation must still pivot into the workload root");
+        let bootstrap = init
+            .find("bootstrap_guest_environment()?")
+            .expect("activation must still run the provisioning steps");
+        let drop = init
+            .find("drop_guest_agent_privilege(")
+            .expect("activation must still drop privilege");
+        assert!(pivot < bootstrap, "provisioning must follow the pivot");
+        assert!(
+            bootstrap < drop,
+            "provisioning must finish while root is still available"
         );
     }
 

--- a/crates/mvm-conformance/Cargo.toml
+++ b/crates/mvm-conformance/Cargo.toml
@@ -101,6 +101,14 @@ mvm-cli = { workspace = true, features = ["builder-vm", "pure-mkfs"] }
 # cannot be type-checked at all. Dev-only.
 mvm-sdk.workspace = true
 mvmctl = { path = "../..", default-features = false }
+# Allocates a host PTY for the interactive-console scenario. `mvmctl -t`
+# refuses without a terminal on stdin, so a scenario driven through
+# `Command::output()` — piped stdin — can never reach the guest's `openpty()`
+# at all, which is why an interactive console that failed on every OCI image
+# had no lane that could see it. `nix` is already in the workspace at this
+# version for five shipped crates; only the `term` feature is new, and it is
+# dev-only here.
+nix = { version = "0.29", features = ["term"] }
 
 [lints]
 workspace = true

--- a/crates/mvm-conformance/tests/steps/launch_e2e.rs
+++ b/crates/mvm-conformance/tests/steps/launch_e2e.rs
@@ -204,6 +204,127 @@ fn launch_with_env(world: &mut CliWorld, args: String, key: String, value: Strin
     world.last_launch = Some(run_in_e2e_home(&args, &[(&key, &value)]));
 }
 
+/// How long an interactive launch is given before the PTY read is abandoned.
+///
+/// Generous on purpose: this is a real cold boot on whatever backend the host
+/// has, and a timeout that fires early would report a slow machine as a broken
+/// console. Nothing hangs on it in the passing case — the read ends when the
+/// child closes the PTY.
+const INTERACTIVE_LAUNCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(240);
+
+/// Run `mvmctl` with a real terminal on its stdin.
+///
+/// `-t`/`--tty` refuses outright without one — "interactive `-t`/`--tty` needs
+/// a terminal on stdin" — so every other step in this file, which drives
+/// `Command::output()` over piped stdin, stops at the CLI before the guest is
+/// ever asked to open a console. That is exactly why a guest whose `openpty()`
+/// failed on every OCI image passed this suite.
+///
+/// The child gets the PTY slave on all three descriptors and the parent keeps
+/// the master, reading until EOF. stdout and stderr are the same stream on a
+/// terminal, which is what a terminal is; the record carries the combined
+/// bytes in `stdout` and leaves `stderr` empty.
+fn run_interactive_in_e2e_home(args: &str) -> LaunchRecord {
+    use std::io::Read;
+    use std::os::fd::{AsRawFd, OwnedFd};
+    use std::process::Stdio;
+
+    let pty =
+        nix::pty::openpty(None, None).expect("allocate a host PTY for the interactive launch");
+    let (master, slave): (OwnedFd, OwnedFd) = (pty.master, pty.slave);
+
+    let home = e2e_home();
+    let mut command: Command = mvmctl_command();
+    command
+        .current_dir(workspace_root())
+        .args(shell_split(args))
+        .isolated_home(&home)
+        .env("MVM_PHASE_TIMING", "1")
+        // A terminal the guest shell can actually address. Without it the
+        // shell falls back to `dumb` and some images print nothing at all,
+        // which would read as a console failure.
+        .env("TERM", "xterm")
+        .stdin(Stdio::from(
+            slave.try_clone().expect("dup the PTY slave for stdin"),
+        ))
+        .stdout(Stdio::from(
+            slave.try_clone().expect("dup the PTY slave for stdout"),
+        ))
+        .stderr(Stdio::from(slave));
+
+    let started = Instant::now();
+    let mut child = command.spawn().expect("failed to spawn mvmctl on a PTY");
+    // The parent's copy of the slave is gone once `command` is dropped; only
+    // the child holds one. Without that the master never sees EOF and the read
+    // below blocks for the full timeout on a *successful* run.
+    drop(command);
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let master_fd = master.as_raw_fd();
+    std::thread::spawn(move || {
+        // SAFETY: `master_fd` is the live PTY master owned by `master` in the
+        // parent frame, which outlives this read: the frame joins on `rx`
+        // before dropping it.
+        let mut reader =
+            unsafe { <std::fs::File as std::os::fd::FromRawFd>::from_raw_fd(master_fd) };
+        let mut buf = Vec::new();
+        // EIO is how a PTY master reports "the last slave closed" on Linux,
+        // and it arrives instead of EOF. Whatever was read before it is the
+        // session's output, not an error.
+        let _ = reader.read_to_end(&mut buf);
+        std::mem::forget(reader);
+        let _ = tx.send(buf);
+    });
+
+    let combined = rx
+        .recv_timeout(INTERACTIVE_LAUNCH_TIMEOUT)
+        .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+        .unwrap_or_else(|_| {
+            let _ = child.kill();
+            String::new()
+        });
+    let status = child.wait().expect("wait for the interactive mvmctl");
+    let wall = started.elapsed();
+    drop(master);
+
+    let dispatch_window_ms = parse_dispatch_window_ms(&combined);
+    LaunchRecord {
+        stdout: combined,
+        stderr: String::new(),
+        exit_code: status.code().unwrap_or(-1),
+        dispatch_window_ms,
+        wall,
+    }
+}
+
+#[when(expr = "I launch {string} on a terminal")]
+fn launch_on_a_terminal(world: &mut CliWorld, args: String) {
+    world.last_launch = Some(run_interactive_in_e2e_home(&args));
+}
+
+/// The guest's controlling terminal must be a `devpts` slave.
+///
+/// `tty` printing `/dev/pts/N` is the whole claim: it means `openpty()` found
+/// the slave filesystem, which is the mount whose absence produced "console
+/// open failed: openpty() failed" on every OCI image. `not a tty` is the
+/// answer when the console was never allocated, and a bare path check would
+/// accept it.
+#[then(expr = "the guest console is a pseudo-terminal")]
+fn guest_console_is_a_pty(world: &mut CliWorld) {
+    let record = last(world);
+    let output = record.combined();
+    assert!(
+        output.contains("/dev/pts/"),
+        "the guest's controlling terminal must be a devpts slave (`/dev/pts/N`), \
+         which is what proves the guest mounted devpts and openpty() succeeded. \
+         Got:\n{output}"
+    );
+    assert!(
+        !output.contains("openpty() failed"),
+        "the guest could not allocate a PTY: {output}"
+    );
+}
+
 fn last(world: &CliWorld) -> &LaunchRecord {
     world
         .last_launch

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -36,6 +36,45 @@ Feature: every README-documented CLI launch mode boots a real guest
     And the guest printed "ari"
     And the guest control plane came up
 
+  # The `-it` shape from the README, and the one every scenario above was
+  # structurally unable to reach: `-t` refuses without a terminal on stdin, so
+  # a suite driving `Command::output()` stops at the CLI's own gate and never
+  # asks the guest for a console. `openpty()` failed on every OCI image for as
+  # long as that was true.
+  #
+  # `tty` is asserted rather than just the echo: a console that was never
+  # allocated still runs the command and still prints, so only the `/dev/pts/N`
+  # answer distinguishes a real PTY from a pipe.
+  @live
+  Scenario: an interactive run gets a real pseudo-terminal in the guest
+    When I launch "machine run --image alpine -it -- /bin/sh -c 'tty; echo console-ok'" on a terminal
+    Then the launch succeeds
+    And the guest console is a pseudo-terminal
+    And the guest printed "console-ok"
+    And the guest control plane came up
+
+  # The same defect stated as the mount it actually is, on the non-interactive
+  # path so it runs on a host with no terminal to give — a CI runner, or this
+  # suite under `just bdd`. devtmpfs supplies /dev/ptmx and the image supplies
+  # an empty /dev/pts directory, which together look like a working PTY setup
+  # and are not one; only /proc/mounts tells them apart.
+  @live
+  Scenario: the guest mounts devpts so a console can be opened
+    When I launch "machine run --image alpine -- sh -c 'grep /dev/pts /proc/mounts'"
+    Then the launch succeeds
+    And the guest printed "devpts /dev/pts devpts"
+    And the guest control plane came up
+
+  # The other half of what devtmpfs does not create. bash process substitution
+  # (`< <(...)`) opens /dev/fd/N, and a guest running no udev has no such
+  # symlink unless PID 1 lays it down.
+  @live
+  Scenario: the /dev/fd family resolves in the guest
+    When I launch "machine run --image alpine -- sh -c 'readlink /dev/fd && readlink /dev/stdout'"
+    Then the launch succeeds
+    And the guest printed "/proc/self/fd"
+    And the guest control plane came up
+
   @live
   Scenario: --mount shares a host directory the workload can read
     When I launch "machine run --image alpine --mount .:/work -- ls /work/README.md"

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -46,7 +46,17 @@ export MVM_EMBED_NO_CACHE="e2e-$(date +%s)"
 
 # Floor on scenarios that must actually execute. See the assertion after the
 # cucumber run for why a count, not just an exit status.
-MIN_SCENARIOS=17
+#
+# EXECUTED, not authored. The suite has 20 scenarios and one of them — the
+# launch-budget threshold — is gated on `MVM_BDD_PERF_BUDGET=1`, so 19 run on a
+# host that does not set it and 20 on one that does. A floor set from the
+# authored count fails everywhere the gated scenario is skipped, which is why
+# this number is 19 and not 20.
+#
+# It was 17 against an authored count of 17, so it had the same defect and had
+# simply never been reached: `pipefail` fails the cucumber pipeline the moment
+# any scenario fails, and the floor is only checked after a fully green run.
+MIN_SCENARIOS=19
 SCENARIO_LOG="$(mktemp -t mvm-e2e-scenarios)"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -179,6 +179,16 @@ for detailed scope and acceptance criteria.
       missing-state behavior. See
       `specs/sprint/delivery/2824-stopped-vm-logs-error.md`.
 
+- [x] **Guest devpts and `/dev/fd` provisioning.** The universal-initramfs boot
+      path created `/dev/pts` and never mounted `devpts` onto it, so `openpty()`
+      failed for every `ConsoleOpen` and no OCI image could serve
+      `machine run -it` or `machine console`. PID 1 now mounts `devpts` and
+      links the `/dev/fd` family between the pivot and the privilege drop,
+      loudly but non-fatally, skipping a mount a container runtime already made.
+      A PTY-driven `@live` scenario reaches the interactive path the suite's
+      piped-stdin steps structurally could not. See
+      `specs/sprint/delivery/guest-devpts-interactive-console.md`.
+
 - [x] **Transient start console diagnostics.** A transient backend-start
       failure now prints the guest console diagnostic before deleting the
       machine state directory, preserving the guest-side cause while retaining

--- a/specs/sprint/delivery/guest-devpts-interactive-console.md
+++ b/specs/sprint/delivery/guest-devpts-interactive-console.md
@@ -1,0 +1,126 @@
+# The guest never mounted devpts, so no OCI image could open a console
+
+`mvmctl machine run --image rust -it -- /bin/bash` failed with:
+
+```
+Error: guest agent returned error: console open failed: openpty() failed
+```
+
+`openpty(3)` opens `/dev/ptmx` and then the slave the kernel allocated for it
+at `/dev/pts/N`. devtmpfs supplies the `ptmx` node; it does not supply the
+slave filesystem. The universal-initramfs boot path created `/dev/pts` as a
+directory in `ensure_runtime_dirs` and never mounted `devpts` onto it, so every
+`ConsoleOpen` request — `machine run -it` and `machine console` alike — died at
+`openpty()` on every OCI image.
+
+The empty directory is what made it survive: `/dev/ptmx` present plus
+`/dev/pts` present reads as a working PTY setup at a glance, and only
+`/proc/mounts` tells the two apart. Confirmed on a live guest before the fix:
+
+```
+$ mvmctl machine run --image alpine -- cat /proc/mounts
+proc /proc proc ...
+sysfs /sys sysfs ...
+devtmpfs /dev devtmpfs ...
+tmpfs /run tmpfs ...
+tmpfs /tmp tmpfs ...
+        # no devpts anywhere
+```
+
+## The same gap, two other places, already fixed
+
+`nix/lib/mk-guest.nix` and `mvm-host-vm-init`'s `mount_pseudofs` both mount
+devpts, and both carry a comment saying the block is kept symmetric with the
+other. `guest_mount.rs` is the third side of that symmetry and was never
+brought into it — the flake-built guests and the builder VM had the mount, and
+only the universal-initramfs path (which is what `--image` boots) did not.
+
+The `/dev/fd` family — `/dev/fd`, `/dev/stdin`, `/dev/stdout`, `/dev/stderr`
+symlinked into `/proc/self/fd` — was missing from that path for the same
+reason, and is fixed in the same function. Nothing creates them here: devtmpfs
+makes device nodes, and this guest runs no udev, no mdev and no
+systemd-tmpfiles. Without them bash process substitution fails with
+`/dev/fd/63: No such file or directory`.
+
+## Where it runs
+
+`provision_pty_devices` is a step in `provision_guest_environment`, between the
+pivot and the privilege drop. Both bounds matter: before the pivot the mount
+lands on a `/dev` the workload never sees, and after the drop there is no
+CAP_SYS_ADMIN left to mount with. A test asserts both.
+
+Failure is loud but not fatal. A non-interactive workload needs neither the PTY
+nor the symlinks, and refusing to boot over a console it will never open would
+turn a degraded shell into a dead machine. It is reported directly rather than
+through `note_optional_step`, which suppresses on a read-only rootfs: both land
+on devtmpfs, so a sealed image is not an explanation here and the failure is
+real either way.
+
+A container runtime that already mounted devpts for the namespace, and took
+CAP_SYS_ADMIN away afterwards, is recognised from `/proc/mounts` and skipped.
+
+## Why no test caught this
+
+The launch-modes suite covers `machine run --image alpine -- <cmd>` in a dozen
+shapes and could not reach this one. `-t`/`--tty` refuses without a terminal on
+stdin — "interactive `-t`/`--tty` needs a terminal on stdin" — and every step in
+that suite drives `Command::output()`, which pipes stdin. The suite stopped at
+the CLI's own gate and never asked a guest for a console. There was no
+interactive scenario because there was no way to write one.
+
+Three scenarios close it, in `s31_launch_e2e/cli_launch_modes.feature`:
+
+- **an interactive run gets a real pseudo-terminal in the guest** — the actual
+  `-it` shape, driven through a host PTY allocated by a new
+  `I launch {string} on a terminal` step. Asserts the guest's `tty` answers
+  `/dev/pts/N`; a console that was never allocated still runs the command and
+  still prints, so only that answer distinguishes a PTY from a pipe.
+- **the guest mounts devpts so a console can be opened** — the same defect as
+  the mount it is, on the non-interactive path, so it runs on a host with no
+  terminal to give.
+- **the /dev/fd family resolves in the guest**.
+
+`scripts/e2e-launch-modes.sh`'s `MIN_SCENARIOS` floor goes 17 → 20.
+
+The unit tests are source-text assertions in `guest_mount.rs` rather than in
+`guest_bootstrap.rs`, where they belong by subject: that module is
+`cfg(target_os = "linux")`, so its tests never run on the macOS hosts this is
+mostly developed on — which is where the missing mount would have been caught.
+
+One of those tests initially passed with the fix commented out: a substring
+search over the function body matched `// provision_pty_devices();` as happily
+as the call, which is the exact shape of losing the step. It now parses
+statement lines with comments stripped, and goes red when the call is removed
+or commented.
+
+## Verified live
+
+macOS 26 / HVF, `--image alpine` and `--image rust`:
+
+```
+$ mvmctl machine run --image alpine -- sh -c 'grep /dev/pts /proc/mounts; readlink /dev/fd'
+devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
+/proc/self/fd
+
+$ script -q /dev/null mvmctl machine run --image rust --env NAME=ari \
+    --mount $PWD:/work -it -- /bin/bash -c 'tty; echo NAME=$NAME; ls /work/Cargo.toml'
+/dev/pts/0
+NAME=ari
+/work/Cargo.toml
+```
+
+## The gate's own floor was unreachable
+
+`scripts/e2e-launch-modes.sh` asserts a minimum count of scenarios actually
+executed, so that a glob matching nothing cannot pass as a green gate. It was
+set to 17 against an authored count of 17 — but one scenario, the launch-budget
+threshold, is gated on `MVM_BDD_PERF_BUDGET=1`, so only 16 ever ran on a host
+without it and the floor could never be met there.
+
+It had never fired, because it is only reached after a fully green cucumber
+run: `pipefail` fails the pipeline as soon as any scenario fails, and the
+script exits before the check. The first all-green run on this host is what
+surfaced it.
+
+The floor is now 19 — the executed count, not the authored one — and the
+comment says which of the two it is.


### PR DESCRIPTION
## The bug

```
$ mvmctl machine run --image rust --env NAME=ari --mount $PWD:/work -it -- /bin/bash
Error: guest agent returned error: console open failed: openpty() failed
```

`openpty(3)` opens `/dev/ptmx` and then the slave the kernel allocated for it at
`/dev/pts/N`. devtmpfs supplies the `ptmx` node; it does not supply the slave
filesystem. The universal-initramfs boot path created `/dev/pts` as a directory
in `ensure_runtime_dirs` and never mounted `devpts` onto it, so every
`ConsoleOpen` request — `machine run -it` and `machine console` alike — died at
`openpty()` on every OCI image.

The empty directory is what let it survive: `/dev/ptmx` present plus `/dev/pts`
present reads as a working PTY setup at a glance, and only `/proc/mounts` tells
the two apart. Confirmed on a live guest before the fix — no `devpts` line
anywhere in the mount table.

`nix/lib/mk-guest.nix` and `mvm-host-vm-init`'s `mount_pseudofs` both mount
devpts, and both carry a comment saying the block is kept symmetric with the
other. `guest_mount.rs` is the third side of that symmetry and was never brought
into it, so the flake-built guests and the builder VM had the mount and only the
path `--image` actually boots did not.

The `/dev/fd` family was missing from the same path for the same reason —
devtmpfs makes device nodes, and this guest runs no udev, mdev or
systemd-tmpfiles — so bash process substitution failed with `/dev/fd/63: No such
file or directory`. Fixed in the same step.

## Where it runs

`provision_pty_devices` sits in `provision_guest_environment`, between the pivot
and the privilege drop. Both bounds matter: earlier and the mount lands on a
`/dev` the workload never sees, later and there is no `CAP_SYS_ADMIN` left to
mount with. A test asserts both.

Loud on failure but not fatal — a non-interactive workload needs neither the PTY
nor the symlinks, and refusing to boot over a console it will never open would
turn a degraded shell into a dead machine. Reported directly rather than through
`note_optional_step`, which suppresses on a read-only rootfs: both land on
devtmpfs, so a sealed image is not an explanation here. A container runtime that
already mounted devpts and then dropped `CAP_SYS_ADMIN` is recognised from
`/proc/mounts` and skipped.

## Why nothing caught it

The launch-modes suite covers `machine run --image alpine -- <cmd>` in a dozen
shapes and was structurally unable to reach this one. `-t`/`--tty` refuses
without a terminal on stdin, and every step in that suite drives
`Command::output()`, which pipes stdin — so the suite stopped at the CLI's own
gate and never asked a guest for a console. There was no interactive scenario
because there was no way to write one.

A new `I launch {string} on a terminal` step allocates a host PTY and gives the
child the slave on all three descriptors. Three `@live` scenarios:

- **an interactive run gets a real pseudo-terminal in the guest** — the actual
  `-it` shape. Asserts the guest's `tty` answers `/dev/pts/N`; a console that was
  never allocated still runs the command and still prints, so only that answer
  distinguishes a PTY from a pipe.
- **the guest mounts devpts so a console can be opened** — the same defect as the
  mount it is, on the non-interactive path, so it runs where there is no terminal
  to give.
- **the /dev/fd family resolves in the guest**.

The unit tests live in `guest_mount.rs` rather than beside the code they describe
in `guest_bootstrap.rs`: that module is `cfg(target_os = "linux")`, so its tests
never run on the macOS hosts this is mostly developed on — which is where the
missing mount would have been caught. One of them initially passed with the fix
commented out, because a substring search over the function body matched
`// provision_pty_devices();` as happily as the call. It now parses statement
lines with comments stripped, and goes red when the step is removed or commented.

## The gate's own floor was unreachable

`scripts/e2e-launch-modes.sh` asserts a minimum count of scenarios actually
executed, so a glob matching nothing cannot pass as a green gate. It was 17
against an authored count of 17 — but one scenario is gated on
`MVM_BDD_PERF_BUDGET=1`, so only 16 ever ran without it. It had never fired,
because it is only reached after a fully green cucumber run and `pipefail` exits
the script first on any red one. Now 19: the executed count, with a comment
saying which of the two it is.

## Verification

macOS 26 / HVF, against a live guest:

```
$ mvmctl machine run --image alpine -- sh -c 'grep /dev/pts /proc/mounts; readlink /dev/fd'
devpts /dev/pts devpts rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000 0 0
/proc/self/fd

$ script -q /dev/null mvmctl machine run --image rust --env NAME=ari \
    --mount $PWD:/work -it -- /bin/bash -c 'tty; echo NAME=$NAME; ls /work/Cargo.toml'
/dev/pts/0
NAME=ari
/work/Cargo.toml
```

- `just e2e-launch` — **19/19 scenarios, 108/108 steps, exit 0**
- `cargo nextest run --workspace` — 12655/12656. The one failure,
  `mvm-vmm host::linux_env::tests::dev_vm_connects_via_libkrun_per_port_socket`,
  fails identically on unmodified `main` (a vsock socket-path assertion) and is
  untouched by this change.
- `cargo test --workspace --doc`, `cargo fmt --all --check`,
  `cargo clippy --workspace --all-targets -D warnings`, `just check-gated`,
  `cargo run -p xtask -- check-all` (61 gates) — all clean.