### PR TITLE
perf(launch): stop re-verifying the audit chain and sleeping past guest readiness

### DIFF
--- a/crates/mvm-hostd/src/audit/merkle.rs
+++ b/crates/mvm-hostd/src/audit/merkle.rs
@@ -22,15 +22,42 @@
 //! [`verify_audit_chain`](crate::supervisor::verify_audit_chain) accepts.
 //! A tampered, reordered, or truncated chain refuses here rather than
 //! publishing a root that would attest a corrupt log.
+//!
+//! ## What the last root pays for
+//!
+//! Verifying every line from genesis costs `O(all history)`, and a root is
+//! published at every admission — so on a host that has launched a lot, the
+//! boot path was re-verifying tens of thousands of entries to add a handful.
+//! That is quadratic in a host's lifetime and it sat in the launch budget.
+//!
+//! A published [`SignedAuditRoot`](mvm_contract::merkle::SignedAuditRoot) is
+//! already a host-signed statement that the first `tree_size` leaves hash to
+//! `root_hash`. So when the leaves read now still hash to it under that
+//! signature, the prefix has been attested at the same strength a genesis walk
+//! would establish line by line, and only the lines appended since need
+//! walking. That is what
+//! `leaves_over_attested_prefix` does, and the seed it rests on is a host
+//! signature rather than a stored integer — a stronger anchor than the
+//! [`ChainCheckpoint`](crate::supervisor::audit_file::ChainCheckpoint) that
+//! `doctor` resumes from, and the reason this one is not confined to a health
+//! check.
+//!
+//! It never accuses. Every doubt — no root, a stale one, a prefix that no
+//! longer hashes to it — declines to the genesis walk, so every refusal this
+//! module emits is still anchored at genesis.
 
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use ed25519_dalek::VerifyingKey;
-use mvm_contract::merkle::{InclusionProof, build_inclusion_proof, merkle_root};
+use mvm_contract::merkle::{
+    InclusionProof, SignedAuditRoot, build_inclusion_proof, merkle_root, verify_signed_root,
+};
 
 use crate::audit::emitter;
-use mvm_contract::verify::verify_audit_chain_bytes;
+use crate::supervisor::audit_file::verify_chain_bytes_resuming;
+use crate::supervisor::audit_set::{SegmentContent, read_topology_verified_set};
+use mvm_contract::verify::{hash_line, verify_audit_chain_bytes};
 
 /// Read a tenant's audit lines as Merkle leaves, in file order, **after**
 /// verifying the chain is intact — from the SAME bytes. The file is read
@@ -44,7 +71,28 @@ use mvm_contract::verify::verify_audit_chain_bytes;
 /// never yields a root. Public so the CLI `prove` verb can resolve a
 /// selector against the identical leaf set the root and proofs are built
 /// over (a single reader, so indices can't drift).
+///
+/// Which lines are verified *here* depends on whether the last published root
+/// still describes this log — see [`leaves_over_attested_prefix`] for the seed
+/// that stands in for the prefix, and what makes it as strong as walking it.
+/// Either way the leaves are the same and a chain that does not verify still
+/// yields no root; only the work differs.
 pub fn read_leaves(audit_dir: &Path, tenant: &str, vk: &VerifyingKey) -> Result<Vec<String>> {
+    if let Some(leaves) = leaves_over_attested_prefix(audit_dir, tenant, vk) {
+        return Ok(leaves);
+    }
+    read_leaves_from_genesis(audit_dir, tenant, vk)
+}
+
+/// [`read_leaves`], always walking every interior from the genesis anchor.
+///
+/// The unconditional path, and the only one that ever produces a refusal — see
+/// [`leaves_over_attested_prefix`], which declines rather than accuses.
+fn read_leaves_from_genesis(
+    audit_dir: &Path,
+    tenant: &str,
+    vk: &VerifyingKey,
+) -> Result<Vec<String>> {
     // Spans the whole segment set, oldest first, not just the active segment.
     //
     // A root over the active segment alone would be a root that silently
@@ -85,6 +133,126 @@ pub fn read_leaves(audit_dir: &Path, tenant: &str, vk: &VerifyingKey) -> Result<
             "refusing to build a Merkle root over an unverified audit chain for {tenant}: {e}"
         )),
     }
+}
+
+/// Leaves for a chain whose prefix is attested by the last published root,
+/// verifying only what was appended after it.
+///
+/// A published [`SignedAuditRoot`] is already a host-signed statement of the
+/// form "the first `tree_size` leaves of this log hash to `root_hash`". So
+/// when the leaves read now still hash to that value under that signature,
+/// the prefix has been attested — by the same key, at the same strength, as
+/// the per-line signatures a genesis walk would check one at a time. Only the
+/// lines appended since need walking, which is what turns a cost that grows
+/// with the whole history into one that grows with a single run's entries.
+///
+/// This is deliberately a stronger seed than [`ChainCheckpoint`] — a stored
+/// integer, which is why that fast path is confined to `doctor`. Forging this
+/// one means forging a host signature, the same bar as forging the chain.
+///
+/// Returns `None` rather than an error on *every* doubt: no published root, a
+/// root for another tenant, a root that will not verify, one that reaches past
+/// the log or back before the live segment, a prefix that no longer hashes to
+/// it, or a suffix that will not walk. A mismatch is as consistent with a
+/// stale root or a rotation as with tampering, and only the genesis walk can
+/// tell those apart — so this path never accuses, it only declines, and every
+/// refusal the caller ever emits stays anchored at genesis.
+///
+/// [`ChainCheckpoint`]: crate::supervisor::audit_file::ChainCheckpoint
+fn leaves_over_attested_prefix(
+    audit_dir: &Path,
+    tenant: &str,
+    vk: &VerifyingKey,
+) -> Option<Vec<String>> {
+    let published = read_published_root(audit_dir, tenant)?;
+    if published.tenant != tenant {
+        return None;
+    }
+    verify_signed_root(&published, vk).ok()?;
+
+    // No interior is walked here. The structural checks still are, so a
+    // removed or spliced segment refuses exactly as it does on the full path;
+    // what the published root is standing in for is the per-line work.
+    let segments = read_segment_bytes(audit_dir, tenant, vk)?;
+    let active = segments.last().filter(|s| s.active)?;
+    let lines: Vec<&str> = segments.iter().flat_map(SegmentContent::lines).collect();
+    let active_start = lines.len() - active.lines().len();
+
+    let attested = usize::try_from(published.tree_size).ok()?;
+    // A root reaching past the log describes a different log. A root landing
+    // before the live segment would need a resume point inside a sealed one,
+    // which is reachable but not worth a second seek path: it happens once per
+    // rotation, and the genesis walk that follows re-establishes the prefix.
+    if attested == 0 || attested > lines.len() || attested < active_start {
+        return None;
+    }
+    if hex::encode(merkle_root(&lines[..attested])) != published.root_hash {
+        return None;
+    }
+
+    // The seed is the attested prefix's final line hash, which is what the
+    // next line's signature commits to. `walk_chain` numbers lines including
+    // blank ones; leaf indices skip them, so the resume point is translated
+    // rather than reused.
+    let seed = hash_line(lines[attested - 1].as_bytes());
+    let resume = raw_line_index(&active.content, attested - active_start)?;
+    verify_chain_bytes_resuming(&active.content, vk, resume, seed).ok()?;
+
+    Some(lines.into_iter().map(str::to_string).collect())
+}
+
+/// The segment set's bytes, oldest first, structurally verified.
+///
+/// An un-rotated host has no set to walk, and its single chain file is that
+/// same list with one element — so the fast path covers it too rather than
+/// leaving a cliff at the first rotation.
+fn read_segment_bytes(
+    audit_dir: &Path,
+    tenant: &str,
+    vk: &VerifyingKey,
+) -> Option<Vec<SegmentContent>> {
+    match read_topology_verified_set(audit_dir, tenant, vk) {
+        Ok(segments) => Some(segments),
+        Err(crate::supervisor::audit_set::SegmentSetError::NoChain { .. }) => {
+            let path = emitter::audit_path_for_tenant(audit_dir, tenant);
+            Some(vec![SegmentContent {
+                seq: 0,
+                content: std::fs::read_to_string(&path).ok()?,
+                path,
+                active: true,
+                entries: None,
+            }])
+        }
+        Err(_) => None,
+    }
+}
+
+/// The published root sidecar, or `None` when there is not a readable one.
+fn read_published_root(audit_dir: &Path, tenant: &str) -> Option<SignedAuditRoot> {
+    let path = emitter::audit_root_path_for_tenant(audit_dir, tenant);
+    serde_json::from_slice(&std::fs::read(path).ok()?).ok()
+}
+
+/// Index into `content.lines()` of the `nth`-th non-blank line.
+///
+/// The two line numberings differ the moment a blank line exists: leaves skip
+/// them, `walk_chain` counts them. Resuming at the wrong index would verify
+/// the wrong suffix, so the translation is explicit.
+fn raw_line_index(content: &str, nth: usize) -> Option<usize> {
+    if nth == 0 {
+        return Some(0);
+    }
+    let mut seen = 0;
+    for (idx, line) in content.lines().enumerate() {
+        if line.is_empty() {
+            continue;
+        }
+        seen += 1;
+        if seen == nth {
+            return Some(idx + 1);
+        }
+    }
+    (seen == nth).then_some(content.lines().count())
 }
 
 /// Build the Merkle root over `tenant`'s audit chain in `audit_dir`,
@@ -243,6 +411,185 @@ mod tests {
             .flatten()
             .filter(|e| e.file_name().to_string_lossy().contains(".seg-"))
             .count()
+    }
+
+    /// Re-sign `root` under `key` after mutating it, so a test can present a
+    /// root that is genuinely signed and still wrong about the log.
+    fn resign(mut root: SignedAuditRoot, key: &SigningKey) -> SignedAuditRoot {
+        use base64::Engine as _;
+        use ed25519_dalek::Signer as _;
+        let payload = mvm_contract::merkle::root_signing_bytes(
+            &root.tenant,
+            root.tree_size,
+            &root.root_hash,
+            &root.timestamp,
+        )
+        .unwrap();
+        root.signature =
+            base64::engine::general_purpose::STANDARD.encode(key.sign(&payload).to_bytes());
+        root.signer_pubkey = hex::encode(key.verifying_key().to_bytes());
+        root
+    }
+
+    fn write_root(dir: &Path, root: &SignedAuditRoot) {
+        std::fs::write(
+            emitter::audit_root_path_for_tenant(dir, "local"),
+            serde_json::to_vec(root).unwrap(),
+        )
+        .unwrap();
+    }
+
+    /// Flip one field of the line at `idx` in `path`, keeping it valid JSON so
+    /// the failure is the chain's to report rather than the parser's.
+    fn tamper_line(path: &Path, idx: usize) {
+        let content = std::fs::read_to_string(path).unwrap();
+        let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+        lines[idx] = lines[idx].replacen("\"img\"", "\"IMG\"", 1);
+        std::fs::write(path, format!("{}\n", lines.join("\n"))).unwrap();
+    }
+
+    #[test]
+    fn the_fast_path_takes_the_published_root_at_its_word_and_agrees_with_genesis() {
+        // The whole point of the fast path is that it is *not* a different
+        // answer. Assert it engaged -- otherwise every test below it passes by
+        // silently falling back -- and that its leaves are the genesis walk's.
+        let (dir, key, _) = seed_chain(4);
+        let vk = key.verifying_key();
+        grow_and_publish(dir.path(), &key, 2, "published");
+        grow_and_publish(dir.path(), &key, 3, "after");
+
+        let fast = leaves_over_attested_prefix(dir.path(), "local", &vk)
+            .expect("a verifying published root must engage the fast path");
+        let full = read_leaves_from_genesis(dir.path(), "local", &vk).unwrap();
+        assert_eq!(fast, full);
+        assert_eq!(fast.len(), 9);
+    }
+
+    #[test]
+    fn a_line_appended_after_the_published_root_is_still_verified() {
+        // The suffix is the part the published root says nothing about, so it
+        // is the part this path must walk itself. If it did not, a tampered
+        // recent entry would be published into a root.
+        let (dir, key, _) = seed_chain(3);
+        let vk = key.verifying_key();
+        grow_and_publish(dir.path(), &key, 1, "published");
+        grow_with_rotation(
+            dir.path(),
+            &key,
+            2,
+            "after",
+            crate::supervisor::RotationPolicy::never(),
+        );
+
+        tamper_line(&dir.path().join("local.jsonl"), 5);
+
+        assert!(
+            leaves_over_attested_prefix(dir.path(), "local", &vk).is_none(),
+            "a tampered suffix line must not pass the resumed walk"
+        );
+        assert!(build_root_in(dir.path(), "local", &vk).is_err());
+    }
+
+    #[test]
+    fn a_tampered_attested_prefix_declines_the_shortcut_and_then_refuses() {
+        // The prefix is exactly what the published root vouches for, so the
+        // shortcut has to notice when the bytes stop hashing to it -- and then
+        // hand the refusal to the genesis walk rather than accusing itself.
+        let (dir, key, _) = seed_chain(4);
+        let vk = key.verifying_key();
+        grow_and_publish(dir.path(), &key, 2, "published");
+        grow_with_rotation(
+            dir.path(),
+            &key,
+            2,
+            "after",
+            crate::supervisor::RotationPolicy::never(),
+        );
+
+        tamper_line(&dir.path().join("local.jsonl"), 1);
+
+        assert!(
+            leaves_over_attested_prefix(dir.path(), "local", &vk).is_none(),
+            "a prefix that no longer hashes to the published root must decline"
+        );
+        assert!(build_root_in(dir.path(), "local", &vk).is_err());
+    }
+
+    #[test]
+    fn a_root_signed_by_another_key_does_not_shortcut_the_walk() {
+        // The seed's whole strength is the host signature over it. A root that
+        // verifies under some *other* key is not a statement this host made.
+        let (dir, key, _) = seed_chain(4);
+        let vk = key.verifying_key();
+        let root = grow_and_publish(dir.path(), &key, 2, "published");
+        write_root(dir.path(), &resign(root, &fresh_key()));
+
+        assert!(leaves_over_attested_prefix(dir.path(), "local", &vk).is_none());
+        // Declining is not refusing: the chain itself is intact, so the
+        // genesis walk still produces a root.
+        assert!(build_root_in(dir.path(), "local", &vk).is_ok());
+    }
+
+    #[test]
+    fn a_root_reaching_past_the_log_declines_rather_than_indexing_off_the_end() {
+        let (dir, key, _) = seed_chain(4);
+        let vk = key.verifying_key();
+        let mut root = grow_and_publish(dir.path(), &key, 2, "published");
+        root.tree_size += 1_000;
+        write_root(dir.path(), &resign(root, &key));
+
+        assert!(leaves_over_attested_prefix(dir.path(), "local", &vk).is_none());
+        assert!(build_root_in(dir.path(), "local", &vk).is_ok());
+    }
+
+    #[test]
+    fn no_published_root_leaves_the_genesis_walk_as_the_only_path() {
+        let (dir, key, _) = seed_chain(3);
+        let vk = key.verifying_key();
+        assert!(leaves_over_attested_prefix(dir.path(), "local", &vk).is_none());
+        assert_eq!(read_leaves(dir.path(), "local", &vk).unwrap().len(), 3);
+    }
+
+    #[test]
+    fn the_fast_path_survives_a_rotation_by_falling_back_once() {
+        // A root published before a rotation lands before the live segment,
+        // which this path does not seek into. It must decline, not misindex --
+        // and the root published after it re-establishes the shortcut.
+        let (dir, key, _) = seed_chain(2);
+        let vk = key.verifying_key();
+        grow_and_publish(dir.path(), &key, 1, "published");
+        grow_with_rotation(
+            dir.path(),
+            &key,
+            4,
+            "post",
+            crate::supervisor::RotationPolicy::at_bytes(256),
+        );
+        assert!(segment_count(dir.path()) > 0, "the fixture must rotate");
+
+        let across = read_leaves(dir.path(), "local", &vk).unwrap();
+        assert_eq!(
+            across,
+            read_leaves_from_genesis(dir.path(), "local", &vk).unwrap()
+        );
+
+        grow_and_publish(dir.path(), &key, 1, "republished");
+        assert!(
+            leaves_over_attested_prefix(dir.path(), "local", &vk).is_some(),
+            "a root published after the rotation must re-engage the fast path"
+        );
+    }
+
+    #[test]
+    fn raw_line_index_translates_leaf_numbering_across_blank_lines() {
+        // Leaves skip blank lines; `walk_chain` counts them. Reusing a leaf
+        // index as a resume point would verify the wrong suffix.
+        let content = "a\n\nb\nc\n";
+        assert_eq!(raw_line_index(content, 0), Some(0));
+        assert_eq!(raw_line_index(content, 1), Some(1));
+        assert_eq!(raw_line_index(content, 2), Some(3));
+        assert_eq!(raw_line_index(content, 3), Some(4));
+        assert_eq!(raw_line_index(content, 4), None);
     }
 
     #[test]

--- a/crates/mvm-hostd/src/supervisor/audit_file.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_file.rs
@@ -970,6 +970,43 @@ pub fn verify_chain_bytes(
     })
 }
 
+/// Verify an already-read segment from `resume_line`, seeding the running
+/// chain hash with `chain_hash` instead of the genesis anchor.
+///
+/// The suffix counterpart of [`verify_chain_bytes`], for a caller that already
+/// holds an authenticated statement about the prefix and needs only what was
+/// appended after it. Cost is `O(lines - resume_line)`.
+///
+/// Sound in the same narrow sense [`verify_audit_chain_incremental`] is: the
+/// resumed line's signature covers its `prev_hash`, so a valid signature there
+/// authenticates the state the prefix ended in. What it does not do is anchor
+/// that prefix, so **every caller owes an account of what authenticates the
+/// seed** — and a caller whose account is a bare stored integer is choosing
+/// the trade this module confines to `doctor`.
+///
+/// A truncated final line is still reported as [`VerifyError::TruncatedTail`]:
+/// the check reads `content`'s terminating byte, which a resumed walk has in
+/// hand exactly as a genesis walk does.
+pub fn verify_chain_bytes_resuming(
+    content: &str,
+    verifying_key: &VerifyingKey,
+    resume_line: usize,
+    chain_hash: [u8; 32],
+) -> Result<SegmentWalk, VerifyError> {
+    let walk = walk_chain(
+        content,
+        verifying_key,
+        ChainStart::Resume {
+            line: resume_line,
+            chain_hash,
+        },
+    )?;
+    Ok(SegmentWalk {
+        entries: walk.entries,
+        tip: walk.chain_hash,
+    })
+}
+
 /// Where a chain walk begins.
 enum ChainStart {
     /// Line 0, with the all-zero chain hash. The zero prefix is the anchor

--- a/crates/mvm-hostd/src/supervisor/audit_set.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_set.rs
@@ -579,6 +579,28 @@ pub fn read_verified_set(
     Ok(walked.contents)
 }
 
+/// Read the whole set with its structure verified but no interior walked.
+///
+/// [`read_verified_set`] with the interiors left out: every handoff, boundary
+/// signature, tip continuity and entry count is still checked, so a removed or
+/// spliced segment is still named — but no segment's interior lines are
+/// verified, and the returned [`SegmentContent::entries`] are all `None`.
+///
+/// This exists for the one caller that needs the *bytes* of the whole set for
+/// a reason other than verifying them — the Merkle leaf builder, which hashes
+/// every line into a tree and holds a separate, authenticated statement about
+/// the prefix. A caller that wants the set attested end to end wants
+/// [`read_verified_set`] and should pay for it.
+pub fn read_topology_verified_set(
+    dir: &Path,
+    base: &str,
+    vk: &VerifyingKey,
+) -> Result<Vec<SegmentContent>, SegmentSetError> {
+    let walked = walk(dir, base, vk, false)?;
+    adjudicate(&walked, vk)?;
+    Ok(walked.contents)
+}
+
 /// A completed walk: the segments read, and the front gap still to adjudicate.
 struct Walked {
     contents: Vec<SegmentContent>,

--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -32,30 +32,49 @@ const VIRTIOFS_ROOT_TAG: &str = "mvmroot";
 pub use mvm_vmm::host::boot_config::booted_with_universal_initramfs;
 
 /// How long activation waits for the guest agent to come up before failing.
-/// The HVF boot confirms the VM process (pid file) in well under a second,
-/// but the guest agent takes a few seconds to mount the early filesystems and
-/// bind its control port, so a single immediate handshake lands before the
-/// agent is listening. Mirrors the Firecracker driver's agent-ready wait.
+///
+/// A generous ceiling on a wait that is normally short: measured on HVF, the
+/// agent binds its control port ~50ms after the VM starts, and the activation
+/// round-trip itself takes ~8ms. The 30s is headroom for a loaded host, not an
+/// expectation — which matters, because a schedule sized for "a few seconds"
+/// is a schedule that cannot see 50ms. See [`activation_retry_delay`].
 const ACTIVATION_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Activate a workload that booted with the universal initramfs.
 ///
 /// Sends [`ActivateEnvironment`] over the agent vsock port and waits for an
 /// ACK. If the guest replies with an error or an unexpected response, the
-/// boot fails closed. The guest agent takes a few seconds to come up after
-/// the VM process starts, so the connect+handshake retries on transient
-/// "agent not listening yet" failures until [`ACTIVATION_READY_TIMEOUT`]
-/// rather than failing the first attempt; a genuine activation rejection
-/// (an `ActivateEnvironmentError` or an unexpected response) is returned
+/// boot fails closed. The agent is not listening the instant the VM process
+/// starts, so the connect+handshake retries on transient "agent not listening
+/// yet" failures until [`ACTIVATION_READY_TIMEOUT`] rather than failing the
+/// first attempt; a genuine activation rejection (an
+/// `ActivateEnvironmentError` or an unexpected response) is returned
 /// immediately, never retried.
 pub fn activate_workload(vm: &dyn RunningVm, config: &VmStartConfig) -> Result<()> {
     let env = build_activation_environment(config)?;
-    let deadline = std::time::Instant::now() + ACTIVATION_READY_TIMEOUT;
+    let started = std::time::Instant::now();
+    let deadline = started + ACTIVATION_READY_TIMEOUT;
     let mut attempt = 0u32;
     loop {
         attempt = attempt.saturating_add(1);
+        let attempt_started = std::time::Instant::now();
         match activate_once(vm, &env) {
-            Ok(()) => return Ok(()),
+            Ok(()) => {
+                // Attempt count and the split between waiting and working are
+                // what distinguish "the guest was slow" from "the schedule
+                // slept through the guest being ready". The coarse phase timer
+                // reports one `activate_workload` span and cannot tell those
+                // apart; that is how a 100ms first backoff hid inside a 160ms
+                // span for as long as it did.
+                tracing::debug!(
+                    attempt,
+                    waited_ms = (attempt_started - started).as_secs_f64() * 1000.0,
+                    activation_ms = attempt_started.elapsed().as_secs_f64() * 1000.0,
+                    total_ms = started.elapsed().as_secs_f64() * 1000.0,
+                    "guest activation complete"
+                );
+                return Ok(());
+            }
             Err(e) if is_retryable_activation_error(&e) && std::time::Instant::now() < deadline => {
                 std::thread::sleep(activation_retry_delay(attempt));
             }
@@ -97,10 +116,35 @@ fn is_retryable_activation_error(err: &anyhow::Error) -> bool {
     })
 }
 
-/// Backoff between activation attempts: grows from 50 ms, capped at 500 ms.
+/// First gap between activation attempts.
+///
+/// Small on purpose. The thing being waited for — the guest agent binding its
+/// control port — happens tens of milliseconds after the VM starts, so a first
+/// backsleep measured in that same order of magnitude decides the launch's
+/// latency rather than observing it.
+const ACTIVATION_POLL_MIN: std::time::Duration = std::time::Duration::from_millis(2);
+
+/// Ceiling on the gap between activation attempts.
+///
+/// The gap grows so a guest that is genuinely slow to come up is not polled
+/// thousands of times, but it stays far below [`ACTIVATION_READY_TIMEOUT`]:
+/// every millisecond of the final gap is latency added to a launch that was
+/// otherwise ready, and the cap is what bounds that error.
+const ACTIVATION_POLL_MAX: std::time::Duration = std::time::Duration::from_millis(25);
+
+/// Backoff between activation attempts: doubles from
+/// [`ACTIVATION_POLL_MIN`], capped at [`ACTIVATION_POLL_MAX`].
+///
+/// This was `50ms << attempt`, capped at 500ms — so the first gap was 100ms.
+/// Measured against a real HVF launch, the agent became reachable ~50ms in and
+/// activation itself took ~8ms, but the first attempt failed and the schedule
+/// then slept 100ms before looking again: `activate_workload` cost ~160ms to
+/// do ~8ms of work. A backoff coarser than the event it polls for does not
+/// measure that event, it replaces it.
 fn activation_retry_delay(attempt: u32) -> std::time::Duration {
-    let scaled = 50u64.saturating_mul(1u64 << attempt.min(16));
-    std::time::Duration::from_millis(scaled.min(500))
+    let doublings = attempt.saturating_sub(1).min(16);
+    let scaled = ACTIVATION_POLL_MIN.saturating_mul(1u32 << doublings);
+    scaled.min(ACTIVATION_POLL_MAX)
 }
 
 /// Send a pre-built [`ActivateEnvironment`] over an already-connected
@@ -331,6 +375,51 @@ mod tests {
     use super::*;
     use mvm_core::net::session::SessionError;
     use mvm_core::util::test_env::TestEnv;
+
+    /// The first retry must not dominate the wait it is polling for.
+    ///
+    /// This schedule used to start at 100ms and double to 500ms. The guest
+    /// agent binds its port ~50ms after the VM starts, so the very first
+    /// backoff overshot the entire thing: a launch spent 100ms asleep to
+    /// discover a readiness that had already happened, and `activate_workload`
+    /// measured ~160ms against ~8ms of actual activation work.
+    #[test]
+    fn the_first_activation_retry_is_shorter_than_the_readiness_it_waits_for() {
+        assert!(
+            activation_retry_delay(1) <= std::time::Duration::from_millis(2),
+            "first retry {:?} must be a poll, not a sleep",
+            activation_retry_delay(1)
+        );
+    }
+
+    #[test]
+    fn activation_retries_back_off_monotonically_to_a_bounded_cap() {
+        let mut previous = std::time::Duration::ZERO;
+        for attempt in 1..=64u32 {
+            let delay = activation_retry_delay(attempt);
+            assert!(
+                delay >= previous,
+                "attempt {attempt} backed off to {delay:?}, below the previous {previous:?}"
+            );
+            assert!(
+                delay <= ACTIVATION_POLL_MAX,
+                "attempt {attempt} delay {delay:?} exceeds the cap"
+            );
+            previous = delay;
+        }
+        assert_eq!(activation_retry_delay(64), ACTIVATION_POLL_MAX);
+    }
+
+    /// A capped poll must still be coarse enough that a guest which never
+    /// comes up does not spin the full deadline away on handshake attempts.
+    #[test]
+    fn the_capped_poll_bounds_attempts_across_the_activation_deadline() {
+        let attempts = ACTIVATION_READY_TIMEOUT.as_millis() / ACTIVATION_POLL_MAX.as_millis();
+        assert!(
+            attempts <= 2_000,
+            "a never-ready guest would make {attempts} handshake attempts before the deadline"
+        );
+    }
 
     const VALID_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 

--- a/specs/sprint/delivery/activation-backoff-slept-through-guest-readiness.md
+++ b/specs/sprint/delivery/activation-backoff-slept-through-guest-readiness.md
@@ -1,0 +1,83 @@
+# The activation backoff slept through the guest being ready
+
+**Status: COMPLETE**
+
+## What was wrong
+
+`activate_workload` retries the connect+handshake to the guest agent until it
+answers. The gap between attempts was:
+
+```rust
+fn activation_retry_delay(attempt: u32) -> Duration {
+    let scaled = 50u64.saturating_mul(1u64 << attempt.min(16));
+    Duration::from_millis(scaled.min(500))   // 100ms, 200ms, 400ms, 500ms...
+}
+```
+
+The first gap was 100 ms. The event it polls for — the guest agent binding its
+control port — happens ~50 ms after the VM starts. So every launch took the
+same shape:
+
+```
+attempt 1  tried_at=0ms     failed_after=48-52ms   sleeping=100ms
+attempt 2  tried_at=151ms   took=6-11ms            total=159-162ms
+```
+
+~8 ms of activation work inside a ~160 ms span, and ~100 ms of it was a sleep
+through a readiness that had already happened. A backoff coarser than the event
+it waits for does not measure that event, it replaces it.
+
+## What changed
+
+The schedule now doubles from 2 ms to a 25 ms cap (`ACTIVATION_POLL_MIN` /
+`ACTIVATION_POLL_MAX`). Nothing else about the loop moved: the same 30 s
+deadline, the same retryable-error set, and a genuine rejection
+(`ActivateEnvironmentError` or an unexpected response) still returns
+immediately and is never retried.
+
+The success path gained one `tracing::debug!` splitting the span into waited
+vs. activated. The coarse phase timer reports a single `activate_workload`
+number and cannot tell "the guest was slow" from "the schedule slept through
+the guest being ready" — which is how a 100 ms first backoff hid inside a
+160 ms span for as long as it did.
+
+Two doc comments were corrected. Both said the agent "takes a few seconds" to
+come up; measured, it takes ~50 ms. That estimate is what made a 100 ms first
+gap look reasonable.
+
+## Measured
+
+Same host, `machine run --image alpine -- sh -c "echo hi"`, HVF:
+
+| | before | after |
+|---|---|---|
+| `activate_workload` | 159–162 ms | **60–68 ms** |
+| `backend start` | 173–175 ms | **77–85 ms** |
+| **dispatch window** | 174–175 ms | **78–85 ms** |
+| total | 289–290 ms | **209–228 ms** |
+
+`PREPARED_COLD_HARD_MAX_MS` is 200 ms on the dispatch window, as a per-sample
+invariant. That went from 175 ms — passing with 25 ms of margin — to ~80 ms.
+
+The remaining `activate_workload` is close to its floor: attempt 2 now fires at
+t≈53–59 ms because attempt 1 fails at ~50 ms and the new gap is 2 ms. That
+~50 ms is the guest agent genuinely coming up, and ~8 ms is the activation
+round-trip. There is no longer meaningful slack in this phase.
+
+## Still open
+
+- **Total is ~220 ms, not under 200 ms.** The dispatch window is what the
+  repo's 200 ms budget measures and that is comfortably met; total wall clock
+  is not, and needs the two below.
+- `admit` is 65–68 ms and **rising** — it was 56 ms earlier the same day. The
+  attested-prefix fast path still reads all segment bytes and builds the tree
+  over every leaf twice, so it grows with history. Caching sealed segments'
+  leaf hashes, validated by recomputing the signed root from them, would make
+  publication `O(entries since the last root)` and take this to ~5 ms.
+- `teardown` is 49–59 ms, most of it the supervisor genuinely shutting down
+  (kqueue-observed, not a polling artifact). Only removable by not waiting for
+  it, which trades against the exit-capture flush.
+- **The first launch after a release build is reliably an outlier** —
+  `backend start` 570–902 ms and, once, a 74 s admission. Four occurrences now,
+  always the first run against a freshly linked binary, all phases affected.
+  Not root-caused. Discard the first sample when benchmarking.

--- a/specs/sprint/delivery/admit-root-publication-off-the-genesis-walk.md
+++ b/specs/sprint/delivery/admit-root-publication-off-the-genesis-walk.md
@@ -1,0 +1,103 @@
+# Admission stopped re-verifying the whole audit chain
+
+**Status: COMPLETE**
+
+## What was wrong
+
+Every `mvmctl machine run` admission published a Merkle transparency-log root,
+and publishing one walked the tenant's entire audit chain from genesis:
+`publish_boundary_root` → `AuditEmitter::publish_root` → `sign_root_in` →
+`build_root_in` → `read_leaves` → `read_verified_set`, which reads every
+segment and Ed25519-verifies every line before the tree is built.
+
+On a host with 22,481 accumulated entries across seven segments (26 MB) that
+measured **912 ms of verification plus 18 ms of tree building**, on the boot
+critical path, per launch:
+
+```
+admit             742.3ms      <- 956ms of it was publish_root
+backend start     204.2ms
+guest ready         2.9ms
+command           163.6ms
+teardown           52.5ms
+total            1165.7ms
+```
+
+Each launch appends ~35 entries and then re-verifies everything before them, so
+the cost grew with the host's whole launch history — quadratic over a host's
+lifetime, and already 3.5x the 300 ms launch budget on its own.
+
+## What changed
+
+`read_leaves` now takes the last published root at its word for the prefix it
+covers, and walks only what was appended since.
+
+A published `SignedAuditRoot` is already a host-signed statement that the first
+`tree_size` leaves hash to `root_hash`. When the leaves read now still hash to
+that value under that signature, the prefix is attested at the same strength a
+genesis walk would establish line by line — so only the suffix needs verifying.
+The seed is a host signature rather than a stored integer, which makes it a
+stronger anchor than the `ChainCheckpoint` that `doctor` resumes from, and is
+why this one is not confined to a health check.
+
+- `merkle::leaves_over_attested_prefix` — the fast path.
+- `audit_set::read_topology_verified_set` — the set's bytes with every handoff,
+  boundary signature and tip continuity still checked, no interior walked.
+- `audit_file::verify_chain_bytes_resuming` — `verify_chain_bytes` seeded from
+  an authenticated prefix instead of the genesis anchor.
+
+It never accuses. Every doubt — no published root, one for another tenant, one
+that will not verify, one reaching past the log or back before the live
+segment, a prefix that no longer hashes to it, a suffix that will not walk —
+declines to the genesis walk. So every refusal the module emits is still
+anchored at genesis, and a mismatch caused by a stale root is never reported as
+tampering.
+
+## What did not change
+
+- `mvmctl trust audit verify` (claim 8's witness) still calls
+  `verify_segment_set` and still walks every interior from genesis.
+- `record_admission` and the `plan.admitted` durability barrier are untouched;
+  the control that claim 8 rests on is the entry, not the root.
+- Published roots, root history, and inclusion proofs are byte-identical — the
+  fast path returns the same leaves, which the tests assert directly.
+
+## Measured
+
+Same host, same 22.5k-entry chain, 20 consecutive launches:
+
+| | before | after |
+|---|---|---|
+| admit | 742 ms | p50 **56 ms** (min 54.7, max 64.5) |
+| total | 1166 ms | **286–308 ms** |
+
+## Tests
+
+Nine added in `mvm-hostd`'s `audit::merkle` suite. The first asserts the fast
+path *engaged* before comparing leaves, because without that every other test
+in the group would pass by silently falling back:
+
+- `the_fast_path_takes_the_published_root_at_its_word_and_agrees_with_genesis`
+- `a_line_appended_after_the_published_root_is_still_verified`
+- `a_tampered_attested_prefix_declines_the_shortcut_and_then_refuses`
+- `a_root_signed_by_another_key_does_not_shortcut_the_walk`
+- `a_root_reaching_past_the_log_declines_rather_than_indexing_off_the_end`
+- `no_published_root_leaves_the_genesis_walk_as_the_only_path`
+- `the_fast_path_survives_a_rotation_by_falling_back_once`
+- `raw_line_index_translates_leaf_numbering_across_blank_lines`
+
+## Still open
+
+- `backend start` is now the largest phase at ~185 ms, essentially all of it
+  `vmm_create`. It is what stands between the current ~300 ms and the 200 ms
+  target, and has not been investigated.
+- The fast path still reads all 26 MB of segments and builds the tree over
+  every leaf twice (once to check the attested prefix, once for the new root):
+  ~55 ms, growing linearly with history. Caching sealed segments' leaf hashes,
+  or carrying a Merkle frontier on the published root, would make publication
+  `O(entries since the last root)`. Not needed for the current budget.
+- One 74 s admission was observed on the first launch after a release build
+  completed, with `backend start` simultaneously 3x its steady value. It did
+  not recur in 26 subsequent launches (p50 56 ms, max 64.5 ms) and was not
+  root-caused. No path in this change can account for it — the fallback is the
+  genesis walk, measured at under 1 s on this chain.


### PR DESCRIPTION
Two independent fixes to cold-launch latency, both found by `MVM_PHASE_TIMING=1`. On this host they take a `machine run` from **1166 ms to ~220 ms**, and the prepared-cold dispatch window from **175 ms to ~80 ms** against its 200 ms per-sample ceiling.

## 1. Admission re-verified the whole audit chain, from genesis, every launch

Every admission publishes a Merkle transparency-log root, and publishing one walked the tenant's entire chain: `publish_boundary_root` → `publish_root` → `build_root_in` → `read_leaves` → `read_verified_set`, which Ed25519-verifies every line of every segment before the tree is built.

On a host with 22,481 entries across seven segments (26 MB) that measured **912 ms of verification plus 18 ms of tree building** — 97% of the `admit` phase. Each launch appends ~35 entries and then re-verifies everything before them, so the cost grew with the host's whole launch history.

A published `SignedAuditRoot` is already a host-signed statement that the first `tree_size` leaves hash to `root_hash`. When the leaves read now still hash to it under that signature, the prefix has been attested at the same strength a genesis walk would establish line by line, so only the lines appended since need walking. The seed is a host signature rather than a stored integer, which makes it a stronger anchor than the `ChainCheckpoint` `doctor` resumes from — and is why this one is not confined to a health check.

It never accuses. No published root, one for another tenant, one that will not verify, one reaching past the log or back before the live segment, a prefix that no longer hashes to it, a suffix that will not walk — every doubt declines to the genesis walk. Every refusal stays anchored at genesis, and a stale root is never reported as tampering.

`mvmctl trust audit verify` still calls `verify_segment_set` and still walks every interior from genesis. Claim 8's witness is untouched, as is the `plan.admitted` durability barrier the claim actually rests on.

## 2. The activation backoff slept through the guest being ready

`activate_workload` retries the connect+handshake until the guest agent answers. The gap was `50ms << attempt` capped at 500 ms — so the first gap was **100 ms**, waiting for an event that happens at **~50 ms**.

Every launch had the same shape: attempt 1 failed at ~50 ms, the schedule slept 100 ms, attempt 2 ran at ~151 ms and succeeded in 6–11 ms. About 8 ms of activation work inside a ~160 ms span.

The schedule now doubles from 2 ms to a 25 ms cap. Nothing else moved: same 30 s deadline, same retryable-error set, and a genuine rejection still returns immediately and is never retried. Two doc comments said the agent takes "a few seconds" to come up — it takes ~50 ms, and that estimate is what made a 100 ms first gap look reasonable.

## Measured

Same host, `machine run --image alpine -- sh -c "echo hi"`, HVF, steady state:

| phase | before | after |
|---|---|---|
| `admit` | 712 ms | **57–68 ms** |
| `activate_workload` | 159–162 ms | **60–68 ms** |
| backend start | 173–175 ms | **77–85 ms** |
| **dispatch window** | 174–175 ms | **78–85 ms** |
| total | 939 ms | **209–228 ms** |

`PREPARED_COLD_HARD_MAX_MS` is 200 ms on the dispatch window as a per-sample invariant. That goes from 175 ms — passing with 25 ms of margin — to ~80 ms.

## Tests

Nine added for the attested-prefix path. The first asserts the fast path *engaged* before comparing leaves, because without it every tamper test below would pass by silently falling back:

- `the_fast_path_takes_the_published_root_at_its_word_and_agrees_with_genesis`
- `a_line_appended_after_the_published_root_is_still_verified`
- `a_tampered_attested_prefix_declines_the_shortcut_and_then_refuses`
- `a_root_signed_by_another_key_does_not_shortcut_the_walk`
- `a_root_reaching_past_the_log_declines_rather_than_indexing_off_the_end`
- `no_published_root_leaves_the_genesis_walk_as_the_only_path`
- `the_fast_path_survives_a_rotation_by_falling_back_once`
- `raw_line_index_translates_leaf_numbering_across_blank_lines`

Three for the backoff schedule, including that the first retry is shorter than the readiness it waits for, and that the cap still bounds attempts across the 30 s deadline.

## Not addressed

- **`admit` is still `O(history)` and creeping** — 57 ms measured in the morning, 68 ms by evening on the same host. The fast path still reads all segment bytes and builds the tree over every leaf twice. Caching sealed segments' leaf hashes, validated by recomputing the signed root from them, would make publication `O(entries since the last root)`.
- **Total is ~220 ms, not under 200 ms.** The dispatch window — the number the repo actually budgets — is comfortably met. Closing total needs the item above or the ~50 ms teardown, which is the supervisor genuinely shutting down.
- **The first launch after a release build is reliably an outlier** (570–902 ms `backend start`, once a 74 s admission). Four occurrences, always the first run against a freshly linked binary, all phases affected. Not root-caused; discard the first sample when benchmarking.
