### PR TITLE
chore: ignore the generated output/ tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,7 @@ graft/
 
 # Qwen Code session directory
 .qwen/
+
+# Generated document output (`output/pdf`). Regenerable, and large enough that
+# committing it once would be hard to undo.
+output/


### PR DESCRIPTION
`output/pdf` shows up untracked in a working checkout and nothing ignored it, so it was one `git add -A` away from being committed. It is generated and regenerable; committing it once would be awkward to undo.