### PR TITLE
fix(build): stop Stage 0 promotion from destroying the cached workload kernel

### DIFF
--- a/crates/mvm-build/src/kernel_fetch.rs
+++ b/crates/mvm-build/src/kernel_fetch.rs
@@ -189,15 +189,73 @@ pub enum KernelResolution {
     NeedsFetch(PathBuf),
 }
 
+/// Directory holding one cached kernel entry — the `vmlinux` plus its digest
+/// sidecar, `config`, and digest cache.
+///
+/// A sibling of `builder-vm/`, deliberately not a child of it. The entry used
+/// to live at `builder-vm/<arch>/kernels/<variant>/`, inside the directory
+/// Stage 0 `remove_dir_all`s whenever the builder-VM source fingerprint
+/// changes. Promoting a new builder image therefore destroyed an unrelated
+/// artifact that costs half an hour to rebuild, and the next boot rebuilt it
+/// from scratch. Nothing about a kernel's identity depends on which builder
+/// image compiled it, so it does not belong in a directory whose contract is
+/// "atomically replaceable".
+pub fn kernel_cache_dir(cache_dir: &Path, arch: &str, variant: &str) -> PathBuf {
+    cache_dir.join("kernels").join(arch).join(variant)
+}
+
 /// Per-arch, per-variant kernel cache path — the location
 /// `mvmctl kernel build` writes and the boot path reads.
 pub fn cached_kernel_path(cache_dir: &Path, arch: &str, variant: &str) -> PathBuf {
+    kernel_cache_dir(cache_dir, arch, variant).join("vmlinux")
+}
+
+/// Where a kernel entry lived before it was moved out of the Stage 0 blast
+/// radius. Read only by [`migrate_legacy_kernel_entry`].
+fn legacy_kernel_cache_dir(cache_dir: &Path, arch: &str, variant: &str) -> PathBuf {
     cache_dir
         .join("builder-vm")
         .join(arch)
         .join("kernels")
         .join(variant)
-        .join("vmlinux")
+}
+
+/// Adopt a kernel entry left at the pre-relocation path.
+///
+/// Renames the whole entry directory, so the digest sidecar and the
+/// size+mtime-keyed digest cache move with the bytes they describe and stay
+/// valid. Only ever moves *into* an absent destination: a kernel already at
+/// the current path is newer by construction and is never clobbered.
+///
+/// Best-effort. A failure here is not an error — the caller falls through to
+/// re-deriving the kernel, which is what would have happened anyway.
+fn migrate_legacy_kernel_entry(cache_dir: &Path, arch: &str, variant: &str) {
+    let destination = kernel_cache_dir(cache_dir, arch, variant);
+    if destination.exists() {
+        return;
+    }
+    let legacy = legacy_kernel_cache_dir(cache_dir, arch, variant);
+    if !legacy.join("vmlinux").is_file() {
+        return;
+    }
+    let Some(parent) = destination.parent() else {
+        return;
+    };
+    if std::fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    match std::fs::rename(&legacy, &destination) {
+        Ok(()) => tracing::info!(
+            from = %legacy.display(),
+            to = %destination.display(),
+            "moved cached kernel out of the builder-VM cache directory"
+        ),
+        Err(e) => tracing::warn!(
+            from = %legacy.display(),
+            error = %e,
+            "could not move cached kernel to its current location; will re-derive"
+        ),
+    }
 }
 
 /// Decide how to obtain the `vmlinux` for a kernel pin without performing any
@@ -210,6 +268,9 @@ pub fn resolve_kernel(
     variant: &str,
     source_checkout: bool,
 ) -> KernelResolution {
+    // Every read of a cached kernel comes through here, so this is the one
+    // place an entry from the previous layout has to be adopted.
+    migrate_legacy_kernel_entry(cache_dir, arch, variant);
     let path = cached_kernel_path(cache_dir, arch, variant);
     if path.exists() {
         match verify_cached_kernel(&path) {
@@ -238,6 +299,74 @@ mod tests {
 
     use mvm_core::{kernel_artifact::compute_artifact_hash, util::test_env::TestEnv};
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn a_kernel_entry_is_not_stored_under_the_builder_vm_cache_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let entry = kernel_cache_dir(tmp.path(), "aarch64", "workload");
+
+        // Stage 0 replaces `builder-vm/<arch>` wholesale on a fingerprint
+        // change, so a kernel stored beneath it is collateral damage.
+        assert!(
+            !entry.starts_with(tmp.path().join("builder-vm")),
+            "kernel entry {} must not live under the builder-VM cache dir",
+            entry.display()
+        );
+        assert_eq!(
+            entry,
+            tmp.path().join("kernels").join("aarch64").join("workload")
+        );
+    }
+
+    #[test]
+    fn a_kernel_left_at_the_previous_location_is_adopted_not_rebuilt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let legacy = legacy_kernel_cache_dir(tmp.path(), "aarch64", "workload");
+        std::fs::create_dir_all(&legacy).unwrap();
+        let legacy_kernel = legacy.join("vmlinux");
+        std::fs::write(&legacy_kernel, b"previously built kernel").unwrap();
+        record_kernel_digest(&legacy_kernel).unwrap();
+
+        let resolved = resolve_kernel(tmp.path(), "aarch64", "workload", true);
+
+        let KernelResolution::Cached(verified) = resolved else {
+            panic!("a kernel at the previous location must be adopted, not rebuilt");
+        };
+        assert_eq!(
+            verified.path(),
+            cached_kernel_path(tmp.path(), "aarch64", "workload")
+        );
+        assert!(
+            !legacy.exists(),
+            "the previous entry should have been moved"
+        );
+    }
+
+    #[test]
+    fn adoption_never_clobbers_a_kernel_already_at_the_current_location() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        let current = cached_kernel_path(tmp.path(), "aarch64", "workload");
+        std::fs::create_dir_all(current.parent().unwrap()).unwrap();
+        std::fs::write(&current, b"the current kernel").unwrap();
+        record_kernel_digest(&current).unwrap();
+
+        let legacy = legacy_kernel_cache_dir(tmp.path(), "aarch64", "workload");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("vmlinux"), b"a stale kernel").unwrap();
+        record_kernel_digest(&legacy.join("vmlinux")).unwrap();
+
+        let KernelResolution::Cached(verified) =
+            resolve_kernel(tmp.path(), "aarch64", "workload", true)
+        else {
+            panic!("the current kernel should still verify");
+        };
+        assert_eq!(
+            std::fs::read(verified.path()).unwrap(),
+            b"the current kernel",
+            "a stale entry must not overwrite the current one"
+        );
+    }
 
     fn write_temp(bytes: &[u8]) -> NamedTempFile {
         let f = NamedTempFile::new().unwrap();

--- a/crates/mvm-cli/src/commands/build/kernel.rs
+++ b/crates/mvm-cli/src/commands/build/kernel.rs
@@ -344,12 +344,11 @@ fn compile_host_arch(
 /// `build_kernel_via_stage0`'s output location.
 #[cfg(feature = "builder-vm")]
 fn kernel_cache_path(arch: &str, label: &str) -> std::path::PathBuf {
-    std::path::Path::new(&mvm_core::config::mvm_cache_dir())
-        .join("builder-vm")
-        .join(arch)
-        .join("kernels")
-        .join(label)
-        .join("vmlinux")
+    mvm_build::kernel_fetch::cached_kernel_path(
+        std::path::Path::new(&mvm_core::config::mvm_cache_dir()),
+        arch,
+        label,
+    )
 }
 
 #[cfg(not(feature = "builder-vm"))]

--- a/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
@@ -1201,7 +1201,7 @@ fn builder_vm_stage0_promotion_replaces_stale_valid_cache() {
 }
 
 #[test]
-fn repro_stage0_promotion_destroys_the_cached_workload_kernel() {
+fn stage0_promotion_leaves_the_cached_workload_kernel_alone() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let cache_dir = tmp.path().join("cache");
     let final_dir = cache_dir.join("builder-vm").join("aarch64");

--- a/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
@@ -1200,6 +1200,40 @@ fn builder_vm_stage0_promotion_replaces_stale_valid_cache() {
     assert!(builder_vm_source_cache_ready(&final_dir, "new"));
 }
 
+#[test]
+fn repro_stage0_promotion_destroys_the_cached_workload_kernel() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cache_dir = tmp.path().join("cache");
+    let final_dir = cache_dir.join("builder-vm").join("aarch64");
+    let staging = cache_dir.join("builder-vm").join(".aarch64.stage0-test");
+
+    // A previously-built, verified workload kernel sits in the cache.
+    let kernel = mvm_build::kernel_fetch::cached_kernel_path(&cache_dir, "aarch64", "workload");
+    std::fs::create_dir_all(kernel.parent().expect("kernel parent")).expect("mkdir kernels");
+    std::fs::write(&kernel, b"a real workload kernel").expect("write kernel");
+    mvm_build::kernel_fetch::record_kernel_digest(&kernel).expect("record digest");
+    assert!(
+        matches!(
+            mvm_build::kernel_fetch::resolve_kernel(&cache_dir, "aarch64", "workload", true),
+            mvm_build::kernel_fetch::KernelResolution::Cached(_)
+        ),
+        "precondition: the planted kernel must resolve as a verified cache hit"
+    );
+
+    // The builder-VM source fingerprint changes, so Stage 0 rebuilds and promotes.
+    write_valid_builder_vm_artifacts(&final_dir);
+    write_builder_vm_source_cache_metadata(&final_dir, "old");
+    write_valid_builder_vm_artifacts(&staging);
+    write_builder_vm_source_cache_metadata(&staging, "new");
+    promote_builder_vm_stage0_cache(&staging, &final_dir, "new").expect("promote");
+
+    assert!(
+        kernel.exists(),
+        "promoting a new builder-VM image must not delete the cached workload kernel at {}",
+        kernel.display()
+    );
+}
+
 // -------------------------------------------------------------------
 // Stage 0 audit-emit helpers.
 //

--- a/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
@@ -78,12 +78,11 @@ pub(crate) fn resolve_kernel_source() -> Option<KernelSource> {
 /// into the per-arch kernel cache, returning its path.
 #[cfg(feature = "builder-vm")]
 pub(super) fn download_builder_kernel(arch: &str) -> Result<std::path::PathBuf> {
-    let dest = std::path::Path::new(&mvm_core::config::mvm_cache_dir())
-        .join("builder-vm")
-        .join(arch)
-        .join("kernels")
-        .join("builder")
-        .join("vmlinux");
+    let dest = mvm_build::kernel_fetch::cached_kernel_path(
+        std::path::Path::new(&mvm_core::config::mvm_cache_dir()),
+        arch,
+        "builder",
+    );
     crate::update::download_kernel(arch, "builder", &dest)?;
     Ok(dest)
 }
@@ -180,12 +179,13 @@ pub(crate) fn build_kernel_via_stage0(
     })?;
 
     let arch = builder_vm_host_arch();
-    let out_dir = format!(
-        "{}/builder-vm/{arch}/kernels/{}",
-        mvm_core::config::mvm_cache_dir(),
-        variant.label()
+    let out_dir_buf = mvm_build::kernel_fetch::kernel_cache_dir(
+        std::path::Path::new(&mvm_core::config::mvm_cache_dir()),
+        arch,
+        variant.label(),
     );
-    let out_dir_path = std::path::Path::new(&out_dir);
+    let out_dir_path = out_dir_buf.as_path();
+    let out_dir = out_dir_path.display().to_string();
     std::fs::create_dir_all(out_dir_path)
         .with_context(|| format!("creating kernel cache dir {out_dir}"))?;
 

--- a/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/tests.rs
@@ -146,8 +146,7 @@ mod default_microvm_tests {
 
     #[test]
     fn missing_workload_kernel_message_explains_automatic_and_manual_paths() {
-        let msg =
-            missing_workload_kernel_message("/cache/builder-vm/aarch64/kernels/workload/vmlinux");
+        let msg = missing_workload_kernel_message("/cache/kernels/aarch64/workload/vmlinux");
         assert!(msg.contains("mvmctl kernel build --which workload"));
         assert!(msg.contains("just kernel-workload"));
         assert!(msg.contains("dm-verity-capable workload kernel"));

--- a/crates/mvm-client/src/launch/tests.rs
+++ b/crates/mvm-client/src/launch/tests.rs
@@ -768,7 +768,7 @@ fn firecracker_admitted_boot_receives_a_concrete_kernel_path() {
     );
 
     // Seed the exact cache location the CLI's machine-run boot path reads:
-    // `<cache>/builder-vm/<arch>/kernels/workload/vmlinux`.
+    // `<cache>/kernels/<arch>/workload/vmlinux`.
     let cache = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
     let arch = mvm_core::arch::GuestArch::host().to_string();
     let cached = mvm_build::kernel_fetch::cached_kernel_path(&cache, &arch, "workload");

--- a/crates/mvm-client/tests/launch_lifecycle_live.rs
+++ b/crates/mvm-client/tests/launch_lifecycle_live.rs
@@ -36,7 +36,7 @@ fn live_env() -> Option<(String, RootfsSource)> {
 
 /// Make the lane self-contained: seed the supplied workload kernel into the
 /// exact cache location the launch path resolves
-/// (`<cache>/builder-vm/<arch>/kernels/workload/vmlinux`) when the cache is
+/// (`<cache>/kernels/<arch>/workload/vmlinux`) when the cache is
 /// cold. An already-populated cache is left untouched — the operator's own
 /// verified kernel wins.
 ///

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -387,12 +387,11 @@ pub(crate) fn workload_kernel_path() -> Option<std::path::PathBuf> {
         let path = std::path::PathBuf::from(explicit);
         return path.is_file().then_some(path);
     }
-    let cached = std::path::PathBuf::from(mvm_core::config::default_mvm_cache_dir())
-        .join("builder-vm")
-        .join(std::env::consts::ARCH)
-        .join("kernels")
-        .join("workload")
-        .join("vmlinux");
+    let cached = mvm_build::kernel_fetch::cached_kernel_path(
+        std::path::Path::new(&mvm_core::config::default_mvm_cache_dir()),
+        std::env::consts::ARCH,
+        "workload",
+    );
     cached.is_file().then_some(cached)
 }
 

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -387,12 +387,23 @@ pub(crate) fn workload_kernel_path() -> Option<std::path::PathBuf> {
         let path = std::path::PathBuf::from(explicit);
         return path.is_file().then_some(path);
     }
-    let cached = mvm_build::kernel_fetch::cached_kernel_path(
+    // Through the verifying seam, not an `is_file()` check. The kernel this
+    // returns is what `@workload_kernel` scenarios boot, so a present-but-
+    // unvouched-for file here surfaces as a mysterious guest failure rather
+    // than a cache fault. This site used to build the cache path by hand,
+    // which is why the gate could not see it.
+    match mvm_build::kernel_fetch::resolve_kernel(
         std::path::Path::new(&mvm_core::config::default_mvm_cache_dir()),
         std::env::consts::ARCH,
         "workload",
-    );
-    cached.is_file().then_some(cached)
+        true,
+    ) {
+        mvm_build::kernel_fetch::KernelResolution::Cached(verified) => {
+            Some(verified.path().to_path_buf())
+        }
+        mvm_build::kernel_fetch::KernelResolution::NeedsBuild(_)
+        | mvm_build::kernel_fetch::KernelResolution::NeedsFetch(_) => None,
+    }
 }
 
 /// `/dev/kvm` exists and this process can open it read-write — the mode a real

--- a/crates/mvm-conformance/tests/steps/cli.rs
+++ b/crates/mvm-conformance/tests/steps/cli.rs
@@ -143,13 +143,8 @@ fn isolated_mvm_home(world: &mut CliWorld) {
 fn isolated_mvm_home_with_non_verity_kernel(world: &mut CliWorld) {
     let home = tempfile::tempdir().expect("create isolated MVM_HOME");
     let arch = std::env::consts::ARCH;
-    let kernel_dir = home
-        .path()
-        .join("cache")
-        .join("builder-vm")
-        .join(arch)
-        .join("kernels")
-        .join("workload");
+    let kernel_dir =
+        mvm_build::kernel_fetch::kernel_cache_dir(&home.path().join("cache"), arch, "workload");
     std::fs::create_dir_all(&kernel_dir).expect("create fake workload kernel cache dir");
     let kernel = kernel_dir.join("vmlinux");
     std::fs::write(&kernel, b"KALLSYMS-free fake kernel bytes\n")
@@ -171,13 +166,11 @@ fn incompatible_workload_kernel_cache_is_evicted(world: &mut CliWorld) {
         .isolated_home
         .as_ref()
         .expect("isolated home must remain available");
-    let kernel_dir = home
-        .path()
-        .join("cache")
-        .join("builder-vm")
-        .join(std::env::consts::ARCH)
-        .join("kernels")
-        .join("workload");
+    let kernel_dir = mvm_build::kernel_fetch::kernel_cache_dir(
+        &home.path().join("cache"),
+        std::env::consts::ARCH,
+        "workload",
+    );
     for name in ["vmlinux", "vmlinux.sha256", "config"] {
         assert!(
             !kernel_dir.join(name).exists(),

--- a/crates/mvm-conformance/tests/steps/volume.rs
+++ b/crates/mvm-conformance/tests/steps/volume.rs
@@ -47,13 +47,11 @@ fn cached_live_workload_kernel(world: &mut CliWorld) {
     // operator mistake.
     let source = crate::workload_kernel_path()
         .expect("`@workload_kernel` scenarios only run when a kernel resolves");
-    let destination = isolated_home(world)
-        .join("cache")
-        .join("builder-vm")
-        .join(std::env::consts::ARCH)
-        .join("kernels")
-        .join("workload")
-        .join("vmlinux");
+    let destination = mvm_build::kernel_fetch::cached_kernel_path(
+        &isolated_home(world).join("cache"),
+        std::env::consts::ARCH,
+        "workload",
+    );
     fs::create_dir_all(
         destination
             .parent()

--- a/crates/mvm-runtime/examples/hvf-dax-smoke.rs
+++ b/crates/mvm-runtime/examples/hvf-dax-smoke.rs
@@ -6,7 +6,7 @@
 //!   --entitlements <(printf '%s' \
 //!     '<plist><dict><key>com.apple.security.hypervisor</key><true/></dict></plist>') \
 //!   target/debug/examples/hvf-dax-smoke
-//! MVM_HVF_KERNEL=.mvm-test/cache/builder-vm/aarch64/kernels/builder/vmlinux \
+//! MVM_HVF_KERNEL=.mvm-test/cache/kernels/aarch64/builder/vmlinux \
 //! MVM_HVF_INITRAMFS=/tmp/hvf-dax-guest/initramfs.cpio \
 //! MVM_HVF_VIRTIOFS_ROOT=/tmp/hvf-dax-root \
 //!   ./target/debug/examples/hvf-dax-smoke
@@ -21,9 +21,8 @@ fn main() {
 
         static STOP: AtomicBool = AtomicBool::new(false);
 
-        let kernel = std::env::var("MVM_HVF_KERNEL").unwrap_or_else(|_| {
-            ".mvm-test/cache/builder-vm/aarch64/kernels/builder/vmlinux".into()
-        });
+        let kernel = std::env::var("MVM_HVF_KERNEL")
+            .unwrap_or_else(|_| ".mvm-test/cache/kernels/aarch64/builder/vmlinux".into());
         let initramfs = std::env::var("MVM_HVF_INITRAMFS")
             .map(|p| std::fs::read(&p).expect("read initramfs"))
             .unwrap_or_else(|_| {

--- a/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
@@ -497,14 +497,11 @@ mod tests {
     fn slot_kernel_source_prefers_verified_workload_kernel_for_aarch64() {
         let tmp = tempfile::tempdir().unwrap();
         let built = tmp.path().join("build").join("vmlinux");
-        let workload = tmp
-            .path()
-            .join("cache")
-            .join("builder-vm")
-            .join("aarch64")
-            .join("kernels")
-            .join("workload")
-            .join("vmlinux");
+        let workload = mvm_build::kernel_fetch::cached_kernel_path(
+            &tmp.path().join("cache"),
+            "aarch64",
+            "workload",
+        );
         std::fs::create_dir_all(workload.parent().unwrap()).unwrap();
         std::fs::write(&workload, b"workload-kernel").unwrap();
         mvm_build::kernel_fetch::record_kernel_digest(&workload).unwrap();
@@ -521,12 +518,7 @@ mod tests {
         let built = tmp.path().join("build").join("vmlinux");
         let cache = tmp.path().join("cache");
         let builder = cache.join("builder-vm").join("x86_64").join("vmlinux");
-        let workload = cache
-            .join("builder-vm")
-            .join("x86_64")
-            .join("kernels")
-            .join("workload")
-            .join("vmlinux");
+        let workload = mvm_build::kernel_fetch::cached_kernel_path(&cache, "x86_64", "workload");
         std::fs::create_dir_all(builder.parent().unwrap()).unwrap();
         std::fs::write(&builder, b"builder-kernel").unwrap();
         std::fs::create_dir_all(workload.parent().unwrap()).unwrap();
@@ -543,12 +535,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let built = tmp.path().join("build").join("vmlinux");
         let cache = tmp.path().join("cache");
-        let workload = cache
-            .join("builder-vm")
-            .join("x86_64")
-            .join("kernels")
-            .join("workload")
-            .join("vmlinux");
+        let workload = mvm_build::kernel_fetch::cached_kernel_path(&cache, "x86_64", "workload");
         std::fs::create_dir_all(workload.parent().unwrap()).unwrap();
         std::fs::write(&workload, b"workload-kernel").unwrap();
         mvm_build::kernel_fetch::record_kernel_digest(&workload).unwrap();
@@ -586,7 +573,7 @@ mod tests {
             .to_string();
 
         assert!(err.contains("flake build produced no vmlinux"));
-        assert!(err.contains("builder-vm/x86_64/kernels/workload/vmlinux"));
+        assert!(err.contains("kernels/x86_64/workload/vmlinux"));
     }
 
     #[test]

--- a/public/src/content/docs/guides/kernels.md
+++ b/public/src/content/docs/guides/kernels.md
@@ -40,8 +40,10 @@ and `workload`. (A `workload-sizeopt-metrics` *flake output* still exists as a
 compatibility alias; see below.)
 
 The compiled or downloaded kernel is cached at
-`~/.mvm/cache/builder-vm/<arch>/kernels/<variant>/vmlinux` and reused by every
-later run that needs it. (There is no `mvmctl dev` command — it was removed.)
+`~/.mvm/cache/kernels/<arch>/<variant>/vmlinux` and reused by every
+later run that needs it. (A kernel left at the older
+`~/.mvm/cache/builder-vm/<arch>/kernels/<variant>/` path is moved to the
+current one the next time it is read, so an existing cache is not rebuilt.) (There is no `mvmctl dev` command — it was removed.)
 
 When the kernel was compiled locally, the cache directory also carries a
 resolved `config` sidecar and `kernel-metrics-<arch>.json`, so you can inspect

--- a/public/src/content/docs/guides/troubleshooting.md
+++ b/public/src/content/docs/guides/troubleshooting.md
@@ -189,7 +189,7 @@ mvmctl build kernel build --which workload --source compile
 ```
 
 For a local compile, the cache also contains the resolved kernel config and
-metrics under `~/.mvm/cache/builder-vm/<arch>/kernels/workload/`. An empty
+metrics under `~/.mvm/cache/kernels/<arch>/workload/`. An empty
 config sidecar or a zero built-in-symbol count indicates that the generated
 kernel artifact is incomplete and should not be used for a sealed workload.
 

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -279,7 +279,7 @@ echo "    $ran launch scenario(s) executed"
 # from the home we just warmed and run them.
 # ---------------------------------------------------------------------------
 echo "==> Rust library seam (mvm-client, in-process)"
-KERNEL="$(find "$E2E_HOME/cache/builder-vm" -name vmlinux -path '*workload*' 2>/dev/null | head -1 || true)"
+KERNEL="$(find "$E2E_HOME/cache/kernels" -name vmlinux -path '*workload*' 2>/dev/null | head -1 || true)"
 ROOTFS="$(find "$E2E_HOME/cache/oci/rootfs" -name rootfs.ext4 2>/dev/null | head -1 || true)"
 
 # Passed explicitly rather than left to `aux_bin::resolve`, which searches the
@@ -311,7 +311,7 @@ else
   # Loud, not silent: a skipped library seam is a coverage hole, and reporting
   # it as nothing is how the last one stayed open.
   echo "!!! SKIPPED the Rust library seam. Missing:" >&2
-  [[ -z "$KERNEL" ]]     && echo "!!!   workload kernel under $E2E_HOME/cache/builder-vm" >&2
+  [[ -z "$KERNEL" ]]     && echo "!!!   workload kernel under $E2E_HOME/cache/kernels" >&2
   [[ -z "$ROOTFS" ]]     && echo "!!!   OCI rootfs under $E2E_HOME/cache/oci/rootfs" >&2
   [[ -z "$SUPERVISOR" ]] && echo "!!!   mvm-hvf-supervisor under $TARGET_DIR" >&2
   echo "!!! A skipped seam is a coverage hole, not a pass." >&2

--- a/scripts/e2e-launch-modes.sh
+++ b/scripts/e2e-launch-modes.sh
@@ -54,6 +54,19 @@ E2E_HOME="${MVM_E2E_HOME:-${MVM_HOME:-$HOME/.mvm}}"
 # cross-compile per gate run, which is the price of measuring the tree.
 export MVM_EMBED_NO_CACHE="e2e-$(date +%s)"
 
+# The builder VM's wall-clock cap, raised from its 30-minute default.
+#
+# This lane can legitimately face a cold workload-kernel build, which is a
+# half-hour of nix on an unloaded host and longer on a busy one. At the default
+# the gate fails on a slow build rather than a broken one — and fails ~30
+# minutes in, after the expensive part, which is the worst possible place to
+# learn nothing. `ci-full.yml` already runs its builder lane at 7200 for the
+# same reason; matching it keeps the two from disagreeing about how long a
+# build is allowed to take.
+#
+# Respects an operator override so a bisect can still set it lower.
+export MVM_BUILDER_VM_TIMEOUT_SECS="${MVM_BUILDER_VM_TIMEOUT_SECS:-7200}"
+
 # Skips this lane will not tolerate.
 #
 # The tally printed after the suite is advice, and advice is not read at the

--- a/scripts/measure-hvf-density.sh
+++ b/scripts/measure-hvf-density.sh
@@ -170,7 +170,7 @@ seed_workload_kernel() {
   local dest
   local seed
   arch="$(host_kernel_arch)"
-  dest="${CACHE_DIR}/builder-vm/${arch}/kernels/workload/vmlinux"
+  dest="${CACHE_DIR}/kernels/${arch}/workload/vmlinux"
   if [[ -f "${dest}" ]]; then
     SEEDED_KERNEL_SOURCE="already-present:${dest}"
     return
@@ -178,7 +178,7 @@ seed_workload_kernel() {
 
   seed="${MVM_HVF_DENSITY_WORKLOAD_KERNEL:-}"
   if [[ -z "${seed}" && "${MVM_HVF_DENSITY_SEED_HOST_KERNEL:-1}" != "0" ]]; then
-    seed="${HOME}/.cache/mvm/builder-vm/${arch}/kernels/workload/vmlinux"
+    seed="${HOME}/.cache/mvm/kernels/${arch}/workload/vmlinux"
   fi
   if [[ -z "${seed}" || ! -f "${seed}" ]]; then
     return

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,20 @@ Last updated: 2026-08-31
 
 ## In progress
 
+- [ ] **Kernel cache moved out of the Stage 0 blast radius.**
+      `specs/sprint/delivery/kernel-cache-outside-stage0-blast-radius.md`.
+      The workload kernel was cached inside `builder-vm/<arch>`, the directory
+      Stage 0 `remove_dir_all`s on a source-fingerprint change, so promoting a
+      new builder image destroyed a half-hour artifact and the next boot rebuilt
+      it — blowing `just e2e-launch`'s 1800s cap. Entries now live at
+      `<cache>/kernels/<arch>/<variant>/`; `resolve_kernel` adopts an entry left
+      at the old path by renaming it. The layout was hand-rebuilt at nine call
+      sites, all now routed through `kernel_cache_dir`/`cached_kernel_path`. The
+      gate's builder cap is raised to 7200s, matching `ci-full.yml`. Workspace
+      tests, Clippy, doctests, policy gates, and a live macOS 26 `e2e-launch`
+      run (migration confirmed a rename, not a rebuild) are green; merge
+      delivery remains.
+
 - [ ] **machine diff handshake retry — issue #3024.**
       `specs/plans/2026-08-31-machine-diff-handshake-retry.md`.
       A typed pre-authentication peer hangup gets one fresh connection; an EOF

--- a/specs/sprint/delivery/kernel-cache-outside-stage0-blast-radius.md
+++ b/specs/sprint/delivery/kernel-cache-outside-stage0-blast-radius.md
@@ -1,0 +1,115 @@
+# Move the kernel cache out of the Stage 0 blast radius
+
+`just e2e-launch` failed on 2026-08-31 with a cold workload-kernel build that
+blew the builder VM's 1800-second wall-clock cap — thirty minutes in, after the
+expensive part. A second run six minutes later, same host and same `~/.mvm`,
+passed 23/23. Nothing about the tree had changed between them.
+
+The kernel was not corrupt and had not failed verification. It was gone, and
+mvm had deleted it.
+
+## The mechanism
+
+`cached_kernel_path` put the workload kernel at
+
+    <cache>/builder-vm/<arch>/kernels/<variant>/vmlinux
+
+which is inside the directory `promote_builder_vm_stage0_cache` calls
+`remove_dir_all` on whenever the builder-VM source fingerprint changes:
+
+    if final_dir.exists() { ... std::fs::remove_dir_all(final_dir)?; }
+    std::fs::rename(staging_dir, final_dir)?;
+
+`final_dir` is `<cache>/builder-vm/<arch>`. So promoting a new builder image
+destroyed, as collateral, an unrelated artifact that costs half an hour of nix
+to rebuild. Nothing in `stage0_cache.rs` or `cache_install.rs` so much as
+mentions `kernels` — there was no preservation step to have gone wrong, and the
+promotion was doing exactly what it was written to do.
+
+The failure needs a fingerprint change to fire, which is why it looked
+intermittent. Two source trees sharing one `~/.mvm` wipe each other's kernel on
+every alternation, and that is precisely what happened: the run before this one
+was from a different worktree.
+
+## Filesystem evidence
+
+The mtimes told the whole story once read correctly:
+
+- `builder-vm/aarch64/` — `rootfs.ext4`, `vmlinux`, `manifest.json`,
+  `.mvm-source.sha256` all stamped 14:03, the artifact set replaced at run 1's
+  start.
+- `builder-vm/aarch64/kernels/` stamped 14:37, meaning `workload/` was created
+  inside it by run *2*. The directory sat empty from 14:03 onward.
+
+## What changed
+
+Kernel entries now live at `<cache>/kernels/<arch>/<variant>/`, a sibling of
+`builder-vm/` rather than a child. Nothing about a kernel's identity depends on
+which builder image compiled it, so it does not belong in a directory whose
+contract is "atomically replaceable". Preserving `kernels/` across the promotion
+was the alternative; it keeps the artifact inside the bomb and re-creates the
+bug the next time someone adds a cache there.
+
+`resolve_kernel` — the one gate every read passes through — adopts an entry left
+at the old path by renaming the directory. The digest sidecar and the
+size+mtime-keyed digest cache move with the bytes they describe, so an adopted
+entry stays verified and no one pays for a rebuild. Adoption only ever moves
+into an absent destination, so a newer entry is never clobbered.
+
+## The layout was hand-rebuilt at nine sites
+
+Relocating a path this simple should have been a one-line change. It was not:
+the layout was reconstructed independently at nine call sites, including the
+*writer*, which built it as a format string. They now all route through
+`kernel_cache_dir` / `cached_kernel_path`.
+
+One straggler survived the first sweep and failed the gate — a shell `find` in
+`e2e-launch-modes.sh` looking for the kernel under `cache/builder-vm`. A grep
+scoped to `*.rs` cannot see it. The script failed loudly rather than skipping the
+seam quietly, which is the only reason it was caught; that guard was added
+deliberately and earned its keep here.
+
+## The cap, separately
+
+`e2e-launch-modes.sh` now exports `MVM_BUILDER_VM_TIMEOUT_SECS=7200`, respecting
+an operator override. The 1800-second default is not enough for a cold
+workload-kernel build on a loaded host — run 1 was at load 11-14 on 16 cores —
+so the gate failed on a slow build rather than a broken one. `ci-full.yml`
+already runs its builder lane at 7200; the two no longer disagree about how long
+a build may take.
+
+This is the second-order fix. On its own it would have left a gate that pays a
+half-hour rebuild on every fingerprint change and merely tolerates it.
+
+## Verification
+
+Unit and workspace: 12,819 tests pass, clippy clean at `-D warnings`, doctests,
+`just check-gated`, and the xtask gates including `check-doc-claims`,
+`check-single-home`, `check-single-network-path` and `check-cli-help-matches-docs`.
+
+Three new tests: an entry is not stored under `builder-vm/`, an entry at the old
+path is adopted rather than rebuilt, and adoption never clobbers a newer entry.
+The reproduction landed red first and asserts its own precondition — that the
+planted kernel resolves as `KernelResolution::Cached` — so it proves destruction
+rather than absence.
+
+Live on macOS 26 / Apple Silicon against the real `~/.mvm`, which still held a
+kernel at the old path:
+
+- The migration fired and was a rename, not a rebuild: all four files kept their
+  original 14:37 mtimes, only the new parent directory was newly created.
+- The adopted kernel still verifies — computed SHA-256 equals the recorded
+  sidecar.
+- `just e2e-launch` passed end to end, booting on the adopted kernel with no
+  kernel build at all, including the in-process `mvm-client` seam
+  (`transient_and_persistent_lifecycle_over_hvf`).
+
+CI cannot exercise this: no hosted macOS runner boots a guest.
+
+## Note for whoever reads the ledger
+
+`check-claim-catalog` and its siblings cannot catch this class. Every gate here
+was green while the cache was being destroyed, because nothing asserts that one
+cache's lifetime is independent of another's. The new
+`a_kernel_entry_is_not_stored_under_the_builder_vm_cache_directory` test is a
+narrow guard against exactly one recurrence, not against the general shape.

--- a/xtask/src/check_verified_kernel_reads.rs
+++ b/xtask/src/check_verified_kernel_reads.rs
@@ -47,6 +47,10 @@ const ALLOWED_UNVERIFIED: &[&str] = &[
     // `resolve_workload_kernel` will serve. It names the location because
     // that is the fixture it writes.
     "crates/mvm-client/src/launch/tests.rs",
+    // Names the location as the *destination* it copies an already-resolved
+    // kernel into, so the scenario's home carries one. The kernel it copies
+    // came from `workload_kernel_path`, which resolves through the seam.
+    "crates/mvm-conformance/tests/steps/volume.rs",
 ];
 
 pub fn run(workspace: &Path) -> Result<()> {


### PR DESCRIPTION
`just e2e-launch` failed on 2026-08-31 with a cold workload-kernel build that blew the builder VM's 1800-second wall-clock cap — thirty minutes in, after the expensive part. A second run six minutes later, same host and same `~/.mvm`, passed 23/23. Nothing about the tree had changed between them.

The kernel was not corrupt and had not failed verification. It was gone, and mvm had deleted it.

## The mechanism

`cached_kernel_path` put the workload kernel at

```
<cache>/builder-vm/<arch>/kernels/<variant>/vmlinux
```

which is inside the directory `promote_builder_vm_stage0_cache` calls `remove_dir_all` on whenever the builder-VM source fingerprint changes (`stage0_cache.rs:857`):

```rust
if final_dir.exists() { ... std::fs::remove_dir_all(final_dir)?; }
std::fs::rename(staging_dir, final_dir)?;
```

`final_dir` is `<cache>/builder-vm/<arch>`. So promoting a new builder image destroyed, as collateral, an unrelated artifact that costs half an hour of nix to rebuild. Neither `stage0_cache.rs` nor `cache_install.rs` so much as mentions `kernels` — there was no preservation step to have gone wrong. The promotion was doing exactly what it was written to do.

It needs a fingerprint change to fire, which is why it looked intermittent. Two source trees sharing one `~/.mvm` wipe each other's kernel on every alternation, and that is what happened here: the run before this one was from a different worktree.

## Filesystem evidence

- `builder-vm/aarch64/` — `rootfs.ext4`, `vmlinux`, `manifest.json`, `.mvm-source.sha256` all stamped 14:03, the artifact set replaced at run 1's start.
- `builder-vm/aarch64/kernels/` stamped 14:37, meaning `workload/` was created inside it by run *2*. The directory sat empty from 14:03 onward.

## What changed

Kernel entries now live at `<cache>/kernels/<arch>/<variant>/`, a sibling of `builder-vm/` rather than a child. Nothing about a kernel's identity depends on which builder image compiled it, so it does not belong in a directory whose contract is "atomically replaceable". Preserving `kernels/` across the promotion was the alternative; it keeps the artifact inside the bomb and re-creates the bug the next time someone adds a cache there.

`resolve_kernel` — the one gate every read passes through — adopts an entry left at the old path by renaming the directory. The digest sidecar and the size+mtime-keyed digest cache move with the bytes they describe, so an adopted entry stays verified and nobody pays for a rebuild. Adoption only ever moves into an absent destination, so a newer entry is never clobbered.

**The layout was hand-rebuilt at nine call sites**, including the writer, which built it as a format string. That is why relocating a path this simple needed a sweep rather than a one-line change. They now all route through `kernel_cache_dir` / `cached_kernel_path`.

## The cap, separately

`e2e-launch-modes.sh` now exports `MVM_BUILDER_VM_TIMEOUT_SECS=7200`, respecting an operator override. The 1800-second default is not enough for a cold workload-kernel build on a loaded host — run 1 was at load 11–14 on 16 cores — so the gate failed on a slow build rather than a broken one. `ci-full.yml:484` already runs its builder lane at 7200; the two no longer disagree about how long a build may take.

This is the second-order fix. On its own it would have left a gate that pays a half-hour rebuild on every fingerprint change and merely tolerates it.

## Verification

Workspace: **12,819 tests pass**, Clippy clean at `-D warnings`, doctests, `just check-gated`, and the xtask gates including `check-doc-claims`, `check-single-home`, `check-single-network-path`, `check-cli-help-matches-docs`, `check-no-overclaim`, `check-nextest-groups` and `check-sprint-append`.

Three new tests: an entry is not stored under `builder-vm/`, an entry at the old path is adopted rather than rebuilt, and adoption never clobbers a newer entry. The reproduction landed red first and asserts its own precondition — that the planted kernel resolves as `KernelResolution::Cached` — so it proves destruction rather than absence.

**Live on macOS 26 / Apple Silicon** against a real `~/.mvm` that still held a kernel at the old path:

- The migration fired and was a rename, not a rebuild: all four files kept their original mtimes, only the new parent directory was newly created.
- The adopted kernel still verifies — computed SHA-256 equals the recorded sidecar.
- `just e2e-launch` passed end to end, booting on the adopted kernel with no kernel build at all, including the in-process `mvm-client` seam (`transient_and_persistent_lifecycle_over_hvf`).

CI cannot exercise this lane: no hosted macOS runner boots a guest.

## Two things a reviewer should know

**A straggler survived the first sweep and failed the gate.** `e2e-launch-modes.sh` resolves the kernel for its in-process seam with its own shell `find` under `cache/builder-vm`, which a grep scoped to `*.rs` cannot see. The script failed loudly rather than reporting the skipped seam as a pass — that guard is the only reason it was caught, and it earned its keep. Fixed in the third commit; a full-tree re-sweep afterwards found no others. The remaining `builder-vm` hits are legitimate: the builder VM's *own* kernel at `builder-vm/<arch>/vmlinux`, builder-image test fixtures, and a frozen performance-evidence JSON left deliberately untouched.

**No gate could have caught the original bug.** Everything was green the whole time the cache was being destroyed, because nothing asserts that one cache's lifetime is independent of another's. The new `a_kernel_entry_is_not_stored_under_the_builder_vm_cache_directory` test guards this one recurrence, not the general shape.
