### PR TITLE
ci(build): let the pinned zig follow the embed feature

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -38,8 +38,9 @@ jobs:
         with:
           packages: libcap-ng-dev lld
 
-      - uses: ./.github/actions/install-zigbuild
-
+      # No zig here: `just bdd` builds mvmctl without `embed-host-bins`, and the
+      # scenarios that would need the payload are `@live`-tagged, which this
+      # hermetic lane skips. The live job below does need it.
       - name: Install just
         uses: taiki-e/install-action@v2
         with:
@@ -103,6 +104,9 @@ jobs:
         with:
           packages: libcap-ng-dev lld qemu-system-x86 qemu-utils
 
+      # Kept: `just bdd-live-ci` builds with `embed-host-bins`, because the
+      # `@live` scenarios boot real microVMs and reach the builder VM. That is
+      # the cross-compile, and it needs the pinned zig.
       - uses: ./.github/actions/install-zigbuild
 
       - name: Install just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,8 +181,6 @@ jobs:
         with:
           packages: lld
 
-      - uses: ./.github/actions/install-zigbuild
-
       - uses: ./.github/actions/rust-cache
 
       - name: Check formatting
@@ -275,8 +273,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-
-      - uses: ./.github/actions/install-zigbuild
 
       - uses: ./.github/actions/rust-cache
 
@@ -454,6 +450,11 @@ jobs:
         with:
           packages: lld
 
+      # The only lane in this workflow that needs the pinned zig. Eight other
+      # jobs installed it because `mvm-cli`'s build script used to cross-compile
+      # the embedded Linux binaries on every build; that is now behind
+      # `embed-host-bins`, which only the step below turns on. If a second lane
+      # ever enables that feature, it needs this too.
       - uses: ./.github/actions/install-zigbuild
 
       - uses: ./.github/actions/rust-cache
@@ -666,8 +667,6 @@ jobs:
         with:
           packages: attr cryptsetup-bin lld
 
-      - uses: ./.github/actions/install-zigbuild
-
       - uses: ./.github/actions/rust-cache
 
       - name: Install cargo-nextest
@@ -739,8 +738,6 @@ jobs:
         with:
           packages: attr cryptsetup-bin libcap-ng-dev lld
 
-      - uses: ./.github/actions/install-zigbuild
-
       - uses: ./.github/actions/rust-cache
 
       - name: Install cargo-nextest
@@ -783,8 +780,6 @@ jobs:
       - uses: ./.github/actions/apt-deps
         with:
           packages: attr cryptsetup-bin lld
-
-      - uses: ./.github/actions/install-zigbuild
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -841,8 +836,6 @@ jobs:
       - uses: ./.github/actions/apt-deps
         with:
           packages: attr cryptsetup-bin lld
-
-      - uses: ./.github/actions/install-zigbuild
 
       - uses: ./.github/actions/rust-cache
 
@@ -977,11 +970,6 @@ jobs:
       # same reasoning that made these manifests signed in the first place.
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
-
-      # Building the root package runs `crates/mvm-cli/build.rs`, which
-      # cross-compiles the embedded host binaries and needs the pinned zig.
-      # Without it the lane fails before it ever boots anything.
-      - uses: ./.github/actions/install-zigbuild
 
       - uses: ./.github/actions/rust-cache
         with:
@@ -1234,13 +1222,6 @@ jobs:
         if: needs.scope.outputs.nix == 'true'
         with:
           packages: lld
-
-      # `cargo test` below builds mvmctl, whose build.rs cross-compiles the
-      # embedded host binaries as static musl and needs the pinned zig. Without
-      # it this dies at compile time, before it starts a guest — which reads as
-      # "the image does not boot" and is nothing of the kind.
-      - uses: ./.github/actions/install-zigbuild
-        if: needs.scope.outputs.nix == 'true'
 
       - name: Build the guest image from this tree
         if: needs.scope.outputs.nix == 'true'

--- a/Justfile
+++ b/Justfile
@@ -357,7 +357,11 @@ e2e-docs-clean:
 
 # witness lanes while proving that the public commands operate a real guest.
 bdd-live-ci:
-    cargo build --bin mvmctl --features user
+    # `embed-host-bins` because these scenarios boot real microVMs: `MVM_BDD_LIVE=1`
+    # admits the `@live` set, which reaches the builder VM. Without the payload
+    # mvmctl refuses at bootstrap. The hermetic `just bdd` lane skips those
+    # scenarios and so deliberately does not pay the cross-compile.
+    cargo build --bin mvmctl --features user,embed-host-bins
     CARGO_BIN_EXE_mvmctl="${CARGO_TARGET_DIR:-target}/debug/mvmctl" MVM_BDD_LIVE=1 MVM_BDD_CI_LIVE_ONLY=1 cargo test -p mvm-conformance --test conformance --features bdd
 
 # Build the per-VM host helper bins into `target/<profile>/`, where

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1055,9 +1055,15 @@ resume` takes a `current_head` and refuses when it differs from the
       half is closed, its probe is deleted), Phase 4 (dead crate edges;
       `deps_audit` and the tree-sitter grammars off the serial path; the
       `mvm-hostd` audit cluster), Phase 5 (sccache 4.2% Rust hit rate, worktree
-      hygiene). Also open: the ten now-mostly-unnecessary `install-zigbuild`
-      steps in `ci.yml`, and the embed store sitting at 17 GB against its 4 GiB
-      ceiling.
+      hygiene). The pinned zig now follows the feature: eight of `ci.yml`'s nine
+      `install-zigbuild` steps are gone, each job traced to what it runs first,
+      and that trace caught `just bdd-live-ci` booting real microVMs without the
+      payload. Still open: the missing `rerun-if-env-changed` on
+      `MVM_EMBED_CACHE_MAX_BYTES` / `MVM_EMBED_CACHE_DIR`. An earlier revision
+      of this entry also listed "the embed store sitting at 17 GB against its
+      4 GiB ceiling" — that was wrong; `prune` holds, and the effective ceiling
+      on that host is a deliberate 64 GiB `[env]` override in a global cargo
+      config.
 
 - [~] **Agent tool and memory planes**
       (`specs/plans/2026-08-18-agent-tool-and-memory-planes.md`). Opened

--- a/specs/plans/2026-08-28-build-script-drops-the-aux-helper-leg.md
+++ b/specs/plans/2026-08-28-build-script-drops-the-aux-helper-leg.md
@@ -129,6 +129,15 @@ binaries. The premise was wrong. Once cargo owns them:
   is still a second resolver that reimplements `aux_bin::resolve`. It does not
   reference the deleted target dir, so it keeps working; collapsing the two
   remains §1 of the freshness plan.
-- The `~/.cache/mvm/embed` store was measured at 17 GB against its 4 GiB
-  `DEFAULT_MAX_BYTES` ceiling, i.e. `prune` is not holding. Unrelated to this
-  leg and not investigated here.
+- An earlier revision of this plan claimed the `~/.cache/mvm/embed` store was
+  "17 GB against its 4 GiB `DEFAULT_MAX_BYTES`, i.e. `prune` is not holding."
+  **That was wrong on both numbers and on the conclusion**, and it is recorded
+  here rather than deleted because the way it was wrong is reusable. The 17 GB
+  came from `du -sh`; the figure `prune` actually sums is the apparent size,
+  6.11 GiB. And 4 GiB is the source default, not the effective ceiling — a
+  probe in the real code path reported
+  `keys=672 total=6562098608 max=68719476736 victims=0`, i.e. a 64 GiB cap set
+  deliberately in this host's *global* `~/.cargo/config.toml` `[env]` table.
+  Cargo's `[env]` injects into build scripts without appearing in `env`, so
+  `env | grep MVM_EMBED` came back empty and read as "no override". `prune`
+  works correctly and the store sits at ~10% of its configured cap.

--- a/specs/plans/2026-08-28-embedded-host-binaries-are-opt-in.md
+++ b/specs/plans/2026-08-28-embedded-host-binaries-are-opt-in.md
@@ -105,13 +105,38 @@ the first time by a tag-push release — the same invisible-until-release gap th
 - [x] CLAUDE.md and the contributor development guide say the toolchain is
       needed at `just embed` time rather than at `cargo build` time.
 
-## Deliberately not done
+## The zig toolchain follows the feature
 
-- **The ten `install-zigbuild` steps in `ci.yml` are left alone.** Most are now
-  unnecessary, since only the `lint-features` lane cross-compiles. Removing them
-  is a straight CI-minutes win but touches jobs this change has not otherwise
-  traced, and a wrongly-removed one fails a lane rather than a test. Worth doing
-  as its own pass.
-- **The `~/.cache/mvm/embed` store is still over its ceiling** — 17 GB against a
-  4 GiB `DEFAULT_MAX_BYTES`, i.e. `prune` is not holding. Unrelated to this
-  change; carried over from the aux-leg plan's open list.
+`ci.yml` installed the pinned zig in nine jobs, because every `mvm-cli` build
+used to cross-compile. Only `lint-features` still does. Each of the other eight
+was traced to what it actually runs before its step was removed:
+
+| job | why it no longer needs zig |
+|---|---|
+| `lint-core`, `lint-policy` | workspace check/test, no `embed-host-bins` |
+| `test-workspace`, `test-workspace-aarch64` | same |
+| `test-release-witness` | builds `mvm-fs`/`core`/`contract`/`hostd`/`agentd` — never `mvm-cli` |
+| `test-linux` | `just bdd`, whose builder-VM scenarios are `@live`-gated and skipped |
+| `boot-latency`, `guest-image-boot` | `cargo test --test runtime_boot_bench`, which "deliberately excludes the builder VM and Nix image build path" |
+
+Tracing rather than pattern-matching found a defect in this change:
+`just bdd-live-ci` sets `MVM_BDD_LIVE=1`, which admits the `@live` scenarios
+that *do* boot real microVMs, and it built `--features user` — no payload. It
+now builds `user,embed-host-bins`, and `bdd.yml`'s live job keeps its zig step
+while its hermetic job drops one it never needed.
+
+## Deliberately not done
+- **`MVM_EMBED_CACHE_MAX_BYTES` and `MVM_EMBED_CACHE_DIR` have no
+  `rerun-if-env-changed`.** Changing the store's ceiling or its location does
+  not re-run the build script, so neither takes effect until something else
+  invalidates it. Small and real; left out of this change because it is about
+  the store rather than about whether the leg runs.
+
+  This is the *only* store finding that survived checking. The claim that
+  `prune` was not holding its ceiling — carried in an earlier revision of the
+  aux-leg plan and in that PR's description — was wrong; see that plan's
+  "Deliberately not done" for how. Separately, the rationale recorded in this
+  host's `~/.cargo/config.toml` for raising the ceiling to 64 GiB is a cache
+  miss costing "~17.8s of nested `cargo build` on the aux-helper leg". That leg
+  no longer exists, so the insurance the raise was buying is obsolete — a host
+  config decision, not a repo one.


### PR DESCRIPTION
Follow-up to #2993, which put the embedded Linux host-binary cross-compile behind `embed-host-bins`. Two things that change implies, plus a correction to a claim that PR shipped.

## The pinned zig follows the feature

`ci.yml` installed the pinned zig in nine jobs, because every `mvm-cli` build used to cross-compile. Only `lint-features` still does. Each of the other eight was traced to what it actually runs before its step was removed:

| job | why it no longer needs zig |
|---|---|
| `lint-core`, `lint-policy` | workspace check/test, no `embed-host-bins` |
| `test-workspace`, `test-workspace-aarch64` | same |
| `test-release-witness` | builds `mvm-fs`/`core`/`contract`/`hostd`/`agentd` — never `mvm-cli` |
| `test-linux` | `just bdd`, whose builder-VM scenarios are `@live`-gated and skipped in that lane |
| `boot-latency`, `guest-image-boot` | `cargo test --test runtime_boot_bench`, which "deliberately excludes the builder VM and Nix image build path" |

The remaining step carries a comment saying it is the only one and what would change that.

## That trace caught a defect in #2993

`just bdd-live-ci` sets `MVM_BDD_LIVE=1`, which admits exactly the `@live` scenarios that boot real microVMs and reach the builder VM — and it built `--features user`. With no embedded payload, every one of them would have failed at bootstrap. It now builds `user,embed-host-bins`.

Correspondingly in `bdd.yml`: the live job keeps its zig step, and the hermetic job drops one it never needed.

This is the argument against removing the nine steps by pattern match. Grepping for `install-zigbuild` and deleting the ones that "look unused" would have left this broken and taken the zig out of the one lane that still needs it.

## Correction: the embed store's prune is fine

#2993 claimed, in its description and in two plan docs, that the content store was "17 GB against its 4 GiB `DEFAULT_MAX_BYTES`, i.e. `prune` is not holding". **That was wrong on both numbers and on the conclusion.** A probe in the real code path reported:

```
root=~/.cache/mvm/embed keys=672 total=6562098608 max=68719476736 victims=0
```

- The 17 GB came from `du -sh`. The figure `prune` sums is the apparent size: **6.11 GiB**.
- 4 GiB is the source default, not the effective ceiling. That host sets a deliberate **64 GiB** override in a global cargo config `[env]` table. Cargo's `[env]` injects into build scripts without appearing in `env`, so `env | grep MVM_EMBED` came back empty and read as "no override".

`prune` works correctly; the store sits at roughly 10% of its configured cap. The error is recorded in the plan doc rather than deleted, because how it was wrong — a disk-usage figure mistaken for apparent size, and a source default mistaken for an effective value — is the reusable part. #2993's merged description still carries the wrong sentence; the corrected record lives in the plan docs.

Worth noting separately: the rationale that host recorded for raising the ceiling was a miss costing "~17.8s of nested `cargo build` on the aux-helper leg". #2993 deleted that leg, so the insurance is obsolete. Host config, not repo code — flagged, not changed.

## One real store finding survives

`MVM_EMBED_CACHE_MAX_BYTES` and `MVM_EMBED_CACHE_DIR` have no `rerun-if-env-changed` in `build.rs`, so changing the ceiling or the store location does not re-run the script and neither takes effect until something else invalidates it. Left as a noted follow-up rather than folded in here, since it is about the store rather than about which lanes need zig.

## Gates

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `just check-gated`, `cargo test --workspace --doc`, `cargo nextest run --workspace`, and `xtask check-all` / `check-claim-witness-freshness` / `check-declared-backing` / `check-mutation-witnesses` / `check-nextest-groups` / `check-single-workload-env`: **all pass**, 12775/12775 tests.

`actionlint` clean on both edited workflows.
