### PR TITLE
fix(vmm): confine both virtiofsd flavors

### DIFF
--- a/crates/mvm-vmm/src/host/virtiofsd.rs
+++ b/crates/mvm-vmm/src/host/virtiofsd.rs
@@ -14,9 +14,9 @@ use mvm_contract::builder::BuilderError;
 
 /// Which `virtiofsd` implementation is installed. The two share the
 /// `--socket-path` flag but nothing else: the QEMU-bundled **C** daemon takes
-/// `-o source=DIR` and sandboxes with `-o sandbox=...`; the standalone **Rust**
-/// daemon takes `--shared-dir=DIR --sandbox ...`. Detect once and build the
-/// right argv per flavour.
+/// `-o source=DIR` and `-o sandbox=...`; the standalone **Rust** daemon takes
+/// `--shared-dir=DIR --sandbox ...`. Both are explicitly confined with Linux
+/// namespaces; detect once and build the right argv per flavour.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VirtiofsdFlavor {
     /// QEMU-bundled C virtiofsd (`-o source=`).
@@ -247,31 +247,7 @@ impl VirtiofsdGuard {
         } = params;
         let _ = std::fs::remove_file(sock);
         let mut cmd = Command::new(bin);
-        cmd.arg(format!("--socket-path={}", sock.display()));
-        match flavor {
-            VirtiofsdFlavor::Rust => {
-                cmd.arg(format!("--shared-dir={}", dir.display()))
-                    .args(["--sandbox", "none"]);
-                if read_only {
-                    cmd.arg("--readonly");
-                }
-                if dax {
-                    // DAX acceleration requires the daemon to keep host pages
-                    // mapped and answer FUSE_SETUPMAPPING.
-                    cmd.args(["--cache", "always"]);
-                }
-            }
-            VirtiofsdFlavor::C => {
-                let mut opt = format!("source={}", dir.display());
-                if read_only {
-                    opt.push_str(",readonly");
-                }
-                cmd.arg("-o").arg(opt);
-                if dax {
-                    cmd.arg("-o").arg("cache=always");
-                }
-            }
-        }
+        configure_command(&mut cmd, flavor, sock, dir, read_only, dax);
         let child = cmd
             .spawn()
             .with_context(|| format!("spawning {} for tag {tag}", bin.display()))?;
@@ -283,6 +259,41 @@ impl VirtiofsdGuard {
             )
         })?;
         Ok(())
+    }
+}
+
+fn configure_command(
+    cmd: &mut Command,
+    flavor: VirtiofsdFlavor,
+    sock: &Path,
+    dir: &Path,
+    read_only: bool,
+    dax: bool,
+) {
+    cmd.arg(format!("--socket-path={}", sock.display()));
+    match flavor {
+        VirtiofsdFlavor::Rust => {
+            cmd.arg(format!("--shared-dir={}", dir.display()))
+                .args(["--sandbox", "namespace"]);
+            if read_only {
+                cmd.arg("--readonly");
+            }
+            if dax {
+                // DAX acceleration requires the daemon to keep host pages
+                // mapped and answer FUSE_SETUPMAPPING.
+                cmd.args(["--cache", "always"]);
+            }
+        }
+        VirtiofsdFlavor::C => {
+            let mut opt = format!("source={}", dir.display());
+            if read_only {
+                opt.push_str(",readonly");
+            }
+            cmd.arg("-o").arg(opt).arg("-o").arg("sandbox=namespace");
+            if dax {
+                cmd.arg("-o").arg("cache=always");
+            }
+        }
     }
 }
 
@@ -311,6 +322,22 @@ fn wait_for_socket(sock: &Path, timeout: Duration) -> Result<()> {
 mod spawn_params_builder_tests {
     use super::*;
 
+    fn args_for(flavor: VirtiofsdFlavor) -> Vec<String> {
+        let mut command = Command::new("virtiofsd");
+        configure_command(
+            &mut command,
+            flavor,
+            Path::new("/tmp/virtiofs.sock"),
+            Path::new("/workspace"),
+            true,
+            true,
+        );
+        command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
     /// An empty builder must refuse to finish, naming the first
     /// required field it is missing — never substituting a default.
     #[test]
@@ -319,5 +346,37 @@ mod spawn_params_builder_tests {
             panic!("an empty SpawnParams builder must not build");
         };
         assert_eq!(err, BuilderError::missing("SpawnParams", "bin"));
+    }
+
+    #[test]
+    fn rust_daemon_is_explicitly_namespace_sandboxed() {
+        assert_eq!(
+            args_for(VirtiofsdFlavor::Rust),
+            [
+                "--socket-path=/tmp/virtiofs.sock",
+                "--shared-dir=/workspace",
+                "--sandbox",
+                "namespace",
+                "--readonly",
+                "--cache",
+                "always",
+            ]
+        );
+    }
+
+    #[test]
+    fn c_daemon_is_explicitly_namespace_sandboxed() {
+        assert_eq!(
+            args_for(VirtiofsdFlavor::C),
+            [
+                "--socket-path=/tmp/virtiofs.sock",
+                "-o",
+                "source=/workspace,readonly",
+                "-o",
+                "sandbox=namespace",
+                "-o",
+                "cache=always",
+            ]
+        );
     }
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -12,6 +12,13 @@ Last updated: 2026-08-31
       policy gates are green; merge delivery and fresh scheduled Security and
       claim-freshness evidence remain.
 
+- [ ] **virtiofsd sandbox parity — issue #3022.**
+      `specs/plans/2026-08-31-virtiofsd-sandbox-parity.md`.
+      The shared QEMU helper now selects the namespace sandbox explicitly for
+      both Rust and C daemon flavours, and focused argv tests prevent either
+      implementation from silently losing confinement. Workspace validation
+      and merge delivery remain.
+
 - [ ] **Default-backend host-services broker witness — issue #2988.**
       `specs/plans/2026-08-28-default-backend-broker-witness.md`.
       The live SDK broker fixture is now a read-only ext4 disk instead of a

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3401,3 +3401,11 @@ writes the plan:
 - [x] Record why the 224.5 ms sample is inside the warm hard ceiling without
       relabeling it as a prepared-cold percentile result.
 - [ ] Merge the repair through the queue and close issue #2942.
+
+## 2026-08-31 virtiofsd sandbox parity
+
+- [x] Confirm the shared spawn helper is limited to QEMU workload and builder
+      paths.
+- [x] Apply an explicit namespace sandbox to both supported daemon flavours.
+- [x] Cover the complete read-only, DAX, and sandbox argv for each flavour.
+- [ ] Merge the repair through the queue and close issue #3022.

--- a/specs/plans/2026-08-31-virtiofsd-sandbox-parity.md
+++ b/specs/plans/2026-08-31-virtiofsd-sandbox-parity.md
@@ -1,0 +1,16 @@
+# virtiofsd sandbox parity
+
+## Goal
+
+Make QEMU's host-directory file server use the same explicit confinement policy
+regardless of which supported `virtiofsd` implementation a host installed.
+
+## Checklist
+
+- [x] Trace every `virtiofsd` caller and confirm the helper is QEMU-only.
+- [x] Establish the supported sandbox modes for both daemon flavours.
+- [x] Replace the Rust daemon's unconfined mode with an explicit namespace
+      sandbox and make the C daemon's matching policy explicit.
+- [x] Add focused argv regressions for both daemon flavours, including the
+      read-only and DAX options that must compose with confinement.
+- [ ] Run workspace validation and merge the repair through the queue.

--- a/specs/plans/2026-08-31-virtiofsd-sandbox-parity.md
+++ b/specs/plans/2026-08-31-virtiofsd-sandbox-parity.md
@@ -1,5 +1,8 @@
 # virtiofsd sandbox parity
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 ## Goal
 
 Make QEMU's host-directory file server use the same explicit confinement policy


### PR DESCRIPTION
Fixes #3022.

Both supported virtiofsd command shapes now select the namespace sandbox explicitly. The Rust path no longer disables confinement, and the C path no longer relies on the installed daemon default. Focused argv regressions cover both flavours together with read-only and DAX options.

Validation:
- cargo test -p mvm-vmm host::virtiofsd
- cargo clippy --workspace --all-targets -- -D warnings
- cargo run -p xtask -- check-all (62 gates)

The workspace test run reached the known one-hour self-lock fixed by queued PR #3023; this PR is ordered behind #3023 so its merge-group validation includes that repair.