### PR TITLE
fix(vmm): stop a machine's measured CPU falling when its vCPU threads exit

### DIFF
--- a/crates/mvm-vmm/src/quota/clock.rs
+++ b/crates/mvm-vmm/src/quota/clock.rs
@@ -2,7 +2,8 @@
 
 use std::sync::Arc;
 #[cfg(any(test, feature = "test-support"))]
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 /// A source of one thread's consumed CPU time (user + system).
@@ -145,6 +146,60 @@ impl<C: ThreadCpuClock> ThreadCpuClock for SummedClock<C> {
             .iter()
             .map(ThreadCpuClock::consumed)
             .fold(Duration::ZERO, |total, one| total.saturating_add(one))
+    }
+}
+
+/// A clock that never reports less than it has already reported.
+///
+/// Consumed CPU only accumulates, so a reading below the previous one did not
+/// happen: it is a read that failed. The failure is not hypothetical — a
+/// thread's CPU accounting dies with the thread, [`ThreadCpuHandle::consumed`]
+/// charges an unreadable thread as zero, and [`SummedClock`] adds that zero
+/// into the machine's total. A machine whose vCPU threads have exited
+/// therefore reads as one that consumed nothing.
+///
+/// Holding the high-water mark keeps the reported total to the last one
+/// actually taken while the threads were alive. That under-reports whatever
+/// those threads spent in their final microseconds, and never over-reports —
+/// the safe direction for a number that is persisted as a measurement and
+/// used to decide whether a workload is over its share.
+pub struct MonotonicClock<C: ThreadCpuClock> {
+    inner: C,
+    /// Micros rather than a `Duration`: the high-water mark is updated from
+    /// whichever thread reads, so it has to be a lock-free cell, and
+    /// `Duration` is not atomic.
+    high_water_us: Arc<AtomicU64>,
+}
+
+impl<C: ThreadCpuClock> MonotonicClock<C> {
+    pub fn new(inner: C) -> Self {
+        Self {
+            inner,
+            high_water_us: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+impl<C: ThreadCpuClock> ThreadCpuClock for MonotonicClock<C> {
+    fn consumed(&self) -> Duration {
+        let reading = u64::try_from(self.inner.consumed().as_micros()).unwrap_or(u64::MAX);
+        // `fetch_max` returns the value that was there before, so the total to
+        // report is the larger of that and this reading.
+        let previous = self.high_water_us.fetch_max(reading, Ordering::SeqCst);
+        Duration::from_micros(previous.max(reading))
+    }
+}
+
+impl<C: ThreadCpuClock + Clone> Clone for MonotonicClock<C> {
+    /// Clones share the high-water mark. Two readers of the same machine must
+    /// not be able to disagree about how much it has consumed, and one of them
+    /// observing a total the other has already passed is exactly that
+    /// disagreement.
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            high_water_us: Arc::clone(&self.high_water_us),
+        }
     }
 }
 
@@ -311,5 +366,65 @@ mod tests {
     fn capturing_a_thread_off_macos_fails_loudly_rather_than_reading_zero() {
         let err = ThreadCpuHandle::for_current_thread().unwrap_err();
         assert!(err.to_string().contains("macOS"), "{err}");
+    }
+
+    #[test]
+    fn a_monotonic_clock_passes_a_rising_sequence_through_unchanged() {
+        let clock = MonotonicClock::new(ScriptedClock::new(vec![
+            Duration::from_millis(10),
+            Duration::from_millis(25),
+            Duration::from_millis(40),
+        ]));
+        assert_eq!(clock.consumed(), Duration::from_millis(10));
+        assert_eq!(clock.consumed(), Duration::from_millis(25));
+        assert_eq!(clock.consumed(), Duration::from_millis(40));
+    }
+
+    /// The defect this type exists for. A thread's CPU accounting dies with
+    /// the thread, and the read that follows is charged as zero, so a
+    /// cumulative total appears to fall. Consumed CPU cannot fall.
+    #[test]
+    fn a_reading_that_falls_is_a_failed_read_and_never_lowers_the_total() {
+        let clock = MonotonicClock::new(ScriptedClock::new(vec![
+            Duration::from_millis(400),
+            Duration::from_millis(120),
+        ]));
+        assert_eq!(clock.consumed(), Duration::from_millis(400));
+        assert_eq!(
+            clock.consumed(),
+            Duration::from_millis(400),
+            "a lower reading is a lost thread, not a machine that un-ran"
+        );
+    }
+
+    /// The shape a real teardown produces: every vCPU thread is gone, so the
+    /// summed read collapses to zero. Reporting that verbatim would attest a
+    /// machine that consumed nothing.
+    #[test]
+    fn a_total_that_collapses_to_zero_holds_the_last_reading_taken_while_alive() {
+        let clock = MonotonicClock::new(ScriptedClock::new(vec![Duration::from_millis(900)]));
+        assert_eq!(clock.consumed(), Duration::from_millis(900));
+        assert_eq!(clock.consumed(), Duration::from_millis(900));
+        assert_eq!(clock.consumed(), Duration::from_millis(900));
+    }
+
+    #[test]
+    fn a_monotonic_clock_reads_zero_before_anything_has_been_measured() {
+        let clock = MonotonicClock::new(ScriptedClock::new(vec![]));
+        assert_eq!(clock.consumed(), Duration::ZERO);
+    }
+
+    /// The high-water mark is shared, not per-handle: the controller reads
+    /// through one clock while nothing else does, but a future second reader
+    /// must not be able to observe a total lower than one already reported.
+    #[test]
+    fn the_high_water_mark_is_shared_across_clones() {
+        let clock = MonotonicClock::new(ScriptedClock::new(vec![
+            Duration::from_millis(300),
+            Duration::from_millis(5),
+        ]));
+        let second = clock.clone();
+        assert_eq!(clock.consumed(), Duration::from_millis(300));
+        assert_eq!(second.consumed(), Duration::from_millis(300));
     }
 }

--- a/crates/mvm-vmm/src/quota/controller.rs
+++ b/crates/mvm-vmm/src/quota/controller.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use crate::quota::clock::ThreadCpuClock;
+use crate::quota::clock::{MonotonicClock, ThreadCpuClock};
 use crate::quota::{PeriodVerdict, QuotaPolicy};
 use crate::vmm::hv::VcpuHandle;
 
@@ -75,6 +75,14 @@ impl<H: VcpuHandle> VcpuQuota<H> {
         let hold_thread = Arc::clone(&hold);
         let stop_thread = Arc::clone(&stop);
         let handles_for_thread = handles.clone();
+        // Wrapped here rather than by the caller so no controller can be built
+        // on a clock that is allowed to fall. A vCPU thread's CPU accounting
+        // dies with the thread and its next read is charged as zero, which
+        // reaches both the record and the policy: the record would attest a
+        // machine that consumed nothing, and the policy compares the total
+        // against an entitlement that only grows, so a fallen total releases
+        // the hold for the rest of the run.
+        let clock = MonotonicClock::new(clock);
         let join = thread::spawn(move || {
             run_controller(handles_for_thread, clock, policy, hold_thread, stop_thread)
         });
@@ -469,6 +477,68 @@ mod tests {
             "measured achievement {}/{} must reflect overshoot, not the target",
             achievement.achieved_millicores,
             achievement.target_millicores
+        );
+    }
+
+    /// The teardown shape, reproduced. Every vCPU thread exits before the
+    /// controller is stopped, so the summed read collapses to zero and the
+    /// last assignment would otherwise be the one that lands in the record —
+    /// attesting that a machine which burned CPU consumed none of it.
+    #[test]
+    fn a_machine_whose_vcpu_threads_have_exited_reports_what_it_consumed() {
+        let period = Duration::from_millis(10);
+        let policy = QuotaPolicy::new(crate::quota::QuotaConfig::new(500, period).unwrap());
+        // Four rising readings taken while the threads are alive, then the
+        // collapse: `ScriptedClock` yields ZERO once its script runs out,
+        // which is exactly what a dead thread's failed read contributes.
+        let clock = ScriptedClock::new(vec![
+            Duration::from_millis(5),
+            Duration::from_millis(10),
+            Duration::from_millis(15),
+            Duration::from_millis(20),
+        ]);
+        let handle = MockHandle::new();
+        let flag = Arc::new(AtomicBool::new(false));
+        handle.bind_flag(Arc::clone(&flag));
+        let quota = VcpuQuota::start_with_flag(vec![handle], clock, policy, Arc::clone(&flag));
+
+        // Long enough to run well past the script and sample the collapse.
+        std::thread::sleep(Duration::from_millis(120));
+        let achievement = quota.stop();
+
+        assert_eq!(
+            achievement.measured_cpu,
+            Duration::from_millis(20),
+            "the last reading taken while the threads were alive is the honest \
+             total; a later zero is a failed read, not a machine that un-ran"
+        );
+        assert!(
+            achievement.achieved_millicores > 0,
+            "a machine that consumed CPU cannot report an achieved share of zero"
+        );
+    }
+
+    /// The same collapse, seen by the policy rather than the record. The
+    /// entitlement grows every period, so a total that falls back below it
+    /// would release the hold permanently and stop bounding the machine.
+    #[test]
+    fn a_collapsed_reading_does_not_release_the_hold_for_the_rest_of_the_run() {
+        let period = Duration::from_millis(10);
+        let policy = QuotaPolicy::new(crate::quota::QuotaConfig::new(500, period).unwrap());
+        // Consumes far past its entitlement, then the threads die.
+        let clock = ScriptedClock::new(vec![Duration::from_millis(50), Duration::from_millis(100)]);
+        let handle = MockHandle::new();
+        let flag = Arc::new(AtomicBool::new(false));
+        handle.bind_flag(Arc::clone(&flag));
+        let quota = VcpuQuota::start_with_flag(vec![handle], clock, policy, Arc::clone(&flag));
+
+        std::thread::sleep(Duration::from_millis(90));
+        let achievement = quota.stop();
+
+        assert_eq!(
+            achievement.measured_cpu,
+            Duration::from_millis(100),
+            "the overshoot has to survive the threads that produced it"
         );
     }
 


### PR DESCRIPTION
A vCPU thread's CPU accounting dies with the thread. `thread_info` on a joined
thread's port returns `KERN_INVALID_ARGUMENT`, `ThreadCpuHandle::consumed`
charges that failed read as zero, and `SummedClock` folds the zero into the
machine's total — so a *cumulative* counter falls, and once every vCPU has
exited it reads as a machine that consumed nothing.

## Why that reaches a persisted record

The controller samples across exactly the window where this happens. Its vCPU
threads exit at `shared.end()`, but it keeps running until `stop()`, which sits
on the far side of the secondaries' joins *and* a watchdog join:

```
shared.end()      → secondaries begin exiting     kernel_boot.rs:2134
join secondaries
…scope returns…
watchdog.join()   ← unbounded                     kernel_boot.rs:2174
q.stop()          ← only now does sampling stop   kernel_boot.rs:2181
```

`run_controller` does `measured_cpu = consumed` every period, so the value that
reaches `VcpuQuotaRecord` is whatever the last sample saw. That can be zero,
giving `measured_cpu_ms: 0` and `achieved_millicores: 0` for a workload that
burned real CPU — and that record is what `cpu_scope::enforced_grants_for_vm`
reads back as the enforced tier.

The new controller test reproduces it against the unpatched code:

```
assertion `left == right` failed: the overshoot has to survive the threads
that produced it
  left: 0ns
 right: 100ms
```

## The second half, stated honestly

The same total is handed to `QuotaPolicy::settle`, where
`hold = consumed_total >= entitlement` and the entitlement only grows. A total
that falls back below it releases the hold for the rest of the run.

**No guest can reach that today.** There is no PSCI `CPU_OFF` handler — the stub
services only `CPU_ON`, `SYSTEM_OFF`, `SYSTEM_RESET`, `VERSION` and
`AFFINITY_INFO` — and `run_secondary` exits only once `shared.stopping()`, which
means the machine is already ending. So this half is latent rather than a live
quota evasion. It is the same defect, and worth closing at the same seam, but it
should not be described as an exploitable bypass.

## The fix

`MonotonicClock<C>` wraps any `ThreadCpuClock` and holds a high-water mark, so a
reading below the last one is treated as the failed read it is.

It wraps inside `start_with_flag` rather than at the call site, so no controller
can be built on a clock that is allowed to fall — the three public constructors
all funnel through it. Consumed CPU is monotonic by definition, so this puts the
invariant on the measurement rather than patching each consumer, and the policy
gets it for free.

The reported total becomes the last one taken while the threads were alive. That
under-reports whatever those threads spent in their final microseconds and never
over-reports, which is the safe direction for a number persisted as a
measurement and used to decide whether a workload is over its share.

Deliberately **not** changed: the teardown ordering. The controller legitimately
runs until `stop()`, and moving that earlier would shrink `measured_wall`.

## Testing

Seven new tests — five on the clock (rising sequence passes through, a falling
reading is held, a collapse to zero holds the last live reading, zero before any
measurement, high-water shared across clones) and two on the controller (the
teardown collapse, and the overshoot surviving the threads that produced it).
Both controller tests were verified red against the unpatched code and green
after.

Workspace suite 12,782/12,782 green, doctests green, `clippy -D warnings` green,
and the full gate list derived from `.github/workflows/` — `check-all` (62
gates), `check-declared-backing`, `check-nextest-groups`,
`check-claim-witness-freshness`, `check-mutation-witnesses`,
`check-single-workload-env` — all exit 0.
