### PR TITLE
refactor(contract): move GuestLibc below the crates that need it

### DIFF
--- a/crates/mvm-build/src/guest_libc.rs
+++ b/crates/mvm-build/src/guest_libc.rs
@@ -13,34 +13,14 @@
 
 use std::path::Path;
 
-/// The C library a guest rootfs is built against.
+/// The guest's C library.
 ///
-/// [`GuestLibc::Unknown`] is not a neutral default. It means the tree carried
-/// no loader this code recognises, or carried more than one, and a caller
-/// gating on it must treat that as *unknown*, never as safe — the same
-/// convention the sidecar's `entrypoint_argv` follows.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum GuestLibc {
-    /// GNU libc. Loader is `ld-linux-<arch>.so.<n>`.
-    Glibc,
-    /// musl libc, as used by Alpine. Loader is `ld-musl-<arch>.so.1`.
-    Musl,
-    /// No recognised loader, or more than one.
-    #[default]
-    Unknown,
-}
-
-impl GuestLibc {
-    /// The value as it appears in the sidecar and in operator-facing text.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Glibc => "glibc",
-            Self::Musl => "musl",
-            Self::Unknown => "unknown",
-        }
-    }
-}
+/// Defined in `mvm-contract` rather than here because two crates that cannot
+/// see each other both need it: this one detects it from an unpacked tree, and
+/// `mvm-fs` keys the SDK sidecar cache on it so a guest is offered the variant
+/// it can load. Those are siblings, so the vocabulary sits underneath both
+/// while the detection — which reads a filesystem — stays here.
+pub use mvm_contract::guest_libc::GuestLibc;
 
 /// Directories a dynamic loader lives in, relative to the rootfs.
 const LOADER_DIRS: [&str; 2] = ["lib", "lib64"];
@@ -159,21 +139,6 @@ mod tests {
         assert_eq!(
             detect_guest_libc(&dir.path().join("nope")),
             GuestLibc::Unknown
-        );
-    }
-
-    #[test]
-    fn unknown_is_the_default() {
-        assert_eq!(GuestLibc::default(), GuestLibc::Unknown);
-    }
-
-    #[test]
-    fn the_wire_form_is_lowercase() {
-        let json = serde_json::to_string(&GuestLibc::Musl).unwrap();
-        assert_eq!(json, "\"musl\"");
-        assert_eq!(
-            serde_json::from_str::<GuestLibc>("\"glibc\"").unwrap(),
-            GuestLibc::Glibc
         );
     }
 }

--- a/crates/mvm-contract/src/guest_libc.rs
+++ b/crates/mvm-contract/src/guest_libc.rs
@@ -1,0 +1,81 @@
+//! Which C library a guest rootfs is built against.
+//!
+//! The type lives here rather than beside the code that detects it, because
+//! two crates that cannot see each other both need it: `mvm-build` observes it
+//! while the unpacked tree is still a directory, and `mvm-fs` keys the SDK
+//! sidecar cache on it so a guest is offered the variant it can load. Those are
+//! siblings, so the shared vocabulary has to sit underneath both.
+//!
+//! Detection stays in `mvm-build` — it reads a filesystem, which this `no_std`
+//! crate cannot.
+
+use serde::{Deserialize, Serialize};
+
+/// The C library a guest rootfs is built against.
+///
+/// [`GuestLibc::Unknown`] is not a neutral default. It means the tree carried
+/// no loader the detector recognises, or carried more than one, and a caller
+/// gating on it must treat that as *unknown*, never as safe — the same
+/// convention the image sidecar's `entrypoint_argv` follows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GuestLibc {
+    /// GNU libc. Loader is `ld-linux-<arch>.so.<n>`; its libc soname is
+    /// `libc.so.6`.
+    Glibc,
+    /// musl libc, as used by Alpine. Loader is `ld-musl-<arch>.so.1`; its libc
+    /// soname is `libc.so`.
+    Musl,
+    /// No recognised loader, or more than one.
+    #[default]
+    Unknown,
+}
+
+impl GuestLibc {
+    /// The value as it appears in the image sidecar, in cache paths, and in
+    /// operator-facing text.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Glibc => "glibc",
+            Self::Musl => "musl",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl core::fmt::Display for GuestLibc {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_is_the_default() {
+        assert_eq!(GuestLibc::default(), GuestLibc::Unknown);
+    }
+
+    #[test]
+    fn the_wire_form_is_lowercase() {
+        assert_eq!(serde_json::to_string(&GuestLibc::Musl).unwrap(), "\"musl\"");
+        assert_eq!(
+            serde_json::from_str::<GuestLibc>("\"glibc\"").unwrap(),
+            GuestLibc::Glibc
+        );
+    }
+
+    /// The cache keys a directory segment on this, so it has to match the wire
+    /// form exactly — a divergence would put the artifact somewhere the
+    /// resolver does not look.
+    #[test]
+    fn the_display_form_matches_the_wire_form() {
+        for libc in [GuestLibc::Glibc, GuestLibc::Musl, GuestLibc::Unknown] {
+            let wire = serde_json::to_string(&libc).unwrap();
+            assert_eq!(format!("\"{libc}\""), wire);
+        }
+    }
+}

--- a/crates/mvm-contract/src/lib.rs
+++ b/crates/mvm-contract/src/lib.rs
@@ -35,6 +35,10 @@ pub mod entrypoint;
 /// A workload's permission set — CPU, wall clock, egress destinations.
 #[cfg(feature = "protocol")]
 pub mod grants;
+/// Which C library a guest rootfs is built against. Shared vocabulary between
+/// the crate that detects it and the crate that keys the SDK sidecar cache on
+/// it; those are siblings, so it sits underneath both.
+pub mod guest_libc;
 #[cfg(feature = "protocol")]
 pub mod ir;
 /// Guest lifecycle markers + snapshot timing (the `mvm-init` ↔ host contract).


### PR DESCRIPTION
Prerequisite for selecting the SDK sidecar variant by the guest's libc (#2969).

Two crates that cannot see each other both need to name a guest's C library. `mvm-build` detects it from an unpacked tree (#2974); `mvm-fs` has to key the SDK sidecar cache on it, so a guest is offered the variant it can actually load. Those are siblings — `mvm-fs` depends only on `mvm-contract` and `mvm-http` — so the type has to sit underneath both.

I found this by trying to write the selection and discovering the cache layout couldn't reference the type at all.

Move the enum to `mvm-contract` and re-export it from `mvm-build`, so existing callers keep their paths. Detection stays where it is: it reads a filesystem, which a `no_std` crate cannot.

### The one addition

`Display`, plus a test asserting it agrees with the serde form.

That is not tidiness. The cache is about to key a *directory segment* on this value. If `Display` and the wire form ever diverged, the artifact would be written where the resolver does not look — and nothing else in the system would notice, because both halves would be internally consistent. The test pins them together before anything depends on it.

### Gates

- `cargo run -p xtask -- check-all` — 61 gates clean
- `cargo nextest run --workspace` — 12681 passed; the one failure is #2973, the macOS-deterministic socket-path assertion, unrelated and pre-existing
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`

### Next

With the type reachable, the sidecar cache layout gains a libc segment and the resolver takes the image's recorded libc — turning the refusal #2987 added into a selection.