### PR TITLE
docs(status): drop the duplicated refactor-status entries

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -21,20 +21,6 @@ Last updated: 2026-09-01
       workspace suite, zero-warning Clippy, workspace check, and gated-target
       compilation are green; merge delivery remains.
 
-- [ ] **Kernel cache moved out of the Stage 0 blast radius.**
-      `specs/sprint/delivery/kernel-cache-outside-stage0-blast-radius.md`.
-      The workload kernel was cached inside `builder-vm/<arch>`, the directory
-      Stage 0 `remove_dir_all`s on a source-fingerprint change, so promoting a
-      new builder image destroyed a half-hour artifact and the next boot rebuilt
-      it — blowing `just e2e-launch`'s 1800s cap. Entries now live at
-      `<cache>/kernels/<arch>/<variant>/`; `resolve_kernel` adopts an entry left
-      at the old path by renaming it. The layout was hand-rebuilt at nine call
-      sites, all now routed through `kernel_cache_dir`/`cached_kernel_path`. The
-      gate's builder cap is raised to 7200s, matching `ci-full.yml`. Workspace
-      tests, Clippy, doctests, policy gates, and a live macOS 26 `e2e-launch`
-      run (migration confirmed a rename, not a rebuild) are green; merge
-      delivery remains.
-
 - [ ] **Egress refusal status contract — issue #3040.**
       `specs/plans/2026-09-01-egress-refusal-status.md`.
       FlowMux now distinguishes a policy refusal (`403 Forbidden`) from an
@@ -50,13 +36,6 @@ Last updated: 2026-09-01
       both architectures. Focused downloader, release-contract,
       workflow-syntax, consumer-example, workspace, Clippy, gated-target,
       formatting, and policy validation is green; merge delivery remains.
-
-- [ ] **machine diff handshake retry — issue #3024.**
-      `specs/plans/2026-08-31-machine-diff-handshake-retry.md`.
-      A typed pre-authentication peer hangup gets one fresh connection; an EOF
-      after authentication is never replayed. Focused regressions cover both
-      boundaries and the bounded retry budget. Workspace validation and merge
-      delivery remain.
 
 - [~] **Documented-example parse-tier promotion.**
       `specs/plans/2026-08-30-doc-example-parse-tier-promotion.md`.


### PR DESCRIPTION
Two entries in `specs/REFACTOR-STATUS.md` appear twice — once under **In progress** claiming "merge delivery remains", once under **Completed**:

| Entry | In progress | Completed |
|---|---|---|
| Kernel cache moved out of the Stage 0 blast radius | line 24 | line 262 |
| machine diff handshake retry — #3024 | line 54 | line 275 |

Both are merged (`927f25bc29` and `a22414f5ce`), so the In-progress copies describe work that is done and read as two live workstreams that do not exist.

## How it happened

Mine, and worth recording because it is not a typo. #3043 moved both entries: deleting them from **In progress** and adding them to **Completed**. The branch was correct — at `651ab17a8f` each entry appears exactly once, under Completed.

The merge queue rebased that branch onto a `main` that had moved, and the rebase applied the additions while dropping the deletions. The merge commit `cc401eb0ae` already carries both copies, so this was not introduced by any of the three PRs that touched the file afterwards.

That is the asymmetry to watch for in this file specifically: an addition to one section and a deletion from another are independent hunks, and a conflict resolution that keeps both sides — the right instinct when two branches each *add* an entry — silently reverts a deletion. The repo's guidance to keep both sides on a `REFACTOR-STATUS` conflict is correct for the common case and wrong for a move.

## This change

Removes the two stale In-progress copies. Nothing else is touched, and no other entry in the file is duplicated — I checked the whole file rather than just the two I knew about.

`check-all` green across all 62 gates, including `check-sprint-append`.
