### PR TITLE
docs(stream): record landed fleet edge caller

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,6 +498,9 @@ length-and-hash match, not an identity, and encoding, derivation and a
 window-straddling split defeat the scan permanently. ADR-001's ledger
 carries the full limits note, marked closed or open individually; do not
 paraphrase this row as enforced without it.
+The fleet stream-edge workflow in mvmd is now the input plane's second
+production caller; that closes no remaining limit and does not promote the
+claim.
 
 `Preview` claim 18 — **a workload's resource consumption is bounded at
 admission, and bound at spawn where the host has a mechanism**. Admission

--- a/README.md
+++ b/README.md
@@ -753,8 +753,9 @@ Claim 15 used to hold by _absence_: there was no host→guest byte path at all.
 The workload input channel built one, so refusing input is now a policy
 decision rather than a consequence of there being nothing to refuse. ADR-001
 carries that rewording, plus a `Preview` claim 17 for the input channel with
-the four limits that keep it a preview — including that it has no operator
-surface yet. See
+the fingerprint-scan and shell-classification limits that keep it a preview.
+Both the operator input surface and mvmd's fleet stream-edge workflow are now
+production callers; reachability is no longer the reason for the status. See
 [Workload input](public/src/content/docs/guides/workload-input.md).
 
     Separately, the restricted ProdSafe grant is issued only to a baked-entrypoint

--- a/public/src/content/docs/guides/fleet-stream-edges.md
+++ b/public/src/content/docs/guides/fleet-stream-edges.md
@@ -7,10 +7,11 @@ A **stream edge** connects one workload's output to another's stdin, so a fleet
 can run a workflow. `mvm` provides the mechanism; `mvmd` declares the edges and
 resolves them. A single-VM `mvmctl` run has no edges.
 
-:::caution[Mechanism only, today]
-The pieces below are on `main` and tested, but nothing in `mvm` declares an
-edge — `mvmd` is the caller. Until it does, this page describes a surface you
-can build against rather than a feature you can drive from the CLI.
+:::note[Fleet-driven surface]
+The pieces below are on `main`, tested, and driven in production by mvmd's
+bounded workflow supervisor. Nothing in `mvm` declares an edge because a
+single-VM invocation has no fleet graph. There is intentionally no `mvmctl`
+command that accepts a fleet edge declaration.
 :::
 
 ## A consumer names a binding, never a VM
@@ -165,16 +166,14 @@ What holds by construction, and is tested:
 
 What is **not** claimed:
 
-- That the refusals fire in production. They have no caller in `mvm`; `mvmd`
-  is expected to call them, and until it does they are declared dormant in
-  `xtask/dormant-controls.toml` so CI notices if that changes.
 - Anything about a consumer's handling of what it receives. An edge delivers
   bytes to stdin; what the workload does with them is the workload's business.
 
-Claim 17 (the workload input plane) stays at `Preview`. An edge would be its
-second production caller, and reassessing that is deferred until one exists —
-promoting a claim on the strength of a caller that has not been written is the
-drift this project's gates exist to prevent.
+The pre-boot refusals and bounded delivery now fire through mvmd's production
+workflow supervisor. Claim 17 (the workload input plane) nevertheless stays at
+`Preview`: the reassessment found its remaining limits are the fingerprint
+scan and shell-entrypoint heuristic documented in the workload-input guide,
+not whether a second caller exists.
 
 ## See also
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-28
+Last updated: 2026-08-29
 
 ## In progress
 
@@ -97,7 +97,9 @@ Last updated: 2026-08-28
       withheld tail before EOF. `StreamPlane::subscribe` and
       `LaunchOutcome::admitted` provide the two narrow capabilities the
       external fleet supervisor needs without re-admission or guest
-      addressing.
+      addressing. mvmd PR #238 now drives those capabilities in a bounded
+      production workflow, and the three fleet-only dormant declarations have
+      been removed.
 
 - [x] **Linux 6.12.106 synchronized kernel pin — issue #2931.**
       `specs/plans/2026-08-27-kernel-6-12-106.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -15,7 +15,9 @@
       the close tail reach the guest instead of stopping in the gate outbox.
       The host plane exposes a redacted per-VM reader and a successful local
       launch exposes its exact admitted plan for the external fleet caller.
-      Focused connector, plane, and client compilation tests are green.
+      mvmd PR #238 now drives the bounded workflow in production, so the three
+      fleet-only controls have left the dormant-control ratchet. Focused
+      connector, plane, and client compilation tests are green.
 
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.

--- a/specs/adrs/035-workload-stream-plane.md
+++ b/specs/adrs/035-workload-stream-plane.md
@@ -30,6 +30,13 @@ defeat the scan permanently.
 Three limits below (§"What this does not do") are stated as limits, not as
 future work. They are true of the shipped code.
 
+The input half now also has its second production caller: mvmd PR
+[#238](https://github.com/tinylabscom/mvmd/pull/238) validates fleet DAGs and
+signed edge grants before boot, resolves opaque bindings, and drives the
+caller-owned `EdgeConnector` into the exact admitted input route. This does not
+promote claim 17. Its remaining `Preview` limits are properties of fingerprint
+scanning and shell-entrypoint classification, not missing reachability.
+
 ## Context
 
 A production microVM has no shell. Claim 4 removes `do_exec` from the agent

--- a/specs/plans/296-fleet-stream-fan-out.md
+++ b/specs/plans/296-fleet-stream-fan-out.md
@@ -2,6 +2,15 @@
 
 **Status:** Complete. WS1–WS6 landed.
 
+**Fleet integration landed (2026-08-29):** mvmd PR
+[#238](https://github.com/tinylabscom/mvmd/pull/238) now validates the complete
+DAG and each signed consumer plan before boot, resolves only fleet-granted
+bindings, then drives `EdgeConnector` through accepted records and an explicit
+close. The workflow has bounded nodes, edges, audit events and step count; it
+fails the graph without reconnecting on any edge error. The three fleet-only
+controls have therefore left `xtask/dormant-controls.toml` as the ratchet
+requires.
+
 **Integration repair (2026-08-28):** `EdgeConnector` now owns the admitted
 `InputRoute`, not a bare `InputSession`, so `step()` carries cleared bytes over
 the guest transport and `close()` delivers the scanner tail before EOF.
@@ -10,9 +19,9 @@ and `LaunchOutcome::admitted` hands the fleet caller the exact authority object
 used for the boot rather than inviting a second admission.
 
 `mvm` ships the mechanism; `mvmd` declares the edges and resolves the bindings.
-That split is why the landed half has **no production caller in this
-repository** — see "Declared dormancy" below. It is a declaration, not an
-oversight.
+That split is why the production caller lives in mvmd rather than this
+repository. The boundary remains deliberate: mvm exposes single-host authority
+objects and never learns what a fleet is.
 
 Connect one workload's output stream to another's input stream, so a fleet can
 run a workflow. `mvmd` declares the edges; `mvm` exposes the primitives and
@@ -127,14 +136,14 @@ Two consequences worth stating plainly, because they will surprise someone:
   edge guarantees by construction (no guest addresses another, no new path out
   of a guest, the four pre-boot refusals, raw refused rather than downgraded,
   safe defaults that cannot be lost by omission, producer never stalled) and
-  what it does not — chiefly that **none of those refusals has fired in
-  production**, because none has a caller here. They are dormant by
-  declaration, and the gate now enforces that in both directions.
+  what it does not. At landing, none of those refusals had fired in production
+  because the fleet caller did not yet exist. The mvmd workflow now exercises
+  them before boot.
 
-  Claim 17 stays `Preview`. An edge would be the input plane's second
-  production caller and the promotion question is deferred until one exists;
-  promoting on a caller nobody has written would make the claim true of code
-  and false of the system. Why it existed: An edge is a different authorization shape than a
+  Claim 17 stays `Preview`. An edge is the input plane's second
+  production caller. That caller now exists in mvmd; the reassessment keeps
+  claim 17 at `Preview` because its remaining limits are the fingerprint scan
+  and shell-entrypoint heuristic, not reachability. Why it existed: An edge is a different authorization shape than a
   per-plan grant, so this is not claim 17 with more rows. State what an edge
   guarantees, what it does not, and witness it. Reassess whether the input plane
   can leave `Preview` once it has a second production caller.
@@ -150,22 +159,22 @@ Two consequences worth stating plainly, because they will surprise someone:
   flight, why fan-in is a merge node, and what happens when a consumer falls
   behind under each mode.
 
-## Declared dormancy
+## External production caller
 
-`validate_topology` and `check_plan_edges` have **no caller inside `mvm`**, and
-will not get one: a single-VM `mvmctl` run has no graph to validate, and this
-repository has no fleet. `mvmd` is the caller.
+`validate_topology`, `check_plan_edges`, and `EdgeConnector` have **no caller
+inside `mvm`**, and will not get one: a single-VM `mvmctl` run has no graph to
+validate, and this repository has no fleet. The production caller landed in
+mvmd PR [#238](https://github.com/tinylabscom/mvmd/pull/238).
 
-That is the shape plan 293's WS4 exists to catch, so it is written down here
-rather than discovered later. The distinction WS4 draws is between a control
-that is dormant *by declaration* and one that is dormant *by accident* — this
-is the former, and when WS4 lands these two belong in its allowlist with this
-paragraph as the justification.
+The dormant-control manifest is a ratchet, not a permanent registry of
+cross-repository boundaries. These entries were correct while the caller was
+absent and were removed when the external production path landed. This section
+preserves why an in-repository reference still should not be invented merely to
+make a text scan see across repositories.
 
-What keeps it honest meanwhile: both are pure functions with no side effects,
-both are covered by their own tests, and neither claims a guarantee that
-anything in `mvm` relies on. The refusals they implement are real only once
-`mvmd` calls them, and no claim in ADR-001 asserts otherwise.
+What keeps the boundary honest is end-to-end evidence on both sides: mvm tests
+the mechanism and mvmd tests the fleet workflow, including wrong bindings,
+cycles, fan-in, resource exhaustion, edge failure and explicit close.
 
 ## Open questions
 

--- a/xtask/dormant-controls.toml
+++ b/xtask/dormant-controls.toml
@@ -16,41 +16,10 @@
 # declaration is stale and the entry should go. The list may only shrink.
 
 [[control]]
-symbol = "validate_topology"
-file = "crates/mvm-contract/src/stream/mod.rs"
-dormant = true
-why = """
-Refuses a cyclic or fan-in edge topology. mvmd is the caller: it declares the \
-edges and holds the whole graph. mvm has no fleet, so a single-VM run has \
-nothing to validate. Pure function, no side effects, covered by its own tests, \
-and no claim in ADR-001 rests on it firing here."""
-
-[[control]]
-symbol = "check_plan_edges"
-file = "crates/mvm-contract/src/stream/edge.rs"
-dormant = true
-why = """
-Refuses a duplicate binding, a raw edge without the operator acknowledgement, \
-and an edge contending with operator stdin. Same reason as the topology \
-validator: mvmd declares the edges, so mvmd is where a plan carrying them is \
-admitted. Reachable from mvm only once mvm grows a caller that declares edges, \
-which it will not."""
-
-[[control]]
 symbol = "grants_input_for"
 file = "crates/mvm-contract/src/stream/input.rs"
 dormant = false
 why = "The input plane's default-deny check. Losing its caller reopens claim 17's grant."
-
-[[control]]
-symbol = "EdgeConnector"
-file = "crates/mvm-hostd/src/stream/edge_connector.rs"
-dormant = true
-why = """
-Pumps one workload's output into another's stdin. Caller-driven by design, and \
-the caller is mvmd: mvm has no fleet and so nothing here declares an edge to \
-drive. Covered by its own integration tests against the real broker, reader \
-and gate."""
 
 [[control]]
 symbol = "report_enforced_grants"


### PR DESCRIPTION
## Summary
- retire the three fleet-only dormant-control declarations now that mvmd PR #238 is the production caller
- update Plan 296, ADR-035, and the operator guide to describe the cross-repository boundary
- reassess claim 17 and keep it Preview for its actual fingerprint-scan and shell-classification limits

## Validation
- `cargo run -q -p xtask -- check-all` (61 gates clean)
- `cargo run -q -p xtask -- check-dormant-controls`
- `cargo run -q -p xtask -- check-doc-claims`

Depends on tinylabscom/mvmd#238 (merged).