### PR TITLE
fix(release): publish both SDK sidecar libc variants

### DIFF
--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -331,16 +331,16 @@ jobs:
             staging/runtime-overlay-${{ matrix.arch }}.tar.gz
             staging/runtime-overlay-${{ matrix.arch }}.tar.gz.sha256
 
-  # ADR-018: the optional glibc SDK-sidecar disk. Mounted read-only at
+  # ADR-018: the optional SDK-sidecar disk. Mounted read-only at
   # /mvm/sdk, and only for workloads whose signed plan binds an SDK-served
-  # host service — so a workload that never calls one never pays for the glibc
-  # closure. Built per-arch from the same `nix/images/runtime-overlay/` flake
-  # as the overlay.
+  # host service — so a workload that never calls one never pays for the
+  # closure. Built per-architecture and per-libc from the same
+  # `nix/images/runtime-overlay/` flake as the overlay.
   #
   # The host-side downloader (`mvm_build::sdk_sidecar::download_sdk_sidecar`)
-  # fetches one arch-qualified tarball plus its sha256 sidecar, and installs the
+  # fetches one arch-and-libc-qualified tarball plus its sha256 sidecar, and installs the
   # extracted canonical names (`sdk.ext4`, `VERSION`, `checksums-sha256.txt`)
-  # into `~/.mvm/cache/sdk-sidecar/<mvmctl-version>/<arch>/`. The asset names
+  # into `~/.mvm/cache/sdk-sidecar/<mvmctl-version>/<arch>/<libc>/`. The asset names
   # here are pinned against that Rust constructor by `tests/release_assets.rs`.
   #
   # Unlike the overlay job this does NOT regenerate the manifest: the
@@ -362,8 +362,28 @@ jobs:
         include:
           - arch: aarch64
             runner: ubuntu-24.04-arm
+            libc: glibc
+            package: sdk-sidecar-image
+            archive: sdk-sidecar-aarch64-glibc.tar.gz
+            checksum: sdk-sidecar-aarch64-glibc.tar.gz.sha256
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+            libc: musl
+            package: sdk-sidecar-image-musl
+            archive: sdk-sidecar-aarch64-musl.tar.gz
+            checksum: sdk-sidecar-aarch64-musl.tar.gz.sha256
           - arch: x86_64
             runner: ubuntu-latest
+            libc: glibc
+            package: sdk-sidecar-image
+            archive: sdk-sidecar-x86_64-glibc.tar.gz
+            checksum: sdk-sidecar-x86_64-glibc.tar.gz.sha256
+          - arch: x86_64
+            runner: ubuntu-latest
+            libc: musl
+            package: sdk-sidecar-image-musl
+            archive: sdk-sidecar-x86_64-musl.tar.gz
+            checksum: sdk-sidecar-x86_64-musl.tar.gz.sha256
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
@@ -374,33 +394,36 @@ jobs:
       - name: Build SDK sidecar image
         env:
           ARCH: ${{ matrix.arch }}
+          LIBC: ${{ matrix.libc }}
+          PACKAGE: ${{ matrix.package }}
+          ARCHIVE: ${{ matrix.archive }}
+          CHECKSUM: ${{ matrix.checksum }}
         run: |
           SYSTEM="${ARCH}-linux"
-          nix build "./nix/images/runtime-overlay#packages.${SYSTEM}.sdk-sidecar-image" \
+          nix build "./nix/images/runtime-overlay#packages.${SYSTEM}.${PACKAGE}" \
             --no-link --print-out-paths > /tmp/store-path.txt
           STORE_PATH=$(head -1 /tmp/store-path.txt)
-          mkdir -p "staging/sdk-sidecar-${ARCH}"
+          mkdir -p "staging/sdk-sidecar-${ARCH}-${LIBC}"
           # cp -L so the payload resolves through nix-store symlinks into the
           # actual blobs; the artifact uploader doesn't follow symlinks.
-          cp -L "$STORE_PATH/sdk.ext4"             "staging/sdk-sidecar-${ARCH}/sdk.ext4"
-          cp -L "$STORE_PATH/VERSION"              "staging/sdk-sidecar-${ARCH}/VERSION"
-          cp -L "$STORE_PATH/checksums-sha256.txt" "staging/sdk-sidecar-${ARCH}/checksums-sha256.txt"
-          tar -C "staging/sdk-sidecar-${ARCH}" \
-            -czf "staging/sdk-sidecar-${ARCH}.tar.gz" \
+          cp -L "$STORE_PATH/sdk.ext4"             "staging/sdk-sidecar-${ARCH}-${LIBC}/sdk.ext4"
+          cp -L "$STORE_PATH/VERSION"              "staging/sdk-sidecar-${ARCH}-${LIBC}/VERSION"
+          cp -L "$STORE_PATH/checksums-sha256.txt" "staging/sdk-sidecar-${ARCH}-${LIBC}/checksums-sha256.txt"
+          tar -C "staging/sdk-sidecar-${ARCH}-${LIBC}" \
+            -czf "staging/${ARCHIVE}" \
             sdk.ext4 VERSION checksums-sha256.txt
           (
             cd staging
-            sha256sum "sdk-sidecar-${ARCH}.tar.gz" \
-              > "sdk-sidecar-${ARCH}.tar.gz.sha256"
+            sha256sum "${ARCHIVE}" > "${CHECKSUM}"
           )
 
       - name: Upload SDK sidecar image artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: sdk-sidecar-image-${{ matrix.arch }}
+          name: sdk-sidecar-image-${{ matrix.arch }}-${{ matrix.libc }}
           path: |
-            staging/sdk-sidecar-${{ matrix.arch }}.tar.gz
-            staging/sdk-sidecar-${{ matrix.arch }}.tar.gz.sha256
+            staging/${{ matrix.archive }}
+            staging/${{ matrix.checksum }}
 
   # Plan 158: the bundled default microVM image `mvmctl up`/`exec` boots when
   # no --flake/--template/--image is given. Ships the PROD variant only
@@ -852,9 +875,15 @@ jobs:
               "builder-vm-vmlinux-${arch}" \
               "builder-vm-rootfs-${arch}.ext4" \
               "builder-vm-${arch}-checksums-sha256.txt" \
-              "runtime-overlay-${arch}.tar.gz" \
-              "sdk-sidecar-${arch}.tar.gz"; do
+              "runtime-overlay-${arch}.tar.gz"; do
               [ -s "artifacts/${f}" ] || missing+=("${f}")
+            done
+            for libc in glibc musl; do
+              for f in \
+                "sdk-sidecar-${arch}-${libc}.tar.gz" \
+                "sdk-sidecar-${arch}-${libc}.tar.gz.sha256"; do
+                [ -s "artifacts/${f}" ] || missing+=("${f}")
+              done
             done
           done
           for f in \
@@ -892,9 +921,12 @@ jobs:
             artifacts/runtime-overlay-*.tar.gz
             artifacts/runtime-overlay-*.tar.gz.sha256
             artifacts/runtime-overlay-*.tar.gz.bundle
-            artifacts/sdk-sidecar-*.tar.gz
-            artifacts/sdk-sidecar-*.tar.gz.sha256
-            artifacts/sdk-sidecar-*.tar.gz.bundle
+            artifacts/sdk-sidecar-*-glibc.tar.gz
+            artifacts/sdk-sidecar-*-glibc.tar.gz.sha256
+            artifacts/sdk-sidecar-*-glibc.tar.gz.bundle
+            artifacts/sdk-sidecar-*-musl.tar.gz
+            artifacts/sdk-sidecar-*-musl.tar.gz.sha256
+            artifacts/sdk-sidecar-*-musl.tar.gz.bundle
             artifacts/qemu-wasm-smoke-pack.tar.gz
             artifacts/qemu-wasm-smoke-pack.tar.gz.sha256
             artifacts/qemu-wasm-smoke-pack.tar.gz.sha256.bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,8 +444,16 @@ jobs:
               "default-microvm-${arch}-checksums-sha256.txt" \
               "builder-vm-vmlinux-${arch}" \
               "builder-vm-rootfs-${arch}.ext4" \
-              "builder-vm-${arch}-checksums-sha256.txt"; do
+              "builder-vm-${arch}-checksums-sha256.txt" \
+              "runtime-overlay-${arch}.tar.gz"; do
               [ -s "artifacts/${f}" ] || missing+=("${f}")
+            done
+            for libc in glibc musl; do
+              for f in \
+                "sdk-sidecar-${arch}-${libc}.tar.gz" \
+                "sdk-sidecar-${arch}-${libc}.tar.gz.sha256"; do
+                [ -s "artifacts/${f}" ] || missing+=("${f}")
+              done
             done
           done
           if [ ${#missing[@]} -gt 0 ]; then
@@ -544,32 +552,48 @@ jobs:
           mkdir -p "${STAGE}"
 
           checked=0
-          for kind in runtime-overlay sdk-sidecar; do
-            for arch in aarch64 x86_64; do
-              archive="artifacts/${kind}-${arch}.tar.gz"
-              [ -f "${archive}" ] || continue
-              for suffix in "" ".sha256" ".bundle"; do
-                src="${archive}${suffix}"
-                if [ ! -f "${src}" ]; then
-                  echo "::error::${src} is missing — a published archive without its checksum and signature cannot be acquired" >&2
-                  exit 1
-                fi
-                cp "${src}" "${STAGE}/"
-              done
+          verify_archive() {
+            local kind="$1"
+            local arch="$2"
+            local libc="${3:-}"
+            local archive example_kind
+            if [ "${kind}" = sdk-sidecar ]; then
+              archive="artifacts/sdk-sidecar-${arch}-${libc}.tar.gz"
+              example_kind=sidecar
+            else
+              archive="artifacts/runtime-overlay-${arch}.tar.gz"
+              example_kind=overlay
+            fi
+            [ -f "${archive}" ] || return 0
+            for suffix in "" ".sha256" ".bundle"; do
+              src="${archive}${suffix}"
+              if [ ! -f "${src}" ]; then
+                echo "::error::${src} is missing — a published archive without its checksum and signature cannot be acquired" >&2
+                exit 1
+              fi
+              cp "${src}" "${STAGE}/"
+            done
 
-              case "${kind}" in
-                runtime-overlay) example_kind=overlay ;;
-                sdk-sidecar)     example_kind=sidecar ;;
-              esac
-              echo "Consuming ${kind}-${arch} through the production download path..."
-              cargo run --release -p mvm-build --example download-release-artifact \
-                --features manifest-verify -- \
-                --kind "${example_kind}" \
-                --base-url "file://$(pwd)/consumer-check" \
-                --version "${VERSION}" \
-                --arch "${arch}" \
-                --cache "$(mktemp -d)"
-              checked=$((checked + 1))
+            consumer_args=(
+              --kind "${example_kind}"
+              --base-url "file://$(pwd)/consumer-check"
+              --version "${VERSION}"
+              --arch "${arch}"
+              --cache "$(mktemp -d)"
+            )
+            if [ -n "${libc}" ]; then
+              consumer_args+=(--libc "${libc}")
+            fi
+            echo "Consuming ${kind}-${arch}${libc:+-${libc}} through the production download path..."
+            cargo run --release -p mvm-build --example download-release-artifact \
+              --features manifest-verify -- "${consumer_args[@]}"
+            checked=$((checked + 1))
+          }
+
+          for arch in aarch64 x86_64; do
+            verify_archive runtime-overlay "${arch}"
+            for libc in glibc musl; do
+              verify_archive sdk-sidecar "${arch}" "${libc}"
             done
           done
 
@@ -641,10 +665,13 @@ jobs:
             artifacts/runtime-overlay-*.tar.gz.sha256
             artifacts/initramfs-*.tar.gz
             artifacts/initramfs-*.tar.gz.sha256
-            artifacts/sdk-sidecar-*.tar.gz
-            artifacts/sdk-sidecar-*.tar.gz.sha256
+            artifacts/sdk-sidecar-*-glibc.tar.gz
+            artifacts/sdk-sidecar-*-glibc.tar.gz.sha256
+            artifacts/sdk-sidecar-*-musl.tar.gz
+            artifacts/sdk-sidecar-*-musl.tar.gz.sha256
             artifacts/runtime-overlay-*.tar.gz.bundle
-            artifacts/sdk-sidecar-*.tar.gz.bundle
+            artifacts/sdk-sidecar-*-glibc.tar.gz.bundle
+            artifacts/sdk-sidecar-*-musl.tar.gz.bundle
             artifacts/default-microvm-vmlinux-*
             artifacts/default-microvm-rootfs-*
             artifacts/default-microvm-meta-*

--- a/crates/mvm-build/examples/download-release-artifact.rs
+++ b/crates/mvm-build/examples/download-release-artifact.rs
@@ -14,7 +14,7 @@
 //!
 //! ```text
 //! download-release-artifact --kind sidecar --base-url file:///abs/staging \
-//!   --version 0.18.0 --arch x86_64 --cache /tmp/verify-cache
+//!   --version 0.18.0 --arch x86_64 --libc musl --cache /tmp/verify-cache
 //! ```
 //!
 //! Exits 0 only when the artifact installs *and* resolves.
@@ -22,6 +22,7 @@
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use mvm_contract::guest_libc::GuestLibc;
 use mvm_core::arch::GuestArch;
 
 enum Kind {
@@ -34,11 +35,13 @@ struct Args {
     base_url: String,
     version: String,
     arch: GuestArch,
+    libc: Option<GuestLibc>,
     cache: PathBuf,
 }
 
 fn parse_args() -> Result<Args, String> {
-    let (mut kind, mut base_url, mut version, mut arch, mut cache) = (None, None, None, None, None);
+    let (mut kind, mut base_url, mut version, mut arch, mut libc, mut cache) =
+        (None, None, None, None, None, None);
     let mut argv = std::env::args().skip(1);
     while let Some(flag) = argv.next() {
         let mut value = || {
@@ -63,15 +66,28 @@ fn parse_args() -> Result<Args, String> {
                     other => return Err(format!("--arch must be aarch64|x86_64, got {other}")),
                 })
             }
+            "--libc" => {
+                let raw = value()?;
+                libc = Some(match raw.as_str() {
+                    "glibc" => GuestLibc::Glibc,
+                    "musl" => GuestLibc::Musl,
+                    other => return Err(format!("--libc must be glibc|musl, got {other}")),
+                })
+            }
             "--cache" => cache = Some(PathBuf::from(value()?)),
             other => return Err(format!("unknown argument {other}")),
         }
     }
+    let kind = kind.ok_or("--kind is required")?;
+    if matches!(&kind, Kind::Sidecar) && libc.is_none() {
+        return Err("--libc is required for --kind sidecar".to_string());
+    }
     Ok(Args {
-        kind: kind.ok_or("--kind is required")?,
+        kind,
         base_url: base_url.ok_or("--base-url is required")?,
         version: version.ok_or("--version is required")?,
         arch: arch.ok_or("--arch is required")?,
+        libc,
         cache: cache.ok_or("--cache is required")?,
     })
 }
@@ -102,13 +118,14 @@ fn main() -> ExitCode {
         .map(|a| format!("runtime overlay {} roothash {}", a.version, a.roothash))
         .map_err(|e| e.to_string()),
         Kind::Sidecar => {
+            let Some(libc) = args.libc else {
+                eprintln!("error: --libc is required for --kind sidecar");
+                return ExitCode::FAILURE;
+            };
             mvm_build::sdk_sidecar::download_sdk_sidecar(
                 &args.version,
                 args.arch,
-                // The published release carries one variant; asking for the
-                // other is refused rather than mislabelled, so this example
-                // exercises the arm that actually has an asset behind it.
-                mvm_contract::guest_libc::GuestLibc::Glibc,
+                libc,
                 &args.cache,
             )
             .map(|a| format!("sdk sidecar {} sha256 {}", a.version, a.image_sha256))

--- a/crates/mvm-build/src/sdk_sidecar.rs
+++ b/crates/mvm-build/src/sdk_sidecar.rs
@@ -27,7 +27,8 @@ use mvm_fs::sdk_sidecar::{
     SdkSidecarLayout, SdkSidecarResolver, verify_sidecar_dir_integrity,
 };
 
-/// The per-arch release filenames the SDK sidecar is published under.
+/// The per-architecture, per-libc release filenames the SDK sidecar is
+/// published under.
 ///
 /// A constructor rather than a `format!` at each call site so the release
 /// workflow's asset names have exactly one Rust-side definition to be asserted
@@ -35,22 +36,22 @@ use mvm_fs::sdk_sidecar::{
 /// download 404s.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SdkSidecarArtifactNames {
-    /// The per-arch release tarball name.
+    /// The release tarball name.
     pub archive: String,
     /// The tarball's sha256 checksum sidecar name.
     pub archive_checksum: String,
 }
 
 impl SdkSidecarArtifactNames {
-    /// Compute the release filenames for `arch`, the same directory-name
-    /// segment the cache layout uses (`"aarch64"` / `"x86_64"`). The arch
-    /// suffix is what keeps the two architectures from colliding in the
-    /// combined release-asset pool.
+    /// Compute the release filenames for `arch` and `libc`, using the same
+    /// directory-name segments as the cache layout. Both dimensions are in the
+    /// filename so a verified archive cannot be installed under the wrong
+    /// libc key while still appearing authentic.
     #[must_use]
-    pub fn for_arch(arch: &str) -> Self {
+    pub fn for_target(arch: &str, libc: GuestLibc) -> Self {
         Self {
-            archive: format!("sdk-sidecar-{arch}.tar.gz"),
-            archive_checksum: format!("sdk-sidecar-{arch}.tar.gz.sha256"),
+            archive: format!("sdk-sidecar-{arch}-{libc}.tar.gz"),
+            archive_checksum: format!("sdk-sidecar-{arch}-{libc}.tar.gz.sha256"),
         }
     }
 }
@@ -100,31 +101,13 @@ pub enum SdkSidecarBuildError {
         reason: String,
     },
 
-    /// A variant was asked for that the published release does not carry.
-    #[error(
-        "the published release carries no {requested} SDK sidecar for {arch} \
-         (it publishes one archive per architecture, built against {published}); \
-         build it from a source checkout instead"
-    )]
-    VariantNotPublished {
-        /// The libc the caller asked for.
-        requested: GuestLibc,
-        /// The libc the published archive is actually built against.
-        published: GuestLibc,
-        /// The architecture the caller asked for.
+    /// An indeterminate libc cannot select a published artifact safely.
+    #[error("cannot select a published SDK sidecar for unknown libc on {arch}")]
+    UnknownLibc {
+        /// The architecture whose image did not identify its libc.
         arch: GuestArch,
     },
 }
-
-/// The libc the published sidecar archive is built against.
-///
-/// The release workflow builds the runtime overlay's unsuffixed
-/// `sdk-sidecar-image` attribute and publishes exactly one
-/// `sdk-sidecar-<arch>.tar.gz` per architecture. Nothing in the asset name
-/// records which variant that is, so this constant is the only place the
-/// coupling is written down: change the attribute the release builds and this
-/// must change with it.
-const PUBLISHED_SIDECAR_LIBC: GuestLibc = GuestLibc::Glibc;
 
 /// Download the SDK sidecar for `version` + `arch` from the published release,
 /// verify it, and install it under `<cache_root>/sdk-sidecar/<version>/<arch>/`.
@@ -160,22 +143,12 @@ pub fn download_sdk_sidecar(
     libc: GuestLibc,
     cache_root: &Path,
 ) -> Result<SdkSidecarArtifact, SdkSidecarBuildError> {
-    // Refused before the first byte moves, because the failure this guards is
-    // silent: the release asset name carries no libc, so a mismatched download
-    // would verify, install under the requested key and resolve — handing the
-    // guest a cdylib it cannot `dlopen`. That is the failure the libc-keyed
-    // cache exists to prevent, and laundering it through a mislabelled entry
-    // would be worse than not keying at all.
-    if libc != PUBLISHED_SIDECAR_LIBC {
-        return Err(SdkSidecarBuildError::VariantNotPublished {
-            requested: libc,
-            published: PUBLISHED_SIDECAR_LIBC,
-            arch,
-        });
+    if libc == GuestLibc::Unknown {
+        return Err(SdkSidecarBuildError::UnknownLibc { arch });
     }
 
     let arch_dir = arch.to_string();
-    let names = SdkSidecarArtifactNames::for_arch(&arch_dir);
+    let names = SdkSidecarArtifactNames::for_target(&arch_dir, libc);
     let base = crate::runtime_overlay::release_base_url(version);
 
     let expected = crate::runtime_overlay::fetch_expected_hashes(
@@ -793,11 +766,11 @@ mod tests {
         /// Stage a release directory carrying `archive`, with the archive's
         /// checksum sidecar computed from `checksum_over` (which is the archive
         /// itself for a sound release, and something else for a drift test).
-        fn stage(archive: &[u8], checksum_over: Option<&[u8]>) -> Self {
+        fn stage_for_libc(libc: GuestLibc, archive: &[u8], checksum_over: Option<&[u8]>) -> Self {
             let root = tempfile::tempdir().expect("release fixture root");
             let release_dir = root.path().join(format!("v{FIXTURE_VERSION}"));
             std::fs::create_dir_all(&release_dir).expect("create the release dir");
-            let names = SdkSidecarArtifactNames::for_arch(&GuestArch::host().to_string());
+            let names = SdkSidecarArtifactNames::for_target(&GuestArch::host().to_string(), libc);
             std::fs::write(release_dir.join(&names.archive), archive).expect("write the archive");
             if let Some(bytes) = checksum_over {
                 std::fs::write(
@@ -813,10 +786,18 @@ mod tests {
             }
         }
 
-        fn sound() -> Self {
+        fn stage(archive: &[u8], checksum_over: Option<&[u8]>) -> Self {
+            Self::stage_for_libc(GuestLibc::Glibc, archive, checksum_over)
+        }
+
+        fn sound_for_libc(libc: GuestLibc) -> Self {
             let archive = well_formed_archive(FIXTURE_VERSION);
             let checksum = archive.clone();
-            Self::stage(&archive, Some(&checksum))
+            Self::stage_for_libc(libc, &archive, Some(&checksum))
+        }
+
+        fn sound() -> Self {
+            Self::sound_for_libc(GuestLibc::Glibc)
         }
 
         fn base_url(&self) -> String {
@@ -843,9 +824,18 @@ mod tests {
         fixture: &ReleaseFixture,
         cache: &Path,
     ) -> Result<SdkSidecarArtifact, String> {
+        download_from_for_libc(env, fixture, cache, GuestLibc::Glibc)
+    }
+
+    fn download_from_for_libc(
+        env: &mut TestEnv,
+        fixture: &ReleaseFixture,
+        cache: &Path,
+        libc: GuestLibc,
+    ) -> Result<SdkSidecarArtifact, String> {
         env.set("MVM_OVERLAY_BASE_URL", fixture.base_url());
         env.set(crate::release_signature::SKIP_COSIGN_VERIFY_ENV, "1");
-        download_sdk_sidecar(FIXTURE_VERSION, GuestArch::host(), GuestLibc::Glibc, cache)
+        download_sdk_sidecar(FIXTURE_VERSION, GuestArch::host(), libc, cache)
             .map_err(|e| format!("{e}"))
     }
 
@@ -862,44 +852,37 @@ mod tests {
             .map_err(|e| format!("{e}"))
     }
 
-    /// The release asset name carries no libc, so a musl request would have
-    /// downloaded the glibc archive, verified it, installed it under the musl
-    /// key and resolved — handing a musl guest a cdylib it cannot `dlopen`.
-    /// The refusal has to come before the transport runs, or a mislabelled
-    /// entry is already on disk by the time anyone notices.
     #[test]
-    fn an_unpublished_variant_is_refused_before_any_transport() {
+    fn a_published_musl_variant_installs_under_the_musl_key() {
         let mut env = TestEnv::new();
         let cache_dir = tempfile::tempdir().expect("tempdir");
         let cache = cache_dir.path();
-        // Unreachable on purpose: reaching it at all is the failure.
+        let fixture = ReleaseFixture::sound_for_libc(GuestLibc::Musl);
+
+        let artifact = download_from_for_libc(&mut env, &fixture, cache, GuestLibc::Musl)
+            .expect("the published musl sidecar must install");
+
+        assert_eq!(artifact.libc, GuestLibc::Musl);
+        assert_eq!(artifact.image, layout_of(cache, GuestLibc::Musl).image);
+    }
+
+    #[test]
+    fn an_unknown_libc_is_refused_before_transport() {
+        let mut env = TestEnv::new();
+        let cache = tempfile::tempdir().expect("tempdir");
         env.set("MVM_OVERLAY_BASE_URL", "http://127.0.0.1:1/never");
-        env.set(crate::release_signature::SKIP_COSIGN_VERIFY_ENV, "1");
 
-        let err = download_sdk_sidecar(FIXTURE_VERSION, GuestArch::host(), GuestLibc::Musl, cache)
-            .expect_err("the published release carries no musl sidecar");
+        let error = download_sdk_sidecar(
+            FIXTURE_VERSION,
+            GuestArch::host(),
+            GuestLibc::Unknown,
+            cache.path(),
+        )
+        .expect_err("an unknown libc cannot select a release asset");
 
         assert!(
-            matches!(
-                err,
-                SdkSidecarBuildError::VariantNotPublished {
-                    requested: GuestLibc::Musl,
-                    published: GuestLibc::Glibc,
-                    ..
-                }
-            ),
-            "{err}"
-        );
-        assert!(
-            !SdkSidecarLayout::under(
-                cache,
-                FIXTURE_VERSION,
-                &GuestArch::host().to_string(),
-                GuestLibc::Musl,
-            )
-            .artifact_dir
-            .exists(),
-            "a refused download must leave nothing a resolver could pick up"
+            matches!(error, SdkSidecarBuildError::UnknownLibc { .. }),
+            "{error}"
         );
     }
 
@@ -916,7 +899,7 @@ mod tests {
     /// Nothing a resolver could ever pick up was left behind — the only thing
     /// allowed to remain is an abandoned staging directory.
     fn assert_cache_holds_no_artifact(cache: &Path) {
-        let layout = layout_of(cache, PUBLISHED_SIDECAR_LIBC);
+        let layout = layout_of(cache, GuestLibc::Glibc);
         assert!(
             !layout.artifact_dir.exists(),
             "a refused download must leave no artifact dir at {}",
@@ -924,7 +907,7 @@ mod tests {
         );
         assert!(
             SdkSidecarResolver::new(cache.to_path_buf(), FIXTURE_VERSION.to_string())
-                .resolve(&GuestArch::host().to_string(), PUBLISHED_SIDECAR_LIBC)
+                .resolve(&GuestArch::host().to_string(), GuestLibc::Glibc)
                 .is_err(),
             "a refused download must leave nothing the resolver accepts"
         );
@@ -978,13 +961,19 @@ mod tests {
     }
 
     #[test]
-    fn artifact_names_are_arch_qualified() {
-        let names = SdkSidecarArtifactNames::for_arch("aarch64");
-        assert_eq!(names.archive, "sdk-sidecar-aarch64.tar.gz");
-        assert_eq!(names.archive_checksum, "sdk-sidecar-aarch64.tar.gz.sha256");
-        let names = SdkSidecarArtifactNames::for_arch("x86_64");
-        assert_eq!(names.archive, "sdk-sidecar-x86_64.tar.gz");
-        assert_eq!(names.archive_checksum, "sdk-sidecar-x86_64.tar.gz.sha256");
+    fn artifact_names_are_arch_and_libc_qualified() {
+        let names = SdkSidecarArtifactNames::for_target("aarch64", GuestLibc::Glibc);
+        assert_eq!(names.archive, "sdk-sidecar-aarch64-glibc.tar.gz");
+        assert_eq!(
+            names.archive_checksum,
+            "sdk-sidecar-aarch64-glibc.tar.gz.sha256"
+        );
+        let names = SdkSidecarArtifactNames::for_target("x86_64", GuestLibc::Musl);
+        assert_eq!(names.archive, "sdk-sidecar-x86_64-musl.tar.gz");
+        assert_eq!(
+            names.archive_checksum,
+            "sdk-sidecar-x86_64-musl.tar.gz.sha256"
+        );
     }
 
     #[test]
@@ -996,7 +985,7 @@ mod tests {
         let artifact =
             download_from(&mut env, &fixture, cache.path()).expect("a sound release installs");
 
-        let layout = layout_of(cache.path(), PUBLISHED_SIDECAR_LIBC);
+        let layout = layout_of(cache.path(), GuestLibc::Glibc);
         assert_eq!(artifact.image, layout.image);
         assert_eq!(artifact.version, FIXTURE_VERSION);
         assert_eq!(artifact.arch, GuestArch::host().to_string());
@@ -1008,7 +997,7 @@ mod tests {
         // The installed bytes satisfy the same contract the launch path
         // enforces — the transport cannot widen it.
         SdkSidecarResolver::new(cache.path().to_path_buf(), FIXTURE_VERSION.to_string())
-            .resolve(&GuestArch::host().to_string(), PUBLISHED_SIDECAR_LIBC)
+            .resolve(&GuestArch::host().to_string(), GuestLibc::Glibc)
             .expect("the installed entry must resolve");
     }
 
@@ -1159,7 +1148,7 @@ mod tests {
     #[test]
     fn a_crash_between_stage_and_rename_leaves_no_partial_artifact() {
         let cache = tempfile::tempdir().unwrap();
-        let layout = layout_of(cache.path(), PUBLISHED_SIDECAR_LIBC);
+        let layout = layout_of(cache.path(), GuestLibc::Glibc);
         let source = tempfile::tempdir().unwrap();
         let image = sidecar_ext4_bytes();
         let version_text = format!("{FIXTURE_VERSION}\n");
@@ -1196,7 +1185,7 @@ mod tests {
         // resolver's point of view.
         promote_staging(&staging, &layout.artifact_dir).expect("promotion must succeed");
         SdkSidecarResolver::new(cache.path().to_path_buf(), FIXTURE_VERSION.to_string())
-            .resolve(&layout.arch, PUBLISHED_SIDECAR_LIBC)
+            .resolve(&layout.arch, GuestLibc::Glibc)
             .expect("the promoted entry resolves");
     }
 
@@ -1208,7 +1197,7 @@ mod tests {
         let cache = tempfile::tempdir().unwrap();
         let fixture = ReleaseFixture::sound();
         download_from(&mut env, &fixture, cache.path()).expect("first install");
-        let layout = layout_of(cache.path(), PUBLISHED_SIDECAR_LIBC);
+        let layout = layout_of(cache.path(), GuestLibc::Glibc);
         std::fs::write(layout.artifact_dir.join("stale-residue"), b"x").unwrap();
 
         download_from(&mut env, &fixture, cache.path()).expect("second install");

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -690,7 +690,10 @@ mod sdk_sidecar_host_resolution_tests {
     /// Stage the two assets `release.yml` publishes for this arch, so the
     /// download path runs end to end against local bytes instead of the network.
     fn seed_sidecar_release_fixture(base: &std::path::Path, version: &str, arch: GuestArch) {
-        let names = mvm_build::sdk_sidecar::SdkSidecarArtifactNames::for_arch(&arch.to_string());
+        let names = mvm_build::sdk_sidecar::SdkSidecarArtifactNames::for_target(
+            &arch.to_string(),
+            mvm_contract::guest_libc::GuestLibc::Glibc,
+        );
         let release_dir = base.join(format!("v{version}"));
         std::fs::create_dir_all(&release_dir).unwrap();
         let archive = sidecar_archive_bytes(version);

--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -23,9 +23,8 @@ const FIXTURE_VERSION: &str = "1.2.3";
 
 /// The variant these scenarios stage and resolve.
 ///
-/// The published release carries one archive per architecture, built against
-/// glibc, so the acquire-and-boot scenario is only meaningful for that variant
-/// — asking for the other is refused before any transport runs.
+/// This scenario chooses glibc; the sibling musl acquisition path is covered by
+/// the downloader's focused release-fixture regression.
 const SCENARIO_LIBC: GuestLibc = GuestLibc::Glibc;
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -149,8 +148,10 @@ fn stage_release(world: &mut CliWorld, checksum_over: &[u8]) {
         .to_path_buf();
     let release_dir = base.join(format!("v{FIXTURE_VERSION}"));
     std::fs::create_dir_all(&release_dir).expect("create the versioned release dir");
-    let names =
-        mvm_build::sdk_sidecar::SdkSidecarArtifactNames::for_arch(&GuestArch::host().to_string());
+    let names = mvm_build::sdk_sidecar::SdkSidecarArtifactNames::for_target(
+        &GuestArch::host().to_string(),
+        GuestLibc::Glibc,
+    );
     std::fs::write(release_dir.join(&names.archive), &archive).expect("write the release archive");
     std::fs::write(
         release_dir.join(&names.archive_checksum),

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -35,6 +35,14 @@ Last updated: 2026-09-01
       regressions. Workspace tests, Clippy, formatting, gated-target checks,
       and documentation gates are green; merge delivery remains.
 
+- [ ] **Published musl SDK sidecar — issue #3045.**
+      `specs/plans/2026-08-31-publish-musl-sdk-sidecar.md`.
+      SDK sidecar release names now bind architecture and libc; both release
+      trains require, attach, sign, and consume glibc and musl artifacts for
+      both architectures. Focused downloader, release-contract,
+      workflow-syntax, consumer-example, workspace, Clippy, gated-target,
+      formatting, and policy validation is green; merge delivery remains.
+
 - [ ] **machine diff handshake retry — issue #3024.**
       `specs/plans/2026-08-31-machine-diff-handshake-retry.md`.
       A typed pre-authentication peer hangup gets one fresh connection; an EOF

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -20,6 +20,15 @@
       zero-warning Clippy, Linux/BDD gated compilation, and policy checks are
       green. Merge delivery remains.
 
+- [ ] **Published musl SDK sidecar — issue #3045.**
+      `specs/plans/2026-08-31-publish-musl-sdk-sidecar.md`.
+      Release assets now bind both architecture and libc, the image matrix
+      builds all four supported combinations, and both release trains require
+      and consume the glibc and musl archives before publishing. Focused
+      downloader, release-contract, workflow-syntax, consumer-example,
+      workspace, Clippy, gated-target, formatting, and policy validation is
+      green; merge delivery remains.
+
 - [ ] **Wasmtime security update — issues #3018 and #3020.**
       `specs/plans/2026-08-31-wasmtime-security-update.md`.
       The optional Wasm backend's locked Wasmtime family is updated from
@@ -3464,3 +3473,13 @@ writes the plan:
 - [x] Complete the full workspace, Clippy, formatting, gated-target, and
       documentation validation matrix.
 - [ ] Merge through the queue and close issue #3040 from landed evidence.
+
+## 2026-08-31 published musl SDK sidecar
+
+- [x] Put architecture and libc in every SDK sidecar archive name.
+- [x] Build and upload the glibc and musl derivations for both architectures.
+- [x] Select the requested variant without a single-published-libc constant.
+- [x] Require and exercise both variants before either release train publishes.
+- [x] Cover musl acquisition, unknown-libc refusal, and release-name coupling.
+- [x] Complete workspace and gated validation.
+- [ ] Merge the repair through the queue and close issue #3045.

--- a/specs/plans/2026-08-31-publish-musl-sdk-sidecar.md
+++ b/specs/plans/2026-08-31-publish-musl-sdk-sidecar.md
@@ -1,0 +1,22 @@
+# Publish both SDK sidecar libc variants
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+## Goal
+
+Publish distinct glibc and musl SDK sidecar archives for every supported
+architecture, and make the downloader select the archive whose filename binds
+the requested libc.
+
+## Checklist
+
+- [x] Qualify SDK sidecar release names by architecture and libc.
+- [x] Build and upload glibc and musl sidecars for aarch64 and x86_64.
+- [x] Remove the single-published-libc assumption from the downloader.
+- [x] Make both release trains require, attach, sign, and consume both variants.
+- [x] Add positive musl acquisition, unknown-libc refusal, release-matrix, and
+      asset-name regressions.
+- [x] Complete workspace, Clippy, gated-target, formatting, and policy
+      validation.
+- [ ] Merge the repair through the queue and close issue #3045.

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -59,10 +59,15 @@ fn assert_publishes(workflow: &str, asset: &str) {
 #[test]
 fn release_publishes_every_sdk_sidecar_asset_the_downloader_requests() {
     let workflow = boot_image_workflow();
-    for token in [SHELL_ARCH_TOKEN, MATRIX_ARCH_TOKEN] {
-        let names = mvmctl::build::sdk_sidecar::SdkSidecarArtifactNames::for_arch(token);
-        assert_publishes(&workflow, &names.archive);
-        assert_publishes(&workflow, &names.archive_checksum);
+    for arch in ["aarch64", "x86_64"] {
+        for libc in [
+            mvmctl::build::guest_libc::GuestLibc::Glibc,
+            mvmctl::build::guest_libc::GuestLibc::Musl,
+        ] {
+            let names = mvmctl::build::sdk_sidecar::SdkSidecarArtifactNames::for_target(arch, libc);
+            assert_publishes(&workflow, &names.archive);
+            assert_publishes(&workflow, &names.archive_checksum);
+        }
     }
 }
 
@@ -125,8 +130,10 @@ fn the_release_job_attaches_the_sdk_sidecar_assets() {
     // fresh install before the boot image tag is ever consulted.
     for workflow in [&boot_image, &release_workflow()] {
         for pattern in [
-            "artifacts/sdk-sidecar-*.tar.gz",
-            "artifacts/sdk-sidecar-*.tar.gz.sha256",
+            "artifacts/sdk-sidecar-*-glibc.tar.gz",
+            "artifacts/sdk-sidecar-*-glibc.tar.gz.sha256",
+            "artifacts/sdk-sidecar-*-musl.tar.gz",
+            "artifacts/sdk-sidecar-*-musl.tar.gz.sha256",
         ] {
             assert!(
                 workflow.contains(pattern),
@@ -141,9 +148,17 @@ fn the_release_job_attaches_the_sdk_sidecar_assets() {
 #[test]
 fn release_attaches_the_signature_bundle_the_verifier_fetches() {
     let workflow = release_workflow();
-    let sidecar = mvmctl::build::sdk_sidecar::SdkSidecarArtifactNames::for_arch("*");
     let overlay = mvmctl::build::runtime_overlay::RuntimeOverlayArtifactNames::for_arch("*");
-    for asset in [sidecar.archive, overlay.archive] {
+    let mut assets = vec![overlay.archive];
+    for libc in [
+        mvmctl::build::guest_libc::GuestLibc::Glibc,
+        mvmctl::build::guest_libc::GuestLibc::Musl,
+    ] {
+        assets.push(
+            mvmctl::build::sdk_sidecar::SdkSidecarArtifactNames::for_target("*", libc).archive,
+        );
+    }
+    for asset in assets {
         let bundle = mvmctl::build::release_signature::bundle_asset_name(&asset);
         assert!(
             workflow.contains(&format!("artifacts/{bundle}")),
@@ -218,7 +233,7 @@ fn the_release_consumes_its_own_artifacts_before_publishing_them() {
 /// Both published architectures must be built, or a whole platform's users get
 /// the fail-closed refusal this artifact exists to prevent.
 #[test]
-fn the_sdk_sidecar_job_builds_both_published_arches() {
+fn the_sdk_sidecar_job_builds_every_published_arch_and_libc() {
     let workflow = boot_image_workflow();
     let job = workflow
         .split("  sdk-sidecar-image:")
@@ -232,6 +247,18 @@ fn the_sdk_sidecar_job_builds_both_published_arches() {
         assert!(
             job.contains(&format!("arch: {arch}")),
             "the sdk-sidecar-image matrix must build {arch}"
+        );
+    }
+    for libc in ["glibc", "musl"] {
+        assert!(
+            job.contains(&format!("libc: {libc}")),
+            "the sdk-sidecar-image matrix must build {libc}"
+        );
+    }
+    for package in ["sdk-sidecar-image", "sdk-sidecar-image-musl"] {
+        assert!(
+            job.contains(&format!("package: {package}")),
+            "the sdk-sidecar-image matrix must build {package}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- publish distinct glibc and musl SDK sidecar archives for both supported architectures
- bind downloader selection and release asset names to the requested libc
- require, sign, attach, and consumer-verify all four sidecar variants in both release trains
- add musl acquisition, unknown-libc refusal, matrix, and asset-contract regressions

## Validation

- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- cargo check --workspace
- just check-gated
- cargo fmt --all -- --check
- cargo run -p xtask -- check-all
- actionlint .github/workflows/release.yml .github/workflows/release-boot-image.yml

Fixes #3045