### PR TITLE
fix(hostd): stop a supervisor test queueing an hour for a lock it holds

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime/image_lock.rs
+++ b/crates/mvm-build/src/builder_vm_runtime/image_lock.rs
@@ -208,6 +208,15 @@ impl LockWait {
     /// tempdir, so a waiting default lets one crate's test suite queue
     /// behind another process's builder for the full hour. A test that
     /// wants to exercise waiting passes [`Self::of`] explicitly.
+    ///
+    /// That flip covers **this crate's own test build and nothing else**.
+    /// `cfg!` is evaluated where it is compiled, so when this crate is built
+    /// as an ordinary dependency of another crate's test binary it is not
+    /// under `cfg(test)`, and that binary's tests inherit
+    /// [`DEFAULT_LOCK_WAIT`] — an hour, spent queueing rather than failing.
+    /// A test outside this crate therefore has to state its own budget; it
+    /// cannot borrow this one. `mvm-libkrun-supervisor` learned that the
+    /// expensive way and now takes its wait as an argument.
     pub fn from_env() -> Self {
         if cfg!(test) {
             return Self::none();
@@ -983,13 +992,35 @@ mod tests {
     }
 
     #[test]
-    fn the_test_build_never_queues_for_a_lock() {
+    fn this_crates_own_test_build_never_queues_for_a_lock() {
         // Unit tests reach production entry points that lock the
         // host-wide store image. Waiting there makes one suite queue
         // behind another process's builder — a 35-minute "passing"
-        // test. The default must stay fail-fast under cfg(test) no
-        // matter what the environment says.
+        // test. The default stays fail-fast under cfg(test) no matter
+        // what the environment says.
+        //
+        // Read what this does and does not prove. `cfg!(test)` is true
+        // here because *this crate* is being compiled as a test, so this
+        // asserts a property of this crate's test build alone. It says
+        // nothing about a test in a crate that merely depends on this
+        // one: there this crate is an ordinary library, the flip does not
+        // happen, and the caller gets the production hour. Reading this
+        // test as a workspace-wide guarantee is what let
+        // `mvm-libkrun-supervisor` ship a test that queued for an hour.
         assert_eq!(LockWait::from_env(), LockWait::none());
+    }
+
+    /// The other half of the same fact, asserted directly rather than left
+    /// to be inferred: the production default really is the long wait, so a
+    /// caller that does not state a budget and is not inside this crate's
+    /// test build gets an hour.
+    #[test]
+    fn the_production_default_is_the_long_wait() {
+        assert_eq!(
+            LockWait::of(DEFAULT_LOCK_WAIT),
+            LockWait::of(Duration::from_secs(60 * 60))
+        );
+        assert_ne!(LockWait::of(DEFAULT_LOCK_WAIT), LockWait::none());
     }
 
     #[test]

--- a/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
@@ -174,13 +174,26 @@ fn apply_egress_relay_override(cfg: &mut SupervisorConfig) {
 /// booting it while another VM holds the lock is the filesystem corruption the
 /// lock exists to prevent.
 fn hold_exclusive_image_lock(cfg: &SupervisorConfig) -> Result<Option<std::fs::File>, ExitCode> {
+    hold_exclusive_image_lock_with(cfg, mvm_build::builder_vm_runtime::LockWait::from_env())
+}
+
+/// [`hold_exclusive_image_lock`] with the wait budget supplied rather than
+/// resolved from the environment.
+///
+/// A caller that asserts what happens under contention has to say how long it
+/// is willing to queue, because nothing else here can say it for them.
+/// `LockWait::from_env` falls back to fail-fast under `cfg!(test)`, but
+/// `cfg!` is evaluated in the crate being compiled — mvm-build — so a test
+/// living in this crate is not a test as far as that check is concerned, and
+/// inherits the production hour instead.
+fn hold_exclusive_image_lock_with(
+    cfg: &SupervisorConfig,
+    wait: mvm_build::builder_vm_runtime::LockWait,
+) -> Result<Option<std::fs::File>, ExitCode> {
     let Some(lock_path) = cfg.exclusive_image_lock.as_ref() else {
         return Ok(None);
     };
-    match mvm_build::builder_vm_runtime::hold_image_lock(
-        lock_path,
-        mvm_build::builder_vm_runtime::LockWait::from_env(),
-    ) {
+    match mvm_build::builder_vm_runtime::hold_image_lock(lock_path, wait) {
         Ok(file) => {
             append_supervisor_breadcrumb(
                 std::path::Path::new(&cfg.vm_state_dir),
@@ -491,6 +504,7 @@ fn append_supervisor_breadcrumb(vm_state_dir: &std::path::Path, stage: &str, det
 mod tests {
     use super::{
         append_supervisor_breadcrumb, apply_egress_relay_override, hold_exclusive_image_lock,
+        hold_exclusive_image_lock_with,
     };
     use libkrun_sys::{BridgeRestartPolicy, KrunContext, NetworkingMode, SupervisorConfig};
 
@@ -563,10 +577,13 @@ mod tests {
 
         let mut cfg = sample_cfg(NetworkingMode::VsockDirect, None);
         cfg.exclusive_image_lock = Some(lock_path);
-        // Under cfg(test) the wait budget is fail-fast, so this returns rather
-        // than queueing for the hour a real supervisor would wait.
+        // The budget is stated here rather than inherited. `cfg!(test)` is
+        // evaluated in whichever crate compiles it, so mvm-build's
+        // test-build default does not reach a test that lives here — this
+        // test queued for the production hour instead of refusing.
         assert!(
-            hold_exclusive_image_lock(&cfg).is_err(),
+            hold_exclusive_image_lock_with(&cfg, mvm_build::builder_vm_runtime::LockWait::none())
+                .is_err(),
             "a supervisor that cannot take the lock must refuse to boot"
         );
         drop(held);


### PR DESCRIPTION
`a_contended_image_lock_refuses_to_boot` pre-holds the store-image lock and
asserts the supervisor refuses to boot. It ran for **one hour**, queueing
against a lock it was holding itself.

## The defect was written down in the test's own comment

```rust
// Under cfg(test) the wait budget is fail-fast, so this returns rather
// than queueing for the hour a real supervisor would wait.
```

`cfg!` is evaluated in the crate being compiled. The flip to fail-fast lives in
`mvm-build`'s `LockWait::from_env`, so it applies when **mvm-build** is built as
a test — not when mvm-build is an ordinary dependency of *this* crate's test
binary. The test inherited `DEFAULT_LOCK_WAIT`, an hour.

## Why nothing caught it

- `.config/nextest.toml` sets `slow-timeout = { period = "60s" }` with **no**
  `terminate-after`, so a slow test is reported, not killed. (Deliberate — the
  comment above it says a `terminate-after` set by feel rather than by
  measurement would cause its own problems. Not changed here.)
- The supervisor bin is `required-features = ["libkrun-sys"]`, which no CI lane
  compiles, so the hang never ran in CI at all.

## The fix

`hold_exclusive_image_lock_with(cfg, wait)` — the supervisor takes its wait as
an argument. A test asserting what happens under contention now states the
budget it is asserting under, instead of inheriting one from a crate that
cannot see it. The production entry point is unchanged and still resolves from
the environment.

**Before: 1 hour. After: 13 ms.**

```
Summary [0.013s] 6 tests run: 6 passed, 0 skipped
```

## The two things that made the mechanism look sound

Both corrected, because leaving them is how this recurs:

- `LockWait::from_env`'s doc described the `cfg(test)` flip without saying it
  covers *this crate's own test build and nothing else*. It now says so, and
  names the failure mode.
- `the_test_build_never_queues_for_a_lock` asserts `from_env() == none()` and
  passes **only because it is in-crate** — its comment claimed the default holds
  "no matter what the environment says", which reads as a workspace-wide
  guarantee. Renamed to `this_crates_own_test_build_never_queues_for_a_lock`,
  with a comment stating what it does and does not prove, plus a companion test
  asserting the production default really is the long wait.

## Scope check

Swept every out-of-crate caller of the locking entry points rather than fixing
the one instance:

| Site | Verdict |
|---|---|
| `mvm-hvf-supervisor.rs:295` | inside `fn main` — production, correct |
| `mvm-runtime/.../hvf_persistent.rs:303` | test, already passes `LockWait::none()` |
| `hvf_builder.rs:90,254`, `parse.rs:282` | production |

`a_contended_image_lock_refuses_to_boot` was the only test inheriting the
production default.

## Testing

Workspace 12,801/12,801, doctests, `clippy --workspace --all-targets -D
warnings`, and the full gate list derived from `.github/workflows/` —
`check-all` (62 gates), `check-declared-backing`, `check-nextest-groups`,
`check-claim-witness-freshness`, `check-mutation-witnesses`,
`check-single-workload-env` — all exit 0. The previously-hanging suite was run
under `--features libkrun-sys` and passes in 13 ms.
