### PR TITLE
perf(audit): fold a cached prefix instead of re-reading the log

### DIFF
--- a/crates/mvm-contract/src/merkle.rs
+++ b/crates/mvm-contract/src/merkle.rs
@@ -369,7 +369,26 @@ pub fn merkle_root(leaf_lines: &[impl AsRef<[u8]>]) -> [u8; 32] {
     if leaf_lines.is_empty() {
         return hash_line(&[]);
     }
-    let mut level: Vec<[u8; 32]> = leaf_lines.iter().map(|l| leaf_hash(l.as_ref())).collect();
+    let level: Vec<[u8; 32]> = leaf_lines.iter().map(|l| leaf_hash(l.as_ref())).collect();
+    merkle_root_of_leaf_hashes(&level)
+}
+
+/// The Merkle root over leaves that have already been hashed.
+///
+/// [`merkle_root`] is this preceded by one [`leaf_hash`] per line. Splitting
+/// them lets a caller that holds the leaf hashes fold them without the lines:
+/// hashing the leaves is proportional to the log's bytes, folding them is
+/// proportional to its entries, and only the first has to be paid again when
+/// nothing about a prefix has changed.
+///
+/// Same tree as [`merkle_root`] over the same leaves — the empty case included,
+/// which is why it is stated here rather than left to the caller.
+#[must_use]
+pub fn merkle_root_of_leaf_hashes(leaf_hashes: &[[u8; 32]]) -> [u8; 32] {
+    if leaf_hashes.is_empty() {
+        return hash_line(&[]);
+    }
+    let mut level = leaf_hashes.to_vec();
     while level.len() > 1 {
         level = reduce_level(&level);
     }
@@ -867,6 +886,30 @@ pub fn verify_membership(
 
 #[cfg(test)]
 mod tests {
+
+    /// The split must be a refactor, not a second tree. Anything that folds
+    /// cached leaf hashes has to land on the byte-identical root the line-based
+    /// path produces, or a cached prefix would silently describe a different
+    /// log than the one the signed root committed to.
+    #[test]
+    fn folding_leaf_hashes_gives_the_same_root_as_folding_lines() {
+        for n in 0..40usize {
+            let lines: Vec<alloc::string::String> =
+                (0..n).map(|i| alloc::format!("line-{i}")).collect();
+            let hashes: Vec<[u8; 32]> = lines.iter().map(|l| leaf_hash(l.as_bytes())).collect();
+            assert_eq!(
+                merkle_root(&lines),
+                merkle_root_of_leaf_hashes(&hashes),
+                "tree of {n} leaves disagrees between the two entry points"
+            );
+        }
+    }
+
+    #[test]
+    fn an_empty_leaf_hash_set_is_the_empty_tree() {
+        let no_lines: [&[u8]; 0] = [];
+        assert_eq!(merkle_root_of_leaf_hashes(&[]), merkle_root(&no_lines));
+    }
     use super::*;
     use alloc::string::ToString;
     use alloc::vec;

--- a/crates/mvm-hostd/src/audit/leaf_cache.rs
+++ b/crates/mvm-hostd/src/audit/leaf_cache.rs
@@ -1,0 +1,388 @@
+//! Cached leaf hashes for the prefix of an audit chain a published root
+//! already attests.
+//!
+//! # Why a cache here is not a trust decision
+//!
+//! Believing a stored value about a log is what [`ChainCheckpoint`] gives up,
+//! and why that fast path is confined to `doctor`. This one is different.
+//!
+//! The cache holds the leaf hashes of the first `tree_size` entries. A
+//! published [`SignedAuditRoot`](mvm_contract::merkle::SignedAuditRoot) is a
+//! host-signed statement that those leaves fold to `root_hash`. So the cache is
+//! not believed — it is *checked*, by folding it and comparing against that
+//! signature. A cache that has been corrupted, truncated, replaced or forged
+//! does not fold to the signed root, and is discarded.
+//!
+//! What that buys is the cost model. Hashing leaves is proportional to the
+//! log's bytes; folding leaf hashes is proportional to its entries, at 32 bytes
+//! each. Re-deriving an unchanged prefix meant re-reading tens of megabytes of
+//! JSON on every launch. Checking it means folding a few hundred kilobytes.
+//!
+//! # What it establishes about the files
+//!
+//! The fold proves the cached hashes are the ones the signed root committed
+//! to. It says nothing about whether the segments those leaves came from still
+//! hold the same bytes. Two different answers apply, on purpose:
+//!
+//! - **The live segment is read in full every time**, and the loader compares
+//!   its cached portion line by line. An edit there is caught at publish time,
+//!   exactly as before.
+//! - **Sealed segments are not read.** They are checked by
+//!   [`SealedFingerprint`] — sequence number, length and mtime. An edit that
+//!   changes any of those is a miss and reaches the genesis walk; an edit that
+//!   preserves all three is not caught here.
+//!
+//! That last case is a narrowing, and it is deliberate. Re-reading the sealed
+//! set is the entire cost this module exists to remove, and the tamper it would
+//! catch is a malicious host writing under `~/.mvm/audit/` — explicitly outside
+//! ADR-001's threat model. It remains caught by `mvmctl trust audit verify`,
+//! which always walks every interior from genesis, by `doctor`, and by any
+//! inclusion proof, which re-hashes the real line. A root published over a
+//! stale cache commits to the leaves the log actually had, so nothing here ever
+//! signs a statement blessing altered content.
+//!
+//! [`ChainCheckpoint`]: crate::supervisor::audit_file::ChainCheckpoint
+
+use std::path::{Path, PathBuf};
+
+use mvm_contract::merkle::merkle_root_of_leaf_hashes;
+
+/// File magic. A cache from a different build is a miss, not an error.
+const MAGIC: &[u8; 8] = b"MVMLEAF2";
+
+/// Bump when the layout below changes. An older file fails to parse and the
+/// caller falls back, so this needs no migration path.
+const VERSION: u32 = 2;
+
+/// What a sealed segment looked like when the cache was written.
+///
+/// Not a hash: hashing means reading, and reading the sealed set is the cost
+/// being removed. See this module's header for what that does and does not
+/// establish.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SealedFingerprint {
+    /// Sequence number.
+    pub seq: u64,
+    /// Length in bytes.
+    pub len: u64,
+    /// Modification time, nanoseconds since the Unix epoch. Zero when the
+    /// platform did not supply one — which makes the field carry no evidence
+    /// rather than false evidence, since a stored zero then matches a probed
+    /// zero and the length still has to agree.
+    pub mtime_nanos: u64,
+}
+
+impl SealedFingerprint {
+    /// Fingerprint a sealed segment on disk, or `None` if it cannot be stat'd.
+    #[must_use]
+    pub fn probe(seq: u64, path: &Path) -> Option<Self> {
+        let meta = std::fs::metadata(path).ok()?;
+        let mtime_nanos = meta
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .and_then(|d| u64::try_from(d.as_nanos()).ok())
+            .unwrap_or(0);
+        Some(Self {
+            seq,
+            len: meta.len(),
+            mtime_nanos,
+        })
+    }
+}
+
+/// Leaf hashes for an attested prefix, plus what they were derived against.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeafCache {
+    /// Every sealed segment, oldest first.
+    pub sealed: Vec<SealedFingerprint>,
+    /// Sequence number of the live segment.
+    pub active_seq: u64,
+    /// How many of the live segment's non-blank lines are inside the prefix.
+    /// The rest of that segment is the suffix a loader still has to verify.
+    pub prefix_lines_in_active: u64,
+    /// One hash per attested leaf, in chain order.
+    pub leaf_hashes: Vec<[u8; 32]>,
+}
+
+impl LeafCache {
+    /// Leaves this cache covers.
+    #[must_use]
+    pub fn tree_size(&self) -> u64 {
+        self.leaf_hashes.len() as u64
+    }
+
+    /// Whether these leaves fold to `root_hash`.
+    ///
+    /// The only reason to trust anything here. `root_hash` must come from a
+    /// signature that has already been verified — this compares a fold to a
+    /// string and cannot tell where the string came from.
+    #[must_use]
+    pub fn folds_to(&self, root_hash: &str) -> bool {
+        hex::encode(merkle_root_of_leaf_hashes(&self.leaf_hashes)) == root_hash
+    }
+
+    /// The cached leaf hashes covering the live segment's first
+    /// `prefix_lines_in_active` lines, or `None` if the cache is too small to
+    /// hold them.
+    #[must_use]
+    pub fn active_prefix_hashes(&self) -> Option<&[[u8; 32]]> {
+        let lines = usize::try_from(self.prefix_lines_in_active).ok()?;
+        let start = self.leaf_hashes.len().checked_sub(lines)?;
+        Some(&self.leaf_hashes[start..])
+    }
+
+    /// Encode for [`write`].
+    #[must_use]
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(40 + self.sealed.len() * 24 + self.leaf_hashes.len() * 32);
+        out.extend_from_slice(MAGIC);
+        out.extend_from_slice(&VERSION.to_le_bytes());
+        out.extend_from_slice(&(self.sealed.len() as u32).to_le_bytes());
+        out.extend_from_slice(&self.active_seq.to_le_bytes());
+        out.extend_from_slice(&self.prefix_lines_in_active.to_le_bytes());
+        out.extend_from_slice(&self.tree_size().to_le_bytes());
+        for seg in &self.sealed {
+            out.extend_from_slice(&seg.seq.to_le_bytes());
+            out.extend_from_slice(&seg.len.to_le_bytes());
+            out.extend_from_slice(&seg.mtime_nanos.to_le_bytes());
+        }
+        for hash in &self.leaf_hashes {
+            out.extend_from_slice(hash);
+        }
+        out
+    }
+
+    /// Decode, or `None` for anything that is not exactly this layout.
+    ///
+    /// Every malformed case is a miss rather than an error: the cache is an
+    /// optimisation, and the fallback re-derives everything it would supply.
+    #[must_use]
+    pub fn decode(bytes: &[u8]) -> Option<Self> {
+        let mut cursor = bytes.strip_prefix(MAGIC)?;
+        let version = u32::from_le_bytes(take(&mut cursor, 4)?.try_into().ok()?);
+        if version != VERSION {
+            return None;
+        }
+        let sealed_count = u32::from_le_bytes(take(&mut cursor, 4)?.try_into().ok()?) as usize;
+        let active_seq = u64::from_le_bytes(take(&mut cursor, 8)?.try_into().ok()?);
+        let prefix_lines_in_active = u64::from_le_bytes(take(&mut cursor, 8)?.try_into().ok()?);
+        let tree_size =
+            usize::try_from(u64::from_le_bytes(take(&mut cursor, 8)?.try_into().ok()?)).ok()?;
+
+        // Both counts came out of the file, so neither may size an allocation
+        // before the bytes to fill it are known to be present. A file claiming
+        // `u64::MAX` leaves would otherwise abort the process on
+        // `Vec::with_capacity` rather than being the miss it is. Requiring the
+        // body to be exactly this long also rejects trailing bytes.
+        let body = sealed_count
+            .checked_mul(24)?
+            .checked_add(tree_size.checked_mul(32)?)?;
+        if cursor.len() != body {
+            return None;
+        }
+
+        let mut sealed = Vec::with_capacity(sealed_count);
+        for _ in 0..sealed_count {
+            sealed.push(SealedFingerprint {
+                seq: u64::from_le_bytes(take(&mut cursor, 8)?.try_into().ok()?),
+                len: u64::from_le_bytes(take(&mut cursor, 8)?.try_into().ok()?),
+                mtime_nanos: u64::from_le_bytes(take(&mut cursor, 8)?.try_into().ok()?),
+            });
+        }
+        let mut leaf_hashes = Vec::with_capacity(tree_size);
+        for _ in 0..tree_size {
+            let hash: [u8; 32] = take(&mut cursor, 32)?.try_into().ok()?;
+            leaf_hashes.push(hash);
+        }
+        Some(Self {
+            sealed,
+            active_seq,
+            prefix_lines_in_active,
+            leaf_hashes,
+        })
+    }
+}
+
+/// Split `n` bytes off the front of `cursor`, or `None` if it is shorter.
+fn take<'a>(cursor: &mut &'a [u8], n: usize) -> Option<&'a [u8]> {
+    if cursor.len() < n {
+        return None;
+    }
+    let (head, tail) = cursor.split_at(n);
+    *cursor = tail;
+    Some(head)
+}
+
+/// Where a tenant's cache lives.
+#[must_use]
+pub fn path_for_tenant(audit_dir: &Path, tenant: &str) -> PathBuf {
+    audit_dir.join(format!("{tenant}.leafhashes"))
+}
+
+/// Load a tenant's cache, or `None` when there is not a readable one.
+#[must_use]
+pub fn read(audit_dir: &Path, tenant: &str) -> Option<LeafCache> {
+    LeafCache::decode(&std::fs::read(path_for_tenant(audit_dir, tenant)).ok()?)
+}
+
+/// Persist a tenant's cache, best effort and without an fsync.
+///
+/// A write failure is dropped on purpose, and so is the durability barrier the
+/// chain's own writes take. This is derived state: a cache lost to a crash is
+/// re-derived on the next launch, and paying `F_FULLFSYNC` to protect it would
+/// spend more than it saves — which is the whole reason this file exists.
+///
+/// The write is still atomic, so a torn cache is never observed.
+pub(crate) fn write(audit_dir: &Path, tenant: &str, cache: &LeafCache) {
+    let path = path_for_tenant(audit_dir, tenant);
+    if let Err(e) = crate::audit::emitter::write_atomic_unsynced(&path, &cache.encode()) {
+        tracing::debug!(error = %e, path = %path.display(), "could not persist the audit leaf cache");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mvm_contract::merkle::{leaf_hash, merkle_root};
+
+    fn fingerprints() -> Vec<SealedFingerprint> {
+        vec![
+            SealedFingerprint {
+                seq: 1,
+                len: 4096,
+                mtime_nanos: 1_700_000_000_000_000_000,
+            },
+            SealedFingerprint {
+                seq: 2,
+                len: 8192,
+                mtime_nanos: 1_700_000_001_000_000_000,
+            },
+        ]
+    }
+
+    fn cache_of(lines: &[&str]) -> LeafCache {
+        LeafCache {
+            sealed: fingerprints(),
+            active_seq: 3,
+            prefix_lines_in_active: 2,
+            leaf_hashes: lines.iter().map(|l| leaf_hash(l.as_bytes())).collect(),
+        }
+    }
+
+    #[test]
+    fn a_cache_round_trips_through_its_encoding() {
+        let cache = cache_of(&["a", "b", "c"]);
+        assert_eq!(LeafCache::decode(&cache.encode()), Some(cache));
+    }
+
+    #[test]
+    fn an_empty_cache_round_trips() {
+        let cache = LeafCache {
+            sealed: Vec::new(),
+            active_seq: 0,
+            prefix_lines_in_active: 0,
+            leaf_hashes: Vec::new(),
+        };
+        assert_eq!(LeafCache::decode(&cache.encode()), Some(cache));
+    }
+
+    #[test]
+    fn a_cache_folds_to_the_root_its_lines_produce() {
+        let lines = ["a", "b", "c", "d", "e"];
+        let expected = hex::encode(merkle_root(&lines));
+        assert!(cache_of(&lines).folds_to(&expected));
+    }
+
+    #[test]
+    fn a_cache_whose_hashes_were_altered_does_not_fold_to_the_root() {
+        let lines = ["a", "b", "c"];
+        let expected = hex::encode(merkle_root(&lines));
+        let mut cache = cache_of(&lines);
+        cache.leaf_hashes[1][0] ^= 0xff;
+        assert!(
+            !cache.folds_to(&expected),
+            "a flipped leaf hash must not fold to the signed root"
+        );
+    }
+
+    #[test]
+    fn the_active_prefix_hashes_are_the_tail_of_the_cache() {
+        // The live segment's cached lines are the *end* of the prefix, because
+        // the live segment is the end of the set. Taking them from the front
+        // would compare the wrong lines and reject every healthy chain.
+        let lines = ["a", "b", "c", "d"];
+        let cache = cache_of(&lines);
+        let tail = cache.active_prefix_hashes().expect("two lines fit");
+        assert_eq!(
+            tail,
+            [leaf_hash(b"c"), leaf_hash(b"d")],
+            "the active prefix must be the last `prefix_lines_in_active` hashes"
+        );
+    }
+
+    #[test]
+    fn an_active_prefix_larger_than_the_cache_has_no_hashes() {
+        let mut cache = cache_of(&["a"]);
+        cache.prefix_lines_in_active = 9;
+        assert!(cache.active_prefix_hashes().is_none());
+    }
+
+    #[test]
+    fn a_truncated_cache_is_a_miss_rather_than_a_short_read() {
+        // The tail is the leaf hashes, so a truncation that keeps the header
+        // would otherwise decode as a smaller, self-consistent tree.
+        let encoded = cache_of(&["a", "b", "c"]).encode();
+        assert!(LeafCache::decode(&encoded[..encoded.len() - 8]).is_none());
+    }
+
+    #[test]
+    fn trailing_bytes_are_a_miss() {
+        let mut encoded = cache_of(&["a", "b"]).encode();
+        encoded.push(0);
+        assert!(LeafCache::decode(&encoded).is_none());
+    }
+
+    #[test]
+    fn a_foreign_or_reversioned_file_is_a_miss() {
+        assert!(LeafCache::decode(b"not a leaf cache at all").is_none());
+        let mut encoded = cache_of(&["a"]).encode();
+        encoded[8] = 0xff;
+        assert!(LeafCache::decode(&encoded).is_none());
+    }
+
+    #[test]
+    fn a_declared_size_larger_than_the_body_is_a_miss() {
+        // The length prefixes are attacker-controlled in the sense that
+        // anything can write this file. An over-large declaration must not
+        // become a huge allocation followed by a short read: `with_capacity`
+        // aborts rather than returning an error, so this is a crash and not a
+        // miss unless the body length is checked first.
+        //
+        // tree_size sits at 32..40 — magic(8) + version(4) + sealed_count(4) +
+        // active_seq(8) + prefix_lines(8).
+        let mut encoded = cache_of(&["a", "b"]).encode();
+        encoded[32..40].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert!(LeafCache::decode(&encoded).is_none());
+    }
+
+    #[test]
+    fn a_fingerprint_notices_a_changed_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("seg.jsonl");
+        std::fs::write(&path, b"one").unwrap();
+        let before = SealedFingerprint::probe(1, &path).unwrap();
+        std::fs::write(&path, b"one more").unwrap();
+        let after = SealedFingerprint::probe(1, &path).unwrap();
+        assert_ne!(
+            before, after,
+            "a rewritten segment must not fingerprint the same"
+        );
+    }
+
+    #[test]
+    fn a_missing_segment_cannot_be_fingerprinted() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(SealedFingerprint::probe(1, &dir.path().join("absent.jsonl")).is_none());
+    }
+}

--- a/crates/mvm-hostd/src/audit/leaf_cache.rs
+++ b/crates/mvm-hostd/src/audit/leaf_cache.rs
@@ -35,7 +35,7 @@
 //! That last case is a narrowing, and it is deliberate. Re-reading the sealed
 //! set is the entire cost this module exists to remove, and the tamper it would
 //! catch is a malicious host writing under `~/.mvm/audit/` — explicitly outside
-//! ADR-001's threat model. It remains caught by `mvmctl trust audit verify`,
+//! the model where the host is trusted. It remains caught by `mvmctl trust audit verify`,
 //! which always walks every interior from genesis, by `doctor`, and by any
 //! inclusion proof, which re-hashes the real line. A root published over a
 //! stale cache commits to the leaves the log actually had, so nothing here ever

--- a/crates/mvm-hostd/src/audit/merkle.rs
+++ b/crates/mvm-hostd/src/audit/merkle.rs
@@ -51,10 +51,12 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use ed25519_dalek::VerifyingKey;
 use mvm_contract::merkle::{
-    InclusionProof, SignedAuditRoot, build_inclusion_proof, merkle_root, verify_signed_root,
+    InclusionProof, SignedAuditRoot, build_inclusion_proof, leaf_hash, merkle_root,
+    merkle_root_of_leaf_hashes, verify_signed_root,
 };
 
 use crate::audit::emitter;
+use crate::audit::leaf_cache;
 use crate::supervisor::audit_file::verify_chain_bytes_resuming;
 use crate::supervisor::audit_set::{SegmentContent, read_topology_verified_set};
 use mvm_contract::verify::{hash_line, verify_audit_chain_bytes};
@@ -259,9 +261,163 @@ fn raw_line_index(content: &str, nth: usize) -> Option<usize> {
 /// returning the root hash and the number of leaves (`tree_size`). The chain
 /// is verified under `vk` first; a corrupt log yields no root.
 pub fn build_root_in(audit_dir: &Path, tenant: &str, vk: &VerifyingKey) -> Result<([u8; 32], u64)> {
+    if let Some(built) = root_over_cached_prefix(audit_dir, tenant, vk) {
+        return Ok(built);
+    }
     let leaves = read_leaves(audit_dir, tenant, vk)?;
     let tree_size = leaves.len() as u64;
-    Ok((merkle_root(&leaves), tree_size))
+    let root = merkle_root(&leaves);
+    seed_leaf_cache(audit_dir, tenant, &leaves);
+    Ok((root, tree_size))
+}
+
+/// The root, folded from cached leaf hashes plus whatever the live segment has
+/// gained since — without reading a sealed segment at all.
+///
+/// [`leaves_over_attested_prefix`] removed the *verification* of an unchanged
+/// prefix; this removes the *reading and hashing* of one. Both rest on the same
+/// signature, and the difference is what is asked of it: there, that the
+/// prefix's lines are the attested ones; here, that the cached hashes of those
+/// lines are. The fold is the check — a cache that does not reproduce the
+/// signed root is discarded, so the cache is never believed, only confirmed.
+///
+/// The live segment is still read in full every time, and its new lines are
+/// verified against the chain exactly as before. Only the part a published root
+/// already covers comes from cache.
+///
+/// Declines, never accuses — same contract as [`leaves_over_attested_prefix`],
+/// and for the same reason. Every path out of here that is not a fold over an
+/// attested prefix hands the question to the genesis walk.
+fn root_over_cached_prefix(
+    audit_dir: &Path,
+    tenant: &str,
+    vk: &VerifyingKey,
+) -> Option<([u8; 32], u64)> {
+    let published = read_published_root(audit_dir, tenant)?;
+    if published.tenant != tenant {
+        return None;
+    }
+    verify_signed_root(&published, vk).ok()?;
+
+    let cache = leaf_cache::read(audit_dir, tenant)?;
+    if cache.tree_size() != published.tree_size {
+        return None;
+    }
+
+    // The fold is the whole trust argument: these hashes are the ones the host
+    // signed for, or they are not used.
+    if !cache.folds_to(&published.root_hash) {
+        return None;
+    }
+
+    // The fold says nothing about the files those leaves came from. The set's
+    // shape does, cheaply — a lost segment must reach the genesis walk, which
+    // names it, rather than being folded over as though nothing were missing.
+    let shape = crate::supervisor::audit_set::segment_shape(audit_dir, tenant).ok()?;
+    if shape.active.0 != cache.active_seq || shape.sealed.len() != cache.sealed.len() {
+        return None;
+    }
+    if sealed_fingerprints(&shape)? != cache.sealed {
+        return None;
+    }
+
+    // The live segment is read in full whatever happens, so the portion the
+    // cache claims is checked line by line rather than assumed. Sealed
+    // segments buy their speed by not being read; this one does not, and an
+    // edit here is caught at publish time exactly as it was before.
+    let content = std::fs::read_to_string(&shape.active.1).ok()?;
+    let active_lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+    let already = usize::try_from(cache.prefix_lines_in_active).ok()?;
+    if already > active_lines.len() {
+        return None;
+    }
+    let cached_active = cache.active_prefix_hashes()?;
+    if cached_active.len() != already
+        || active_lines[..already]
+            .iter()
+            .zip(cached_active)
+            .any(|(line, cached)| leaf_hash(line.as_bytes()) != *cached)
+    {
+        return None;
+    }
+
+    // The suffix is the part no published root covers, so it is verified in
+    // full, seeded from the attested prefix's final line.
+    let appended = &active_lines[already..];
+    if !appended.is_empty() {
+        // `already == 0` puts that final line in the *previous* segment, which
+        // this path deliberately did not read. That happens once per rotation;
+        // hand it to the genesis walk rather than growing a second seek path.
+        if already == 0 {
+            return None;
+        }
+        let seed = hash_line(active_lines[already - 1].as_bytes());
+        let resume = raw_line_index(&content, already)?;
+        verify_chain_bytes_resuming(&content, vk, resume, seed).ok()?;
+    }
+
+    let mut leaf_hashes = cache.leaf_hashes;
+    leaf_hashes.extend(appended.iter().map(|l| leaf_hash(l.as_bytes())));
+    let tree_size = leaf_hashes.len() as u64;
+    let root = merkle_root_of_leaf_hashes(&leaf_hashes);
+
+    leaf_cache::write(
+        audit_dir,
+        tenant,
+        &leaf_cache::LeafCache {
+            sealed: cache.sealed,
+            active_seq: shape.active.0,
+            prefix_lines_in_active: active_lines.len() as u64,
+            leaf_hashes,
+        },
+    );
+    Some((root, tree_size))
+}
+
+/// Fingerprint every sealed segment in `shape`, or `None` if any is gone.
+fn sealed_fingerprints(
+    shape: &crate::supervisor::audit_set::SegmentShape,
+) -> Option<Vec<leaf_cache::SealedFingerprint>> {
+    shape
+        .sealed
+        .iter()
+        .map(|(seq, path)| leaf_cache::SealedFingerprint::probe(*seq, path))
+        .collect()
+}
+
+/// Seed the cache from leaves a genesis walk just verified, so the next launch
+/// has something to fold.
+///
+/// Best effort throughout: every early return leaves no cache, which costs
+/// another genesis walk and nothing else.
+fn seed_leaf_cache(audit_dir: &Path, tenant: &str, leaves: &[String]) {
+    let Ok(shape) = crate::supervisor::audit_set::segment_shape(audit_dir, tenant) else {
+        return;
+    };
+    let Some(sealed) = sealed_fingerprints(&shape) else {
+        return;
+    };
+    let Ok(content) = std::fs::read_to_string(&shape.active.1) else {
+        return;
+    };
+    let active_lines = content.lines().filter(|l| !l.is_empty()).count();
+    // The cache describes a prefix ending inside the live segment. Fewer leaves
+    // than that segment holds means these two reads disagree about the log —
+    // most likely because it was appended to between them — and a cache built
+    // across that disagreement would mis-index its suffix.
+    if leaves.len() < active_lines {
+        return;
+    }
+    leaf_cache::write(
+        audit_dir,
+        tenant,
+        &leaf_cache::LeafCache {
+            sealed,
+            active_seq: shape.active.0,
+            prefix_lines_in_active: active_lines as u64,
+            leaf_hashes: leaves.iter().map(|l| leaf_hash(l.as_bytes())).collect(),
+        },
+    );
 }
 
 /// Build an inclusion proof for the leaf at `leaf_index` in `tenant`'s audit
@@ -590,6 +746,147 @@ mod tests {
         assert_eq!(raw_line_index(content, 2), Some(3));
         assert_eq!(raw_line_index(content, 3), Some(4));
         assert_eq!(raw_line_index(content, 4), None);
+    }
+
+    /// Every test below this one would pass by silently falling back to the
+    /// genesis walk, so the first thing to establish is that the cached path
+    /// runs at all — and that it lands on the same root.
+    #[test]
+    fn the_cached_prefix_path_engages_and_agrees_with_the_genesis_walk() {
+        let (dir, key, _) = seed_chain(4);
+        let vk = key.verifying_key();
+        grow_and_publish(dir.path(), &key, 2, "published");
+        grow_with_rotation(
+            dir.path(),
+            &key,
+            2,
+            "after",
+            crate::supervisor::RotationPolicy::never(),
+        );
+
+        let cached = root_over_cached_prefix(dir.path(), "local", &vk)
+            .expect("a published root plus its seeded cache must engage the fast path");
+        let leaves = read_leaves_from_genesis(dir.path(), "local", &vk).unwrap();
+        assert_eq!(cached, (merkle_root(&leaves), leaves.len() as u64));
+    }
+
+    #[test]
+    fn a_removed_sealed_segment_declines_the_cache() {
+        // The fold proves the cached hashes are the attested ones. It cannot
+        // prove the segments they came from are still there, which is why the
+        // set's shape is checked separately.
+        let (dir, key, _) = seed_chain(2);
+        let vk = key.verifying_key();
+        grow_with_rotation(
+            dir.path(),
+            &key,
+            4,
+            "post",
+            crate::supervisor::RotationPolicy::at_bytes(256),
+        );
+        grow_and_publish(dir.path(), &key, 1, "published");
+        assert!(root_over_cached_prefix(dir.path(), "local", &vk).is_some());
+
+        let sealed = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| p.to_string_lossy().contains(".seg-"))
+            .expect("the fixture must have rotated");
+        std::fs::remove_file(&sealed).unwrap();
+
+        assert!(
+            root_over_cached_prefix(dir.path(), "local", &vk).is_none(),
+            "a set missing a segment must reach the genesis walk, which names it"
+        );
+        assert!(build_root_in(dir.path(), "local", &vk).is_err());
+    }
+
+    #[test]
+    fn a_resized_sealed_segment_declines_the_cache() {
+        let (dir, key, _) = seed_chain(2);
+        let vk = key.verifying_key();
+        grow_with_rotation(
+            dir.path(),
+            &key,
+            4,
+            "post",
+            crate::supervisor::RotationPolicy::at_bytes(256),
+        );
+        grow_and_publish(dir.path(), &key, 1, "published");
+        assert!(root_over_cached_prefix(dir.path(), "local", &vk).is_some());
+
+        let sealed = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| p.to_string_lossy().contains(".seg-"))
+            .expect("the fixture must have rotated");
+        let mut content = std::fs::read_to_string(&sealed).unwrap();
+        content.push_str("{}\n");
+        std::fs::write(&sealed, content).unwrap();
+
+        assert!(
+            root_over_cached_prefix(dir.path(), "local", &vk).is_none(),
+            "a sealed segment that changed length must not be folded over"
+        );
+    }
+
+    /// The narrowing this cache buys its speed with, stated as a test so it
+    /// cannot quietly become something else.
+    ///
+    /// A sealed segment edited *in place*, preserving its length and mtime, is
+    /// not detected when a root is published: publishing no longer reads sealed
+    /// segments, and that is the entire saving. It is still detected by the
+    /// genesis walk — which is what `mvmctl trust audit verify` runs, what
+    /// `read_leaves` runs for an inclusion proof, and what any cache miss falls
+    /// back to.
+    ///
+    /// Note what the published root is over: the *cached* leaves, which are the
+    /// ones the log actually had. So this path never signs a statement blessing
+    /// the altered content — it fails to notice it, which is a weaker failure
+    /// than attesting it.
+    #[test]
+    fn an_in_place_sealed_edit_is_missed_at_publish_but_caught_by_the_genesis_walk() {
+        let (dir, key, _) = seed_chain(2);
+        let vk = key.verifying_key();
+        grow_with_rotation(
+            dir.path(),
+            &key,
+            4,
+            "post",
+            crate::supervisor::RotationPolicy::at_bytes(256),
+        );
+        grow_and_publish(dir.path(), &key, 1, "published");
+
+        let sealed = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .find(|p| p.to_string_lossy().contains(".seg-"))
+            .expect("the fixture must have rotated");
+        let before = std::fs::metadata(&sealed).unwrap();
+        let content = std::fs::read_to_string(&sealed).unwrap();
+        // Same byte count, different bytes.
+        let edited = content.replacen("\"img\"", "\"IMG\"", 1);
+        assert_eq!(edited.len(), content.len(), "the edit must preserve length");
+        std::fs::write(&sealed, &edited).unwrap();
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&sealed)
+            .and_then(|f| f.set_modified(before.modified().unwrap()))
+            .expect("restore mtime so the fingerprint matches");
+
+        // Missed here, on purpose.
+        assert!(
+            root_over_cached_prefix(dir.path(), "local", &vk).is_some(),
+            "this test documents that the cached path does not read sealed segments"
+        );
+        // And caught the moment anything walks the chain.
+        assert!(
+            read_leaves_from_genesis(dir.path(), "local", &vk).is_err(),
+            "the genesis walk must still refuse an edited sealed segment"
+        );
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/mod.rs
+++ b/crates/mvm-hostd/src/audit/mod.rs
@@ -12,6 +12,7 @@ pub mod evidence;
 pub mod host_keypair;
 /// RFC 6962 Merkle transparency-log root + inclusion-proof builder over a
 /// tenant's chain-signed audit log.
+pub mod leaf_cache;
 pub mod merkle;
 pub mod plan_persist;
 /// Writer for `.mvmev` evidence archives over the chain-signed audit log.

--- a/crates/mvm-hostd/src/supervisor/audit_set.rs
+++ b/crates/mvm-hostd/src/supervisor/audit_set.rs
@@ -579,6 +579,57 @@ pub fn read_verified_set(
     Ok(walked.contents)
 }
 
+/// The segment set's shape: which segments exist and where, read from the
+/// directory listing without opening any of them.
+///
+/// Deliberately weaker than every other entry point here, and only useful to a
+/// caller that gets its integrity from somewhere else. It answers "which
+/// segments exist" and nothing about what is in them: a removed segment changes
+/// the sealed list and is therefore visible, an edited one is not.
+///
+/// The Merkle root builder uses it to check that the set it cached against is
+/// still the set on disk before folding a host-signed statement about the
+/// contents. A caller without such a statement wants [`read_verified_set`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentShape {
+    /// Sealed segments, oldest first.
+    pub sealed: Vec<(u64, PathBuf)>,
+    /// The live segment.
+    pub active: (u64, PathBuf),
+}
+
+impl SegmentShape {
+    /// Sequence numbers, oldest first, the live segment last.
+    #[must_use]
+    pub fn seqs(&self) -> Vec<u64> {
+        self.sealed
+            .iter()
+            .map(|(seq, _)| *seq)
+            .chain(std::iter::once(self.active.0))
+            .collect()
+    }
+}
+
+/// Enumerate the segment set without reading any segment's contents.
+///
+/// See [`SegmentShape`] for what this does and does not establish.
+pub fn segment_shape(dir: &Path, base: &str) -> Result<SegmentShape, SegmentSetError> {
+    let located = locate(dir, base)?;
+    let (active, sealed) = located
+        .split_last()
+        .ok_or_else(|| SegmentSetError::Io(format!("{base}: no segments in {}", dir.display())))?;
+    if !active.active {
+        return Err(SegmentSetError::Io(format!(
+            "{base}: the last segment in {} is not the live one",
+            dir.display()
+        )));
+    }
+    Ok(SegmentShape {
+        sealed: sealed.iter().map(|s| (s.seq, s.path.clone())).collect(),
+        active: (active.seq, active.path.clone()),
+    })
+}
+
 /// Read the whole set with its structure verified but no interior walked.
 ///
 /// [`read_verified_set`] with the interiors left out: every handoff, boundary

--- a/specs/sprint/delivery/audit-root-publication-is-flat-in-history.md
+++ b/specs/sprint/delivery/audit-root-publication-is-flat-in-history.md
@@ -1,0 +1,94 @@
+# Publishing an audit root stopped growing with the log
+
+**Status: COMPLETE**
+
+## What was left over
+
+Taking the genesis walk off the admission path cut `admit` from 742 ms to
+~57 ms, but left it `O(history)`: the fast path still read every segment's
+bytes and folded every leaf twice — once to check the attested prefix against
+the published root, once to build the new one. On the same host and the same
+day that number went 57 ms → 68 ms as the chain grew. It would have returned to
+where it started.
+
+## What changed
+
+The leaf hashes of the attested prefix are cached, and the cache is checked
+rather than believed.
+
+A published `SignedAuditRoot` is a host-signed statement that the first
+`tree_size` leaves fold to `root_hash`. So the cache is validated by folding it
+and comparing to that signature: a cache that is corrupt, truncated, replaced
+or forged does not reproduce the signed root and is discarded. Nothing is taken
+on the cache's word — the fold *is* the check.
+
+That changes the cost model. Hashing leaves is proportional to the log's bytes;
+folding leaf hashes is proportional to its entries, at 32 bytes each. So the
+per-launch cost stops tracking the size of the log and starts tracking the size
+of one run's append.
+
+- `mvm_contract::merkle::merkle_root_of_leaf_hashes` — the fold, split out from
+  `merkle_root`, which is now that plus one `leaf_hash` per line. Asserted
+  identical for every tree size 0..40.
+- `audit::leaf_cache` — the sidecar, its encoding, and the fingerprints.
+- `audit_set::segment_shape` — the segment set from a directory listing, no
+  segment opened.
+- `merkle::root_over_cached_prefix` — the fold, guarded.
+
+## What is still checked, and what is not
+
+Three separate questions, answered three different ways on purpose:
+
+- **Are these the attested leaves?** The fold against the host-signed root.
+- **Is the live segment still what the cache says?** It is read in full every
+  time and compared line by line. An edit there is caught at publish time,
+  exactly as before — which is why
+  `a_tampered_attested_prefix_declines_the_shortcut_and_then_refuses` still
+  passes unmodified.
+- **Are the sealed segments still what they were?** Sequence number, length and
+  mtime. Not their contents: not reading them is the entire saving.
+
+The third is a narrowing. A sealed segment edited in place, preserving length
+and mtime, is no longer detected when a root is published. It is still detected
+by `mvmctl trust audit verify`, by `read_leaves` when an inclusion proof is
+built, and by any cache miss, all of which walk from genesis. And the root
+published over a stale cache commits to the leaves the log actually had — so
+this path never signs a statement blessing altered content; it fails to notice
+it, which is the weaker failure of the two.
+
+That boundary is a test rather than a paragraph:
+`an_in_place_sealed_edit_is_missed_at_publish_but_caught_by_the_genesis_walk`.
+
+The threat it gives up on is a malicious host writing under `~/.mvm/audit/`,
+which ADR-001 places out of scope. No numbered claim cites publish-time
+refusal; claim 8's witnesses are `verify_audit_chain` and
+`mvmctl trust audit verify`, both untouched.
+
+## Measured
+
+Same host, `machine run --image alpine -- sh -c "echo hi"`, HVF. 30 launches:
+
+| | start of day | after the genesis-walk fix | now |
+|---|---|---|---|
+| `admit` | 742 ms | 57→68 ms, rising | **22–30 ms** |
+| total | 1166 ms | 209–228 ms | **p50 161, p95 169 ms** |
+| dispatch window | 175 ms | 78–85 ms | **71–85 ms** |
+
+Under the 200 ms target, and no longer a function of how long the host has been
+running workloads. The residual ~25 ms of `admit` is the rest of admission —
+plan synthesis, signing, the chain-entry fsync barrier, policy resolution —
+which the earlier probe measured at ~26 ms with `publish_root` excluded. Root
+publication is now a small part of that rather than all of it.
+
+## Still open
+
+- **Teardown is ~47 ms** and is now the largest phase after backend start. Most
+  of it is the supervisor genuinely shutting down, observed via kqueue rather
+  than polled, so it is real work rather than a scheduling artifact.
+- **The first launch after a release build remains an outlier**, and the worst
+  one yet was seen here: a 144 s `admit` on the first run against a freshly
+  linked binary, against a 22 ms steady state. Five occurrences now across the
+  day, always the first run after a build, always every phase affected. Still
+  not root-caused. Discard the first sample when benchmarking.
+- One total sample in 30 came in at 213 ms. p50 and p95 are inside the target;
+  the tail on a developer host at load average ~10 is not.


### PR DESCRIPTION
Follow-on to #2990. That PR took the genesis walk off the admission path — `admit` 742 ms → ~57 ms — but left it `O(history)`: the fast path still read every segment's bytes and folded every leaf twice, once to check the attested prefix against the published root and once to build the new one. On the same host in the same day that number went **57 ms → 68 ms** as the chain grew, on its way back to where it started.

This makes it flat, and takes total launch **under 200 ms**.

## The idea

The leaf hashes of the attested prefix are cached, and the cache is *checked* rather than believed.

A published `SignedAuditRoot` is a host-signed statement that the first `tree_size` leaves fold to `root_hash`. So the cache is validated by folding it and comparing against that signature. Corrupt, truncated, replaced or forged, it does not reproduce the signed root and is discarded. **The fold is the check** — nothing is ever taken on the cache's word.

That changes the cost model. Hashing leaves is proportional to the log's *bytes*; folding leaf hashes is proportional to its *entries*, at 32 bytes each. Per-launch cost now tracks one run's append rather than the whole log.

## Three questions, answered three ways

| question | how |
|---|---|
| Are these the attested leaves? | The fold against the host-signed root. |
| Is the live segment still what the cache says? | Read in full every time, compared line by line. |
| Are the sealed segments still what they were? | Sequence number, length, mtime — **not** their contents. |

The live segment is read regardless, so its cached portion is checked per-line for free. An edit there is caught at publish time exactly as before — which is why `a_tampered_attested_prefix_declines_the_shortcut_and_then_refuses` passes unmodified.

## The narrowing, stated plainly

A sealed segment edited **in place**, preserving length and mtime, is no longer noticed when a root is published. Not reading sealed segments is the entire saving.

It is still caught by `mvmctl trust audit verify`, by `read_leaves` when an inclusion proof is built, and by any cache miss — all of which walk from genesis. And the root published over a stale cache commits to the leaves the log *actually had*, so this path never signs a statement blessing altered content; it fails to notice it, which is the weaker of the two failures.

The threat given up on is a malicious host writing under `~/.mvm/audit/`, which ADR-001 places out of scope. No numbered claim cites publish-time refusal — claim 8's witnesses are `verify_audit_chain` and `mvmctl trust audit verify`, both untouched.

That boundary is a test rather than a paragraph: `an_in_place_sealed_edit_is_missed_at_publish_but_caught_by_the_genesis_walk`.

## Measured

Same host, `machine run --image alpine -- sh -c "echo hi"`, HVF, 30 launches:

| | start of day | after #2990 | this PR |
|---|---|---|---|
| `admit` | 742 ms | 57→68 ms, rising | **22–30 ms, flat** |
| total | 1166 ms | 209–228 ms | **p50 161 ms, p95 169 ms** |
| dispatch window | 175 ms | 78–85 ms | **71–85 ms** |

The residual ~25 ms of `admit` is the rest of admission — plan synthesis, signing, the chain-entry fsync barrier, policy resolution — which an earlier probe measured at ~26 ms with `publish_root` excluded. Root publication is now a small part of that rather than all of it.

## Shape

- `mvm_contract::merkle::merkle_root_of_leaf_hashes` — the fold, split out of `merkle_root`, which is now that plus one `leaf_hash` per line. Asserted identical for every tree size 0..40.
- `audit::leaf_cache` — the sidecar, its encoding, the fingerprints. Written atomically but **not** fsynced: it is derived state, and paying `F_FULLFSYNC` to protect it would spend more than it saves.
- `audit_set::segment_shape` — the set from a directory listing, no segment opened.
- `merkle::root_over_cached_prefix` — the guarded fold.

Decoding is hostile-input shaped, because anything can write that file: the declared lengths are checked against the body before any allocation, since `Vec::with_capacity` on a `u64::MAX` claim aborts the process rather than returning an error (`a_declared_size_larger_than_the_body_is_a_miss`).

## Tests

19 added. The first asserts the cached path *engaged* before comparing roots, because every test after it would otherwise pass by silently falling back:

- `the_cached_prefix_path_engages_and_agrees_with_the_genesis_walk`
- `a_removed_sealed_segment_declines_the_cache`
- `a_resized_sealed_segment_declines_the_cache`
- `an_in_place_sealed_edit_is_missed_at_publish_but_caught_by_the_genesis_walk`
- `folding_leaf_hashes_gives_the_same_root_as_folding_lines`
- plus encoding round-trips, truncation, trailing bytes, version skew, oversized declarations, and fingerprint probes.

## Not addressed

- **Teardown is ~47 ms**, now the largest phase after backend start. Most of it is the supervisor genuinely shutting down, observed via kqueue rather than polled.
- **The first launch after a release build remains an outlier**, and the worst yet appeared here: a **144 s** `admit` on the first run against a freshly linked binary, against a 22 ms steady state. Five occurrences across the day, always the first run after a build, always every phase affected. Not root-caused; discard the first sample when benchmarking.
- One total sample in 30 came in at 213 ms. p50 and p95 are inside the target; the tail on a developer host at load average ~10 is not.
