### PR TITLE
test(e2e): rebuild the per-VM supervisors before the launch gate boots

### DIFF
--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -154,6 +154,10 @@ echo "==> building mvmctl + host helpers"
 # cargo makes this a no-op when they are already current, so always doing it
 # costs a fingerprint check. The signing step below must follow it: a re-linked
 # supervisor loses its Hypervisor.framework entitlement.
+#
+# Not `just embed-refresh`: that clears the nested musl cross-compile of the
+# *embedded* host-vm binaries, a different set, and this gate boots no builder
+# VM that would rebuild them.
 echo "==> building the per-VM host helpers"
 just build-supervisors
 


### PR DESCRIPTION
## The gap

`scripts/e2e-launch-modes.sh` builds `mvmctl` and `xtask`, then signs and boots.
It never relinks `mvm-hvf-supervisor`, and `cargo build --bin mvmctl` does not
either — so the supervisor sits at whatever revision last built it while the
host side keeps gaining config fields.

The supervisor parses the config `mvmctl` pipes to its stdin with
`deny_unknown_fields`. One field newer than the binary and it exits 1 before a
guest exists:

```
Error: parse HvfSupervisorConfig JSON from stdin

Caused by:
    unknown field `vcpus`, expected one of `kernel`, `cmdline`, `memory_mib`, …
```

which the launch path reported only as `hvf supervisor exited before writing its
PID file`, pointing at a guest console that is empty precisely because no guest
ever ran.

`scripts/e2e-documented-surface.sh` already rebuilds the helpers for exactly this
reason — its comment records the 33 scenarios that failed that way, none of them
naming the stale binary. The launch gate never got the same step and is just as
exposed: it failed its warm launch against a supervisor several days stale, with
nothing to go on but a PID file that never appeared.

## The change

`just build-supervisors` after the `mvmctl` / `xtask` builds. cargo makes it a
fingerprint check when the binaries are already current, so the cost of doing it
unconditionally is that check — and presence is not freshness, which is why this
is not a test that the files exist.

Two placement details, both load-bearing:

- **Before `mvmctl env sign`, not after.** Relinking drops the
  Hypervisor.framework entitlement, and macOS kills an unentitled binary with
  SIGKILL. That surfaces through the *same* sentence as the stale-binary case,
  so the signing comment now says which status means which: `signal: 9` is
  unentitled, `exit status: 1` is stale.
- **Not `just embed-refresh`.** That clears the nested musl cross-compile of the
  *embedded* host-vm binaries — a different set — and this gate boots no builder
  VM that would rebuild them.

The mechanism itself is documented once, in the sibling script; this comment
points there rather than keeping a second copy to drift.

## Verification

`bash -n` clean. `shellcheck` reports only a pre-existing SC2155 on line 44,
untouched here.

A full `just e2e-launch` against this change, in a cold worktree, is running as
this PR opens; I will post the result. Worth stating plainly: **CI cannot check
this file.** The launch gate needs a host that boots a guest and no hosted macOS
runner does, so a local run is the only verification this change will ever get.

The prior run of this same gate — same machine, same suite, with the supervisor
rebuilt by hand instead of by this step — passed end to end, including
`transient_and_persistent_lifecycle_over_hvf`. This change automates the step
that made that run possible.

## Related

Complementary to #3027, not redundant with it. That one makes the failure name
its own cause wherever `mvmctl` runs, including outside this gate. This one stops
the gate from meeting it at all. Either alone leaves a real hole.
