### PR TITLE
fix(cli): retry diff handshake peer hangups

### DIFF
--- a/crates/mvm-cli/src/commands/vm/diff.rs
+++ b/crates/mvm-cli/src/commands/vm/diff.rs
@@ -2,6 +2,8 @@
 
 use anyhow::{Context, Result};
 use clap::Args as ClapArgs;
+use mvm_core::net::session::SessionError;
+use std::time::Duration;
 
 use crate::ui;
 
@@ -69,7 +71,86 @@ fn fs_diff(name: &str) -> Result<Vec<FsChange>> {
             return mvm_agentd::vsock::query_fs_diff(&mock_dir.to_string_lossy());
         }
     }
-    let mut stream =
-        mvm_runtime::vsock_transport::for_vm(name)?.connect(mvm_agentd::vsock::GUEST_AGENT_PORT)?;
-    mvm_agentd::vsock::query_fs_diff_on(&mut stream)
+    retry_initial_handshake(|| {
+        let mut stream = mvm_runtime::vsock_transport::for_vm(name)?
+            .connect(mvm_agentd::vsock::GUEST_AGENT_PORT)?;
+        mvm_agentd::vsock::query_fs_diff_on(&mut stream)
+    })
+}
+
+/// Retry only an authenticated-session handshake that ended before the peer
+/// sent any proof. The request cannot have reached the guest in that state, so
+/// replaying it on a fresh connection is safe. An EOF after the request was
+/// sent has a different error chain and is returned without retrying.
+fn retry_initial_handshake<T>(mut attempt: impl FnMut() -> Result<T>) -> Result<T> {
+    match attempt() {
+        Err(error) if is_handshake_peer_hangup(&error) => {
+            std::thread::sleep(Duration::from_millis(100));
+            attempt()
+        }
+        outcome => outcome,
+    }
+}
+
+fn is_handshake_peer_hangup(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<SessionError>()
+            .is_some_and(SessionError::is_peer_hangup)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::io::{Error, ErrorKind};
+
+    fn handshake_hangup() -> anyhow::Error {
+        anyhow::Error::new(SessionError::Io(Error::from(ErrorKind::UnexpectedEof)))
+            .context("host session handshake failed")
+    }
+
+    #[test]
+    fn a_peer_hangup_before_authentication_is_retried_once() {
+        let attempts = Cell::new(0);
+        let value = retry_initial_handshake(|| {
+            attempts.set(attempts.get() + 1);
+            if attempts.get() == 1 {
+                Err(handshake_hangup())
+            } else {
+                Ok(7)
+            }
+        })
+        .expect("second connection succeeds");
+
+        assert_eq!(value, 7);
+        assert_eq!(attempts.get(), 2);
+    }
+
+    #[test]
+    fn an_eof_after_authentication_is_not_replayed() {
+        let attempts = Cell::new(0);
+        let error = retry_initial_handshake::<()>(|| {
+            attempts.set(attempts.get() + 1);
+            Err(anyhow::Error::new(Error::from(ErrorKind::UnexpectedEof))
+                .context("control frame read failed"))
+        })
+        .expect_err("post-request EOF must be returned");
+
+        assert_eq!(attempts.get(), 1);
+        assert!(error.to_string().contains("control frame read failed"));
+    }
+
+    #[test]
+    fn a_second_handshake_hangup_is_bounded() {
+        let attempts = Cell::new(0);
+        retry_initial_handshake::<()>(|| {
+            attempts.set(attempts.get() + 1);
+            Err(handshake_hangup())
+        })
+        .expect_err("the retry budget must be bounded");
+
+        assert_eq!(attempts.get(), 2);
+    }
 }

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,13 @@ Last updated: 2026-08-31
 
 ## In progress
 
+- [ ] **machine diff handshake retry — issue #3024.**
+      `specs/plans/2026-08-31-machine-diff-handshake-retry.md`.
+      A typed pre-authentication peer hangup gets one fresh connection; an EOF
+      after authentication is never replayed. Focused regressions cover both
+      boundaries and the bounded retry budget. Workspace validation and merge
+      delivery remain.
+
 - [ ] **Wasmtime security update — issues #3018 and #3020.**
       `specs/plans/2026-08-31-wasmtime-security-update.md`.
       The complete optional Wasmtime dependency family is locked to patched

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -19,13 +19,6 @@ Last updated: 2026-08-31
       policy gates are green; merge delivery and fresh scheduled Security and
       claim-freshness evidence remain.
 
-- [ ] **virtiofsd sandbox parity — issue #3022.**
-      `specs/plans/2026-08-31-virtiofsd-sandbox-parity.md`.
-      The shared QEMU helper now selects the namespace sandbox explicitly for
-      both Rust and C daemon flavours, and focused argv tests prevent either
-      implementation from silently losing confinement. Workspace validation
-      and merge delivery remain.
-
 - [ ] **Default-backend host-services broker witness — issue #2988.**
       `specs/plans/2026-08-28-default-backend-broker-witness.md`.
       The live SDK broker fixture is now a read-only ext4 disk instead of a
@@ -238,6 +231,13 @@ This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
 
 ## Completed issue closeouts
+
+- [x] **virtiofsd sandbox parity — issue #3022.**
+      `specs/plans/2026-08-31-virtiofsd-sandbox-parity.md`.
+      The shared QEMU helper selects the namespace sandbox explicitly for both
+      Rust and C daemon flavours, and focused argv tests prevent either
+      implementation from silently losing confinement. PR #3026 passed its
+      merge-group gates and landed on 2026-08-31.
 
 - [x] **Issue #2951 — ad-hoc exec honors the image environment.** Streaming
       exec now uses the shared workload resolver, so image-declared `PATH`,

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3408,4 +3408,14 @@ writes the plan:
       paths.
 - [x] Apply an explicit namespace sandbox to both supported daemon flavours.
 - [x] Cover the complete read-only, DAX, and sandbox argv for each flavour.
-- [ ] Merge the repair through the queue and close issue #3022.
+- [x] Merge the repair through the queue and close issue #3022.
+
+## 2026-08-31 machine diff handshake retry
+
+- [x] Keep the retry predicate typed to a peer hangup during the authenticated
+      handshake.
+- [x] Reconnect once only when no operational request could have reached the
+      guest.
+- [x] Prove response-read EOFs are returned without replay and repeated
+      handshake hangups exhaust a bounded budget.
+- [ ] Merge the repair through the queue and close issue #3024.

--- a/specs/plans/2026-08-31-machine-diff-handshake-retry.md
+++ b/specs/plans/2026-08-31-machine-diff-handshake-retry.md
@@ -1,0 +1,18 @@
+# machine diff handshake retry
+
+## Goal
+
+Make `machine diff` tolerate a control peer that closes before completing the
+authenticated session handshake without ever replaying an RPC that may have
+reached the guest.
+
+## Checklist
+
+- [x] Trace `machine diff` through the backend-aware transport and authenticated
+      session opener.
+- [x] Distinguish a typed pre-authentication peer hangup from an EOF while
+      reading an operational response.
+- [x] Retry the former once on a fresh connection and keep the budget bounded.
+- [x] Add regressions for success-after-retry, no post-request replay, and a
+      peer that hangs up twice.
+- [ ] Run workspace validation and merge the repair through the queue.

--- a/specs/plans/2026-08-31-machine-diff-handshake-retry.md
+++ b/specs/plans/2026-08-31-machine-diff-handshake-retry.md
@@ -1,5 +1,8 @@
 # machine diff handshake retry
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 ## Goal
 
 Make `machine diff` tolerate a control peer that closes before completing the

--- a/specs/plans/2026-08-31-virtiofsd-sandbox-parity.md
+++ b/specs/plans/2026-08-31-virtiofsd-sandbox-parity.md
@@ -16,4 +16,4 @@ regardless of which supported `virtiofsd` implementation a host installed.
       sandbox and make the C daemon's matching policy explicit.
 - [x] Add focused argv regressions for both daemon flavours, including the
       read-only and DAX options that must compose with confinement.
-- [ ] Run workspace validation and merge the repair through the queue.
+- [x] Run workspace validation and merge the repair through the queue.


### PR DESCRIPTION
## Summary

- retry `machine diff` once when a fresh authenticated-session handshake ends in a typed peer hangup
- never retry an EOF after authentication, avoiding replay after the request may have executed
- bound the recovery path to two total connection attempts

## Validation

- `cargo test -p mvm-cli commands::vm::diff::tests` (3 passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo run -p xtask -- check-all` (62 gates clean)
- `cargo run -p xtask -- check-declared-backing`
- `cargo test --workspace` progressed through the affected and broad workspace crates with no failures; the host-state-dependent tail was stopped rather than waiting on the shared builder image lock, and PR CI supplies the isolated full-workspace result

Fixes #3024
