### PR TITLE
ci(e2e): fail the macOS lane fast, naming the host it cannot run on

### DIFF
--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -148,6 +148,38 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Fail in seconds, naming the real constraint, instead of spending ~35
+      # minutes building and then dying on "pipe inject config to supervisor" —
+      # which reads as a supervisor bug rather than as a host that cannot run
+      # one.
+      #
+      # No GitHub-hosted macOS runner can boot an mvm guest today:
+      #
+      #   arm64 (macos-latest)  Hypervisor.framework is nested and reports
+      #                         HV_UNSUPPORTED. libkrun goes through the same
+      #                         framework, so it does not escape this either —
+      #                         the passing `libkrun (macOS Apple Silicon)` job
+      #                         builds, tests and lints, and never boots.
+      #   x86_64 (this runner)  has the virtualization extensions, but
+      #                         `mvm-hvf-supervisor` is Apple-Silicon-only and
+      #                         links as a stub, and the libkrun Homebrew
+      #                         formula is ARM-only so it cannot be installed.
+      #
+      # This lane needs a self-hosted Apple Silicon runner. Until one exists it
+      # is red by construction — see issue #3011 — and it is a release blocker on
+      # purpose: a tag
+      # cut without it is a tag with no evidence that the documented examples
+      # boot on macOS at all.
+      - name: Preflight — this host can run the workload backend
+        run: |
+          set -euo pipefail
+          arch="$(uname -m)"
+          echo "runner arch: $arch"
+          if [ "$arch" != "arm64" ]; then
+            echo "::error::mvm-hvf-supervisor is Apple-Silicon-only and links as a stub on $arch, and the libkrun Homebrew formula is ARM-only. No workload backend can start here. This lane needs a self-hosted Apple Silicon runner; see issue #3011." >&2
+            exit 1
+          fi
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
 


### PR DESCRIPTION
Follow-on to #2989. Does **not** weaken the release gate — it makes the blocked
state legible and cheap.

## What was happening

`e2e-docs-macos` spent ~35 minutes building and then failed with:

```
Error: building SDK sidecar 0.18.0 for x86_64
  1: resolving HVF builder image: hvf builder VMM-level failure: bake hvf builder rootfs: pipe inject config to supervisor
```

That names the supervisor, not the host that cannot run one. The real cause is
one line earlier and easy to scroll past:

```
mvm-hvf-supervisor runs only on macOS / Apple silicon (Hypervisor.framework); this is a stub build
```

## No hosted macOS runner can boot an mvm guest

| Runner | libkrun | HVF |
|---|---|---|
| `macos-latest` (arm64) | installs and links | Hypervisor.framework is nested, reports `HV_UNSUPPORTED` |
| `macos-15-intel` (this job) | Homebrew formula is **ARM-only**, cannot install | supervisor is Apple-Silicon-only, links as a **stub** |

libkrun goes through Hypervisor.framework too, so arm64's `HV_UNSUPPORTED`
blocks it as well. The `libkrun (macOS Apple Silicon)` job that passes on
`macos-latest` only builds, tests and lints — it never boots, so it is not
evidence that a guest can start there.

The Intel label was chosen for a real reason, recorded in the job's own comment
(arm64 reports `HV_UNSUPPORTED`). It trades one impossibility for another.

## This change

A preflight step checks the arch and exits in seconds with that explanation and
a pointer to #3011, instead of burning ~35 minutes of runner time per nightly on
a misleading error.

## What it deliberately does not do

**The lane stays in `release.needs`.** It is red by construction until a
self-hosted Apple Silicon runner exists, and that is the intended behaviour: a
tag cut without it carries no evidence that the documented examples boot on the
backend most users run.

Dropping macOS from the gate was considered and rejected — it removes the
enforcement rather than solving the problem, and the enforcement is the point.
Switching the lane to libkrun was also considered: it fails on Intel (ARM-only
formula) and on arm64 (same `HV_UNSUPPORTED`).

Tracking issue: #3011.

## Verification

- `actionlint` clean; all three workflows parse
- `xtask check-all` — 62 gates clean
- `github_actions_extended_e2e` + `release_assets` — 46/46, including the
  assertions that `ci-full.yml` and `release.yml` both still call the shared
  workflow and that `release.needs` still names `e2e-docs`