### PR TITLE
fix(security): repair scheduled supply-chain witnesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,9 +577,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -726,6 +726,11 @@ mod tests {
         assert!(caps.vsock);
         assert!(caps.no_routable_guest_nic);
         assert!(caps.host_vsock_proxy);
+        assert_eq!(
+            caps.max_vcpus,
+            Some(u32::from(u8::MAX)),
+            "libkrun's u8 vCPU boundary must remain visible to admission"
+        );
         assert_eq!(d.snapshot_capability(), SnapshotCapability::Unsupported);
         assert_eq!(d.security_profile().tier, "Tier 2");
     }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -24,6 +24,14 @@ Last updated: 2026-08-28
       workspace Clippy, formatting, and policy gates are green. Merge delivery
       remains.
 
+- [ ] **Security lane red repair — issue #2982.**
+      `specs/plans/2026-08-28-security-lane-red-repair.md`.
+      The scheduled supply-chain failure is repaired with non-yanked
+      `chacha20 0.10.2`; a lockfile regression pins it. Libkrun's vCPU ceiling
+      now has a mutation witness, and eight stale baseline exemptions are
+      removed. Focused validation is green; full gates and merge delivery
+      remain.
+
 - [ ] **HVF machine restore dispatch — issue #2961.**
       `specs/plans/2026-08-27-hvf-machine-restore-dispatch.md`.
       The `machine` fork/restore surfaces now share the backend-origin

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -24,13 +24,14 @@ Last updated: 2026-08-28
       workspace Clippy, formatting, and policy gates are green. Merge delivery
       remains.
 
-- [ ] **Security lane red repair — issue #2982.**
+- [ ] **Security lane red repair — issues #2982 and #2986.**
       `specs/plans/2026-08-28-security-lane-red-repair.md`.
       The scheduled supply-chain failure is repaired with non-yanked
       `chacha20 0.10.2`; a lockfile regression pins it. Libkrun's vCPU ceiling
       now has a mutation witness, and eight stale baseline exemptions are
-      removed. Focused validation is green; full gates and merge delivery
-      remain.
+      removed. Focused tests, workspace tests, isolated doctests, workspace
+      Clippy, formatting, `cargo deny`, and policy gates are green. A fresh
+      Security run and merge delivery remain.
 
 - [ ] **HVF machine restore dispatch — issue #2961.**
       `specs/plans/2026-08-27-hvf-machine-restore-dispatch.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -42,6 +42,15 @@
       tests, the isolated `mvm-agentd` doctest, workspace Clippy, formatting,
       and policy gates are green. Merge delivery remains.
 
+- [ ] **Security lane red repair — issue #2982.**
+      `specs/plans/2026-08-28-security-lane-red-repair.md`.
+      The lockfile now resolves non-yanked `chacha20 0.10.2`, guarded by a
+      dependency regression. The libkrun capability test witnesses its vCPU
+      ceiling, and eight exemptions that CI already catches have been removed
+      from the mutation baseline. Focused tests, `cargo deny`, and the static
+      mutation-surface gate are green; full validation and merge delivery
+      remain.
+
 - [ ] **Recorded-backend pause and resume — issue #2929.**
       `specs/plans/2026-08-27-recorded-backend-pause-resume.md`.
       Existing-machine lifecycle operations resolve the VMM that owns the live

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -42,14 +42,15 @@
       tests, the isolated `mvm-agentd` doctest, workspace Clippy, formatting,
       and policy gates are green. Merge delivery remains.
 
-- [ ] **Security lane red repair — issue #2982.**
+- [ ] **Security lane red repair — issues #2982 and #2986.**
       `specs/plans/2026-08-28-security-lane-red-repair.md`.
       The lockfile now resolves non-yanked `chacha20 0.10.2`, guarded by a
       dependency regression. The libkrun capability test witnesses its vCPU
       ceiling, and eight exemptions that CI already catches have been removed
-      from the mutation baseline. Focused tests, `cargo deny`, and the static
-      mutation-surface gate are green; full validation and merge delivery
-      remain.
+      from the mutation baseline. Focused tests, `cargo deny`, the static
+      mutation-surface gate, all ordinary workspace tests, the isolated
+      `mvm-agentd` doctest, workspace Clippy, formatting, and policy gates are
+      green. A fresh Security run and merge delivery remain.
 
 - [ ] **Recorded-backend pause and resume — issue #2929.**
       `specs/plans/2026-08-27-recorded-backend-pause-resume.md`.

--- a/specs/plans/2026-08-28-security-lane-red-repair.md
+++ b/specs/plans/2026-08-28-security-lane-red-repair.md
@@ -1,0 +1,26 @@
+# Security lane red repair
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#2982](https://github.com/tinylabscom/mvm/issues/2982)
+
+## Outcome
+
+The scheduled Security workflow no longer resolves the yanked `chacha20
+0.10.1` release, and the mutation witness suite observes libkrun's advertised
+vCPU ceiling. Mutation exemptions that the current suite already catches are
+removed so the baseline remains a ratchet rather than an archive.
+
+## Delivery checklist
+
+- [x] Reproduce the yanked dependency and mutation-witness failures from the
+      scheduled Security run.
+- [x] Update the lockfile to `chacha20 0.10.2` and add a lockfile regression.
+- [x] Assert libkrun's advertised vCPU ceiling and remove the eight stale
+      mutation exemptions reported by CI.
+- [x] Pass the focused dependency and libkrun regressions, `cargo deny`, and
+      the static mutation-surface gate.
+- [ ] Pass workspace tests, zero-warning Clippy, policy gates, and the Linux
+      mutation-witness lane.
+- [ ] Merge the tested pull request and close #2982 through its linkage.

--- a/specs/plans/2026-08-28-security-lane-red-repair.md
+++ b/specs/plans/2026-08-28-security-lane-red-repair.md
@@ -3,7 +3,8 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Issue:** [#2982](https://github.com/tinylabscom/mvm/issues/2982)
+**Issues:** [#2982](https://github.com/tinylabscom/mvm/issues/2982),
+[#2986](https://github.com/tinylabscom/mvm/issues/2986)
 
 ## Outcome
 
@@ -21,6 +22,7 @@ removed so the baseline remains a ratchet rather than an archive.
       mutation exemptions reported by CI.
 - [x] Pass the focused dependency and libkrun regressions, `cargo deny`, and
       the static mutation-surface gate.
-- [ ] Pass workspace tests, zero-warning Clippy, policy gates, and the Linux
-      mutation-witness lane.
-- [ ] Merge the tested pull request and close #2982 through its linkage.
+- [x] Pass workspace tests, zero-warning Clippy, and policy gates.
+- [ ] Pass a fresh Security run, including the Linux mutation-witness lane.
+- [ ] Merge the tested pull request and close #2982 and #2986 through its
+      linkage.

--- a/specs/sprint/delivery/2982-security-lane-red-repair.md
+++ b/specs/sprint/delivery/2982-security-lane-red-repair.md
@@ -7,7 +7,9 @@
       mutation exemptions reported as caught by the Linux Security lane.
 - [x] Passed the focused regressions, `cargo deny`, and the static
       mutation-surface gate.
-- [ ] Pass the full validation matrix and Linux mutation-witness lane.
+- [x] Pass workspace tests, isolated doctests, workspace Clippy, formatting,
+      and repository policy gates.
+- [ ] Pass a fresh Security run, including the Linux mutation-witness lane.
 - [ ] Merge the linked pull request through the queue.
 
 Owning plan: `specs/plans/2026-08-28-security-lane-red-repair.md`.

--- a/specs/sprint/delivery/2982-security-lane-red-repair.md
+++ b/specs/sprint/delivery/2982-security-lane-red-repair.md
@@ -1,0 +1,13 @@
+# Security lane red repair
+
+- [x] Reproduced the scheduled supply-chain and mutation-witness failures.
+- [x] Replaced yanked `chacha20 0.10.1` with `0.10.2` and pinned that result
+      with a lockfile regression.
+- [x] Added a direct libkrun vCPU-capability witness and removed eight stale
+      mutation exemptions reported as caught by the Linux Security lane.
+- [x] Passed the focused regressions, `cargo deny`, and the static
+      mutation-surface gate.
+- [ ] Pass the full validation matrix and Linux mutation-witness lane.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-08-28-security-lane-red-repair.md`.

--- a/tests/security_lane_dependencies.rs
+++ b/tests/security_lane_dependencies.rs
@@ -1,0 +1,22 @@
+use std::path::Path;
+
+fn workspace_lockfile() -> toml::Value {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.lock");
+    let contents = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+    toml::from_str(&contents).expect("Cargo.lock must parse as TOML")
+}
+
+#[test]
+fn chacha20_uses_the_non_yanked_patch_release() {
+    let lockfile = workspace_lockfile();
+    let versions = lockfile["package"]
+        .as_array()
+        .expect("Cargo.lock package list")
+        .iter()
+        .filter(|package| package["name"].as_str() == Some("chacha20"))
+        .filter_map(|package| package["version"].as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(versions, ["0.10.2"]);
+}

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -508,11 +508,6 @@
     },
     {
       "file": "crates/mvm-backends/src/driver/hvf.rs",
-      "mutant": "replace <impl VmmDriver for HvfDriver>::supports_directory_shares -> bool with false",
-      "reason": "HVF capability constant; the directory-share path is exercised by live HVF runs and BDD scenarios."
-    },
-    {
-      "file": "crates/mvm-backends/src/driver/hvf.rs",
       "mutant": "replace <impl VmmDriver for HvfDriver>::supports_resident_handoff -> bool with false",
       "reason": "HVF capability constant; the resident-handoff path is exercised by live HVF warm-claim tests and BDD scenarios."
     },
@@ -560,11 +555,6 @@
       "file": "crates/mvm-backends/src/driver/hvf.rs",
       "mutant": "replace match guard !spec .vsock .iter() .any(|port| port.service == GuestService::NetworkFlow) with true in relay_supervisor_config_with_handoff",
       "reason": "HVF supervisor config relay is macOS-specific and exercises vsock channel setup that is validated by live HVF BDD scenarios, not by Linux unit tests."
-    },
-    {
-      "file": "crates/mvm-backends/src/driver/hvf.rs",
-      "mutant": "replace match guard !spec.vsock.iter().any(|port| port.service == GuestService::NetworkFlow) with true in relay_supervisor_config_with_handoff",
-      "reason": "The substitution-service port selection is part of HVF supervisor config relay; the correct shape is asserted by live HVF runs and BDD scenarios."
     },
     {
       "file": "crates/mvm-backends/src/driver/hvf.rs",
@@ -830,36 +820,6 @@
       "file": "crates/mvm-backends/src/fc/host.rs",
       "mutant": "replace jailer_is_installed -> Result<bool> with Ok(true)",
       "reason": "This function probes the builder VM for a Firecracker asset. Mutating the probe result only changes how the environment is reported, not a security decision; the real gate is the subsequent install/download path which still verifies actual files."
-    },
-    {
-      "file": "crates/mvm-backends/src/fc/host.rs",
-      "mutant": "replace output.status.success() with false in has_kernel",
-      "reason": "has_kernel probes the builder VM for a vmlinux file. Mutating the probe to always report false only changes how the environment is reported, not a security decision; the real gate is the subsequent install/download path which still verifies actual files."
-    },
-    {
-      "file": "crates/mvm-backends/src/fc/host.rs",
-      "mutant": "replace output.status.success() with false in has_squashfs",
-      "reason": "has_squashfs probes the builder VM for a squashfs rootfs. Mutating the probe to always report false only changes how the environment is reported, not a security decision; the real gate is the subsequent install/download path which still verifies actual files."
-    },
-    {
-      "file": "crates/mvm-backends/src/fc/host.rs",
-      "mutant": "replace output.status.success() with false in is_installed",
-      "reason": "is_installed probes the builder VM for a firecracker binary. Mutating the probe to always report false only changes how the environment is reported, not a security decision; the real gate is the subsequent install/download path which still verifies actual files."
-    },
-    {
-      "file": "crates/mvm-backends/src/fc/host.rs",
-      "mutant": "replace output.status.success() with true in has_kernel",
-      "reason": "has_kernel probes the builder VM for a vmlinux file. Mutating the probe to always report true only changes how the environment is reported, not a security decision; the real gate is the subsequent install/download path which still verifies actual files."
-    },
-    {
-      "file": "crates/mvm-backends/src/fc/host.rs",
-      "mutant": "replace output.status.success() with true in has_squashfs",
-      "reason": "has_squashfs probes the builder VM for a squashfs rootfs. Mutating the probe to always report true only changes how the environment is reported, not a security decision; the real gate is the subsequent install/download path which still verifies actual files."
-    },
-    {
-      "file": "crates/mvm-backends/src/fc/host.rs",
-      "mutant": "replace output.status.success() with true in is_installed",
-      "reason": "is_installed probes the builder VM for a firecracker binary. Mutating the probe to always report true only changes how the environment is reported, not a security decision; the real gate is the subsequent install/download path which still verifies actual files."
     },
     {
       "file": "crates/mvm-backends/src/fc/host.rs",


### PR DESCRIPTION
Closes #2982
Closes #2986

## Summary
- update the lockfile to the non-yanked chacha20 0.10.2 patch release and pin it with a dependency regression
- witness libkrun maximum-vCPU admission directly
- remove eight mutation exemptions already caught by the current suite
- restore fresh Security-lane evidence for the claim-bearing watcher

## Validation
- cargo test --workspace (all ordinary tests passed; aggregate doctest target contamination reproduced)
- cargo test -p mvm-agentd --doc
- cargo test --test security_lane_dependencies
- cargo test -p mvm-backends identity_and_capabilities_delegate_to_the_libkrun_backend
- cargo deny check
- cargo run -p xtask -- check-mutation-witnesses
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo run -p xtask -- check-sprint-append
- cargo run -p xtask -- check-plan-names