### PR TITLE
test(vmm): resolve portable dev VM socket path

### DIFF
--- a/crates/mvm-vmm/src/host/linux_env.rs
+++ b/crates/mvm-vmm/src/host/linux_env.rs
@@ -413,10 +413,10 @@ mod tests {
         env.set("HOME", tmp.path());
         env.remove("MVM_HOME");
 
-        // The dev env dials the libkrun dev VM's per-port vsock listener at
-        // `<vm_state_dir>/vsock-<port>.sock` — the same path
-        // `LibkrunTransport::for_vm` resolves, so the flake-build env and the
-        // console can't drift onto different sockets.
+        // The dev env dials the libkrun dev VM's per-port vsock listener in
+        // the canonical socket directory. That directory is normally the VM
+        // state directory and becomes the hashed short namespace when any
+        // socket path would exceed the platform limit.
         let port = mvm_agentd::vsock::GUEST_AGENT_PORT;
         let sock = mvm_core::config::vm_vsock_port_socket(DEV_VM_NAME, port);
         assert!(
@@ -425,7 +425,7 @@ mod tests {
         );
         assert_eq!(
             sock,
-            mvm_core::config::vm_state_dir(DEV_VM_NAME)
+            mvm_core::config::vm_socket_dir(DEV_VM_NAME)
                 .join(mvm_core::config::vsock_socket_filename(port))
         );
     }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -10,6 +10,12 @@ Last updated: 2026-08-28
       structural tests and workspace Clippy are green. Linux Nix builds and
       merge delivery remain.
 
+- [ ] **Portable dev-VM socket resolver test — issue #2973.**
+      `specs/plans/2026-08-28-portable-dev-vm-socket-test.md`.
+      The test now asserts the canonical state-or-short socket namespace; the
+      focused regression, all 598 `mvm-vmm` tests, workspace tests, and
+      workspace Clippy are green. Merge delivery remains.
+
 - [ ] **HVF machine restore dispatch — issue #2961.**
       `specs/plans/2026-08-27-hvf-machine-restore-dispatch.md`.
       The `machine` fork/restore surfaces now share the backend-origin

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -19,6 +19,14 @@
       independently tracked #2973 failure. Linux Nix builds and merge delivery
       remain.
 
+- [ ] **Portable dev-VM socket resolver test — issue #2973.**
+      `specs/plans/2026-08-28-portable-dev-vm-socket-test.md`.
+      The libkrun per-port socket assertion now follows the canonical socket
+      directory resolver, preserving both the normal state-dir arm and the
+      macOS-safe shortened arm. The focused regression, all 598 `mvm-vmm`
+      tests, workspace tests, and workspace Clippy are green; merge delivery
+      remains.
+
 - [ ] **Recorded-backend pause and resume — issue #2929.**
       `specs/plans/2026-08-27-recorded-backend-pause-resume.md`.
       Existing-machine lifecycle operations resolve the VMM that owns the live

--- a/specs/plans/2026-08-28-portable-dev-vm-socket-test.md
+++ b/specs/plans/2026-08-28-portable-dev-vm-socket-test.md
@@ -1,0 +1,23 @@
+# Portable dev-VM socket resolver test
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#2973](https://github.com/tinylabscom/mvm/issues/2973)
+
+## Outcome
+
+The dev-VM libkrun socket test asserts the canonical socket-directory choice
+instead of assuming every host can place Unix sockets beneath the VM state
+directory. It continues to pin the per-port filename while accepting the
+intentional hashed short namespace on deep macOS paths.
+
+## Delivery checklist
+
+- [x] Reproduce the deterministic failure under the stock macOS temporary
+      directory.
+- [x] Update the assertion to the shared state-or-short directory resolver.
+- [x] Pass the focused regression and the full `mvm-vmm` test suite.
+- [x] Pass workspace Clippy, formatting, and repository policy gates.
+- [x] Record the completed implementation in the sprint and refactor rollup.
+- [ ] Merge the tested pull request and close #2973 through its linkage.

--- a/specs/sprint/delivery/2973-portable-dev-vm-socket-test.md
+++ b/specs/sprint/delivery/2973-portable-dev-vm-socket-test.md
@@ -1,0 +1,11 @@
+# Portable dev-VM socket resolver test
+
+- [x] Reproduced the deterministic macOS Unix-socket path assertion.
+- [x] Replaced the state-directory-only expectation with the canonical
+      state-or-short socket-directory resolver.
+- [x] Passed the focused regression and all 598 `mvm-vmm` tests.
+- [x] Passed workspace tests and Clippy; an initial contended doctest compile
+      was green on its immediate isolated rerun.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-08-28-portable-dev-vm-socket-test.md`.


### PR DESCRIPTION
Closes #2973

## Summary
- assert the libkrun per-port socket through the canonical state-or-short socket resolver
- preserve the exact vsock port filename assertion
- record the fix in the active plan, sprint, and refactor rollup

## Validation
- focused macOS regression
- all 598 mvm-vmm tests
- cargo test --workspace (initial contended doctest compile passed on isolated rerun)
- cargo test -p mvm-cli --doc
- cargo clippy --workspace -- -D warnings
- cargo fmt --all -- --check
- sprint append and plan-name gates