### PR TITLE
fix(flowmux): distinguish policy refusal from upstream failure

### DIFF
--- a/crates/mvm-agentd/src/flowmux.rs
+++ b/crates/mvm-agentd/src/flowmux.rs
@@ -61,6 +61,9 @@ pub enum FlowMuxError {
     /// The host refused an operation.
     #[error("refused: {0}")]
     Refused(String),
+    /// Policy admitted the target, but the host could not connect upstream.
+    #[error("upstream connect failed: {0}")]
+    UpstreamConnect(String),
     /// An internal channel was closed unexpectedly.
     #[error("client channel closed")]
     ChannelClosed,
@@ -1175,6 +1178,52 @@ mod tests {
         host.await.unwrap();
     }
 
+    #[tokio::test]
+    async fn guest_client_distinguishes_an_upstream_connect_failure() {
+        let (guest_stream, host_stream) = tokio::io::duplex(4096);
+        let (guest_key, _guest_anchor) = generate_keypair();
+        let (host_key, host_anchor) = generate_keypair();
+
+        let host = tokio::spawn(async move {
+            let (mut host_stream, mut host_session) = host_handshake(host_stream, host_key).await;
+
+            let _hello = recv_frame(&mut host_stream, &mut host_session)
+                .await
+                .unwrap();
+            send_frame(
+                &mut host_stream,
+                &mut host_session,
+                Opcode::HelloAck,
+                0,
+                &Handshake::local("test-host").encode(),
+            )
+            .await;
+
+            let (_opcode, sid, _len, _payload) = recv_frame(&mut host_stream, &mut host_session)
+                .await
+                .unwrap();
+            send_frame(
+                &mut host_stream,
+                &mut host_session,
+                Opcode::ConnectFailed,
+                sid,
+                b"connection failed",
+            )
+            .await;
+        });
+
+        let client = FlowMuxClient::connect(guest_stream, guest_key, host_anchor)
+            .await
+            .expect("guest handshake");
+        let err = client.open_tcp("example.com:80").await.unwrap_err();
+        assert!(
+            matches!(err, FlowMuxError::UpstreamConnect(_)),
+            "unexpected err: {err}"
+        );
+
+        host.await.unwrap();
+    }
+
     /// A fresh client has not handshaken yet. Publishing `Ready` at
     /// construction let a caller open a flow into a session that had agreed
     /// nothing, so a mismatched host looked healthy until the flow failed.
@@ -1451,6 +1500,7 @@ mod connect_retry_tests {
         for err in [
             FlowMuxError::Handshake("bad signature".into()),
             FlowMuxError::Refused("not admitted".into()),
+            FlowMuxError::UpstreamConnect("connection failed".into()),
             FlowMuxError::Frame("bad length prefix".into()),
             FlowMuxError::SessionClosed("go away".into()),
             FlowMuxError::ChannelClosed,

--- a/crates/mvm-agentd/src/flowmux/pump.rs
+++ b/crates/mvm-agentd/src/flowmux/pump.rs
@@ -343,6 +343,12 @@ where
                     let _ = respond.send(Err(FlowMuxError::refused(reason)));
                 }
             }
+            Opcode::ConnectFailed => {
+                let reason = String::from_utf8_lossy(&payload).into_owned();
+                if let Some(pending) = self.pending_opens.remove(&stream_id) {
+                    complete_pending_open_error(pending, FlowMuxError::UpstreamConnect(reason));
+                }
+            }
             Opcode::Resolved => {
                 if let Some(respond) = self.pending_resolves.remove(&stream_id) {
                     let _ = respond.send(Ok(payload));

--- a/crates/mvm-agentd/src/flowmux_egress.rs
+++ b/crates/mvm-agentd/src/flowmux_egress.rs
@@ -37,6 +37,18 @@ fn flowmux_to_io(error: FlowMuxError) -> io::Error {
     io::Error::new(io::ErrorKind::ConnectionAborted, error.to_string())
 }
 
+fn http_failure_status(error: &FlowMuxError) -> &'static str {
+    match error {
+        FlowMuxError::Refused(_) => "403 Forbidden",
+        FlowMuxError::Handshake(_)
+        | FlowMuxError::Frame(_)
+        | FlowMuxError::SessionClosed(_)
+        | FlowMuxError::Transport(_)
+        | FlowMuxError::UpstreamConnect(_)
+        | FlowMuxError::ChannelClosed => "502 Bad Gateway",
+    }
+}
+
 /// Bind the loopback proxy at `listen` and serve egress over one FlowMux
 /// session indefinitely.
 pub async fn run(listen: SocketAddr, flowmux: FlowMuxReconnectClient) -> io::Result<()> {
@@ -135,7 +147,7 @@ async fn serve_http_connect(
         }
         Err(error) => {
             let mut client = client;
-            write_connect_reply(&mut client, ProxyReplyStyle::HttpConnect, ConnectAck::Fail)
+            write_http_response(&mut client, http_failure_status(&error))
                 .await
                 .ok();
             Err(flowmux_to_io(error))
@@ -194,7 +206,7 @@ async fn serve_http_forward(
         }
         Err(error) => {
             let mut client = client;
-            write_http_response(&mut client, "502 Bad Gateway")
+            write_http_response(&mut client, http_failure_status(&error))
                 .await
                 .ok();
             Err(flowmux_to_io(error))
@@ -600,6 +612,18 @@ mod http_forward_tests {
         let signing = SigningKey::from_bytes(&bytes);
         let verifying = signing.verifying_key();
         (signing, verifying)
+    }
+
+    #[test]
+    fn policy_refusal_and_upstream_failure_have_distinct_http_statuses() {
+        assert_eq!(
+            http_failure_status(&FlowMuxError::Refused("not admitted".into())),
+            "403 Forbidden"
+        );
+        assert_eq!(
+            http_failure_status(&FlowMuxError::UpstreamConnect("connection failed".into())),
+            "502 Bad Gateway"
+        );
     }
 
     async fn send_frame<S>(

--- a/crates/mvm-contract/src/protocol/network_flow/frame.rs
+++ b/crates/mvm-contract/src/protocol/network_flow/frame.rs
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn an_unknown_opcode_is_refused() {
-        for v in [0x00u8, 0x04, 0x17, 0x56, 0xff] {
+        for v in [0x00u8, 0x04, 0x18, 0x56, 0xff] {
             let mut bytes = encode(Opcode::Data, 1, b"x").expect("encode");
             bytes[LENGTH_PREFIX_LEN + 5] = v;
             assert_eq!(decode(&bytes), Err(FrameError::UnknownOpcode(v)));
@@ -748,6 +748,7 @@ mod tests {
             (Opcode::WindowUpdate, 0x14),
             (Opcode::HalfClose, 0x15),
             (Opcode::Reset, 0x16),
+            (Opcode::ConnectFailed, 0x17),
             (Opcode::OpenUdp, 0x20),
             (Opcode::UdpOpened, 0x21),
             (Opcode::UdpSend, 0x22),

--- a/crates/mvm-contract/src/protocol/network_flow/hello.rs
+++ b/crates/mvm-contract/src/protocol/network_flow/hello.rs
@@ -24,7 +24,7 @@ use alloc::vec::Vec;
 /// different fail-closed rule. Leave it alone for changes a peer cannot
 /// observe. It is a declaration, not a derivation — nothing computes it,
 /// which is exactly why the bump belongs in the diff that earns it.
-pub const BEHAVIOR_REVISION: u32 = 2;
+pub const BEHAVIOR_REVISION: u32 = 3;
 
 /// The longest build label a peer may send. Long enough for a crate name
 /// and a version, short enough that it can never be the interesting part

--- a/crates/mvm-contract/src/protocol/network_flow/opcode.rs
+++ b/crates/mvm-contract/src/protocol/network_flow/opcode.rs
@@ -33,6 +33,8 @@ pub enum Opcode {
     HalfClose = 0x15,
     /// both: abortive teardown.
     Reset = 0x16,
+    /// host→guest: policy admitted the target, but the upstream connect failed.
+    ConnectFailed = 0x17,
 
     // ── UDP ──────────────────────────────────────────────────────────
     /// guest→host: open a UDP association.
@@ -140,6 +142,7 @@ impl Opcode {
             0x14 => Self::WindowUpdate,
             0x15 => Self::HalfClose,
             0x16 => Self::Reset,
+            0x17 => Self::ConnectFailed,
             0x20 => Self::OpenUdp,
             0x21 => Self::UdpOpened,
             0x22 => Self::UdpSend,
@@ -177,6 +180,7 @@ impl Opcode {
         Self::WindowUpdate,
         Self::HalfClose,
         Self::Reset,
+        Self::ConnectFailed,
         Self::OpenUdp,
         Self::UdpOpened,
         Self::UdpSend,
@@ -219,6 +223,7 @@ impl Opcode {
             Self::IcmpEcho | Self::IcmpReply | Self::IcmpRefused => FlowClass::Icmp,
             Self::Opened
             | Self::Refused
+            | Self::ConnectFailed
             | Self::Data
             | Self::WindowUpdate
             | Self::HalfClose
@@ -239,7 +244,7 @@ impl Opcode {
     pub const fn confirming_classes(self) -> Option<&'static [FlowClass]> {
         Some(match self {
             Self::Opened => &[FlowClass::Tcp, FlowClass::Http],
-            Self::Refused => &[
+            Self::Refused | Self::ConnectFailed => &[
                 FlowClass::Tcp,
                 FlowClass::Http,
                 FlowClass::Udp,
@@ -277,6 +282,7 @@ impl Opcode {
             self,
             Self::Reset
                 | Self::Refused
+                | Self::ConnectFailed
                 | Self::CloseUdp
                 | Self::Resolved
                 | Self::ResolveRefused
@@ -314,6 +320,7 @@ impl Opcode {
             Self::HelloAck
             | Self::Opened
             | Self::Refused
+            | Self::ConnectFailed
             | Self::UdpOpened
             | Self::UdpRecv
             | Self::Resolved
@@ -394,7 +401,7 @@ mod tests {
 
     #[test]
     fn unknown_discriminants_are_rejected_rather_than_passed_through() {
-        for v in [0x00u8, 0x04, 0x0f, 0x17, 0x25, 0x33, 0x43, 0x56, 0x7f, 0xff] {
+        for v in [0x00u8, 0x04, 0x0f, 0x18, 0x25, 0x33, 0x43, 0x56, 0x7f, 0xff] {
             assert_eq!(Opcode::from_u8(v), None, "{v:#04x} should be unknown");
         }
     }

--- a/crates/mvm-contract/src/protocol/network_flow/state.rs
+++ b/crates/mvm-contract/src/protocol/network_flow/state.rs
@@ -538,6 +538,7 @@ impl SessionValidator {
                 Ok(())
             }
             Opcode::Refused
+            | Opcode::ConnectFailed
             | Opcode::InboundRefused
             | Opcode::Reset
             | Opcode::CloseUdp

--- a/crates/mvm-hostd/src/supervisor/flowmux.rs
+++ b/crates/mvm-hostd/src/supervisor/flowmux.rs
@@ -722,7 +722,7 @@ impl FlowMuxSession {
             None => {
                 warn!(stream_id, %target, "FlowMux TCP connect failed");
                 let _ = lock_registry(&self.registry).retire(stream_id);
-                self.send_refused(stream_id, "connection failed")?;
+                self.send_connect_failed(stream_id, "connection failed")?;
                 self.emit_audit(
                     EventCategory::Host,
                     "host.flow.denied",
@@ -1380,6 +1380,13 @@ impl FlowMuxSession {
         warn!(stream_id, %reason, "FlowMux sending Refused");
         self.write_frame(Opcode::Refused, stream_id, reason.as_bytes())?;
         self.mark_sent(Opcode::Refused, stream_id);
+        Ok(())
+    }
+
+    fn send_connect_failed(&mut self, stream_id: u32, reason: &str) -> Result<(), FlowMuxError> {
+        warn!(stream_id, %reason, "FlowMux sending ConnectFailed");
+        self.write_frame(Opcode::ConnectFailed, stream_id, reason.as_bytes())?;
+        self.mark_sent(Opcode::ConnectFailed, stream_id);
         Ok(())
     }
 
@@ -2607,7 +2614,7 @@ mod tests {
             format!("{}:{}", ip, free_port).as_bytes(),
         );
         let (opcode, _stream_id, payload) = read_flowmux_frame(&mut guest, &mut guest_session);
-        assert_eq!(opcode, Opcode::Refused);
+        assert_eq!(opcode, Opcode::ConnectFailed);
         assert!(!payload.is_empty());
 
         drop(guest);

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-31
+Last updated: 2026-09-01
 
 ## In progress
 
@@ -17,6 +17,13 @@ Last updated: 2026-08-31
       tests, Clippy, doctests, policy gates, and a live macOS 26 `e2e-launch`
       run (migration confirmed a rename, not a rebuild) are green; merge
       delivery remains.
+
+- [ ] **Egress refusal status contract — issue #3040.**
+      `specs/plans/2026-09-01-egress-refusal-status.md`.
+      FlowMux now distinguishes a policy refusal (`403 Forbidden`) from an
+      admitted target whose upstream connection failed (`502 Bad Gateway`) on
+      the wire, with a behavior-revision bump and focused host/guest protocol
+      regressions. Full validation and merge delivery remain.
 
 - [ ] **machine diff handshake retry — issue #3024.**
       `specs/plans/2026-08-31-machine-diff-handshake-retry.md`.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -23,7 +23,8 @@ Last updated: 2026-09-01
       FlowMux now distinguishes a policy refusal (`403 Forbidden`) from an
       admitted target whose upstream connection failed (`502 Bad Gateway`) on
       the wire, with a behavior-revision bump and focused host/guest protocol
-      regressions. Full validation and merge delivery remain.
+      regressions. Workspace tests, Clippy, formatting, gated-target checks,
+      and documentation gates are green; merge delivery remains.
 
 - [ ] **machine diff handshake retry — issue #3024.**
       `specs/plans/2026-08-31-machine-diff-handshake-retry.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3440,3 +3440,16 @@ writes the plan:
 - [x] Prove response-read EOFs are returned without replay and repeated
       handshake hangups exhaust a bounded budget.
 - [ ] Merge the repair through the queue and close issue #3024.
+
+## 2026-09-01 egress refusal status contract
+
+- [x] Give an admitted target whose upstream connection fails its own
+      wire-stable FlowMux `ConnectFailed` outcome.
+- [x] Keep policy refusal distinct and translate it to HTTP 403 while genuine
+      upstream/transport failure remains HTTP 502.
+- [x] Bump the FlowMux behavior revision so stale host and guest halves refuse
+      one another instead of disagreeing about the new outcome.
+- [x] Add focused host, guest, HTTP-status, opcode, state-machine, and handshake
+      regressions.
+- [ ] Complete the full validation matrix, merge through the queue, and close
+      issue #3040 from landed evidence.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3451,5 +3451,6 @@ writes the plan:
       one another instead of disagreeing about the new outcome.
 - [x] Add focused host, guest, HTTP-status, opcode, state-machine, and handshake
       regressions.
-- [ ] Complete the full validation matrix, merge through the queue, and close
-      issue #3040 from landed evidence.
+- [x] Complete the full workspace, Clippy, formatting, gated-target, and
+      documentation validation matrix.
+- [ ] Merge through the queue and close issue #3040 from landed evidence.

--- a/specs/plans/2026-09-01-egress-refusal-status.md
+++ b/specs/plans/2026-09-01-egress-refusal-status.md
@@ -1,0 +1,20 @@
+# Egress refusal status contract
+
+Issue #3040 exposed that the guest loopback HTTP proxy translated every failed
+FlowMux TCP open into `502 Bad Gateway`. That erased the distinction between a
+host refused before any upstream connection was attempted and an admitted host
+whose upstream connection actually failed.
+
+## Delivery checklist
+
+- [x] Add a wire-stable `ConnectFailed` FlowMux outcome for an admitted target
+      whose upstream connection fails, and bump the behavior revision.
+- [x] Preserve `Refused` for policy decisions and surface it to HTTP clients as
+      `403 Forbidden`.
+- [x] Preserve genuine upstream and transport failures as `502 Bad Gateway`.
+- [x] Cover the host decision, guest decoding, status mapping, discriminant,
+      direction, state-machine, and handshake-revision contracts.
+- [ ] Pass workspace tests, Clippy, formatting, gated-target checks, and the
+      sprint/refactor documentation gates.
+- [ ] Merge the repair through the queue and close issue #3040 from the merged
+      evidence.

--- a/specs/plans/2026-09-01-egress-refusal-status.md
+++ b/specs/plans/2026-09-01-egress-refusal-status.md
@@ -1,5 +1,8 @@
 # Egress refusal status contract
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 Issue #3040 exposed that the guest loopback HTTP proxy translated every failed
 FlowMux TCP open into `502 Bad Gateway`. That erased the distinction between a
 host refused before any upstream connection was attempted and an admitted host
@@ -14,7 +17,7 @@ whose upstream connection actually failed.
 - [x] Preserve genuine upstream and transport failures as `502 Bad Gateway`.
 - [x] Cover the host decision, guest decoding, status mapping, discriminant,
       direction, state-machine, and handshake-revision contracts.
-- [ ] Pass workspace tests, Clippy, formatting, gated-target checks, and the
+- [x] Pass workspace tests, Clippy, formatting, gated-target checks, and the
       sprint/refactor documentation gates.
 - [ ] Merge the repair through the queue and close issue #3040 from the merged
       evidence.


### PR DESCRIPTION
## Summary
- add a wire-stable FlowMux outcome for admitted upstream connection failures
- map policy refusal to HTTP 403 while preserving HTTP 502 for upstream and transport failures
- bump the FlowMux behavior revision and cover host, guest, opcode, state-machine, and HTTP mappings

Fixes #3040

## Validation
- just dev-test
- cargo clippy --workspace -- -D warnings
- cargo check --workspace
- just check-gated
- cargo run -p xtask -- check-sprint-append
- cargo run -p xtask -- check-declared-backing
- cargo run -p xtask -- check-plan-names
- cargo run -p xtask -- check-no-spec-refs-in-comments