### PR TITLE
ci(e2e): give the Linux documented-surface lane a budget it can finish in

### DIFF
--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -26,7 +26,22 @@ jobs:
   e2e-docs-linux:
     name: Documented surface e2e (Linux, Firecracker)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 120, not 60. At 60 this job never once finished: it died at exactly
+    # 60m00s on three consecutive runs, which GitHub reports as `cancelled`
+    # rather than as a timeout — so it read as an infrastructure hiccup instead
+    # of a budget that was too small, and the Linux half of the release gate
+    # went unproven for as long as that was true.
+    #
+    # The arithmetic was never going to work: `e2e-documented-surface.sh` gives
+    # the cucumber suite alone a 3600s deadline, and the job must also check
+    # out, install the toolchain, build `mvmctl`, install Firecracker and warm
+    # the artifact home before the suite starts. The job budget has to exceed
+    # the suite budget by the whole of setup, and it did not exceed it at all.
+    #
+    # Keeping the suite's own deadline below the job's also means a genuine
+    # hang produces the script's "TIMEOUT after Ns — killing the suite" message,
+    # naming the scenario it stopped on, rather than an opaque cancellation.
+    timeout-minutes: 120
     env:
       # Must track `FC_VERSION_DEFAULT` in mvm-core. The workload launch path
       # passes flags older Firecracker releases reject before opening the API


### PR DESCRIPTION
The Linux documented-surface lane has **never once completed**. It is one half
of the release gate added in #2989, so that half has been unproven since it
landed.

## It was a timeout, reported as a cancellation

Three consecutive runs died at exactly **60m00s** against `timeout-minutes: 60`:

```
started=2026-08-31T02:55:26Z  completed=2026-08-31T03:55:41Z  conclusion=cancelled
```

GitHub reports a timed-out job as `cancelled`, which reads as an infrastructure
hiccup rather than as a budget that is too small. That is why it went unnoticed
across several runs — I twice assumed a concurrency cancellation and moved on.

## The arithmetic could never have worked

`e2e-documented-surface.sh` gives the **cucumber suite alone** a 3600s deadline
(`E2E_TIMEOUT_SECS`). The job must additionally check out, install the toolchain,
build `mvmctl`, install Firecracker and warm the artifact home before the suite
starts. The job budget has to exceed the suite budget by the whole of setup — it
did not exceed it at all.

For comparison, the macOS lane in the same file is already 90.

## This change

`timeout-minutes: 120`, so the suite's own deadline stays comfortably below the
job's.

That ordering matters beyond the arithmetic: with the job budget larger, a
genuine hang now surfaces the script's own message —

```
!!! TIMEOUT after 3600s — killing the suite.
!!! A live scenario hung instead of failing. The last scenario printed
!!! above is where it stopped
```

— which names the scenario it stopped on, instead of an opaque cancellation that
names nothing.

## Related

- #3012 does the same for the macOS lane's failure mode (fail fast, name the
  real constraint) — independent, both are "make these lanes tell the truth"
- #3011 tracks the self-hosted Apple Silicon runner the macOS lane needs

## Verification

- `actionlint` clean; workflow parses
- `github_actions_extended_e2e` + `release_assets` — 46/46, including the
  assertions that both callers still reach the shared workflow and that
  `release.needs` still names `e2e-docs`