### PR TITLE
fix(ci): rebuild stale guest artifacts before live witnesses

### DIFF
--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -639,11 +639,10 @@ impl VmmDriver for FcDriver {
         // authenticated identity handshake still gates admission after
         // resume, so preloading changes placement of VMM work, not authority.
         VmCapabilities {
-            // None: this driver hands `vcpu_count` to Firecracker's
-            // machine-config API unmodified and imposes no ceiling of its own.
-            // `None` says exactly that — distinct from a backend that has a
-            // limit and has not declared one, which would read as `Some(large)`.
-            max_vcpus: None,
+            // Firecracker's machine-config wire field is an unsigned byte.
+            // Declare that protocol ceiling so portable oversized requests are
+            // clamped before serialization instead of failing at the API.
+            max_vcpus: Some(u32::from(u8::MAX)),
             pause_resume: true,
             snapshots: false,
             snapshot_capability: SnapshotCapability::Unsupported,
@@ -1400,6 +1399,7 @@ mod tests {
         assert!(caps.no_routable_guest_nic);
         assert!(caps.host_vsock_proxy);
         assert!(!caps.tap_networking);
+        assert_eq!(caps.max_vcpus, Some(u32::from(u8::MAX)));
         assert_eq!(d.snapshot_capability(), SnapshotCapability::Unsupported);
         // The driver reports the claim-bearing tier itself now, rather than
         // asking a legacy shell for it.

--- a/features/suites/s2_egress_vsock/admitted_egress_live.feature
+++ b/features/suites/s2_egress_vsock/admitted_egress_live.feature
@@ -20,7 +20,7 @@ Feature: Admitted egress completes end-to-end over the vsock seam
   @live
   Scenario: A non-admitted name is refused, not resolved
     When I run mvmctl with "machine run --image curlimages/curl:8.21.0 --allow-host example.com -- curl -fsSL https://not-admitted.test"
-    Then the command exits with code 1
+    Then the command exits with code 22
 
   @live @tls_tunnel_client
   Scenario: DNS queries land in the chain-signed audit log

--- a/features/suites/s30_service_plane/host_kv.feature
+++ b/features/suites/s30_service_plane/host_kv.feature
@@ -62,4 +62,4 @@ Feature: A workload reaches a key-value store without a network path
     Given the SDK service-plane fixture is materialized as a read-only disk image
     When I run the SDK service-plane fixture in an isolated live home binding service "host.time.v1"
     Then the command exits with code 1
-    And the output contains "not bound"
+    And the error output contains "not bound"

--- a/features/suites/s5_lifecycle/transient_sandbox_boot.feature
+++ b/features/suites/s5_lifecycle/transient_sandbox_boot.feature
@@ -27,8 +27,14 @@ Feature: Transient sandbox boot
 
   @live
   Scenario: machine run boots a transient sandbox from a Nix flake
-    When I run mvmctl in an isolated live home with "machine run --name bdd-nix-boot --flake examples/exit_code --timeout 120"
+    When I run mvmctl in an isolated live home with "machine run --name bdd-nix-boot --flake examples/exit_code"
     Then the command exits with code 7
+
+  @live
+  Scenario: a sealed flake refuses a timeout the backend cannot enforce
+    When I run mvmctl in an isolated live home with "machine run --name bdd-nix-timeout --flake examples/exit_code --timeout 120"
+    Then the command exits with code 1
+    And the error output contains "cannot enforce every declared grant"
 
   # The universal initramfs made the agent PID 1 and, for a while, carried over
   # only the mounting half of the older init. A workload booted with `lo` down

--- a/public/src/content/docs/guides/exec.md
+++ b/public/src/content/docs/guides/exec.md
@@ -133,7 +133,10 @@ mvmctl machine run --flake . --timeout 300 -- ./long-running-task.sh
 ```
 
 Defaults: 2 vCPUs (`--cpus`), 512 MiB (`--memory`). **`--timeout` has no
-default** — omit it and the run is unbounded.
+default** — omit it and the run is unbounded. A sealed run fails closed when
+its selected backend cannot enforce a wall-clock grant; currently Firecracker
+and QEMU do not own a long-lived supervisor timer. Use `mvmctl doctor` to check
+the active backend before relying on `--timeout` for a sealed workload.
 
 ## Driving from a launch plan
 

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -373,16 +373,11 @@ warm_launch_artifacts() {
     && echo "    runtime overlay ready" \
     || echo "    runtime overlay: not warmed (scenarios needing it will say so)"
 
-  # Layout is cache/initramfs/<version>/<arch>/initramfs.cpio.gz. Globbed on
-  # version rather than hardcoded, so a version bump does not silently turn
-  # this check into "never cached" and pay the build every run.
-  if find "$E2E_HOME/cache/initramfs" -name initramfs.cpio.gz -size +0c 2>/dev/null \
-     | read -r _; then
-    echo "    universal initramfs already cached"
-    return 0
-  fi
-
-  echo "    building the universal initramfs once (cross-compiles guest binaries)"
+  # Always enter launch resolution. The initramfs cache key includes a source
+  # fingerprint that evicts an artifact containing guest binaries from an
+  # older checkout. A plain file-existence check bypasses that validation and
+  # can boot stale guest-agent behavior while testing a new host binary.
+  echo "    validating the source-matched universal initramfs"
   MVM_HOME="$E2E_HOME" "$MVMCTL" machine run --name bdd-warmup --image alpine \
     -- /bin/true >/dev/null 2>&1 &
   local warm_pid=$! waited=0

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -159,6 +159,11 @@ Last updated: 2026-09-01
       ICMP sockets to the runner group, and threads the documented service-plane
       ext4 fixture through transient launch resolution as a read-only block
       volume while retaining fail-closed directory-share capability checks.
+      The latest rerun showed the warm-up reused an existing universal
+      initramfs without validating its guest-source fingerprint. It now always
+      enters launch resolution, evicting stale guest agents before the live
+      suite. Firecracker declares its u8 vCPU wire ceiling, and the refusal
+      witnesses now assert the actual child/status-channel contracts.
       Focused tests, workspace tests, isolated doctests, workspace Clippy,
       formatting, and policy gates are green. A fresh Extended CI run and merge
       delivery remain.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -183,6 +183,12 @@
       unprivileged ICMP sockets, and carries the service-plane's read-only ext4
       fixture through transient launch resolution as a block volume instead of
       rejecting it as a directory share.
+      The next fully merged rerun proved the artifact warm-up bypassed the
+      initramfs source fingerprint whenever a cache file existed, so current
+      host code booted a stale guest agent. The warm-up now always validates
+      and rebuilds source-stale guest binaries. Firecracker also advertises its
+      u8 vCPU wire ceiling before serialization, and the live refusal witnesses
+      match child exit status, stderr ownership, and backend timeout admission.
       Focused tests, all ordinary workspace tests, the isolated `mvm-agentd`
       doctest, workspace Clippy, formatting, and repository policy gates are
       green. The live rerun and merge delivery remain.

--- a/specs/plans/2026-08-28-extended-ci-red-repair.md
+++ b/specs/plans/2026-08-28-extended-ci-red-repair.md
@@ -55,6 +55,16 @@ a competing BLAKE3 address or re-hash the archive.
   runner group ICMP sockets. Transient launch resolution preserves disk-image
   mounts as backend-agnostic block volumes while continuing to capability-gate
   live directory shares.
+- The first rerun on the fully merged queue exposed a cross-checkout artifact
+  hole: the warm-up treated an existing initramfs file as current without
+  invoking the source-fingerprint gate. The lane therefore tested the latest
+  host binary against an older guest agent, producing dm-verity, FlowMux,
+  stop-drain, and warm-readiness failures that disagreed with the checked-in
+  guest code. The warm-up now always enters launch resolution so stale guest
+  binaries are evicted and rebuilt. The same run exposed Firecracker's u8
+  machine-config boundary and two stale BDD assertions; the backend now
+  declares that vCPU ceiling, while the witnesses preserve child exit status
+  and stderr ownership.
 
 ## Delivery checklist
 
@@ -92,5 +102,11 @@ a competing BLAKE3 address or re-hash the archive.
       resolution without weakening directory-share backend refusal.
 - [x] Pass the focused mount, receipt/preflight, workspace, gated, formatting,
       and zero-warning Clippy checks for the follow-on repair.
+- [x] Revalidate the universal initramfs source fingerprint on every live
+      warm-up, with a structural regression forbidding file-existence shortcuts.
+- [x] Declare Firecracker's u8 vCPU wire ceiling and cover the advertised
+      capability so oversized portable requests clamp before serialization.
+- [x] Reconcile the live refusal witnesses with the child process exit code,
+      stderr channel, and fail-closed timeout-admission contracts.
 - [ ] Pass a fresh Extended CI run containing all repaired witness lanes.
 - [ ] Merge the corrective pull request and close #3007 through its linkage.

--- a/tests/github_actions_extended_e2e.rs
+++ b/tests/github_actions_extended_e2e.rs
@@ -305,6 +305,28 @@ fn documented_surface_warms_the_source_matched_sdk_sidecar() {
 }
 
 #[test]
+fn documented_surface_revalidates_the_source_matched_initramfs() {
+    let script = documented_surface_script();
+    let warm = script
+        .split_once("warm_launch_artifacts() {")
+        .expect("warm_launch_artifacts function")
+        .1
+        .split_once("\n}")
+        .expect("warm_launch_artifacts body")
+        .0;
+
+    assert!(
+        warm.contains("\"$MVMCTL\" machine run --name bdd-warmup"),
+        "the warm-up must enter launch resolution so its source fingerprint can evict a stale initramfs"
+    );
+    assert!(
+        !warm.contains("universal initramfs already cached")
+            && !warm.contains("find \"$E2E_HOME/cache/initramfs\""),
+        "file existence is not freshness: a cached initramfs may contain a guest agent from an older checkout"
+    );
+}
+
+#[test]
 fn supervisor_build_requires_a_detected_libkrun_header() {
     let just = justfile();
     let recipe = just


### PR DESCRIPTION
## Summary
- always resolve the source-matched initramfs before documented live witnesses, evicting stale guest artifacts
- expose Firecracker's real u8 vCPU ceiling and align documented live assertions with backend behavior
- document fail-closed timeout handling and preserve the corresponding BDD coverage

## Validation
- cargo test --test github_actions_extended_e2e
- cargo test -p mvm-backends
- cargo clippy -p mvm-backends -- -D warnings
- cargo fmt --all -- --check
- bash -n scripts/e2e-documented-surface.sh
- documented website command coverage BDD witness
- cargo run -p xtask -- check-sprint-append

Addresses #3007. The issue remains open until a fresh Extended CI run confirms the repaired live lanes.