### PR TITLE
fix(e2e): let the runners honour a worktree own MVM_HOME

### DIFF
--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -19,7 +19,18 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 REPO="$PWD"
 
-E2E_HOME="${MVM_E2E_HOME:-$HOME/.mvm}"
+# Prefer an explicit `MVM_E2E_HOME`, then `MVM_HOME`, then the real home.
+#
+# `scripts/dev-env.sh` gives each worktree its own `MVM_HOME` *and* its own
+# `CARGO_TARGET_DIR`. Defaulting straight to `$HOME/.mvm` honoured the second
+# half of that and ignored the first: a worktree built its own binaries and then
+# pointed them at the main checkout's artifacts. The guest boots and the host
+# session handshake dies with `Socket is not connected`, which reads as a broken
+# backend rather than as two trees sharing one home.
+#
+# That made worktree-based e2e work impossible by construction, so every
+# verification had to run in the main checkout.
+E2E_HOME="${MVM_E2E_HOME:-${MVM_HOME:-$HOME/.mvm}}"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"
 

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -20,7 +20,18 @@ set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 REPO="$PWD"
 
-E2E_HOME="${MVM_E2E_HOME:-$HOME/.mvm}"
+# Prefer an explicit `MVM_E2E_HOME`, then `MVM_HOME`, then the real home.
+#
+# `scripts/dev-env.sh` gives each worktree its own `MVM_HOME` *and* its own
+# `CARGO_TARGET_DIR`. Defaulting straight to `$HOME/.mvm` honoured the second
+# half of that and ignored the first: a worktree built its own binaries and then
+# pointed them at the main checkout's artifacts. The guest boots and the host
+# session handshake dies with `Socket is not connected`, which reads as a broken
+# backend rather than as two trees sharing one home.
+#
+# That made worktree-based e2e work impossible by construction, so every
+# verification had to run in the main checkout.
+E2E_HOME="${MVM_E2E_HOME:-${MVM_HOME:-$HOME/.mvm}}"
 
 # A CHANGING value, exported for every cargo invocation below.
 #


### PR DESCRIPTION
Both e2e runners defaulted `E2E_HOME` to `$HOME/.mvm`:

```sh
E2E_HOME="${MVM_E2E_HOME:-$HOME/.mvm}"
```

`scripts/dev-env.sh` gives each worktree its own `MVM_HOME` **and** its own `CARGO_TARGET_DIR`. The runners honoured the second and ignored the first — so a worktree built its own `mvmctl`, supervisors and helpers, then pointed them at the **main checkout is** artifact home.

The symptom is not obviously about homes at all:

```
Error: starting transient microVM
  0: activate workload after boot
  1: send ActivateEnvironment to guest
  2: host session handshake failed
  3: session i/o error: Socket is not connected (os error 57)
```

That reads as a broken backend. It is two source trees sharing one home.

## Why it matters beyond the error

It made worktree-based e2e work **impossible by construction**. Every verification had to run from the main checkout — against the tree someone else may be editing, and competing for the same cargo build lock. I hit this, assumed it was my own setup, and kept falling back to main; it is a real defect and it was hiding in plain sight behind a plausible-looking runtime error.

## Change

```sh
E2E_HOME="${MVM_E2E_HOME:-${MVM_HOME:-$HOME/.mvm}}"
```

An explicit `MVM_E2E_HOME` still wins. A plain checkout with no `MVM_HOME` set is unchanged. A dev-env-sourced worktree becomes self-consistent with no extra ceremony.

## Verified

`./scripts/e2e-launch-modes.sh` from a worktree with dev-env sourced — the exact case that previously died at the handshake — now reports

```
home:  .../.worktrees/mvm-launch-fix/.mvm-test
```

and passes **25 of 25 scenarios**, with the one expected `@perf_budget` skip named.