### PR TITLE
fix(stream): deliver fleet edges through guest input

### DIFF
--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -28,7 +28,7 @@ use mvm_core::plan::ExecutionPlan;
 use mvm_core::protocol::vm_backend::{VmId, VmStatus};
 use mvm_core::rootfs_source::RootfsSource;
 use mvm_hostd::audit::emitter::AuditEmitter;
-use mvm_hostd::plan_admission::{InMemoryNonceLedger, StartedMachine, SystemClock};
+use mvm_hostd::plan_admission::{AdmittedPlan, InMemoryNonceLedger, StartedMachine, SystemClock};
 use mvm_hostd::run::{LocalRunContext, LocalRunRequest, admit_and_boot_local};
 use mvm_runtime::AnyBackend;
 use mvm_runtime::machine::persist as mp;
@@ -52,6 +52,13 @@ pub struct LaunchOutcome {
     pub machine: MachineState,
     /// Content-addressed id of the admitted plan.
     pub plan_id: String,
+    /// The admitted authority object used for this boot.
+    ///
+    /// Fleet stream orchestration needs the exact admitted plan to open the
+    /// consumer's default-deny input route. Exposing that object keeps the
+    /// caller from admitting a second copy with a second nonce merely to gain
+    /// an input capability.
+    pub admitted: AdmittedPlan,
     pub(crate) mode: LifecycleMode,
     pub(crate) plan: ExecutionPlan,
 }
@@ -750,6 +757,7 @@ impl LocalBackend {
         started: StartedMachine,
         transient: bool,
     ) -> LaunchOutcome {
+        let plan = started.admitted.plan().clone();
         LaunchOutcome {
             machine: MachineState {
                 id: MachineId(started.vm_id.0.clone()),
@@ -766,12 +774,13 @@ impl LocalBackend {
                 ..Default::default()
             },
             plan_id: started.admitted.plan_id().0.clone(),
+            admitted: started.admitted,
             mode: if transient {
                 LifecycleMode::Transient
             } else {
                 LifecycleMode::Persistent
             },
-            plan: started.admitted.plan().clone(),
+            plan,
         }
     }
 }

--- a/crates/mvm-hostd/src/stream/edge_connector.rs
+++ b/crates/mvm-hostd/src/stream/edge_connector.rs
@@ -45,10 +45,11 @@
 use std::collections::VecDeque;
 
 use mvm_contract::stream::edge::{EdgeBackpressure, EdgeRedaction, StreamEdge};
-use mvm_contract::stream::input::{CloseInput, InputFrame};
+use mvm_contract::stream::input::InputFrame;
 
 use super::fanout::ReaderHandle;
-use super::input_gate::{InputRefusal, InputSession};
+use super::input_gate::InputRefusal;
+use super::input_route::{InputRoute, InputRouteError};
 
 /// What one [`EdgeConnector::step`] did.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -81,6 +82,9 @@ pub enum EdgeError {
     /// The consumer's input gate refused a frame.
     #[error("the consumer's input gate refused the edge: {0}")]
     Refused(#[from] InputRefusal),
+    /// The admitted route could not carry a frame to the guest.
+    #[error("the consumer's input route failed: {0}")]
+    Route(InputRouteError),
     /// A reliable edge lost records.
     #[error(
         "reliable edge lost records after seq {after_seq}: the consumer fell behind and the \
@@ -123,7 +127,7 @@ pub fn servable(edge: &StreamEdge) -> Result<(), EdgeError> {
 /// Pumps one producer's records into one consumer's stdin.
 pub struct EdgeConnector {
     binding: String,
-    session: InputSession,
+    route: InputRoute,
     reader: ReaderHandle,
     backpressure: EdgeBackpressure,
     /// Next frame sequence to hand the gate. Strictly increasing across the
@@ -139,20 +143,20 @@ pub struct EdgeConnector {
 }
 
 impl EdgeConnector {
-    /// Bind a reader to a consumer's input session.
+    /// Bind a reader to a consumer's admitted input route.
     ///
     /// # Errors
     ///
     /// [`EdgeError::RawUnavailable`] when the edge asks for unmasked bytes.
     pub fn new(
         edge: &StreamEdge,
-        session: InputSession,
+        route: InputRoute,
         reader: ReaderHandle,
     ) -> Result<Self, EdgeError> {
         servable(edge)?;
         Ok(Self {
             binding: edge.binding.clone(),
-            session,
+            route,
             reader,
             backpressure: edge.backpressure,
             next_seq: 0,
@@ -200,7 +204,7 @@ impl EdgeConnector {
             // Refresh even with nothing to send. An edge whose producer is
             // quiet must not lose the single-writer lease to the TTL and then
             // find another writer holding it.
-            self.session.refresh()?;
+            self.route.refresh().map_err(map_route_error)?;
             return Ok(match gap_at {
                 Some(after_seq) => EdgeStep::Gap {
                     after_seq,
@@ -217,18 +221,18 @@ impl EdgeConnector {
                 seq: self.next_seq,
                 payload,
             };
-            match self.session.write(frame) {
+            match self.route.write(frame) {
                 Ok(()) => {
                     self.next_seq += 1;
                     records += 1;
                     bytes += len;
                 }
                 Err(err) => {
-                    // The frame is gone — `write` consumed it — but everything
-                    // behind it is still owed to the consumer, and the caller
-                    // may retry. Leaving `carry` intact is what makes a
-                    // refusal recoverable rather than a silent truncation.
-                    return Err(EdgeError::Refused(err));
+                    // Route errors end this edge. A supervisor re-runs the
+                    // workflow rather than attempting to reconnect across a
+                    // fresh scanner or guessing whether the guest observed a
+                    // transport failure.
+                    return Err(map_route_error(err));
                 }
             }
         }
@@ -243,12 +247,19 @@ impl EdgeConnector {
     ///
     /// # Errors
     ///
-    /// [`InputRefusal`] when the session cannot be closed cleanly.
-    pub fn close(self) -> Result<CloseInput, InputRefusal> {
-        // `InputSession::close` flushes the scanner's withheld tail into the
-        // trailing bytes. Dropping the session instead would swallow it, which
-        // is a truncation the consumer cannot see.
-        self.session.close()
+    /// [`InputRouteError`] when the route cannot be closed cleanly.
+    pub fn close(self) -> Result<(), InputRouteError> {
+        // `InputRoute::close` flushes the scanner's withheld tail through the
+        // guest transport before EOF. Dropping the route instead would
+        // swallow it, which is a truncation the consumer cannot see.
+        self.route.close()
+    }
+}
+
+fn map_route_error(error: InputRouteError) -> EdgeError {
+    match error {
+        InputRouteError::Refused(refusal) => EdgeError::Refused(refusal),
+        other => EdgeError::Route(other),
     }
 }
 

--- a/crates/mvm-hostd/src/stream/plane.rs
+++ b/crates/mvm-hostd/src/stream/plane.rs
@@ -75,6 +75,7 @@ use crate::audit::plan_persist;
 use crate::stream::broker::{StreamBroker, StreamCaptureIdentity, stream_capture_config};
 use crate::stream::console_source::{ConsoleSource, ConsoleSourceHandle, SharedBroker};
 use crate::stream::entrypoint_source::EntrypointSink;
+use crate::stream::fanout::ReaderHandle;
 use crate::stream::input_gate::InputRefusal;
 use crate::stream::input_route::{InputRoute, InputRouteError, InputTransport, WireSequence};
 use crate::stream::journal;
@@ -162,6 +163,22 @@ impl StreamPlane {
         let mut names: Vec<String> = self.registry().keys().cloned().collect();
         names.sort();
         names
+    }
+
+    /// Subscribe to the redacted output of a VM this plane owns.
+    ///
+    /// Returns `None` for every absent source. Authorization and binding
+    /// resolution belong to the fleet caller; this method deliberately does
+    /// not expose why a name failed to resolve. A successful subscription is
+    /// recorded by the broker in the source workload's chain-signed audit
+    /// log.
+    pub fn subscribe(&self, vm: &str) -> Option<ReaderHandle> {
+        let broker = {
+            let registry = self.registry();
+            Arc::clone(&registry.get(vm)?.broker)
+        };
+        let mut broker = broker.lock().unwrap_or_else(PoisonError::into_inner);
+        Some(broker.subscribe())
     }
 
     /// Stand up `vm`'s capture under `redaction` and start following its
@@ -1057,6 +1074,9 @@ mod tests {
         assert!(config::vm_stream_socket("plane-vm").exists());
 
         let follower = Follower::attach("plane-vm");
+        let mut edge_reader = plane
+            .subscribe("plane-vm")
+            .expect("an attached VM is subscribable");
         assert_eq!(follower.availability, StreamAvailability::LiveOnly);
 
         std::fs::write(&console, b"from the console\n").expect("write the console capture");
@@ -1067,6 +1087,17 @@ mod tests {
             record.origin
         );
         assert_eq!(record.payload, b"from the console\n");
+        assert_eq!(
+            edge_reader
+                .recv()
+                .expect("the edge reader saw the frame")
+                .payload,
+            b"from the console\n"
+        );
+        assert!(
+            plane.subscribe("not-attached").is_none(),
+            "all absent sources have the same result"
+        );
 
         plane.release("plane-vm");
     }

--- a/crates/mvm-hostd/tests/stream_edge_connector.rs
+++ b/crates/mvm-hostd/tests/stream_edge_connector.rs
@@ -9,6 +9,7 @@
 use mvm_contract::protocol::broker::ServiceId;
 use mvm_contract::stream::edge::{EdgeBackpressure, EdgeRedaction, StreamEdge};
 use mvm_contract::stream::input::INPUT_GRANT_SERVICE;
+use mvm_contract::stream::input::{CloseInput, InputFrame};
 use mvm_contract::stream::record::{StreamKind, StreamSource};
 use mvm_core::plan::{PlanSeccompTier, SecretReleasePolicy, SynthesisInput};
 use mvm_core::policy::RedactionPolicy;
@@ -17,11 +18,68 @@ use mvm_hostd::audit::emitter::AuditEmitter;
 use mvm_hostd::plan_admission::{AdmittedPlan, InMemoryNonceLedger, SystemClock, admit_for_run};
 use mvm_hostd::stream::{
     EdgeConnector, EdgeError, EdgeStep, InputAudit, InputBinding, InputGate, InputRefusal,
-    StreamBroker, StreamRedaction,
+    InputRoute, InputTransport, StreamBroker, StreamRedaction, WireSequence,
 };
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
+
+#[derive(Clone, Default)]
+struct CapturedInput {
+    bytes: Arc<Mutex<Vec<u8>>>,
+    close: Arc<Mutex<Option<CloseInput>>>,
+}
+
+impl CapturedInput {
+    fn bytes(&self) -> Vec<u8> {
+        self.bytes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    fn close(&self) -> Option<CloseInput> {
+        self.close
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+impl InputTransport for CapturedInput {
+    fn deliver(&mut self, frame: &InputFrame) -> anyhow::Result<()> {
+        self.bytes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extend_from_slice(&frame.payload);
+        Ok(())
+    }
+
+    fn close(&mut self, close: &CloseInput) -> anyhow::Result<()> {
+        self.bytes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extend_from_slice(&close.trailing);
+        *self
+            .close
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(close.clone());
+        Ok(())
+    }
+}
+
+fn input_route(vm: &str, admitted: &AdmittedPlan) -> (InputRoute, CapturedInput) {
+    let capture = CapturedInput::default();
+    let route = InputRoute::open(
+        vm,
+        admitted,
+        Box::new(capture.clone()),
+        WireSequence::default(),
+    )
+    .expect("the plan grants input");
+    (route, capture)
+}
 
 fn unique_vm(prefix: &str) -> String {
     static NEXT: AtomicU64 = AtomicU64::new(0);
@@ -137,14 +195,14 @@ fn a_producers_output_reaches_a_consumers_stdin_in_order() {
     let consumer = unique_vm("consumer");
     let plan = admitted_with_grant(&consumer);
     let _chain = bind_chain(&consumer);
-    let session = InputGate::open(&consumer, &plan).expect("the plan grants input");
+    let (route, captured) = input_route(&consumer, &plan);
 
     let mut b = broker(&unique_vm("producer"));
     let reader = b.subscribe();
     ingest(&mut b, b"first\n");
     ingest(&mut b, b"second\n");
 
-    let mut edge = EdgeConnector::new(&StreamEdge::new("upstream"), session, reader)
+    let mut edge = EdgeConnector::new(&StreamEdge::new("upstream"), route, reader)
         .expect("a redacted edge is servable");
     match edge.step().expect("the pump runs") {
         EdgeStep::Delivered { records, bytes } => {
@@ -153,8 +211,10 @@ fn a_producers_output_reaches_a_consumers_stdin_in_order() {
         }
         other => panic!("expected delivery, got {other:?}"),
     }
+    assert_eq!(captured.bytes(), b"first\nsecond\n");
 
-    let closed = edge.close().expect("close");
+    edge.close().expect("close");
+    let closed = captured.close().expect("the transport saw EOF");
     assert_eq!(
         closed.after_seq,
         Some(1),
@@ -197,12 +257,11 @@ fn stepping_across_the_ttl_keeps_the_lease_from_a_competitor() {
                 AuditEmitter::with_dir(key, chain_dir.path()).expect("chain"),
             )),
     );
-    let session = InputGate::open(&consumer, &plan).expect("grant");
+    let (route, _captured) = input_route(&consumer, &plan);
 
     let mut b = broker(&unique_vm("producer-idle"));
     let reader = b.subscribe();
-    let mut edge =
-        EdgeConnector::new(&StreamEdge::new("quiet"), session, reader).expect("servable");
+    let mut edge = EdgeConnector::new(&StreamEdge::new("quiet"), route, reader).expect("servable");
 
     // Step across more than one whole TTL, with nothing to send. Six gaps of
     // this size outlast the TTL, while each one still leaves the next step room
@@ -239,12 +298,11 @@ fn an_unstepped_edge_lets_the_lease_lapse() {
                 AuditEmitter::with_dir(key, chain_dir.path()).expect("chain"),
             )),
     );
-    let session = InputGate::open(&consumer, &plan).expect("grant");
+    let (route, _captured) = input_route(&consumer, &plan);
 
     let mut b = broker(&unique_vm("producer-lapse"));
     let reader = b.subscribe();
-    let _edge =
-        EdgeConnector::new(&StreamEdge::new("abandoned"), session, reader).expect("servable");
+    let _edge = EdgeConnector::new(&StreamEdge::new("abandoned"), route, reader).expect("servable");
 
     std::thread::sleep(PAST_THE_LEASE);
     assert!(
@@ -262,7 +320,7 @@ fn records_buffered_before_the_edge_existed_are_delivered() {
     let consumer = unique_vm("consumer-backlog");
     let plan = admitted_with_grant(&consumer);
     let _chain = bind_chain(&consumer);
-    let session = InputGate::open(&consumer, &plan).expect("grant");
+    let (route, captured) = input_route(&consumer, &plan);
 
     let mut b = broker(&unique_vm("producer-backlog"));
     let reader = b.subscribe();
@@ -270,11 +328,15 @@ fn records_buffered_before_the_edge_existed_are_delivered() {
         ingest(&mut b, format!("line-{i}\n").as_bytes());
     }
 
-    let mut edge = EdgeConnector::new(&StreamEdge::new("backlog"), session, reader).expect("ok");
+    let mut edge = EdgeConnector::new(&StreamEdge::new("backlog"), route, reader).expect("ok");
     match edge.step().expect("pump") {
         EdgeStep::Delivered { records, .. } => assert_eq!(records, 5, "the backlog crossed whole"),
         other => panic!("expected delivery, got {other:?}"),
     }
+    assert_eq!(
+        captured.bytes(),
+        b"line-0\nline-1\nline-2\nline-3\nline-4\n"
+    );
 }
 
 /// Frame sequence must advance across steps, not restart. The gate rejects a
@@ -286,11 +348,11 @@ fn frame_sequence_advances_across_steps() {
     let consumer = unique_vm("consumer-seq");
     let plan = admitted_with_grant(&consumer);
     let _chain = bind_chain(&consumer);
-    let session = InputGate::open(&consumer, &plan).expect("grant");
+    let (route, captured) = input_route(&consumer, &plan);
 
     let mut b = broker(&unique_vm("producer-seq"));
     let reader = b.subscribe();
-    let mut edge = EdgeConnector::new(&StreamEdge::new("seq"), session, reader).expect("ok");
+    let mut edge = EdgeConnector::new(&StreamEdge::new("seq"), route, reader).expect("ok");
 
     ingest(&mut b, b"one\n");
     assert!(matches!(
@@ -306,7 +368,8 @@ fn frame_sequence_advances_across_steps() {
         "a restarted sequence would have been refused as a replay here"
     );
 
-    let closed = edge.close().expect("close");
+    edge.close().expect("close");
+    let closed = captured.close().expect("the transport saw EOF");
     assert_eq!(closed.after_seq, Some(1), "two frames, seq 0 and 1");
 }
 
@@ -317,7 +380,7 @@ fn a_raw_edge_is_refused_at_construction() {
     let consumer = unique_vm("consumer-raw");
     let plan = admitted_with_grant(&consumer);
     let _chain = bind_chain(&consumer);
-    let session = InputGate::open(&consumer, &plan).expect("grant");
+    let (route, _captured) = input_route(&consumer, &plan);
 
     let mut b = broker(&unique_vm("producer-raw"));
     let reader = b.subscribe();
@@ -326,7 +389,7 @@ fn a_raw_edge_is_refused_at_construction() {
         redaction: EdgeRedaction::Raw,
         backpressure: EdgeBackpressure::Lossy,
     };
-    match EdgeConnector::new(&edge, session, reader) {
+    match EdgeConnector::new(&edge, route, reader) {
         Err(EdgeError::RawUnavailable { binding }) => assert_eq!(binding, "fidelity"),
         Ok(_) => panic!("a raw edge must not be served from a post-seam reader"),
         Err(other) => panic!("expected RawUnavailable, got {other}"),

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -86,6 +86,13 @@ Last updated: 2026-08-28
 
 ## Completed
 
+- [x] **Fleet stream edge delivery handoff.** The edge pump now terminates in
+      the bounded, exactly-once guest input route; close carries the scanner's
+      withheld tail before EOF. `StreamPlane::subscribe` and
+      `LaunchOutcome::admitted` provide the two narrow capabilities the
+      external fleet supervisor needs without re-admission or guest
+      addressing.
+
 - [x] **Linux 6.12.106 synchronized kernel pin — issue #2931.**
       `specs/plans/2026-08-27-kernel-6-12-106.md`.
       Both kernel consumers use the kernel.org-verified archive and SRI hash;

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,13 @@
 
 ## In progress
 
+- [x] **Fleet stream edge delivery handoff.** Plan 296's caller-driven
+      connector now owns the production input route, so accepted records and
+      the close tail reach the guest instead of stopping in the gate outbox.
+      The host plane exposes a redacted per-VM reader and a successful local
+      launch exposes its exact admitted plan for the external fleet caller.
+      Focused connector, plane, and client compilation tests are green.
+
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.
       The custom workload/builder kernel and libkrunfw firmware build now use

--- a/specs/plans/296-fleet-stream-fan-out.md
+++ b/specs/plans/296-fleet-stream-fan-out.md
@@ -2,6 +2,13 @@
 
 **Status:** Complete. WS1–WS6 landed.
 
+**Integration repair (2026-08-28):** `EdgeConnector` now owns the admitted
+`InputRoute`, not a bare `InputSession`, so `step()` carries cleared bytes over
+the guest transport and `close()` delivers the scanner tail before EOF.
+`StreamPlane::subscribe` exposes the redacted reader by host-resolved VM name,
+and `LaunchOutcome::admitted` hands the fleet caller the exact authority object
+used for the boot rather than inviting a second admission.
+
 `mvm` ships the mechanism; `mvmd` declares the edges and resolves the bindings.
 That split is why the landed half has **no production caller in this
 repository** — see "Declared dormancy" below. It is a declaration, not an
@@ -91,9 +98,9 @@ Two consequences worth stating plainly, because they will surprise someone:
   a connector that had picked those answers here would have picked them blind.
   What it does own is local: acceptance order (one pass, never reordered,
   `seq` strictly increasing across the edge's life), lease upkeep on every
-  step including idle ones, and `close()` routing through
-  `InputSession::close` so the scanner's withheld tail is delivered rather
-  than dropped.
+  step including idle ones, and `close()` routing through `InputRoute::close`
+  so the scanner's withheld tail is carried to the guest before EOF rather
+  than merely returned to the caller or dropped.
 
   **E2 cannot be served from this reader, and that is a finding.** Redaction
   runs before hashing, so a record reaching a `ReaderHandle` has already


### PR DESCRIPTION
## Summary
- route `EdgeConnector` through the bounded production `InputRoute` so accepted bytes reach the guest
- flush the secret-scanner tail through the guest transport before EOF
- expose a redacted per-VM subscription and the exact admitted launch plan for the MVMD supervisor
- document the Plan 296 integration repair

Prerequisite for tinylabscom/mvmd#214.

## Validation
- `just fmt-check`
- `just check`
- `cargo test -p mvm-hostd -p mvm-client`
- `cargo clippy -p mvm-hostd -p mvm-client --all-targets -- -D warnings`
- `just model`
- `cargo run -p xtask -- check-dormant-controls`
- `cargo run -p xtask -- check-sprint-append`