### PR TITLE
fix(e2e): rebuild the per-VM helpers, and boot the README python examples

### DIFF
--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -85,6 +85,38 @@ Feature: every README-documented CLI launch mode boots a real guest
     And the guest printed "/work/README.md"
     And the guest control plane came up
 
+  # The README's flagship transient example, and the only image it names that
+  # is not alpine. Booting alpine everywhere proved the launch path but never
+  # the image the documentation actually puts in front of a first-time reader.
+  @live
+  Scenario: the documented python image runs a one-liner
+    When I launch "machine run --image python:3.12 -- python -c 'print(2 + 2)'"
+    Then the launch succeeds
+    And the guest printed "4"
+    And the guest control plane came up
+
+  # The README's install-then-run workflow: admitted egress to a package index,
+  # a real install inside the guest, and the installed package imported back.
+  #
+  # The README form also mounts `$PWD` read-only and runs `/work/app.py` from
+  # it. That half is dropped here deliberately — `--mount` needs a virtio-fs
+  # directory share, which Firecracker has no device for, so keeping it would
+  # gate this behind `@dir_share` and lose the scenario on the Linux lane. The
+  # share itself is covered by its own scenario; what is unique here is that a
+  # workload can reach a package index only because two hosts were admitted,
+  # and can then run what it installed.
+  @live
+  Scenario: the documented pip install reaches an admitted package index
+    # No nested double quotes: the step tokenizer does not carry them through to
+    # the guest, so a `python -c "..."` payload arrives unquoted and the guest
+    # shell dies on the parentheses with `Syntax error: word unexpected`. The
+    # assertion is on the installed tree rather than an imported version string
+    # for the same reason.
+    When I launch "machine run --image python:3.12 --allow-host pypi.org:443 --allow-host files.pythonhosted.org:443 -- sh -c 'python -m pip install --no-cache-dir --target /tmp/python-deps pandas && ls /tmp/python-deps | grep -q pandas && echo pandas-installed'"
+    Then the launch succeeds
+    And the guest printed "pandas-installed"
+    And the guest control plane came up
+
   @live
   Scenario: --allow-host admits egress and the guest reaches it
     # The exact shape that regressed. `--allow-host` puts `mvm.vsock_egress=1` on

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -72,18 +72,18 @@ ALLOWED_SKIPS="needs-perf-budget-host,needs-dir-share"
 # Floor on scenarios that must actually execute. See the assertion after the
 # cucumber run for why a count, not just an exit status.
 #
-# EXECUTED, not authored. The suite has 20 scenarios and one of them — the
-# launch-budget threshold — is gated on `MVM_BDD_PERF_BUDGET=1`, so 19 run on a
-# host that does not set it and 20 on one that does. A floor set from the
-# authored count fails everywhere the gated scenario is skipped, which is why
-# this number is 23: 23 authored. The launch-budget scenario stays env-gated,
-# so a host without MVM_BDD_PERF_BUDGET runs 22 — the floor is the executed
-# count on the least-capable host this lane is expected to pass on.
+# EXECUTED, not authored. 26 scenarios are authored across the three feature
+# files. Two are capability-gated — the launch-budget threshold on
+# `MVM_BDD_PERF_BUDGET`, and the `--mount` share on `@dir_share`, which
+# Firecracker cannot serve. So the least-capable host this lane is expected to
+# pass on executes 24, and that is the floor. A floor set from the authored
+# count fails everywhere a gated scenario is legitimately skipped.
 #
-# It was 17 against an authored count of 17, so it had the same defect and had
-# simply never been reached: `pipefail` fails the cucumber pipeline the moment
-# any scenario fails, and the floor is only checked after a fully green run.
-MIN_SCENARIOS=22
+# Raise this with every scenario added. It was 17 against an authored count of
+# 17, so it had the same defect and had simply never been reached: `pipefail`
+# fails the cucumber pipeline the moment any scenario fails, and the floor is
+# only checked after a fully green run.
+MIN_SCENARIOS=24
 SCENARIO_LOG="$(mktemp -t mvm-e2e-scenarios)"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"
@@ -121,9 +121,41 @@ echo "    home:  $E2E_HOME"
 # ---------------------------------------------------------------------------
 # 1. Build the binaries the suite drives.
 # ---------------------------------------------------------------------------
+# Deliberately no `just embed-refresh` here. That recipe clears the nested musl
+# cross-compile of the *embedded* host-vm binaries, which is a different set
+# from the per-VM helpers rebuilt below, and clearing it mid-tree makes the
+# nested build fail outright:
+#   could not write output to .../host-vm-target/.../deps/...: No such file or
+#   directory
+# The staleness this gate actually hits is the supervisor, handled below.
 echo "==> building mvmctl + host helpers"
 ./scripts/cargo-fast.sh build --bin mvmctl --features embed-host-bins
 ./scripts/cargo-fast.sh build -p xtask
+
+# Build the library-seam test targets here too, not when phase 2 reaches them.
+# `cargo build --bin mvmctl` does not build another crate's test targets, so
+# they were compiling *after* 23 scenarios had already booted guests — a minute
+# of build output in the middle of a run, and a compile error there arriving
+# only once the expensive part was already paid for.
+./scripts/cargo-fast.sh build -p mvm-client --tests
+
+# Always rebuild the per-VM helpers, never just check they exist.
+#
+# Presence is not freshness. `cargo build --bin mvmctl` regenerates some of them
+# and not others, so a stale `mvm-hvf-supervisor` from an earlier build survives
+# a refresh — and a stale one is worse than a missing one. It parses the config
+# `mvmctl` hands it with `deny_unknown_fields`, so a field added on the host
+# side makes it exit 1 with "unknown field", which the launch path reports only
+# as "hvf supervisor exited before writing its PID file". That message names
+# neither the binary nor its age, and the guest console is empty because the
+# supervisor died before the guest ever ran — so nothing in the output points
+# at the real cause.
+#
+# cargo makes this a no-op when they are already current, so always doing it
+# costs a fingerprint check. The signing step below must follow it: a re-linked
+# supervisor loses its Hypervisor.framework entitlement.
+echo "==> building the per-VM host helpers"
+just build-supervisors
 
 # ---------------------------------------------------------------------------
 # 2. Warm the shared artifact home.
@@ -142,9 +174,12 @@ echo "==> building mvmctl + host helpers"
 # macOS kills an unentitled Hypervisor.framework binary with SIGKILL, and the
 # only symptom is "hvf supervisor exited before writing its PID file (status:
 # signal: 9)" — which names neither the signature nor the rebuild that dropped
-# it. `cargo build` re-links the per-VM supervisor whenever its dependency graph
-# changes and does not re-sign it, so a build step must always be followed by
-# this one or every HVF boot dies.
+# it. Read the status: `signal: 9` is this, an unentitled binary; `exit status:
+# 1` is a *stale* supervisor refusing a config field it does not know. The two
+# arrive through the same message and have nothing else in common.
+#
+# Signing must follow the helper build above, because re-linking drops the
+# entitlement.
 echo "==> signing VMM binaries"
 "$MVMCTL" env sign
 


### PR DESCRIPTION
Three fixes to the launch gate, all found by running it.

## 1. A stale supervisor was refused at spawn

The gate built only `mvmctl` and `xtask`, so an old `mvm-hvf-supervisor` survived. It parses the config `mvmctl` hands it with `deny_unknown_fields`, so a field added host-side makes it **exit 1** — which the launch path reports only as `hvf supervisor exited before writing its PID file`, naming neither the binary nor its age. The guest console is empty because the supervisor died before the guest ran, so nothing in the output points at the cause.

Read the status to tell the two apart: `signal: 9` is an unentitled binary, `exit status: 1` is a stale one.

Fixed with `just build-supervisors`. Deliberately **not** `just embed-refresh` — that clears the nested musl cross-compile of the *embedded host-vm* binaries, a different set, and clearing it mid-tree makes the nested build fail outright with `could not write output to .../host-vm-target/...`. I tried it that way first and broke the build; the comment now records why, because making the two runners look alike is the obvious instinct and it is wrong here.

## 2. Test targets compiled mid-run

`cargo build --bin mvmctl` does not build another crates test targets, so the library-seam phase compiled `mvm-client` *after* 23 scenarios had already booted guests — a minute of build output in the middle of a run, and a compile error arriving only once the expensive part was paid for. Built up front now.

## 3. The READMEs python examples booted nowhere

Every launch scenario used alpine, so the flagship `--image python:3.12` and the install-then-run workflow were documented and unproven.

Both added and passing. The pip scenario drops the READMEs `--mount "$PWD:/work:ro"` half: that needs a virtio-fs directory share, which Firecracker has no device for, so keeping it would gate the scenario behind `@dir_share` and lose it on the Linux lane. The share has its own scenario; what is unique here is that a workload reaches a package index **only because two hosts were admitted**.

It also avoids nested double quotes — the step tokenizer does not carry them into the guest, so a `python -c "..."` payload arrives unquoted and the guest shell dies with `Syntax error: word unexpected`. That cost a run to find, so it is written down in the feature file.

## Scenario floor

`MIN_SCENARIOS` moves 22 → 24. Its comment claimed both *"the suite has 20 scenarios"* and *"this number is 23: 23 authored"*. The real figures: 26 authored across three feature files, 2 capability-gated (`@perf_budget`, `@dir_share`), so 24 execute on the least-capable host.

## Verified

Full `./scripts/e2e-launch-modes.sh` on macOS/HVF: `mvm-client` compiles in the build phase, both new scenarios execute, 25 scenarios run.