### PR TITLE
test(bdd): gate virtio-fs directory shares, and stop handing live steps the wrong home

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ mvmctl machine run --image python:3.12 -- python -c "print(2 + 2)"
 
 # Run a Python file from the host checkout (the mount is read-only).
 # Repeat --mount for additional host directories.
+# --mount needs a backend serving a virtio-fs directory share (libkrun, HVF).
+# Firecracker (the Linux default) has none and refuses before boot: pass a
+# disk-image volume instead, --volume HOST:/GUEST:SIZE.
 mvmctl machine run --image python:3.12 \
   --mount "$PWD:/work:ro" -- python /work/app.py
 

--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -354,6 +354,54 @@ mod sidecar_cache {
     }
 }
 
+/// Which mvm home a live step runs against.
+///
+/// A home the scenario declared for itself wins over the artifact-warm
+/// `MVM_E2E_HOME`. The two phrasings must agree: a scenario that creates a
+/// machine through one step and starts it through another is talking about one
+/// directory, and while they disagreed it failed with `machine "..." does not
+/// exist` — an error naming the machine and never the home it was looked for
+/// in, which is why it read as a product defect.
+///
+/// The warm home still applies to every scenario that declared none, which is
+/// what keeps a live run from re-cross-compiling the guest binaries once per
+/// scenario.
+pub fn live_home_precedence<'a>(
+    scenario_home: Option<&'a std::path::Path>,
+    warm_home: Option<&'a std::path::Path>,
+) -> Option<&'a std::path::Path> {
+    scenario_home.or(warm_home)
+}
+
+#[cfg(test)]
+mod live_home {
+    use super::live_home_precedence;
+    use std::path::Path;
+
+    #[test]
+    fn a_scenario_declared_home_wins_over_the_warm_one() {
+        // The case that broke: create ran against the scenario home, start
+        // against the warm one, and the machine was "missing".
+        assert_eq!(
+            live_home_precedence(Some(Path::new("/scenario")), Some(Path::new("/warm"))),
+            Some(Path::new("/scenario"))
+        );
+    }
+
+    #[test]
+    fn the_warm_home_is_used_when_the_scenario_declared_none() {
+        assert_eq!(
+            live_home_precedence(None, Some(Path::new("/warm"))),
+            Some(Path::new("/warm"))
+        );
+    }
+
+    #[test]
+    fn neither_home_yields_none_so_the_caller_must_create_one() {
+        assert_eq!(live_home_precedence(None, None), None);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -76,6 +76,17 @@ pub const PERF_BUDGET_TAG: &str = "perf_budget";
 /// ignores `ALL_PROXY` and sends the absolute-URI form the proxy refuses rather
 /// than forward in cleartext) cannot satisfy it.
 pub const TLS_TUNNEL_CLIENT_TAG: &str = "tls_tunnel_client";
+/// A scenario that shares a live host directory into the guest over virtio-fs.
+/// libkrun and the in-house HVF VMM both serve one; Firecracker has no virtio-fs
+/// device at all and refuses a `DirShare` volume before boot. Declared rather
+/// than probed, for the same reason as
+/// [`SNAPSHOT_TAG`] — deciding it here would mean re-deriving backend
+/// auto-selection, a copy that drifts silently.
+///
+/// A refusal-shaped scenario needs this tag as much as a success-shaped one:
+/// the share is refused with the same exit code the scenario is asserting, so
+/// without the gate it passes while witnessing nothing.
+pub const DIR_SHARE_TAG: &str = "dir_share";
 
 /// Host capabilities a scenario may require, probed once by the harness.
 ///
@@ -113,6 +124,10 @@ pub struct RuntimeCaps {
     /// `machine checkpoint create --class vm-full` and the pause/resume
     /// round-trip can succeed rather than refusing by capability.
     pub memory_snapshot: bool,
+    /// The active backend serves a live host-directory share (virtio-fs), so a
+    /// scenario passing `--mount` reaches a guest instead of being refused
+    /// before boot.
+    pub dir_share: bool,
 }
 
 /// Decide whether a scenario with `tags` should run given the host `caps`.
@@ -150,6 +165,8 @@ pub enum ScenarioGate {
     NeedsWorkloadKernel,
     /// The backend cannot capture a full-VM memory snapshot on this host.
     NeedsMemorySnapshot,
+    /// The active backend serves no virtio-fs directory share.
+    NeedsDirShare,
     /// No prebuilt guest-binary directory was named.
     NeedsGuestBinDir,
     /// The SDK sidecar image is not in the cache.
@@ -194,6 +211,9 @@ pub fn scenario_gate(tags: &[String], caps: RuntimeCaps) -> ScenarioGate {
     }
     if tagged(SNAPSHOT_TAG) && !caps.memory_snapshot {
         return ScenarioGate::NeedsMemorySnapshot;
+    }
+    if tagged(DIR_SHARE_TAG) && !caps.dir_share {
+        return ScenarioGate::NeedsDirShare;
     }
     if tagged(GUEST_BINS_TAG) && !caps.guest_bin_dir {
         return ScenarioGate::NeedsGuestBinDir;
@@ -241,6 +261,11 @@ impl ScenarioGate {
             Self::NeedsWorkloadKernel => Some(
                 "need a prebuilt workload kernel (MVM_BDD_WORKLOAD_KERNEL, or one \
                  in the host builder-VM cache)",
+            ),
+            Self::NeedsDirShare => Some(
+                "need MVM_BDD_DIR_SHARE=1 on a host whose active backend serves \
+                 virtio-fs directory shares (libkrun and HVF do; Firecracker has \
+                 no virtio-fs device and refuses --mount before boot)",
             ),
             Self::NeedsMemorySnapshot => Some(
                 "need MVM_BDD_SNAPSHOT=1 on a host whose active backend reports \
@@ -347,6 +372,7 @@ mod tests {
         perf_budget_host: false,
         tls_tunnel_client: false,
         memory_snapshot: false,
+        dir_share: false,
         workload_kernel: false,
     };
     const ALL: RuntimeCaps = RuntimeCaps {
@@ -359,8 +385,23 @@ mod tests {
         perf_budget_host: true,
         tls_tunnel_client: true,
         memory_snapshot: true,
+        dir_share: true,
         workload_kernel: true,
     };
+
+    #[test]
+    fn dir_share_scenario_skips_where_the_backend_serves_no_share() {
+        let gate = scenario_gate(
+            &tags(&["live", "dir_share"]),
+            RuntimeCaps {
+                dir_share: false,
+                ..ALL
+            },
+        );
+        assert_eq!(gate, ScenarioGate::NeedsDirShare);
+        assert!(gate.reason().is_some(), "a skip must name what is missing");
+        assert!(scenario_should_run(&tags(&["live", "dir_share"]), ALL));
+    }
 
     #[test]
     fn bundle_scenario_skips_without_a_fixture() {
@@ -392,6 +433,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: false,
                 ..ALL
             },
@@ -415,6 +457,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 ..ALL
             },
         ));
@@ -431,6 +474,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 ..ALL
             },
         );
@@ -533,6 +577,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: false,
             },
         ));
@@ -552,6 +597,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: false,
             },
         ));
@@ -573,6 +619,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: false,
             },
         ));
@@ -589,6 +636,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: false,
             },
         ));
@@ -612,6 +660,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: false,
             },
             RuntimeCaps {
@@ -624,6 +673,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: false,
             },
             RuntimeCaps {
@@ -636,6 +686,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: false,
             },
             RuntimeCaps {
@@ -648,6 +699,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: true,
             },
             RuntimeCaps {
@@ -660,6 +712,7 @@ mod tests {
                 perf_budget_host: false,
                 tls_tunnel_client: false,
                 memory_snapshot: false,
+                dir_share: false,
                 workload_kernel: true,
             },
         ];
@@ -698,6 +751,7 @@ mod tests {
             perf_budget_host: false,
             tls_tunnel_client: false,
             memory_snapshot: false,
+            dir_share: false,
             workload_kernel: false,
         };
         let live_only = RuntimeCaps {
@@ -710,6 +764,7 @@ mod tests {
             perf_budget_host: false,
             tls_tunnel_client: false,
             memory_snapshot: false,
+            dir_share: false,
             workload_kernel: false,
         };
         let bootable = RuntimeCaps {
@@ -722,6 +777,7 @@ mod tests {
             perf_budget_host: false,
             tls_tunnel_client: false,
             memory_snapshot: false,
+            dir_share: false,
             workload_kernel: false,
         };
 
@@ -778,6 +834,7 @@ mod tests {
                     perf_budget_host: false,
                     tls_tunnel_client: false,
                     memory_snapshot: false,
+                    dir_share: false,
                     workload_kernel: false,
                 },
                 true,

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -222,6 +222,7 @@ fn probe_caps() -> RuntimeCaps {
         perf_budget_host: std::env::var_os("MVM_BDD_PERF_BUDGET").is_some(),
         tls_tunnel_client: std::env::var_os("MVM_BDD_TLS_CLIENT").is_some(),
         memory_snapshot: memory_snapshot_supported(),
+        dir_share: dir_share_supported(),
     }
 }
 
@@ -279,6 +280,17 @@ fn guest_bin_dir_available() -> bool {
 /// `mvmctl doctor` prints the matrix; a host whose active backend reports
 /// `save-restore` sets `MVM_BDD_SNAPSHOT=1`. Firecracker reports `unsupported`,
 /// which is why the Linux lane leaves it unset.
+/// Whether the active backend serves a live host-directory share (virtio-fs).
+///
+/// Declared by the operator rather than probed, matching
+/// `memory_snapshot_supported`: the answer depends on which backend a launch
+/// would actually select, and re-deriving that here would be a copy that
+/// drifts. libkrun and HVF serve a share; Firecracker has no virtio-fs device
+/// and refuses a `DirShare` volume before boot.
+fn dir_share_supported() -> bool {
+    std::env::var_os("MVM_BDD_DIR_SHARE").is_some()
+}
+
 fn memory_snapshot_supported() -> bool {
     std::env::var_os("MVM_BDD_SNAPSHOT").is_some()
 }

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -203,15 +203,20 @@ pub(crate) fn run_mvmctl_isolated_live_home(world: &mut CliWorld, args: String) 
     // are cached *under the home*, so every such scenario re-cross-compiles
     // them from scratch — minutes each, repeated across the live suite. The
     // warm home is what makes a live run finish in a sane time.
+    //
+    // A home the scenario declared for itself still wins: `Given an isolated
+    // mvm home` exists so a scenario can be hermetic, or can seed a cache and
+    // then assert on it, and honouring the warm home over that put `machine
+    // create` and `machine start` in two different directories.
     let warm_home = std::env::var_os("MVM_E2E_HOME").map(std::path::PathBuf::from);
     if warm_home.is_none() && world.isolated_home.is_none() {
         world.isolated_home = Some(tempfile::tempdir().expect("create isolated MVM_HOME"));
     }
-    let home: std::path::PathBuf = match (&warm_home, world.isolated_home.as_ref()) {
-        (Some(warm), _) => warm.clone(),
-        (None, Some(dir)) => dir.path().to_path_buf(),
-        (None, None) => unreachable!("one of the two is set above"),
-    };
+    let scenario_home = world.isolated_home.as_ref().map(|dir| dir.path());
+    let home: std::path::PathBuf =
+        mvm_conformance::live_home_precedence(scenario_home, warm_home.as_deref())
+            .expect("one of the two is set above")
+            .to_path_buf();
     let mut command = mvmctl_command();
     command
         .current_dir(workspace_root())

--- a/features/suites/s30_service_plane/declared_bindings.feature
+++ b/features/suites/s30_service_plane/declared_bindings.feature
@@ -27,7 +27,7 @@ Feature: A catalog runtime declares the host services it needs
     When the runtime is detected by its command
     Then detection is refused rather than reporting no match
 
-  @live @sdk_sidecar
+  @live @sdk_sidecar @dir_share
   Scenario: a workload may bind the key-value store at launch
     When I run mvmctl in an isolated live home with "machine run --name bdd-kv-bind --image alpine --host-service host.kv.v1 --timeout 120 -- /bin/echo mvm-bdd-kv-bound"
     Then the command exits with code 0

--- a/features/suites/s30_service_plane/host_kv.feature
+++ b/features/suites/s30_service_plane/host_kv.feature
@@ -46,7 +46,7 @@ Feature: A workload reaches a key-value store without a network path
   # The guest-mount allow-roots are `/data` and `/work`. `/mnt` is mvm-owned
   # (it carries the config and secret drives), so mounting there is refused —
   # which is how the first live attempt of this scenario failed.
-  @live @sdk_sidecar
+  @live @sdk_sidecar @dir_share
   Scenario: a booted workload round-trips a key through the broker
     When I run mvmctl in an isolated live home with "run --runtime python --host-service host.kv.v1 --mount features/suites/s30_service_plane/fixtures:/work/fixtures:ro --timeout 300 -- python /work/fixtures/kv_roundtrip.py"
     Then the command exits with code 0
@@ -54,7 +54,11 @@ Feature: A workload reaches a key-value store without a network path
 
   # Binding is what makes the store reachable, so the refusal has to be
   # observable from inside a guest too -- not only at the registry.
-  @live @sdk_sidecar
+  # `@dir_share` even though this asserts a *refusal*: the share is refused
+  # with the same exit code the scenario expects, and before the guest boots,
+  # so on a backend without virtio-fs it passed while witnessing nothing about
+  # binding.
+  @live @sdk_sidecar @dir_share
   Scenario: an unbound workload is refused from inside the guest
     When I run mvmctl in an isolated live home with "run --runtime python --host-service host.time.v1 --mount features/suites/s30_service_plane/fixtures:/work/fixtures:ro --timeout 300 -- python /work/fixtures/kv_roundtrip.py"
     Then the command exits with code 1

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -75,7 +75,10 @@ Feature: every README-documented CLI launch mode boots a real guest
     And the guest printed "/proc/self/fd"
     And the guest control plane came up
 
-  @live
+  # The one scenario here that is *about* `--mount` rather than merely using it
+  # to deliver a file. libkrun and HVF both serve a virtio-fs share; Firecracker
+  # has no such device and refuses the volume before boot.
+  @live @dir_share
   Scenario: --mount shares a host directory the workload can read
     When I launch "machine run --image alpine --mount .:/work -- ls /work/README.md"
     Then the launch succeeds


### PR DESCRIPTION
Two independent defects the Linux e2e run surfaced.

## 1. Scenarios that need a virtio-fs directory share were not gated

Four scenarios pass `--mount`. libkrun and the in-house HVF VMM both serve a virtio-fs share; **Firecracker has no such device** and refuses the volume before the guest boots. On the Linux lane three of the four failed for that reason rather than for anything they were written to test.

The fourth is worse. *"An unbound workload is refused from inside the guest"* asserts exit 1 — and the share refusal **also exits 1, before boot**. It was passing on Firecracker while witnessing nothing about service binding.

Adds `@dir_share`, declared via `MVM_BDD_DIR_SHARE=1` rather than probed, for the same reason `@snapshot` is declared: deciding it here would re-derive backend auto-selection into a copy that drifts.

The README taught `--mount` without qualification; it now names the backends that serve it and `--volume` as the portable form.

## 2. Live steps ran against a different home than the scenario declared

`Given an isolated mvm home` exists so a scenario can be hermetic, or seed a cache and assert on it. The live step ignored it whenever `MVM_E2E_HOME` was set, so `machine create` and `machine start` in the same scenario pointed at two directories.

It surfaced as `machine "bdd-persistent-volume" does not exist` — naming the machine, never the home it was looked for in, so it read as a defect in `machine start`. Same signature as the `bdd-readme-web` failure in the main suite.

## Evidence

Found running the writable-volume scenarios on the KVM box. They had been **skipped in every run to date** for want of `MVM_BDD_GUEST_BIN_DIR`, so `--volume ... --rw` had no live witness at all. With guest binaries staged they now reach `machine volume mount --guest /data --rw` green and fail only on the home bug above.

Two things worth knowing for anyone staging those binaries: they must be **static musl** (a glibc build is refused — the guest rootfs has no dynamic loader), and the skip message names four binaries while the step needs at least five (`mvm-seccomp-apply`).