### PR TITLE
perf(timing): name the parts of the admit window

### DIFF
--- a/crates/mvm-cli/src/commands/vm/launch_sample.rs
+++ b/crates/mvm-cli/src/commands/vm/launch_sample.rs
@@ -263,6 +263,15 @@ pub struct LaunchSubTimings {
     pub mount_materialize_ms: Option<f64>,
     /// Verity sidecar probe and roothash read for the resolved rootfs.
     pub artifact_verify_ms: Option<f64>,
+    /// Synthesizing, signing and recording the admitted plan.
+    ///
+    /// The `admit` bucket was a window with no named parts, so a launch that
+    /// spent it somewhere unexpected could only say how long, never where.
+    pub admit_plan_ms: Option<f64>,
+    /// Attaching the cached runtime overlay.
+    pub attach_overlay_ms: Option<f64>,
+    /// Attaching the cached universal initramfs.
+    pub attach_initramfs_ms: Option<f64>,
     /// The backend's own VM creation call, start to return.
     ///
     /// How much of guest boot this contains is backend-defined: HVF's `start`
@@ -331,6 +340,9 @@ impl LaunchSubTimings {
             ("mount_cache_lookup", self.mount_cache_lookup_ms),
             ("mount_materialize", self.mount_materialize_ms),
             ("artifact_verify", self.artifact_verify_ms),
+            ("admit_plan", self.admit_plan_ms),
+            ("attach_overlay", self.attach_overlay_ms),
+            ("attach_initramfs", self.attach_initramfs_ms),
             ("vmm_create", self.vmm_create_ms),
             ("guest_kernel_entry", self.guest_kernel_entry_ms),
             ("agent_auth", self.agent_auth_ms),

--- a/crates/mvm-cli/src/commands/vm/phase_timing.rs
+++ b/crates/mvm-cli/src/commands/vm/phase_timing.rs
@@ -180,6 +180,12 @@ pub enum SubPhase {
     MountCacheLookup,
     MountMaterialize,
     ArtifactVerify,
+    /// Synthesizing, signing and recording the admitted plan, inside admit.
+    AdmitPlan,
+    /// Attaching the cached runtime overlay, inside admit.
+    AttachOverlay,
+    /// Attaching the cached universal initramfs, inside admit.
+    AttachInitramfs,
     VmmCreate,
     GuestKernelEntry,
     AgentAuth,
@@ -221,6 +227,9 @@ pub struct LaunchSubMarks {
     mount_cache_lookup: SpanMark,
     mount_materialize: SpanMark,
     artifact_verify: SpanMark,
+    admit_plan: SpanMark,
+    attach_overlay: SpanMark,
+    attach_initramfs: SpanMark,
     vmm_create: SpanMark,
     guest_kernel_entry: SpanMark,
     agent_auth: SpanMark,
@@ -247,6 +256,9 @@ impl LaunchSubMarks {
             SubPhase::MountCacheLookup => &mut self.mount_cache_lookup,
             SubPhase::MountMaterialize => &mut self.mount_materialize,
             SubPhase::ArtifactVerify => &mut self.artifact_verify,
+            SubPhase::AdmitPlan => &mut self.admit_plan,
+            SubPhase::AttachOverlay => &mut self.attach_overlay,
+            SubPhase::AttachInitramfs => &mut self.attach_initramfs,
             SubPhase::VmmCreate => &mut self.vmm_create,
             SubPhase::GuestKernelEntry => &mut self.guest_kernel_entry,
             SubPhase::AgentAuth => &mut self.agent_auth,
@@ -306,6 +318,9 @@ impl LaunchSubMarks {
             mount_cache_lookup_ms: self.mount_cache_lookup.elapsed_ms(),
             mount_materialize_ms: self.mount_materialize.elapsed_ms(),
             artifact_verify_ms: self.artifact_verify.elapsed_ms(),
+            admit_plan_ms: self.admit_plan.elapsed_ms(),
+            attach_overlay_ms: self.attach_overlay.elapsed_ms(),
+            attach_initramfs_ms: self.attach_initramfs.elapsed_ms(),
             vmm_create_ms: self.vmm_create.elapsed_ms(),
             guest_kernel_entry_ms: self.guest_kernel_entry.elapsed_ms(),
             agent_auth_ms: self.agent_auth.elapsed_ms(),
@@ -415,6 +430,9 @@ const SPAN_PARENTS: &[(&str, &str)] = &[
     ("mount_cache_lookup", "drives"),
     ("mount_materialize", "drives"),
     ("artifact_verify", "drives"),
+    ("admit_plan", "admit"),
+    ("attach_overlay", "admit"),
+    ("attach_initramfs", "admit"),
     ("vmm_create", "backend start"),
     ("guest_kernel_entry", "guest ready"),
     ("agent_auth", "guest ready"),
@@ -895,11 +913,14 @@ mod tests {
 
     /// Every sub-phase, so a mis-wired `slot()` arm shows up as one phase
     /// overwriting another rather than as a silently wrong benchmark column.
-    const ALL_SUB_PHASES: [SubPhase; 12] = [
+    const ALL_SUB_PHASES: [SubPhase; 15] = [
         SubPhase::MountFingerprint,
         SubPhase::MountCacheLookup,
         SubPhase::MountMaterialize,
         SubPhase::ArtifactVerify,
+        SubPhase::AdmitPlan,
+        SubPhase::AttachOverlay,
+        SubPhase::AttachInitramfs,
         SubPhase::VmmCreate,
         SubPhase::GuestKernelEntry,
         SubPhase::AgentAuth,
@@ -1065,6 +1086,11 @@ mod tests {
         };
         let sub = LaunchSubTimings {
             artifact_verify_ms: Some(0.2),
+            // The admit window's parts must sum inside `admit_ms` above, so
+            // the tree-arithmetic assertions have a real partition to check.
+            admit_plan_ms: Some(45.9),
+            attach_overlay_ms: Some(0.9),
+            attach_initramfs_ms: Some(0.6),
             vmm_create_ms: Some(12.0),
             guest_kernel_entry_ms: Some(57.1),
             agent_auth_ms: Some(1.1),
@@ -1173,6 +1199,9 @@ mod tests {
             "  drives                             13.4ms    5%",
             "    artifact verify                   0.2ms",
             "  admit                              47.4ms   17%",
+            "    admit plan                       45.9ms",
+            "    attach overlay                    0.9ms",
+            "    attach initramfs                  0.6ms",
             "  backend start                      16.1ms    6%",
             "    vmm create                       12.0ms",
             "  guest ready                        58.2ms   20%",
@@ -1237,11 +1266,22 @@ mod tests {
         let (phases, sub) = observed_launch();
         let out = phases.render_tree(&sub);
         assert!(out.contains("p50 budget 200ms across 20 samples"));
-        for verdict in ["ok", "over", "pass", "fail", "PASS", "FAIL", "✓", "✗"] {
+        // Whole words, not substrings. A span is free to be named "attach
+        // overlay" or "mount cache lookup" without that being a verdict, and a
+        // substring search reads both as one — which it did, silently, for as
+        // long as neither span happened to be populated in this fixture.
+        let words: Vec<&str> = out
+            .split(|c: char| !c.is_alphanumeric())
+            .filter(|w| !w.is_empty())
+            .collect();
+        for verdict in ["ok", "over", "pass", "fail", "PASS", "FAIL"] {
             assert!(
-                !out.contains(verdict),
+                !words.contains(&verdict),
                 "tree renders a verdict token {verdict}"
             );
+        }
+        for mark in ["✓", "✗"] {
+            assert!(!out.contains(mark), "tree renders a verdict mark {mark}");
         }
     }
 

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1349,6 +1349,8 @@ pub fn resolve_launch(
     marks: &mut LaunchResolveMarks,
     sub: &mut crate::commands::vm::phase_timing::LaunchSubMarks,
 ) -> Result<ResolvedLaunch> {
+    use crate::commands::vm::phase_timing::SubPhase;
+
     let backend = select_exec_backend(
         shape_uses_vsock_proxy_backend(shape),
         shape.network_policy,
@@ -1408,6 +1410,7 @@ pub fn resolve_launch(
     // `network_policy` and chain-audit the run. Force cold boot when admitted —
     // snapshot restore is unavailable for workload admission.
     let t_admission = std::time::Instant::now();
+    sub.start(SubPhase::AdmitPlan);
     if let Some(admit_fn) = admit
         && let Some(sub) = admit_fn(
             std::path::Path::new(&image.rootfs),
@@ -1424,6 +1427,7 @@ pub fn resolve_launch(
         start_config.config_files.extend(sub.config_files);
         use_snapshot = false;
     }
+    sub.finish(SubPhase::AdmitPlan);
     tracing::debug!(
         ms = t_admission.elapsed().as_secs_f64() * 1000.0,
         "admit window: admission"
@@ -1457,14 +1461,18 @@ pub fn resolve_launch(
     }
 
     let t_overlay = std::time::Instant::now();
+    sub.start(SubPhase::AttachOverlay);
     crate::commands::vm::up::attach_runtime_overlay_if_cached(&mut start_config, backend.name())?;
+    sub.finish(SubPhase::AttachOverlay);
     tracing::debug!(
         ms = t_overlay.elapsed().as_secs_f64() * 1000.0,
         "admit window: attach runtime overlay"
     );
 
     let t_initramfs = std::time::Instant::now();
+    sub.start(SubPhase::AttachInitramfs);
     crate::commands::vm::up::attach_universal_initramfs_if_cached(&mut start_config)?;
+    sub.finish(SubPhase::AttachInitramfs);
     tracing::debug!(
         ms = t_initramfs.elapsed().as_secs_f64() * 1000.0,
         "admit window: attach universal initramfs"

--- a/specs/sprint/delivery/naming-the-admit-window.md
+++ b/specs/sprint/delivery/naming-the-admit-window.md
@@ -1,0 +1,112 @@
+# Naming the parts of the admit window
+
+**Status: COMPLETE**
+
+## What was wrong
+
+`admit` was a coarse bucket with no named parts. `exec.rs` said so in a comment:
+
+> `admit_ms` is a window, not a call: it spans config assembly, admission, and
+> the two artifact attachments. Admission instruments itself, and its spans
+> account for roughly half the window, so the rest needs naming before any of it
+> can be acted on.
+
+The consequence was a recurring outlier nobody could explain: five launches
+across two days with an `admit` of 74s, 138s, 144s and worse, against a ~25ms
+steady state, always on the first run after some change. Every phase-timing
+report could say *how long* the window took and nothing about *where*. The
+sub-spans that would have answered it existed only at `tracing::debug`, so
+catching one meant having `RUST_LOG=debug` already attached to the run that
+happened to be slow.
+
+Three mechanisms were tested and refuted before the instrumentation landed, all
+of them plausible and all of them wrong:
+
+| hypothesis | measured | verdict |
+|---|---|---|
+| `F_FULLFSYNC` stalling under I/O | 4–6ms idle, 3–8ms under six concurrent 900MB writers | refuted |
+| audit leaf-cache miss / segment rotation | ~100ms | refuted |
+| macOS validating a freshly written binary on first exec | 0.83s vs 0.11s warm | real, 166x too small |
+
+## What changed
+
+Three sub-phases under `admit`, recorded where the window is assembled and
+rendered by the existing report: `admit_plan`, `attach_overlay`,
+`attach_initramfs`.
+
+## What it found, immediately
+
+The first launch after the change reproduced the outlier and named it:
+
+```
+admit=72415.7ms
+admit_plan=64.0ms  attach_overlay=0.9ms  attach_initramfs=72350.7ms
+```
+
+`attach_universal_initramfs_if_cached` acquires the universal initramfs when
+its cache is cold, inside the admit window, silently — 72 seconds of it. Warm,
+the same span is 0.2–1.8ms.
+
+That accounts for every occurrence. The cache goes cold exactly when the
+observations said: after a build that changes the embedded host binaries the
+initramfs packages, and after a kernel pin bump wipes the artifact cache. It was
+never the audit chain, which is where three sessions of effort went.
+
+The remaining honest gap: the function is named `..._if_cached` and its slow
+path is an acquisition, so a reader has no reason to expect it to block. Moving
+that acquisition out of `admit` into artifact resolution — where the kernel
+download already announces itself with "Preparing the workload kernel…" — is the
+follow-up this measurement argues for, and is not done here.
+
+## A test that was passing for the wrong reason
+
+`tree_reports_the_budget_as_context_and_never_as_a_verdict` asserts the tree
+renders no verdict tokens, by substring. `attach overlay` contains "over", so it
+failed the moment a real span was named that way.
+
+The check was already broken and only looked correct: `mount cache lookup`
+contains "ok", and escaped solely because that span is not populated in the
+fixture. It now compares whole words.
+
+## Not done: teardown
+
+Teardown was root-caused and the fix was attempted, measured, and reverted.
+
+The cause is real and worth recording. `stop_pid_disappearance` scales with
+guest RAM — 26ms at 256MiB, 213ms at 4GiB on the pre-existing build, roughly
+50ms per GB — while the supervisor's own shutdown record totals ~889µs at every
+size:
+
+```json
+{"watchdog_to_vcpu_exit_micros":91,"watchdog_join_micros":2,"io_thread_join_micros":19,
+ "vcpu_destroy_micros":15,"vm_destroy_micros":321,"console_write_micros":441}
+```
+
+So the wait is the kernel reclaiming the guest's address space, not the
+supervisor doing anything.
+
+The attempted fix ended the host's wait on the supervisor's PID-file marker
+instead of on process exit, on the premise that reclamation happens after `main`
+returns. An A/B on one binary, both strategies, same guest size, showed no
+difference:
+
+| | marker | process |
+|---|---|---|
+| 512MiB | 168–177ms | 178–204ms |
+| 2048MiB | 402–479ms | 391–472ms |
+
+The premise was wrong: the guest memory is released *before* the supervisor
+clears its marker, so waiting on the marker is the same wait. The change was
+reverted rather than kept for its story — it added a polling loop in place of an
+event-driven wait and bought nothing.
+
+A real fix has to move the marker removal ahead of the guest-memory drop inside
+the supervisor, which is a change to its shutdown ordering and its durability
+guarantees. Not attempted here.
+
+## Also observed, not investigated
+
+Teardown at 512MiB measured ~36ms on the older main and ~170–200ms on current
+main, with the kernel pin at 6.12.107 and a differently-featured build. That is
+a 5x shift, but the two measurements differ in more than one variable, so it is
+an observation to chase rather than a regression to claim.


### PR DESCRIPTION
`admit` was a coarse bucket with no named parts. `exec.rs` already said so in a comment:

> `admit_ms` is a window, not a call: it spans config assembly, admission, and the two artifact attachments. Admission instruments itself, and its spans account for roughly half the window, so the rest needs naming before any of it can be acted on.

The cost was a recurring outlier nobody could explain — five launches across two days with an `admit` of 74 s, 138 s and 144 s against a ~25 ms steady state. Every report could say *how long* the window took and nothing about *where*, because the spans that would answer it existed only at `tracing::debug`. Catching one meant having `RUST_LOG=debug` already attached to the run that happened to be slow.

Three sub-phases now: `admit_plan`, `attach_overlay`, `attach_initramfs`.

## What it found, on its first run

```
admit=72415.7ms
admit_plan=64.0ms  attach_overlay=0.9ms  attach_initramfs=72350.7ms
```

`attach_universal_initramfs_if_cached` **acquires** the universal initramfs when its cache is cold, inside the admit window, silently — 72 seconds of it. Warm, the same span is 0.2–1.8 ms.

That accounts for every occurrence. The cache goes cold exactly when the observations said: after a build that changes the embedded host binaries the initramfs packages, and after a kernel pin bump wipes the artifact cache. **It was never the audit chain**, which is where the search had been looking.

Three other mechanisms were tested and refuted first, all plausible and all wrong:

| hypothesis | measured | verdict |
|---|---|---|
| `F_FULLFSYNC` stalling under I/O | 4–6 ms idle, 3–8 ms under six concurrent 900 MB writers | refuted |
| audit leaf-cache miss / segment rotation | ~100 ms | refuted |
| macOS validating a freshly written binary on first exec | 0.83 s vs 0.11 s warm | real, 166× too small |

The follow-up this argues for, and which is **not** done here: the function is named `..._if_cached` and its slow path is a multi-second acquisition, so a reader has no reason to expect it to block. Moving that out of `admit` into artifact resolution — where the kernel download already announces itself with "Preparing the workload kernel…" — is the actual fix.

## A test that was passing for the wrong reason

`tree_reports_the_budget_as_context_and_never_as_a_verdict` asserts the tree renders no verdict tokens, by **substring**. `attach overlay` contains "over", so it failed the moment a real span was named that way.

The check was already broken and only looked correct: `mount cache lookup` contains "ok", and escaped solely because that span is not populated in the fixture. It compares whole words now.

## Teardown: root-caused, fix attempted, reverted

Not in this PR, but recorded in the delivery note because the measurements are worth keeping.

`stop_pid_disappearance` scales with guest RAM — 26 ms at 256 MiB, 213 ms at 4 GiB, roughly 50 ms/GB — while the supervisor's own shutdown record totals **889 µs** at every size:

```json
{"watchdog_to_vcpu_exit_micros":91,"watchdog_join_micros":2,"io_thread_join_micros":19,
 "vcpu_destroy_micros":15,"vm_destroy_micros":321,"console_write_micros":441}
```

So the wait is the kernel reclaiming the guest's address space, not the supervisor working.

The attempted fix ended the host's wait on the supervisor's PID-file marker instead of on process exit, on the premise that reclamation happens after `main` returns. An A/B on one binary, both strategies, same guest size, showed no difference:

| | marker | process |
|---|---|---|
| 512 MiB | 168–177 ms | 178–204 ms |
| 2048 MiB | 402–479 ms | 391–472 ms |

The premise was wrong — guest memory is released *before* the supervisor clears its marker — so the change was reverted rather than kept for its story. It replaced an event-driven kqueue wait with a polling loop and bought nothing. A real fix has to move the marker removal ahead of the guest-memory drop inside the supervisor, which changes its shutdown ordering and durability guarantees.

## Also observed, not investigated

Teardown at 512 MiB measured ~36 ms on the older main and ~170–200 ms on current main, with the kernel pin at 6.12.107 and a differently-featured build. That is a 5× shift, but the two measurements differ in more than one variable, so it is an observation to chase rather than a regression to claim.
