### PR TITLE
fix(run): propagate baked workload exit codes

### DIFF
--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -643,6 +643,30 @@ impl<L, R> Either<L, R> {
     }
 }
 
+fn boots_baked_entrypoint(req: &ExecRequest) -> bool {
+    matches!(&req.target, ExecTarget::Inline { argv } if argv.is_empty())
+}
+
+fn baked_entrypoint_result(
+    status: mvm_core::vm_backend::VmExitStatus,
+    capture: bool,
+    vm_name: &str,
+) -> Result<Either<i32, ExecOutput>> {
+    let code = status.code.with_context(|| {
+        format!("baked workload in {vm_name} stopped without reporting its exit code")
+    })?;
+    if capture {
+        Ok(Either::Right(ExecOutput {
+            exit_code: code,
+            stdout: String::new(),
+            stderr: String::new(),
+            phase_timing: None,
+        }))
+    } else {
+        Ok(Either::Left(code))
+    }
+}
+
 /// Side channel by which [`run_inner`] reports the resolved boot posture (which
 /// rootfs strategy the run-path tier gate selected) back to the command layer,
 /// which records it on the chain-signed admission log (`plan.boot_posture`).
@@ -749,6 +773,13 @@ fn run_inner(
             Ok(code) => Ok((Either::Left(code), None)),
             Err(e) => Err(e),
         }
+    } else if boots_baked_entrypoint(&req) {
+        let workload_started = timing.then(std::time::Instant::now);
+        backend
+            .wait(&mvm_core::vm_backend::VmId(vm_name.clone()))
+            .with_context(|| format!("waiting for baked workload in {vm_name}"))
+            .and_then(|status| baked_entrypoint_result(status, capture, &vm_name))
+            .map(|result| (result, workload_started))
     } else {
         run_in_guest(&vm_name, &req, capture, timing, &mut sub_marks)
     };
@@ -1454,6 +1485,68 @@ mod tests {
     use super::*;
 
     use mvm_core::util::test_env::TestEnv;
+
+    fn baked_entrypoint_request() -> ExecRequest {
+        ExecRequest {
+            name: None,
+            warm_pool_size: 0,
+            image: ImageSource::Template("flake-slot".into()),
+            cpus: 1,
+            memory_mib: 256,
+            mem_initial_mib: None,
+            dir_shares: Vec::new(),
+            disk_volumes: Vec::new(),
+            env: Vec::new(),
+            target: ExecTarget::Inline { argv: Vec::new() },
+            timeout_secs: Some(120),
+            pty: false,
+            network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+            stdin: Vec::new(),
+            healthcheck: None,
+            hypervisor: None,
+            sdk_sidecar: None,
+        }
+    }
+
+    #[test]
+    fn an_empty_inline_target_waits_for_the_images_baked_entrypoint() {
+        assert!(boots_baked_entrypoint(&baked_entrypoint_request()));
+
+        let mut request = baked_entrypoint_request();
+        request.target = ExecTarget::Inline {
+            argv: vec!["/bin/true".into()],
+        };
+        assert!(!boots_baked_entrypoint(&request));
+    }
+
+    #[test]
+    fn a_baked_entrypoint_preserves_its_reported_nonzero_exit_code() {
+        let status = mvm_core::vm_backend::VmExitStatus {
+            code: Some(7),
+            success: false,
+        };
+        let result = baked_entrypoint_result(status, false, "vm-flake")
+            .expect("reported exit code must be returned");
+        assert_eq!(result.left(), Some(7));
+    }
+
+    #[test]
+    fn a_baked_entrypoint_without_an_exit_report_fails_closed() {
+        let result = baked_entrypoint_result(
+            mvm_core::vm_backend::VmExitStatus::UNKNOWN,
+            false,
+            "vm-flake",
+        );
+        let error = match result {
+            Ok(_) => panic!("missing exit report must not become success"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("without reporting its exit code")
+        );
+    }
 
     #[test]
     fn build_healthcheck_wraps_shell_command() {

--- a/examples/exit_code/flake.nix
+++ b/examples/exit_code/flake.nix
@@ -11,7 +11,7 @@
   #
   # The host (mvmctl machine run --flake .) reads the reported code and exits with it.
   # This fixture bakes `sh -c 'exit 7'` as the sealed workload so a clean
-  # E2E run of `mvmctl machine run --flake ./examples/exit_code --wait` must exit 7.
+  # E2E run of `mvmctl machine run --flake ./examples/exit_code --timeout 120` must exit 7.
   #
   # ── Canonical user-flake form (matches `mvmctl compile`'s output) ──
   #

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -13,6 +13,14 @@ Last updated: 2026-09-01
       Workspace tests, zero-warning Clippy, Linux/BDD gated compilation, and
       policy checks are green; merge delivery remains.
 
+- [ ] **Flake workload exit-code propagation — issue #3041.**
+      `specs/plans/2026-08-31-flake-exit-code-propagation.md`.
+      Empty manifest argv now means the image owns execution: the run path
+      waits for the backend's sealed workload result, preserves its nonzero
+      exit code, and rejects a missing report. Focused regressions, the
+      workspace suite, zero-warning Clippy, workspace check, and gated-target
+      compilation are green; merge delivery remains.
+
 - [ ] **Kernel cache moved out of the Stage 0 blast radius.**
       `specs/sprint/delivery/kernel-cache-outside-stage0-blast-radius.md`.
       The workload kernel was cached inside `builder-vm/<arch>`, the directory

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -29,6 +29,14 @@
       workspace, Clippy, gated-target, formatting, and policy validation is
       green; merge delivery remains.
 
+- [ ] **Flake workload exit-code propagation — issue #3041.**
+      `specs/plans/2026-08-31-flake-exit-code-propagation.md`.
+      A manifest slot with no inline argv now waits on the backend's sealed
+      workload result, preserves nonzero exit codes, and fails closed when the
+      guest supplies no exit report. Focused regressions, the workspace suite,
+      zero-warning Clippy, workspace check, and gated-target compilation are
+      green; merge delivery remains.
+
 - [ ] **Wasmtime security update — issues #3018 and #3020.**
       `specs/plans/2026-08-31-wasmtime-security-update.md`.
       The optional Wasm backend's locked Wasmtime family is updated from
@@ -3483,3 +3491,14 @@ writes the plan:
 - [x] Cover musl acquisition, unknown-libc refusal, and release-name coupling.
 - [x] Complete workspace and gated validation.
 - [ ] Merge the repair through the queue and close issue #3045.
+
+## 2026-08-31 flake workload exit-code propagation
+
+- [x] Identify the empty inline target emitted for an image-baked flake
+      workload without changing explicit command dispatch.
+- [x] Wait through the selected backend and preserve its reported nonzero exit
+      code.
+- [x] Fail closed when the workload stops without an exit report and correct
+      the example's unsupported CLI flag.
+- [x] Complete workspace and gated validation.
+- [ ] Merge the repair through the queue and close issue #3041.

--- a/specs/plans/2026-08-31-flake-exit-code-propagation.md
+++ b/specs/plans/2026-08-31-flake-exit-code-propagation.md
@@ -1,0 +1,22 @@
+# Flake exit-code propagation
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+## Goal
+
+Make `machine run --flake` wait for the image's baked workload and return its
+reported exit code instead of dispatching an empty guest command that masks a
+nonzero result as success.
+
+## Checklist
+
+- [x] Trace the flake run path from its generated manifest slot through guest
+      command dispatch and backend workload waiting.
+- [x] Distinguish an image-baked entrypoint from an explicit inline command.
+- [x] Return the backend's reported workload exit code and fail closed when no
+      exit report exists.
+- [x] Add focused regressions for command selection, nonzero propagation, and
+      a missing exit report.
+- [x] Run workspace and gated validation.
+- [ ] Merge the repair through the queue.


### PR DESCRIPTION
## Summary

- recognize an empty manifest argv as an image-baked entrypoint
- wait for the selected backend workload result and preserve its reported exit code
- fail closed when no exit report exists and correct the exit-code example command

Fixes #3041

## Validation

- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cargo check --workspace
- just check-gated
- cargo fmt --all -- --check
- cargo run -p xtask -- check-all (62 gates clean)