### PR TITLE
fix(admission): refuse wasm SDK host services explicitly

### DIFF
--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -390,6 +390,25 @@ fn admission_accepts_with_sidecar(world: &mut CliWorld) {
         .expect("the resolved attachment must satisfy the admission gate");
 }
 
+#[then(expr = "wasm admission refuses the requested SDK host service before backend start")]
+fn wasm_admission_refuses_sdk_host_service(world: &mut CliWorld) {
+    let bound = world
+        .sdk_sidecar_services
+        .first()
+        .expect("a prior step must bind an SDK host service")
+        .as_str();
+    let err = mvm_hostd::plan_admission::enforce_sdk_sidecar_backend_compatibility(
+        mvm_core::vm_backend::BackendKind::Wasm,
+        plan_of(world),
+    )
+    .expect_err("wasm must refuse the native SDK sidecar delivery mechanism");
+    let message = err.to_string();
+    assert!(message.contains(bound), "{message}");
+    assert!(message.contains("wasm"), "{message}");
+    assert!(message.contains("SDK host service"), "{message}");
+    assert!(!message.contains("DiskVolumeNotSupported"), "{message}");
+}
+
 #[then(expr = "admission refuses a sidecar attachment for this plan")]
 fn admission_refuses_sidecar(world: &mut CliWorld) {
     // Hand the gate a well-formed sidecar volume the plan never authorized.

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1316,28 +1316,48 @@ pub fn enforce_admitted_shares(
     Ok(())
 }
 
-/// Admission enforcement for the optional glibc SDK sidecar.
+/// Typed reasons the selected backend cannot carry the native SDK sidecar.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SdkSidecarBackendCompatibilityError {
+    #[error(
+        "refusing to launch SDK host service(s) [{services}] on the wasm backend: the SDK \
+         host-services library is delivered as a native shared object on a read-only disk, but \
+         wasm has neither block devices nor a native dynamic loader. Remove these bindings or \
+         use a microVM backend; WASI host-service imports are not implemented"
+    )]
+    WasmHostServicesUnsupported { services: String },
+}
+
+/// Refuse a host-service delivery mechanism the selected backend cannot carry.
 ///
-/// The sidecar carries the host-services cdylib the language SDKs `dlopen`. It
-/// is not in the base rootfs or the static-musl runtime overlay, so it has to be
-/// attached per-workload — and the attachment is authorized by the plan's
-/// host-service bindings, never by an environment variable or a guess about
-/// application content.
+/// This gate runs before attachment-shape validation and backend start so an
+/// SDK host-service request cannot leak as an error about the synthetic disk
+/// volume used to carry its native library.
+pub fn enforce_sdk_sidecar_backend_compatibility(
+    backend: mvm_core::vm_backend::BackendKind,
+    plan: &ExecutionPlan,
+) -> std::result::Result<(), SdkSidecarBackendCompatibilityError> {
+    use mvm_core::plan::{sdk_host_services_in, sdk_sidecar_required};
+
+    if backend != mvm_core::vm_backend::BackendKind::Wasm || !sdk_sidecar_required(plan) {
+        return Ok(());
+    }
+
+    let services = sdk_host_services_in(&plan.services)
+        .iter()
+        .map(|service| service.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(SdkSidecarBackendCompatibilityError::WasmHostServicesUnsupported { services })
+}
+
+/// Admission enforcement for the optional glibc SDK sidecar attachment.
 ///
-/// Both directions fail closed, and both are checked on the one admission path
-/// every backend reaches — including the mock and dev-tier backends, so a
-/// dev/test launch can't quietly acquire a posture production wouldn't:
-///
-/// - The plan binds an SDK-served host service, but no read-only sidecar
-///   attachment is present → refuse. Booting anyway strands the workload with a
-///   `dlopen` failure it cannot act on.
-/// - The plan binds none, but something attached a volume at the sidecar mount
-///   point anyway → refuse. That would smuggle the glibc closure (and a
-///   host-services transport) into a workload the plan never authorized.
-///
-/// A sidecar attachment must additionally be read-only and a disk image: the
-/// guest never writes to it, and a writable or directory-share attachment is a
-/// different, unadmitted shape.
+/// The sidecar carries the host-services cdylib the language SDKs `dlopen`. Its
+/// attachment is authorized by the plan's host-service bindings, never by an
+/// environment variable or a guess about application content. Both directions
+/// fail closed: a bound SDK service requires exactly one read-only disk at the
+/// SDK mount point, and a plan with no SDK binding may not carry one.
 pub fn enforce_sdk_sidecar_attachment(
     volumes: &[mvm_core::vm_backend::VmVolume],
     plan: &ExecutionPlan,
@@ -1720,6 +1740,7 @@ fn apply_admitted_grants(
 fn run_post_admission_gates(
     mut config: VmStartConfig,
     admitted: &AdmittedPlan,
+    backend: BackendKind,
     policy_bundle: Option<&PolicyBundle>,
 ) -> std::result::Result<VmStartConfig, (&'static str, anyhow::Error)> {
     if let Err(e) = populate_audit_substrate(&mut config, admitted, policy_bundle) {
@@ -1733,6 +1754,9 @@ fn run_post_admission_gates(
         admitted.plan(),
     ) {
         return Err(("admitted-environment", e));
+    }
+    if let Err(e) = enforce_sdk_sidecar_backend_compatibility(backend, admitted.plan()) {
+        return Err(("sdk-sidecar", e.into()));
     }
     if let Err(e) = enforce_sdk_sidecar_attachment(&config.volumes, admitted.plan()) {
         return Err(("sdk-sidecar", e));
@@ -1908,8 +1932,12 @@ pub fn start_admitted(params: StartAdmittedParams<'_>) -> Result<StartedMachine>
     // A refusal in any post-admission gate must still terminate the chain:
     // `plan.admitted` already fired, so a gate refusal emits `plan.failed`
     // carrying the refusing stage rather than leaving a dangling admission.
-    let mut config = match run_post_admission_gates(params.config, &admitted, params.policy_bundle)
-    {
+    let mut config = match run_post_admission_gates(
+        params.config,
+        &admitted,
+        backend.kind(),
+        params.policy_bundle,
+    ) {
         Ok(config) => config,
         Err((stage, err)) => {
             if let Some(emitter) = params.emitter
@@ -2704,6 +2732,37 @@ mod tests {
                 "{service} bound + sidecar attached read-only must be admitted"
             );
         }
+    }
+
+    /// Wasm has neither block devices nor a native dynamic loader, so the
+    /// ext4-hosted SDK cdylib cannot reach that tier. Refuse in terms of the
+    /// requested service before the backend leaks a synthetic disk-volume
+    /// implementation detail.
+    #[test]
+    fn wasm_sdk_binding_is_refused_at_the_delivery_seam() {
+        let plan = plan_binding(&["host.time.v1"]);
+        let err = enforce_sdk_sidecar_backend_compatibility(
+            mvm_core::vm_backend::BackendKind::Wasm,
+            &plan,
+        )
+        .expect_err("wasm cannot receive or load the SDK sidecar");
+        let msg = err.to_string();
+        assert!(msg.contains("wasm"), "{msg}");
+        assert!(msg.contains("host.time.v1"), "{msg}");
+        assert!(msg.contains("SDK host service"), "{msg}");
+        assert!(!msg.contains("DiskVolumeNotSupported"), "{msg}");
+    }
+
+    #[test]
+    fn microvm_backend_keeps_the_sdk_sidecar_delivery_path() {
+        let plan = plan_binding(&["host.time.v1"]);
+        assert!(
+            enforce_sdk_sidecar_backend_compatibility(
+                mvm_core::vm_backend::BackendKind::Firecracker,
+                &plan,
+            )
+            .is_ok()
+        );
     }
 
     /// A bound SDK host service with no sidecar attachment fails closed, and the

--- a/features/suites/s21_host_services/sdk_sidecar_attachment.feature
+++ b/features/suites/s21_host_services/sdk_sidecar_attachment.feature
@@ -26,6 +26,13 @@ Feature: SDK sidecar attaches only for admitted SDK host-service bindings
     And admission accepts the launch with the sidecar attachment
     And the assembled workload cmdline names the SDK sidecar device the backend attached
 
+  Scenario: wasm refuses SDK host services at admission in user terms
+    Given a verified SDK sidecar in the cache
+    And a workload plan that binds host service "host.time.v1"
+    When the launch path resolves the SDK sidecar
+    Then the SDK sidecar is attached read-only at "/mvm/sdk"
+    And wasm admission refuses the requested SDK host service before backend start
+
   Scenario: the SDK sidecar bypasses user-volume activation beside a wheel mount
     Given a verified SDK sidecar in the cache
     And a workload plan that binds host service "host.time.v1"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -19,8 +19,10 @@ Last updated: 2026-08-28
 - [ ] **Wasm SDK host-service admission — issue #2977.**
       `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.
       Wasm now refuses the native SDK-sidecar mechanism at the backend-aware
-      admission seam instead of leaking a disk-volume backend error. Full
-      validation and merge delivery remain.
+      admission seam instead of leaking a disk-volume backend error. Focused
+      regressions, the gated BDD runner, workspace tests, isolated doctests,
+      workspace Clippy, formatting, and policy gates are green. Merge delivery
+      remains.
 
 - [ ] **HVF machine restore dispatch — issue #2961.**
       `specs/plans/2026-08-27-hvf-machine-restore-dispatch.md`.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -16,6 +16,12 @@ Last updated: 2026-08-28
       focused regression, all 598 `mvm-vmm` tests, workspace tests, and
       workspace Clippy are green. Merge delivery remains.
 
+- [ ] **Wasm SDK host-service admission — issue #2977.**
+      `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.
+      Wasm now refuses the native SDK-sidecar mechanism at the backend-aware
+      admission seam instead of leaking a disk-volume backend error. Full
+      validation and merge delivery remain.
+
 - [ ] **HVF machine restore dispatch — issue #2961.**
       `specs/plans/2026-08-27-hvf-machine-restore-dispatch.md`.
       The `machine` fork/restore surfaces now share the backend-origin

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -31,8 +31,9 @@
       `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.
       The SDK delivery gate now refuses wasm bindings with a typed,
       service-specific reason before attachment validation or backend start.
-      Focused unit regressions and the BDD runner compile are green; full
-      validation and merge delivery remain.
+      Focused unit regressions, the gated BDD runner, all ordinary workspace
+      tests, the isolated `mvm-agentd` doctest, workspace Clippy, formatting,
+      and policy gates are green. Merge delivery remains.
 
 - [ ] **Recorded-backend pause and resume — issue #2929.**
       `specs/plans/2026-08-27-recorded-backend-pause-resume.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -27,6 +27,13 @@
       tests, workspace tests, and workspace Clippy are green; merge delivery
       remains.
 
+- [ ] **Wasm SDK host-service admission — issue #2977.**
+      `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.
+      The SDK delivery gate now refuses wasm bindings with a typed,
+      service-specific reason before attachment validation or backend start.
+      Focused unit regressions and the BDD runner compile are green; full
+      validation and merge delivery remain.
+
 - [ ] **Recorded-backend pause and resume — issue #2929.**
       `specs/plans/2026-08-27-recorded-backend-pause-resume.md`.
       Existing-machine lifecycle operations resolve the VMM that owns the live

--- a/specs/plans/2026-08-28-wasm-sdk-host-service-admission.md
+++ b/specs/plans/2026-08-28-wasm-sdk-host-service-admission.md
@@ -1,0 +1,24 @@
+# Wasm SDK host-service admission
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#2977](https://github.com/tinylabscom/mvm/issues/2977)
+
+## Outcome
+
+An admitted wasm launch that binds a native SDK host service is refused at the
+delivery seam in terms of the requested services. The typed refusal explains
+that the current SDK library needs a read-only disk and native dynamic loader,
+so the wasm backend never leaks the synthetic attachment as a generic disk
+volume error.
+
+## Delivery checklist
+
+- [x] Add a failing regression for a wasm SDK host-service binding.
+- [x] Add a typed backend-compatibility refusal before attachment validation.
+- [x] Preserve native microVM SDK-sidecar delivery.
+- [x] Add a user-visible BDD scenario and compile the gated runner.
+- [ ] Pass the focused BDD scenario, workspace tests, Clippy, and policy gates.
+- [ ] Record the completed implementation in the sprint and refactor rollup.
+- [ ] Merge the tested pull request and close #2977 through its linkage.

--- a/specs/plans/2026-08-28-wasm-sdk-host-service-admission.md
+++ b/specs/plans/2026-08-28-wasm-sdk-host-service-admission.md
@@ -19,6 +19,6 @@ volume error.
 - [x] Add a typed backend-compatibility refusal before attachment validation.
 - [x] Preserve native microVM SDK-sidecar delivery.
 - [x] Add a user-visible BDD scenario and compile the gated runner.
-- [ ] Pass the focused BDD scenario, workspace tests, Clippy, and policy gates.
-- [ ] Record the completed implementation in the sprint and refactor rollup.
+- [x] Pass the focused BDD scenario, workspace tests, Clippy, and policy gates.
+- [x] Record the completed implementation in the sprint and refactor rollup.
 - [ ] Merge the tested pull request and close #2977 through its linkage.

--- a/specs/sprint/delivery/2977-wasm-sdk-host-service-admission.md
+++ b/specs/sprint/delivery/2977-wasm-sdk-host-service-admission.md
@@ -4,7 +4,7 @@
 - [x] Added a typed wasm refusal that names the requested SDK host services.
 - [x] Kept Firecracker and other native delivery paths admissible.
 - [x] Added the hermetic BDD scenario and compiled its gated runner.
-- [ ] Record full validation after it passes.
+- [x] Record full validation after it passes.
 - [ ] Merge the linked pull request through the queue.
 
 Owning plan: `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.

--- a/specs/sprint/delivery/2977-wasm-sdk-host-service-admission.md
+++ b/specs/sprint/delivery/2977-wasm-sdk-host-service-admission.md
@@ -1,0 +1,10 @@
+# Wasm SDK host-service admission
+
+- [x] Reproduced the absence of a backend-aware SDK delivery gate.
+- [x] Added a typed wasm refusal that names the requested SDK host services.
+- [x] Kept Firecracker and other native delivery paths admissible.
+- [x] Added the hermetic BDD scenario and compiled its gated runner.
+- [ ] Record full validation after it passes.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-08-28-wasm-sdk-host-service-admission.md`.


### PR DESCRIPTION
Closes #2977

## Summary
- refuse native SDK host-service sidecars on the wasm backend at admission
- report the requested services and the missing disk/native-loader capabilities
- preserve native microVM delivery and add unit plus BDD coverage

## Validation
- cargo test -p mvm-hostd --lib
- cargo test -p mvm-conformance --features bdd --test conformance --no-run
- cargo test --workspace (all ordinary tests passed; aggregate doctest target contamination reproduced)
- cargo test -p mvm-agentd --doc
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo run -p xtask -- check-sprint-append
- cargo run -p xtask -- check-plan-names