### PR TITLE
fix(sdk): copy the workspace, not the flake subdirectory, for sidecar builds

### DIFF
--- a/crates/mvm-cli/src/commands/env/builder_vm/sdk_sidecar.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/sdk_sidecar.rs
@@ -103,6 +103,18 @@ fn build_sdk_sidecar_via_hvf(
     Ok(())
 }
 
+/// Render the `cmd.sh` the builder guest runs to produce the SDK sidecar
+/// image.
+///
+/// The flake reference names the whole staged workspace and selects the
+/// builder-VM flake with `?dir=`, rather than naming the subdirectory
+/// directly. The builder-VM flake reaches out of its own directory to import
+/// the workspace's runtime-overlay flake, and `path:` copies exactly the tree
+/// it names into the store: naming the subdirectory leaves that relative walk
+/// pointing at the store root's parent, so the import resolves to `/nix/...`
+/// and the build fails before it compiles anything. `?dir=` copies the
+/// workspace and evaluates the flake inside it, so the walk lands where the
+/// flake expects and the copy stays immutable.
 #[cfg(feature = "builder-vm")]
 fn sdk_sidecar_builder_script(arch: mvm_core::arch::GuestArch) -> String {
     let image = mvm_fs::sdk_sidecar::SDK_SIDECAR_IMAGE_FILE;
@@ -122,7 +134,7 @@ build-users-group =
 substituters = https://cache.nixos.org/
 trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
 mkdir -p "$XDG_CACHE_HOME" "$XDG_STATE_HOME"
-out=$(/sbin/nix build 'path:/work/nix/images/builder-vm#packages.{arch}-linux.sdk-sidecar-image' \
+out=$(/sbin/nix build 'path:/work?dir=nix/images/builder-vm#packages.{arch}-linux.sdk-sidecar-image' \
   --no-link --print-out-paths --no-write-lock-file --impure --print-build-logs)
 test -n "$out"
 for name in '{image}' '{version}' '{checksums}'; do
@@ -150,5 +162,30 @@ mod tests {
         assert!(script.contains("\"/out/$name\""));
         assert!(script.contains("--no-write-lock-file"));
         assert!(script.contains("--impure"));
+    }
+
+    /// The builder-VM flake imports the workspace's runtime-overlay flake by
+    /// walking out of its own directory, so the store copy has to be the whole
+    /// workspace. Naming the subdirectory directly copies only that
+    /// subdirectory and the walk escapes it — the build then dies on a missing
+    /// `/nix/images/runtime-overlay/flake.nix` before compiling anything.
+    #[test]
+    fn sidecar_flake_reference_copies_the_workspace_and_selects_the_subdirectory() {
+        for arch in [
+            mvm_core::arch::GuestArch::X86_64,
+            mvm_core::arch::GuestArch::Aarch64,
+        ] {
+            let script = sdk_sidecar_builder_script(arch);
+            assert!(
+                script.contains(&format!(
+                    "'path:/work?dir=nix/images/builder-vm#packages.{arch}-linux.sdk-sidecar-image'"
+                )),
+                "sidecar build must select the builder-VM flake out of a whole-workspace copy: {script}"
+            );
+            assert!(
+                !script.contains("path:/work/nix/images/builder-vm"),
+                "naming the flake subdirectory strands the runtime-overlay import: {script}"
+            );
+        }
     }
 }

--- a/specs/sprint/delivery/sdk-sidecar-flake-reference.md
+++ b/specs/sprint/delivery/sdk-sidecar-flake-reference.md
@@ -1,0 +1,68 @@
+# The SDK sidecar build named a flake nix would not copy whole
+
+`mvmctl build sdk-sidecar build` could not build the sidecar on the HVF builder
+path. It failed inside the builder sandbox with
+
+```
+error: path '/nix/images/runtime-overlay/flake.nix' does not exist
+```
+
+before compiling anything, for the shipped **glibc** sidecar — this was never
+specific to the musl variant added alongside it.
+
+## What was wrong
+
+The builder-VM flake reaches out of its own directory to import the workspace's
+runtime-overlay flake, resolving the workspace root as `../../..` when
+`MVM_WORKSPACE_PATH` is unset. The build named the flake as
+
+```
+path:/work/nix/images/builder-vm#packages.<arch>-linux.sdk-sidecar-image
+```
+
+and `path:` copies exactly the tree it names into the store. So the relative
+walk started at `/nix/store/<hash>-source/` and landed on `/nix` — a real
+directory, which is why the error reads as a missing file rather than an escape.
+
+## The fix
+
+Name the whole staged workspace and select the flake inside it:
+
+```
+path:/work?dir=nix/images/builder-vm#packages.<arch>-linux.sdk-sidecar-image
+```
+
+Nix copies `/work` and evaluates the flake at the subdirectory, so `../../..`
+resolves to the copied workspace root. Verified against nix 2.35 with a fixture
+whose flake reads a marker file three levels up: the subdirectory form escapes
+the copy, the `?dir=` form reads the marker.
+
+This removes the need for an override rather than adding one. Pointing
+`MVM_WORKSPACE_PATH` at `/work` also clears the error, but it aims the flake at
+a mutable staged tree instead of an immutable store copy, and a build taken that
+way failed differently (`E0761`, an ambiguous `audit` module that exists in
+neither the checkout nor a fresh `/work` staging copy). That second failure is
+unexplained and is *not* addressed here; the fix avoids the mutable path
+entirely.
+
+## Why it hid
+
+There are two sidecar build paths and only one set the workspace root.
+`stage0-init.rs` exports `MVM_WORKSPACE_PATH=/work`, so it took the env arm and
+worked; the builder-VM shell job in
+`crates/mvm-cli/src/commands/env/builder_vm/sdk_sidecar.rs` exports `HOME`,
+`XDG_*` and `NIX_*` but never that one, so it took the broken relative arm.
+Nothing detects the difference until a build reaches for a runtime-overlay
+attribute.
+
+The asymmetry is left in place: Stage 0's resolution is unchanged, since making
+it share this reference form would make nix copy the whole workspace for every
+Stage 0 build — a cost worth measuring before paying, and not needed to fix the
+broken path.
+
+## Test
+
+`sidecar_flake_reference_copies_the_workspace_and_selects_the_subdirectory`
+pins the reference form for both arches and rejects the subdirectory form by
+name. It fails on the pre-fix string, and `cargo mutants` over the file catches
+both mutants of the function it covers.


### PR DESCRIPTION
`mvmctl build sdk-sidecar build` could not build the sidecar on the HVF builder
path. It failed inside the builder sandbox with

```
error: path '/nix/images/runtime-overlay/flake.nix' does not exist
```

before compiling anything — for the shipped **glibc** sidecar, not just the musl
variant added alongside it.

## What was wrong

The builder-VM flake reaches out of its own directory to import the workspace's
runtime-overlay flake, resolving the workspace root as `../../..` when
`MVM_WORKSPACE_PATH` is unset. The build named the flake as

```
path:/work/nix/images/builder-vm#packages.<arch>-linux.sdk-sidecar-image
```

and `path:` copies exactly the tree it names into the store. So the relative
walk started at `/nix/store/<hash>-source/` and landed on `/nix` — a real
directory, which is why the error reads as a missing file rather than an escape.

## The fix

Name the whole staged workspace and select the flake inside it:

```
path:/work?dir=nix/images/builder-vm#packages.<arch>-linux.sdk-sidecar-image
```

Nix copies `/work` and evaluates the flake at the subdirectory, so `../../..`
resolves to the copied workspace root. Verified against nix 2.35 with a fixture
whose flake reads a marker file three levels up: the subdirectory form escapes
the copy, the `?dir=` form reads the marker.

This removes the need for an override rather than adding one. Setting
`MVM_WORKSPACE_PATH=/work` also clears the error, but aims the flake at a
mutable staged tree instead of an immutable store copy.

## Why it hid

There are two sidecar build paths and only one set the workspace root.
`stage0-init.rs` exports `MVM_WORKSPACE_PATH=/work`, so it took the env arm and
worked; the builder-VM shell job in
`crates/mvm-cli/src/commands/env/builder_vm/sdk_sidecar.rs` exports `HOME`,
`XDG_*` and `NIX_*` but never that one, so it took the broken relative arm.
Nothing detects the difference until a build reaches for a runtime-overlay
attribute.

The asymmetry is left in place deliberately: Stage 0's resolution is unchanged,
since making it share this reference form would make nix copy the whole
workspace for every Stage 0 build — a cost worth measuring before paying, and
not needed to fix the broken path.

## Test

`sidecar_flake_reference_copies_the_workspace_and_selects_the_subdirectory`
pins the reference form for both arches and rejects the subdirectory form by
name. It fails on the pre-fix string, and `cargo mutants` over the file catches
both mutants of the function it covers.

## Note on scope

This is necessary but not sufficient to build the sidecar. With it applied the
build gets past the flake import and then hits a separate defect in the guest's
staging roots, fixed in #3034. Together they build the aarch64 sidecar through
the HVF builder for the first time.

`cargo run -p xtask -- check-all` passes.

Refs #2969