### PR TITLE
fix(vmm): say why a supervisor died instead of naming an empty console

### DIFF
--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -366,15 +366,17 @@ fn boot_with_handoff(
             .map_err(|e| anyhow!("poll supervisor: {e}"))?
         {
             bail!(
-                "hvf supervisor exited before writing its PID file (status: {status}); see {}",
-                paths.console_log.display()
+                "hvf supervisor exited before writing its PID file (status: {status}); see {}{}",
+                paths.console_log.display(),
+                mvm_vmm::host::console_capture::supervisor_stderr_detail(&paths.state_dir)
             );
         }
         if Instant::now() >= deadline {
             let _ = child.kill();
             bail!(
-                "hvf supervisor did not confirm boot within {PID_FILE_TIMEOUT:?}; see {}",
-                paths.console_log.display()
+                "hvf supervisor did not confirm boot within {PID_FILE_TIMEOUT:?}; see {}{}",
+                paths.console_log.display(),
+                mvm_vmm::host::console_capture::supervisor_stderr_detail(&paths.state_dir)
             );
         }
         std::thread::sleep(mvm_core::poll_backoff::poll_delay(attempt));

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -299,17 +299,19 @@ pub fn restore_hvf_vm(req: &HvfRestoreRequest<'_>) -> Result<RestoredHvfVm> {
         }
         if let Some(status) = child.try_wait().context("polling the HVF supervisor")? {
             bail!(
-                "HVF restore of '{}' exited before publishing its pid (status: {status}); see {}",
+                "HVF restore of '{}' exited before publishing its pid (status: {status}); see {}{}",
                 req.vm_name,
-                cfg.console_log.display()
+                cfg.console_log.display(),
+                mvm_vmm::host::console_capture::supervisor_stderr_detail(req.state_dir)
             );
         }
         if Instant::now() >= deadline {
             let _ = child.kill();
             bail!(
-                "HVF restore of '{}' did not confirm within {PID_FILE_TIMEOUT:?}; see {}",
+                "HVF restore of '{}' did not confirm within {PID_FILE_TIMEOUT:?}; see {}{}",
                 req.vm_name,
-                cfg.console_log.display()
+                cfg.console_log.display(),
+                mvm_vmm::host::console_capture::supervisor_stderr_detail(req.state_dir)
             );
         }
         std::thread::sleep(std::time::Duration::from_millis(5));

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -422,16 +422,18 @@ impl VmmDriver for LibkrunDriver {
                 .map_err(|e| anyhow!("poll supervisor: {e}"))?
             {
                 bail!(
-                    "libkrun supervisor exited before writing its PID file (status: {status}); see {}",
-                    console_log.display()
+                    "libkrun supervisor exited before writing its PID file (status: {status}); see {}{}",
+                    console_log.display(),
+                    mvm_vmm::host::console_capture::supervisor_stderr_detail(&state_dir)
                 );
             }
             if Instant::now() >= deadline {
                 let _ = child.kill();
                 bail!(
-                    "libkrun supervisor did not confirm boot within {:?}; see {}",
+                    "libkrun supervisor did not confirm boot within {:?}; see {}{}",
                     crate::driver::libkrun_process::PID_FILE_TIMEOUT,
-                    console_log.display()
+                    console_log.display(),
+                    mvm_vmm::host::console_capture::supervisor_stderr_detail(&state_dir)
                 );
             }
             std::thread::sleep(Duration::from_millis(50));

--- a/crates/mvm-vmm/src/host/console_capture.rs
+++ b/crates/mvm-vmm/src/host/console_capture.rs
@@ -46,6 +46,60 @@ pub fn supervisor_stderr(state_dir: &Path) -> Stdio {
         .unwrap_or_else(|_| Stdio::inherit())
 }
 
+/// How many trailing lines of the supervisor's stderr an error message carries.
+const SUPERVISOR_STDERR_TAIL_LINES: usize = 20;
+
+/// The supervisor's own last words, formatted as a suffix for a launch error.
+///
+/// A per-VM supervisor that dies before its guest exists writes nothing to the
+/// guest console — the guest never ran — so an error naming only `console.log`
+/// names an empty file. The reason it refused is on its stderr, and a transient
+/// run deletes that file along with the state directory before anyone can open
+/// it. Inlining the tail is the only way the reason reaches the person who ran
+/// the command.
+///
+/// Returns an empty string when the supervisor said nothing, so a caller can
+/// append it unconditionally.
+///
+/// Line-bounded and line-preserving, unlike the network endpoint's byte-bounded
+/// `stderr_tail`, which collapses onto one line. A supervisor's refusal is an
+/// `anyhow` report — a summary, a blank line, a `Caused by:` block — and
+/// collapsing that is what makes it unreadable at exactly the moment it is the
+/// only evidence there is.
+pub fn supervisor_stderr_detail(state_dir: &Path) -> String {
+    let path = state_dir.join(SUPERVISOR_STDERR_LOG);
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return String::new();
+    };
+    let lines = contents.lines().collect::<Vec<_>>();
+    let tail = lines[lines.len().saturating_sub(SUPERVISOR_STDERR_TAIL_LINES)..].join("\n");
+    let tail = tail.trim();
+    if tail.is_empty() {
+        return String::new();
+    }
+    format!(
+        "\nsupervisor stderr ({}):\n{tail}{}",
+        path.display(),
+        stale_supervisor_hint(tail)
+    )
+}
+
+/// The one diagnosis an unknown config field admits.
+///
+/// The host↔supervisor config types deny unknown fields, so a field the
+/// supervisor does not recognise means its binary predates the `mvmctl` that
+/// wrote the config — not a bad value. Nothing in the exit status the launch
+/// path sees distinguishes that from any other refusal; only the stderr can.
+fn stale_supervisor_hint(stderr_tail: &str) -> &'static str {
+    if stderr_tail.contains("unknown field") {
+        "\n\nThat supervisor binary is older than this mvmctl: it refused a config field \
+         this build sends. Rebuild it with `just build-supervisors`, then re-sign with \
+         `mvmctl env sign`."
+    } else {
+        ""
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -80,5 +134,74 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("no-such-state-dir");
         let _stdio = supervisor_stderr(&missing);
+    }
+
+    #[test]
+    fn failure_detail_carries_the_supervisor_stderr_into_the_message() {
+        // The whole point: a transient run deletes the state dir, so a message
+        // that only names the file leaves nothing to read.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(SUPERVISOR_STDERR_LOG),
+            b"Error: parse HvfSupervisorConfig JSON from stdin\n",
+        )
+        .unwrap();
+        let detail = supervisor_stderr_detail(dir.path());
+        assert!(
+            detail.contains("parse HvfSupervisorConfig JSON from stdin"),
+            "stderr must be inlined, got: {detail}"
+        );
+        assert!(detail.contains(SUPERVISOR_STDERR_LOG), "got: {detail}");
+    }
+
+    #[test]
+    fn failure_detail_is_empty_when_the_supervisor_said_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(supervisor_stderr_detail(dir.path()), "");
+        std::fs::write(dir.path().join(SUPERVISOR_STDERR_LOG), b"   \n\n").unwrap();
+        assert_eq!(supervisor_stderr_detail(dir.path()), "");
+    }
+
+    #[test]
+    fn failure_detail_keeps_only_the_tail_of_a_long_log() {
+        let dir = tempfile::tempdir().unwrap();
+        let body: String = (0..200).map(|i| format!("line {i}\n")).collect();
+        std::fs::write(dir.path().join(SUPERVISOR_STDERR_LOG), body).unwrap();
+        let detail = supervisor_stderr_detail(dir.path());
+        assert!(detail.contains("line 199"), "tail must survive: {detail}");
+        assert!(
+            !detail.contains("line 0\n"),
+            "head must be dropped: {detail}"
+        );
+    }
+
+    #[test]
+    fn failure_detail_names_the_rebuild_when_the_supervisor_is_older_than_the_host() {
+        // An unknown config field means one thing only: the binary predates the
+        // mvmctl that wrote the config. Say so, and name the fix.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(SUPERVISOR_STDERR_LOG),
+            b"unknown field `vcpus`, expected one of `kernel`, `cmdline`\n",
+        )
+        .unwrap();
+        let detail = supervisor_stderr_detail(dir.path());
+        assert!(
+            detail.contains("just build-supervisors"),
+            "an unknown field must name the rebuild: {detail}"
+        );
+    }
+
+    #[test]
+    fn failure_detail_leaves_an_ordinary_error_without_a_rebuild_hint() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(SUPERVISOR_STDERR_LOG),
+            b"Error: create vcpu: HV_ERROR\n",
+        )
+        .unwrap();
+        let detail = supervisor_stderr_detail(dir.path());
+        assert!(!detail.contains("just build-supervisors"), "got: {detail}");
+        assert!(detail.contains("HV_ERROR"), "got: {detail}");
     }
 }


### PR DESCRIPTION
## The failure this fixes

`just e2e-launch` died at the warm step with nothing to go on:

```
[mvm] Guest console at ~/.mvm/vms/cozy-quokka-085e/console.log was empty before transient cleanup.
Error: starting transient microVM

Caused by:
    hvf supervisor exited before writing its PID file (status: exit status: 1);
    see ~/.mvm/vms/cozy-quokka-085e/console.log
```

The console log it names is empty, and by the time you read the message the
whole directory is gone. The actual reason was one file over, in
`supervisor.stderr.log`:

```
Error: parse HvfSupervisorConfig JSON from stdin

Caused by:
    unknown field `vcpus`, expected one of `kernel`, `cmdline`, `memory_mib`, …
```

An on-disk `mvm-hvf-supervisor` older than the `mvmctl` that spawned it.
`cargo build --bin mvmctl` does not relink it, so it rots silently while the
host side gains config fields; `vcpus` landed on 2026-08-27. Recovering that
text took shimming `MVM_HVF_SUPERVISOR_PATH` at a tee, because a transient run
deletes the state directory — stderr log included — before anything reads it.

## The change

`supervisor_stderr_detail(state_dir)` returns the tail of the supervisor's own
stderr, formatted as a suffix a caller appends unconditionally (empty when the
supervisor said nothing). Every launch site that spawns a supervisor and waits
for its pid now appends it: the hvf and libkrun boot paths and the hvf restore
path, on both the early-exit and the timeout branch. The inject path already
inherits stderr and is unchanged.

An unknown field admits exactly one diagnosis — the host↔supervisor config
types deny unknown fields, so the binary predates the config — and nothing in
the exit status distinguishes that from any other refusal. So the message says
it, and names the rebuild:

```
hvf supervisor exited before writing its PID file (status: exit status: 1); see …/console.log
supervisor stderr (…/supervisor.stderr.log):
Error: parse HvfSupervisorConfig JSON from stdin

Caused by:
    unknown field `vcpus`, expected one of `kernel`, `cmdline`, `memory_mib` at line 1 column 325

That supervisor binary is older than this mvmctl: it refused a config field this
build sends. Rebuild it with `just build-supervisors`, then re-sign with
`mvmctl env sign`.
```

The tail is line-bounded and line-preserving, deliberately unlike the network
endpoint's byte-bounded `stderr_tail` that collapses onto one line: a
supervisor's refusal is an `anyhow` report, and collapsing a `Caused by:` block
is what makes it unreadable at the one moment it is the only evidence there is.
The doc comment says so, so the next reader does not consolidate the two.

## Verification

- Failure path, live on macOS 26 / Apple Silicon: a stand-in supervisor that
  refuses `vcpus` produces the message quoted above.
- Success path, live: `mvmctl machine run --image alpine -- echo hello-from-guest`
  → `hello-from-guest`, real HVF guest. The detail is only computed on failure.
- `just e2e-launch`: exit 0, including `transient_and_persistent_lifecycle_over_hvf`.
- 8 new unit tests; `mvm-vmm` (794) and `mvm-backends` suites green; workspace
  clippy and `cargo fmt --all` clean.

## Not covered here

Prevention — rebuilding the per-VM helpers inside the launch gate so it cannot
run against a rotted supervisor again — is a separate change to
`scripts/e2e-launch-modes.sh` and is not in this PR. This one makes the failure
name itself wherever it happens, including for anyone running `mvmctl` outside
that gate.
