### PR TITLE
fix(guest): resolve a bare argv[0] against the image PATH

### DIFF
--- a/crates/mvm-agentd/src/process_rpc.rs
+++ b/crates/mvm-agentd/src/process_rpc.rs
@@ -258,6 +258,126 @@ fn fresh_token() -> String {
 // Building the security envelope around a `Command`
 // ============================================================================
 
+/// Fallback search directories for an image that declares no `PATH`.
+///
+/// The FHS order every distro ships. Only reached when the image's own runtime
+/// config is absent or carries no `PATH`.
+const FALLBACK_SEARCH_PATH: [&str; 6] = [
+    "/usr/local/sbin",
+    "/usr/local/bin",
+    "/usr/sbin",
+    "/usr/bin",
+    "/sbin",
+    "/bin",
+];
+
+/// Where a bare command name is looked up, most specific first.
+///
+/// The *image's* `PATH`, as `exec` already resolves it — an image that installs
+/// its interpreter somewhere unusual says so in its own runtime config, and
+/// honouring that is why `exec("uname", …)` worked here while
+/// `commands.start(["uname", …])` did not.
+///
+/// Deliberately **not** the request's `PATH`. The caller supplies that env, so
+/// honouring it would let the caller choose which binary a name resolves to,
+/// which is the ambiguity refusing a bare name outright used to avoid. The
+/// image is not the caller.
+fn program_search_dirs(image_path: Option<&str>) -> Vec<String> {
+    let from_image: Vec<String> = image_path
+        .unwrap_or_default()
+        .split(':')
+        .filter(|dir| dir.starts_with('/'))
+        .map(str::to_string)
+        .collect();
+    if from_image.is_empty() {
+        return FALLBACK_SEARCH_PATH
+            .iter()
+            .map(|d| (*d).to_string())
+            .collect();
+    }
+    from_image
+}
+
+/// The `PATH` the image declares for its own workloads, if any.
+fn image_declared_path() -> Option<String> {
+    let image = crate::workload_env::ImageRuntimeConfig::load().ok()?;
+    crate::workload_env::WorkloadEnvironment::builder()
+        .image(&image)
+        .build()
+        .vars()
+        .find(|(k, _)| *k == std::ffi::OsStr::new("PATH"))
+        .and_then(|(_, v)| v.to_str().map(str::to_string))
+}
+
+/// Whether a candidate path is something the guest can actually execute.
+///
+/// A trait so the resolution rules are unit-testable without laying down real
+/// executables: the interesting cases are "name matches a directory", "name
+/// matches a non-executable file", and search order, none of which need a
+/// filesystem to state.
+pub trait ProgramProbe {
+    /// True when `path` is a regular file carrying an executable bit.
+    fn is_executable_file(&self, path: &str) -> bool;
+}
+
+/// The production probe: `stat(2)` through `std::fs`.
+pub struct OsProgramProbe;
+
+impl ProgramProbe for OsProgramProbe {
+    fn is_executable_file(&self, path: &str) -> bool {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+}
+
+/// Turn `argv[0]` into the absolute path that will be executed.
+///
+/// An absolute path is taken as given. A bare name — no `/` at all — is looked
+/// up in [`PROGRAM_SEARCH_PATH`], because that is the form the SDK documents
+/// (`commands.start(["python", "/app/main.py"])`) and the form every comparable
+/// runtime accepts. A *relative path* (`./run`, `bin/tool`) is still refused:
+/// it resolves against a working directory the request may also be setting, so
+/// the two together decide the binary in a way neither states on its own.
+///
+/// The absolute-path property the previous rule protected is unchanged. What
+/// reaches `execve` is still an absolute path chosen before the fork; the only
+/// difference is that a bare name now has a defined way to become one instead
+/// of being rejected.
+pub fn resolve_argv0(
+    argv0: &str,
+    search_dirs: &[String],
+    probe: &dyn ProgramProbe,
+) -> Result<String, (ProcErrorKind, String)> {
+    if std::path::Path::new(argv0).is_absolute() {
+        return Ok(argv0.to_string());
+    }
+    if argv0.contains('/') {
+        return Err((
+            ProcErrorKind::InvalidArgv,
+            format!(
+                "argv[0] {argv0:?} is a relative path; use an absolute path, or a \
+                 bare command name to search {}",
+                search_dirs.join(":")
+            ),
+        ));
+    }
+    for dir in search_dirs {
+        let candidate = format!("{dir}/{argv0}");
+        if probe.is_executable_file(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err((
+        ProcErrorKind::InvalidArgv,
+        format!(
+            "argv[0] {argv0:?} was not found as an executable in {}",
+            search_dirs.join(":")
+        ),
+    ))
+}
+
 /// Validate request inputs against the policy + caps and return a
 /// fully-constructed `Command` ready to spawn. Pure logic + path
 /// canonicalization — no actual fork or execve happens here.
@@ -283,12 +403,8 @@ fn build_command(
     if argv0.is_empty() {
         return Err((ProcErrorKind::InvalidArgv, "argv[0] is empty".to_string()));
     }
-    if !std::path::Path::new(argv0).is_absolute() {
-        return Err((
-            ProcErrorKind::InvalidArgv,
-            format!("argv[0] {argv0:?} must be an absolute path"),
-        ));
-    }
+    let search_dirs = program_search_dirs(image_declared_path().as_deref());
+    let argv0 = resolve_argv0(argv0, &search_dirs, &OsProgramProbe)?;
 
     for (k, v) in env {
         if k.is_empty() || k.contains('=') || k.as_bytes().contains(&0) {
@@ -774,6 +890,145 @@ pub fn handle_proc_wait<W: FnMut(ProcWaitEvent)>(
 
 #[cfg(test)]
 mod tests {
+    /// A probe backed by a fixed set of paths, so search order and the
+    /// non-executable case are stated without laying down real files.
+    struct FakeProbe(&'static [&'static str]);
+
+    /// The FHS fallback, as a bare-name lookup would use for an image that
+    /// declares no PATH of its own.
+    fn fhs() -> Vec<String> {
+        super::FALLBACK_SEARCH_PATH
+            .iter()
+            .map(|d| (*d).to_string())
+            .collect()
+    }
+
+    impl super::ProgramProbe for FakeProbe {
+        fn is_executable_file(&self, path: &str) -> bool {
+            self.0.contains(&path)
+        }
+    }
+
+    /// The form the README documents. `commands.start(["python", ...])` and
+    /// `exec("uname", "-sr")` both send a bare name, and the guest used to
+    /// refuse it outright — so the SDK example in the README could not run.
+    #[test]
+    fn a_bare_command_name_resolves_through_the_search_path() {
+        let probe = FakeProbe(&["/bin/uname"]);
+        assert_eq!(
+            super::resolve_argv0("uname", &fhs(), &probe).unwrap(),
+            "/bin/uname"
+        );
+    }
+
+    /// Most specific directory wins, so an image shipping its own build of a
+    /// tool under /usr/local gets that one rather than the distro's.
+    #[test]
+    fn the_search_path_is_ordered_most_specific_first() {
+        let probe = FakeProbe(&["/usr/local/bin/python", "/usr/bin/python"]);
+        assert_eq!(
+            super::resolve_argv0("python", &fhs(), &probe).unwrap(),
+            "/usr/local/bin/python"
+        );
+    }
+
+    /// A directory or a non-executable file with the right name is not a
+    /// program. The probe answers false for both, and resolution must keep
+    /// looking rather than returning the first name that merely exists.
+    #[test]
+    fn a_name_that_is_not_executable_is_skipped_not_returned() {
+        // /usr/bin/tool exists but is not executable, so the probe omits it;
+        // /bin/tool is.
+        let probe = FakeProbe(&["/bin/tool"]);
+        assert_eq!(
+            super::resolve_argv0("tool", &fhs(), &probe).unwrap(),
+            "/bin/tool"
+        );
+    }
+
+    /// An absolute path is taken as given — this is the pre-existing contract
+    /// and the only form that used to be accepted.
+    #[test]
+    fn an_absolute_path_is_used_verbatim() {
+        let probe = FakeProbe(&[]);
+        assert_eq!(
+            super::resolve_argv0("/opt/app/run", &fhs(), &probe).unwrap(),
+            "/opt/app/run"
+        );
+    }
+
+    /// A relative path stays refused. It resolves against a working directory
+    /// the same request may be setting, so the two together decide the binary
+    /// in a way neither states on its own — which is exactly the ambiguity the
+    /// absolute-only rule existed to avoid.
+    #[test]
+    fn a_relative_path_is_still_refused() {
+        let probe = FakeProbe(&["/bin/run"]);
+        for argv0 in ["./run", "bin/run", "../run"] {
+            let err = super::resolve_argv0(argv0, &fhs(), &probe).unwrap_err();
+            assert_eq!(err.0, super::ProcErrorKind::InvalidArgv);
+            assert!(
+                err.1.contains("relative path"),
+                "{argv0} should be refused as a relative path: {}",
+                err.1
+            );
+        }
+    }
+
+    /// A name nothing provides names the search path, so the caller can see
+    /// where it was looked for rather than guessing.
+    #[test]
+    fn an_unresolvable_name_reports_where_it_looked() {
+        let probe = FakeProbe(&[]);
+        let err = super::resolve_argv0("nosuchtool", &fhs(), &probe).unwrap_err();
+        assert_eq!(err.0, super::ProcErrorKind::InvalidArgv);
+        assert!(err.1.contains("/usr/local/bin"), "{}", err.1);
+        assert!(err.1.contains("/bin"), "{}", err.1);
+    }
+
+    /// An image that installs its interpreter somewhere unusual says so in its
+    /// own runtime config, and that is what a bare name searches. This is the
+    /// case a hardcoded FHS list gets wrong.
+    #[test]
+    fn the_image_declared_path_decides_the_search_order() {
+        let dirs = super::program_search_dirs(Some("/opt/app/bin:/usr/bin"));
+        assert_eq!(dirs, vec!["/opt/app/bin", "/usr/bin"]);
+        let probe = FakeProbe(&["/opt/app/bin/tool", "/usr/bin/tool"]);
+        assert_eq!(
+            super::resolve_argv0("tool", &dirs, &probe).unwrap(),
+            "/opt/app/bin/tool"
+        );
+    }
+
+    /// An image declaring no PATH falls back to the FHS order rather than
+    /// searching nothing, which would refuse every bare name.
+    #[test]
+    fn an_image_without_a_path_falls_back_to_the_fhs_order() {
+        assert_eq!(super::program_search_dirs(None), fhs());
+        assert_eq!(super::program_search_dirs(Some("")), fhs());
+        // A relative entry is not a search directory.
+        assert_eq!(super::program_search_dirs(Some("bin:.")), fhs());
+    }
+
+    /// The caller supplies the request's env, so honouring its PATH would let
+    /// the caller choose which binary a bare name resolves to. The search list
+    /// is fixed in the source and the resolver takes no env at all.
+    #[test]
+    fn resolution_does_not_consult_a_caller_supplied_path() {
+        let src = include_str!("process_rpc.rs");
+        let body = src
+            .split("pub fn resolve_argv0")
+            .nth(1)
+            .expect("resolve_argv0 must exist")
+            .split("\n}")
+            .next()
+            .expect("function body ends at the first closing brace");
+        assert!(
+            !body.contains("std::env") && !body.contains("var("),
+            "resolution must not read the process environment: {body}"
+        );
+    }
+
     use super::*;
 
     fn small_caps() -> Caps {
@@ -798,11 +1053,33 @@ mod tests {
         assert_eq!(err.0, ProcErrorKind::InvalidArgv);
     }
 
+    /// A relative *path* stays refused, because it resolves against a working
+    /// directory the same request may be setting.
+    ///
+    /// This used to assert that a bare `echo` was refused, under the name
+    /// `build_command_rejects_relative_argv0` — but a bare name is not a
+    /// relative path, and refusing it is what stopped the README's own SDK
+    /// example (`commands.start(["python", ...])`, `exec("uname", "-sr")`)
+    /// from running at all. A bare name now resolves; see
+    /// `a_bare_command_name_resolves_through_the_search_path`.
     #[test]
-    fn build_command_rejects_relative_argv0() {
+    fn build_command_rejects_a_relative_path_argv0() {
         let env = BTreeMap::new();
-        let err = build_command(&["echo".to_string()], &env, None).unwrap_err();
+        let err = build_command(&["./echo".to_string()], &env, None).unwrap_err();
         assert_eq!(err.0, ProcErrorKind::InvalidArgv);
+        assert!(err.1.contains("relative path"), "{}", err.1);
+    }
+
+    /// The bare-name form the SDK sends reaches a real program.
+    ///
+    /// `/bin/echo` is on every image this runs on, including the host running
+    /// the unit suite, so this exercises the production probe rather than a
+    /// stand-in.
+    #[test]
+    fn build_command_resolves_a_bare_command_name() {
+        let env = BTreeMap::new();
+        build_command(&["echo".to_string()], &env, None)
+            .expect("a bare command name on the search path must resolve");
     }
 
     #[test]

--- a/crates/mvm-conformance/fixtures/e2e/sandbox_script.py
+++ b/crates/mvm-conformance/fixtures/e2e/sandbox_script.py
@@ -1,9 +1,9 @@
 """Runtime-SDK fixture for the end-to-end launch suite.
 
 The README's runtime SDK shape, reduced to the operations the transport has to
-carry: create a sandbox and run a command in it.
+carry: create a sandbox, write a file into it, and run a command.
 
-Three deliberate departures from the README's illustrative snippet, each because
+Two deliberate departures from the README's illustrative snippet, each because
 this one has to actually execute on both the plan and the live path:
 
 * `commands.start` rather than `exec`. Both are real SDK surfaces, but `exec` is
@@ -16,13 +16,13 @@ this one has to actually execute on both the plan and the live path:
   A digest is content-addressed, so this does not rot with the upstream
   `alpine:latest` tag.
 
-* No `files.write`. The README shows one, and it is a real surface, but the
-  whole guest-RPC `fs`/`proc` verb family currently answers "Unexpected response
-  to ... verb" against a running HVF guest — see issue #2887, which predates
-  this suite. `commands.start` below hits the same wall, which is why the
-  live-mode scenario driving this fixture is tagged `@wip` on that issue. The
-  plan-mode scenario needs no guest and stays green. Restore `files.write` when
-  #2887 is fixed.
+`files.write` is back. It was removed when the whole guest-RPC `fs`/`proc` verb
+family answered "Unexpected response to ... verb" against a running HVF guest
+(#2887); that turned out to be a grant refusal misreported as a protocol
+mismatch, and the grant half is fixed too — a `--profile dev` launch now carries
+the DevOnly verbs. `/tmp` rather than the README's `/app`: the workload root is
+mounted read-only, so a tmpfs path is what a reader can actually write to
+without declaring a share.
 """
 
 import mvm
@@ -33,4 +33,5 @@ ALPINE = (
 )
 
 with mvm.Sandbox.create(image=ALPINE) as sb:
+    sb.files.write("/tmp/hello.txt", "hi from mvm")
     sb.commands.start(["uname", "-s"])

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -107,20 +107,26 @@ Feature: every README-documented CLI launch mode boots a real guest
   # package index would trade a launch regression for an upstream outage.
   @live
   Scenario: --allow-host and --mount together on one launch
-    When I launch "machine run --image alpine --allow-host github.com --mount .:/work -- sh -c 'ls /work/README.md && ping -c 1 github.com'"
+    # Three probes, and `ping` exits 0 when any of them is answered — so the
+    # exit code is the assertion and no output parsing is needed. One packet is
+    # enough to demonstrate egress and not enough to gate a release on: this
+    # went red once here on a dropped ICMP echo while the same command passed
+    # immediately afterwards. The claim is "the guest reached an admitted
+    # host", not "no packet was ever lost".
+    When I launch "machine run --image alpine --allow-host github.com --mount .:/work -- sh -c 'ls /work/README.md && ping -c 3 github.com >/dev/null && echo egress-ok'"
     Then the launch succeeds
     And the guest printed "/work/README.md"
-    And the guest printed "1 received"
+    And the guest printed "egress-ok"
     And the guest control plane came up
 
   # The README sizes a machine and admits a host in the same command. `--cpus`
   # and `--memory` were covered without egress, and egress without sizing.
   @live
   Scenario: --cpus, --memory and --allow-host on one launch
-    When I launch "machine run --image alpine --cpus 2 --memory 512M --allow-host github.com -- sh -c 'echo $(nproc) && ping -c 1 github.com'"
+    When I launch "machine run --image alpine --cpus 2 --memory 512M --allow-host github.com -- sh -c 'echo cpus=$(nproc) && ping -c 3 github.com >/dev/null && echo egress-ok'"
     Then the launch succeeds
-    And the guest printed "2"
-    And the guest printed "1 received"
+    And the guest printed "cpus=2"
+    And the guest printed "egress-ok"
     And the guest control plane came up
 
   # `-vvv` is in the README's egress example. Verbosity changes what the launch
@@ -128,9 +134,9 @@ Feature: every README-documented CLI launch mode boots a real guest
   # log statement would only ever have reproduced for a user.
   @live
   Scenario: -vvv does not disturb a launch that admits a host
-    When I launch "machine run --image alpine -vvv --allow-host github.com -- ping -c 1 github.com"
+    When I launch "machine run --image alpine -vvv --allow-host github.com -- sh -c 'ping -c 3 github.com >/dev/null && echo egress-ok'"
     Then the launch succeeds
-    And the guest printed "1 received"
+    And the guest printed "egress-ok"
     And the guest control plane came up
 
   @live

--- a/features/suites/s31_launch_e2e/sdk_and_library_modes.feature
+++ b/features/suites/s31_launch_e2e/sdk_and_library_modes.feature
@@ -48,20 +48,18 @@ Feature: the README's SDK entry points reach the same launch path
   # form the README tells a reader to use when they want those verbs to work, so
   # "the escape hatch is documented" and "the escape hatch functions" were never
   # the same statement.
-  # FAILS TODAY, and the failure is the point of writing it down.
+  # The README's own `--profile dev` line. The scenario above proves the same
+  # script is refused *without* it, which is the opposite claim: nothing ran the
+  # form the README tells a reader to use when they want those verbs to work, so
+  # "the escape hatch is documented" and "the escape hatch functions" were never
+  # the same statement.
   #
-  # `--profile dev` does clear the grant gate — the refusal above does not fire —
-  # and the script then dies on `mvmctl machine proc start` exit 1 against the
-  # guest it just booted. That is the residual named in the title of #2887,
-  # "dev-mode launches still cannot grant DevOnly verbs", which was closed on
-  # 2026-08-27 with the reporting half fixed and this half not.
-  #
-  # `@wip` rather than `@live` so a pre-existing defect does not red the release
-  # lane the moment that lane starts blocking releases. It is not `@live`, so it
-  # cannot serve as a `witness` in readme_examples.toml, and the manifest records
-  # this README line as unproven rather than covered. Retag `@live` when the verb
-  # works and the exemption goes away with it.
-  @wip
+  # It did not work when it was first written, and the reason was not the one
+  # #2887 recorded. The grant half of that issue is fixed — a `--profile dev`
+  # launch does carry the DevOnly verbs — and what was left was that the guest
+  # refused a bare `argv[0]`, which is the form the SDK sends and the README
+  # documents.
+  @live
   Scenario: a runtime-SDK script reaches DevOnly surfaces under an explicit dev profile
     When I launch "run --mode live --profile dev crates/mvm-conformance/fixtures/e2e/sandbox_script.py"
     Then the launch succeeds

--- a/features/suites/s8_readme_contract/readme_examples.toml
+++ b/features/suites/s8_readme_contract/readme_examples.toml
@@ -181,7 +181,7 @@ witness = "suites/s31_launch_e2e/sdk_and_library_modes.feature::a runtime-SDK sc
 
 [[example]]
 command = "mvmctl run --mode live --profile dev ./script.py"
-exempt = "DOES NOT WORK TODAY. `--profile dev` clears the grant gate and the script then dies on `mvmctl machine proc start` exit 1 against the guest it just booted — the residual named in the title of #2887, closed 2026-08-27 with the reporting half fixed and this half not. `sdk_and_library_modes.feature::a runtime-SDK script reaches DevOnly surfaces under an explicit dev profile` drives it and is tagged @wip on that. This entry is an exemption and not a witness precisely because the README documents something that does not currently function; delete it and retag the scenario @live when it does."
+witness = "suites/s31_launch_e2e/sdk_and_library_modes.feature::a runtime-SDK script reaches DevOnly surfaces under an explicit dev profile"
 
 [[example]]
 command = "mvmctl run --peer db.mvm.peer:5432=127.0.0.1:34567 -- ./my-service"

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -436,7 +436,14 @@ SUITE_STARTED=""
 # a backend with no memory-snapshot tier (Firecracker reports `unsupported`;
 # the macOS job sets MVM_BDD_SNAPSHOT and does not skip these), and the two
 # fixtures that need material this lane does not publish.
-ALLOWED_SKIPS="pending,needs-perf-budget-host,needs-memory-snapshot,needs-bundle-fixture,needs-tls-tunnel-client"
+#
+# `needs-dir-share` is set below rather than tolerated blindly: libkrun and HVF
+# serve virtio-fs directory shares and must run those scenarios, while
+# Firecracker has no virtio-fs device and cannot. Opting in means a capable
+# backend runs them and only a genuinely incapable one skips — the alternative,
+# tolerating the skip without opting in, silently dropped the witness for the
+# README's two `--mount` examples on a host that could have run it.
+ALLOWED_SKIPS="pending,needs-perf-budget-host,needs-memory-snapshot,needs-bundle-fixture,needs-tls-tunnel-client,needs-dir-share"
 
 echo "==> documented examples + machine journey (cucumber, @live)"
 SUITE_STARTED=1
@@ -449,6 +456,7 @@ set +e
 SUITE_LOG="$(mktemp "${TMPDIR:-/tmp}/mvm-e2e-suite.XXXXXX")"
 CARGO_BIN_EXE_mvmctl="$MVMCTL" \
 MVM_BDD_LIVE=1 \
+MVM_BDD_DIR_SHARE=1 \
 MVM_BDD_STRICT_SKIPS=1 \
 MVM_BDD_ALLOWED_SKIPS="$ALLOWED_SKIPS" \
 MVM_E2E_HOME="$E2E_HOME" \

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -56,10 +56,18 @@ export MVM_EMBED_NO_CACHE="e2e-$(date +%s)"
 # deliberately absent: if one of those fires, the lane did not boot what it
 # claims to boot, and that has to be a failure rather than a footnote.
 #
-# `pending` is the @wip dev-profile scenario tracking the #2887 residual;
 # `needs-perf-budget-host` is a latency threshold that measures the disk on
-# rotational storage rather than the code.
-ALLOWED_SKIPS="pending,needs-perf-budget-host"
+# rotational storage rather than the code. Nothing here is @wip any more, so
+# `pending` is not tolerated: a scenario parked mid-change would otherwise
+# reduce this lane's coverage silently.
+#
+# `needs-dir-share` is set below rather than tolerated blindly: libkrun and HVF
+# serve virtio-fs directory shares and must run those scenarios, while
+# Firecracker has no virtio-fs device and cannot. Opting in means a capable
+# backend runs them and only a genuinely incapable one skips — the alternative,
+# tolerating the skip without opting in, silently dropped the witness for the
+# README's two `--mount` examples on a host that could have run it.
+ALLOWED_SKIPS="needs-perf-budget-host,needs-dir-share"
 
 # Floor on scenarios that must actually execute. See the assertion after the
 # cucumber run for why a count, not just an exit status.
@@ -68,13 +76,14 @@ ALLOWED_SKIPS="pending,needs-perf-budget-host"
 # launch-budget threshold — is gated on `MVM_BDD_PERF_BUDGET=1`, so 19 run on a
 # host that does not set it and 20 on one that does. A floor set from the
 # authored count fails everywhere the gated scenario is skipped, which is why
-# this number is 21: 23 authored, less the env-gated launch budget and the
-# @wip dev-profile scenario tracking the #2887 residual.
+# this number is 23: 23 authored. The launch-budget scenario stays env-gated,
+# so a host without MVM_BDD_PERF_BUDGET runs 22 — the floor is the executed
+# count on the least-capable host this lane is expected to pass on.
 #
 # It was 17 against an authored count of 17, so it had the same defect and had
 # simply never been reached: `pipefail` fails the cucumber pipeline the moment
 # any scenario fails, and the floor is only checked after a fully green run.
-MIN_SCENARIOS=21
+MIN_SCENARIOS=22
 SCENARIO_LOG="$(mktemp -t mvm-e2e-scenarios)"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"
@@ -179,6 +188,7 @@ MVM_HOME="$E2E_HOME" "$MVMCTL" doctor || true
 echo "==> CLI + SDK launch modes (cucumber, @live)"
 CARGO_BIN_EXE_mvmctl="$MVMCTL" \
 MVM_BDD_LIVE=1 \
+MVM_BDD_DIR_SHARE=1 \
 MVM_BDD_STRICT_SKIPS=1 \
 MVM_BDD_ALLOWED_SKIPS="$ALLOWED_SKIPS" \
 MVM_E2E_HOME="$E2E_HOME" \

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -284,6 +284,16 @@ for detailed scope and acceptance criteria.
       missing-state behavior. See
       `specs/sprint/delivery/2824-stopped-vm-logs-error.md`.
 
+- [x] **The guest resolves a bare `argv[0]`.** The README documents
+      `commands.start(["python", …])` and `exec("uname", …)`, the SDK forwards
+      argv verbatim, and the guest refused any non-absolute `argv[0]` — so the
+      documented form could not run, while its sibling `exec` accepted it. A
+      bare name now resolves against the image's declared `PATH` (the search
+      `exec` already used), a relative path stays refused, and the request's own
+      `PATH` is never consulted. #2887's grant half turned out to have been
+      fixed already, so the scenario is `@live` and its README example is a real
+      witness. See `specs/sprint/delivery/guest-resolves-bare-argv0.md`.
+
 - [x] **Skipped scenarios fail a gating lane; website coverage ratcheted.**
       `MVM_BDD_STRICT_SKIPS` turns the skip tally into a gate with a per-lane
       allow-list, so a runner that quietly loses a capability reddens the lane

--- a/specs/sprint/delivery/guest-resolves-bare-argv0.md
+++ b/specs/sprint/delivery/guest-resolves-bare-argv0.md
@@ -1,0 +1,116 @@
+# The guest refused the command form its own README documents
+
+`mvmctl run --mode live --profile dev ./script.py` is in the README and did not
+work. The gate that found it recorded it as unproven; this is the fix.
+
+## What #2887 said, and what was actually left
+
+The issue was closed with a comment escalating a policy question: fs/proc are
+DevOnly verbs, `default_agent_verbs` builds the grant from
+`prod_safe_verb_names()`, `parse_agent_verb_override` rejects any non-ProdSafe
+verb outright — so "a `machine run` launch can never carry a grant that
+authorizes these verbs", and deciding otherwise was a claim-4 call that "wants an
+owner rather than a drive-by".
+
+That is no longer true, and it is worth saying plainly because it is why the
+`@wip` tag outlived its reason. Against a live guest today:
+
+```
+$ mvmctl machine run -d --name devprof --image alpine --profile dev --ttl 300s
+$ mvmctl machine fs read devprof /etc/hostname
+localhost
+$ mvmctl machine proc start devprof -- /bin/uname -s
+ptok-9dd27e1b4d20e8fe16d2f620f9faa527
+```
+
+Both DevOnly verbs are authorized. The grant half was fixed by whatever landed
+between that comment and now, and nothing updated the issue or the tag.
+
+What was left is much smaller:
+
+```
+$ mvmctl machine proc start devprof -- uname -s
+Error: Guest proc error (InvalidArgv): argv[0] "uname" must be an absolute path
+```
+
+## Three parts that did not agree
+
+- **README**: `sb.commands.start(["python", "/app/main.py"])` and
+  `sb.exec("uname", "-sr")` — bare command names.
+- **SDK**: `_sandbox.py` forwards argv verbatim (`shell += ["--", *argv]`). No
+  resolution, and none is possible host-side: the SDK does not know the guest's
+  filesystem.
+- **Guest**: `process_rpc.rs` refused any non-absolute `argv[0]`.
+
+So the documented form could not run. The restriction carried no rationale
+comment and arrived in a bulk crate-consolidation commit (#1720), not in a
+change that was about it.
+
+Meanwhile `exec` — the other half of the same documented pair — *did* accept a
+bare name, because it builds a `WorkloadEnvironment` carrying the image's own
+`PATH` and lets `Command` resolve through it
+(`ad_hoc_exec_resolves_a_bare_command_from_the_image_path`). Two sibling verbs,
+two different answers to the same input.
+
+## The fix
+
+`resolve_argv0` turns `argv[0]` into the absolute path that will be executed:
+
+- an absolute path is taken as given — unchanged
+- a **bare name** is looked up in the image's declared `PATH`, falling back to
+  the FHS order when the image declares none
+- a **relative path** (`./run`, `bin/tool`) is still refused: it resolves against
+  a working directory the same request may be setting, so the two together decide
+  the binary in a way neither states on its own
+
+The property the old rule protected is unchanged: what reaches `execve` is still
+an absolute path chosen in the parent before the fork. The only difference is
+that a bare name now has a defined way to become one instead of being rejected.
+
+**The request's own `PATH` is deliberately not consulted.** The caller supplies
+that env, so honouring it would let the caller choose which binary a name
+resolves to — which is the ambiguity refusing bare names avoided in the first
+place. The image is not the caller, and the image is what `exec` already trusts.
+A source-text test asserts the resolver reads no process environment.
+
+## The test that had to change, and why that is not a weakened assertion
+
+`build_command_rejects_relative_argv0` asserted a bare `echo` was refused. A bare
+name is not a relative path, and refusing it is exactly what stopped the README's
+example running. It is now
+`build_command_rejects_a_relative_path_argv0` — `./echo` — plus
+`build_command_resolves_a_bare_command_name`. The relative-path refusal it was
+named for is strictly preserved; what it actually tested was the bug.
+
+## Verified
+
+```
+$ mvmctl run --mode live --profile dev crates/mvm-conformance/fixtures/e2e/sandbox_script.py
+EXIT=0
+```
+
+`files.write` is restored to the fixture. It was removed with a comment pointing
+at #2887 and an instruction to restore it when fixed; it works, so it is back.
+The scenario is retagged `@live` from `@wip`, and its manifest entry in
+`readme_examples.toml` is promoted from an exemption to a real witness — the
+README example is now proven rather than recorded as broken.
+
+`scripts/e2e-launch-modes.sh` drops `pending` from its tolerated skips: nothing
+in that lane is `@wip` any more, so a scenario parked mid-change would otherwise
+reduce its coverage silently. Floor 21 → 22.
+
+## The strict-skip gate paid for itself on its first real run
+
+Turning the skip tally into a gate immediately caught something the tally had
+been printing and nobody had acted on: `--mount shares a host directory the
+workload can read` carries `@dir_share`, which needs `MVM_BDD_DIR_SHARE=1`, and
+neither lane set it. That scenario is the witness for **both** of the README's
+`--mount` examples, so two documented examples had a witness that did not
+execute on a host perfectly capable of running it.
+
+The message names the reason: libkrun and HVF serve virtio-fs directory shares;
+Firecracker has no virtio-fs device and refuses `--mount` before boot. So both
+lanes now set `MVM_BDD_DIR_SHARE=1` *and* tolerate `needs-dir-share` — a capable
+backend runs the scenario, and only a genuinely incapable one skips it.
+Tolerating the skip without opting in would have been the wrong half of that:
+it silences the gate on exactly the host that could have proved the thing.


### PR DESCRIPTION
**Recovers work stranded by #2989's squash merge.** These commits were pushed to
that branch after it merged, so they never reached `main` — confirmed by
content, not by `git log`: `resolve_argv0` had zero occurrences in
`origin/main:crates/mvm-agentd/src/process_rpc.rs`.

`main` is self-consistent without it — the manifest entry still reads
`exempt = "DOES NOT WORK TODAY…"` and the scenario is still `@wip` — so nothing
was claiming a fix that wasn't there. It just isn't fixed yet.

## The defect

`mvmctl run --mode live --profile dev ./script.py` is in the README and does not
work on `main`:

```
$ mvmctl machine proc start devprof -- uname -s
Error: Guest proc error (InvalidArgv): argv[0] "uname" must be an absolute path
```

Three parts disagreed: the README documents bare names
(`commands.start(["python", "/app/main.py"])`, `exec("uname", "-sr")`), the SDK
forwards argv verbatim and cannot resolve host-side, and the guest refused any
non-absolute `argv[0]` — a restriction with no rationale comment that arrived in
the #1720 crate-consolidation commit.

Meanwhile `exec`, the other half of that documented pair, **did** accept a bare
name, resolving through the image's declared `PATH`
(`ad_hoc_exec_resolves_a_bare_command_from_the_image_path`). Two sibling verbs,
two answers to the same input.

## Not the policy question #2887 recorded

That issue closed having escalated a claim-4 decision: fs/proc can never be
granted. Against a live guest that is no longer true — `--profile dev`
authorizes both `machine fs read` and `machine proc start`. The grant half was
fixed in between and nothing updated the issue. **No claim-4 decision was
needed.** I've annotated #2887 with the evidence.

## The fix

`resolve_argv0` reuses the search `exec` already used:

- absolute path → unchanged
- **bare name** → the image's declared `PATH`, FHS order as fallback
- **relative path** (`./run`) → still refused: it resolves against a working
  directory the same request may also be setting

The property the old rule protected is intact — what reaches `execve` is still
an absolute path chosen before the fork. The request's own `PATH` is
deliberately never consulted (the caller supplies that env; the image is not the
caller), and a source-text test asserts the resolver reads no process
environment.

`build_command_rejects_relative_argv0` asserted a bare `echo` was refused. A
bare name is not a relative path, and refusing it *was* the bug — split so the
refusal it was named for is preserved and the thing it actually tested is gone.

## Also recovered

- `files.write` restored to the e2e fixture, as #2887 asked once fixed
- the scenario is `@live`, and its README example is promoted from an exemption
  to a real **witness**
- both e2e lanes set `MVM_BDD_DIR_SHARE=1` and tolerate `needs-dir-share`. The
  strict-skip gate caught that the `@dir_share` `--mount` scenario — the witness
  for **both** README `--mount` examples — was being skipped on a host that
  serves virtio-fs
- the three new egress scenarios assert on `ping -c 3`'s exit code rather than a
  parsed reply count; one went red on a dropped packet while the same command
  passed immediately after

## Verified against current `main`

- `mvmctl run --mode live --profile dev …/sandbox_script.py` → **exit 0**
- `mvm-agentd` argv0 suite — 8/8
- README coverage gate — 15/15
- `xtask check-all` — 62 gates clean
- `just e2e-launch` on macOS/HVF (pre-rebase) — 23/23 scenarios, exit 0