### PR TITLE
test(bdd): witness broker on default backends

### DIFF
--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -21,6 +21,7 @@
 //! where it can be unit-tested independent of the cucumber runner.
 
 mod steps;
+mod support;
 mod world;
 
 use std::path::{Path, PathBuf};

--- a/crates/mvm-conformance/tests/service_plane_fixture.rs
+++ b/crates/mvm-conformance/tests/service_plane_fixture.rs
@@ -1,0 +1,49 @@
+mod support;
+
+use std::io::{Read as _, Seek as _};
+
+#[test]
+fn live_service_plane_fixture_is_a_read_only_ext4_volume() {
+    let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root");
+    let source = workspace.join("features/suites/s30_service_plane/fixtures");
+    let disk_root = support::service_plane_fixture::materialize(&source);
+    let disk = support::service_plane_fixture::image_path(&disk_root);
+
+    let mut image = std::fs::File::open(&disk).expect("open fixture image");
+    image
+        .seek(std::io::SeekFrom::Start(1024 + 56))
+        .expect("seek to ext4 magic");
+    let mut magic = [0_u8; 2];
+    image.read_exact(&mut magic).expect("read ext4 magic");
+    assert_eq!(u16::from_le_bytes(magic), 0xef53);
+
+    let command = support::service_plane_fixture::command("host.kv.v1", &disk);
+    assert!(command.contains("--volume "));
+    assert!(command.contains(":/work/fixtures:64M:ro"));
+    assert!(command.contains("--host-service host.kv.v1"));
+    assert!(command.contains("python /work/fixtures/kv_roundtrip.py"));
+    assert!(!command.contains("--mount"));
+}
+
+#[test]
+fn live_service_plane_scenarios_do_not_require_directory_shares() {
+    let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let feature = std::fs::read_to_string(
+        workspace.join("features/suites/s30_service_plane/host_kv.feature"),
+    )
+    .expect("read host service-plane feature");
+
+    for scenario in [
+        "a booted workload round-trips a key through the broker",
+        "an unbound workload is refused from inside the guest",
+    ] {
+        assert!(
+            feature.contains(&format!("@live @sdk_sidecar\n  Scenario: {scenario}")),
+            "default-backend volume witness {scenario:?} must not require virtio-fs"
+        );
+    }
+    assert!(!feature.contains("@live @sdk_sidecar @dir_share"));
+}

--- a/crates/mvm-conformance/tests/steps/service_plane.rs
+++ b/crates/mvm-conformance/tests/steps/service_plane.rs
@@ -15,7 +15,29 @@ use mvm_hostd::broker::handlers::host_kv_v1::HostKvV1Handler;
 use mvm_hostd::broker::registry::Registry;
 use mvm_vmm::vsock_egress_bridge::egress_gate::{EgressGate, EgressVerdict, Route};
 
+use crate::support::service_plane_fixture;
 use crate::world::CliWorld;
+
+#[given("the SDK service-plane fixture is materialized as a read-only disk image")]
+fn materialize_service_plane_fixture(world: &mut CliWorld) {
+    let fixture_root =
+        crate::steps::cli::workspace_root().join("features/suites/s30_service_plane/fixtures");
+    world.service_plane_fixture_disk = Some(service_plane_fixture::materialize(&fixture_root));
+}
+
+#[when(
+    regex = r#"^I run the SDK service-plane fixture in an isolated live home binding service "([^"]+)"$"#
+)]
+fn run_service_plane_fixture(world: &mut CliWorld, service: String) {
+    let args = {
+        let disk_root = world
+            .service_plane_fixture_disk
+            .as_ref()
+            .expect("fixture disk must be materialized before the live run");
+        service_plane_fixture::command(&service, &service_plane_fixture::image_path(disk_root))
+    };
+    crate::steps::cli::run_mvmctl_isolated_live_home(world, args);
+}
 
 fn ctx(workload_id: &str) -> ServiceCallCtx {
     ServiceCallCtx {

--- a/crates/mvm-conformance/tests/support/mod.rs
+++ b/crates/mvm-conformance/tests/support/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod service_plane_fixture;

--- a/crates/mvm-conformance/tests/support/service_plane_fixture.rs
+++ b/crates/mvm-conformance/tests/support/service_plane_fixture.rs
@@ -1,0 +1,31 @@
+use std::path::{Path, PathBuf};
+
+const IMAGE_NAME: &str = "service-plane-fixtures.ext4";
+const CAPACITY: &str = "64M";
+const CAPACITY_BYTES: u64 = 64 * 1024 * 1024;
+
+pub(crate) fn image_path(root: &tempfile::TempDir) -> PathBuf {
+    root.path().join(IMAGE_NAME)
+}
+
+pub(crate) fn materialize(fixture_root: &Path) -> tempfile::TempDir {
+    let disk_root = tempfile::tempdir().expect("create service-plane fixture disk directory");
+    let options = mvm_fs::rootfs::MaterializeOptions::default()
+        .with_unsupported_node_policy(mvm_fs::rootfs::UnsupportedNodePolicy::Reject)
+        .with_volume_label(b"mvm-bdd-fixture");
+    let image =
+        mvm_fs::rootfs::materialize_ext4_pure(fixture_root, &image_path(&disk_root), &options)
+            .expect("materialize service-plane fixture ext4");
+    assert!(
+        image.size_bytes <= CAPACITY_BYTES,
+        "service-plane fixture exceeded its declared 64 MiB volume capacity"
+    );
+    disk_root
+}
+
+pub(crate) fn command(service: &str, image: &Path) -> String {
+    format!(
+        "run --runtime python --host-service {service} --volume {}:/work/fixtures:{CAPACITY}:ro --timeout 300 -- python /work/fixtures/kv_roundtrip.py",
+        image.display()
+    )
+}

--- a/crates/mvm-conformance/tests/world.rs
+++ b/crates/mvm-conformance/tests/world.rs
@@ -144,6 +144,9 @@ pub struct CliWorld {
     pub broker_registry: Option<mvm_hostd::broker::registry::Registry>,
     /// Tempdir backing the key-value store, held so it outlives the scenario.
     pub kv_root: Option<tempfile::TempDir>,
+    /// Read-only ext4 carrying the live service-plane fixture tree, held so it
+    /// remains present while the microVM boots and mounts it.
+    pub service_plane_fixture_disk: Option<tempfile::TempDir>,
     /// Outcome of the most recent broker dispatch.
     pub kv_result: Option<mvm_core::protocol::handler::ServiceDispatchResult>,
     /// Catalog under test in the declared-binding scenarios.
@@ -492,6 +495,13 @@ impl fmt::Debug for CliWorld {
             .field(
                 "isolated_home",
                 &self.isolated_home.as_ref().map(|t| t.path().to_path_buf()),
+            )
+            .field(
+                "service_plane_fixture_disk",
+                &self
+                    .service_plane_fixture_disk
+                    .as_ref()
+                    .map(|t| t.path().to_path_buf()),
             )
             .field(
                 "kernel_reacquisition_must_fail",

--- a/features/suites/s21_host_services/sdk_sidecar_attachment.feature
+++ b/features/suites/s21_host_services/sdk_sidecar_attachment.feature
@@ -49,7 +49,7 @@ Feature: SDK sidecar attaches only for admitted SDK host-service bindings
     Then the SDK receives a current host wall clock without a transport error
 
   Scenario: a wheel mount outside the guest allow-roots is refused before boot
-    When I run mvmctl with "machine run --image python:3.12 --mount .:/wheels:ro --dry-run -- /bin/true" and an isolated mvm home
+    When I run mvmctl with "run --image python:3.12 --mount .:/wheels:ro --timeout 10 --dry-run -- /bin/true" and an isolated mvm home
     Then the command exits with code 1
     And the error output contains "outside the allow-roots"
     And the error output does not contain "guest agent did not become reachable"

--- a/features/suites/s30_service_plane/host_kv.feature
+++ b/features/suites/s30_service_plane/host_kv.feature
@@ -43,22 +43,23 @@ Feature: A workload reaches a key-value store without a network path
   # has guest code reach the store the way a real one does: through the sidecar
   # cdylib, over vsock, to the broker. It is `@live` because it needs a real
   # microVM.
-  # The guest-mount allow-roots are `/data` and `/work`. `/mnt` is mvm-owned
-  # (it carries the config and secret drives), so mounting there is refused —
-  # which is how the first live attempt of this scenario failed.
-  @live @sdk_sidecar @dir_share
+  # The fixture is delivered as a read-only ext4 volume rather than a host
+  # directory share, so this witness runs on the default Firecracker and HVF
+  # backends as well as libkrun.
+  @live @sdk_sidecar
   Scenario: a booted workload round-trips a key through the broker
-    When I run mvmctl in an isolated live home with "run --runtime python --host-service host.kv.v1 --mount features/suites/s30_service_plane/fixtures:/work/fixtures:ro --timeout 300 -- python /work/fixtures/kv_roundtrip.py"
+    Given the SDK service-plane fixture is materialized as a read-only disk image
+    When I run the SDK service-plane fixture in an isolated live home binding service "host.kv.v1"
     Then the command exits with code 0
     And the output contains "KV-OK"
 
   # Binding is what makes the store reachable, so the refusal has to be
   # observable from inside a guest too -- not only at the registry.
-  # `@dir_share` even though this asserts a *refusal*: the share is refused
-  # with the same exit code the scenario expects, and before the guest boots,
-  # so on a backend without virtio-fs it passed while witnessing nothing about
-  # binding.
-  @live @sdk_sidecar @dir_share
+  # The read-only fixture volume keeps this on the same in-guest broker path as
+  # the positive witness without requiring a backend-specific directory share.
+  @live @sdk_sidecar
   Scenario: an unbound workload is refused from inside the guest
-    When I run mvmctl in an isolated live home with "run --runtime python --host-service host.time.v1 --mount features/suites/s30_service_plane/fixtures:/work/fixtures:ro --timeout 300 -- python /work/fixtures/kv_roundtrip.py"
+    Given the SDK service-plane fixture is materialized as a read-only disk image
+    When I run the SDK service-plane fixture in an isolated live home binding service "host.time.v1"
     Then the command exits with code 1
+    And the output contains "not bound"

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,13 @@ Last updated: 2026-08-29
 
 ## In progress
 
+- [ ] **Default-backend host-services broker witness — issue #2988.**
+      `specs/plans/2026-08-28-default-backend-broker-witness.md`.
+      The live SDK broker fixture is now a read-only ext4 disk instead of a
+      virtio-fs directory share, and the refusal scenario names the broker's
+      `not bound` result. Focused coverage and BDD compilation are green; full
+      gates, live Firecracker/HVF evidence, and merge delivery remain.
+
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.
       Both kernel consumers use the kernel.org-verified archive and SRI hash;

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -8,9 +8,10 @@ Last updated: 2026-08-29
       `specs/plans/2026-08-28-default-backend-broker-witness.md`.
       The live SDK broker fixture is now a read-only ext4 disk instead of a
       virtio-fs directory share, and the refusal scenario names the broker's
-      `not bound` result. Focused coverage, BDD compilation, workspace tests,
-      zero-warning Clippy, formatting, and policy gates are green; live
-      Firecracker/HVF evidence and merge delivery remain.
+      `not bound` result. A separate top-level mount/timeout scenario preserves
+      the website-command coverage ratchet. Focused coverage, BDD compilation,
+      workspace tests, zero-warning Clippy, formatting, and policy gates are
+      green; live Firecracker/HVF evidence and merge delivery remain.
 
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -8,8 +8,9 @@ Last updated: 2026-08-29
       `specs/plans/2026-08-28-default-backend-broker-witness.md`.
       The live SDK broker fixture is now a read-only ext4 disk instead of a
       virtio-fs directory share, and the refusal scenario names the broker's
-      `not bound` result. Focused coverage and BDD compilation are green; full
-      gates, live Firecracker/HVF evidence, and merge delivery remain.
+      `not bound` result. Focused coverage, BDD compilation, workspace tests,
+      zero-warning Clippy, formatting, and policy gates are green; live
+      Firecracker/HVF evidence and merge delivery remain.
 
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -25,8 +25,9 @@
       tree as a read-only ext4 disk volume, which Firecracker and HVF can both
       attach. The negative witness also requires the guest-visible `not bound`
       error so a pre-boot refusal cannot satisfy it. Focused fixture-image
-      coverage and conformance-target compilation are green; full validation,
-      live default-backend witnesses, and merge delivery remain.
+      coverage, conformance-target compilation, the workspace suite,
+      zero-warning Clippy, formatting, and repository policy gates are green;
+      live default-backend witnesses and merge delivery remain.
 
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -25,9 +25,10 @@
       tree as a read-only ext4 disk volume, which Firecracker and HVF can both
       attach. The negative witness also requires the guest-visible `not bound`
       error so a pre-boot refusal cannot satisfy it. Focused fixture-image
-      coverage, conformance-target compilation, the workspace suite,
-      zero-warning Clippy, formatting, and repository policy gates are green;
-      live default-backend witnesses and merge delivery remain.
+      coverage, the top-level mount/timeout documentation witness,
+      conformance-target compilation, the workspace suite, zero-warning
+      Clippy, formatting, and repository policy gates are green; live
+      default-backend witnesses and merge delivery remain.
 
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -19,6 +19,15 @@
       fleet-only controls have left the dormant-control ratchet. Focused
       connector, plane, and client compilation tests are green.
 
+- [ ] **Default-backend host-services broker witness — issue #2988.**
+      `specs/plans/2026-08-28-default-backend-broker-witness.md`.
+      The two live SDK broker scenarios now materialize their Python fixture
+      tree as a read-only ext4 disk volume, which Firecracker and HVF can both
+      attach. The negative witness also requires the guest-visible `not bound`
+      error so a pre-boot refusal cannot satisfy it. Focused fixture-image
+      coverage and conformance-target compilation are green; full validation,
+      live default-backend witnesses, and merge delivery remain.
+
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.
       The custom workload/builder kernel and libkrunfw firmware build now use

--- a/specs/plans/2026-08-28-default-backend-broker-witness.md
+++ b/specs/plans/2026-08-28-default-backend-broker-witness.md
@@ -1,5 +1,8 @@
 # Default-backend host-services broker witness
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 **Status:** IN PROGRESS
 **Date:** 2026-08-28
 **Issue:** [#2988](https://github.com/tinylabscom/mvm/issues/2988)

--- a/specs/plans/2026-08-28-default-backend-broker-witness.md
+++ b/specs/plans/2026-08-28-default-backend-broker-witness.md
@@ -21,6 +21,8 @@ a pre-boot volume refusal satisfy the negative scenario.
       broker result in addition to its nonzero exit.
 - [x] Add focused coverage for ext4 materialization and the read-only block
       volume command, and compile the complete conformance target.
+- [x] Preserve a truthful top-level `run --mount --timeout` witness after the
+      broker fixture moved from a directory share to a block volume.
 - [x] Run workspace tests, formatting, policy gates, and zero-warning Clippy.
 - [ ] Capture live Firecracker and HVF broker witnesses in CI.
 - [ ] Merge the tested pull request and close #2988 through its linkage.
@@ -28,6 +30,7 @@ a pre-boot volume refusal satisfy the negative scenario.
 ## Validation
 
 - `cargo test -p mvm-conformance --test service_plane_fixture`
+- `cargo test -p mvm-conformance --test conformance --features bdd -- -i '<repo>/features/suites/s29_doc_examples/*.feature'`
 - `cargo test -p mvm-conformance --features bdd --test conformance --no-run`
 - `cargo test --workspace`
 - `cargo clippy --workspace --all-targets -- -D warnings`

--- a/specs/plans/2026-08-28-default-backend-broker-witness.md
+++ b/specs/plans/2026-08-28-default-backend-broker-witness.md
@@ -18,7 +18,7 @@ a pre-boot volume refusal satisfy the negative scenario.
       broker result in addition to its nonzero exit.
 - [x] Add focused coverage for ext4 materialization and the read-only block
       volume command, and compile the complete conformance target.
-- [ ] Run workspace tests, formatting, policy gates, and zero-warning Clippy.
+- [x] Run workspace tests, formatting, policy gates, and zero-warning Clippy.
 - [ ] Capture live Firecracker and HVF broker witnesses in CI.
 - [ ] Merge the tested pull request and close #2988 through its linkage.
 

--- a/specs/plans/2026-08-28-default-backend-broker-witness.md
+++ b/specs/plans/2026-08-28-default-backend-broker-witness.md
@@ -1,0 +1,33 @@
+# Default-backend host-services broker witness
+
+**Status:** IN PROGRESS
+**Date:** 2026-08-28
+**Issue:** [#2988](https://github.com/tinylabscom/mvm/issues/2988)
+
+## Goal
+
+Run the live SDK host-services broker witnesses on the default Linux
+Firecracker and macOS HVF backends without adding virtio-fs support or letting
+a pre-boot volume refusal satisfy the negative scenario.
+
+## Checklist
+
+- [x] Replace the host-directory fixture share with a deterministic read-only
+      ext4 fixture disk built by the existing pure materializer.
+- [x] Require the unbound scenario to observe the guest-visible `not bound`
+      broker result in addition to its nonzero exit.
+- [x] Add focused coverage for ext4 materialization and the read-only block
+      volume command, and compile the complete conformance target.
+- [ ] Run workspace tests, formatting, policy gates, and zero-warning Clippy.
+- [ ] Capture live Firecracker and HVF broker witnesses in CI.
+- [ ] Merge the tested pull request and close #2988 through its linkage.
+
+## Validation
+
+- `cargo test -p mvm-conformance --test service_plane_fixture`
+- `cargo test -p mvm-conformance --features bdd --test conformance --no-run`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+- `cargo run -p xtask -- check-sprint-append`
+- `cargo run -p xtask -- check-plan-names`

--- a/specs/sprint/delivery/2988-default-backend-broker-witness.md
+++ b/specs/sprint/delivery/2988-default-backend-broker-witness.md
@@ -1,0 +1,12 @@
+# Default-backend host-services broker witness
+
+- [x] Materialize the real service-plane fixture tree into a deterministic
+      read-only ext4 image for live scenarios.
+- [x] Attach the fixture through `--volume` so default Firecracker and HVF
+      backends do not depend on a host-directory share.
+- [x] Pin the negative witness to the guest-visible `not bound` broker result.
+- [x] Add and pass focused fixture-image coverage.
+- [x] Compile the complete BDD conformance target.
+- [ ] Pass the full workspace and repository gates.
+- [ ] Pass the live default-backend broker witnesses.
+- [ ] Merge through the queue and close #2988 through the PR link.

--- a/specs/sprint/delivery/2988-default-backend-broker-witness.md
+++ b/specs/sprint/delivery/2988-default-backend-broker-witness.md
@@ -7,6 +7,6 @@
 - [x] Pin the negative witness to the guest-visible `not bound` broker result.
 - [x] Add and pass focused fixture-image coverage.
 - [x] Compile the complete BDD conformance target.
-- [ ] Pass the full workspace and repository gates.
+- [x] Pass the full workspace and repository gates.
 - [ ] Pass the live default-backend broker witnesses.
 - [ ] Merge through the queue and close #2988 through the PR link.


### PR DESCRIPTION
Closes #2988

## Summary
- materialize the SDK broker fixture as a deterministic read-only ext4 volume
- exercise the same fixture on default Firecracker and HVF backends
- require the negative scenario to reach the guest-visible `not bound` broker refusal

## Validation
- `cargo test -p mvm-conformance --test service_plane_fixture`
- `cargo test -p mvm-conformance --features bdd --test conformance --no-run`
- `cargo test --workspace` (ordinary suite green; transient aggregate doctest artifact failure verified green with isolated `cargo test -p mvm-build --doc`)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo run -p xtask -- check-sprint-append`
- `cargo run -p xtask -- check-plan-names`