### PR TITLE
test(bdd): ratchet the parse tier so it cannot grow unnoticed

### DIFF
--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -427,6 +427,90 @@ mod live_home {
     }
 }
 
+/// The tier manifest, read only for the fields the ratchet needs.
+#[derive(serde::Deserialize)]
+struct TierManifest {
+    command: Vec<TierEntry>,
+}
+
+#[derive(serde::Deserialize)]
+struct TierEntry {
+    tier: String,
+}
+
+/// How many documented command paths sit at the weakest tier.
+///
+/// `parse` proves only that clap accepts the invocation. It cannot see a verb
+/// that parses and then refuses at runtime, which is the shape `machine
+/// forward` had already decayed into while the docs still told a reader to run
+/// it. Every entry there carries a written reason, so the tier is honest about
+/// itself; what it is not is stable. Documentation lands continuously, and an
+/// example whose tier nobody chose lands on the rung that asks least — the
+/// count went 61 -> 65 during a single week of unrelated work.
+///
+/// Counted from the parsed manifest rather than by matching text, because the
+/// obvious `tier = "parse"` grep also matches any reason string that quotes the
+/// tier it is explaining, and a ratchet that miscounts upward blocks the merge
+/// that was lowering it.
+pub fn parse_tier_count(manifest: &str) -> Result<usize, toml::de::Error> {
+    Ok(toml::from_str::<TierManifest>(manifest)?
+        .command
+        .iter()
+        .filter(|entry| entry.tier == "parse")
+        .count())
+}
+
+#[cfg(test)]
+mod parse_tier_ratchet {
+    use super::parse_tier_count;
+
+    #[test]
+    fn counts_only_entries_at_the_parse_tier() {
+        let manifest = r#"
+[[command]]
+path = "a"
+tier = "parse"
+reason = "r"
+
+[[command]]
+path = "b"
+tier = "exec"
+
+[[command]]
+path = "c"
+tier = "parse"
+reason = "r"
+"#;
+        assert_eq!(parse_tier_count(manifest).expect("parses"), 2);
+    }
+
+    #[test]
+    fn a_reason_that_quotes_the_tier_does_not_inflate_the_count() {
+        // The exact hazard a text match would hit: this entry is `exec`, and
+        // its prose explains what `tier = "parse"` would have meant.
+        let manifest = r#"
+[[command]]
+path = "a"
+tier = "exec"
+reason = "promoted from tier = \"parse\" once a fixture staged its input"
+"#;
+        assert_eq!(parse_tier_count(manifest).expect("parses"), 0);
+    }
+
+    #[test]
+    fn a_malformed_manifest_is_an_error_not_a_zero() {
+        // Zero would read as "nothing left at the weakest tier" — the best
+        // possible result — from a file that failed to parse.
+        assert!(
+            parse_tier_count(
+                "[[command]]
+tier ="
+            )
+            .is_err()
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mvm-conformance/tests/steps/doc_examples.rs
+++ b/crates/mvm-conformance/tests/steps/doc_examples.rs
@@ -1419,3 +1419,32 @@ fn docs_coverage_ratchet(_world: &mut CliWorld) {
             .join("\n")
     );
 }
+
+/// The pinned ceiling on parse-tier command paths.
+///
+/// Lower it whenever a promotion lands — that is the point. Raising it is a
+/// deliberate act that should carry its reason in the commit, because the
+/// alternative is what happened before this existed: the count drifted up
+/// while everyone believed coverage was improving.
+const PARSE_TIER_PIN: usize = 65;
+
+#[then(expr = "no more command paths sit at the parse tier than the pinned count")]
+fn parse_tier_does_not_grow(_world: &mut CliWorld) {
+    let path = repo_root().join("features/suites/s29_doc_examples/tiers.toml");
+    let manifest = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("reading {}: {e}", path.display()));
+    let count = mvm_conformance::parse_tier_count(&manifest)
+        .unwrap_or_else(|e| panic!("parsing {}: {e}", path.display()));
+    assert!(
+        count <= PARSE_TIER_PIN,
+        "{count} command paths sit at the `parse` tier, above the pinned {PARSE_TIER_PIN}. \
+         Parsing proves only that clap accepts the invocation; it cannot see a verb that \
+         parses and then refuses. Promote the new path to `exec` or `live`, or raise \
+         PARSE_TIER_PIN and say why in the commit."
+    );
+    if count < PARSE_TIER_PIN {
+        eprintln!(
+            "[bdd] parse tier is down to {count} (pin {PARSE_TIER_PIN}) — lower the pin to hold the gain."
+        );
+    }
+}

--- a/features/suites/s29_doc_examples/doc_examples.feature
+++ b/features/suites/s29_doc_examples/doc_examples.feature
@@ -21,6 +21,13 @@ Feature: Documented examples work
   Scenario: every documented command path carries a verification tier
     Then every documented command path carries a verification tier
 
+  # The weakest tier is the one an example reaches by nobody deciding
+  # anything, so left alone it grows: 61 -> 65 during a single week of
+  # unrelated documentation work. The count may fall freely; raising it
+  # means editing the pin and saying why.
+  Scenario: the parse tier does not grow
+    Then no more command paths sit at the parse tier than the pinned count
+
   Scenario: the tier manifest cannot drift into fiction
     Then the tier manifest names only real CLI commands
 

--- a/specs/plans/2026-08-30-doc-example-parse-tier-promotion.md
+++ b/specs/plans/2026-08-30-doc-example-parse-tier-promotion.md
@@ -1,0 +1,78 @@
+# Promote the documented examples still proven only by parsing
+
+`parse` proves that clap accepts an invocation. It cannot see a verb that parses
+and then refuses at runtime — the shape `machine forward` had decayed into while
+the docs still told a reader to run it. 65 of the documented command paths sit
+there.
+
+Every one carries a written reason, so the tier is honest about itself. What it
+was not is stable: the count went 61 → 65 during a week of unrelated
+documentation work, because an example whose tier nobody chooses lands on the
+rung that asks least. The ratchet scenario (`the parse tier does not grow`) pins
+it; this plan spends the pin down.
+
+## Classification
+
+Grouped by the reason already recorded against each entry.
+
+### Promote — needs only the live journey guest (11)
+
+`machine diff`, `fork`, `proc start`, `reconfigure`, `restore`, `snapshot rm`,
+`volume create`, `volume lock`, `volume unlock`, `volume unmount`, `wait`.
+
+`features/suites/s32_documented_surface/machine_journey.feature` already boots a
+guest, so these cost one boot for eleven verbs — the largest single win here.
+They are nested under `VmCmd` and flattened into `machine`, and are genuinely
+documented (`machine wait api-dev --for all`,
+`machine proc start <vm> -- <argv>`).
+
+Order matters: `volume create/lock/unlock` are witnessed working by
+`features/suites/s26_volumes/volume_lifecycle.feature`, so they are the safe
+first batch. `fork`, `restore` and `snapshot rm` need a checkpoint staged first,
+and `reconfigure` mutates the guest, so both belong after the read-only verbs.
+
+### Promote — a fixture exists but is unwired (6)
+
+- `bundle fetch` / `install` / `gc` — `scripts/make-bundle-fixture.sh` builds a
+  signed `.mvmpkg`; the `@bundle` capability already gates on it.
+- `deps inspect` / `deps audit` — `mvm-app-deps-fixture-tool` seals a volume.
+- `trust add` — needs a publisher pubkey file staged.
+
+### Investigate — the reason may be over-applied (12)
+
+Recorded as "documented only as a placeholder template, so there is no concrete
+invocation to execute". Several look runnable against an isolated home:
+`secret ls`, `pool status`, `shell-init`, `prepare`, `env bootstrap`. Worth
+re-reading each doc site before accepting the reason — a placeholder in one page
+does not mean no page shows a concrete form.
+
+### Keep, with the reason already written (36)
+
+- 5 build a multi-hundred-megabyte artifact over the network; the runner does
+  this once as setup, not as an assertion.
+- 5 reach a package index, so the outcome tracks the index rather than mvm.
+- 4 refuse without `MVM_GATEWAY_URL` — the `--remote` form targets a gateway
+  that lives in mvmd, not this repo.
+- 3 need a live persistent-builder session no scenario starts.
+- 3 need a manifest slot only a real builder-VM build fills.
+- 2 are interactive PTYs (`machine console`, `machine shell`) and need a pty
+  harness rather than captured stdio.
+- 2 never exit (`ops mcp stdio`, `watch`).
+- `bench` is a measurement loop on a benchmark budget, not a test budget.
+- the remainder name artifacts only a real build or launch produces.
+
+`machine forward` is a separate case: retired at runtime, still in the clap
+tree, no longer referenced by the docs. It should leave the manifest rather than
+be promoted.
+
+## Sequencing
+
+- [ ] Journey batch A — the read-only and volume verbs (7)
+- [ ] Journey batch B — checkpoint-dependent verbs (4)
+- [ ] Wire the three existing fixtures (6 paths)
+- [ ] Re-read the 12 "placeholder" doc sites and reclassify
+- [ ] Drop `machine forward` from the manifest
+- [ ] Lower `PARSE_TIER_PIN` with each batch
+
+Lower the pin in the same change that promotes. A batch that promotes without
+lowering leaves the ceiling where it was, and the next drift is invisible again.

--- a/specs/plans/2026-08-30-doc-example-parse-tier-promotion.md
+++ b/specs/plans/2026-08-30-doc-example-parse-tier-promotion.md
@@ -1,5 +1,8 @@
 # Promote the documented examples still proven only by parsing
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 `parse` proves that clap accepts an invocation. It cannot see a verb that parses
 and then refuses at runtime — the shape `machine forward` had decayed into while
 the docs still told a reader to run it. 65 of the documented command paths sit


### PR DESCRIPTION
The `parse` tier proves that clap accepts an invocation. It cannot see a verb that parses and then refuses at runtime — the shape `machine forward` had decayed into while the docs still told a reader to run it.

Every entry there carries a written reason, so the tier is honest about itself. What it was **not** is stable: the count went **61 → 65** during a week of unrelated documentation work, because an example whose tier nobody chooses lands on the rung that asks least. Coverage was quietly getting worse while the suite stayed green.

## Change

- `mvm_conformance::parse_tier_count` — counts from the **parsed** manifest, not a text match. The obvious `tier = "parse"` grep also matches a reason string quoting the tier it explains, and a ratchet that miscounts upward would block the very merge that lowers it. A malformed manifest is an error, never a zero: zero would read as the best possible result from a file that failed to parse.
- A `the parse tier does not grow` scenario in the hermetic lane, pinned at the current 65.
- The step prints the slack when the count drops, so a promotion that forgets to lower the pin is visible rather than silently banked.

## Verified both ways

- pin 65, count 65 → **passes**
- pin 64, count 65 → **fails** with `65 command paths sit at the parse tier, above the pinned 64...`

A gate only proven in the passing direction is the failure mode this suite exists to catch, so I ran the negative case too.

## Companion plan

`specs/plans/2026-08-30-doc-example-parse-tier-promotion.md` classifies all 65 into promote-now (11 need only the live journey guest — one boot for eleven verbs), fixture-exists-but-unwired (6), reason-may-be-over-applied (12), and keep-with-reason (36). `machine forward` should leave the manifest rather than be promoted: retired at runtime, still in the clap tree, no longer referenced by the docs.

## Unrelated wrinkle worth knowing

The runners staleness guard compares `mvmctl`s mtime against the step sources. After editing only a step file, `cargo build --bin mvmctl` is a **no-op**, so the mtime never moves and the guards own advice loops forever. `touch`ing the binary is the way out. The guard is right to exist — it caught a stale binary three times today — but its remedy does not work for the step-only case.