### PR TITLE
fix(e2e): stop forcing a fetch the contributor binary cannot perform

### DIFF
--- a/crates/mvm-cli/src/commands/env/builder_vm/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/bootstrap.rs
@@ -399,7 +399,7 @@ pub(super) fn perform_builder_vm_download_published(arch: &str, out_dir: &str) -
                 "Builder VM image is missing and a fetch was requested, but this \
                  `mvmctl` was built without the `release-artifact-bootstrap` \
                  feature, so it cannot pull a published prebuilt. The in-repo \
-                 builder VM flake IS present at {flake_dir} — unset \
+                 builder VM flake IS present at {flake_dir}/flake.nix — unset \
                  `MVM_BOOT_IMAGE` (or set it to `build`) to build from it, \
                  which is what a source checkout is expected to do."
             );

--- a/crates/mvm-cli/src/commands/env/builder_vm/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/bootstrap.rs
@@ -388,6 +388,22 @@ pub(super) fn perform_builder_vm_download_published(arch: &str, out_dir: &str) -
     #[cfg(not(feature = "release-artifact-bootstrap"))]
     {
         let _ = (arch, out_dir);
+        // Report which of the two situations this actually is. The message
+        // used to assert the in-repo flake was missing without ever looking
+        // for one, so a checkout that *had* the flake — and had simply been
+        // routed here by `MVM_BOOT_IMAGE=fetch` — sent the reader hunting for
+        // a file sitting in front of them. Two Linux baseline runs were lost
+        // to that before anyone checked whether the file existed.
+        if let Ok(flake_dir) = super::find_builder_vm_flake() {
+            anyhow::bail!(
+                "Builder VM image is missing and a fetch was requested, but this \
+                 `mvmctl` was built without the `release-artifact-bootstrap` \
+                 feature, so it cannot pull a published prebuilt. The in-repo \
+                 builder VM flake IS present at {flake_dir} — unset \
+                 `MVM_BOOT_IMAGE` (or set it to `build`) to build from it, \
+                 which is what a source checkout is expected to do."
+            );
+        }
         anyhow::bail!(
             "Builder VM image is missing and no in-repo builder VM flake \
              was found. This `mvmctl` binary was built without the \

--- a/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/builder_vm_bootstrap_tests.rs
@@ -310,6 +310,27 @@ fn stage0_locked_input_sources_read_builder_flake_lock() {
 /// it's the one contributors hit.
 #[cfg(not(feature = "release-artifact-bootstrap"))]
 #[test]
+fn the_refusal_says_the_flake_is_present_when_it_is() {
+    // The message used to assert the in-repo flake was missing without ever
+    // looking for one, so a checkout that had it — and had merely been routed
+    // down the fetch path by `MVM_BOOT_IMAGE=fetch` — sent the reader hunting
+    // for a file in front of them. These tests run from a source checkout, so
+    // this is the branch a contributor actually hits.
+    let err = perform_builder_vm_download_published("aarch64", "/tmp/mvm-flake-present-test")
+        .expect_err("download must refuse without release-artifact-bootstrap");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("IS present"),
+        "a checkout with the flake must not be told the flake is missing: {msg}"
+    );
+    assert!(
+        msg.contains("MVM_BOOT_IMAGE"),
+        "the message must name the knob that routed it here: {msg}"
+    );
+}
+
+#[cfg(not(feature = "release-artifact-bootstrap"))]
+#[test]
 fn perform_builder_vm_download_published_bails_without_feature() {
     let err = perform_builder_vm_download_published("aarch64", "/tmp/mvm-w4-test-out")
         .expect_err("download must refuse without release-artifact-bootstrap");

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -321,14 +321,24 @@ just sdk-build-typescript
 # initramfs. Acquiring them inside a scenario would put minutes on each one, and
 # a scenario that times out reads as a launch failure rather than a cold cache.
 # ---------------------------------------------------------------------------
-# This suite verifies the documented CLI surface, not the builder VM image.
-# A source checkout otherwise rebuilds that image from the in-repo flake on
-# every cold run, which couples the whole suite to an unrelated Nix build —
-# and when that build cannot reach crates.io from inside Stage 0, nothing here
-# runs at all. Fetch the published image instead. A contributor working *on*
-# the image sets MVM_BOOT_IMAGE themselves and this defers to them.
-export MVM_BOOT_IMAGE="${MVM_BOOT_IMAGE:-fetch}"
-echo "    boot image: $MVM_BOOT_IMAGE"
+# This suite verifies the documented CLI surface, not the builder VM image, so
+# fetching a published image instead of rebuilding it from the in-repo flake is
+# the cheaper shape — a source checkout otherwise couples the whole suite to an
+# unrelated Nix build.
+#
+# But it is only cheaper where it works. A contributor `mvmctl` is built without
+# `release-artifact-bootstrap` and *cannot* fetch, so forcing `fetch` there does
+# not trade a slow build for a fast download; it trades a slow build for no
+# builder VM at all, and every flake-build scenario fails. That is the common
+# case, not the exotic one.
+#
+# So let the resolver decide from the checkout, which is the job it exists to
+# do: a source tree builds, an installed binary fetches. Anyone holding a
+# fetch-capable binary can still set MVM_BOOT_IMAGE=fetch and this defers to it.
+if [[ -n "${MVM_BOOT_IMAGE:-}" ]]; then
+  export MVM_BOOT_IMAGE
+fi
+echo "    boot image: ${MVM_BOOT_IMAGE:-auto (resolver decides from the checkout)}"
 
 # Bootstrap failure is reported, not fatal. It warms the builder VM image, which
 # the flake-build scenarios need and the OCI-image ones do not — so aborting here


### PR DESCRIPTION
Closes #3053.

## The default

`scripts/e2e-documented-surface.sh` exported `MVM_BOOT_IMAGE=fetch`. The reasoning was sound — this suite verifies the documented CLI surface, not the builder VM image, and rebuilding that image from the in-repo flake couples the whole run to an unrelated Nix build.

But it is only cheaper where it works. A contributor `mvmctl` is built without `release-artifact-bootstrap` and **cannot fetch at all**, so forcing `fetch` there does not trade a slow build for a fast download — it trades a slow build for **no builder VM**, and every flake-build scenario with it. That is the common case, not the exotic one, and it contradicts the CLAUDE.md invariant that a source checkout builds locally.

The resolver already decides this correctly from the checkout. Let it. An explicit `MVM_BOOT_IMAGE=fetch` still wins.

## The misleading error

```
Builder VM image is missing and no in-repo builder VM flake was found.
... Run from a source checkout that has nix/images/builder-vm/flake.nix
```

emitted on a checkout where that file was present (27 KB). The bail lives in the `cfg(not(release-artifact-bootstrap))` arm and asserted the flake was missing **without ever looking for one**.

It now checks. When the flake is there:

```
Builder VM image is missing and a fetch was requested, but this `mvmctl` was
built without the `release-artifact-bootstrap` feature, so it cannot pull a
published prebuilt. The in-repo builder VM flake IS present at
/…/nix/images/builder-vm — unset `MVM_BOOT_IMAGE` (or set it to `build`) to
build from it, which is what a source checkout is expected to do.
```

## Cost of the original

Two full Linux baseline runs were lost to this — the second because I raised the watchdog, treating the timeout as the cause. The run only completed once `MVM_BOOT_IMAGE=build` was set by hand: 296 scenarios, 285 passed, 10 failed.

## Verified

The new message reproduced directly against a cold `MVM_HOME` with `MVM_BOOT_IMAGE=fetch`.