### PR TITLE
feat(sdk): build and package a musl SDK host-services sidecar

### DIFF
--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -212,11 +212,18 @@
       # dynamic loader the rootfs provides.
       mvmSdkCdylibFor =
         system:
+        mvmSdkCdylibForLibc system "glibc";
+
+      # The same derivation, parameterized by the libc the object is built
+      # against. A guest can only dlopen the variant matching its own, and the
+      # host selects from the libc recorded in the image's `mvm-meta.json`.
+      mvmSdkCdylibForLibc =
+        system: libc:
         let
           pkgs = import nixpkgs { inherit system; };
         in
         import (workspace + "/nix/packages/mvm-sdk-cdylib.nix") {
-          inherit pkgs;
+          inherit pkgs libc;
           lib = pkgs.lib;
           mvmSrc = workspace;
         };
@@ -537,6 +544,10 @@
         runtime-overlay = mkRuntimeOverlay system;
         sdk-sidecar = mkSdkSidecar system;
         sdk-sidecar-image = mkSdkSidecarImage system;
+        # Exposed individually so each libc variant can be built and inspected
+        # on its own; the musl one is what an Alpine guest can load.
+        sdk-cdylib-glibc = mvmSdkCdylibForLibc system "glibc";
+        sdk-cdylib-musl = mvmSdkCdylibForLibc system "musl";
       });
     };
 }

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -283,11 +283,26 @@
 
       mkSdkSidecar =
         system:
+        mkSdkSidecarForLibc system "glibc";
+
+      # The musl sidecar carries only what the guest lacks.
+      #
+      # The glibc tree bundles a loader and a libc because the workload rootfs
+      # has neither — the catalog is Alpine. A musl guest already has both: its
+      # own interpreter is running under `/lib/ld-musl-<arch>.so.1`. So the musl
+      # tree is the cdylib plus musl's libgcc, which the object still records as
+      # NEEDED — rustc emits `-lgcc_s` for unwinding and `-static-libgcc` does
+      # not remove it. The RPATH stays, because that libgcc is what the object
+      # finds through it.
+      mkSdkSidecarForLibc =
+        system: libc:
         let
           pkgs = import nixpkgs { inherit system; };
-          hostsvc = mvmSdkCdylibFor system;
+          isMusl = libc == "musl";
+          hostsvc = mvmSdkCdylibForLibc system libc;
+          muslLibgcc = "${pkgs.pkgsMusl.lib.getLib pkgs.pkgsMusl.stdenv.cc.cc}/lib/libgcc_s.so.1";
         in
-        pkgs.runCommand "mvm-sdk-sidecar-${system}"
+        pkgs.runCommand "mvm-sdk-sidecar-${libc}-${system}"
           {
             nativeBuildInputs = [ pkgs.patchelf ];
             passthru = {
@@ -299,11 +314,20 @@
             set -euo pipefail
 
             mkdir -p "$out/lib"
-            cp ${sdkRuntimeLoaderFor pkgs} "$out/lib/${sdkRuntimeLoaderBaseFor pkgs}"
             cp ${hostsvc}/lib/libmvm_host_services.so \
               "$out/lib/libmvm_host_services.so"
-            cp ${sdkRuntimeLibcFor pkgs} "$out/lib/libc.so.6"
-            cp ${sdkRuntimeLibgccFor pkgs} "$out/lib/libgcc_s.so.1"
+            ${
+              if isMusl then
+                ''
+                  cp ${muslLibgcc} "$out/lib/libgcc_s.so.1"
+                ''
+              else
+                ''
+                  cp ${sdkRuntimeLoaderFor pkgs} "$out/lib/${sdkRuntimeLoaderBaseFor pkgs}"
+                  cp ${sdkRuntimeLibcFor pkgs} "$out/lib/libc.so.6"
+                  cp ${sdkRuntimeLibgccFor pkgs} "$out/lib/libgcc_s.so.1"
+                ''
+            }
             chmod u+w "$out/lib/libmvm_host_services.so"
             patchelf \
               --set-rpath /mvm/sdk/lib \
@@ -311,7 +335,7 @@
             chmod 0555 "$out/lib"/*
             echo "${overlayVersion}" > "$out/VERSION"
             cat > "$out/README" <<'EOF'
-            This read-only sidecar supplies the glibc SDK host-services cdylib.
+            This read-only sidecar supplies the ${libc} SDK host-services cdylib.
             Attach it at /mvm/sdk for workloads that use mvm.audit or mvm.host.
             EOF
             chmod 0444 "$out/VERSION" "$out/README"
@@ -331,11 +355,15 @@
       # boot instead of surfacing as an in-guest dlopen failure.
       mkSdkSidecarImage =
         system:
+        mkSdkSidecarImageForLibc system "glibc";
+
+      mkSdkSidecarImageForLibc =
+        system: libc:
         let
           pkgs = import nixpkgs { inherit system; };
-          tree = mkSdkSidecar system;
+          tree = mkSdkSidecarForLibc system libc;
         in
-        pkgs.runCommand "mvm-sdk-sidecar-image-${system}"
+        pkgs.runCommand "mvm-sdk-sidecar-image-${libc}-${system}"
           {
             nativeBuildInputs = [
               pkgs.e2fsprogs
@@ -548,6 +576,8 @@
         # on its own; the musl one is what an Alpine guest can load.
         sdk-cdylib-glibc = mvmSdkCdylibForLibc system "glibc";
         sdk-cdylib-musl = mvmSdkCdylibForLibc system "musl";
+        sdk-sidecar-musl = mkSdkSidecarForLibc system "musl";
+        sdk-sidecar-image-musl = mkSdkSidecarImageForLibc system "musl";
       });
     };
 }

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -222,7 +222,7 @@
         let
           pkgs = import nixpkgs { inherit system; };
         in
-        import (workspace + "/nix/packages/mvm-sdk-cdylib.nix") {
+        import (workspaceRoot + "/nix/packages/mvm-sdk-cdylib.nix") {
           inherit pkgs libc;
           lib = pkgs.lib;
           mvmSrc = workspace;

--- a/nix/packages/mvm-sdk-cdylib.nix
+++ b/nix/packages/mvm-sdk-cdylib.nix
@@ -22,10 +22,52 @@
   pkgs,
   lib,
   mvmSrc,
+  # Which libc the cdylib is built against. A guest can only `dlopen` the
+  # variant matching its own: musl's loader fails resolving glibc-only symbols
+  # such as `_dl_find_object`, and one process cannot use two libcs. The host
+  # records each image's libc in its `mvm-meta.json` sidecar and selects.
+  libc ? "glibc",
 }:
 
-pkgs.rustPlatform.buildRustPackage {
-  pname = "mvm-sdk-cdylib";
+assert lib.assertOneOf "libc" libc [ "glibc" "musl" ];
+
+let
+  isMusl = libc == "musl";
+
+  # Same-arch musl triple. The cdylib is built for the guest that will load it,
+  # and every backend runs a same-arch guest.
+  muslTarget =
+    if pkgs.stdenv.hostPlatform.isAarch64 then
+      "aarch64-unknown-linux-musl"
+    else if pkgs.stdenv.hostPlatform.isx86_64 then
+      "x86_64-unknown-linux-musl"
+    else
+      throw "no musl target for this host platform";
+
+  # Native cargo plus a rustc sysroot carrying the musl std — the mechanism
+  # `embedded-rust-toolchain.nix` exists for. `pkgsMusl.rustPlatform` would
+  # instead rebuild the toolchain itself against musl, which this crate does
+  # not need: its closure is pure Rust, so nothing here compiles C.
+  muslToolchain = pkgs.callPackage ./embedded-rust-toolchain.nix {
+    cargo = pkgs.rust_1_91.packages.prebuilt.cargo;
+    rustc = pkgs.rust_1_91.packages.prebuilt.rustc;
+    target = muslTarget;
+  };
+
+  # The linker driver, and the thing that actually decides the output's libc.
+  # Naming a `*-linux-musl` target is NOT sufficient: with `crt-static` off the
+  # default driver is the host `cc`, which links against the host's glibc and
+  # produces a glibc object that builds clean and fails inside an Alpine guest.
+  # Only `pkgsMusl`'s cc wrapper is borrowed here, which comes from the binary
+  # cache; no package set is rebuilt against musl.
+  # `/bin/gcc` specifically: the wrapper does not reliably provide a `cc`
+  # alias, and a linker path that does not exist fails loudly, whereas an
+  # unset linker fails silently by falling back to the host cc.
+  muslLinker = "${pkgs.pkgsMusl.stdenv.cc}/bin/gcc";
+in
+
+pkgs.rustPlatform.buildRustPackage ({
+  pname = "mvm-sdk-cdylib" + lib.optionalString isMusl "-musl";
   version = "0.18.0";
 
   src = mvmSrc;
@@ -63,12 +105,43 @@ pkgs.rustPlatform.buildRustPackage {
       find target -name 'libmvm_host_services*.so' -print \
         -exec install -m0644 {} $out/lib/libmvm_host_services.so \;
     fi
+
+    # Assert the artifact is the libc it claims to be, by its NEEDED soname:
+    # musl's is `libc.so`, glibc's is `libc.so.6`. This is not belt-and-braces.
+    # A `*-linux-musl` build with the wrong linker driver produces a glibc
+    # object, exports the right symbols, and reports success — the failure only
+    # appears later as a relocation error inside a guest. Refuse to publish a
+    # mislabelled object instead.
+    needed="$(${pkgs.binutils}/bin/readelf -d $out/lib/libmvm_host_services.so \
+      | grep NEEDED || true)"
+    echo "$needed"
+    ${if isMusl then ''
+      if ! echo "$needed" | grep -q 'Shared library: \[libc\.so\]'; then
+        echo "expected a musl object (NEEDED libc.so); got the above" >&2
+        exit 1
+      fi
+    '' else ''
+      if ! echo "$needed" | grep -q 'Shared library: \[libc\.so\.6\]'; then
+        echo "expected a glibc object (NEEDED libc.so.6); got the above" >&2
+        exit 1
+      fi
+    ''}
   '';
 
   meta = with lib; {
-    description = "mvm in-guest host-services FFI — one JSON-in/JSON-out C ABI over the broker clients, loaded by every language SDK";
+    description = "mvm in-guest host-services FFI (${libc}) — one JSON-in/JSON-out C ABI over the broker clients, loaded by every language SDK";
     homepage = "https://github.com/tinylabscom/mvm";
     license = licenses.asl20;
     platforms = platforms.linux;
   };
-}
+} // lib.optionalAttrs isMusl {
+  # Cross-compile to musl with a native toolchain. `-crt-static` off because a
+  # cdylib needs a dynamic loader; the guest supplies musl's.
+  nativeBuildInputs = [ muslToolchain ];
+  CARGO_BUILD_TARGET = muslTarget;
+  # The linker goes in RUSTFLAGS rather than `CARGO_TARGET_<TRIPLE>_LINKER`.
+  # Both are documented, but only this one was verified end to end to produce
+  # a musl object here; the env-var form left the default host `cc` in place
+  # and silently yielded glibc, which the NEEDED assertion below caught.
+  RUSTFLAGS = "-C target-feature=-crt-static -C linker=${muslLinker}";
+})


### PR DESCRIPTION
The variant every catalogued runtime actually needs. Nix-only — two files, no Rust changes.

Every runtime in the built-in catalog is Alpine, and an Alpine guest cannot load the glibc cdylib at all: musl's loader fails resolving glibc-only symbols such as `_dl_find_object`, and shipping a second loader alongside does not help because the process doing the loading already has one. So the object mounted into those guests has to be built for their libc.

Both the cdylib derivation and the sidecar assembler are parameterized by `libc` rather than forked into second copies. The glibc path is unchanged.

### The musl sidecar is a different shape, not a mirror

The glibc tree bundles four files — loader, cdylib, `libc.so.6`, `libgcc_s.so.1` — because the workload rootfs has neither a loader nor glibc. A musl guest already has both; its own interpreter is running under them. So the musl tree is two files: the cdylib and musl's `libgcc_s.so.1`, which the object still records as `NEEDED` because rustc emits `-lgcc_s` for unwinding and `-static-libgcc` does not remove it (verified — the entry survives). The RPATH stays, since that libgcc is what the object finds through it.

### The build asserts its own libc, and that caught a real bug

The derivation checks its output's `NEEDED` soname before publishing — musl's is `libc.so`, glibc's is `libc.so.6` — and refuses a mismatch.

That is not defensive decoration. Naming a `*-linux-musl` target is **not sufficient**: with `crt-static` off, the default linker driver is the host `cc`, which links against the host's glibc and produces an object that compiles clean, exports both C ABI symbols, and fails only later as a relocation error inside a guest.

The assertion fired on the first build of this PR, when the linker was configured through `CARGO_TARGET_<TRIPLE>_LINKER` and silently had no effect:

```
NEEDED  libc.so.6
NEEDED  ld-linux-x86-64.so.2
expected a musl object (NEEDED libc.so); got the above
```

Fixed by setting it via `RUSTFLAGS -C linker=`, pointed at `pkgsMusl.stdenv.cc`'s `/bin/gcc` specifically — the wrapper has no reliable `cc` alias, and a linker path that does not exist fails loudly where an unset one fails silently.

### Cost

`pkgsMusl.stdenv.cc` comes from the binary cache; no package set is rebuilt against musl. The toolchain is `embedded-rust-toolchain.nix` — native cargo plus a musl `rust-std`. That mechanism only works because the FFI crate's closure is pure Rust (#2981); the same build previously died compiling `ring`'s C.

### Verified with nix on Linux (x86_64)

```
sdk-cdylib-musl        NEEDED libc.so                    1,034,616 bytes
sdk-cdylib-glibc       NEEDED libc.so.6 + ld-linux       (unchanged)
sdk-sidecar-musl       2 files, 1.2 MB; bundled libgcc is itself musl-linked
sdk-sidecar-glibc      4 files (unchanged)
```

Both images assemble. Both variants export `mvm_hsvc_call` and `mvm_hsvc_free`.

### Scope

**Nothing selects between them yet.** No runtime path offers the musl image; the host-side choice lands at the seam #2987 establishes. aarch64 is also unbuilt — the derivation picks the triple from the host platform, so the shape holds, but this was verified on x86_64.

### Gates

`cargo run -p xtask -- check-all` — 62 gates clean.

Refs #2969.