### PR TITLE
fix(ci): close residual documented-surface regressions

### DIFF
--- a/crates/mvm-agentd/src/vsock/framing.rs
+++ b/crates/mvm-agentd/src/vsock/framing.rs
@@ -276,7 +276,8 @@ impl AuthenticatedSession {
     /// Read, authenticate, decrypt, and deserialize one control frame.
     pub fn read<T: serde::de::DeserializeOwned>(&mut self, stream: &mut impl Read) -> Result<T> {
         let sealed = read_sealed_frame(stream, MAX_SEALED_FRAME_SIZE)
-            .map_err(|error| anyhow::anyhow!("control frame read failed: {error}"))?;
+            .map_err(anyhow::Error::new)
+            .context("control frame read failed")?;
         let plaintext = self
             .inner
             .open(&sealed)
@@ -313,6 +314,28 @@ mod tests {
             rand::rng().fill_bytes(&mut __ed_seed);
             SigningKey::from_bytes(&__ed_seed)
         }
+    }
+
+    struct WouldBlockReader;
+
+    impl std::io::Read for WouldBlockReader {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::ErrorKind::WouldBlock.into())
+        }
+    }
+
+    #[test]
+    fn control_frame_read_preserves_would_block_for_bounded_retry() {
+        let error = read_sealed_frame(&mut WouldBlockReader, MAX_SEALED_FRAME_SIZE)
+            .map_err(anyhow::Error::new)
+            .context("control frame read failed")
+            .expect_err("a would-block reader has no frame");
+
+        assert!(error.chain().any(|cause| {
+            cause
+                .downcast_ref::<std::io::Error>()
+                .is_some_and(|io| io.kind() == std::io::ErrorKind::WouldBlock)
+        }));
     }
 
     // ========================================================================

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -153,7 +153,7 @@ pub(in crate::commands) fn start_persistent_oci_machine(
         resolved_digest,
         rootfs_path,
         profile,
-        cpus,
+        mut cpus,
         memory_mib,
         mem_initial_mib,
         volumes,
@@ -167,6 +167,18 @@ pub(in crate::commands) fn start_persistent_oci_machine(
         grants,
     } = params;
     validate_vm_name(name).with_context(|| format!("Invalid VM name: {:?}", name))?;
+    if let Some(granted) = mvm_client::clamp_vcpus_for_backend(backend_name, cpus) {
+        crate::ui::warn(&format!(
+            "{backend_name} supports at most {granted} vCPU(s); {cpus} requested, booting with {granted}"
+        ));
+        tracing::info!(
+            backend = backend_name,
+            requested = cpus,
+            granted,
+            "vcpu request clamped to the backend ceiling"
+        );
+        cpus = granted;
+    }
     let mut prepared_volumes =
         super::super::volume::merge_registered_volumes_for_launch(name, volumes)
             .context("resolving registered local volumes before admission")?;

--- a/crates/mvm-client/src/boot.rs
+++ b/crates/mvm-client/src/boot.rs
@@ -166,6 +166,14 @@ pub fn start_prepared(
     Ok(())
 }
 
+/// Clamp a requested vCPU count against the selected backend before admission
+/// records the grant and before the backend serializes its machine config.
+#[must_use]
+pub fn clamp_vcpus_for_backend(backend_name: &str, requested: u32) -> Option<u32> {
+    let backend = mvm_runtime::backend::AnyBackend::from_hypervisor(backend_name);
+    mvm_core::vm_backend::clamp_vcpus(requested, backend.capabilities().max_vcpus)
+}
+
 /// Report what actually bounded the VM [`start_prepared`] just started.
 ///
 /// This is the seam that puts `VmBackend::apply_grants` on the path `mvmctl`
@@ -250,6 +258,15 @@ pub fn require_hypervisor_selectable(name: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::ResumeBootLocalRequest;
+
+    #[test]
+    fn firecracker_vcpus_are_clamped_before_the_u8_api_boundary() {
+        assert_eq!(
+            super::clamp_vcpus_for_backend("firecracker", 9_999),
+            Some(u32::from(u8::MAX))
+        );
+        assert_eq!(super::clamp_vcpus_for_backend("firecracker", 2), None);
+    }
 
     #[test]
     fn resume_boot_builder_reports_the_first_missing_required_field() {

--- a/crates/mvm-client/src/lib.rs
+++ b/crates/mvm-client/src/lib.rs
@@ -47,8 +47,8 @@ pub use mvm_core::naming::validate_vm_name;
 
 pub use boot::{
     ResumeBootLocalRequest, ResumeBootLocalRequestBuilder, backend_is_running, backend_kind_for,
-    backend_stop_by_name, enforced_grants_after_start, require_hypervisor_selectable,
-    resume_and_boot_local, start_prepared,
+    backend_stop_by_name, clamp_vcpus_for_backend, enforced_grants_after_start,
+    require_hypervisor_selectable, resume_and_boot_local, start_prepared,
 };
 pub use connect::{Target, connect};
 pub use grants::{enforced_grants_of, record_enforced_grants};

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,12 @@ Last updated: 2026-09-01
 
 ## In progress
 
+- [ ] **Extended CI residual regressions — issues #3051 and #3052.**
+      `specs/plans/2026-08-28-extended-ci-red-repair.md`.
+      Persistent launches clamp vCPUs before admission, authenticated frame
+      reads preserve retryable I/O sources. Focused regressions are green;
+      broad validation and merge delivery remain.
+
 - [ ] **Warm claim authenticated readiness — issue #3039.**
       `specs/plans/2026-08-31-warm-claim-authenticated-readiness.md`.
       A restored child advances only after an authenticated Ping proves its

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3508,3 +3508,12 @@ writes the plan:
       the example's unsupported CLI flag.
 - [x] Complete workspace and gated validation.
 - [ ] Merge the repair through the queue and close issue #3041.
+
+## 2026-09-01 Extended CI residual regressions
+
+- [x] Clamp persistent Firecracker vCPU requests before admission and API
+      serialization.
+- [x] Preserve typed `WouldBlock` control-frame errors for bounded retry during
+      sustained egress transfers.
+- [ ] Complete the broad validation matrix and merge the repair for #3051,
+      and #3052.

--- a/specs/plans/2026-08-28-extended-ci-red-repair.md
+++ b/specs/plans/2026-08-28-extended-ci-red-repair.md
@@ -4,7 +4,9 @@ Backing: shipped-source
 Validation: check-sprint-append
 
 **Issues:** [#2979](https://github.com/tinylabscom/mvm/issues/2979),
-[#3007](https://github.com/tinylabscom/mvm/issues/3007)
+[#3007](https://github.com/tinylabscom/mvm/issues/3007),
+[#3051](https://github.com/tinylabscom/mvm/issues/3051),
+[#3052](https://github.com/tinylabscom/mvm/issues/3052)
 
 ## Outcome
 
@@ -65,6 +67,10 @@ a competing BLAKE3 address or re-hash the archive.
   machine-config boundary and two stale BDD assertions; the backend now
   declares that vCPU ceiling, while the witnesses preserve child exit status
   and stderr ownership.
+- The next complete Linux witness exposed two residual boundaries: persistent
+  machine launches bypassed the backend vCPU clamp, and authenticated frame
+  reads erased the I/O source needed to recognize `EAGAIN`. The persistent path
+  now clamps before admission, and frame errors preserve their typed source.
 
 ## Delivery checklist
 
@@ -108,5 +114,11 @@ a competing BLAKE3 address or re-hash the archive.
       capability so oversized portable requests clamp before serialization.
 - [x] Reconcile the live refusal witnesses with the child process exit code,
       stderr channel, and fail-closed timeout-admission contracts.
+- [x] Clamp persistent-machine vCPU requests before admission and Firecracker
+      machine-config serialization.
+- [x] Preserve `WouldBlock` through authenticated control-frame context so the
+      existing bounded liveness loop can retry sustained transfers.
+- [ ] Pass focused formatting, Clippy, workspace, gated, and policy checks for
+      the residual repair.
 - [ ] Pass a fresh Extended CI run containing all repaired witness lanes.
 - [ ] Merge the corrective pull request and close #3007 through its linkage.


### PR DESCRIPTION
Closes #3051.
Closes #3052.

Repairs the two residual failures surfaced by the fresh Linux documented-surface witness:

- clamp persistent-machine vCPU requests against the selected backend before admission and Firecracker serialization
- preserve the typed I/O source on authenticated control-frame reads so the existing bounded liveness loop retries EAGAIN/WouldBlock

Validation:
- cargo test -p mvm-agentd -p mvm-client -p mvm-cli
- cargo clippy -p mvm-agentd -p mvm-client -p mvm-cli -- -D warnings
- pre-commit workspace Clippy and affected all-target gates
- cargo fmt --all
- cargo run -p xtask -- check-sprint-append