### PR TITLE
feat(xtask): ratchet the virtio-fs surface so it cannot grow back

### DIFF
--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -1790,7 +1790,7 @@ mod linux {
                     None
                 }
             };
-            let _exit_code = run_dispatch_loop(cold_boot_timings);
+            let _exit_code = run_dispatch_loop(cold_boot_timings, disk_transport);
             stamp(&timings, |t| {
                 t.poweroff_start_ms = Some(BootTimings::ms_since(anchor))
             });
@@ -2215,7 +2215,14 @@ mod linux {
     ///
     /// Returns `0` on graceful `Shutdown`, non-zero on listener
     /// setup failure (caller `power_off`s either way).
-    fn run_dispatch_loop(mut cold_boot_timings: Option<BootTimings>) -> i32 {
+    /// `disk_transport` is `Some` when the host staged this VM's inputs on a
+    /// raw block device rather than virtio-fs shares. A persistent builder then
+    /// re-reads `/job` off that device per dispatch and writes each dispatch's
+    /// artifacts back onto the output device — see [`restage_disk_transport_job`].
+    fn run_dispatch_loop(
+        mut cold_boot_timings: Option<BootTimings>,
+        disk_transport: Option<crate::DiskTransport>,
+    ) -> i32 {
         // No accept timeout — the dispatch loop is persistent and
         // blocks waiting for the supervisor's next submit. The
         // outer `mvmctl persistent-builder stop` signals shutdown via a
@@ -2277,6 +2284,28 @@ mod linux {
                     eprintln!(
                         "mvm-host-vm-init: dispatch loop: starting job {job_id} at {job_dir_relpath}"
                     );
+                    // Disk transport: this dispatch's `/job` contents are on the
+                    // input disk the host just rewrote. Fatal for the dispatch
+                    // rather than the VM — a persistent builder must survive one
+                    // bad job, so this reports a failed Result and keeps serving.
+                    if let Some(t) = &disk_transport
+                        && let Err(e) = restage_disk_transport_job(t)
+                    {
+                        eprintln!("mvm-host-vm-init: dispatch loop: job staging failed: {e}");
+                        let failed = crate::dispatch_response::DispatchResponse {
+                            job_id: job_id.clone(),
+                            exit_code: 2,
+                            stderr_tail: format!("disk-transport job staging failed: {e}"),
+                            boot_timings: cold_boot_timings.take(),
+                            build_ms: 0,
+                        };
+                        if !write_frame(&mut conn, failed.to_json().as_bytes()) {
+                            eprintln!(
+                                "mvm-host-vm-init: dispatch loop: write staging-failure Result failed"
+                            );
+                        }
+                        continue;
+                    }
                     let response = execute_dispatched_job(
                         &mut conn,
                         job_id,
@@ -2284,6 +2313,14 @@ mod linux {
                         &job_dir_relpath,
                         cold_boot_timings.take(),
                     );
+                    // Publish this dispatch's artifacts before the host is told
+                    // the job is done: the host reads the output disk as soon as
+                    // it sees the Result, so collecting afterwards would race it.
+                    if let Some(t) = &disk_transport
+                        && let Err(e) = collect_disk_transport_output(t)
+                    {
+                        eprintln!("mvm-host-vm-init: dispatch loop: output collection failed: {e}");
+                    }
                     eprintln!("mvm-host-vm-init: dispatch loop: job completed; writing Result");
                     if !write_frame(&mut conn, response.as_bytes()) {
                         eprintln!("mvm-host-vm-init: dispatch loop: write Result failed mid-frame");
@@ -3230,6 +3267,35 @@ mod linux {
         std::fs::create_dir_all(dir).map_err(|e| format!("mkdir {dir}: {e}"))
     }
 
+    /// Empty `dir` **without replacing the directory itself**.
+    ///
+    /// [`reset_stage_dir`] removes and recreates, which is right at boot and
+    /// wrong for anything already bind-mounted: `/job` and `/out` are binds onto
+    /// these inodes, so removing the source leaves the mount pointing at a
+    /// deleted directory and every later write lands somewhere nothing reads.
+    /// A persistent builder re-stages between dispatches, after the binds exist,
+    /// so it needs this form.
+    fn clear_dir_contents(dir: &str) -> Result<(), String> {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return std::fs::create_dir_all(dir).map_err(|e| format!("mkdir {dir}: {e}"));
+            }
+            Err(e) => return Err(format!("read {dir}: {e}")),
+        };
+        for entry in entries {
+            let entry = entry.map_err(|e| format!("read entry under {dir}: {e}"))?;
+            let path = entry.path();
+            let removed = if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                std::fs::remove_dir_all(&path)
+            } else {
+                std::fs::remove_file(&path)
+            };
+            removed.map_err(|e| format!("remove {}: {e}", path.display()))?;
+        }
+        Ok(())
+    }
+
     /// Populate `/job`, `/work`, `/mvm-bins`, and (when the host packed one)
     /// `/closure-seed` from the input disk, and back `/out` with a writable
     /// dir on the persistent nix-store disk. This is the disk-transport
@@ -3272,6 +3338,44 @@ mod linux {
         reset_stage_dir(&out_backing)?;
         std::fs::create_dir_all(OUT_DIR).map_err(|e| format!("mkdir {OUT_DIR}: {e}"))?;
         disk_bind_mount(&out_backing, OUT_DIR)?;
+        Ok(())
+    }
+
+    /// Re-stage `/job` for one dispatch of a *persistent* builder.
+    ///
+    /// The one-shot path stages once at boot and powers off after a single job.
+    /// A persistent VM takes many, and each carries its own `cmd.sh` /
+    /// `install_spec.json`. The host rewrites the input disk — a raw tar, so it
+    /// can be replaced wholesale — before it sends the `Run` frame, and this
+    /// re-reads the `job` member off the device. Ordering is what makes it safe:
+    /// the host finishes writing before it sends, and dispatches serialize
+    /// behind the supervisor's mutex, so no read ever straddles a write.
+    ///
+    /// Only the `job` member is extracted. `work`, `mvm-bins` and the closure
+    /// seed are boot-time inputs that do not change between dispatches, and
+    /// re-extracting a large `work` tree per job would cost real time for no
+    /// effect.
+    fn restage_disk_transport_job(t: &crate::DiskTransport) -> Result<(), String> {
+        let job_stage = format!("{DISK_INPUT_STAGE}/job");
+        // Contents-only: `/job` is bind-mounted onto this directory.
+        clear_dir_contents(&job_stage)?;
+        let status = Command::new("/bin/busybox")
+            .args(["tar", "xf", &t.input_dev, "-C", DISK_INPUT_STAGE, "job"])
+            .status()
+            .map_err(|e| format!("spawn tar x job {}: {e}", t.input_dev))?;
+        if !status.success() {
+            return Err(format!(
+                "tar x job {} exited {:?}",
+                t.input_dev,
+                status.code()
+            ));
+        }
+        // `/out` accumulates across dispatches the same way it accumulates
+        // across builds, and for the same reason the boot path resets it: the
+        // host would otherwise read back a tar of every artifact any earlier
+        // dispatch left behind, including `result-*` symlinks into guest-only
+        // store paths that are dangling on the host and fail extraction.
+        clear_dir_contents(&format!("{NIX_STORE_MOUNT}/out"))?;
         Ok(())
     }
 
@@ -4086,6 +4190,48 @@ mod linux {
             let stage = dir.path().join("builder-input");
 
             reset_stage_dir(stage.to_str().expect("utf-8 path")).expect("reset");
+
+            assert!(stage.is_dir());
+        }
+
+        /// The property the persistent path depends on, and the reason it
+        /// cannot reuse `reset_stage_dir`: `/job` is bind-mounted onto the
+        /// staging directory, so the directory must survive being emptied.
+        /// Remove and recreate and the bind points at a deleted inode — every
+        /// later write lands somewhere nothing reads, silently.
+        #[test]
+        fn clear_dir_contents_empties_without_replacing_the_directory() {
+            use std::os::unix::fs::MetadataExt;
+
+            let dir = tempfile::tempdir().expect("tempdir");
+            let stage = dir.path().join("job");
+            std::fs::create_dir_all(stage.join("nested")).expect("nested");
+            std::fs::write(stage.join("cmd.sh"), b"old").expect("file");
+            std::fs::write(stage.join("nested/leftover"), b"old").expect("nested file");
+            let before = std::fs::metadata(&stage).expect("stat").ino();
+
+            clear_dir_contents(stage.to_str().expect("utf-8 path")).expect("clear");
+
+            assert_eq!(
+                std::fs::metadata(&stage).expect("stat").ino(),
+                before,
+                "the directory itself must survive, or the bind mount is orphaned"
+            );
+            assert_eq!(
+                std::fs::read_dir(&stage).expect("read").count(),
+                0,
+                "a previous dispatch's files must not leak into the next one"
+            );
+        }
+
+        /// Same first-boot tolerance `reset_stage_dir` has: a persistent VM
+        /// re-stages before the directory necessarily exists.
+        #[test]
+        fn clear_dir_contents_creates_the_directory_when_absent() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let stage = dir.path().join("job");
+
+            clear_dir_contents(stage.to_str().expect("utf-8 path")).expect("clear");
 
             assert!(stage.is_dir());
         }

--- a/crates/mvm-build/src/builder_disk_transport.rs
+++ b/crates/mvm-build/src/builder_disk_transport.rs
@@ -20,6 +20,7 @@
 //! stops extraction before the disk's zero padding, so a fixed-size disk carrying
 //! a shorter archive round-trips cleanly.
 
+use std::os::unix::fs::FileExt;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -92,6 +93,62 @@ pub fn pack_input_disk(
         .with_context(|| format!("open {} to size", out_image.display()))?;
     f.set_len(disk_size)
         .with_context(|| format!("size input disk to {disk_size}"))?;
+    Ok(())
+}
+
+/// Rewrite a **already-attached** input disk in place, for one dispatch of a
+/// persistent builder.
+///
+/// [`pack_input_disk`] sizes the file to its contents with `set_len`, which is
+/// right before boot and wrong afterwards. A running VM's `DiskImage` captured
+/// the file's length **once, when it opened it**, and zero-fills every guest
+/// read past that offset. Grow the file mid-session and the guest sees a
+/// truncated archive — `tar` stops at whatever it finds, which is not an error
+/// it can report as one. So this never changes the length: it writes within the
+/// capacity the VM booted with, and refuses when the archive will not fit rather
+/// than producing a disk that reads as silently short.
+///
+/// Only the `job` tree is repacked in practice. `work` and `mvm-bins` were
+/// bind-mounted by the guest at boot and are never re-read, so re-archiving a
+/// large workspace on every dispatch would cost real time for no effect.
+///
+/// The trailing bytes of the previous dispatch's archive are left alone.
+/// `tar::Builder::finish` writes the end-of-archive marker (two zero blocks),
+/// and extraction stops there, so stale tail bytes are unreachable as archive
+/// content — the same property that lets a fixed-size disk carry a short
+/// archive at boot.
+pub fn repack_input_disk_in_place(inputs: &[InputTree<'_>], image: &Path) -> Result<()> {
+    let capacity = std::fs::metadata(image)
+        .with_context(|| format!("stat {} to learn its capacity", image.display()))?
+        .len();
+    let mut buf = Vec::new();
+    {
+        let mut b = tar::Builder::new(&mut buf);
+        for tree in inputs {
+            b.append_dir_all(tree.name, tree.src)
+                .with_context(|| format!("archive '{}' from {}", tree.name, tree.src.display()))?;
+        }
+        b.finish().context("finish dispatch input tar")?;
+    }
+    if buf.len() as u64 > capacity {
+        anyhow::bail!(
+            "dispatch inputs are {} bytes but the attached input disk holds {capacity}; \
+             the guest reads zeros past its booted capacity, so a larger archive would \
+             extract as silently truncated rather than fail",
+            buf.len()
+        );
+    }
+    let f = std::fs::OpenOptions::new()
+        .write(true)
+        .open(image)
+        .with_context(|| format!("open {} to repack", image.display()))?;
+    f.write_all_at(&buf, 0)
+        .with_context(|| format!("write dispatch inputs to {}", image.display()))?;
+    // The guest reads this device on the next frame it is sent. Without the
+    // flush the write can still be in the host's page cache while the guest's
+    // pread races it, and the failure looks like a corrupt archive.
+    f.sync_data()
+        .with_context(|| format!("flush {}", image.display()))?;
     Ok(())
 }
 
@@ -276,5 +333,96 @@ mod tests {
         let bytes = fs::read(&image).unwrap();
         assert_eq!(bytes.len() as u64 % SECTOR, 0);
         assert!(bytes.iter().all(|&b| b == 0));
+    }
+
+    /// The invariant a running VM depends on: its `DiskImage` captured the
+    /// file's length when it opened it and zero-fills reads past that offset,
+    /// so a repack that changed the length would be read as a short archive.
+    #[test]
+    fn repacking_in_place_never_changes_the_disk_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("job-1");
+        fs::create_dir_all(&first).unwrap();
+        fs::write(first.join("cmd.sh"), vec![b'a'; 4096]).unwrap();
+        let image = dir.path().join("in.img");
+        pack_input_disk(
+            &[InputTree {
+                name: "job",
+                src: &first,
+            }],
+            None,
+            &image,
+            64 * 1024,
+        )
+        .unwrap();
+        let capacity = fs::metadata(&image).unwrap().len();
+
+        // A second dispatch with a much smaller payload.
+        let second = dir.path().join("job-2");
+        fs::create_dir_all(&second).unwrap();
+        fs::write(second.join("cmd.sh"), b"echo hi").unwrap();
+        repack_input_disk_in_place(
+            &[InputTree {
+                name: "job",
+                src: &second,
+            }],
+            &image,
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::metadata(&image).unwrap().len(),
+            capacity,
+            "the attached disk's length must not move under the running guest"
+        );
+        // And the new payload is what extracts — the previous dispatch's longer
+        // archive is past the end-of-archive marker and unreachable.
+        let dest = dir.path().join("x");
+        read_output_disk(&image, &dest).unwrap();
+        assert_eq!(fs::read(dest.join("job/cmd.sh")).unwrap(), b"echo hi");
+    }
+
+    /// Refusing is the whole point: a too-large archive written into a fixed
+    /// capacity extracts as silently truncated, which no layer below reports.
+    #[test]
+    fn repacking_refuses_inputs_larger_than_the_booted_capacity() {
+        let dir = tempfile::tempdir().unwrap();
+        let small = dir.path().join("job-small");
+        fs::create_dir_all(&small).unwrap();
+        fs::write(small.join("cmd.sh"), b"x").unwrap();
+        let image = dir.path().join("in.img");
+        pack_input_disk(
+            &[InputTree {
+                name: "job",
+                src: &small,
+            }],
+            None,
+            &image,
+            SECTOR,
+        )
+        .unwrap();
+        let capacity = fs::metadata(&image).unwrap().len();
+
+        let big = dir.path().join("job-big");
+        fs::create_dir_all(&big).unwrap();
+        fs::write(big.join("cmd.sh"), vec![b'z'; 512 * 1024]).unwrap();
+        let err = repack_input_disk_in_place(
+            &[InputTree {
+                name: "job",
+                src: &big,
+            }],
+            &image,
+        )
+        .expect_err("an oversized dispatch payload must refuse");
+
+        assert!(
+            err.to_string().contains("input disk holds"),
+            "the refusal must name the capacity: {err}"
+        );
+        assert_eq!(
+            fs::metadata(&image).unwrap().len(),
+            capacity,
+            "a refused repack must not have resized the disk on its way out"
+        );
     }
 }

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -198,15 +198,47 @@ Five coordinated changes, host and guest:
 
 - [ ] `persistent_builder_spec`: replace the four shares with an input and an
       output disk, and add the three transport cmdline tokens.
+- [x] `repack_input_disk_in_place` — **landed**. A persistent builder rewrites
+      its input disk between dispatches, and `pack_input_disk` cannot do it: it
+      calls `set_len`. A running VM's `DiskImage` captures the file length
+      **once, at open**, and zero-fills reads past it — so growing the file hands
+      the guest an archive it reads as short, and `tar` reports success on it.
+      The in-place form never changes the length and refuses an archive that
+      will not fit, because refusing is the only way that failure is visible.
 - [ ] `HvfPersistentHostVm::start`: `pack_input_disk` the boot-time inputs
       (`work`, `mvm-bins`, closure seed) and `create_output_disk`. Both helpers
-      already exist and are what the one-shot builder calls.
-- [ ] **Readiness has to move, and this is the non-obvious one.** The host waits
-      for the guest by polling for a `dispatch.ready` file *inside the `/job`
-      share* (`wait_until_dispatch_ready`). With no share the host cannot see
-      that marker at all. Replace it with connect-polling on the dispatch
-      socket: the guest listening on its vsock port is the readiness signal,
-      and it is one the host can observe without a shared filesystem.
+      already exist and are what the one-shot builder calls. Size the input disk
+      with headroom — the capacity is fixed for the VM's life. Per-dispatch
+      repacks carry only the `job` tree (the guest bind-mounted `work` and
+      `mvm-bins` at boot and never re-reads them), so they are always smaller
+      than the boot pack.
+- [ ] **Readiness has to move, and connect-polling is NOT the answer.** The host
+      waits for the guest by polling for a `dispatch.ready` file *inside the
+      `/job` share* (`wait_until_dispatch_ready`). With no share the host cannot
+      see that marker at all.
+
+      The obvious replacement — connect to the dispatch UDS and treat success as
+      readiness — is wrong, and the repo already knows it. `hvf.rs`'s agent probe
+      says so in as many words: *"Probe the authenticated RPC stream directly;
+      this waits for a real guest response rather than treating the host-side
+      listener as readiness."* The supervisor owns that UDS and accepts on it
+      whether or not the guest is listening on the vsock port behind it, so a
+      bare connect reports ready for a guest that never started.
+
+      Two options, neither free:
+
+      - Add a `Ping`/`Pong` pair to `HostVmRequest`/`HostVmResponse`. Crisp, but
+        a wire change on both sides — so the guest needs a second change and a
+        second image rebuild.
+      - Delete `wait_until_dispatch_ready` and let the **first dispatch** be the
+        readiness proof, with a bounded retry in the dispatch client that also
+        checks VM liveness — which is where the connection is made anyway, and
+        keeps the fail-fast-on-dead-VM behaviour the wait exists for. Smaller,
+        adds no protocol surface, but moves the failure from `start()` to the
+        first build.
+
+      Prefer the second unless the diagnostics loss bites. Do not ship a bare
+      connect-poll.
 - [ ] Host dispatch client: repack the input disk with the new job payload
       before each `Run`, and `read_output_disk` into the artifact dir after each
       `Result` — rather than once after poweroff.

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -210,13 +210,23 @@ Five coordinated changes, host and guest:
 - [ ] Host dispatch client: repack the input disk with the new job payload
       before each `Run`, and `read_output_disk` into the artifact dir after each
       `Result` — rather than once after poweroff.
-- [ ] Guest dispatch loop: re-stage `/job` from the input disk on each `Run`,
-      and call `collect_disk_transport_output` after each job. Today that
-      collection runs only on the one-shot path — `run_dispatch_loop` returns
-      straight into `power_off()` and never reaches it. `/out` must be reset per
-      dispatch for the reason the boot path already documents: otherwise the
-      host reads back a tar of every artifact any earlier build left behind,
-      including dangling `result-*` symlinks that fail extraction outright.
+- [x] Guest dispatch loop: re-stages `/job` from the input disk on each `Run`
+      and collects `/out` onto the output disk after each job — the collection
+      previously ran only on the one-shot path, since `run_dispatch_loop`
+      returns straight into `power_off()`. `/out` is reset per dispatch for the
+      reason the boot path documents: otherwise the host reads back a tar of
+      every artifact any earlier dispatch left, including dangling `result-*`
+      symlinks that fail extraction outright. Only the `job` member is
+      re-extracted; `work` and `mvm-bins` do not change between dispatches.
+
+      `clear_dir_contents` is new, and is why this could not reuse
+      `reset_stage_dir`: that one removes and recreates the directory, which is
+      right at boot and wrong afterwards, because `/job` and `/out` are
+      bind-mounted onto those inodes. Orphan the bind and every later write
+      lands somewhere nothing reads, silently. A test pins the surviving inode.
+
+      **Runs only in the Linux test lane.** The guest bin is `cfg`-gated, so
+      these tests compile on macOS via `just check-gated` but execute in CI.
 - [ ] **Cannot be validated in CI or on a non-macOS host.** Every guest-booting
       lane skips on hosted runners, and the persistent builder is what
       `mvmctl build` uses on macOS 26+. Land this only behind a real

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -3,8 +3,9 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status: IN PROGRESS — Stages A and B landed. Stage C (builder VM) is
-unstarted and gated on the `out` decision; Stage D (the gate) follows it.**
+**Status: IN PROGRESS — Stages A, B and D landed. No workload tier reaches
+virtio-fs, and a ratchet gate keeps it that way. Stage C is down to one path:
+the persistent HVF builder, which needs live Apple Silicon validation.**
 
 No guest gets a virtio-fs device. Not a workload, not the builder VM, not the
 dev-tier root. The host filesystem reaches a guest as a block image or it does
@@ -162,24 +163,59 @@ because the goal is *nowhere*, not *nowhere that matters*.
 
 Remaining shares are `work`, `out`, `job`, `mvm-bins` and the closure seed.
 
-- [ ] `work`, `job`, `mvm-bins`, closure seed — inbound and read-only. Same
-      treatment as Stage A; `work` is already done on Stage 0.
-- [ ] `out` is the hard one and needs a decision: the guest **writes** artifacts
-      the host must read back. Options: a writable virtio-blk image the host
-      mounts read-only after poweroff (needs a host-side ext4 *reader*, which
-      `mvm-fs` does not have — it has a writer); or stream artifacts out over
-      the existing vsock channel. Neither is free. Do not start Stage C until
-      this is chosen.
+**`out` is already solved, and this plan was wrong about it.** The decision it
+said to make — ext4 reader vs vsock stream — was moot before it was written.
+`mvm_build::builder_disk_transport` is a **raw tar written straight onto a disk
+image, no filesystem on the transport disk**: the host packs a tar and the guest
+`tar x`es it; the guest packs artifacts and the host `tar x`es them. Both sides
+only ever run `tar`, so no host-side ext4 reader is needed — which is exactly
+why it was built, since HVF's host is macOS and macOS can neither format nor
+read an ext4. tar's end-of-archive marker stops extraction before the disk's
+zero padding, so a fixed-size disk carrying a shorter archive round-trips.
+
+**The one-shot builder already uses it** (`libkrun_builder.rs` packs the input
+disk and reads the output disk; `builder_spec` lays out four disks in vda–vdd
+order and asks for no shares). What is left is narrower than "the builder VM":
+
+- [x] `work`, `job`, `mvm-bins`, closure seed — inbound. Done for the one-shot
+      builder via the disk transport; `work` was already done on Stage 0.
+- [ ] The **persistent** HVF builder (`persistent_builder_spec`) is the only
+      remaining share-based path. It is persistent — one VM, many dispatches,
+      exchanging files with the host *while running* — so a disk packed once at
+      boot does not drop in. It already carries a `GuestService::BuilderDispatch`
+      vsock channel and a `dispatch.ready` marker protocol, so the work is
+      extending a channel that exists rather than inventing a transport:
+      stream the per-dispatch job tar in and the artifact tar out over it.
+      Touches `mvm-host-vm-init`'s dispatch loop and the host dispatch client.
+- [ ] **Cannot be validated in CI or on a non-macOS host.** Every guest-booting
+      lane skips on hosted runners, and the persistent builder is what
+      `mvmctl build` uses on macOS 26+. Land this only behind a real
+      `mvmctl build` on Apple Silicon; a broken builder has no CI witness.
 - [ ] Delete `crates/mvm-vmm/src/host/virtiofsd.rs`, both QEMU call sites, and
       the `virtiofsd` host dependency from the Linux install docs.
 
 ### Stage D — the gate
 
-- [ ] `xtask check-no-virtio-fs`, modelled on `check-single-network-path`:
-      fails on `virtio_fs` / `VirtioFs` / `virtiofsd` / `add_virtio_fs`
-      anywhere in the workspace outside the libkrun FFI bindings, which declare
-      the C API whether or not we call it.
-- [ ] Add it to the CI gate list. A removal without a gate grows back.
+Landed **before** Stage C rather than after, as a ratchet. Waiting for the
+surface to reach zero before gating it meant the removal was unprotected for
+exactly as long as it took to finish — and the finishing is the slow part.
+
+- [x] `xtask check-no-virtio-fs`. It counts only sites that **attach a device or
+      construct a share** (`add_virtiofs*`, `VirtioFs::new`/`with_tag`,
+      `VirtioFsShare {`, `HvfVirtioFsShare {`, `krun_add_virtiofs`), with
+      comments and strings blanked first. The word-matching version the plan
+      originally described would have fired on ~70 files that merely discuss
+      virtio-fs, and could have been satisfied by rewording a comment instead of
+      deleting code.
+- [x] Pinned at **23 sites across 11 files**, each row carrying why it survives
+      and what retires it. The count must match exactly: a new site fails as
+      growth, and a *removed* one fails as a stale pin, so the table can only
+      shrink and cannot drift into a ceiling nobody maintains. Four rows from
+      the first draft turned out to be comment-only and were dropped — the gate
+      caught them itself.
+- [x] Added to `check-all`, which runs on every PR (`ci.yml`). Four tests ship
+      with it, including one asserting the pattern still matches every real
+      attach form: a gate that cannot fail is decoration.
 
 ## What this costs
 
@@ -191,7 +227,10 @@ Remaining shares are `work`, `out`, `job`, `mvm-bins` and the closure seed.
   on the *dispatch window* (`backend_start + vsock_wait`), and the mount spans
   are parented to `drives`, which is outside it. A launch with no `--mount` is
   unchanged, and a custom volume is already a block image.
-- **Stage C is weeks**, most of it in `out`, for a guest that runs our code.
+- **Stage C is smaller than "weeks"** — that estimate assumed `out` needed a
+  new mechanism, and it does not (see Stage C). What is left is one transport
+  swap on the persistent builder. The cost is not code volume; it is that no CI
+  lane can witness it.
 - **The QEMU workload driver may simply lose directory shares** rather than gain
   images — it is opt-in dev/test and `auto_select` never picks it, so it is the
   one place where deleting the feature outright is defensible.

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -280,6 +280,38 @@ Five coordinated changes, host and guest:
       client change. It is separately validatable on the Linux/KVM box, which
       makes it the better of the two to do first.
 
+      **Recipe, mapped against the tree.** Both QEMU sites are one-shot
+      (`run_shell_script_qemu` ~L1005 and `run_build_qemu` ~L1279 in
+      `qemu_builder.rs`), so this is the simple migration, not the persistent
+      one — no in-place repack, no per-dispatch staging. Two private helpers in
+      `libkrun_builder.rs` already do the work and need only widening to
+      `pub(crate)`: `prepare_builder_transport_disks` (packs the input disk,
+      creates the output disk) and `extract_builder_transport_output`.
+
+      Per site: build `[job, work, mvm-bins]` `InputTree`s the way
+      `libkrun_builder.rs` does at L1132 and L1654, call the prep helper, attach
+      the two images as ordinary `-drive`s, drop the `virtiofsd` spawn loop, the
+      `memory-backend-memfd` + `-numa` object (it exists only because
+      vhost-user-fs requires a shared memory backend whose size equals `-m`),
+      and the `vhost-user-fs-pci` device loop, then extract from the output disk
+      after QEMU exits.
+
+      **Disk order matters and should match the one-shot spec exactly**: vda
+      rootfs, vdb nix-store, vdc input, vdd output, vde runtime overlay,
+      identity last. That is what the guest's cmdline defaults
+      (`mvm.builder_input=/dev/vdc`, `mvm.builder_output=/dev/vdd`) and
+      `BUILDER_RUNTIME_DEVICE=/dev/vde` already assume. Today QEMU puts the
+      runtime overlay at vdc, so it moves — update the `mvm.runtime_data=` token
+      from `qemu_runtime_overlay_attachment` to match. The identity drive is
+      found by ext4 label, not slot, so it is unaffected.
+
+      **One open question**: QEMU carries `closure_share_dir`, a *directory*
+      share. The disk transport's closure support takes a NAR *file*
+      (`pack_input_disk`'s `closure_nar`, archived at
+      `closure-seed/<CLOSURE_FILE>`). libkrun passes `None` there, so the
+      existing helper has no closure path to copy. Resolve how
+      `closure_share_dir` is built before assuming it maps straight across.
+
 - [ ] The QEMU **workload** driver's share arm is a different matter and *is*
       free: workload specs carry `shares: Vec::new()` unconditionally since
       Stage A, so `qemu.rs`'s share handling is unreachable for workloads.

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -179,18 +179,55 @@ order and asks for no shares). What is left is narrower than "the builder VM":
 
 - [x] `work`, `job`, `mvm-bins`, closure seed — inbound. Done for the one-shot
       builder via the disk transport; `work` was already done on Stage 0.
-- [ ] The **persistent** HVF builder (`persistent_builder_spec`) is the only
-      remaining share-based path. It is persistent — one VM, many dispatches,
-      exchanging files with the host *while running* — so a disk packed once at
-      boot does not drop in. It already carries a `GuestService::BuilderDispatch`
-      vsock channel and a `dispatch.ready` marker protocol, so the work is
-      extending a channel that exists rather than inventing a transport:
-      stream the per-dispatch job tar in and the artifact tar out over it.
-      Touches `mvm-host-vm-init`'s dispatch loop and the host dispatch client.
+**The guest is already most of the way there.** `mvm-host-vm-init` has a
+complete disk-transport mode, selected by `mvm.builder_transport=disk` with
+`mvm.builder_input=` / `mvm.builder_output=` naming the devices:
+`stage_disk_transport_input` extracts `job`/`work`/`mvm-bins`/`closure-seed`
+off the raw input disk and bind-mounts them at the same paths the shares used,
+and `setup_modules_and_virtiofs` skips every virtio-fs mount when it is active.
+The one-shot builder runs this way today. Nothing new has to be invented — the
+persistent case just does not use it yet.
+
+No protocol change is needed either. The input disk is a raw tar the host can
+rewrite between dispatches; the guest re-reads it with `tar xf` per dispatch, so
+`Run.job_dir_relpath` keeps working and stays pointing into `/job`. Sequencing is
+already safe: the host finishes writing before it sends `Run`, and V1 serializes
+dispatches behind the supervisor's mutex.
+
+Five coordinated changes, host and guest:
+
+- [ ] `persistent_builder_spec`: replace the four shares with an input and an
+      output disk, and add the three transport cmdline tokens.
+- [ ] `HvfPersistentHostVm::start`: `pack_input_disk` the boot-time inputs
+      (`work`, `mvm-bins`, closure seed) and `create_output_disk`. Both helpers
+      already exist and are what the one-shot builder calls.
+- [ ] **Readiness has to move, and this is the non-obvious one.** The host waits
+      for the guest by polling for a `dispatch.ready` file *inside the `/job`
+      share* (`wait_until_dispatch_ready`). With no share the host cannot see
+      that marker at all. Replace it with connect-polling on the dispatch
+      socket: the guest listening on its vsock port is the readiness signal,
+      and it is one the host can observe without a shared filesystem.
+- [ ] Host dispatch client: repack the input disk with the new job payload
+      before each `Run`, and `read_output_disk` into the artifact dir after each
+      `Result` — rather than once after poweroff.
+- [ ] Guest dispatch loop: re-stage `/job` from the input disk on each `Run`,
+      and call `collect_disk_transport_output` after each job. Today that
+      collection runs only on the one-shot path — `run_dispatch_loop` returns
+      straight into `power_off()` and never reaches it. `/out` must be reset per
+      dispatch for the reason the boot path already documents: otherwise the
+      host reads back a tar of every artifact any earlier build left behind,
+      including dangling `result-*` symlinks that fail extraction outright.
 - [ ] **Cannot be validated in CI or on a non-macOS host.** Every guest-booting
       lane skips on hosted runners, and the persistent builder is what
       `mvmctl build` uses on macOS 26+. Land this only behind a real
       `mvmctl build` on Apple Silicon; a broken builder has no CI witness.
+- [ ] **Sequence the guest half first.** `mvm-host-vm-init` is cross-compiled and
+      baked into the builder rootfs, so a guest change only takes effect after
+      the image is rebuilt. Landing the guest's per-dispatch staging while the
+      host still declares shares is inert — disk transport stays off — which
+      makes it separately validatable and removes version skew from the host
+      flip. Flipping the host first against an old baked guest hangs the
+      dispatch loop with no useful error.
 - [ ] Delete `crates/mvm-vmm/src/host/virtiofsd.rs`, both QEMU call sites, and
       the `virtiofsd` host dependency from the Linux install docs.
 

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -270,8 +270,26 @@ Five coordinated changes, host and guest:
       makes it separately validatable and removes version skew from the host
       flip. Flipping the host first against an old baked guest hangs the
       dispatch loop with no useful error.
-- [ ] Delete `crates/mvm-vmm/src/host/virtiofsd.rs`, both QEMU call sites, and
-      the `virtiofsd` host dependency from the Linux install docs.
+- [ ] **The QEMU builder needs the same migration, and the plan missed it.**
+      `qemu_builder.rs` serves `work` / `out` / `job` / `mvm-bins` over
+      vhost-user/virtiofsd — not the disk transport — and QEMU is the *Linux
+      auto-detect default builder*. So this is not the "opt-in dev/test backend
+      we can just delete the feature from": deleting its shares breaks every
+      Linux build. It needs the same treatment as the persistent HVF builder,
+      and the guest side already supports it, so it should be mostly a spec and
+      client change. It is separately validatable on the Linux/KVM box, which
+      makes it the better of the two to do first.
+
+- [ ] The QEMU **workload** driver's share arm is a different matter and *is*
+      free: workload specs carry `shares: Vec::new()` unconditionally since
+      Stage A, so `qemu.rs`'s share handling is unreachable for workloads.
+
+- [ ] Only once both builders are on the disk transport can
+      `crates/mvm-vmm/src/host/virtiofsd.rs` (382 lines), its QEMU call sites,
+      and the `virtiofsd` host dependency in the Linux install docs go — and
+      with them the `--sandbox none` flag that started this plan. That is also
+      when `check-no-virtio-fs` drops to FFI-only rows and the ratchet becomes
+      an absolute rather than a ceiling.
 
 ### Stage D — the gate
 

--- a/specs/sprint/delivery/virtio-fs-ratchet-gate.md
+++ b/specs/sprint/delivery/virtio-fs-ratchet-gate.md
@@ -1,0 +1,59 @@
+# A ratchet on the virtio-fs surface
+
+`xtask check-no-virtio-fs` pins every site that attaches a virtio-fs device or
+constructs a share, with a reason per file and what would retire it. A new site
+fails as growth. A *removed* site also fails, as a stale pin — so the table can
+only shrink, and cannot rot into a ceiling nobody maintains.
+
+23 sites across 11 files, all of them builder-VM plumbing or the libkrun C FFI.
+No workload tier reaches virtio-fs at all.
+
+## Landed before the removal finished, not after
+
+The plan put this gate last, after Stage C. That ordering leaves the removal
+unprotected for exactly as long as the removal takes — and the remaining work
+needs hardware validation, so "as long as it takes" is open-ended. A ratchet
+does not need the surface to be zero to be useful; it needs it to be *known*.
+
+## Counting code, not the word
+
+The plan's original design failed on `virtio_fs` / `VirtioFs` / `virtiofsd`
+anywhere outside the FFI bindings. That would have fired on ~70 files, nearly
+all of which only *discuss* virtio-fs — including several explaining why we are
+removing it. Worse, a word-matching gate is satisfied by rewording a comment.
+
+So the pattern matches the forms that actually attach a device — `add_virtiofs*`,
+`VirtioFs::new`/`with_tag`, `VirtioFsShare {`, `HvfVirtioFsShare {`,
+`krun_add_virtiofs` — over source with comments and strings blanked first. A
+test pins each of those forms, because a pattern that silently stops matching
+one turns a whole class of attach site invisible.
+
+Four rows in the first draft turned out to be doc comments rather than code. The
+gate caught them on its first run, which is the behaviour worth having.
+
+## What the inventory turned up
+
+Two findings that change the remaining plan, both recorded there:
+
+**`out` was never the blocker.** The plan said Stage C could not start until we
+chose between a host-side ext4 reader and vsock streaming.
+`mvm_build::builder_disk_transport` already resolves it and has for some time: a
+raw tar written straight onto a disk image with no filesystem, so both sides only
+run `tar` and the host needs no ext4 reader. That is precisely why it exists —
+HVF's host is macOS, which can neither format nor read an ext4.
+
+**The one-shot builder already migrated.** `libkrun_builder.rs` packs the input
+disk and reads the output disk; `builder_spec` lays out four disks and asks for
+no shares. The only share-based path left is the *persistent* HVF builder, which
+is persistent — many dispatches against one live VM — so a disk packed once at
+boot does not substitute. It already has a `BuilderDispatch` vsock channel, so
+that migration extends an existing protocol rather than inventing a transport.
+
+## Verification
+
+Both failure directions were exercised against the real tree before landing: a
+new attach site in an unpinned file is reported as new surface, and an extra site
+in a pinned file is reported as growth. Four unit tests ship with the gate,
+including one asserting the pattern still matches every real attach form.
+
+`check-all` — 63 gates clean. The gate runs on every PR through `ci.yml`.

--- a/xtask/src/check_all.rs
+++ b/xtask/src/check_all.rs
@@ -113,6 +113,7 @@ pub const GATES: &[Gate] = &[
         "check-single-network-path",
         crate::check_single_network_path::run,
     ),
+    ("check-no-virtio-fs", crate::check_no_virtio_fs::run),
     (
         "check-single-workload-env",
         crate::check_single_workload_env::run,

--- a/xtask/src/check_no_virtio_fs.rs
+++ b/xtask/src/check_no_virtio_fs.rs
@@ -1,0 +1,249 @@
+//! Ratchet on the virtio-fs surface: it may shrink, never grow.
+//!
+//! virtio-fs puts a FUSE server on the host — in a daemon for QEMU, in the
+//! VMM's own address space for libkrun and HVF — and points it at a host
+//! directory. Every request it parses arrives from the guest. That is a large,
+//! guest-driven parser on the wrong side of the boundary, and it is the one
+//! mechanism by which a guest addresses host filesystem *structure* rather than
+//! opaque blocks. A block device is a byte array with no protocol to attack.
+//!
+//! No workload tier reaches it any more. What is left is builder-VM plumbing
+//! and the libkrun C FFI, each pinned below with the reason it survives and
+//! what would retire it. This check does not assert the surface is gone — it asserts
+//! nothing has been *added* to it, and that entries disappear from the table as
+//! the code disappears.
+//!
+//! The check counts only sites that **attach a device or construct a share**.
+//! Prose mentioning virtio-fs is not counted: ~70 files discuss it, and a gate
+//! that fired on the word would be noise, gamed by rewording rather than by
+//! deleting code.
+
+use anyhow::{Result, bail};
+use regex::Regex;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use crate::fs_walk::for_each_file;
+use crate::rust_source::blank_comments_and_strings;
+
+/// Sites that attach a virtio-fs device to a guest, or build the share value
+/// that becomes one. Deliberately narrow — see the module comment.
+const ATTACH_PATTERN: &str = r"add_virtiofs[0-9]?\(|VirtioFs::(new|with_tag)|VirtioFsShare\s*\{|HvfVirtioFsShare\s*\{|krun_add_virtiofs";
+
+/// The pinned surface: `(path, count, why it is still here)`.
+///
+/// Lower a count when you delete a site; delete the row when it reaches zero.
+/// The check fails on a count that is too high (something was added) *and* on
+/// one that is too low (something was removed without updating this table), so
+/// the number stays a true statement about the tree rather than a ceiling that
+/// drifts.
+const PINNED: &[(&str, usize, &str)] = &[
+    // ── the C API, declared whether or not we call it ────────────────────────
+    (
+        "crates/deps/libkrun-sys/src/sys.rs",
+        6,
+        "the libkrun C FFI's safe wrapper; declares the API the dylib exports",
+    ),
+    (
+        "crates/deps/libkrun-sys/src/start.rs",
+        3,
+        "maps SupervisorConfig mounts onto the libkrun C API for the builder VM",
+    ),
+    // ── builder VM: the trusted tier, still exchanging files as shares ───────
+    (
+        "crates/mvm-runtime/src/builder_runner/spec.rs",
+        1,
+        "the HVF *persistent* builder's work/mvm-bins/job/out shares. Retired by \
+         moving the per-dispatch exchange onto the BuilderDispatch vsock channel \
+         that already exists; the one-shot builder already uses the disk transport",
+    ),
+    // ── the seam every backend maps its shares through ───────────────────────
+    (
+        "crates/mvm-vmm/src/driver/spec.rs",
+        1,
+        "the VirtioFsShare type itself; empty for every workload spec",
+    ),
+    (
+        "crates/mvm-vmm/src/host/hvf_supervisor.rs",
+        1,
+        "HvfVirtioFsShare on the supervisor wire config, builder VMs only",
+    ),
+    (
+        "crates/mvm-backends/src/driver/hvf.rs",
+        1,
+        "maps spec shares onto the HVF supervisor config",
+    ),
+    (
+        "crates/mvm-backends/src/driver/libkrun.rs",
+        5,
+        "one mapper plus tests asserting a workload spec carries no shares",
+    ),
+    (
+        "crates/mvm-backends/src/driver/qemu.rs",
+        2,
+        "QEMU's vhost-user/virtiofsd wiring. Opt-in dev/test only — auto_select \
+         never returns it and it carries no untrusted workload, so this is the \
+         one backend where deleting the feature outright is defensible",
+    ),
+    (
+        "crates/mvm-backends/src/driver/fc.rs",
+        1,
+        "a test: Firecracker must keep *refusing* a share",
+    ),
+    // ── the HVF device model ─────────────────────────────────────────────────
+    (
+        "crates/mvm-vmm/src/vmm/virtio.rs",
+        1,
+        "the VirtioFs MMIO device. Reachable only from a builder VM now that the \
+         dev-tier virtio-fs root is gone",
+    ),
+    (
+        "crates/mvm-runtime/src/backends/hvf/kernel_boot.rs",
+        1,
+        "attaches the builder's shares to the HVF device model",
+    ),
+];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let re = Regex::new(ATTACH_PATTERN).expect("attach pattern compiles");
+    let mut found: BTreeMap<String, usize> = BTreeMap::new();
+
+    for dir in ["crates", "src", "xtask"] {
+        let root = workspace.join(dir);
+        if !root.exists() {
+            continue;
+        }
+        for_each_file(&root, Some("rs"), &mut |path, source| {
+            // The FFI's generated bindings declare the C symbols and are not a
+            // call site; counting them would pin bindgen output.
+            let rel = match path.strip_prefix(workspace) {
+                Ok(r) => r.to_string_lossy().replace('\\', "/"),
+                Err(_) => return,
+            };
+            if rel.ends_with("libkrun_bindings.rs") || rel.starts_with("xtask/") {
+                return;
+            }
+            let code = blank_comments_and_strings(source);
+            let n = re.find_iter(&code).count();
+            if n > 0 {
+                found.insert(rel, n);
+            }
+        })?;
+    }
+
+    let pinned: BTreeMap<&str, (usize, &str)> =
+        PINNED.iter().map(|(p, n, why)| (*p, (*n, *why))).collect();
+
+    let mut problems: Vec<String> = Vec::new();
+
+    for (path, n) in &found {
+        match pinned.get(path.as_str()) {
+            None => problems.push(format!(
+                "NEW virtio-fs surface in {path} ({n} site(s)).\n    \
+                 virtio-fs is being removed, not extended. Attach a block device \
+                 instead — or, if this is genuinely builder-VM plumbing, add a \
+                 row to PINNED in xtask/src/check_no_virtio_fs.rs saying why and \
+                 what retires it."
+            )),
+            Some((want, _)) if n > want => problems.push(format!(
+                "{path} grew from {want} to {n} virtio-fs site(s). The surface \
+                 may shrink, never grow."
+            )),
+            Some((want, _)) if n < want => problems.push(format!(
+                "{path} shrank from {want} to {n} virtio-fs site(s) — good. \
+                 Lower its count in xtask/src/check_no_virtio_fs.rs so the table \
+                 stays a true statement about the tree."
+            )),
+            Some(_) => {}
+        }
+    }
+
+    for (path, (want, _)) in &pinned {
+        if !found.contains_key(*path) {
+            problems.push(format!(
+                "{path} is pinned at {want} virtio-fs site(s) but has none left. \
+                 Delete its row from xtask/src/check_no_virtio_fs.rs."
+            ));
+        }
+    }
+
+    if !problems.is_empty() {
+        bail!(
+            "check-no-virtio-fs failed:\n  - {}",
+            problems.join("\n  - ")
+        );
+    }
+
+    let total: usize = found.values().sum();
+    println!(
+        "check-no-virtio-fs: clean ({total} attach/construct sites across {} pinned \
+         files, all builder-VM or FFI; no workload tier reaches virtio-fs)",
+        found.len()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workspace() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask sits under the workspace root")
+            .to_path_buf()
+    }
+
+    #[test]
+    fn passes_on_this_workspace() {
+        run(&workspace()).expect("the pinned table matches the tree");
+    }
+
+    #[test]
+    fn the_pattern_catches_every_way_a_share_is_attached_or_built() {
+        // A gate that cannot fail is decoration. Each of these is a real form
+        // that appears in the tree; if the pattern stops matching one, a whole
+        // class of attach site goes invisible to the ratchet.
+        let re = Regex::new(ATTACH_PATTERN).unwrap();
+        for form in [
+            "krun.add_virtiofs(&tag, path)",
+            "krun.add_virtiofs2(&tag, path, shm)",
+            "krun.add_virtiofs3(&tag, path, shm, true)",
+            "bindings::krun_add_virtiofs(ctx, tag, path)",
+            "VirtioFs::new(base, irq, ram, RAM_BASE, size, root)",
+            "VirtioFs::with_tag(base, irq, ram, RAM_BASE, size, root, tag)",
+            "let s = VirtioFsShare { tag, host_path, read_only, dax };",
+            "HvfVirtioFsShare { path, tag }",
+        ] {
+            assert!(re.is_match(form), "pattern missed an attach form: {form}");
+        }
+    }
+
+    #[test]
+    fn prose_alone_does_not_count_as_surface() {
+        // ~70 files discuss virtio-fs. Counting the word would make the gate
+        // noise, and would let someone satisfy it by rewording a comment rather
+        // than deleting code.
+        let re = Regex::new(ATTACH_PATTERN).unwrap();
+        let source = concat!(
+            "/// libkrun's `krun_add_virtiofs` has no read-only toggle.\n",
+            "// VirtioFsShare { .. } used to be built here.\n",
+            "fn f() { let msg = \"krun_add_virtiofs\"; }\n",
+        );
+        let code = blank_comments_and_strings(source);
+        assert_eq!(re.find_iter(&code).count(), 0);
+    }
+
+    #[test]
+    fn every_pinned_row_names_a_distinct_file_and_gives_a_reason() {
+        let mut seen = std::collections::BTreeSet::new();
+        for (path, count, why) in PINNED {
+            assert!(seen.insert(*path), "{path} is pinned twice");
+            assert!(*count > 0, "{path} is pinned at zero; delete the row");
+            assert!(
+                why.len() > 20,
+                "{path} needs a reason a reader can act on, not a label"
+            );
+        }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -53,6 +53,7 @@ mod check_no_network_literals;
 mod check_no_overclaim;
 mod check_no_spec_refs_in_comments;
 mod check_no_string_backend_dispatch;
+mod check_no_virtio_fs;
 mod check_no_vz;
 mod check_one_guest_protocol;
 mod check_per_vm_host_binaries_sync;
@@ -349,6 +350,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_no_guest_tool_client::run(&workspace)
         }
+        Some("check-no-virtio-fs") => {
+            let workspace = workspace_root();
+            check_no_virtio_fs::run(&workspace)
+        }
         Some("check-single-network-path") => {
             let workspace = workspace_root();
             check_single_network_path::run(&workspace)
@@ -422,7 +427,7 @@ fn main() -> Result<()> {
             check_all::run_all(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-sdk-transport-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-sdk-transport-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-virtio-fs, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -565,6 +570,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-single-network-path              assert one endpoint, one NetworkFlow channel, no guest NIC/L3 path, and one workload socket owner"
+            );
+            println!(
+                "  check-no-virtio-fs                     ratchet the virtio-fs attach surface: builder VM and FFI only, may shrink but never grow"
             );
             eprintln!(
                 "  check-workflow-paths                    assert every workflow working-directory and cargo-fuzz target still exists"


### PR DESCRIPTION
Stage D of `specs/plans/2026-08-31-remove-virtio-fs.md`, landing **before** Stage C rather than after.

`xtask check-no-virtio-fs` pins every site that attaches a virtio-fs device or constructs a share, with a reason per file and what would retire it. A new site fails as growth. A *removed* site also fails, as a stale pin — so the table can only shrink, and cannot rot into a ceiling nobody maintains.

**23 sites across 11 files**, all builder-VM plumbing or the libkrun C FFI. No workload tier reaches virtio-fs at all, following #3047.

## Why it lands before the removal is finished

The plan put this last. That leaves the removal unprotected for exactly as long as the removal takes — and what's left needs hardware validation, so that's open-ended. A ratchet doesn't need the surface to be zero to be useful; it needs it to be *known*.

## Counting code, not the word

The plan's original design failed on `virtio_fs` / `VirtioFs` / `virtiofsd` anywhere outside the FFI bindings. That fires on ~70 files, nearly all of which only *discuss* virtio-fs — several of them explaining why we're removing it. Worse, a word-matching gate is satisfied by rewording a comment.

So the pattern matches the forms that actually attach a device — `add_virtiofs*`, `VirtioFs::new`/`with_tag`, `VirtioFsShare {`, `HvfVirtioFsShare {`, `krun_add_virtiofs` — over source with comments and strings blanked first. A test pins each form, because a pattern that silently stops matching one turns a whole class of attach site invisible.

Four rows in the first draft turned out to be doc comments rather than code. The gate caught them on its first run.

## Two findings that change the rest of the plan

Both are now recorded in the plan doc, correcting it:

**`out` was never the blocker.** The plan said Stage C couldn't start until we chose between a host-side ext4 reader and vsock streaming. `mvm_build::builder_disk_transport` already resolves it: a raw tar written straight onto a disk image with **no filesystem**, so both sides only run `tar` and the host needs no ext4 reader. That's exactly why it exists — HVF's host is macOS, which can neither format nor read an ext4.

**The one-shot builder already migrated.** `libkrun_builder.rs` packs the input disk and reads the output disk; `builder_spec` lays out four disks and asks for no shares. The only share-based path left is the **persistent** HVF builder — persistent meaning many dispatches against one live VM, so a disk packed once at boot doesn't substitute. It already carries a `BuilderDispatch` vsock channel, so that migration extends an existing protocol rather than inventing a transport.

Stage C is therefore much smaller than the plan's "weeks" estimate. Its real cost is that **no CI lane can witness it**: every guest-booting lane skips on hosted runners, and the persistent builder is what `mvmctl build` uses on macOS 26+. The plan now says to land it only behind a real `mvmctl build` on Apple Silicon.

## Verification

Both failure directions exercised against the real tree before landing — a new attach site in an unpinned file reports as new surface; an extra site in a pinned file reports as growth. Four unit tests ship with the gate.

- `cargo run -p xtask -- check-all` — 63 gates clean (this gate runs on every PR via `ci.yml`)
- `cargo nextest run -p xtask` — 667 passed
- `cargo fmt --all -- --check`, `cargo clippy -p xtask --all-targets -- -D warnings` — clean
