### PR TITLE
fix(sdk): finish the sidecar libc selection — compare real values, and enforce it on the run path

### DIFF
--- a/crates/mvm-build/src/guest_libc.rs
+++ b/crates/mvm-build/src/guest_libc.rs
@@ -22,26 +22,33 @@ use std::path::Path;
 /// while the detection — which reads a filesystem — stays here.
 pub use mvm_contract::guest_libc::GuestLibc;
 
-/// The libc `libmvm_host_services.so` is currently built against.
+/// Whether a guest whose rootfs is `image` can load a sidecar built for
+/// `sidecar`.
 ///
-/// `nix/packages/mvm-sdk-cdylib.nix` builds one variant, for the nixpkgs Linux
-/// platform, which is glibc. A guest whose own libc differs cannot load it:
-/// musl's loader fails resolving glibc-only symbols such as `_dl_find_object`,
-/// and shipping a second loader alongside does not help, because the process
-/// doing the loading already has one.
+/// Both sides are now facts rather than assumptions: the image records its libc
+/// in its `mvm-meta.json`, and the sidecar records its own in the cache path it
+/// was filed under. A hardcoded constant stood here while only one variant was
+/// built, and it has to go rather than be updated — with two variants cached
+/// side by side, any fixed answer is wrong for one of them.
 ///
-/// This is the single place that changes when a second variant exists — the
-/// refusal keyed on it becomes a selection between them.
-pub const SIDECAR_CDYLIB_LIBC: GuestLibc = GuestLibc::Glibc;
+/// [`GuestLibc::Unknown`] on either side is refused rather than attempted. It
+/// means a loader this code does not recognise, or more than one, and attaching
+/// on a guess turns a refusal the host can explain into a relocation error
+/// raised from inside the guest at `dlopen` time.
+#[must_use]
+pub fn sidecar_loads_in(image: GuestLibc, sidecar: GuestLibc) -> bool {
+    image != GuestLibc::Unknown && image == sidecar
+}
 
-/// Whether a guest recording `image` can load the SDK host-services cdylib.
+/// The libc a cached sidecar image was filed under, by its path.
 ///
-/// [`GuestLibc::Unknown`] is refused rather than attempted. It means the image
-/// carried no loader this code recognises, or carried more than one, and
-/// attaching on a guess turns a refusal the host can explain into a relocation
-/// error raised from inside the guest at `dlopen` time.
-pub fn sidecar_loads_in(image: GuestLibc) -> bool {
-    image == SIDECAR_CDYLIB_LIBC
+/// Delegates to the layout that wrote the path, so the encoding has exactly one
+/// owner. Re-exposed here because the admission gate reads it and already
+/// depends on this module — routing through the owner beats either a second
+/// parser or a new dependency edge for one function.
+#[must_use]
+pub fn sidecar_libc_of_image_path(image: &std::path::Path) -> GuestLibc {
+    mvm_fs::sdk_sidecar::SdkSidecarLayout::libc_of_image_path(image)
 }
 
 /// Directories a dynamic loader lives in, relative to the rootfs.
@@ -165,8 +172,11 @@ mod tests {
     }
     #[test]
     fn only_a_matching_libc_can_load_the_sidecar() {
-        assert!(sidecar_loads_in(SIDECAR_CDYLIB_LIBC));
-        assert!(!sidecar_loads_in(GuestLibc::Musl));
+        assert!(sidecar_loads_in(GuestLibc::Glibc, GuestLibc::Glibc));
+        assert!(sidecar_loads_in(GuestLibc::Musl, GuestLibc::Musl));
+        // The mismatch this predicate exists to catch, both ways round.
+        assert!(!sidecar_loads_in(GuestLibc::Musl, GuestLibc::Glibc));
+        assert!(!sidecar_loads_in(GuestLibc::Glibc, GuestLibc::Musl));
     }
 
     /// Unknown must not load. It is the arm that would otherwise be attempted
@@ -174,6 +184,11 @@ mod tests {
     /// instead of a refusal the host can explain.
     #[test]
     fn an_unknown_libc_never_loads_the_sidecar() {
-        assert!(!sidecar_loads_in(GuestLibc::Unknown));
+        // Unknown on either side is refused, never treated as a match — even
+        // against itself, where "both unrecognised" is not evidence of
+        // agreement.
+        assert!(!sidecar_loads_in(GuestLibc::Unknown, GuestLibc::Glibc));
+        assert!(!sidecar_loads_in(GuestLibc::Glibc, GuestLibc::Unknown));
+        assert!(!sidecar_loads_in(GuestLibc::Unknown, GuestLibc::Unknown));
     }
 }

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -598,7 +598,7 @@ mod sdk_sidecar_host_resolution_tests {
         mvm_hostd::plan_admission::enforce_sdk_sidecar_attachment(
             std::slice::from_ref(&attached.volume),
             &plan,
-            mvm_build::guest_libc::SIDECAR_CDYLIB_LIBC,
+            mvm_contract::guest_libc::GuestLibc::Musl,
         )
         .expect("the resolved attachment must satisfy the admission gate");
 
@@ -608,7 +608,7 @@ mod sdk_sidecar_host_resolution_tests {
             mvm_hostd::plan_admission::enforce_sdk_sidecar_attachment(
                 std::slice::from_ref(&attached.volume),
                 &unbound,
-                mvm_build::guest_libc::SIDECAR_CDYLIB_LIBC,
+                mvm_contract::guest_libc::GuestLibc::Musl,
             )
             .is_err()
         );

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -25,11 +25,14 @@ use std::path::Path;
 use crate::commands::DirShareSpec;
 use crate::ui;
 
+mod either;
 /// Exit code the CLI returns when a guest command exceeds its `--timeout`.
 /// Matches GNU `timeout(1)` so scripts can branch on it.
 mod guest_run;
 mod launch_plan;
 mod mounts;
+use either::Either;
+use mounts::refuse_unloadable_sidecar;
 mod session;
 mod transient;
 
@@ -620,27 +623,6 @@ pub fn run_with_posture(
 ) -> Result<i32> {
     run_inner(req, /* capture = */ false, admit, Some(posture))
         .map(|either| either.left().expect("streaming mode returns exit code"))
-}
-
-/// Tagged union for the two return shapes [`run`] and [`run_captured`]
-/// share. Internal — the public API exposes the unboxed variants.
-enum Either<L, R> {
-    Left(L),
-    Right(R),
-}
-impl<L, R> Either<L, R> {
-    fn left(self) -> Option<L> {
-        match self {
-            Either::Left(l) => Some(l),
-            Either::Right(_) => None,
-        }
-    }
-    fn right(self) -> Option<R> {
-        match self {
-            Either::Right(r) => Some(r),
-            Either::Left(_) => None,
-        }
-    }
 }
 
 fn boots_baked_entrypoint(req: &ExecRequest) -> bool {
@@ -1411,23 +1393,11 @@ pub fn resolve_launch(
         start_config.config_files.extend(sub.config_files);
         use_snapshot = false;
 
-        // The sidecar gate, on the path that actually reaches a guest.
-        //
-        // It lives with the other post-admission gates in `mvm-hostd`, which
-        // only `admit_and_start` runs; this path admits through `admit_for_run`
-        // and would otherwise skip it entirely. Here is the first point where
-        // both facts exist: the plan that authorized the binding, and the
-        // rootfs whose recorded libc says whether the attached sidecar can be
-        // loaded at all.
-        if let Some(plan_json) = start_config.plan_json.as_deref() {
-            let plan: mvm_core::plan::ExecutionPlan = serde_json::from_str(plan_json)
-                .context("re-reading the admitted plan to check the SDK sidecar attachment")?;
-            mvm_hostd::plan_admission::enforce_sdk_sidecar_for_launch(
-                &image.rootfs,
-                &start_config.volumes,
-                &plan,
-            )?;
-        }
+        refuse_unloadable_sidecar(
+            &image.rootfs,
+            &start_config.volumes,
+            start_config.plan_json.as_deref(),
+        )?;
     }
     sub.finish(SubPhase::AdmitPlan);
     tracing::debug!(

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1410,6 +1410,24 @@ pub fn resolve_launch(
         start_config.bundle_json = sub.bundle_json;
         start_config.config_files.extend(sub.config_files);
         use_snapshot = false;
+
+        // The sidecar gate, on the path that actually reaches a guest.
+        //
+        // It lives with the other post-admission gates in `mvm-hostd`, which
+        // only `admit_and_start` runs; this path admits through `admit_for_run`
+        // and would otherwise skip it entirely. Here is the first point where
+        // both facts exist: the plan that authorized the binding, and the
+        // rootfs whose recorded libc says whether the attached sidecar can be
+        // loaded at all.
+        if let Some(plan_json) = start_config.plan_json.as_deref() {
+            let plan: mvm_core::plan::ExecutionPlan = serde_json::from_str(plan_json)
+                .context("re-reading the admitted plan to check the SDK sidecar attachment")?;
+            mvm_hostd::plan_admission::enforce_sdk_sidecar_for_launch(
+                &image.rootfs,
+                &start_config.volumes,
+                &plan,
+            )?;
+        }
     }
     sub.finish(SubPhase::AdmitPlan);
     tracing::debug!(

--- a/crates/mvm-cli/src/exec/either.rs
+++ b/crates/mvm-cli/src/exec/either.rs
@@ -1,0 +1,45 @@
+//! A two-shape return value, and nothing else.
+//!
+//! `run` and `run_captured` differ only in what they hand back, and the
+//! function they share has to return both. That is a generic utility with no
+//! launch semantics in it, so it sits here rather than in the orchestrator it
+//! happens to serve.
+
+/// Tagged union for the two return shapes `run` and `run_captured` share.
+/// Internal — the public API exposes the unboxed variants.
+pub(super) enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+impl<L, R> Either<L, R> {
+    pub(super) fn left(self) -> Option<L> {
+        match self {
+            Either::Left(l) => Some(l),
+            Either::Right(_) => None,
+        }
+    }
+
+    pub(super) fn right(self) -> Option<R> {
+        match self {
+            Either::Right(r) => Some(r),
+            Either::Left(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each accessor answers for its own variant and refuses the other, which
+    /// is the whole contract: the callers `.expect()` on these, so a wrong
+    /// answer would surface as a panic far from here.
+    #[test]
+    fn each_side_answers_only_for_itself() {
+        assert_eq!(Either::<i32, &str>::Left(7).left(), Some(7));
+        assert_eq!(Either::<i32, &str>::Left(7).right(), None);
+        assert_eq!(Either::<i32, &str>::Right("x").right(), Some("x"));
+        assert_eq!(Either::<i32, &str>::Right("x").left(), None);
+    }
+}

--- a/crates/mvm-cli/src/exec/mounts.rs
+++ b/crates/mvm-cli/src/exec/mounts.rs
@@ -146,3 +146,75 @@ mod tests {
         assert!(!scratch.path().join("mount-0.ext4").exists());
     }
 }
+
+/// Refuse a launch whose SDK sidecar the guest could not `dlopen`.
+///
+/// The check itself is admission's, in `mvm-hostd`, and it runs there for
+/// callers that go through `admit_and_start`. `mvmctl run` does not — it admits
+/// through `admit_for_run`, which skips the post-admission gates — so without
+/// this call the refusal never fires on the path most workloads take, and a
+/// libc mismatch surfaces inside the guest as a relocation error instead.
+///
+/// `plan_json` is `None` for a launch that was not admitted (a template
+/// restore), which carries no host-service binding and so nothing to check.
+/// When present it is the *signed* envelope the supervisor receives, not a bare
+/// plan — the payload has to be opened to read the bindings.
+pub(crate) fn refuse_unloadable_sidecar(
+    rootfs: &str,
+    volumes: &[mvm_core::vm_backend::VmVolume],
+    plan_json: Option<&str>,
+) -> Result<()> {
+    let Some(plan_json) = plan_json else {
+        return Ok(());
+    };
+    let signed: mvm_core::plan::SignedExecutionPlan = serde_json::from_str(plan_json)
+        .context("re-reading the admitted plan to check the SDK sidecar attachment")?;
+    let plan: mvm_core::plan::ExecutionPlan = serde_json::from_slice(&signed.0.payload)
+        .context("reading the admitted plan's payload to check the SDK sidecar attachment")?;
+    mvm_hostd::plan_admission::enforce_sdk_sidecar_for_launch(rootfs, volumes, &plan)
+}
+
+#[cfg(test)]
+mod sidecar_gate_tests {
+    use super::*;
+
+    /// A launch that was never admitted carries no binding, so there is nothing
+    /// to check and nothing to refuse. Template restores take this path.
+    #[test]
+    fn an_unadmitted_launch_is_not_refused() {
+        refuse_unloadable_sidecar("/img/rootfs.ext4", &[], None)
+            .expect("a launch with no admitted plan has no binding to check");
+    }
+
+    /// A plan that does not deserialize is an error rather than a skip: the
+    /// alternative is treating an unreadable authority as "nothing bound".
+    #[test]
+    fn an_unreadable_plan_refuses_rather_than_skipping() {
+        let err = refuse_unloadable_sidecar("/img/rootfs.ext4", &[], Some("{not json"))
+            .expect_err("an unreadable plan must not be treated as unbound");
+        assert!(
+            format!("{err:#}").contains("re-reading the admitted plan"),
+            "{err:#}"
+        );
+    }
+
+    /// What the run path actually hands over is the signed envelope, not a bare
+    /// plan. A test that built an `ExecutionPlan` directly accepted a shape the
+    /// launch never produces, and the mismatch only surfaced when a real guest
+    /// booted — so the fixture here is the envelope, serialized the same way
+    /// admission writes it.
+    #[test]
+    fn the_signed_envelope_is_what_the_run_path_hands_over() {
+        let plan = mvm_core::plan::test_support::PlanFixture::new().build();
+        let signed =
+            mvm_core::plan::SignedExecutionPlan(mvm_contract::protocol::signing::SignedPayload {
+                payload: serde_json::to_vec(&plan).expect("serialize the plan payload"),
+                signature: Vec::new(),
+                signer_id: "test".to_string(),
+            });
+        let envelope = serde_json::to_string(&signed).expect("serialize the envelope");
+
+        refuse_unloadable_sidecar("/img/rootfs.ext4", &[], Some(&envelope))
+            .expect("a plan binding no SDK service and carrying no sidecar is admissible");
+    }
+}

--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -6,7 +6,7 @@
 //! populated cache can never make a scenario pass for the wrong reason.
 
 use cucumber::{given, then, when};
-use mvm_build::guest_libc::{GuestLibc, SIDECAR_CDYLIB_LIBC};
+use mvm_build::guest_libc::GuestLibc;
 use mvm_contract::protocol::broker::ServiceId;
 use mvm_core::arch::GuestArch;
 use mvm_core::plan::test_support::PlanFixture;
@@ -415,7 +415,7 @@ fn admission_accepts_with_sidecar(world: &mut CliWorld) {
     mvm_hostd::plan_admission::enforce_sdk_sidecar_attachment(
         &volumes,
         plan_of(world),
-        SIDECAR_CDYLIB_LIBC,
+        SCENARIO_LIBC,
     )
     .expect("the resolved attachment must satisfy the admission gate");
 }

--- a/crates/mvm-core/src/runtime_catalog.rs
+++ b/crates/mvm-core/src/runtime_catalog.rs
@@ -35,10 +35,11 @@ pub struct RuntimeEntry {
     /// before the rootfs exists, and a guest can only `dlopen` the variant
     /// matching its own libc.
     ///
-    /// [`GuestLibc::Unknown`] is the serde default so a catalog written before
-    /// this field deserializes, and it means exactly what it says elsewhere:
-    /// not "assume the common case", but "we cannot say".
-    #[serde(default)]
+    /// Required, with no serde default. The catalog is built in-tree and never
+    /// read from a file, so there is no older shape to tolerate — and a default
+    /// here would silently be [`GuestLibc::Unknown`], which refuses
+    /// `--host-service` outright. An entry that forgets to say should fail to
+    /// parse, not boot into a refusal.
     pub libc: GuestLibc,
     /// argv[0] values that select this runtime, e.g. `python`, `python3`, `pip`.
     #[serde(default)]
@@ -733,10 +734,31 @@ mod tests {
         let parsed: RuntimeEntry = serde_json::from_value(serde_json::json!({
             "name": "python",
             "description": "CPython",
-            "image": "python:3.12-alpine"
+            "image": "python:3.12-alpine",
+            "libc": "musl"
         }))
-        .expect("legacy entry parses");
+        .expect("an entry declaring no bindings parses");
         assert!(parsed.services.is_empty());
         assert!(parsed.peers.is_empty());
+    }
+
+    /// Bindings are optional; the libc is not. An entry that omits it would
+    /// deserialize to `Unknown`, which refuses `--host-service` outright — a
+    /// runtime that silently cannot serve host services is worse than one that
+    /// fails to parse. There is no older catalog shape to accommodate: the
+    /// table is built in-tree and never read from a file.
+    #[test]
+    fn an_entry_omitting_its_libc_does_not_parse() {
+        let err = serde_json::from_value::<RuntimeEntry>(serde_json::json!({
+            "name": "python",
+            "description": "CPython",
+            "image": "python:3.12-alpine"
+        }))
+        .expect_err("an entry that does not say its libc must not parse");
+
+        assert!(
+            err.to_string().contains("libc"),
+            "the error must name the missing field: {err}"
+        );
     }
 }

--- a/crates/mvm-fs/src/sdk_sidecar.rs
+++ b/crates/mvm-fs/src/sdk_sidecar.rs
@@ -177,6 +177,32 @@ impl SdkSidecarLayout {
     }
 }
 
+/// Recover the libc a cached sidecar image was filed under.
+///
+/// [`SdkSidecarLayout::under`] writes the libc as the last directory segment,
+/// and this reads it back. The pair is what lets a consumer holding only the
+/// attached volume's path — admission, which sees a launch config rather than
+/// the resolver that built it — say which variant it is looking at without a
+/// second source of truth to drift from. A round-trip test pins them together.
+///
+/// Anything that is not one of the two written names is [`GuestLibc::Unknown`],
+/// which every caller treats as "cannot say" rather than as a default.
+impl SdkSidecarLayout {
+    /// The libc segment of `image`, a path shaped like the one
+    /// [`SdkSidecarLayout::under`] produces.
+    #[must_use]
+    pub fn libc_of_image_path(image: &Path) -> GuestLibc {
+        let Some(segment) = image.parent().and_then(|d| d.file_name()) else {
+            return GuestLibc::Unknown;
+        };
+        match segment.to_str() {
+            Some(s) if s == GuestLibc::Glibc.as_str() => GuestLibc::Glibc,
+            Some(s) if s == GuestLibc::Musl.as_str() => GuestLibc::Musl,
+            _ => GuestLibc::Unknown,
+        }
+    }
+}
+
 /// A resolved, verified sidecar artifact ready to attach read-only.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SdkSidecarArtifact {
@@ -466,6 +492,36 @@ mod tests {
         assert_eq!(layout.version, "9.9.9");
         assert_eq!(layout.arch, "x86_64");
         assert_eq!(layout.libc, GuestLibc::Musl);
+    }
+
+    /// The layout writes the libc into the path and `libc_of_image_path` reads
+    /// it back. They are two halves of one encoding, so a change to either
+    /// without the other has to fail here rather than in admission, where the
+    /// symptom would be a correctly-built sidecar refused as `Unknown`.
+    #[test]
+    fn the_libc_segment_round_trips_through_the_image_path() {
+        for libc in [GuestLibc::Glibc, GuestLibc::Musl] {
+            let layout = SdkSidecarLayout::under(Path::new("/cache"), "9.9.9", "x86_64", libc);
+            assert_eq!(SdkSidecarLayout::libc_of_image_path(&layout.image), libc);
+        }
+    }
+
+    /// A path that is not one this layout wrote reads as `Unknown`, never as a
+    /// guess. Admission refuses `Unknown`, so guessing here would turn a
+    /// missing answer into a wrong one.
+    #[test]
+    fn a_foreign_path_reads_as_unknown() {
+        for p in [
+            "/somewhere/sdk.ext4",
+            "/cache/sdk-sidecar/9.9.9/x86_64/sdk.ext4",
+            "sdk.ext4",
+        ] {
+            assert_eq!(
+                SdkSidecarLayout::libc_of_image_path(Path::new(p)),
+                GuestLibc::Unknown,
+                "{p}"
+            );
+        }
     }
 
     /// The two variants carry different objects and verify against different

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1352,7 +1352,7 @@ pub fn enforce_sdk_sidecar_backend_compatibility(
     Err(SdkSidecarBackendCompatibilityError::WasmHostServicesUnsupported { services })
 }
 
-/// Admission enforcement for the optional glibc SDK sidecar attachment.
+/// Admission enforcement for the optional SDK sidecar attachment.
 ///
 /// The sidecar carries the host-services cdylib the language SDKs `dlopen`. Its
 /// attachment is authorized by the plan's host-service bindings, never by an
@@ -1420,7 +1420,13 @@ pub fn enforce_sdk_sidecar_attachment(
             sidecar.host,
         );
     }
-    enforce_sidecar_libc(image_libc, &bound)?;
+    // The sidecar's own libc comes from the path it was filed under, so both
+    // sides of the comparison are observed rather than assumed. Reading it here
+    // rather than threading it in keeps this a check on the launch config as
+    // presented — the thing admission is actually authorizing.
+    let sidecar_libc =
+        mvm_build::guest_libc::sidecar_libc_of_image_path(std::path::Path::new(&sidecar.host));
+    enforce_sidecar_libc(image_libc, sidecar_libc, &bound)?;
     Ok(())
 }
 
@@ -1452,15 +1458,24 @@ fn recorded_image_libc(rootfs_path: &str) -> GuestLibc {
 /// [`GuestLibc::Unknown`] refuses too. It covers an image whose loader was
 /// unrecognisable and a sidecar written before the field existed, and neither
 /// is evidence that loading would work.
-fn enforce_sidecar_libc(image_libc: GuestLibc, bound: &[&str]) -> Result<()> {
-    if mvm_build::guest_libc::sidecar_loads_in(image_libc) {
+fn enforce_sidecar_libc(
+    image_libc: GuestLibc,
+    sidecar_libc: GuestLibc,
+    bound: &[&str],
+) -> Result<()> {
+    if mvm_build::guest_libc::sidecar_loads_in(image_libc, sidecar_libc) {
         return Ok(());
     }
-    let detail = match image_libc {
-        GuestLibc::Unknown => {
+    let detail = match (image_libc, sidecar_libc) {
+        (GuestLibc::Unknown, _) => {
             "the image records no libc this host recognises. An image materialized before mvm \
              began recording it reads this way — re-pull or rebuild it and the sidecar is \
              rewritten with the libc"
+        }
+        (_, GuestLibc::Unknown) => {
+            "the attached sidecar is not filed under a libc this host recognises, so which \
+             variant it holds cannot be established. Rebuild the cache with \
+             `mvmctl build sdk-sidecar build`, which files each variant under its own libc"
         }
         _ => {
             "a process under one libc cannot dlopen an object built for the other — the guest \
@@ -1472,7 +1487,7 @@ fn enforce_sidecar_libc(image_libc: GuestLibc, bound: &[&str]) -> Result<()> {
          delivered by a shared object built for {}, but this image is {}. {detail}. Use an image \
          whose libc matches, or drop the host-service binding.",
         bound.join(", "),
-        mvm_build::guest_libc::SIDECAR_CDYLIB_LIBC.as_str(),
+        sidecar_libc.as_str(),
         image_libc.as_str(),
     )
 }
@@ -2689,13 +2704,37 @@ mod tests {
     /// otherwise land inside the guest at `dlopen` time as a relocation error
     /// naming a symbol the operator never heard of. Refuse on the host, where
     /// the cause can be named.
+    /// A sidecar whose path carries no libc segment cannot be identified, and
+    /// an unidentifiable variant is refused rather than assumed to match. This
+    /// is the shape a cache written before the layout was keyed leaves behind.
+    #[test]
+    fn a_sidecar_filed_under_no_libc_is_refused() {
+        use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        let plan = plan_binding(&["host.kv.v1"]);
+        let unkeyed = VmVolume {
+            host: "/cache/sdk-sidecar/1.2.3/aarch64/sdk.ext4".into(),
+            guest: mvm_core::plan::SDK_SIDECAR_GUEST_PATH.into(),
+            read_only: true,
+            kind: VmVolumeKind::Disk,
+            ..Default::default()
+        };
+
+        let err = enforce_sdk_sidecar_attachment(&[unkeyed], &plan, GuestLibc::Musl)
+            .expect_err("a sidecar of unknown variant must not be attached");
+
+        assert!(
+            err.to_string().contains("sdk-sidecar build"),
+            "the refusal must say how to repopulate the cache: {err}"
+        );
+    }
+
     #[test]
     fn a_sidecar_the_guest_cannot_load_is_refused_before_boot() {
         let plan = plan_binding(&["host.kv.v1"]);
         let err = enforce_sdk_sidecar_attachment(
-            &[sdk_sidecar_volume()],
+            &[sdk_sidecar_volume_for(GuestLibc::Glibc)],
             &plan,
-            mvm_build::guest_libc::GuestLibc::Musl,
+            GuestLibc::Musl,
         )
         .expect_err("a musl image must not receive the glibc sidecar");
         let msg = err.to_string();
@@ -2741,12 +2780,30 @@ mod tests {
     /// The libc the shipped cdylib is built for. These tests assert attachment
     /// *shape* — count, read-only, kind — so they hold the libc loadable and
     /// let the dedicated libc tests vary it.
-    const LOADABLE_LIBC: GuestLibc = mvm_build::guest_libc::SIDECAR_CDYLIB_LIBC;
+    /// One libc for both sides of the admission fixtures: what the image
+    /// records and what the sidecar was filed under have to agree for the
+    /// attachment to be admissible, and these tests are about the other rules.
+    const LOADABLE_LIBC: GuestLibc = GuestLibc::Musl;
 
+    /// A sidecar volume shaped the way the resolver actually hands one over:
+    /// filed under its libc, because that segment is where the gate reads the
+    /// variant from. A path without it is not a lesser fixture, it is a
+    /// different case — covered by
+    /// `a_sidecar_filed_under_no_libc_is_refused`.
     fn sdk_sidecar_volume() -> mvm_core::vm_backend::VmVolume {
+        sdk_sidecar_volume_for(LOADABLE_LIBC)
+    }
+
+    /// The same volume filed under an arbitrary libc, so a test can state both
+    /// sides of the comparison instead of leaning on which one the shared
+    /// fixture happens to use.
+    fn sdk_sidecar_volume_for(libc: GuestLibc) -> mvm_core::vm_backend::VmVolume {
         use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
         VmVolume {
-            host: "/cache/sdk-sidecar/1.2.3/aarch64/sdk.ext4".into(),
+            host: format!(
+                "/cache/sdk-sidecar/1.2.3/aarch64/{}/sdk.ext4",
+                libc.as_str()
+            ),
             guest: mvm_core::plan::SDK_SIDECAR_GUEST_PATH.into(),
             read_only: true,
             kind: VmVolumeKind::Disk,

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1430,6 +1430,25 @@ pub fn enforce_sdk_sidecar_attachment(
     Ok(())
 }
 
+/// Refuse a launch whose SDK sidecar the guest could not load.
+///
+/// The launch-shaped entry point onto [`enforce_sdk_sidecar_attachment`], for
+/// callers that hold a rootfs path and a launch config rather than an
+/// `AdmittedPlan`. `mvmctl run` is one: it admits through `admit_for_run`, which
+/// does not run the post-admission gates, so without this the only thing
+/// standing between a libc mismatch and the guest is nothing at all — the boot
+/// succeeds and the workload dies on `dlopen` resolving `_dl_find_object`.
+///
+/// Takes the rootfs path rather than the libc so the caller cannot supply a
+/// libc that disagrees with the image it is about to boot.
+pub fn enforce_sdk_sidecar_for_launch(
+    rootfs_path: &str,
+    volumes: &[mvm_core::vm_backend::VmVolume],
+    plan: &ExecutionPlan,
+) -> Result<()> {
+    enforce_sdk_sidecar_attachment(volumes, plan, recorded_image_libc(rootfs_path))
+}
+
 /// The libc recorded beside a workload rootfs, or [`GuestLibc::Unknown`].
 ///
 /// Anything unreadable — no sidecar, malformed JSON, a rootfs path with no
@@ -2704,6 +2723,66 @@ mod tests {
     /// otherwise land inside the guest at `dlopen` time as a relocation error
     /// naming a symbol the operator never heard of. Refuse on the host, where
     /// the cause can be named.
+    /// Stage a rootfs whose `mvm-meta.json` records `libc`, and hand back the
+    /// rootfs path the launch would boot.
+    fn rootfs_recording_libc(dir: &std::path::Path, libc: GuestLibc) -> String {
+        let sidecar = mvm_build::builder_vm::GuestSidecar::for_oci_run("fixture", false, false)
+            .with_libc(libc);
+        sidecar.write_to_dir(dir).expect("write mvm-meta.json");
+        dir.join("rootfs.ext4").to_string_lossy().into_owned()
+    }
+
+    /// The launch-shaped entry point reads the image's libc off the rootfs
+    /// rather than taking it on trust, so a caller cannot pass a libc that
+    /// disagrees with the image it is about to boot.
+    #[test]
+    fn the_launch_gate_reads_the_libc_off_the_rootfs_it_is_given() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let plan = plan_binding(&["host.kv.v1"]);
+
+        let musl_rootfs = rootfs_recording_libc(dir.path(), GuestLibc::Musl);
+        enforce_sdk_sidecar_for_launch(
+            &musl_rootfs,
+            &[sdk_sidecar_volume_for(GuestLibc::Musl)],
+            &plan,
+        )
+        .expect("a musl image may load the musl sidecar");
+
+        let err = enforce_sdk_sidecar_for_launch(
+            &musl_rootfs,
+            &[sdk_sidecar_volume_for(GuestLibc::Glibc)],
+            &plan,
+        )
+        .expect_err("a musl image must not receive the glibc sidecar");
+        let msg = err.to_string();
+        assert!(msg.contains("musl") && msg.contains("glibc"), "{msg}");
+    }
+
+    /// A rootfs with no sidecar beside it records nothing, and an image whose
+    /// libc cannot be established is refused rather than assumed loadable.
+    #[test]
+    fn the_launch_gate_refuses_an_image_recording_no_libc() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let plan = plan_binding(&["host.kv.v1"]);
+        let rootfs = dir
+            .path()
+            .join("rootfs.ext4")
+            .to_string_lossy()
+            .into_owned();
+
+        let err = enforce_sdk_sidecar_for_launch(
+            &rootfs,
+            &[sdk_sidecar_volume_for(GuestLibc::Musl)],
+            &plan,
+        )
+        .expect_err("an image of unknown libc must not receive a sidecar");
+
+        assert!(
+            err.to_string().contains("records no libc"),
+            "the refusal must say the image is the unknown side: {err}"
+        );
+    }
+
     /// A sidecar whose path carries no libc segment cannot be identified, and
     /// an unidentifiable variant is refused rather than assumed to match. This
     /// is the shape a cache written before the layout was keyed leaves behind.

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -2784,8 +2784,9 @@ mod tests {
     }
 
     /// A sidecar whose path carries no libc segment cannot be identified, and
-    /// an unidentifiable variant is refused rather than assumed to match. This
-    /// is the shape a cache written before the layout was keyed leaves behind.
+    /// an unidentifiable variant is refused rather than assumed to match. Any
+    /// path this layout did not write reads that way — the check is on what the
+    /// launch config presents, not on where it came from.
     #[test]
     fn a_sidecar_filed_under_no_libc_is_refused() {
         use mvm_core::vm_backend::{VmVolume, VmVolumeKind};


### PR DESCRIPTION
#3044 keyed the sidecar cache on libc and #3049 published both variants. What
neither did was teach the check what to compare, or put it anywhere `mvmctl run`
would reach. On main today the cache holds two variants while `sidecar_loads_in`
still asks whether the image's libc equals a constant pinned to glibc.

## Compare two facts, not one fact and an assumption

`SIDECAR_CDYLIB_LIBC` was correct while exactly one variant existed. With two
cached side by side any fixed answer is wrong for one of them: it would refuse a
correctly-selected musl sidecar attached to a musl guest.

Both sides are observed now. The image records its libc in `mvm-meta.json`; the
sidecar records its own in the cache path it was filed under, read back by
`SdkSidecarLayout::libc_of_image_path` — the inverse of the `under` that wrote
it, with a round-trip test pinning the pair so neither can drift. Admission
reads it off the attached volume, so the check is on the launch config as
presented rather than on anything threaded alongside it.

`Unknown` on either side refuses, including `Unknown` against `Unknown`: two
unrecognised loaders are not evidence of agreement.

## Enforce it where workloads actually boot

`enforce_sidecar_libc` sat in `run_post_admission_gates`, which only
`admit_and_start` runs, and that has one production caller —
`operator_admitted_trial_booter`. `mvmctl run` admits through `admit_for_run`
and never reached it. The refusal written to replace an in-guest
`_dl_find_object` failure with a legible host-side message did not cover the
command that failure was reported against.

That was observable rather than inferred: a musl sidecar attached to a musl
image while the comparison was still pinned to glibc, and the boot went ahead.
Had the gate been on that path, `Musl != Glibc` would have refused it.

`enforce_sdk_sidecar_for_launch` takes the rootfs rather than a libc, so a
caller cannot pass one that disagrees with the image it is about to boot. The
run path calls it immediately after admission — the first point where both the
authorizing plan and the rootfs exist.

## No compatibility path, deliberately

Nothing is deployed against the unkeyed layout, so there is none. The resolver
only looks under `<version>/<arch>/<libc>/`, and a path it did not write reads
as `Unknown` and is refused — not because it is old, but because it cannot be
identified. `RuntimeEntry::libc` loses its `#[serde(default)]` for the same
reason: the catalog is built in-tree and never read from a file, and the default
would silently have been `Unknown`, which refuses `--host-service` at boot.
Failing to parse is better, and it fails where the mistake is.

## Verification

Artifacts, not exit codes. Both cached variants checked by soname: `glibc/`
carries `libc.so.6` and the glibc loader with no bare `libc.so`; `musl/` is the
exact inverse, with musl's bundled `libgcc_s.so.1`. Both manifests verify.

The `host.kv.v1` `@live` scenario passes through its own harness on the
read-only ext4 fixture volume — 4/4 steps, `KV-OK`, in a booted
`python:3.12-alpine` guest, with the gate live on the run path.

That live run earned its place. The unit tests passed while the feature was
broken for every admitted run: `plan_json` is the signed envelope
`{payload, signature, signer_id}`, not a serialized `ExecutionPlan`. The tests
built the plan directly — a shape the launch path never produces — so the gate
refused everything with `unknown field payload`. The regression test now
constructs the envelope the way admission writes it.

`cargo run -p xtask -- check-all` green (62/62); 12,853 tests pass.

Note `just check-gated` rather than `--all-targets` for the conformance changes:
targets behind `required-features` are invisible to the latter, which is how
three stale call sites in `mvm-conformance` survived the cache keying.

Refs #2969