### PR TITLE
fix(warm): authenticate restored child readiness

### DIFF
--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -564,6 +564,18 @@ fn residency_source() -> mvm_core::residency::ResidencySource {
     mvm_core::residency::resolve_residency().1
 }
 
+fn warm_launch_mode(
+    source: mvm_core::residency::ResidencySource,
+    require_claim_override: bool,
+) -> WarmLaunchMode {
+    if require_claim_override || matches!(source, mvm_core::residency::ResidencySource::EnvOverride)
+    {
+        WarmLaunchMode::Required
+    } else {
+        WarmLaunchMode::Optional
+    }
+}
+
 pub fn warm_to_target(pool: &SupervisorStandbyPool, p: &WarmParams<'_>) -> Result<WarmResult> {
     if p.target == 0 {
         return Ok(WarmResult {
@@ -1017,11 +1029,10 @@ pub fn try_warm_claim(
     let bundle_json = cfg.bundle_json.clone();
     let claim_start_config = cfg.clone();
     let pool = SupervisorStandbyPool::open()?;
-    let claim_mode = if std::env::var("MVM_HVF_WARM_REQUIRE_CLAIM").as_deref() == Ok("1") {
-        WarmLaunchMode::Required
-    } else {
-        WarmLaunchMode::Optional
-    };
+    let claim_mode = warm_launch_mode(
+        residency_source(),
+        std::env::var("MVM_HVF_WARM_REQUIRE_CLAIM").as_deref() == Ok("1"),
+    );
     let make_claim = |handle: &StandbyHandle| {
         // The audit substrate (`gateway-<vm>.sock`) is name-keyed; the claimed VM runs
         // under the standby-id, so compute it for `handle.id`.
@@ -1515,6 +1526,30 @@ mod tests {
         assert!(unsupported_standby_pool_is_fatal(
             mvm_core::residency::ResidencySource::EnvOverride
         ));
+    }
+
+    #[test]
+    fn an_operator_requested_warm_launch_refuses_a_failed_claim() {
+        assert_eq!(
+            warm_launch_mode(mvm_core::residency::ResidencySource::EnvOverride, false),
+            WarmLaunchMode::Required
+        );
+    }
+
+    #[test]
+    fn a_host_default_warm_launch_may_fall_back_to_cold() {
+        assert_eq!(
+            warm_launch_mode(mvm_core::residency::ResidencySource::AutoDetect, false),
+            WarmLaunchMode::Optional
+        );
+    }
+
+    #[test]
+    fn a_required_claim_override_remains_fail_closed() {
+        assert_eq!(
+            warm_launch_mode(mvm_core::residency::ResidencySource::AutoDetect, true),
+            WarmLaunchMode::Required
+        );
     }
 
     #[test]

--- a/crates/mvm-vmm/src/post_restore.rs
+++ b/crates/mvm-vmm/src/post_restore.rs
@@ -157,6 +157,23 @@ pub const POST_RESTORE_PROBE_INTERVAL: Duration = Duration::from_millis(50);
 /// another; tests pass their own.
 pub const POST_RESTORE_READY_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Bound each authenticated readiness exchange so one accepted-but-unserved
+/// transport cannot consume the whole restore deadline in a blocking read.
+const POST_RESTORE_PROBE_IO_TIMEOUT: Duration = Duration::from_secs(1);
+
+fn authenticated_agent_is_ready(stream: &mut std::os::unix::net::UnixStream) -> bool {
+    if stream
+        .set_read_timeout(Some(POST_RESTORE_PROBE_IO_TIMEOUT))
+        .is_err()
+        || stream
+            .set_write_timeout(Some(POST_RESTORE_PROBE_IO_TIMEOUT))
+            .is_err()
+    {
+        return false;
+    }
+    mvm_agentd::vsock::probe_agent_ready(stream).is_ok()
+}
+
 /// After a snapshot restore resumes vCPUs, wait for the guest agent to be
 /// reachable (so a slow-to-reattach guest does not spuriously report
 /// `Undelivered`), then signal the guest to finish re-establishing itself.
@@ -258,9 +275,10 @@ impl PostRestoreSignal for VsockPostRestoreSignal {
         let Ok(transport) = crate::vsock_transport::for_vm(vm_name) else {
             return false;
         };
-        transport
-            .connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
-            .is_ok()
+        let Ok(mut stream) = transport.connect(mvm_agentd::vsock::GUEST_AGENT_PORT) else {
+            return false;
+        };
+        authenticated_agent_is_ready(&mut stream)
     }
 
     fn post_restore(&self, vm_name: &str) -> Result<PostRestoreOutcome> {
@@ -297,6 +315,63 @@ impl PostRestoreSignal for VsockPostRestoreSignal {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ed25519_dalek::SigningKey;
+    use rand::Rng;
+    use std::os::unix::net::UnixStream;
+
+    fn seeded_host_signer(home: &std::path::Path) -> SigningKey {
+        let mut seed = [0u8; 32];
+        rand::rng().fill_bytes(&mut seed);
+        let keys = mvm_core::config::mvm_keys_dir();
+        assert!(keys.starts_with(home));
+        std::fs::create_dir_all(&keys).unwrap();
+        std::fs::write(keys.join("host-signer.ed25519"), seed).unwrap();
+        SigningKey::from_bytes(&seed)
+    }
+
+    #[test]
+    fn post_restore_readiness_rejects_a_connected_but_silent_guest() {
+        let home = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", home.path());
+        let _host_key = seeded_host_signer(home.path());
+        let (mut host, guest) = UnixStream::pair().unwrap();
+        drop(guest);
+
+        assert!(!authenticated_agent_is_ready(&mut host));
+    }
+
+    #[test]
+    fn post_restore_readiness_accepts_an_authenticated_guest_ping() {
+        let home = tempfile::tempdir().unwrap();
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.set("MVM_HOME", home.path());
+        let host_key = seeded_host_signer(home.path());
+        let anchor = host_key.verifying_key();
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        guest
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let guest_thread = std::thread::spawn(move || {
+            let mut guest_seed = [0u8; 32];
+            rand::rng().fill_bytes(&mut guest_seed);
+            let mut session = mvm_agentd::vsock::AuthenticatedSession::guest(
+                &mut guest,
+                SigningKey::from_bytes(&guest_seed),
+                &anchor,
+            )
+            .expect("guest handshake");
+            let request: mvm_agentd::vsock::GuestRequest =
+                session.read(&mut guest).expect("read readiness request");
+            assert!(matches!(request, mvm_agentd::vsock::GuestRequest::Ping));
+            session
+                .write(&mut guest, &mvm_agentd::vsock::GuestResponse::Pong)
+                .expect("write readiness response");
+        });
+
+        assert!(authenticated_agent_is_ready(&mut host));
+        guest_thread.join().unwrap();
+    }
 
     /// A mock signal source that becomes ready after a configurable number of
     /// probes so the "poll until ready, then send once" policy is testable

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,15 @@ Last updated: 2026-08-31
 
 ## In progress
 
+- [ ] **Warm claim authenticated readiness — issue #3039.**
+      `specs/plans/2026-08-31-warm-claim-authenticated-readiness.md`.
+      A restored child advances only after an authenticated Ping proves its
+      guest agent is serving; accepted-but-silent transports stay in the bounded
+      readiness loop. Explicit warm residency now fails closed on a rejected
+      claim, while auto-detected warm residency may retain its cold fallback.
+      Workspace tests, zero-warning Clippy, Linux/BDD gated compilation, and
+      policy checks are green; merge delivery remains.
+
 - [ ] **Kernel cache moved out of the Stage 0 blast radius.**
       `specs/sprint/delivery/kernel-cache-outside-stage0-blast-radius.md`.
       The workload kernel was cached inside `builder-vm/<arch>`, the directory

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,16 @@
 
 ## In progress
 
+- [ ] **Warm claim authenticated readiness — issue #3039.**
+      `specs/plans/2026-08-31-warm-claim-authenticated-readiness.md`.
+      Post-restore readiness now requires the existing authenticated guest-agent
+      Ping instead of a bare socket connection, with bounded per-probe I/O.
+      Explicit warm residency refuses a failed claim instead of silently
+      cold-booting; host-default warm residency remains best-effort. Focused
+      positive, silent-peer, and launch-policy regressions, workspace tests,
+      zero-warning Clippy, Linux/BDD gated compilation, and policy checks are
+      green. Merge delivery remains.
+
 - [ ] **Wasmtime security update — issues #3018 and #3020.**
       `specs/plans/2026-08-31-wasmtime-security-update.md`.
       The optional Wasm backend's locked Wasmtime family is updated from

--- a/specs/plans/2026-08-31-warm-claim-authenticated-readiness.md
+++ b/specs/plans/2026-08-31-warm-claim-authenticated-readiness.md
@@ -1,0 +1,35 @@
+# Warm claim authenticated readiness
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+Issue: #3039
+
+## Problem
+
+A restored standby child was considered ready as soon as the VMM accepted a
+connection to its guest-agent port. The transport exists before the guest agent
+is serving, so the following authenticated `PostRestore` RPC could race the
+guest and fail. Optional warm launches then discarded the dead standby and
+cold-booted, hiding the failed claim behind a warning.
+
+## Contract
+
+- [x] Settle post-restore readiness on the guest-agent wire with the existing
+      authenticated Ping exchange, not a successful socket connection.
+- [x] Bound each probe's reads and writes so an accepted but unserved transport
+      cannot consume the complete restore deadline.
+- [x] Keep auto-detected warm residency best-effort, but treat an operator's
+      explicit `MVM_RESIDENCY` request as requiring a successful warm claim.
+- [x] Cover both a connected silent peer and a serving authenticated guest.
+- [x] Cover required versus optional warm-launch policy without process-global
+      environment mutation.
+- [x] Pass workspace tests, workspace Clippy, gated Linux/BDD compilation, and
+      repository policy checks.
+- [ ] Merge through the queue and let the merged PR close #3039.
+
+## Security
+
+Readiness uses the same authenticated session handshake as the operational RPC.
+A socket owner that cannot prove the pinned host/guest session and answer a
+framed Ping is never allowed to advance the restore state machine.


### PR DESCRIPTION
## Summary
- require an authenticated guest-agent Ping before post-restore delivery
- bound each readiness probe and keep polling connected-but-silent transports
- fail visibly when an explicit warm-residency claim fails while preserving host-default cold fallback

## Validation
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cargo check --workspace
- just check-gated
- repository sprint/backing/plan/comment policy checks

Fixes #3039