### PR TITLE
test(hostd): wait for replacement worker identity

### DIFF
--- a/crates/mvm-hostd/tests/host_agent_restart.rs
+++ b/crates/mvm-hostd/tests/host_agent_restart.rs
@@ -306,6 +306,16 @@ async fn worker_restart_restores_journaled_registration_and_chain() {
     let worker_pid = fixture.worker_pid().expect("worker pid");
     kill_process_group(worker_pid);
 
+    // A successful kill(2) does not mean the old process has stopped
+    // accepting work yet. Under workspace load, connecting immediately can
+    // reach that dying worker after its signer helper has exited and observe
+    // a transient broker error. Wait for the supervisor's replacement
+    // identity before asserting restored registration and chain state.
+    let worker_deadline = Instant::now() + BROKER_RECOVERY_TIMEOUT;
+    fixture
+        .wait_for_worker_replacement(worker_pid, worker_deadline)
+        .await;
+
     let resp = fixture.wait_for_emit("after-worker-restart").await;
     assert!(matches!(resp, ServiceResponse::Ok { .. }));
     assert_eq!(fixture.chain_entries(), 2);

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -19,8 +19,8 @@ Last updated: 2026-08-28
 - [ ] **Worker restart identity barrier — issue #2976.**
       `specs/plans/2026-08-28-worker-restart-identity-barrier.md`.
       Recovery assertions now begin only after the old worker PID has been
-      replaced by a live supervisor-published identity. Workspace validation
-      and merge delivery remain.
+      replaced by a live supervisor-published identity. The focused and
+      workspace validation gates are green; merge delivery remains.
 
 - [ ] **Wasm SDK host-service admission — issue #2977.**
       `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -16,6 +16,12 @@ Last updated: 2026-08-28
       focused regression, all 598 `mvm-vmm` tests, workspace tests, and
       workspace Clippy are green. Merge delivery remains.
 
+- [ ] **Worker restart identity barrier — issue #2976.**
+      `specs/plans/2026-08-28-worker-restart-identity-barrier.md`.
+      Recovery assertions now begin only after the old worker PID has been
+      replaced by a live supervisor-published identity. Workspace validation
+      and merge delivery remain.
+
 - [ ] **Wasm SDK host-service admission — issue #2977.**
       `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.
       Wasm now refuses the native SDK-sidecar mechanism at the backend-aware

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -34,6 +34,13 @@
       tests, workspace tests, and workspace Clippy are green; merge delivery
       remains.
 
+- [ ] **Worker restart identity barrier — issue #2976.**
+      `specs/plans/2026-08-28-worker-restart-identity-barrier.md`.
+      The restart regression now waits for the supervisor-published
+      replacement PID before testing journal restoration and audit continuity.
+      The focused regression and full restart suite are green; workspace
+      validation and merge delivery remain.
+
 - [ ] **Wasm SDK host-service admission — issue #2977.**
       `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.
       The SDK delivery gate now refuses wasm bindings with a typed,

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -38,8 +38,9 @@
       `specs/plans/2026-08-28-worker-restart-identity-barrier.md`.
       The restart regression now waits for the supervisor-published
       replacement PID before testing journal restoration and audit continuity.
-      The focused regression and full restart suite are green; workspace
-      validation and merge delivery remain.
+      The focused regression, full restart suite, ordinary workspace tests,
+      isolated `mvm-cli` doctests, workspace Clippy, formatting, and repository
+      policy gates are green; merge delivery remains.
 
 - [ ] **Wasm SDK host-service admission — issue #2977.**
       `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.

--- a/specs/plans/2026-08-28-worker-restart-identity-barrier.md
+++ b/specs/plans/2026-08-28-worker-restart-identity-barrier.md
@@ -1,0 +1,22 @@
+# Worker restart identity barrier
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#2976](https://github.com/tinylabscom/mvm/issues/2976)
+
+## Outcome
+
+The restart integration test observes the supervisor-published replacement
+worker identity before sending the post-crash broker call. This prevents a
+successful process-group signal from being mistaken for proof that the dying
+worker and signer helper have completed their transition.
+
+## Delivery checklist
+
+- [x] Identify the missing state transition in the workspace-only failure.
+- [x] Wait for a live replacement PID before asserting restored registration.
+- [x] Pass the focused regression and complete host-agent restart suite.
+- [ ] Pass workspace tests, Clippy, formatting, and repository policy gates.
+- [ ] Record the completed implementation in the sprint and refactor rollup.
+- [ ] Merge the tested pull request and close #2976 through its linkage.

--- a/specs/plans/2026-08-28-worker-restart-identity-barrier.md
+++ b/specs/plans/2026-08-28-worker-restart-identity-barrier.md
@@ -17,6 +17,6 @@ worker and signer helper have completed their transition.
 - [x] Identify the missing state transition in the workspace-only failure.
 - [x] Wait for a live replacement PID before asserting restored registration.
 - [x] Pass the focused regression and complete host-agent restart suite.
-- [ ] Pass workspace tests, Clippy, formatting, and repository policy gates.
-- [ ] Record the completed implementation in the sprint and refactor rollup.
+- [x] Pass workspace tests, Clippy, formatting, and repository policy gates.
+- [x] Record the completed implementation in the sprint and refactor rollup.
 - [ ] Merge the tested pull request and close #2976 through its linkage.

--- a/specs/sprint/delivery/2976-worker-restart-identity-barrier.md
+++ b/specs/sprint/delivery/2976-worker-restart-identity-barrier.md
@@ -1,0 +1,10 @@
+# Worker restart identity barrier
+
+- [x] Located the race between process-group signaling and worker exit.
+- [x] Added an explicit replacement-worker identity barrier before recovery
+      assertions.
+- [x] Passed the focused regression and all four host-agent restart tests.
+- [ ] Record workspace validation after it passes.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-08-28-worker-restart-identity-barrier.md`.

--- a/specs/sprint/delivery/2976-worker-restart-identity-barrier.md
+++ b/specs/sprint/delivery/2976-worker-restart-identity-barrier.md
@@ -4,7 +4,9 @@
 - [x] Added an explicit replacement-worker identity barrier before recovery
       assertions.
 - [x] Passed the focused regression and all four host-agent restart tests.
-- [ ] Record workspace validation after it passes.
+- [x] Recorded a green focused restart suite, all ordinary workspace tests,
+      isolated `mvm-cli` doctests, workspace Clippy, formatting, and repository
+      policy gates.
 - [ ] Merge the linked pull request through the queue.
 
 Owning plan: `specs/plans/2026-08-28-worker-restart-identity-barrier.md`.


### PR DESCRIPTION
## Summary
- wait for the supervisor-published replacement worker PID after killing the old worker process group
- begin journal restoration and audit continuity assertions only after the replacement identity is live
- record the completed validation in the owning plan, sprint entry, and refactor rollup

## Validation
- `cargo test -p mvm-hostd --test host_agent_restart`
- `cargo test --workspace` (all ordinary tests green; aggregate rustdoc linkage retried in isolation)
- `cargo test -p mvm-cli --doc`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo run -p xtask -- check-sprint-append`
- `cargo run -p xtask -- check-plan-names`

Closes #2976