### PR TITLE
feat(builder): move the persistent HVF builder onto the disk transport

### DIFF
--- a/crates/mvm-backends/src/driver/fc.rs
+++ b/crates/mvm-backends/src/driver/fc.rs
@@ -1300,6 +1300,8 @@ mod tests {
                 log_path: "/tmp/console.log".into(),
             },
             trusted_builder: false,
+            // Not a persistent builder: nothing here outlives its launcher.
+            builder_egress_endpoint: None,
             plan_binding: None,
         }
     }

--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -238,6 +238,9 @@ fn relay_supervisor_config_with_handoff(
             .collect(),
         vsock: true,
         trusted_builder_egress: spec.trusted_builder,
+        // Only a VM that outlives its launcher sets this; everyone else spawns
+        // their own endpoint and stays alive to parent it.
+        builder_egress_endpoint: spec.builder_egress_endpoint.clone(),
         console_log: paths.console_log.clone(),
         pid_file: paths.pid_file.clone(),
         workload_exit: paths.workload_exit.clone(),
@@ -1081,6 +1084,7 @@ mod tests {
 
     fn spec_with(kernel: KernelImage, vsock: Vec<VsockPort>, blocks: Vec<BlockDev>) -> VmmSpec {
         VmmSpec {
+            builder_egress_endpoint: None,
             name: "w".into(),
             kernel,
             initramfs: Some("/img/initrd.cpio".into()),

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -153,6 +153,11 @@ pub fn hvf_child_restore_config(
     Ok(HvfSupervisorConfig {
         // Same tier as the parent it forked from.
         trusted_builder_egress: parent.trusted_builder_egress,
+        // Never inherited. The request names the *parent's* VM, state dir and
+        // identity drive; a child adopting it would spawn a second endpoint
+        // over the parent's socket and overwrite the identity drive of a VM
+        // that is still running off it. A restored child is not a builder.
+        builder_egress_endpoint: None,
         kernel: parent.kernel.clone(),
         cmdline: parent.cmdline.clone(),
         memory_mib: parent.memory_mib,
@@ -324,6 +329,7 @@ mod tests {
     fn parent_config(state: &Path, disks: Vec<HvfDisk>) -> HvfSupervisorConfig {
         HvfSupervisorConfig {
             trusted_builder_egress: false,
+            builder_egress_endpoint: None,
             kernel: state.join("Image"),
             cmdline: Some("console=ttyAMA0 root=/dev/vda ro".into()),
             memory_mib: 512,
@@ -434,6 +440,34 @@ mod tests {
         // The half this function exists for is still done: a restored child is
         // itself checkpointable only if its own launch config is on disk.
         assert!(dir.join("supervisor.json").is_file());
+    }
+
+    #[test]
+    fn a_restored_child_never_inherits_the_parents_egress_endpoint_request() {
+        // The request names the *parent's* vm, state dir, socket and identity
+        // drive. A child that inherited it would spawn a second endpoint over
+        // the running parent's socket and rewrite the identity drive that
+        // parent's guest is still authenticating against — so this is the same
+        // family as the relay drop the module docs describe, not an
+        // optimisation.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let anchors = materialized(dir);
+        let mut parent = parent_config(dir, vec![]);
+        parent.builder_egress_endpoint =
+            Some(mvm_vmm::host::hvf_supervisor::BuilderEgressEndpoint {
+                vm_name: "the-parent".into(),
+                state_dir: dir.join("parent-state"),
+                socket: dir.join("parent.sock"),
+                identity_drive: dir.join("parent-identity.ext4"),
+            });
+
+        let cfg = hvf_child_restore_config(&parent, &anchors, &request("child", dir)).unwrap();
+
+        assert!(
+            cfg.builder_egress_endpoint.is_none(),
+            "a restored child must not adopt its parent's endpoint request"
+        );
     }
 
     #[test]

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -666,6 +666,8 @@ mod tests {
                 log_path: "/tmp/console.log".into(),
             },
             trusted_builder: false,
+            // Not a persistent builder: nothing here outlives its launcher.
+            builder_egress_endpoint: None,
             plan_binding: None,
         }
     }

--- a/crates/mvm-backends/src/driver/qemu.rs
+++ b/crates/mvm-backends/src/driver/qemu.rs
@@ -682,6 +682,8 @@ mod tests {
                 log_path: "/state/w/console.log".into(),
             },
             trusted_builder: false,
+            // Not a persistent builder: nothing here outlives its launcher.
+            builder_egress_endpoint: None,
             plan_binding: None,
         }
     }

--- a/crates/mvm-backends/src/mock.rs
+++ b/crates/mvm-backends/src/mock.rs
@@ -505,6 +505,7 @@ mod tests {
 
     fn sample_spec(name: &str) -> VmmSpec {
         VmmSpec {
+            builder_egress_endpoint: None,
             name: name.to_string(),
             kernel: KernelImage::Bundled,
             initramfs: None,

--- a/crates/mvm-build/src/bin/mvm-host-vm-init.rs
+++ b/crates/mvm-build/src/bin/mvm-host-vm-init.rs
@@ -3336,8 +3336,37 @@ mod linux {
         // dangling on the host and fail the extraction outright.
         let out_backing = format!("{NIX_STORE_MOUNT}/out");
         reset_stage_dir(&out_backing)?;
+        // A dispatched job runs under `setpriv --reuid=BUILDER_UID`, and this
+        // directory is created by PID 1 as root. Under the virtio-fs transport
+        // the host made its side of `/out` group/other-writable before the
+        // guest ever saw it; on a disk there is no host side to do that, so it
+        // has to happen here or every dispatched write to `/out` fails with
+        // EACCES — including the artifacts the output disk exists to carry.
+        chown_builder(&out_backing)?;
         std::fs::create_dir_all(OUT_DIR).map_err(|e| format!("mkdir {OUT_DIR}: {e}"))?;
         disk_bind_mount(&out_backing, OUT_DIR)?;
+        Ok(())
+    }
+
+    /// Give the builder uid ownership of a directory PID 1 created.
+    ///
+    /// Ownership rather than a permissive mode: `clear_dir_contents` empties
+    /// `/out` between dispatches without recreating it, so the owner set here
+    /// survives the whole session, and nothing outside the build ever needs to
+    /// write there.
+    fn chown_builder(dir: &str) -> Result<(), String> {
+        use std::os::unix::ffi::OsStrExt;
+        let c_path = std::ffi::CString::new(std::ffi::OsStr::new(dir).as_bytes())
+            .map_err(|e| format!("path {dir}: {e}"))?;
+        // SAFETY: `c_path` is a NUL-terminated path valid for this call, and
+        // chown takes it by const pointer without retaining it.
+        let rc = unsafe { libc::chown(c_path.as_ptr(), BUILDER_UID, BUILDER_GID) };
+        if rc != 0 {
+            return Err(format!(
+                "chown {dir} to {BUILDER_UID}:{BUILDER_GID}: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
         Ok(())
     }
 

--- a/crates/mvm-build/src/builder_disk_transport.rs
+++ b/crates/mvm-build/src/builder_disk_transport.rs
@@ -29,6 +29,17 @@ use anyhow::{Context, Result};
 /// sector boundary so the guest sees an exact capacity.
 const SECTOR: u64 = 512;
 
+/// Floor for an input disk. [`pack_input_disk`] grows past it to hold the
+/// archive, so this only matters when the inputs are small — it keeps a
+/// persistent session's disk from shrinking to nothing between dispatches,
+/// which would change the capacity a running guest already read.
+pub const INPUT_DISK_MIN_BYTES: u64 = 16 << 20;
+
+/// Capacity for an output disk. Has to hold a whole guest image tar — a
+/// `rootfs.ext4` plus a kernel — since the guest writes the archive raw and
+/// cannot grow the device it was handed.
+pub const OUTPUT_DISK_BYTES: u64 = 8192 << 20;
+
 /// Archive directory the optional seeded-closure NAR rides under, mirroring
 /// the guest's `/closure-seed` mount point
 /// (`mvm-host-vm-init`'s `CLOSURE_SEED_NAR` contract). Kept in sync with the

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -66,6 +66,7 @@ pub mod packed_artifact;
 /// libkrun creates; spawning the libkrun VM itself lives in
 /// `LibkrunPersistentHostVm`.
 pub mod persistent_builder;
+pub mod persistent_builder_transport;
 /// Build-provenance recorder: content-addresses produced artifacts into the
 /// signed plan's `BuildProvenance`.
 pub mod provenance;

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -71,7 +71,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::builder_disk_transport::{
-    InputTree, create_output_disk, pack_input_disk, read_output_disk,
+    INPUT_DISK_MIN_BYTES, InputTree, OUTPUT_DISK_BYTES, create_output_disk, pack_input_disk,
+    read_output_disk,
 };
 use crate::builder_vm::{
     BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmDisk, BuilderVmError,
@@ -89,7 +90,6 @@ use crate::builder_vm_runtime::{
     stage_filtered_work_input, stage_job_dir, stage_persistent_job_dir, stage_shell_job_dir,
     supervisor_exit_error, verbose_from_env,
 };
-use crate::pipeline::build::BUILDER_OUTPUT_DISK_MIB;
 
 /// Default vCPU count for the builder VM. Nix builds are
 /// embarrassingly parallel at the derivation level; 4 cores is the
@@ -144,7 +144,6 @@ const BUILDER_INPUT_DEVICE: &str = "/dev/vdc";
 const BUILDER_OUTPUT_DEVICE: &str = "/dev/vdd";
 const BUILDER_RUNTIME_DEVICE: &str = "/dev/vde";
 const BUILDER_VIRTIOFS_RUNTIME_DEVICE: &str = "/dev/vdc";
-const BUILDER_INPUT_DISK_MIN: u64 = 16 << 20;
 const BUILDER_VSOCK_EGRESS_TOKEN: &str = "mvm.vsock_egress=1";
 const BUILDER_SUBST_PID_FILE: &str = "substitution.pid";
 const BUILDER_SUBST_STDERR_LOG_FILE: &str = "substitution.stderr.log";
@@ -647,13 +646,7 @@ pub(crate) fn prepare_builder_transport_disks(
 ) -> Result<(PathBuf, PathBuf), BuilderVmError> {
     let input_disk = vm_state_dir.join("input.img");
     let output_disk = vm_state_dir.join("output.img");
-    pack_input_disk(
-        input_trees,
-        closure_nar,
-        &input_disk,
-        BUILDER_INPUT_DISK_MIN,
-    )
-    .map_err(|e| {
+    pack_input_disk(input_trees, closure_nar, &input_disk, INPUT_DISK_MIN_BYTES).map_err(|e| {
         BuilderVmError::ExtractionFailed(format!(
             "pack builder input disk {}: {e}",
             input_disk.display()
@@ -1155,7 +1148,7 @@ impl LibkrunBuilderVm {
                 },
             ],
             self.closure_nar.as_deref(),
-            u64::from(BUILDER_OUTPUT_DISK_MIB) << 20,
+            OUTPUT_DISK_BYTES,
         )?;
 
         let mut krun = krun_context_for_image(&vm_name, &image)?
@@ -1678,7 +1671,7 @@ impl BuilderVm for LibkrunBuilderVm {
                 },
             ],
             self.closure_nar.as_deref(),
-            u64::from(BUILDER_OUTPUT_DISK_MIB) << 20,
+            OUTPUT_DISK_BYTES,
         )?;
         let mut krun = krun_context_for_image(&vm_name, &image)?
             .with_resources(self.vcpus, self.memory_mib)

--- a/crates/mvm-build/src/persistent_builder.rs
+++ b/crates/mvm-build/src/persistent_builder.rs
@@ -743,6 +743,13 @@ pub fn dispatch_socket_path(vm_state_dir: &Path) -> PathBuf {
 // on every build and routes through `PersistentBuilderVm` (which
 // implements `BuilderVm` via the wire) when a session is alive.
 
+// The disk transport is a session concern, so it is re-exported here: callers
+// reach it through the session type that carries it, not through a second
+// module they have to know about.
+pub use crate::persistent_builder_transport::{
+    SessionDiskTransport, guest_artifact_dir, read_dispatch_artifacts, repack_dispatch_input,
+};
+
 /// Session record format mirroring
 /// `mvm_cli::commands::build::persistent_builder::SessionRecord`.
 /// Duplicated here to keep mvm-build off the mvm-cli direction in
@@ -754,9 +761,15 @@ pub struct SessionRecord {
     pub session_id: String,
     /// libkrun-managed Unix socket the supervisor connects to.
     pub dispatch_socket_path: PathBuf,
-    /// Per-session job dir (bound at `/job` in the guest). Hosts
-    /// stage per-dispatch artifacts here before submitting.
+    /// Per-session job dir. Hosts stage each dispatch here before submitting
+    /// and read its artifacts back here afterwards. Reaches the guest as a
+    /// `/job` share, or — when [`SessionRecord::disk_transport`] is set — over
+    /// the transport disks, in which case the guest never sees this path.
     pub job_dir: PathBuf,
+    /// Set when this session exchanges jobs over raw disks rather than shares.
+    /// Absent means shares, which is what a libkrun-backed session uses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk_transport: Option<SessionDiskTransport>,
     /// Workspace bound at `/work`. Recorded for `mvmctl
     /// persistent-builder status`; not load-bearing here.
     pub workspace_root: PathBuf,
@@ -1081,15 +1094,17 @@ pub fn stage_flake_dispatch_job(
     session_job_dir: &Path,
     flake_ref: &str,
     attr: &str,
+    transport: Option<&SessionDiskTransport>,
 ) -> std::io::Result<String> {
     let job_id = uuid::Uuid::new_v4().to_string();
     let sub = session_job_dir.join(&job_id);
     let artifact_dir = sub.join(ARTIFACT_SUBDIR);
     std::fs::create_dir_all(&artifact_dir)?;
+    let out_dir = guest_artifact_dir(transport, &job_id);
     let script = format!(
         "#!/bin/sh\n\
          set -eu\n\
-         OUT_DIR='/job/{job_id}/{artifact_subdir}'\n\
+         OUT_DIR='{out_dir}'\n\
          mkdir -p \"$OUT_DIR\"\n\
          STORE_PATH=$(nix --extra-experimental-features 'nix-command flakes' \\\n\
              build --no-link --print-out-paths \\\n\
@@ -1124,7 +1139,6 @@ pub fn stage_flake_dispatch_job(
          if [ -f \"$STORE_PATH/manifest.json\" ]; then\n\
              cp -L \"$STORE_PATH/manifest.json\" \"$OUT_DIR/manifest.json\"\n\
          fi\n",
-        artifact_subdir = ARTIFACT_SUBDIR,
         store_path_sidecar = STORE_PATH_SIDECAR,
         flake_ref = shell_single_quote(flake_ref),
         attr = shell_single_quote(attr),
@@ -1226,10 +1240,24 @@ impl crate::builder_vm::BuilderVm for PersistentBuilderVm {
         };
 
         let _ = touch_active_session(current_unix_secs());
-        let job_id = stage_flake_dispatch_job(&self.session.job_dir, flake_ref, attr_path)
-            .map_err(|e| {
-                BuilderVmError::ExtractionFailed(format!("staging persistent dispatch job: {e}"))
+        let transport = self.session.disk_transport.as_ref();
+        let job_id =
+            stage_flake_dispatch_job(&self.session.job_dir, flake_ref, attr_path, transport)
+                .map_err(|e| {
+                    BuilderVmError::ExtractionFailed(format!(
+                        "staging persistent dispatch job: {e}"
+                    ))
+                })?;
+
+        // Disk-backed session: put this job on the input disk before the guest
+        // is told to run it. The guest re-reads the disk on `Run`, so the write
+        // has to be complete by then — which it is, because `submit` below is
+        // what sends the frame.
+        if let Some(t) = transport {
+            repack_dispatch_input(t, &self.session.job_dir, &job_id).map_err(|e| {
+                BuilderVmError::ExtractionFailed(format!("packing the dispatch input disk: {e}"))
             })?;
+        }
 
         let supervisor = PersistentBuilderSupervisor::new(&self.session.dispatch_socket_path)
             .with_frame_read_timeout(Duration::from_secs(60));
@@ -1242,6 +1270,15 @@ impl crate::builder_vm::BuilderVm for PersistentBuilderVm {
                 "persistent dispatch exit {} — stderr tail:\n{}",
                 outcome.exit_code, outcome.stderr_tail
             )));
+        }
+
+        // The guest wrote this dispatch's artifact tar before it answered, so
+        // reading now cannot race it. Landing them under `artifact_dir_for`
+        // makes the rest of this function transport-blind.
+        if let Some(t) = transport {
+            read_dispatch_artifacts(t, &self.session.job_dir, &job_id).map_err(|e| {
+                BuilderVmError::ExtractionFailed(format!("reading the dispatch output disk: {e}"))
+            })?;
         }
 
         let artifact_dir = artifact_dir_for(&self.session.job_dir, &job_id);
@@ -1299,6 +1336,23 @@ impl PersistentBuilderVm {
         mounts: &crate::builder_vm::BuilderMounts,
     ) -> Result<crate::builder_vm::BuilderArtifacts, crate::builder_vm::BuilderVmError> {
         use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderVmError};
+
+        // The guest's install arm writes its result and sealed-volume sidecars
+        // into `/job/<job_id>/out`, which the disk transport does not collect —
+        // it collects `/out` and nothing else. Running anyway would report a
+        // clean dispatch and then find no `result.json`, and worse, a claim-11
+        // sealed volume would lose the SBOM and CVE sidecars its verification
+        // depends on. Refuse instead, and say which half is missing.
+        if self.session.disk_transport.is_some() {
+            return Err(BuilderVmError::VmmUnavailable {
+                requested: "persistent-builder install".to_string(),
+                reason: "the guest writes install artifacts to /job/<job_id>/out, which the \
+                         disk transport does not read back — it collects /out and nothing \
+                         else. Run the install through a one-shot builder until the guest's \
+                         install arm writes to /out."
+                    .to_string(),
+            });
+        }
 
         let job_id =
             stage_install_dispatch_job(&self.session.job_dir, host_spec_path).map_err(|e| {
@@ -1442,6 +1496,7 @@ mod tests {
         let record = SessionRecord {
             session_id: "abc".to_string(),
             dispatch_socket_path: PathBuf::from("/tmp/sock"),
+            disk_transport: None,
             job_dir: PathBuf::from("/tmp/jobs"),
             workspace_root: PathBuf::from("/work"),
             supervisor_pid: 4242,
@@ -1501,6 +1556,7 @@ mod tests {
         let record = SessionRecord {
             session_id: "abc".to_string(),
             dispatch_socket_path: PathBuf::from("/tmp/sock"),
+            disk_transport: None,
             job_dir: PathBuf::from("/tmp/jobs"),
             workspace_root: PathBuf::from("/work"),
             supervisor_pid: 4242,
@@ -1521,6 +1577,7 @@ mod tests {
         let record = SessionRecord {
             session_id: "abc".to_string(),
             dispatch_socket_path: PathBuf::from("/tmp/sock"),
+            disk_transport: None,
             job_dir: PathBuf::from("/tmp/jobs"),
             workspace_root: PathBuf::from("/work"),
             supervisor_pid: 4242,
@@ -1541,6 +1598,7 @@ mod tests {
         let record = SessionRecord {
             session_id: "abc".to_string(),
             dispatch_socket_path: PathBuf::from("/tmp/sock"),
+            disk_transport: None,
             job_dir: PathBuf::from("/tmp/jobs"),
             workspace_root: PathBuf::from("/work"),
             supervisor_pid: 4242,
@@ -1567,6 +1625,7 @@ mod tests {
         let record = SessionRecord {
             session_id: "x".to_string(),
             dispatch_socket_path: PathBuf::from("/dev/null"),
+            disk_transport: None,
             job_dir: PathBuf::from("/tmp"),
             workspace_root: PathBuf::from("/tmp"),
             supervisor_pid: std::process::id(),
@@ -1596,6 +1655,7 @@ mod tests {
         let record = SessionRecord {
             session_id: "live".into(),
             dispatch_socket_path: run_dir.join("dispatch.sock"),
+            disk_transport: None,
             job_dir: run_dir.join("jobs"),
             workspace_root: scratch.path().to_path_buf(),
             // This process: alive by construction.
@@ -1681,6 +1741,7 @@ mod tests {
         let record = SessionRecord {
             session_id: "x".to_string(),
             dispatch_socket_path: PathBuf::from("/dev/null"),
+            disk_transport: None,
             job_dir: PathBuf::from("/tmp"),
             workspace_root: PathBuf::from("/tmp"),
             supervisor_pid: DEFINITELY_DEAD_PID,
@@ -1706,9 +1767,13 @@ mod tests {
         // actual VM dispatch.
         let scratch = tempfile::tempdir().expect("tempdir");
         let job_dir = scratch.path().to_path_buf();
-        let job_id =
-            stage_flake_dispatch_job(&job_dir, "path:/work", "packages.aarch64-linux.default")
-                .expect("stage");
+        let job_id = stage_flake_dispatch_job(
+            &job_dir,
+            "path:/work",
+            "packages.aarch64-linux.default",
+            None,
+        )
+        .expect("stage");
         let cmd_path = job_dir.join(&job_id).join("cmd.sh");
         assert!(cmd_path.is_file(), "{}", cmd_path.display());
         let body = std::fs::read_to_string(&cmd_path).expect("read");
@@ -1728,9 +1793,13 @@ mod tests {
     fn stage_flake_dispatch_job_seals_final_artifact_without_a_new_builder_subcommand() {
         let scratch = tempfile::tempdir().expect("tempdir");
         let job_dir = scratch.path().to_path_buf();
-        let job_id =
-            stage_flake_dispatch_job(&job_dir, "path:/work", "packages.aarch64-linux.default")
-                .expect("stage");
+        let job_id = stage_flake_dispatch_job(
+            &job_dir,
+            "path:/work",
+            "packages.aarch64-linux.default",
+            None,
+        )
+        .expect("stage");
         let body = std::fs::read_to_string(job_dir.join(&job_id).join("cmd.sh")).expect("read");
         assert!(
             body.contains("/sbin/mvm-host-vm-init run-before-build-hook"),

--- a/crates/mvm-build/src/persistent_builder_transport.rs
+++ b/crates/mvm-build/src/persistent_builder_transport.rs
@@ -67,19 +67,47 @@ pub fn repack_dispatch_input(
     job_id: &str,
 ) -> std::io::Result<()> {
     let floor = std::fs::metadata(&transport.input_disk)?.len();
-    let job_sub = session_job_dir.join(job_id);
+
+    // Stage this dispatch alone under a `job` root, and archive that root as a
+    // tree. Two things depend on the shape:
+    //
+    // - The guest extracts with `tar xf <dev> -C <stage> job`, naming `job` as
+    //   a member. Archiving entries as `job/<job_id>/…` with no `job/` entry of
+    //   their own does not give it that member and the extraction fails.
+    // - Archiving `session_job_dir` directly would give it, but would also
+    //   carry every earlier dispatch — including the artifacts read back into
+    //   `<job_id>/out/`, which is a whole guest image by the second build.
+    let staging = tempfile::TempDir::new()?;
+    let staged_job = staging.path().join(job_id);
+    copy_dir(&session_job_dir.join(job_id), &staged_job)?;
+
     crate::builder_disk_transport::pack_input_disk(
         &[crate::builder_disk_transport::InputTree {
-            // Archived under the job id so the guest resolves the same
-            // `/job/<job_id>/cmd.sh` the `Run` frame's relpath names.
-            name: &format!("job/{job_id}"),
-            src: &job_sub,
+            name: "job",
+            src: staging.path(),
         }],
         None,
         &transport.input_disk,
         floor,
     )
     .map_err(std::io::Error::other)
+}
+
+/// Plain recursive copy of a dispatch's staged job dir. Deliberately not
+/// `copy_dir_filtered`: that one drops build-output directories, and a job dir
+/// legitimately contains a directory named `out`.
+fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir(&entry.path(), &to)?;
+        } else {
+            std::fs::copy(entry.path(), &to)?;
+        }
+    }
+    Ok(())
 }
 
 /// Extract the artifact tar the guest wrote for this dispatch into the host
@@ -150,6 +178,32 @@ mod tests {
         assert!(
             !dest.join("job/old-job").exists(),
             "a repack must not carry the previous dispatch's artifacts"
+        );
+    }
+
+    #[test]
+    fn a_repacked_input_disk_carries_job_as_a_tree_the_guest_can_name() {
+        // The guest extracts with `tar xf <dev> -C <stage> job`, naming `job`
+        // as an archive member. Entries called `job/<id>/…` with no `job/`
+        // entry of their own do not give it that member, and the extraction
+        // fails with a message about the member rather than about the shape.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let job_dir = scratch.path().join("jobs");
+        std::fs::create_dir_all(job_dir.join("j1")).unwrap();
+        std::fs::write(job_dir.join("j1").join("cmd.sh"), b"#!/bin/sh\n").unwrap();
+        let t = transport_at(scratch.path());
+        crate::builder_disk_transport::create_output_disk(&t.input_disk, 1 << 20).unwrap();
+
+        repack_dispatch_input(&t, &job_dir, "j1").expect("repack");
+
+        let names: Vec<String> = tar::Archive::new(std::fs::File::open(&t.input_disk).unwrap())
+            .entries()
+            .unwrap()
+            .map(|e| e.unwrap().path().unwrap().display().to_string())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "job" || n == "job/"),
+            "the archive must carry `job` as its own entry, got {names:?}"
         );
     }
 

--- a/crates/mvm-build/src/persistent_builder_transport.rs
+++ b/crates/mvm-build/src/persistent_builder_transport.rs
@@ -58,16 +58,17 @@ pub fn guest_artifact_dir(transport: Option<&SessionDiskTransport>, job_id: &str
 /// were packed at boot and are bind-mounted in the guest, so re-sending a large
 /// workspace tree per dispatch would cost real time for no effect.
 ///
-/// The disk never shrinks. Its capacity was read by the guest's virtio-blk
-/// driver at boot and cannot be renegotiated, so the current file length is the
-/// floor every repack pads back up to.
+/// Written **in place**, never resized. The guest's `DiskImage` captured this
+/// device's length once, at open, and zero-fills reads past it, so a repack that
+/// grew the file would hand the guest an archive it reads as short — and `tar`
+/// reports success on a short archive. `repack_input_disk_in_place` refuses an
+/// over-capacity archive instead, because refusing is the only way that failure
+/// is visible.
 pub fn repack_dispatch_input(
     transport: &SessionDiskTransport,
     session_job_dir: &Path,
     job_id: &str,
 ) -> std::io::Result<()> {
-    let floor = std::fs::metadata(&transport.input_disk)?.len();
-
     // Stage this dispatch alone under a `job` root, and archive that root as a
     // tree. Two things depend on the shape:
     //
@@ -81,14 +82,12 @@ pub fn repack_dispatch_input(
     let staged_job = staging.path().join(job_id);
     copy_dir(&session_job_dir.join(job_id), &staged_job)?;
 
-    crate::builder_disk_transport::pack_input_disk(
+    crate::builder_disk_transport::repack_input_disk_in_place(
         &[crate::builder_disk_transport::InputTree {
             name: "job",
             src: staging.path(),
         }],
-        None,
         &transport.input_disk,
-        floor,
     )
     .map_err(std::io::Error::other)
 }
@@ -208,10 +207,10 @@ mod tests {
     }
 
     #[test]
-    fn a_repacked_input_disk_never_shrinks_below_its_boot_capacity() {
-        // The guest's virtio-blk driver read this device's capacity at boot and
-        // cannot renegotiate it. A repack that shortened the file would leave
-        // the guest reading past the end of it.
+    fn a_repacked_input_disk_keeps_the_capacity_the_guest_booted_with() {
+        // The guest's `DiskImage` captured this device's length once, at open.
+        // Any resize — either direction — desynchronises it from what the guest
+        // believes the capacity to be.
         let scratch = tempfile::tempdir().expect("tempdir");
         let job_dir = scratch.path().join("jobs");
         std::fs::create_dir_all(job_dir.join("j1")).unwrap();
@@ -226,8 +225,28 @@ mod tests {
         assert_eq!(
             std::fs::metadata(&t.input_disk).unwrap().len(),
             boot_len,
-            "the disk shrank under the guest's feet"
+            "the disk was resized under the guest's feet"
         );
+    }
+
+    #[test]
+    fn a_dispatch_too_large_for_the_disk_is_refused_rather_than_truncated() {
+        // The failure this guards is silent: the guest zero-fills reads past
+        // its booted capacity, and `tar` reports success on a short archive. So
+        // an over-capacity dispatch has to fail here, on the host, or it
+        // "succeeds" into a build that ran the wrong thing.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let job_dir = scratch.path().join("jobs");
+        std::fs::create_dir_all(job_dir.join("big")).unwrap();
+        std::fs::write(job_dir.join("big").join("blob"), vec![7u8; 64 * 1024]).unwrap();
+        let t = transport_at(scratch.path());
+        // A disk far too small for that payload.
+        crate::builder_disk_transport::create_output_disk(&t.input_disk, 4096).unwrap();
+
+        let err = repack_dispatch_input(&t, &job_dir, "big")
+            .expect_err("an over-capacity dispatch must be refused");
+        let msg = format!("{err}");
+        assert!(msg.contains("input disk holds"), "{msg}");
     }
 
     #[test]

--- a/crates/mvm-build/src/persistent_builder_transport.rs
+++ b/crates/mvm-build/src/persistent_builder_transport.rs
@@ -1,0 +1,209 @@
+//! How a persistent builder session moves a job in and its artifacts out when
+//! the guest has no virtio-fs.
+//!
+//! A share-backed session needs none of this: `/job` and `/out` are the same
+//! host directory the guest writes into, so staging a file *is* delivering it.
+//! A disk-backed one exchanges the same payloads as raw tars on two block
+//! devices — [`crate::builder_disk_transport`] is the codec, and this module is
+//! the per-dispatch lifetime on top of it.
+//!
+//! The ordering that makes rewriting a disk under a running guest safe is not
+//! locking: the host finishes writing before it sends `Run`, and dispatches
+//! serialize behind the supervisor's mutex, so no guest read ever straddles a
+//! host write.
+
+use std::path::{Path, PathBuf};
+
+use crate::persistent_builder::{ARTIFACT_SUBDIR, artifact_dir_for};
+
+/// The raw block devices a disk-backed session exchanges jobs and artifacts
+/// over, in place of virtio-fs shares.
+///
+/// The two travel together because neither is usable alone: the host writes a
+/// job onto the input disk and reads that job's artifacts off the output disk,
+/// so a record carrying one and not the other describes no working session.
+///
+/// Absent on a session whose guest mounts shares — today the libkrun
+/// persistent builder, whose VMM has virtio-fs and still uses it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SessionDiskTransport {
+    /// Rewritten with the next job's payload before each `Run`. Read-only to
+    /// the guest, which re-extracts only its `job` member per dispatch.
+    pub input_disk: PathBuf,
+    /// The guest writes each dispatch's artifact tar here; the host reads it
+    /// back after that dispatch's `Result`.
+    pub output_disk: PathBuf,
+}
+
+/// The in-guest directory a dispatch's `cmd.sh` must copy artifacts into.
+///
+/// The two transports collect from different places, and a script pointed at
+/// the wrong one succeeds while producing nothing the host can read:
+///
+/// - **Shares**: `/job` and `/out` are the same host directory, so writing to
+///   `/job/<job_id>/out` puts bytes exactly where [`artifact_dir_for`] looks.
+/// - **Disks**: `/job` is a bind onto the guest's own input stage and is never
+///   read back. The guest tars `/out` — and only `/out` — onto the output
+///   disk, so that is the one directory whose contents survive the boundary.
+pub fn guest_artifact_dir(transport: Option<&SessionDiskTransport>, job_id: &str) -> String {
+    match transport {
+        Some(_) => format!("/{ARTIFACT_SUBDIR}"),
+        None => format!("/job/{job_id}/{ARTIFACT_SUBDIR}"),
+    }
+}
+
+/// Rewrite the input disk so it carries exactly this dispatch's job payload.
+///
+/// Only the `job` member is written: `work`, `mvm-bins` and the closure seed
+/// were packed at boot and are bind-mounted in the guest, so re-sending a large
+/// workspace tree per dispatch would cost real time for no effect.
+///
+/// The disk never shrinks. Its capacity was read by the guest's virtio-blk
+/// driver at boot and cannot be renegotiated, so the current file length is the
+/// floor every repack pads back up to.
+pub fn repack_dispatch_input(
+    transport: &SessionDiskTransport,
+    session_job_dir: &Path,
+    job_id: &str,
+) -> std::io::Result<()> {
+    let floor = std::fs::metadata(&transport.input_disk)?.len();
+    let job_sub = session_job_dir.join(job_id);
+    crate::builder_disk_transport::pack_input_disk(
+        &[crate::builder_disk_transport::InputTree {
+            // Archived under the job id so the guest resolves the same
+            // `/job/<job_id>/cmd.sh` the `Run` frame's relpath names.
+            name: &format!("job/{job_id}"),
+            src: &job_sub,
+        }],
+        None,
+        &transport.input_disk,
+        floor,
+    )
+    .map_err(std::io::Error::other)
+}
+
+/// Extract the artifact tar the guest wrote for this dispatch into the host
+/// path [`artifact_dir_for`] names, so a disk-backed session presents the same
+/// on-disk layout a share-backed one does and every caller downstream is
+/// unchanged.
+pub fn read_dispatch_artifacts(
+    transport: &SessionDiskTransport,
+    session_job_dir: &Path,
+    job_id: &str,
+) -> std::io::Result<PathBuf> {
+    let dest = artifact_dir_for(session_job_dir, job_id);
+    crate::builder_disk_transport::read_output_disk(&transport.output_disk, &dest)
+        .map_err(std::io::Error::other)?;
+    Ok(dest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transport_at(dir: &Path) -> SessionDiskTransport {
+        SessionDiskTransport {
+            input_disk: dir.join("input.img"),
+            output_disk: dir.join("output.img"),
+        }
+    }
+
+    #[test]
+    fn guest_artifact_dir_follows_what_each_transport_collects() {
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let t = transport_at(scratch.path());
+        // Disks: the guest tars `/out` and nothing else.
+        assert_eq!(guest_artifact_dir(Some(&t), "job-1"), "/out");
+        // Shares: `/job` and `/out` are one host directory, and the host
+        // reads the per-dispatch subdir under it.
+        assert_eq!(guest_artifact_dir(None, "job-1"), "/job/job-1/out");
+    }
+
+    #[test]
+    fn a_repacked_input_disk_carries_only_this_dispatch_under_its_job_id() {
+        // What the guest does on `Run` is `tar xf <dev> -C <stage> job`, then
+        // resolves `/job/<job_id>/cmd.sh`. So the archive has to name the job
+        // id, and must not drag along a previous dispatch — whose `out/` holds
+        // a whole rootfs image by the time the next build starts.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let job_dir = scratch.path().join("jobs");
+        let t = transport_at(scratch.path());
+        crate::builder_disk_transport::create_output_disk(&t.input_disk, 1 << 20)
+            .expect("seed the input disk");
+
+        for id in ["old-job", "new-job"] {
+            let sub = job_dir.join(id);
+            std::fs::create_dir_all(sub.join("out")).unwrap();
+            std::fs::write(sub.join("cmd.sh"), format!("#!/bin/sh\necho {id}\n")).unwrap();
+        }
+        std::fs::write(
+            job_dir.join("old-job").join("out").join("rootfs.ext4"),
+            vec![0u8; 4096],
+        )
+        .unwrap();
+
+        repack_dispatch_input(&t, &job_dir, "new-job").expect("repack");
+
+        let dest = scratch.path().join("unpacked");
+        crate::builder_disk_transport::read_output_disk(&t.input_disk, &dest).expect("read back");
+        assert!(dest.join("job/new-job/cmd.sh").is_file());
+        assert!(
+            !dest.join("job/old-job").exists(),
+            "a repack must not carry the previous dispatch's artifacts"
+        );
+    }
+
+    #[test]
+    fn a_repacked_input_disk_never_shrinks_below_its_boot_capacity() {
+        // The guest's virtio-blk driver read this device's capacity at boot and
+        // cannot renegotiate it. A repack that shortened the file would leave
+        // the guest reading past the end of it.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let job_dir = scratch.path().join("jobs");
+        std::fs::create_dir_all(job_dir.join("j1")).unwrap();
+        std::fs::write(job_dir.join("j1").join("cmd.sh"), b"#!/bin/sh\n").unwrap();
+        let t = transport_at(scratch.path());
+        crate::builder_disk_transport::create_output_disk(&t.input_disk, 8 << 20)
+            .expect("seed a large input disk");
+        let boot_len = std::fs::metadata(&t.input_disk).unwrap().len();
+
+        repack_dispatch_input(&t, &job_dir, "j1").expect("repack");
+
+        assert_eq!(
+            std::fs::metadata(&t.input_disk).unwrap().len(),
+            boot_len,
+            "the disk shrank under the guest's feet"
+        );
+    }
+
+    #[test]
+    fn read_dispatch_artifacts_lands_them_where_artifact_dir_for_looks() {
+        // This is what makes every caller downstream transport-blind: after the
+        // read, a disk-backed session presents the same on-disk layout a
+        // share-backed one does.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let job_dir = scratch.path().join("jobs");
+        let t = transport_at(scratch.path());
+
+        // Stand in for the guest: a tar of `/out`'s contents, written raw.
+        let guest_out = scratch.path().join("guest-out");
+        std::fs::create_dir_all(&guest_out).unwrap();
+        std::fs::write(guest_out.join("vmlinux"), b"kernel").unwrap();
+        std::fs::write(guest_out.join("rootfs.ext4"), b"rootfs").unwrap();
+        crate::builder_disk_transport::pack_input_disk(
+            &[crate::builder_disk_transport::InputTree {
+                name: ".",
+                src: &guest_out,
+            }],
+            None,
+            &t.output_disk,
+            1 << 20,
+        )
+        .expect("write the output disk");
+
+        let dest = read_dispatch_artifacts(&t, &job_dir, "j1").expect("read back");
+        assert_eq!(dest, artifact_dir_for(&job_dir, "j1"));
+        assert_eq!(std::fs::read(dest.join("vmlinux")).unwrap(), b"kernel");
+        assert_eq!(std::fs::read(dest.join("rootfs.ext4")).unwrap(), b"rootfs");
+    }
+}

--- a/crates/mvm-cli/src/commands/build/persistent_builder.rs
+++ b/crates/mvm-cli/src/commands/build/persistent_builder.rs
@@ -50,7 +50,8 @@ use mvm_build::libkrun_builder::{
     DISPATCH_SOCK_MARKER, LibkrunPersistentHostVm, PersistentVmHandle,
 };
 use mvm_build::persistent_builder::{
-    DispatchOutcome, PersistentBuilderSupervisor, current_unix_secs,
+    DispatchOutcome, PersistentBuilderSupervisor, SessionDiskTransport, current_unix_secs,
+    guest_artifact_dir, read_dispatch_artifacts, repack_dispatch_input,
 };
 
 use crate::commands::Cli;
@@ -116,10 +117,15 @@ struct SessionRecord {
     /// Path libkrun exposes for AF_VSOCK port 21471 proxy. The
     /// supervisor connects here.
     dispatch_socket_path: PathBuf,
-    /// Per-VM job dir (bound at `/job` in the guest). `submit`
-    /// stages each call's cmd.sh under a fresh
-    /// `<job_dir_relpath>` here.
+    /// Per-VM job dir. `submit` stages each call's cmd.sh under a fresh
+    /// `<job_dir_relpath>` here and reads that dispatch's artifacts back here.
+    /// Reaches the guest as a `/job` share, or — when `disk_transport` is set —
+    /// over the transport disks, in which case the guest never sees this path.
     job_dir: PathBuf,
+    /// Set when this session exchanges jobs over raw disks rather than shares.
+    /// Absent means shares, which is what the libkrun backend uses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    disk_transport: Option<SessionDiskTransport>,
     /// Workspace bound at `/work` in the guest. Recorded for
     /// `status` output; not load-bearing.
     workspace_root: PathBuf,
@@ -280,6 +286,7 @@ fn as_build_record(record: &SessionRecord) -> mvm_build::persistent_builder::Ses
         dispatch_socket_path: record.dispatch_socket_path.clone(),
         job_dir: record.job_dir.clone(),
         workspace_root: record.workspace_root.clone(),
+        disk_transport: record.disk_transport.clone(),
         supervisor_pid: record.supervisor_pid,
         last_activity_unix_secs: record.last_activity_unix_secs,
     }
@@ -315,19 +322,24 @@ fn ensure_persistent_host_bins() -> Result<PathBuf> {
 /// can outlive this command.
 fn start_hvf_persistent(workspace: PathBuf, memory_mib: u32) -> Result<SessionRecord> {
     let host_bin_dir = ensure_persistent_host_bins()?;
-    let (kernel, rootfs, _closure_nar) =
+    let (kernel, rootfs, closure_nar) =
         crate::commands::build::hvf_builder_image::resolve_hvf_builder_image()
             .map_err(|e| anyhow::anyhow!(e))
             .context("resolving the hvf builder image for the persistent builder")?;
 
     let session_id = format!("{:x}", current_unix_secs());
-    let vm = mvm_runtime::builder_runner::HvfPersistentHostVm::new(
+    let mut vm = mvm_runtime::builder_runner::HvfPersistentHostVm::new(
         kernel,
         rootfs,
         &workspace,
         host_bin_dir,
     )
     .with_resources(DEFAULT_PERSISTENT_VCPUS, memory_mib);
+    // A builder pack may ship a pre-fetched toolchain closure. It rides the
+    // input disk, so it has to be known before the disk is packed.
+    if let Some(nar) = closure_nar {
+        vm = vm.with_closure_nar(nar);
+    }
     let session = vm
         .start(&session_id)
         .context("spawning persistent builder VM (HvfPersistentHostVm::start)")?;
@@ -336,6 +348,11 @@ fn start_hvf_persistent(workspace: PathBuf, memory_mib: u32) -> Result<SessionRe
         session_id: session.session_id().to_string(),
         dispatch_socket_path: session.dispatch_socket_path(),
         job_dir: session.job_dir().to_path_buf(),
+        // HVF has no virtio-fs: every job and every artifact crosses on a disk.
+        disk_transport: Some(SessionDiskTransport {
+            input_disk: session.input_disk().to_path_buf(),
+            output_disk: session.output_disk().to_path_buf(),
+        }),
         workspace_root: workspace,
         supervisor_pid: session
             .supervisor_pid()
@@ -365,6 +382,9 @@ fn start_libkrun_persistent(workspace: PathBuf, memory_mib: u32) -> Result<Sessi
         session_id: handle.session_id().to_string(),
         dispatch_socket_path: handle.dispatch_socket_path(),
         job_dir: handle.job_dir().to_path_buf(),
+        // libkrun serves `/job` and `/out` as virtio-fs shares, so the host
+        // already sees what the guest writes and needs no transport disks.
+        disk_transport: None,
         workspace_root: workspace,
         supervisor_pid: read_supervisor_pid(handle.vm_state_dir()),
         last_activity_unix_secs: Some(current_unix_secs()),
@@ -401,7 +421,16 @@ fn run_submit(args: SubmitArgs) -> Result<()> {
         .attr
         .unwrap_or_else(|| format!("packages.{}-linux.default", host_arch_for_attr()));
     let _ = mvm_build::persistent_builder::touch_active_session(current_unix_secs());
-    let job_dir_relpath = stage_flake_cmd_sh(&record.job_dir, &args.flake, &attr)?;
+    let transport = record.disk_transport.as_ref();
+    let job_dir_relpath = stage_flake_cmd_sh(&record.job_dir, &args.flake, &attr, transport)?;
+
+    // Disk-backed session: the job has to be on the input disk before the
+    // guest is told to run it. `submit` below is what sends the frame, so
+    // finishing here is what makes the ordering safe.
+    if let Some(t) = transport {
+        repack_dispatch_input(t, &record.job_dir, &job_dir_relpath)
+            .context("packing the dispatch input disk")?;
+    }
 
     let supervisor = PersistentBuilderSupervisor::new(&record.dispatch_socket_path)
         // Nix can spend a long time in a quiet compiler phase while the
@@ -422,6 +451,19 @@ fn run_submit(args: SubmitArgs) -> Result<()> {
     let _ = mvm_build::persistent_builder::touch_active_session(current_unix_secs());
 
     print_outcome(&outcome);
+
+    // The guest wrote its artifact tar before answering, so reading now cannot
+    // race it. This lands them where `artifact_dir_for` looks, which is what
+    // keeps the reporting below identical across both transports.
+    if let Some(t) = transport
+        && let Err(e) = read_dispatch_artifacts(t, &record.job_dir, &job_dir_relpath)
+    {
+        // Best-effort on a failed dispatch: the guest still collects after
+        // every job, so this usually carries the Nix log even when the build
+        // did not produce artifacts. A hard error here would replace the
+        // build's own diagnosis with a transport one.
+        eprintln!("warning: reading the dispatch output disk failed: {e}");
+    }
 
     if outcome.exit_code == 0 {
         let artifact_dir = artifact_dir_for(&record.job_dir, &job_dir_relpath);
@@ -578,7 +620,12 @@ const ARTIFACT_SUBDIR: &str = "out";
 /// Matches the shape `LibkrunBuilderVm::run_build` produces for
 /// the single-shot path so the guest's `run_job` helper accepts
 /// the input unchanged.
-fn stage_flake_cmd_sh(job_dir: &std::path::Path, flake_ref: &str, attr: &str) -> Result<String> {
+fn stage_flake_cmd_sh(
+    job_dir: &std::path::Path,
+    flake_ref: &str,
+    attr: &str,
+    transport: Option<&SessionDiskTransport>,
+) -> Result<String> {
     let job_id = uuid::Uuid::new_v4().to_string();
     let sub = job_dir.join(&job_id);
     let artifact_dir = sub.join(ARTIFACT_SUBDIR);
@@ -642,14 +689,14 @@ fn stage_flake_cmd_sh(job_dir: &std::path::Path, flake_ref: &str, attr: &str) ->
          stalled-download-timeout = 300'\n\
          mkdir -p \"$XDG_CACHE_HOME\" \"$XDG_STATE_HOME\"\n\
          nix() {{ env HOME=\"$HOME\" XDG_CACHE_HOME=\"$XDG_CACHE_HOME\" XDG_STATE_HOME=\"$XDG_STATE_HOME\" /sbin/nix \"$@\"; }}\n\
-         OUT_DIR='/job/{job_id}/{artifact_subdir}'\n\
-         JOB_DIR='/job/{job_id}'\n\
-         NIX_LOG=\"$JOB_DIR/nix-stderr.log\"\n\
-         NIX_STATUS=\"$JOB_DIR/nix-exit-status\"\n\
+         OUT_DIR='{out_dir}'\n\
+         NIX_LOG=\"$OUT_DIR/nix-stderr.log\"\n\
+         NIX_STATUS=\"$OUT_DIR/nix-exit-status\"\n\
          mkdir -p \"$OUT_DIR\"\n\
-         # Keep the complete Nix diagnostic on the host-visible job share.\n\
-         # A build can terminate before the terminal Result frame is\n\
-         # written; this file remains available for post-mortem inspection.\n\
+         # Keep the complete Nix diagnostic beside the artifacts, which is\n\
+         # the one directory the host reads back on either transport. A build\n\
+         # can terminate before the terminal Result frame is written; this\n\
+         # file remains available for post-mortem inspection.\n\
          set +e\n\
          STORE_PATH=$(nix --extra-experimental-features 'nix-command flakes' \\\n\
              build --no-link --print-out-paths \\\n\
@@ -690,7 +737,7 @@ fn stage_flake_cmd_sh(job_dir: &std::path::Path, flake_ref: &str, attr: &str) ->
                  cp -L \"$STORE_PATH/$sidecar\" \"$OUT_DIR/$sidecar\"\n\
              fi\n\
          done\n",
-        artifact_subdir = ARTIFACT_SUBDIR,
+        out_dir = guest_artifact_dir(transport, &job_id),
         flake_ref = shell_escape(flake_ref),
         attr = shell_escape(attr),
         egress_proxy_url = mvm_core::guest_netd::DEFAULT_EGRESS_PROXY_URL,
@@ -870,8 +917,13 @@ mod tests {
     fn stage_flake_cmd_sh_writes_valid_shell_under_per_job_subdir() {
         let scratch = tempfile::tempdir().expect("tempdir");
         let job_dir = scratch.path().to_path_buf();
-        let relpath = stage_flake_cmd_sh(&job_dir, "path:/work", "packages.aarch64-linux.default")
-            .expect("stage");
+        let relpath = stage_flake_cmd_sh(
+            &job_dir,
+            "path:/work",
+            "packages.aarch64-linux.default",
+            None,
+        )
+        .expect("stage");
         let cmd_path = job_dir.join(&relpath).join("cmd.sh");
         assert!(cmd_path.is_file(), "{}", cmd_path.display());
         let body = std::fs::read_to_string(&cmd_path).expect("read");
@@ -891,6 +943,7 @@ mod tests {
             scratch.path(),
             "path:/work",
             "packages.aarch64-linux.default",
+            None,
         )
         .expect("stage");
         let body =
@@ -933,8 +986,13 @@ mod tests {
         // racing the guest's mkdir).
         let scratch = tempfile::tempdir().expect("tempdir");
         let job_dir = scratch.path().to_path_buf();
-        let relpath = stage_flake_cmd_sh(&job_dir, "path:/work", "packages.aarch64-linux.default")
-            .expect("stage");
+        let relpath = stage_flake_cmd_sh(
+            &job_dir,
+            "path:/work",
+            "packages.aarch64-linux.default",
+            None,
+        )
+        .expect("stage");
         let artifact_dir = artifact_dir_for(&job_dir, &relpath);
         assert!(
             artifact_dir.is_dir(),
@@ -980,8 +1038,10 @@ mod tests {
         assert!(body.contains("stalled-download-timeout = 300"));
         assert!(body.contains("export XDG_STATE_HOME=/tmp/.local/state"));
         assert!(body.contains("nix() { env HOME=\"$HOME\""));
-        assert!(body.contains("NIX_LOG=\"$JOB_DIR/nix-stderr.log\""));
-        assert!(body.contains("NIX_STATUS=\"$JOB_DIR/nix-exit-status\""));
+        // Beside the artifacts, not in the job dir: `$OUT_DIR` is the one
+        // directory the host reads back on either transport.
+        assert!(body.contains("NIX_LOG=\"$OUT_DIR/nix-stderr.log\""));
+        assert!(body.contains("NIX_STATUS=\"$OUT_DIR/nix-exit-status\""));
         assert!(body.contains("cat \"$NIX_LOG\" >&2"));
         assert!(body.contains("--impure --no-write-lock-file"));
         let expected_guest_path = format!("/job/{relpath}/out");
@@ -998,6 +1058,57 @@ mod tests {
         // `cp -L` (not just `cp`) so the host gets real bytes,
         // not store-path symlinks that don't resolve.
         assert!(body.contains("cp -L"), "must use cp -L: {body}");
+    }
+
+    #[test]
+    fn a_disk_backed_dispatch_writes_artifacts_to_the_collected_directory() {
+        // The trap this pins: the guest tars `/out` — and only `/out` — onto
+        // the output disk. Under the disk transport `/job` is a bind onto the
+        // guest's own input stage, so a cmd.sh still pointing at
+        // `/job/<id>/out` runs clean and produces nothing the host can read.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let transport = SessionDiskTransport {
+            input_disk: scratch.path().join("input.img"),
+            output_disk: scratch.path().join("output.img"),
+        };
+        let relpath = stage_flake_cmd_sh(
+            scratch.path(),
+            "path:/work",
+            "packages.aarch64-linux.default",
+            Some(&transport),
+        )
+        .expect("stage");
+        let body =
+            std::fs::read_to_string(scratch.path().join(&relpath).join("cmd.sh")).expect("read");
+
+        assert!(body.contains("OUT_DIR='/out'"), "{body}");
+        assert!(
+            !body.contains(&format!("/job/{relpath}/out")),
+            "a disk-backed dispatch must not target the uncollected job dir: {body}"
+        );
+    }
+
+    #[test]
+    fn a_share_backed_dispatch_still_writes_into_the_shared_job_dir() {
+        // The other half of the same contract: with shares, `/job` and `/out`
+        // are the same host directory, and `artifact_dir_for` looks under the
+        // job dir. Retargeting this one at `/out` would write to the wrong
+        // place on libkrun.
+        let scratch = tempfile::tempdir().expect("tempdir");
+        let relpath = stage_flake_cmd_sh(
+            scratch.path(),
+            "path:/work",
+            "packages.aarch64-linux.default",
+            None,
+        )
+        .expect("stage");
+        let body =
+            std::fs::read_to_string(scratch.path().join(&relpath).join("cmd.sh")).expect("read");
+
+        assert!(
+            body.contains(&format!("OUT_DIR='/job/{relpath}/out'")),
+            "{body}"
+        );
     }
 
     #[test]
@@ -1038,6 +1149,7 @@ mod tests {
         let record = SessionRecord {
             session_id: "abc123".to_string(),
             dispatch_socket_path: PathBuf::from("/tmp/sock"),
+            disk_transport: None,
             job_dir: PathBuf::from("/tmp/jobs"),
             workspace_root: PathBuf::from("/work"),
             supervisor_pid: 4242,

--- a/crates/mvm-conformance/tests/steps/hvf_save_restore.rs
+++ b/crates/mvm-conformance/tests/steps/hvf_save_restore.rs
@@ -58,6 +58,7 @@ impl mvm_runtime::checkpoint::VmFullRestore for NeverReachedRestore {
 /// the parent — the shape a live, admitted, dev-console HVF workload has.
 fn parent_config(state_dir: &std::path::Path) -> HvfSupervisorConfig {
     HvfSupervisorConfig {
+        builder_egress_endpoint: None,
         kernel: state_dir.join("Image"),
         cmdline: Some("console=ttyAMA0 root=/dev/vda ro".into()),
         memory_mib: 512,

--- a/crates/mvm-conformance/tests/steps/verified_boot.rs
+++ b/crates/mvm-conformance/tests/steps/verified_boot.rs
@@ -110,6 +110,7 @@ fn map_elf_kernel(world: &mut CliWorld) {
     let kernel = state.path().join("vmlinux");
     std::fs::write(&kernel, b"\x7fELFconformance-kernel").expect("write ELF kernel fixture");
     let spec = VmmSpec {
+        builder_egress_endpoint: None,
         name: "bdd-libkrun-kernel-format".to_string(),
         kernel: KernelImage::Path(kernel.clone()),
         initramfs: None,

--- a/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
@@ -529,6 +529,7 @@ fn spawn_owned_builder_endpoint(
     .context("spawning the builder's egress endpoint")
 }
 
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 fn duration_micros(duration: std::time::Duration) -> u64 {
     u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
 }

--- a/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
@@ -263,6 +263,18 @@ fn main() -> anyhow::Result<()> {
         .map(std::fs::read)
         .transpose()
         .context("read initramfs")?;
+    // A VM that outlives its launcher owns its egress endpoint *here*, because
+    // the endpoint self-reaps when orphaned and this process is the only one
+    // whose life is the VM's. It has to run before the disks below: the
+    // identity drive it writes is one of them, and the guest refuses to boot if
+    // its egress proxy is unbound.
+    if let Some(endpoint) = cfg.builder_egress_endpoint.as_ref()
+        && let Err(e) = spawn_owned_builder_endpoint(endpoint)
+    {
+        eprintln!("supervisor: refusing to boot a builder with no egress endpoint: {e:#}");
+        std::process::exit(8);
+    }
+
     // Build the virtio-blk backings in `/dev/vda`… order. A read-only disk is
     // file-served (hypervisor-enforced RO, no RAM cost); a read-write disk is
     // file-served and persists writes; an ephemeral disk is loaded into RAM and
@@ -460,6 +472,63 @@ fn main() -> anyhow::Result<()> {
 }
 
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+/// Mint this boot's FlowMux identity, write the drive the guest reads it off,
+/// and spawn the trusted builder's egress endpoint as a child of this process.
+///
+/// The identity is minted **here** rather than handed over: the endpoint's
+/// config carries the host signer by value, and this supervisor's own config is
+/// persisted to disk beside the VM, so passing it through would put a signing
+/// key on disk. `mint_from_host_signer` reads the same
+/// `~/.mvm/keys/host-signer.ed25519` the config already names by path
+/// elsewhere, so nothing new becomes reachable — the key just never travels.
+///
+/// The policy and secret set are fixed at this call site, not taken from the
+/// wire: a trusted builder gets `trusted_build_egress` and no secrets, and no
+/// field on `BuilderEgressEndpoint` can widen either.
+fn spawn_owned_builder_endpoint(
+    endpoint: &mvm_vmm::host::hvf_supervisor::BuilderEgressEndpoint,
+) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    let identity = mvm_vmm::host::flowmux_identity::FlowMuxIdentityMaterial::mint_from_host_signer(
+        endpoint.vm_name.clone(),
+    )
+    .context("minting the builder's FlowMux identity")?;
+    identity
+        .write_drive(&endpoint.identity_drive)
+        .with_context(|| {
+            format!(
+                "writing the builder's FlowMux identity drive {}",
+                endpoint.identity_drive.display()
+            )
+        })?;
+
+    let policy = mvm_core::policy::network_policy::NetworkPolicy::trusted_build_egress();
+    mvm_vmm::host::network_endpoint_spawn::spawn_network_endpoint(
+        mvm_vmm::host::network_endpoint_spawn::SubstitutionSpawnParams {
+            vm_name: &endpoint.vm_name,
+            state_dir: &endpoint.state_dir,
+            tenant: "builder",
+            secrets: &[],
+            redaction: &mvm_core::policy::RedactionPolicy::default(),
+            transport: mvm_vmm::host::network_endpoint_spawn::EndpointTransport::Uds {
+                path: endpoint.socket.clone(),
+            },
+            terminator_listen: None,
+            egress_proxy: None,
+            tls_intermediate: None,
+            network_policy: Some(&policy),
+            network_limits: mvm_core::plan::NetworkLimits::default(),
+            ingress: &[],
+            resolver_remote: None,
+            binding_store_dir: None,
+            flowmux_identity: Some(identity.spawn_config().clone()),
+            session_marker: None,
+        },
+    )
+    .context("spawning the builder's egress endpoint")
+}
+
 fn duration_micros(duration: std::time::Duration) -> u64 {
     u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
 }

--- a/crates/mvm-runtime/examples/hvf-relay-egress.rs
+++ b/crates/mvm-runtime/examples/hvf-relay-egress.rs
@@ -161,6 +161,7 @@ fn main() {
         }
 
         let spec = VmmSpec {
+            builder_egress_endpoint: None,
             name: name.to_string(),
             kernel: KernelImage::Path(kernel.into()),
             initramfs: Some(initramfs.into()),

--- a/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
+++ b/crates/mvm-runtime/src/backends/hvf/kernel_boot.rs
@@ -1818,6 +1818,20 @@ unsafe fn run(
                 if let Err(e) = v.set_host_dial_sockets(ports) {
                     eprintln!("mvm-hvf: host-dial socket bind failed: {e}");
                 }
+                // The builder's control channels are exempt from idle
+                // eviction; the console ports above are not. A dispatch client
+                // holds its connection open across a whole `nix build` and is
+                // silent for exactly as long as the build takes, so reclaiming
+                // it for being quiet severs a healthy request mid-flight and
+                // reports a dispatch failure for a build that is running fine.
+                // A console, by contrast, is the case idle reclaim is for.
+                //
+                // Nothing leaks: a peer that has actually gone is still
+                // reclaimed by the bridge's EOF arm, which is what detects a
+                // dead client. Idle only ever described a live quiet one.
+                v.set_long_lived_host_dial_ports(
+                    builder_control_sockets.iter().map(|(port, _)| *port),
+                );
             }
             if v.set_handoff_control(
                 handoff_socket.as_deref(),

--- a/crates/mvm-runtime/src/builder_runner/hvf_builder.rs
+++ b/crates/mvm-runtime/src/builder_runner/hvf_builder.rs
@@ -188,7 +188,7 @@ fn map_runner_failure(detail: String) -> BuilderVmError {
 /// layout and source-checkout rebuild policy stay single-sourced. Mapped to
 /// [`BuilderVmError::RuntimeOverlayUnavailable`] (not a VMM-level failure), so
 /// it surfaces unchanged with no auto-fallback to another builder backend.
-fn require_runtime_overlay_ext4() -> Result<PathBuf, BuilderVmError> {
+pub(super) fn require_runtime_overlay_ext4() -> Result<PathBuf, BuilderVmError> {
     mvm_build::libkrun_builder::require_runtime_overlay_ext4()
         .map_err(|e| BuilderVmError::RuntimeOverlayUnavailable(format!("{e:#}")))
 }

--- a/crates/mvm-runtime/src/builder_runner/hvf_persistent.rs
+++ b/crates/mvm-runtime/src/builder_runner/hvf_persistent.rs
@@ -29,11 +29,14 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
+use mvm_build::builder_disk_transport::{
+    INPUT_DISK_MIN_BYTES, InputTree, OUTPUT_DISK_BYTES, create_output_disk, pack_input_disk,
+};
 use mvm_build::builder_vm::{BuilderVmError, builder_vm_cache_dir};
 use mvm_build::builder_vm_runtime::{
-    DISPATCH_READY_MARKER, PERSISTENT_BUILDER_READY_TIMEOUT, ensure_nix_store_image_unlocked,
-    stage_persistent_job_dir,
+    PERSISTENT_BUILDER_READY_TIMEOUT, ensure_nix_store_image_unlocked, stage_persistent_job_dir,
 };
+use mvm_build::persistent_builder::PersistentBuilderSupervisor;
 use mvm_core::config::{vm_hvf_vsock_port_socket_at, vm_state_dir};
 use mvm_net::channel::GuestService;
 
@@ -49,6 +52,17 @@ const DEFAULT_MEMORY_MIB: u32 = 16 * 1024;
 /// Poll interval while waiting for the guest to publish its dispatch listener.
 const READY_POLL: Duration = Duration::from_millis(50);
 
+/// How long one readiness probe waits for the guest's reply before being
+/// treated as "not up yet". Short, because a probe that gets no answer is the
+/// expected state for most of a cold boot and the loop simply tries again.
+const READY_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Workload id the readiness probe asks after. The nil UUID names nothing, and
+/// is not meant to: the probe cares that a well-formed reply *came back*, not
+/// what it said, so an id no spawn ever mints keeps the probe from disturbing a
+/// real workload.
+const READY_PROBE_WORKLOAD_ID: uuid::Uuid = uuid::Uuid::nil();
+
 /// Builder for a persistent HVF builder session.
 ///
 /// The image (an HVF-bootable kernel plus a rootfs whose baked
@@ -58,6 +72,7 @@ pub struct HvfPersistentHostVm {
     kernel: PathBuf,
     rootfs: PathBuf,
     runtime_overlay: Option<PathBuf>,
+    closure_nar: Option<PathBuf>,
     workspace_root: PathBuf,
     host_bin_dir: PathBuf,
     nix_store_mib: u32,
@@ -79,6 +94,7 @@ impl HvfPersistentHostVm {
             kernel: kernel.into(),
             rootfs: rootfs.into(),
             runtime_overlay: None,
+            closure_nar: None,
             workspace_root: workspace_root.into(),
             host_bin_dir: host_bin_dir.into(),
             nix_store_mib: DEFAULT_NIX_STORE_MIB,
@@ -89,6 +105,15 @@ impl HvfPersistentHostVm {
 
     pub fn with_runtime_overlay(mut self, overlay: impl Into<PathBuf>) -> Self {
         self.runtime_overlay = Some(overlay.into());
+        self
+    }
+
+    /// The builder image's optional seeded Nix store closure. Rides the input
+    /// disk so the guest can import it at boot instead of fetching the same
+    /// toolchain over the network. Absent for images that carry no seed, which
+    /// is the common case.
+    pub fn with_closure_nar(mut self, nar: impl Into<PathBuf>) -> Self {
+        self.closure_nar = Some(nar.into());
         self
     }
 
@@ -147,14 +172,44 @@ impl HvfPersistentHostVm {
             .map_err(|e: BuilderVmError| anyhow::anyhow!(e))
             .context("staging the dispatch marker")?;
 
+        // Boot-time inputs, packed once. `job` carries only the dispatch
+        // marker at this point — its presence is what makes the guest bind
+        // `/job` onto the input stage, which every later dispatch rewrites.
+        // `work` and `mvm-bins` are packed here and never again: the guest
+        // re-extracts only the `job` member per dispatch.
+        let input_disk = state_dir.join("input.img");
+        let output_disk = state_dir.join("output.img");
+        pack_input_disk(
+            &[
+                InputTree {
+                    name: "job",
+                    src: &job_dir,
+                },
+                InputTree {
+                    name: "work",
+                    src: &self.workspace_root,
+                },
+                InputTree {
+                    name: "mvm-bins",
+                    src: &self.host_bin_dir,
+                },
+            ],
+            self.closure_nar.as_deref(),
+            &input_disk,
+            INPUT_DISK_MIN_BYTES,
+        )
+        .with_context(|| format!("packing the builder input disk {}", input_disk.display()))?;
+        create_output_disk(&output_disk, OUTPUT_DISK_BYTES).with_context(|| {
+            format!("creating the builder output disk {}", output_disk.display())
+        })?;
+
         let spec = persistent_builder_spec(&PersistentBuilderSpecInputs {
             name: &vm_name,
             kernel: &self.kernel,
             rootfs: &self.rootfs,
             nix_store: nix_store.path(),
-            job_dir: &job_dir,
-            workspace_root: &self.workspace_root,
-            host_bin_dir: &self.host_bin_dir,
+            input_disk: &input_disk,
+            output_disk: &output_disk,
             runtime_overlay: self.runtime_overlay.as_deref(),
             console_log: state_dir.join("console.log"),
             egress_socket: socket_for(&state_dir, GuestService::NetworkFlow),
@@ -173,6 +228,8 @@ impl HvfPersistentHostVm {
             session_id: session_id.to_string(),
             state_dir,
             job_dir,
+            input_disk,
+            output_disk,
             vm,
         };
         session.wait_until_dispatch_ready(PERSISTENT_BUILDER_READY_TIMEOUT)?;
@@ -185,6 +242,28 @@ fn socket_for(state_dir: &Path, service: GuestService) -> PathBuf {
     vm_hvf_vsock_port_socket_at(state_dir, service.port())
 }
 
+/// One readiness probe: ask the dispatch loop about a workload that does not
+/// exist and see whether it answers.
+///
+/// Both outcomes the guest can produce — a status report saying `not_found`,
+/// or a typed failure — are answers, and either one means the loop is serving.
+/// Only a transport failure (nothing listening on the guest port yet, the
+/// bridge closing the connection, or no reply inside the probe window) means
+/// "not yet". The request has no side effect: it starts and stops nothing.
+fn dispatch_loop_answers(socket: &Path) -> bool {
+    use mvm_build::builder_protocol::WorkloadId;
+    use mvm_build::persistent_builder::PersistentBuilderError;
+
+    let probe =
+        PersistentBuilderSupervisor::new(socket).with_frame_read_timeout(READY_PROBE_TIMEOUT);
+    match probe.submit_workload_status(WorkloadId(READY_PROBE_WORKLOAD_ID)) {
+        Ok(_) => true,
+        // The guest framed a refusal for an id it does not know. It answered.
+        Err(PersistentBuilderError::WorkloadFailed { .. }) => true,
+        Err(_) => false,
+    }
+}
+
 /// A live persistent builder session.
 ///
 /// Holds no store lock: the supervisor took it and holds it until the VM
@@ -194,6 +273,8 @@ pub struct PersistentHvfSession {
     session_id: String,
     state_dir: PathBuf,
     job_dir: PathBuf,
+    input_disk: PathBuf,
+    output_disk: PathBuf,
     vm: Box<dyn RunningVm>,
 }
 
@@ -208,10 +289,24 @@ impl PersistentHvfSession {
         &self.state_dir
     }
 
-    /// Host dir bound at `/job`: where each dispatch is staged and its
-    /// artifacts read back.
+    /// Host-side staging dir for the session. Each dispatch's `cmd.sh` is
+    /// written under it and that dispatch's artifacts are read back into it.
+    /// The guest never sees this directory — the input and output disks carry
+    /// its contents across the boundary.
     pub fn job_dir(&self) -> &Path {
         &self.job_dir
+    }
+
+    /// Input transport disk. The dispatch client rewrites it with the next
+    /// job's payload before sending `Run`.
+    pub fn input_disk(&self) -> &Path {
+        &self.input_disk
+    }
+
+    /// Output transport disk. The guest writes each dispatch's artifact tar
+    /// here and the client reads it back after that dispatch's `Result`.
+    pub fn output_disk(&self) -> &Path {
+        &self.output_disk
     }
 
     /// Host socket the dispatch client dials to reach the guest's job loop.
@@ -243,15 +338,28 @@ impl PersistentHvfSession {
             .context("waiting on the persistent builder VM")
     }
 
-    /// Wait for the guest to publish `<job_dir>/dispatch.ready`.
+    /// Wait until the guest's dispatch loop answers on its vsock port.
+    ///
+    /// The guest still writes a `dispatch.ready` file, but it writes it into
+    /// `/job` — which under the disk transport is a bind onto the guest's own
+    /// input stage, not a host directory. The host cannot see it, and the
+    /// failure mode of waiting for it anyway is a hang at startup rather than
+    /// an error, so readiness moved onto the channel the dispatch client will
+    /// use regardless.
+    ///
+    /// The probe is a round trip, not a connect. The host UDS is bound by the
+    /// backend before the guest boots, so `connect` succeeds against a VM whose
+    /// vsock driver is not up yet and proves nothing. Asking a question and
+    /// getting *any* well-formed answer proves the loop is accepting and
+    /// framing — which is exactly the property the caller needs.
     ///
     /// Fails fast if the VM dies first: without this the caller would wait the
     /// full readiness window on a guest that panicked seconds in, and then
     /// report a timeout rather than the boot failure that actually happened.
     fn wait_until_dispatch_ready(&self, timeout: Duration) -> Result<()> {
-        let ready = self.job_dir.join(DISPATCH_READY_MARKER);
+        let socket = self.dispatch_socket_path();
         let deadline = Instant::now() + timeout;
-        while !ready.exists() {
+        while !dispatch_loop_answers(&socket) {
             if !matches!(
                 self.vm.status(),
                 Ok(mvm_core::vm_backend::VmStatus::Running)
@@ -265,9 +373,9 @@ impl PersistentHvfSession {
             if Instant::now() >= deadline {
                 let _ = self.vm.kill();
                 bail!(
-                    "the persistent builder VM did not publish {} within {timeout:?}; killed. \
+                    "the persistent builder VM did not answer on {} within {timeout:?}; killed. \
                      See {}",
-                    ready.display(),
+                    socket.display(),
                     self.state_dir.join("console.log").display()
                 );
             }

--- a/crates/mvm-runtime/src/builder_runner/hvf_persistent.rs
+++ b/crates/mvm-runtime/src/builder_runner/hvf_persistent.rs
@@ -44,12 +44,7 @@ use mvm_net::channel::GuestService;
 use super::hvf_builder::require_runtime_overlay_ext4;
 use super::spec::{PersistentBuilderSpecInputs, persistent_builder_spec};
 use crate::driver::traits::RunningVm;
-use crate::network_endpoint_spawn::{
-    EndpointTransport, SubstitutionSpawnParams, spawn_network_endpoint,
-};
 use mvm_backends::driver::hvf::HvfDriver;
-use mvm_core::policy::RedactionPolicy;
-use mvm_core::policy::network_policy::NetworkPolicy;
 
 /// Default persistent nix-store disk size (MiB), matching the one-shot builder.
 const DEFAULT_NIX_STORE_MIB: u32 = 64 * 1024;
@@ -233,19 +228,10 @@ impl HvfPersistentHostVm {
                 .context("resolving the runtime overlay for the persistent builder")?,
         };
 
-        // This session's FlowMux identity, minted the same way the one-shot
-        // builder mints its own. The guest reads it before starting the egress
-        // client and refuses to boot without it, and a builder with no NIC
-        // that cannot reach the proxy cannot fetch anything to build with.
-        let identity =
-            mvm_vmm::host::flowmux_identity::FlowMuxIdentityMaterial::mint_from_host_signer(
-                &vm_name,
-            )
-            .context("minting the persistent builder's FlowMux identity")?;
+        // The identity and the endpoint are the supervisor's to create, not
+        // this process's — see `builder_egress_endpoint` below. Only the drive
+        // *path* is needed here, because the spec attaches it as a disk.
         let identity_drive = state_dir.join(mvm_vmm::host::flowmux_identity::IDENTITY_DRIVE_FILE);
-        identity
-            .write_drive(&identity_drive)
-            .context("writing the persistent builder's FlowMux identity drive")?;
 
         let spec = persistent_builder_spec(&PersistentBuilderSpecInputs {
             name: &vm_name,
@@ -260,44 +246,25 @@ impl HvfPersistentHostVm {
             egress_socket: socket_for(&state_dir, GuestService::NetworkFlow),
             dispatch_socket: socket_for(&state_dir, GuestService::BuilderDispatch),
             builderd_socket: socket_for(&state_dir, GuestService::BuilderdControl),
+            builder_egress_endpoint: mvm_vmm::host::hvf_supervisor::BuilderEgressEndpoint {
+                vm_name: vm_name.clone(),
+                state_dir: state_dir.clone(),
+                socket: socket_for(&state_dir, GuestService::NetworkFlow),
+                identity_drive: identity_drive.clone(),
+            },
             vcpus: self.vcpus,
             memory_mib: self.memory_mib,
         });
 
-        // The host end of the guest's only route to the network. The builder
-        // guest has no NIC and refuses to boot if its egress client cannot bind
-        // the local proxy, and the client cannot bind until something is
-        // listening here. Same policy and same spawn helper the one-shot
-        // builder uses — claim 10's single decision point is this endpoint, and
-        // routing a second builder tier around it is exactly what
-        // `check-single-network-path` exists to prevent.
-        //
-        // Deliberately not guarded: a session outlives the command that starts
-        // it, so an `EndpointGuard` would reap the endpoint at this function's
-        // return and leave the VM unable to fetch anything. `stop` reaps it.
-        let egress_socket = socket_for(&state_dir, GuestService::NetworkFlow);
-        let builder_policy = NetworkPolicy::trusted_build_egress();
-        spawn_network_endpoint(SubstitutionSpawnParams {
-            vm_name: &vm_name,
-            state_dir: &state_dir,
-            tenant: "builder",
-            secrets: &[],
-            redaction: &RedactionPolicy::default(),
-            transport: EndpointTransport::Uds {
-                path: egress_socket,
-            },
-            terminator_listen: None,
-            egress_proxy: None,
-            tls_intermediate: None,
-            network_policy: Some(&builder_policy),
-            network_limits: mvm_core::plan::NetworkLimits::default(),
-            ingress: &[],
-            resolver_remote: None,
-            binding_store_dir: None,
-            flowmux_identity: Some(identity.spawn_config().clone()),
-            session_marker: None,
-        })
-        .context("spawning the persistent builder's network endpoint")?;
+        // The endpoint is spawned by the *supervisor*, not here, and the reason
+        // is lifetime rather than capability. `mvm-network-endpoint` self-reaps
+        // the moment it is orphaned — correct for a one-shot build or a
+        // workload run, where the spawner owns the VM for its whole life. A
+        // session inverts that: this command exits and the VM outlives it, so
+        // an endpoint parented here died seconds after boot and the guest
+        // silently lost its only route to the network. The supervisor's life is
+        // the VM's, so parenting it there is what the orphan guard is actually
+        // protecting.
 
         // The supervisor holds the store lock, not this process.
         let vm = HvfDriver::new()

--- a/crates/mvm-runtime/src/builder_runner/hvf_persistent.rs
+++ b/crates/mvm-runtime/src/builder_runner/hvf_persistent.rs
@@ -34,15 +34,22 @@ use mvm_build::builder_disk_transport::{
 };
 use mvm_build::builder_vm::{BuilderVmError, builder_vm_cache_dir};
 use mvm_build::builder_vm_runtime::{
-    PERSISTENT_BUILDER_READY_TIMEOUT, ensure_nix_store_image_unlocked, stage_persistent_job_dir,
+    PERSISTENT_BUILDER_READY_TIMEOUT, ensure_nix_store_image_unlocked, stage_filtered_work_input,
+    stage_persistent_job_dir,
 };
 use mvm_build::persistent_builder::PersistentBuilderSupervisor;
 use mvm_core::config::{vm_hvf_vsock_port_socket_at, vm_state_dir};
 use mvm_net::channel::GuestService;
 
+use super::hvf_builder::require_runtime_overlay_ext4;
 use super::spec::{PersistentBuilderSpecInputs, persistent_builder_spec};
 use crate::driver::traits::RunningVm;
+use crate::network_endpoint_spawn::{
+    EndpointTransport, SubstitutionSpawnParams, spawn_network_endpoint,
+};
 use mvm_backends::driver::hvf::HvfDriver;
+use mvm_core::policy::RedactionPolicy;
+use mvm_core::policy::network_policy::NetworkPolicy;
 
 /// Default persistent nix-store disk size (MiB), matching the one-shot builder.
 const DEFAULT_NIX_STORE_MIB: u32 = 64 * 1024;
@@ -177,6 +184,16 @@ impl HvfPersistentHostVm {
         // `/job` onto the input stage, which every later dispatch rewrites.
         // `work` and `mvm-bins` are packed here and never again: the guest
         // re-extracts only the `job` member per dispatch.
+        //
+        // `work` is filtered first, exactly as the one-shot builder filters it.
+        // The raw tree carries `target/`, which on a developer's checkout is
+        // tens of gigabytes of build output the guest never reads — enough to
+        // fill the extraction disk and fail the boot with a `tar: write error`
+        // rather than anything naming the cause. The staging dir must outlive
+        // the pack.
+        let work_staging = stage_filtered_work_input(&self.workspace_root)
+            .map_err(|e: BuilderVmError| anyhow::anyhow!(e))
+            .context("staging the filtered workspace for the builder input disk")?;
         let input_disk = state_dir.join("input.img");
         let output_disk = state_dir.join("output.img");
         pack_input_disk(
@@ -187,7 +204,7 @@ impl HvfPersistentHostVm {
                 },
                 InputTree {
                     name: "work",
-                    src: &self.workspace_root,
+                    src: work_staging.path(),
                 },
                 InputTree {
                     name: "mvm-bins",
@@ -199,9 +216,36 @@ impl HvfPersistentHostVm {
             INPUT_DISK_MIN_BYTES,
         )
         .with_context(|| format!("packing the builder input disk {}", input_disk.display()))?;
+        drop(work_staging);
         create_output_disk(&output_disk, OUTPUT_DISK_BYTES).with_context(|| {
             format!("creating the builder output disk {}", output_disk.display())
         })?;
+
+        // Same requirement the one-shot HVF builder enforces, and for the same
+        // reason: this is a lean `Rootfs` builder whose baked image carries no
+        // guest binaries, so without the overlay the guest refuses to boot. A
+        // caller-supplied overlay wins; otherwise resolve the shared one rather
+        // than booting a guest that will only tell us it is missing.
+        let resolved_overlay = match self.runtime_overlay.clone() {
+            Some(path) => path,
+            None => require_runtime_overlay_ext4()
+                .map_err(|e: BuilderVmError| anyhow::anyhow!(e))
+                .context("resolving the runtime overlay for the persistent builder")?,
+        };
+
+        // This session's FlowMux identity, minted the same way the one-shot
+        // builder mints its own. The guest reads it before starting the egress
+        // client and refuses to boot without it, and a builder with no NIC
+        // that cannot reach the proxy cannot fetch anything to build with.
+        let identity =
+            mvm_vmm::host::flowmux_identity::FlowMuxIdentityMaterial::mint_from_host_signer(
+                &vm_name,
+            )
+            .context("minting the persistent builder's FlowMux identity")?;
+        let identity_drive = state_dir.join(mvm_vmm::host::flowmux_identity::IDENTITY_DRIVE_FILE);
+        identity
+            .write_drive(&identity_drive)
+            .context("writing the persistent builder's FlowMux identity drive")?;
 
         let spec = persistent_builder_spec(&PersistentBuilderSpecInputs {
             name: &vm_name,
@@ -210,7 +254,8 @@ impl HvfPersistentHostVm {
             nix_store: nix_store.path(),
             input_disk: &input_disk,
             output_disk: &output_disk,
-            runtime_overlay: self.runtime_overlay.as_deref(),
+            runtime_overlay: Some(resolved_overlay.as_path()),
+            identity_drive: &identity_drive,
             console_log: state_dir.join("console.log"),
             egress_socket: socket_for(&state_dir, GuestService::NetworkFlow),
             dispatch_socket: socket_for(&state_dir, GuestService::BuilderDispatch),
@@ -218,6 +263,41 @@ impl HvfPersistentHostVm {
             vcpus: self.vcpus,
             memory_mib: self.memory_mib,
         });
+
+        // The host end of the guest's only route to the network. The builder
+        // guest has no NIC and refuses to boot if its egress client cannot bind
+        // the local proxy, and the client cannot bind until something is
+        // listening here. Same policy and same spawn helper the one-shot
+        // builder uses — claim 10's single decision point is this endpoint, and
+        // routing a second builder tier around it is exactly what
+        // `check-single-network-path` exists to prevent.
+        //
+        // Deliberately not guarded: a session outlives the command that starts
+        // it, so an `EndpointGuard` would reap the endpoint at this function's
+        // return and leave the VM unable to fetch anything. `stop` reaps it.
+        let egress_socket = socket_for(&state_dir, GuestService::NetworkFlow);
+        let builder_policy = NetworkPolicy::trusted_build_egress();
+        spawn_network_endpoint(SubstitutionSpawnParams {
+            vm_name: &vm_name,
+            state_dir: &state_dir,
+            tenant: "builder",
+            secrets: &[],
+            redaction: &RedactionPolicy::default(),
+            transport: EndpointTransport::Uds {
+                path: egress_socket,
+            },
+            terminator_listen: None,
+            egress_proxy: None,
+            tls_intermediate: None,
+            network_policy: Some(&builder_policy),
+            network_limits: mvm_core::plan::NetworkLimits::default(),
+            ingress: &[],
+            resolver_remote: None,
+            binding_store_dir: None,
+            flowmux_identity: Some(identity.spawn_config().clone()),
+            session_marker: None,
+        })
+        .context("spawning the persistent builder's network endpoint")?;
 
         // The supervisor holds the store lock, not this process.
         let vm = HvfDriver::new()
@@ -325,8 +405,17 @@ impl PersistentHvfSession {
         self.vm.host_process_id()
     }
 
-    /// Force-terminate the session. Releases the store lock with it.
+    /// Force-terminate the session. Releases the store lock with it, and reaps
+    /// the network endpoint the session spawned — it is deliberately unguarded
+    /// so it can outlive the starting command, so nothing else would.
     pub fn kill(self) -> Result<()> {
+        mvm_vmm::host::network_endpoint_spawn::reap_network_endpoint(
+            &self.state_dir,
+            &mvm_core::naming::persistent_builder_vm_name(
+                mvm_core::naming::BuilderVmSlot::Hvf,
+                &self.session_id,
+            ),
+        );
         self.vm.kill().context("killing the persistent builder VM")
     }
 

--- a/crates/mvm-runtime/src/builder_runner/inject.rs
+++ b/crates/mvm-runtime/src/builder_runner/inject.rs
@@ -56,6 +56,8 @@ pub fn inject_host_binaries(req: &InjectRequest<'_>) -> Result<()> {
 
     let console_log = req.work_dir.join("inject-console.log");
     let cfg = HvfSupervisorConfig {
+        // A one-shot inject VM; nothing outlives this process.
+        builder_egress_endpoint: None,
         // Irrelevant here: this helper VM carries no egress relay at all.
         trusted_builder_egress: false,
         kernel: req.kernel.to_path_buf(),

--- a/crates/mvm-runtime/src/builder_runner/mod.rs
+++ b/crates/mvm-runtime/src/builder_runner/mod.rs
@@ -15,6 +15,6 @@ pub use hvf_persistent::{HvfPersistentHostVm, PersistentHvfSession};
 pub use inject::{InjectRequest, default_inject_work_dir, inject_host_binaries};
 pub use runner::{BuilderBuild, BuilderOutcome, BuilderRunner};
 pub use spec::{
-    BUILDER_CMDLINE, BuilderSpecInputs, PERSISTENT_BUILDER_CMDLINE, PersistentBuilderSpecInputs,
-    builder_spec, persistent_builder_spec,
+    BUILDER_CMDLINE, BuilderSpecInputs, PersistentBuilderSpecInputs, builder_spec,
+    persistent_builder_spec,
 };

--- a/crates/mvm-runtime/src/builder_runner/spec.rs
+++ b/crates/mvm-runtime/src/builder_runner/spec.rs
@@ -161,6 +161,12 @@ pub struct PersistentBuilderSpecInputs<'a> {
     pub console_log: PathBuf,
     /// Host-side egress relay UDS wired to `EGRESS_PORT`.
     pub egress_socket: PathBuf,
+    /// This session's FlowMux identity drive (read-only). Same requirement the
+    /// one-shot builder has: the guest reads its signing key and the host
+    /// anchor off it before starting the egress client, which will not bind
+    /// without them — and a builder with no NIC that cannot reach the proxy
+    /// cannot build.
+    pub identity_drive: &'a Path,
     /// Host UDS for the guest's job-dispatch listener (the host dials).
     pub dispatch_socket: PathBuf,
     /// Host UDS for the resident builder daemon's typed control plane.
@@ -199,6 +205,10 @@ pub fn persistent_builder_spec(inputs: &PersistentBuilderSpecInputs<'_>) -> VmmS
     } else {
         BUILDER_CMDLINE.to_string()
     };
+    // Appended last and found in the guest by ext4 label rather than by slot,
+    // so the optional overlay above cannot shift it out from under the guest.
+    let identity_slot = blocks.len() as u8;
+    blocks.push(block(inputs.identity_drive, identity_slot, true));
     // Same RTC-less clock seed the one-shot builder takes: a cold store's HTTPS
     // fetch fails cert validation against a ~1970 clock.
     let cmdline = format!(
@@ -252,6 +262,7 @@ mod tests {
             input_disk: Path::new("/state/input.img"),
             output_disk: Path::new("/state/output.img"),
             runtime_overlay: None,
+            identity_drive: Path::new("/state/flowmux-identity.ext4"),
             console_log: PathBuf::from("/state/console.log"),
             egress_socket: PathBuf::from("/state/vsock-5253.sock"),
             dispatch_socket: PathBuf::from("/state/vsock-21471.sock"),
@@ -288,8 +299,9 @@ mod tests {
         );
 
         // Same vda–vdd order as the one-shot builder, so the cmdline device
-        // names above are true of the slots the backend attaches.
-        assert_eq!(spec.blocks.len(), 4);
+        // names above are true of the slots the backend attaches, plus this
+        // session's identity drive appended last.
+        assert_eq!(spec.blocks.len(), 5);
         assert_eq!(spec.blocks[0].device_node(), "/dev/vda");
         assert!(spec.blocks[0].read_only);
         assert_eq!(spec.blocks[1].device_node(), "/dev/vdb");
@@ -303,6 +315,14 @@ mod tests {
         assert_eq!(spec.blocks[3].device_node(), "/dev/vdd");
         assert_eq!(spec.blocks[3].source, PathBuf::from("/state/output.img"));
         assert!(!spec.blocks[3].read_only, "the guest writes its artifacts");
+        // Without this the guest's egress client cannot authenticate its
+        // session, and a builder with no NIC that cannot reach the proxy
+        // refuses to boot rather than building against nothing.
+        assert_eq!(
+            spec.blocks[4].source,
+            PathBuf::from("/state/flowmux-identity.ext4")
+        );
+        assert!(spec.blocks[4].read_only);
         // File-served, never RAM-backed: the output has to survive for the
         // host to read it back after each dispatch.
         assert!(spec.blocks.iter().all(|b| !b.ephemeral));
@@ -334,13 +354,19 @@ mod tests {
         inputs.runtime_overlay = Some(overlay);
         let spec = persistent_builder_spec(&inputs);
 
-        assert_eq!(spec.blocks.len(), 5);
+        assert_eq!(spec.blocks.len(), 6);
         assert_eq!(spec.blocks[4].device_node(), BUILDER_RUNTIME_DEVICE);
         assert_eq!(spec.blocks[4].source, overlay);
         assert!(spec.blocks[4].read_only);
         assert!(
             spec.cmdline
                 .contains(&format!("mvm.runtime_data={BUILDER_RUNTIME_DEVICE}"))
+        );
+        // The identity drive still lands after the overlay, and the guest
+        // finds it by ext4 label rather than by this position.
+        assert_eq!(
+            spec.blocks[5].source,
+            PathBuf::from("/state/flowmux-identity.ext4")
         );
     }
 

--- a/crates/mvm-runtime/src/builder_runner/spec.rs
+++ b/crates/mvm-runtime/src/builder_runner/spec.rs
@@ -1,13 +1,12 @@
 //! Maps a builder VM's resolved host artifacts onto the backend-agnostic
 //! `VmmSpec` a `VmmDriver` boots. The builder is the disk-only, trusted sibling
 //! of the workload path: four virtio-blk disks (no virtio-fs), booting the
-//! builder's PID 1 with no claim-10 egress gate.
+//! builder's PID 1 with no claim-10 egress gate. One-shot and persistent
+//! builders take the same boot contract and differ only in lifetime.
 
 use std::path::{Path, PathBuf};
 
-use crate::driver::{
-    BlockDev, ConsoleCapture, KernelImage, VirtioFsShare, VmmSpec, VsockDirection, VsockPort,
-};
+use crate::driver::{BlockDev, ConsoleCapture, KernelImage, VmmSpec, VsockDirection, VsockPort};
 use mvm_net::channel::GuestService;
 
 /// Kernel cmdline for the disk-transport builder on the HVF VMM. Mirrors
@@ -21,22 +20,6 @@ pub const BUILDER_CMDLINE: &str = "earlycon=pl011,0x9000000 console=ttyAMA0 pani
      mvm.builder_transport=disk mvm.builder_input=/dev/vdc mvm.builder_output=/dev/vdd \
      mvm.vsock_egress=1";
 const BUILDER_RUNTIME_DEVICE: &str = "/dev/vde";
-
-/// Kernel cmdline for a **persistent** builder: the same boot contract as
-/// [`BUILDER_CMDLINE`], minus the disk-transport selection.
-///
-/// Omitting `mvm.builder_transport=disk` is the whole switch. `mvm-host-vm-init`
-/// reads that token and, when it is absent, mounts `/job`, `/work`, `/out` and
-/// `/mvm-bins` from virtio-fs instead of unpacking them off a block device. A
-/// long-lived session needs exactly that: the input disk is packed once, before
-/// boot, so a second dispatch would have nowhere to put its inputs.
-pub const PERSISTENT_BUILDER_CMDLINE: &str = "earlycon=pl011,0x9000000 console=ttyAMA0 panic=-1 nokaslr \
-     loglevel=8 root=/dev/vda ro rootfstype=ext4 init=/sbin/mvm-host-vm-init \
-     mvm.vsock_egress=1";
-
-/// Runtime-overlay device for the persistent layout. With no input/output
-/// disks the overlay is the third block, not the fifth.
-const PERSISTENT_BUILDER_RUNTIME_DEVICE: &str = "/dev/vdc";
 
 /// The resolved host artifacts a builder VM boots with. Disk slots are fixed:
 /// `vda` rootfs (RO), `vdb` nix-store (RW, persistent), `vdc` input (RO), `vdd`
@@ -150,10 +133,12 @@ pub fn builder_spec(inputs: &BuilderSpecInputs<'_>) -> VmmSpec {
     }
 }
 
-/// The resolved host artifacts a **persistent** builder VM boots with. No
-/// input/output disks: per-dispatch payloads ride live virtio-fs shares, so the
-/// block layout is `vda` rootfs (RO), `vdb` nix-store (RW), and — when present —
-/// `vdc` runtime overlay (RO).
+/// The resolved host artifacts a **persistent** builder VM boots with. Same
+/// disk layout as [`BuilderSpecInputs`] — `vda` rootfs (RO), `vdb` nix-store
+/// (RW), `vdc` input (RO), `vdd` output (RW), optional `vde` overlay (RO) —
+/// because a session takes the same boot contract as a one-shot build. What
+/// differs is lifetime: the host rewrites the input disk and re-reads the
+/// output disk once per dispatch instead of once per VM.
 pub struct PersistentBuilderSpecInputs<'a> {
     pub name: &'a str,
     /// arm64 boot `Image` for the builder VM.
@@ -163,14 +148,13 @@ pub struct PersistentBuilderSpecInputs<'a> {
     /// Persistent nix-store disk (writable; survives across builds *and*
     /// across dispatches, which is the point of the session).
     pub nix_store: &'a Path,
-    /// Host dir served at `/job` — where the host stages each dispatch and
-    /// reads its artifacts back.
-    pub job_dir: &'a Path,
-    /// Host dir served at `/work` — the live source tree, reflecting host
-    /// edits for the session's lifetime.
-    pub workspace_root: &'a Path,
-    /// Host dir served at `/mvm-bins` — the extracted host binaries.
-    pub host_bin_dir: &'a Path,
+    /// Input disk: the packed `{job, work, mvm-bins}` tar (read-only to the
+    /// guest). The host rewrites it in place before each `Run`, and the guest
+    /// re-extracts only the `job` member per dispatch.
+    pub input_disk: &'a Path,
+    /// Output disk: the guest writes each dispatch's artifact tar here, and
+    /// the host reads it back after that dispatch's `Result`.
+    pub output_disk: &'a Path,
     /// Optional read-only runtime overlay ext4 for the builder guest.
     pub runtime_overlay: Option<&'a Path>,
     /// Write-only console capture path.
@@ -187,14 +171,14 @@ pub struct PersistentBuilderSpecInputs<'a> {
 
 /// Compose the persistent builder `VmmSpec`.
 ///
-/// Two differences from [`builder_spec`], and both are what make a session
-/// possible rather than a single run:
+/// One difference from [`builder_spec`], and it is what makes a session
+/// possible rather than a single run: the spec names the builder control
+/// ports, so the backend binds host sockets the dispatch client can dial.
 ///
-/// 1. The cmdline omits `mvm.builder_transport=disk`, so the guest mounts its
-///    job directories from virtio-fs and each dispatch can stage fresh inputs
-///    into a running VM.
-/// 2. The spec names the builder control ports, so the backend binds host
-///    sockets the dispatch client can dial.
+/// The boot contract is otherwise identical, disk transport included. A
+/// persistent guest re-reads the `job` member off the input disk on every
+/// `Run` and re-writes the output disk after every job, so one pair of
+/// transport disks serves the whole session rather than one build.
 pub fn persistent_builder_spec(inputs: &PersistentBuilderSpecInputs<'_>) -> VmmSpec {
     let block = |source: &Path, slot: u8, read_only: bool| BlockDev {
         source: source.to_path_buf(),
@@ -204,17 +188,16 @@ pub fn persistent_builder_spec(inputs: &PersistentBuilderSpecInputs<'_>) -> VmmS
     };
 
     let mut blocks = vec![
-        block(inputs.rootfs, 0, true),     // vda: rootfs, RO
-        block(inputs.nix_store, 1, false), // vdb: nix-store, RW persist
+        block(inputs.rootfs, 0, true),       // vda: rootfs, RO
+        block(inputs.nix_store, 1, false),   // vdb: nix-store, RW persist
+        block(inputs.input_disk, 2, true),   // vdc: input tar, RO
+        block(inputs.output_disk, 3, false), // vdd: output tar, RW persist
     ];
     let cmdline = if let Some(runtime_overlay) = inputs.runtime_overlay {
-        blocks.push(block(runtime_overlay, 2, true)); // vdc: runtime overlay, RO
-        format!(
-            "{PERSISTENT_BUILDER_CMDLINE} \
-             mvm.runtime_data={PERSISTENT_BUILDER_RUNTIME_DEVICE}"
-        )
+        blocks.push(block(runtime_overlay, 4, true)); // vde: runtime overlay, RO
+        format!("{BUILDER_CMDLINE} mvm.runtime_data={BUILDER_RUNTIME_DEVICE}")
     } else {
-        PERSISTENT_BUILDER_CMDLINE.to_string()
+        BUILDER_CMDLINE.to_string()
     };
     // Same RTC-less clock seed the one-shot builder takes: a cold store's HTTPS
     // fetch fails cert validation against a ~1970 clock.
@@ -222,27 +205,6 @@ pub fn persistent_builder_spec(inputs: &PersistentBuilderSpecInputs<'_>) -> VmmS
         "{cmdline} {}",
         mvm_build::builder_vm::builder_hostepoch_cmdline_token()
     );
-
-    let share = |tag: &str, host_path: &Path, read_only: bool| VirtioFsShare {
-        tag: tag.to_string(),
-        host_path: host_path.to_path_buf(),
-        read_only,
-        dax: false,
-    };
-    // The read-only split mirrors `mvm-host-vm-init`'s
-    // `virtiofs_tag_is_read_only`: `work` and `mvm-bins` are inputs the guest
-    // must not write back, while `job` and `out` carry per-dispatch payloads
-    // and artifacts in the other direction. Marking one wrongly fails the
-    // dispatch inside the guest, so a test pins the exact split.
-    let shares = vec![
-        share("work", inputs.workspace_root, true),
-        share("mvm-bins", inputs.host_bin_dir, true),
-        share("job", inputs.job_dir, false),
-        // `/out` is the same host directory as `/job`: the guest writes each
-        // dispatch's artifacts into the job dir the host is already watching,
-        // which is the arrangement the libkrun persistent VM uses.
-        share("out", inputs.job_dir, false),
-    ];
 
     let host_dials = |service: GuestService, host_uds: &PathBuf| VsockPort {
         service,
@@ -269,7 +231,7 @@ pub fn persistent_builder_spec(inputs: &PersistentBuilderSpecInputs<'_>) -> VmmS
         console: ConsoleCapture {
             log_path: inputs.console_log.clone(),
         },
-        shares,
+        shares: Vec::new(),
         trusted_builder: true,
         // The builder VM boots from no admitted plan, so it carries no
         // wall-clock bound to enforce.
@@ -287,9 +249,8 @@ mod tests {
             kernel: Path::new("/img/Image"),
             rootfs: Path::new("/img/builder-rootfs.ext4"),
             nix_store: Path::new("/cache/nix-store.img"),
-            job_dir: Path::new("/cache/jobs/s1"),
-            workspace_root: Path::new("/src/repo"),
-            host_bin_dir: Path::new("/cache/host-bins"),
+            input_disk: Path::new("/state/input.img"),
+            output_disk: Path::new("/state/output.img"),
             runtime_overlay: None,
             console_log: PathBuf::from("/state/console.log"),
             egress_socket: PathBuf::from("/state/vsock-5253.sock"),
@@ -301,39 +262,50 @@ mod tests {
     }
 
     #[test]
-    fn a_persistent_builder_does_not_select_the_disk_transport() {
-        // The one token that decides it: with `mvm.builder_transport=disk` the
-        // guest unpacks a block device staged before boot, and a second
-        // dispatch has nowhere to put its inputs.
+    fn a_persistent_builder_selects_the_disk_transport() {
+        // The token that decides it: with `mvm.builder_transport=disk` the
+        // guest unpacks `/job`, `/work` and `/mvm-bins` off a block device
+        // instead of mounting virtio-fs shares. A persistent session works
+        // because the host rewrites that device between dispatches.
         let spec = persistent_builder_spec(&persistent_inputs());
-        assert!(!spec.cmdline.contains("mvm.builder_transport"));
-        assert!(!spec.cmdline.contains("mvm.builder_input"));
-        assert!(!spec.cmdline.contains("mvm.builder_output"));
+        assert!(spec.cmdline.contains("mvm.builder_transport=disk"));
+        assert!(spec.cmdline.contains("mvm.builder_input=/dev/vdc"));
+        assert!(spec.cmdline.contains("mvm.builder_output=/dev/vdd"));
         // Still the builder's PID 1 and the same egress posture.
         assert!(spec.cmdline.contains("init=/sbin/mvm-host-vm-init"));
         assert!(spec.cmdline.contains("mvm.vsock_egress=1"));
     }
 
     #[test]
-    fn a_persistent_builder_carries_live_shares_instead_of_transport_disks() {
+    fn a_persistent_builder_carries_transport_disks_and_no_shares() {
         let spec = persistent_builder_spec(&persistent_inputs());
 
-        // Only rootfs + nix-store: no input/output disks to go stale.
-        assert_eq!(spec.blocks.len(), 2);
+        // The claim this whole stage exists for: a builder guest gets no
+        // virtio-fs device, so it has no channel to host filesystem structure.
+        assert!(
+            spec.shares.is_empty(),
+            "a persistent builder must declare no virtio-fs shares"
+        );
+
+        // Same vda–vdd order as the one-shot builder, so the cmdline device
+        // names above are true of the slots the backend attaches.
+        assert_eq!(spec.blocks.len(), 4);
         assert_eq!(spec.blocks[0].device_node(), "/dev/vda");
         assert!(spec.blocks[0].read_only);
         assert_eq!(spec.blocks[1].device_node(), "/dev/vdb");
         assert!(!spec.blocks[1].read_only, "the store must stay writable");
-
-        let tags: Vec<&str> = spec.shares.iter().map(|s| s.tag.as_str()).collect();
-        assert_eq!(tags, vec!["work", "mvm-bins", "job", "out"]);
-
-        // The read-only split must match what the guest init expects, or a
-        // dispatch write into /job fails inside the VM.
-        for share in &spec.shares {
-            let expect_ro = matches!(share.tag.as_str(), "work" | "mvm-bins");
-            assert_eq!(share.read_only, expect_ro, "tag {}", share.tag);
-        }
+        assert_eq!(spec.blocks[2].device_node(), "/dev/vdc");
+        assert_eq!(spec.blocks[2].source, PathBuf::from("/state/input.img"));
+        assert!(
+            spec.blocks[2].read_only,
+            "the guest never writes its inputs"
+        );
+        assert_eq!(spec.blocks[3].device_node(), "/dev/vdd");
+        assert_eq!(spec.blocks[3].source, PathBuf::from("/state/output.img"));
+        assert!(!spec.blocks[3].read_only, "the guest writes its artifacts");
+        // File-served, never RAM-backed: the output has to survive for the
+        // host to read it back after each dispatch.
+        assert!(spec.blocks.iter().all(|b| !b.ephemeral));
     }
 
     #[test]
@@ -354,23 +326,22 @@ mod tests {
 
     #[test]
     fn the_persistent_runtime_overlay_lands_where_its_cmdline_says() {
-        // With no input/output disks the overlay is the third block, so the
-        // cmdline device must move with it — a stale /dev/vde would mount
-        // nothing and fail the required-overlay policy.
+        // The overlay follows the transport disks, so it is the fifth block —
+        // a cmdline naming any other device would mount nothing and fail the
+        // required-overlay policy.
         let mut inputs = persistent_inputs();
         let overlay = Path::new("/img/runtime-overlay.ext4");
         inputs.runtime_overlay = Some(overlay);
         let spec = persistent_builder_spec(&inputs);
 
-        assert_eq!(spec.blocks.len(), 3);
-        assert_eq!(
-            spec.blocks[2].device_node(),
-            PERSISTENT_BUILDER_RUNTIME_DEVICE
+        assert_eq!(spec.blocks.len(), 5);
+        assert_eq!(spec.blocks[4].device_node(), BUILDER_RUNTIME_DEVICE);
+        assert_eq!(spec.blocks[4].source, overlay);
+        assert!(spec.blocks[4].read_only);
+        assert!(
+            spec.cmdline
+                .contains(&format!("mvm.runtime_data={BUILDER_RUNTIME_DEVICE}"))
         );
-        assert!(spec.blocks[2].read_only);
-        assert!(spec.cmdline.contains(&format!(
-            "mvm.runtime_data={PERSISTENT_BUILDER_RUNTIME_DEVICE}"
-        )));
     }
 
     fn inputs() -> BuilderSpecInputs<'static> {

--- a/crates/mvm-runtime/src/builder_runner/spec.rs
+++ b/crates/mvm-runtime/src/builder_runner/spec.rs
@@ -127,6 +127,9 @@ pub fn builder_spec(inputs: &BuilderSpecInputs<'_>) -> VmmSpec {
         },
         shares: Vec::new(),
         trusted_builder: true,
+        // A one-shot build spawns its own endpoint and stays alive for the
+        // VM's whole life, so it needs no supervisor-owned one.
+        builder_egress_endpoint: None,
         // The builder VM boots from no admitted plan, so it carries no
         // wall-clock bound to enforce.
         plan_binding: None,
@@ -171,6 +174,11 @@ pub struct PersistentBuilderSpecInputs<'a> {
     pub dispatch_socket: PathBuf,
     /// Host UDS for the resident builder daemon's typed control plane.
     pub builderd_socket: PathBuf,
+    /// Ask the supervisor to own this session's egress endpoint and identity
+    /// drive. A session outlives the command that starts it, and the endpoint
+    /// self-reaps when orphaned, so the supervisor is the only process whose
+    /// life matches the VM's.
+    pub builder_egress_endpoint: mvm_vmm::host::hvf_supervisor::BuilderEgressEndpoint,
     pub vcpus: u32,
     pub memory_mib: u32,
 }
@@ -243,6 +251,7 @@ pub fn persistent_builder_spec(inputs: &PersistentBuilderSpecInputs<'_>) -> VmmS
         },
         shares: Vec::new(),
         trusted_builder: true,
+        builder_egress_endpoint: Some(inputs.builder_egress_endpoint.clone()),
         // The builder VM boots from no admitted plan, so it carries no
         // wall-clock bound to enforce.
         plan_binding: None,
@@ -267,6 +276,12 @@ mod tests {
             egress_socket: PathBuf::from("/state/vsock-5253.sock"),
             dispatch_socket: PathBuf::from("/state/vsock-21471.sock"),
             builderd_socket: PathBuf::from("/state/vsock-21473.sock"),
+            builder_egress_endpoint: mvm_vmm::host::hvf_supervisor::BuilderEgressEndpoint {
+                vm_name: "bld-persistent".into(),
+                state_dir: PathBuf::from("/state"),
+                socket: PathBuf::from("/state/vsock-5253.sock"),
+                identity_drive: PathBuf::from("/state/flowmux-identity.ext4"),
+            },
             vcpus: 4,
             memory_mib: 8192,
         }

--- a/crates/mvm-runtime/tests/fc_warm_pool_live.rs
+++ b/crates/mvm-runtime/tests/fc_warm_pool_live.rs
@@ -78,6 +78,7 @@ fn host_signer_pub_cmdline_token() -> String {
 /// out of the saved memory.
 fn parent_boot_spec(name: &str, images: &LiveImages, state_dir: &Path) -> VmmSpec {
     VmmSpec {
+        builder_egress_endpoint: None,
         name: name.to_string(),
         kernel: KernelImage::Path(images.kernel.clone()),
         initramfs: None,

--- a/crates/mvm-vmm/src/driver/spec.rs
+++ b/crates/mvm-vmm/src/driver/spec.rs
@@ -121,6 +121,11 @@ pub struct VmmSpec {
     /// without an egress relay. Workload launches leave this false so a
     /// missing relay fails closed rather than booting ungated.
     pub trusted_builder: bool,
+    /// Set when the VM outlives the process that launches it, so its egress
+    /// endpoint must be parented to the supervisor rather than to that process.
+    /// Only the persistent builder sets it; every other launch spawns its own
+    /// endpoint and stays alive for the VM's whole life.
+    pub builder_egress_endpoint: Option<crate::host::hvf_supervisor::BuilderEgressEndpoint>,
     /// What a supervisor needs to enforce the plan's wall-clock bound and
     /// record the kill. `None` on the boot paths that carry no plan — Stage 0
     /// and the builder VM — which therefore have no bound to enforce.

--- a/crates/mvm-vmm/src/host/hvf_supervisor.rs
+++ b/crates/mvm-vmm/src/host/hvf_supervisor.rs
@@ -55,6 +55,29 @@ pub struct HostDialSocket {
     pub host_socket: PathBuf,
 }
 
+/// What the supervisor needs to stand up a trusted builder's egress endpoint
+/// and the identity drive that boot's guest reads its keys off.
+///
+/// Deliberately narrow: it names paths and a VM, and grants no ability to spawn
+/// an endpoint for any other tier or policy. The supervisor applies the
+/// trusted-builder egress policy and an empty secret set unconditionally, so
+/// nothing on this wire can widen what the endpoint serves.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuilderEgressEndpoint {
+    /// VM name; keys the endpoint's per-VM env path and its FlowMux session.
+    pub vm_name: String,
+    /// Per-VM state dir; the endpoint's pid file and session marker land here.
+    pub state_dir: PathBuf,
+    /// UDS the endpoint binds — the same path `egress_relay_socket` names, so
+    /// the supervisor's relay finds it.
+    pub socket: PathBuf,
+    /// Where to write this boot's FlowMux identity drive. The guest reads its
+    /// signing key and the host anchor off it and will not start its egress
+    /// client without them, so it has to exist before the VM boots.
+    pub identity_drive: PathBuf,
+}
+
 pub use crate::hvf_handoff::HvfHandoffRequest;
 
 /// Filename for the optional supervisor-internal shutdown profile.
@@ -183,6 +206,26 @@ pub struct HvfSupervisorConfig {
     /// `~/.mvm/keys/host-signer.ed25519` — the key that chain is signed under.
     #[serde(default)]
     pub signing_key_path: Option<PathBuf>,
+    /// Ask the supervisor to spawn — and therefore own — the trusted builder's
+    /// egress endpoint, instead of inheriting one a caller spawned.
+    ///
+    /// This exists because of a lifetime mismatch, not a capability one. The
+    /// endpoint self-reaps the instant it is orphaned
+    /// (`mvm_hostd::parent_death::exit_when_orphaned`), which is right when the
+    /// spawner owns the VM — a one-shot build, a workload run. A *persistent*
+    /// builder session inverts that: the command that starts it exits and the
+    /// VM outlives it, so an endpoint parented to that command dies seconds
+    /// after boot and the guest silently loses its only route to the network.
+    /// Parenting it to the supervisor restores the invariant the guard is
+    /// really for: the endpoint dies exactly when the VM does.
+    ///
+    /// Carries no key material. The endpoint's config needs the host signer by
+    /// *value*, and this struct is persisted to disk beside the VM — so the
+    /// supervisor mints the FlowMux identity itself from
+    /// `~/.mvm/keys/host-signer.ed25519`, the same key [`Self::signing_key_path`]
+    /// already names by path.
+    #[serde(default)]
+    pub builder_egress_endpoint: Option<BuilderEgressEndpoint>,
     /// Per-VM host→guest agent RPC socket. The supervisor binds it so host clients
     /// (`machine invoke`) reach the guest agent over vsock. `None` ⇒ no agent
     /// listener (the supervisor falls back to the `MVM_HVF_AGENT_SOCKET` dev hook).
@@ -277,6 +320,7 @@ mod tests {
             virtiofs_shares: vec![],
             vsock: true,
             trusted_builder_egress: false,
+            builder_egress_endpoint: None,
             console_log: "/state/console.log".into(),
             pid_file: "/state/hvf.pid".into(),
             workload_exit: "/state/workload.exit".into(),
@@ -380,6 +424,7 @@ mod tests {
             virtiofs_shares: vec![],
             vsock: true,
             trusted_builder_egress: false,
+            builder_egress_endpoint: None,
             console_log: "/state/console.log".into(),
             pid_file: "/state/hvf.pid".into(),
             workload_exit: "/state/workload.exit".into(),

--- a/crates/mvm-vmm/src/host/spec_map.rs
+++ b/crates/mvm-vmm/src/host/spec_map.rs
@@ -323,6 +323,9 @@ pub fn workload_device_spec(config: &VmStartConfig, cmdline: &str, console_log: 
         // on the type because the builder VM still uses it.
         shares: Vec::new(),
         trusted_builder: false,
+        // Workload launches spawn their own endpoint and stay alive for the
+        // VM's whole life, so there is no supervisor-owned one to ask for.
+        builder_egress_endpoint: None,
         plan_binding: workload_plan_binding(config),
     }
 }

--- a/crates/mvm-vmm/src/vmm/host_dial_bridge.rs
+++ b/crates/mvm-vmm/src/vmm/host_dial_bridge.rs
@@ -40,7 +40,7 @@
 //! and the builder ports it now also carries are builder-tier only — a workload
 //! guest, sealed or not, is handed neither list.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -89,6 +89,16 @@ pub(crate) struct HostDialBridge {
     active: Option<Arc<AtomicUsize>>,
     /// Host-side EOF/error/idle closures waiting for a guest `OP_RST`.
     host_closed: Vec<(u32, u32)>,
+    /// Guest ports whose connections are exempt from idle eviction.
+    ///
+    /// Idle eviction reclaims a slot from a connection that is *alive but
+    /// quiet*; a connection whose peer has actually gone is already reclaimed by
+    /// the EOF arm in [`Self::drain_host`]. That distinction is what makes the
+    /// exemption safe, and it is why silence is the wrong signal for a
+    /// request/response control channel: a builder holding one open across a
+    /// `nix build` is silent for exactly as long as the build takes, and
+    /// severing it reports a dispatch failure for a build that is running fine.
+    long_lived: HashSet<u32>,
 }
 
 impl HostDialBridge {
@@ -99,7 +109,17 @@ impl HostDialBridge {
             next_port: FIRST_HOST_DIAL_PORT,
             active: None,
             host_closed: Vec::new(),
+            long_lived: HashSet::new(),
         }
+    }
+
+    /// Mark guest ports whose connections must not be evicted for being idle.
+    ///
+    /// Callers pass the long-lived *control* ports (the builder's dispatch and
+    /// daemon channels). Console data ports are deliberately left evictable: an
+    /// abandoned-but-open console is exactly the case idle reclaim is for.
+    pub fn set_long_lived_ports(&mut self, ports: impl IntoIterator<Item = u32>) {
+        self.long_lived = ports.into_iter().collect();
     }
 
     /// Bind one non-blocking host listener per `(guest_port, path)`, replacing any
@@ -289,7 +309,8 @@ impl HostDialBridge {
             .conns
             .iter()
             .filter(|(_, conn)| {
-                now.saturating_duration_since(conn.last_activity) >= CONNECTION_IDLE_TIMEOUT
+                !self.long_lived.contains(&conn.guest_port)
+                    && now.saturating_duration_since(conn.last_activity) >= CONNECTION_IDLE_TIMEOUT
             })
             .map(|(&conn_id, conn)| (conn_id, conn.guest_port))
             .collect();
@@ -573,6 +594,91 @@ mod tests {
         bridge.drain_host();
 
         assert_eq!(bridge.take_host_closed(), vec![(conn_id, 20_001)]);
+        assert!(!bridge.is_host_dial_stream(conn_id));
+    }
+
+    /// A long-lived control channel is silent for exactly as long as the
+    /// operation it is waiting on. Evicting it reports a failure for work that
+    /// is still running — which is what happened to a builder dispatch across a
+    /// `nix build`.
+    #[test]
+    fn a_long_lived_port_survives_being_idle_past_the_timeout() {
+        let mut bridge = HostDialBridge::new();
+        let (stream, _peer) = UnixStream::pair().unwrap();
+        // `accept_new` does this for a real connection; a test that inserts one
+        // directly and then survives eviction reaches `drain_host`'s read, and
+        // a blocking socket with a live peer never returns from it.
+        stream.set_nonblocking(true).unwrap();
+        let conn_id = FIRST_HOST_DIAL_PORT;
+        let dispatch_port = 21_471;
+        bridge.set_long_lived_ports([dispatch_port]);
+        bridge.conns.insert(
+            conn_id,
+            HostDialConn {
+                stream,
+                guest_port: dispatch_port,
+                established: true,
+                last_activity: Instant::now() - CONNECTION_IDLE_TIMEOUT - Duration::from_secs(1),
+            },
+        );
+
+        bridge.drain_host();
+
+        assert!(
+            bridge.take_host_closed().is_empty(),
+            "a long-lived control channel must not be evicted for being quiet"
+        );
+        assert!(bridge.is_host_dial_stream(conn_id));
+    }
+
+    /// The exemption is per port, not global: a console on the same bridge is
+    /// still reclaimed, which is the case idle eviction exists for.
+    #[test]
+    fn exempting_one_port_leaves_the_others_evictable() {
+        let mut bridge = HostDialBridge::new();
+        bridge.set_long_lived_ports([21_471]);
+        let (console, _console_peer) = UnixStream::pair().unwrap();
+        let console_id = FIRST_HOST_DIAL_PORT + 1;
+        bridge.conns.insert(
+            console_id,
+            HostDialConn {
+                stream: console,
+                guest_port: 20_001,
+                established: true,
+                last_activity: Instant::now() - CONNECTION_IDLE_TIMEOUT - Duration::from_secs(1),
+            },
+        );
+
+        bridge.drain_host();
+
+        assert_eq!(bridge.take_host_closed(), vec![(console_id, 20_001)]);
+    }
+
+    /// The property that makes the exemption safe: a peer that has actually
+    /// gone is reclaimed by the EOF arm, not by the idle sweep. Without this,
+    /// exempting a port would leak its slot for the VM's lifetime.
+    #[test]
+    fn a_long_lived_port_is_still_reclaimed_when_its_peer_hangs_up() {
+        let mut bridge = HostDialBridge::new();
+        let (stream, peer) = UnixStream::pair().unwrap();
+        stream.set_nonblocking(true).unwrap();
+        let conn_id = FIRST_HOST_DIAL_PORT;
+        let dispatch_port = 21_471;
+        bridge.set_long_lived_ports([dispatch_port]);
+        bridge.conns.insert(
+            conn_id,
+            HostDialConn {
+                stream,
+                guest_port: dispatch_port,
+                established: true,
+                last_activity: Instant::now(),
+            },
+        );
+        drop(peer);
+
+        bridge.drain_host();
+
+        assert_eq!(bridge.take_host_closed(), vec![(conn_id, dispatch_port)]);
         assert!(!bridge.is_host_dial_stream(conn_id));
     }
 }

--- a/crates/mvm-vmm/src/vmm/vsock.rs
+++ b/crates/mvm-vmm/src/vmm/vsock.rs
@@ -245,8 +245,15 @@ impl VsockShared {
         self.handlers.set_host_dial_sockets(ports)
     }
 
+    /// Exempt these guest ports from idle eviction in **both** layers that can
+    /// reclaim a quiet stream: the host-dial bridge, which closes the host
+    /// socket, and the transport's credit table, which sends the guest an
+    /// `OP_RST`. Fixing only one leaves the other to sever the connection.
     pub fn set_long_lived_host_dial_ports(&mut self, ports: impl IntoIterator<Item = u32>) {
-        self.handlers.set_long_lived_host_dial_ports(ports);
+        let ports: Vec<u32> = ports.into_iter().collect();
+        self.handlers
+            .set_long_lived_host_dial_ports(ports.iter().copied());
+        self.transport.set_long_lived_ports(ports);
     }
 
     pub fn set_host_dial_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {

--- a/crates/mvm-vmm/src/vmm/vsock.rs
+++ b/crates/mvm-vmm/src/vmm/vsock.rs
@@ -245,6 +245,10 @@ impl VsockShared {
         self.handlers.set_host_dial_sockets(ports)
     }
 
+    pub fn set_long_lived_host_dial_ports(&mut self, ports: impl IntoIterator<Item = u32>) {
+        self.handlers.set_long_lived_host_dial_ports(ports);
+    }
+
     pub fn set_host_dial_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {
         self.handlers.set_host_dial_activity(counter);
     }
@@ -424,6 +428,11 @@ impl VirtioVsock {
     pub fn capture_workload_exit(&mut self, stop: &'static std::sync::atomic::AtomicBool) {
         self.lock().capture_workload_exit(stop);
         self.host_runtime.workload_exit_stop = Some(stop);
+        self.notify_io();
+    }
+
+    pub fn set_long_lived_host_dial_ports(&mut self, ports: impl IntoIterator<Item = u32>) {
+        self.lock().set_long_lived_host_dial_ports(ports);
         self.notify_io();
     }
 

--- a/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
+++ b/crates/mvm-vmm/src/vmm/vsock_handlers/mod.rs
@@ -251,6 +251,13 @@ impl VsockHandlerRegistry {
             .bind_ports(ports)
     }
 
+    pub(crate) fn set_long_lived_host_dial_ports(&mut self, ports: impl IntoIterator<Item = u32>) {
+        self.host_handler_mut::<HostDialVsockHandler>()
+            .expect("console handler present")
+            .bridge
+            .set_long_lived_ports(ports);
+    }
+
     pub(crate) fn set_host_dial_activity(&mut self, counter: Arc<std::sync::atomic::AtomicUsize>) {
         self.host_handler_mut::<HostDialVsockHandler>()
             .expect("console handler present")

--- a/crates/mvm-vmm/src/vmm/vsock_transport.rs
+++ b/crates/mvm-vmm/src/vmm/vsock_transport.rs
@@ -143,6 +143,11 @@ pub(crate) struct VsockTransportCore {
     pub(crate) recv_cnt: HashMap<VsockConnectionKey, RecvCredit>,
     pub(crate) pending_rx: VecDeque<(VsockHdr, Vec<u8>)>,
     tx_credit: HashMap<VsockConnectionKey, TxCredit>,
+    /// Guest ports whose streams are exempt from idle eviction. Evicting one
+    /// sends the guest an `OP_RST`, which tears down a stream that is merely
+    /// quiet — and a request/response control channel is quiet for exactly as
+    /// long as the operation it is waiting on.
+    long_lived: std::collections::HashSet<u32>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -178,6 +183,7 @@ impl VsockTransportCore {
             recv_cnt: HashMap::new(),
             pending_rx: VecDeque::new(),
             tx_credit: HashMap::new(),
+            long_lived: std::collections::HashSet::new(),
         }
     }
 
@@ -313,6 +319,10 @@ impl VsockTransportCore {
         true
     }
 
+    pub(crate) fn set_long_lived_ports(&mut self, ports: impl IntoIterator<Item = u32>) {
+        self.long_lived = ports.into_iter().collect();
+    }
+
     pub(crate) fn evict_idle_connections(&mut self) -> Vec<VsockConnectionKey> {
         self.evict_idle_connections_at(Instant::now())
     }
@@ -333,7 +343,9 @@ impl VsockTransportCore {
         let mut expired: Vec<_> = latest_activity
             .into_iter()
             .filter_map(|(key, activity)| {
-                (now.saturating_duration_since(activity) >= CONNECTION_IDLE_TIMEOUT).then_some(key)
+                (!self.long_lived.contains(&key.guest_port)
+                    && now.saturating_duration_since(activity) >= CONNECTION_IDLE_TIMEOUT)
+                    .then_some(key)
             })
             .collect();
         expired.sort_unstable_by_key(|key| (key.host_port, key.guest_port));
@@ -1048,6 +1060,32 @@ mod tests {
         }));
         assert_eq!(core.tx_credit_available(9000, refused_port), 0);
         assert_eq!(core.tx_credit.len(), MAX_CONNECTIONS);
+    }
+
+    /// The transport is the *second* layer that can reclaim a quiet stream, and
+    /// it does so by sending the guest an `OP_RST`. Exempting a port in the
+    /// host-dial bridge alone still let this one tear the stream down — which
+    /// is exactly what severed a builder dispatch across a `nix build`.
+    #[test]
+    fn a_long_lived_guest_port_is_not_evicted_for_being_idle() {
+        let mut core = transport();
+        let now = Instant::now();
+        let header = VsockHdr {
+            dst_port: 9000,
+            src_port: 21_471,
+            buf_alloc: 64,
+            ..Default::default()
+        };
+        core.set_long_lived_ports([21_471]);
+        assert!(core.record_tx_credit_at(
+            &header,
+            now - CONNECTION_IDLE_TIMEOUT - Duration::from_secs(1)
+        ));
+
+        assert!(
+            core.evict_idle_connections_at(now).is_empty(),
+            "a long-lived control port must not be reset for being quiet"
+        );
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -85,6 +85,15 @@ Last updated: 2026-09-01
       took it from 23 pinned sites to 54. Remaining: the persistent HVF builder
       (needs live Apple Silicon) and libkrun's seeded closure, which is still a
       virtio-fs share the transport helper can now carry.
+      The persistent HVF builder has since moved too: `persistent_builder_spec`
+      declares no shares, readiness moved from a marker file inside the (now
+      unshared) `/job` onto a dispatch round trip, and the host rewrites the
+      input disk per `Run` and reads the output disk per `Result`. Live-validated
+      on macOS 26.5.2 — two `nix build` dispatches into one session, both exit 0.
+      Remaining: libkrun's seeded closure, the guest's install arm (which writes
+      to `/job/<job_id>/out` and is refused on a disk-backed session rather than
+      silently losing its claim-11 sidecars), and deleting the now-dead share
+      plumbing.
 
 - [ ] **Warm standby image claim repair — issue #3002.**
       `specs/plans/2026-08-28-warm-standby-image-claim.md`.
@@ -1286,9 +1295,10 @@ resume` takes a `current_head` and refuses when it differs from the
         pid and command) instead of failing the second build outright;
         `MVM_BUILDER_LOCK_WAIT_SECS` bounds the wait and `0` restores
         fail-fast for CI
-  - [x] Phase 2 — `HvfPersistentHostVm` uses the virtio-fs persistent-builder
-        spec (`work`, `mvm-bins`, `job`, `out` shares) so the multiplexing
-        path exists on the macOS 26+ default backend
+  - [x] Phase 2 — `HvfPersistentHostVm` uses the persistent-builder spec so the
+        multiplexing path exists on the macOS 26+ default backend. It carried
+        `work`/`mvm-bins`/`job`/`out` as virtio-fs shares until the remove-
+        virtio-fs plan's Stage C moved it onto the disk transport
   - [x] Phase 3 — a contended store image adopts a live persistent session or
         auto-starts one (arbitrated by a start marker), so concurrent builds
         share one VM instead of queueing

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -366,17 +366,51 @@ Five coordinated changes, host and guest:
       flip. Flipping the host first against an old baked guest hangs the
       dispatch loop with no useful error. Done: the guest half shipped first,
       and the builder image must be rebuilt before this host flip is exercised.
-- [ ] **The persistent builder's network endpoint does not outlive the command
-      that spawns it.** Found by the live run: the session boots, dispatches,
-      and re-stages correctly, but the guest's egress client loses its only
-      route to the network mid-build (`FlowMux reconnect exhausted`) because
-      the host-side `mvm-network-endpoint` has already exited. The one-shot
-      builder never hits this — its endpoint's lifetime *is* the VM's. Needs a
-      detached spawn plus a reap on `stop`; it is claim-10 infrastructure, so
-      it wants its own change rather than a rider on this one. **This is what
-      blocks a completed build through the persistent HVF builder**, and with
-      it the only unproven leg of the disk transport (`read_dispatch_artifacts`
-      against a real output disk).
+- [x] **The persistent builder's network endpoint did not outlive the command
+      that spawned it.** Fixed. The cause was not a leak or a missing detach —
+      `spawn_network_endpoint` already calls `setsid`. It is
+      `mvm_hostd::parent_death::exit_when_orphaned`, armed in the endpoint's own
+      `main`: it watches its parent and exits cleanly (status 0, hence the
+      silence) the moment it is reparented. That is deliberate — the endpoint
+      holds a workload's secrets in the clear and must not serve as an orphan —
+      and a persistent session is the first case where the VM outlives its
+      spawner, so parent-death stopped being a good proxy for VM-death.
+
+      The endpoint is now spawned by the **supervisor**, whose death *is* the
+      VM's, so the guard keeps enforcing the property it exists for. It carries
+      no key material: the endpoint's config needs the host signer by value and
+      `supervisor.json` is persisted beside the VM, so the supervisor mints the
+      FlowMux identity itself from the same `~/.mvm/keys/host-signer.ed25519`
+      the config already names by path elsewhere, and writes the identity drive
+      before opening disks. The policy and the empty secret set are fixed at
+      that call site, so nothing on the wire can widen them, and a restored
+      child never inherits the request (it names the parent's VM, socket and
+      drive).
+
+      Verified live: the endpoint stays up with the supervisor as its parent,
+      serves the guest's egress through a whole `nix build`, and self-reaps when
+      the supervisor exits.
+- [ ] **The HVF vsock bridge evicts the dispatch connection after 60s of
+      silence** (`CONNECTION_IDLE_TIMEOUT`, `vsock_transport.rs`). This is what
+      now blocks a completed build. The host sends `Run`, the guest starts
+      `nix build`, and any evaluation quiet for over a minute has its host-side
+      connection closed by `evict_idle_at` — the client sees a clean EOF and
+      reports `dispatch ended without Result frame after 0 stderr chunks` while
+      the build carries on fine inside the guest. Confirmed twice, including
+      with a connection the guest had not yet read, so it is the idle policy
+      rather than anything job-specific.
+
+      A one-shot builder never hits it: it holds no dispatch connection across a
+      build, it powers off and the host reads the output disk. Only a persistent
+      session keeps a control channel open across a long quiet operation.
+
+      Not a one-line raise: the timeout is a shared host resource boundary next
+      to `MAX_CONNECTIONS`, and it also governs workload console streams. The
+      options are a per-service idle policy (the builder dispatch port is
+      long-lived and legitimately quiet), or a keepalive on the dispatch channel.
+      **This is the last thing between Stage C and a completed live build**, and
+      with it the only unproven leg of the disk transport
+      (`read_dispatch_artifacts` against a real output disk).
 - [x] **The QEMU builder needs the same migration, and the plan missed it.**
       **Landed.** Both one-shot sites are on the disk transport; the `virtiofsd`
       spawn loops, the `memory-backend-memfd` + `-numa` object and the

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -259,8 +259,11 @@ dispatches behind the supervisor's mutex.
 
 Five coordinated changes, host and guest:
 
-- [ ] `persistent_builder_spec`: replace the four shares with an input and an
-      output disk, and add the three transport cmdline tokens.
+- [x] `persistent_builder_spec`: replace the four shares with an input and an
+      output disk, and add the three transport cmdline tokens. The two cmdlines
+      collapsed into one — a persistent builder now boots the same contract as
+      a one-shot, `vda`–`vdd` in the same order, so `PERSISTENT_BUILDER_CMDLINE`
+      and its runtime-overlay device constant went with the shares.
 - [x] `repack_input_disk_in_place` — **landed**. A persistent builder rewrites
       its input disk between dispatches, and `pack_input_disk` cannot do it: it
       calls `set_len`. A running VM's `DiskImage` captures the file length
@@ -268,43 +271,69 @@ Five coordinated changes, host and guest:
       the guest an archive it reads as short, and `tar` reports success on it.
       The in-place form never changes the length and refuses an archive that
       will not fit, because refusing is the only way that failure is visible.
-- [ ] `HvfPersistentHostVm::start`: `pack_input_disk` the boot-time inputs
+- [x] `HvfPersistentHostVm::start`: `pack_input_disk` the boot-time inputs
       (`work`, `mvm-bins`, closure seed) and `create_output_disk`. Both helpers
-      already exist and are what the one-shot builder calls. Size the input disk
-      with headroom — the capacity is fixed for the VM's life. Per-dispatch
-      repacks carry only the `job` tree (the guest bind-mounted `work` and
-      `mvm-bins` at boot and never re-reads them), so they are always smaller
-      than the boot pack.
-- [ ] **Readiness has to move, and connect-polling is NOT the answer.** The host
+      already exist and are what the one-shot builder calls. `job` is packed
+      too, carrying only `dispatch.sock.marker`: its presence in the archive is
+      what makes the guest bind `/job`, and the marker is what makes it enter
+      the dispatch loop rather than run one job and power off.
+
+      `work` is filtered through `stage_filtered_work_input` first, as the
+      one-shot pack filters it. Packing the raw tree put 45 GB of `target/` on
+      the input disk, filled the 64 GiB store image mid-extraction, and left
+      every later boot failing at `setup_nix_store` — a failure naming neither
+      the disk nor the cause. `mvmctl cache repair --store-only` recovers.
+
+      The capacity is fixed for the VM's life, so the boot pack sets the size
+      every later repack has to live inside. Per-dispatch repacks carry only the
+      `job` tree (the guest bind-mounted `work` and `mvm-bins` at boot and never
+      re-reads them), so they are always far smaller than the boot pack.
+- [x] **Readiness has to move, and connect-polling is NOT the answer.** The host
       waits for the guest by polling for a `dispatch.ready` file *inside the
       `/job` share* (`wait_until_dispatch_ready`). With no share the host cannot
       see that marker at all.
 
       The obvious replacement — connect to the dispatch UDS and treat success as
-      readiness — is wrong, and the repo already knows it. `hvf.rs`'s agent probe
+      readiness — is wrong, and the repo already knew it. `hvf.rs`'s agent probe
       says so in as many words: *"Probe the authenticated RPC stream directly;
       this waits for a real guest response rather than treating the host-side
-      listener as readiness."* The supervisor owns that UDS and accepts on it
-      whether or not the guest is listening on the vsock port behind it, so a
-      bare connect reports ready for a guest that never started.
+      listener as readiness."* Confirmed live: the backend binds that UDS during
+      VM setup, before the guest boots, and the bridge only closes the
+      connection when the *guest kernel* answers `OP_RST` — so early in boot a
+      probe neither connects-and-fails nor gets refused. It hangs open and reads
+      as ready.
 
-      Two options, neither free:
+      This plan offered two fixes: add a `Ping`/`Pong` pair (a wire change on
+      both sides, so a second guest change and a second image rebuild), or delete
+      the wait and let the first dispatch prove readiness (moves the failure out
+      of `start()`).
 
-      - Add a `Ping`/`Pong` pair to `HostVmRequest`/`HostVmResponse`. Crisp, but
-        a wire change on both sides — so the guest needs a second change and a
-        second image rebuild.
-      - Delete `wait_until_dispatch_ready` and let the **first dispatch** be the
-        readiness proof, with a bounded retry in the dispatch client that also
-        checks VM liveness — which is where the connection is made anyway, and
-        keeps the fail-fast-on-dead-VM behaviour the wait exists for. Smaller,
-        adds no protocol surface, but moves the failure from `start()` to the
-        first build.
-
-      Prefer the second unless the diagnostics loss bites. Do not ship a bare
-      connect-poll.
-- [ ] Host dispatch client: repack the input disk with the new job payload
+      **What shipped is a third option that costs neither:** a round trip on an
+      existing request — `submit_workload_status` for the nil UUID. Any
+      well-formed reply, a `not_found` report or a typed failure, proves the loop
+      is accepting and framing. No protocol surface is added, and the
+      fail-fast-on-dead-VM diagnostics stay in `start()` where they were.
+- [x] Host dispatch client: repack the input disk with the new job payload
       before each `Run`, and `read_output_disk` into the artifact dir after each
-      `Result` — rather than once after poweroff.
+      `Result` — rather than once after poweroff. Both dispatch clients are
+      wired: `PersistentBuilderVm::run_build` (what `mvmctl build` uses) and the
+      `persistent-builder submit` verb. The repack pads back up to the disk's
+      current length, because the guest's virtio-blk driver read that capacity
+      at boot and cannot renegotiate it.
+- [x] **A fifth change the plan missed, and the one that would have shipped
+      broken.** The guest collects `/out` and only `/out` onto the output disk,
+      but both host stagers rendered a `cmd.sh` writing to `/job/<job_id>/out` —
+      which under the disk transport is the guest's own input stage, never read
+      back. A build would have reported success and produced nothing. The
+      guest-visible artifact dir is now chosen per transport
+      (`guest_artifact_dir`), and the host reads the output disk into the same
+      `artifact_dir_for` path a share-backed session writes to, so every caller
+      downstream is transport-blind.
+
+      The guest's **install** arm has the same shape and no host-side fix: it
+      hardcodes `/job/<job_id>/out`. Rather than lose a claim-11 sealed volume's
+      SBOM and CVE sidecars silently, an install dispatch on a disk-backed
+      session is refused with a message naming the missing half.
 - [x] Guest dispatch loop: re-stages `/job` from the input disk on each `Run`
       and collects `/out` onto the output disk after each job — the collection
       previously ran only on the one-shot path, since `run_dispatch_loop`
@@ -322,19 +351,21 @@ Five coordinated changes, host and guest:
 
       **Runs only in the Linux test lane.** The guest bin is `cfg`-gated, so
       these tests compile on macOS via `just check-gated` but execute in CI.
-- [ ] **Cannot be validated in CI**, though it is validatable by hand: every
+- [x] **Cannot be validated in CI**, though it is validatable by hand: every
       guest-booting lane skips on hosted runners, so this needs a real Apple
       Silicon run. The rest of this box was wrong and is struck — the persistent
       builder is **not** what `mvmctl build` uses on macOS 26+. It is a hidden,
       opt-in subcommand with a single-shot fallback, so a break here degrades to
-      a slower build rather than a broken one.
-- [ ] **Sequence the guest half first.** `mvm-host-vm-init` is cross-compiled and
+      a slower build rather than a broken one. **Done:** two `nix build`
+      dispatches into one session on macOS 26.5.2, both exit 0.
+- [x] **Sequence the guest half first.** `mvm-host-vm-init` is cross-compiled and
       baked into the builder rootfs, so a guest change only takes effect after
       the image is rebuilt. Landing the guest's per-dispatch staging while the
       host still declares shares is inert — disk transport stays off — which
       makes it separately validatable and removes version skew from the host
       flip. Flipping the host first against an old baked guest hangs the
-      dispatch loop with no useful error.
+      dispatch loop with no useful error. Done: the guest half shipped first,
+      and the builder image must be rebuilt before this host flip is exercised.
 - [x] **The QEMU builder needs the same migration, and the plan missed it.**
       **Landed.** Both one-shot sites are on the disk transport; the `virtiofsd`
       spawn loops, the `memory-backend-memfd` + `-numa` object and the
@@ -362,6 +393,7 @@ Five coordinated changes, host and guest:
          vde token and the absence of the vdc one.
 
       Original entry, for the record:
+
       `qemu_builder.rs` serves `work` / `out` / `job` / `mvm-bins` over
       vhost-user/virtiofsd — not the disk transport — and QEMU is the *Linux
       auto-detect default builder*. So this is not the "opt-in dev/test backend
@@ -430,6 +462,22 @@ Five coordinated changes, host and guest:
       with them the `--sandbox none` flag that started this plan. That is also
       when `check-no-virtio-fs` drops to FFI-only rows and the ratchet becomes
       an absolute rather than a ceiling.
+      and the builder image must be rebuilt before this host flip is exercised.
+- [ ] The **libkrun** persistent builder still serves `work`/`mvm-bins`/`job`/
+      `out` as shares (`libkrun_builder.rs`). Its VMM has virtio-fs, so nothing
+      forced the move; the session record already carries the two-state
+      distinction (`disk_transport: Option<…>`), so flipping it is a matter of
+      packing disks in `LibkrunPersistentHostVm::start` and recording them.
+- [ ] The guest's **install** arm writes to `/job/<job_id>/out`, which the disk
+      transport does not collect. Point it at `/out` like the flake arm, then
+      drop the refusal in `PersistentBuilderVm::run_install_dispatch`. Needs a
+      guest change and therefore an image rebuild.
+- [ ] Now-dead HVF share plumbing: `HvfVirtioFsShare`, the `hvf.rs` mapper, the
+      `virtio.rs` VirtioFs MMIO device, and `kernel_boot.rs`'s attach. No spec
+      constructs a share any more, so these map and attach nothing. Pinned in
+      `check-no-virtio-fs` with that reason.
+- [ ] Delete `crates/mvm-vmm/src/host/virtiofsd.rs`, both QEMU call sites, and
+      the `virtiofsd` host dependency from the Linux install docs.
 
 ### Stage D — the gate
 

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -3,11 +3,14 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status: IN PROGRESS — Stages A, B and D landed, and Stage C's QEMU builder
-with them. No workload tier reaches virtio-fs, and a ratchet gate keeps it that
-way. Stage C is down to two paths: the persistent HVF builder, which needs live
-Apple Silicon validation, and libkrun's seeded closure, which is two tokens once
-someone can run a live libkrun build.**
+**Status: IN PROGRESS — Stages A, B and D landed, and with them Stage C's QEMU
+builder *and* its persistent HVF builder. The HVF half is live-validated: two
+`nix build` dispatches into one session on macOS 26.5.2 / Apple Silicon, both
+exit 0, artifacts read off the output disk. No workload tier reaches virtio-fs,
+no builder *spec* constructs a share, and a ratchet gate keeps it that way.
+Stage C is down to libkrun's seeded closure (two tokens once someone can run a
+live libkrun build), the guest's install arm, and deleting the now-dead share
+plumbing.**
 
 No guest gets a virtio-fs device. Not a workload, not the builder VM, not the
 dev-tier root. The host filesystem reaches a guest as a block image or it does
@@ -390,27 +393,21 @@ Five coordinated changes, host and guest:
       Verified live: the endpoint stays up with the supervisor as its parent,
       serves the guest's egress through a whole `nix build`, and self-reaps when
       the supervisor exits.
-- [ ] **The HVF vsock bridge evicts the dispatch connection after 60s of
-      silence** (`CONNECTION_IDLE_TIMEOUT`, `vsock_transport.rs`). This is what
-      now blocks a completed build. The host sends `Run`, the guest starts
-      `nix build`, and any evaluation quiet for over a minute has its host-side
-      connection closed by `evict_idle_at` — the client sees a clean EOF and
-      reports `dispatch ended without Result frame after 0 stderr chunks` while
-      the build carries on fine inside the guest. Confirmed twice, including
-      with a connection the guest had not yet read, so it is the idle policy
-      rather than anything job-specific.
+- [x] **The HVF vsock idle eviction severed the dispatch connection.** Fixed,
+      and it was in **two** layers, which is why fixing one was not enough:
+      `host_dial_bridge::evict_idle_at` closes the host socket, and the
+      transport's credit table (`vsock_transport::evict_idle_connections_at`)
+      sends the guest an `OP_RST`. Exempting the port in the bridge alone still
+      let the transport tear the stream down — observed live as the guest
+      logging `write StderrChunk failed` while its build ran to completion.
 
-      A one-shot builder never hits it: it holds no dispatch connection across a
-      build, it powers off and the host reads the output disk. Only a persistent
-      session keeps a control channel open across a long quiet operation.
+      Idle eviction is now per guest port in both layers, with the builder's
+      control ports exempt and console data ports still evictable. What makes
+      that safe is that idle was never the mechanism that reclaims a dead peer —
+      `drain_host`'s EOF arm is, and it still runs for every connection. Idle
+      only ever described a stream that is alive and quiet, which for a
+      request/response control channel is indistinguishable from working.
 
-      Not a one-line raise: the timeout is a shared host resource boundary next
-      to `MAX_CONNECTIONS`, and it also governs workload console streams. The
-      options are a per-service idle policy (the builder dispatch port is
-      long-lived and legitimately quiet), or a keepalive on the dispatch channel.
-      **This is the last thing between Stage C and a completed live build**, and
-      with it the only unproven leg of the disk transport
-      (`read_dispatch_artifacts` against a real output disk).
 - [x] **The QEMU builder needs the same migration, and the plan missed it.**
       **Landed.** Both one-shot sites are on the disk transport; the `virtiofsd`
       spawn loops, the `memory-backend-memfd` + `-numa` object and the

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -366,6 +366,17 @@ Five coordinated changes, host and guest:
       flip. Flipping the host first against an old baked guest hangs the
       dispatch loop with no useful error. Done: the guest half shipped first,
       and the builder image must be rebuilt before this host flip is exercised.
+- [ ] **The persistent builder's network endpoint does not outlive the command
+      that spawns it.** Found by the live run: the session boots, dispatches,
+      and re-stages correctly, but the guest's egress client loses its only
+      route to the network mid-build (`FlowMux reconnect exhausted`) because
+      the host-side `mvm-network-endpoint` has already exited. The one-shot
+      builder never hits this — its endpoint's lifetime *is* the VM's. Needs a
+      detached spawn plus a reap on `stop`; it is claim-10 infrastructure, so
+      it wants its own change rather than a rider on this one. **This is what
+      blocks a completed build through the persistent HVF builder**, and with
+      it the only unproven leg of the disk transport (`read_dispatch_artifacts`
+      against a real output disk).
 - [x] **The QEMU builder needs the same migration, and the plan missed it.**
       **Landed.** Both one-shot sites are on the disk transport; the `virtiofsd`
       spawn loops, the `memory-backend-memfd` + `-numa` object and the
@@ -462,7 +473,6 @@ Five coordinated changes, host and guest:
       with them the `--sandbox none` flag that started this plan. That is also
       when `check-no-virtio-fs` drops to FFI-only rows and the ratchet becomes
       an absolute rather than a ceiling.
-      and the builder image must be rebuilt before this host flip is exercised.
 - [ ] The **libkrun** persistent builder still serves `work`/`mvm-bins`/`job`/
       `out` as shares (`libkrun_builder.rs`). Its VMM has virtio-fs, so nothing
       forced the move; the session record already carries the two-state

--- a/specs/sprint/delivery/virtio-fs-stage-c-persistent-hvf-builder.md
+++ b/specs/sprint/delivery/virtio-fs-stage-c-persistent-hvf-builder.md
@@ -96,11 +96,30 @@ guest and warns about it).
   stays up with the supervisor as its parent, serves Nix's fetches, and
   self-reaps when the supervisor exits.
 
-**Still not proven: a completed build, and therefore `read_dispatch_artifacts`
-against a real output disk** (unit-tested only). The remaining blocker is the
-vsock bridge's 60-second idle eviction, not the transport — see the plan. The
-host loses its dispatch connection during a quiet `nix build` while the build
-itself proceeds normally inside the guest.
+- **A whole build, twice.** Two `nix build` dispatches into one live session,
+  both `exit_code: 0`, each reading its artifacts off the output disk into its
+  own artifact dir. The first took 465s cold; the second 797ms off the warm
+  store, which is the point of a persistent session. `vmlinux` and
+  `rootfs.ext4` both land at their real sizes, alongside the verity sidecars.
+
+That closes the last unproven leg: `read_dispatch_artifacts` against a real
+output disk, from a real build.
+
+## The idle-eviction fix, and why one layer was not enough
+
+A quiet `nix build` lost its dispatch connection after 60 seconds. The cause was
+`CONNECTION_IDLE_TIMEOUT`, applied in **two** independent places:
+`host_dial_bridge::evict_idle_at` closes the host socket, and the transport's
+credit table sends the guest an `OP_RST`. Exempting the port in the bridge alone
+still let the transport tear the stream down — visible live as the guest logging
+`write StderrChunk failed` while its build ran happily to completion.
+
+Both layers now take a per-port exemption: builder control ports are exempt,
+console data ports are not. The property that makes it safe is that idle was
+never what reclaims a dead peer — `drain_host`'s EOF arm is, and it still runs
+for every connection. Idle only ever described a stream that is alive and quiet,
+which for a request/response control channel is indistinguishable from working
+normally.
 
 ## The endpoint lifetime fix
 

--- a/specs/sprint/delivery/virtio-fs-stage-c-persistent-hvf-builder.md
+++ b/specs/sprint/delivery/virtio-fs-stage-c-persistent-hvf-builder.md
@@ -69,8 +69,55 @@ guest change and an image rebuild; it is tracked in the plan.
 warnings`, `cargo fmt --all --check`, and `cargo run -p xtask -- check-all`
 (63/63) are all clean.
 
-**Not yet verified live.** No CI lane boots a builder — every guest-booting lane
-skips on hosted runners — so this needs a real `mvmctl build` on macOS 26+ Apple
-Silicon against a **rebuilt** builder image. `mvm-host-vm-init` is
-cross-compiled and baked into the rootfs; a stale baked guest against this host
-hangs the dispatch loop with no useful error. Do not merge without it.
+## Live validation on macOS 26.5.2 / Apple Silicon
+
+Run against a rebuilt builder image (the image cache key includes the
+`mvm-host-vm-init` hash, so the guest change rotates it automatically — but
+`MVM_EMBED_NO_CACHE=1` is needed first, or `build.rs` reuses a stale baked
+guest and warns about it).
+
+**Proven end to end:**
+
+- The input disk packs and attaches as `vdc`, the output disk as `vdd`, and the
+  guest boots the disk transport off them (`mvm.builder_transport=disk` with
+  both device tokens on the observed cmdline).
+- The guest binds `/job`, `/work` and `/mvm-bins` from the input disk — Nix
+  evaluated a flake at `path:/work`, which is only possible if the workspace
+  crossed on that disk.
+- **The new readiness path works.** `start` returns when the dispatch loop
+  answers, with no `dispatch.ready` file anywhere the host can see.
+- **The per-dispatch repack works.** Two dispatches into one live session: the
+  host rewrote the input disk, the guest re-staged `/job/<job_id>` off it and
+  ran that dispatch's `cmd.sh`, streaming stderr back over the channel.
+- The session record carries the transport, and `stop` tears the session down
+  cleanly.
+
+**Not proven: a completed build, and therefore `read_dispatch_artifacts`
+against a real output disk** (it is unit-tested only). The blocker is not the
+transport — it is that the host-side `mvm-network-endpoint` this session spawns
+dies with the command that spawned it, so the guest's egress client loses its
+only route to the network mid-build (`FlowMux reconnect exhausted`). The
+one-shot builder never hits this because its endpoint's lifetime *is* the VM's
+lifetime; a persistent session inverts that. Fixing it means spawning the
+endpoint detached and reaping it on `stop`, which is lifecycle design in a
+claim-10 component and is deliberately not in this change.
+
+## Pre-existing gaps this uncovered
+
+The persistent HVF builder had never booted. Getting far enough to exercise
+Stage C at all required fixing three things that have nothing to do with
+virtio-fs, each by calling the helper the one-shot builder already calls:
+
+- No runtime overlay was ever resolved, so the guest refused to boot
+  (`require_runtime_overlay_ext4`).
+- No FlowMux identity drive was ever minted, so the egress client could not
+  authenticate and the guest refused to boot (`mint_from_host_signer`).
+- No network endpoint was ever spawned, so the egress client could not bind
+  (`spawn_network_endpoint`). This one is wired but, as above, does not yet
+  survive its spawning command.
+
+A fourth was mine: the input pack must use `stage_filtered_work_input`, as the
+one-shot pack does. Packing the raw workspace put 45 GB of `target/` on the
+input disk, filled the 64 GiB store image mid-extraction, and left every later
+boot failing at `setup_nix_store` for an unrelated-looking reason
+(`mvmctl cache repair --store-only` recovers).

--- a/specs/sprint/delivery/virtio-fs-stage-c-persistent-hvf-builder.md
+++ b/specs/sprint/delivery/virtio-fs-stage-c-persistent-hvf-builder.md
@@ -1,0 +1,76 @@
+# Stage C — the persistent HVF builder moves off virtio-fs
+
+Plan: `specs/plans/2026-08-31-remove-virtio-fs.md`, Stage C.
+Follows the guest half (PR #3056), which was inert until this flip.
+
+## What landed
+
+The persistent HVF builder exchanges jobs and artifacts over two raw block
+devices instead of four virtio-fs shares. `persistent_builder_spec` declares no
+shares at all, so `check-no-virtio-fs` dropped `builder_runner/spec.rs` from its
+pinned table — the signal Stage C names for itself. The gate now ratchets 22
+sites across 10 files, none of them a builder spec.
+
+The two builder cmdlines collapsed into one. A persistent builder now boots the
+same contract as a one-shot — `vda` rootfs, `vdb` nix-store, `vdc` input, `vdd`
+output, optional `vde` overlay — so `PERSISTENT_BUILDER_CMDLINE` and its
+separate runtime-overlay device constant went away with the shares rather than
+being maintained as a second copy of the same string.
+
+Per-dispatch lifetime lives in a new `persistent_builder_transport` module:
+`SessionDiskTransport`, `guest_artifact_dir`, `repack_dispatch_input`,
+`read_dispatch_artifacts`. Both dispatch clients use it —
+`PersistentBuilderVm::run_build` (what `mvmctl build` routes through) and the
+`persistent-builder submit` verb. The session record carries
+`disk_transport: Option<…>`, which is a real two-state distinction rather than
+backcompat padding: the libkrun persistent builder still uses shares.
+
+## Three things that were not in the plan
+
+**Readiness could not be connect-polling.** The plan called for it, and it does
+not work here. The backend binds the host UDS during VM setup, before the guest
+boots, so `connect` succeeds against a guest whose vsock driver is not up. The
+bridge only closes that connection when the guest kernel answers `OP_RST`, so
+early in boot a probe neither connects-and-fails nor gets refused — it hangs
+open and reads as ready, which is the same silent hang the plan was trying to
+remove. Readiness is a round trip instead: `submit_workload_status` for the nil
+UUID. Any well-formed reply proves the loop is accepting and framing. Existing
+request, no side effect, no protocol change.
+
+**A fifth coordinated change, and the one that would have shipped broken.** The
+guest tars `/out` — and only `/out` — onto the output disk. Both host stagers
+rendered a `cmd.sh` writing to `/job/<job_id>/out`, which under the disk
+transport is the guest's own input stage on the nix-store disk, never read back.
+The four planned changes alone would have produced a build that reported success
+and emitted nothing. The guest-visible artifact dir is now chosen per transport,
+and the host reads the output disk into the same `artifact_dir_for` path a
+share-backed session writes to, so everything downstream is transport-blind.
+
+**The install arm has the same shape and no host-side fix.** The guest hardcodes
+`/job/<job_id>/out` for install jobs. Rather than lose a claim-11 sealed
+volume's SBOM and CVE sidecars silently, an install dispatch on a disk-backed
+session is refused with a message naming the missing half. Fixing it needs a
+guest change and an image rebuild; it is tracked in the plan.
+
+## Smaller notes
+
+- Transport disk sizes moved into `builder_disk_transport` so the one-shot and
+  persistent paths size from one source instead of two copies of the number.
+- The Nix diagnostic log moved from `$JOB_DIR` to `$OUT_DIR`, which is
+  host-readable on *both* transports; the output disk is now read back whether
+  or not the dispatch succeeded, since a failed build is when its log matters.
+- `mvm-build/src/persistent_builder.rs` crossed the 1500-line production cap, so
+  the transport helpers became their own module rather than an `#[allow]`.
+
+## Verification
+
+`just check-gated`, `cargo nextest run --workspace` (12853 passed),
+`cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -D
+warnings`, `cargo fmt --all --check`, and `cargo run -p xtask -- check-all`
+(63/63) are all clean.
+
+**Not yet verified live.** No CI lane boots a builder — every guest-booting lane
+skips on hosted runners — so this needs a real `mvmctl build` on macOS 26+ Apple
+Silicon against a **rebuilt** builder image. `mvm-host-vm-init` is
+cross-compiled and baked into the rootfs; a stale baked guest against this host
+hangs the dispatch loop with no useful error. Do not merge without it.

--- a/specs/sprint/delivery/virtio-fs-stage-c-persistent-hvf-builder.md
+++ b/specs/sprint/delivery/virtio-fs-stage-c-persistent-hvf-builder.md
@@ -92,15 +92,38 @@ guest and warns about it).
 - The session record carries the transport, and `stop` tears the session down
   cleanly.
 
-**Not proven: a completed build, and therefore `read_dispatch_artifacts`
-against a real output disk** (it is unit-tested only). The blocker is not the
-transport — it is that the host-side `mvm-network-endpoint` this session spawns
-dies with the command that spawned it, so the guest's egress client loses its
-only route to the network mid-build (`FlowMux reconnect exhausted`). The
-one-shot builder never hits this because its endpoint's lifetime *is* the VM's
-lifetime; a persistent session inverts that. Fixing it means spawning the
-endpoint detached and reaping it on `stop`, which is lifecycle design in a
-claim-10 component and is deliberately not in this change.
+- **The guest's egress works for a whole build.** The supervisor-owned endpoint
+  stays up with the supervisor as its parent, serves Nix's fetches, and
+  self-reaps when the supervisor exits.
+
+**Still not proven: a completed build, and therefore `read_dispatch_artifacts`
+against a real output disk** (unit-tested only). The remaining blocker is the
+vsock bridge's 60-second idle eviction, not the transport — see the plan. The
+host loses its dispatch connection during a quiet `nix build` while the build
+itself proceeds normally inside the guest.
+
+## The endpoint lifetime fix
+
+Worth writing down because the obvious diagnosis was wrong twice. The endpoint
+was not leaking and was not missing a detach — `spawn_network_endpoint` already
+calls `setsid`. It self-reaps: `exit_when_orphaned`, armed in its own `main`,
+watches the parent and exits with status 0 the instant it is reparented, which
+is why its log simply stopped after a successful handshake.
+
+That guard is deliberate — the endpoint holds a workload's secrets in the clear
+and must not serve as an orphan. A persistent session is simply the first case
+where the VM outlives its spawner, so parent-death stopped being a good proxy
+for VM-death. The fix keeps the guard and gives it a better parent: the
+supervisor, whose death *is* the VM's.
+
+No key crosses the new wire. The endpoint's config carries the host signer by
+value and `supervisor.json` is persisted beside the VM, so the supervisor mints
+the FlowMux identity itself from the same `~/.mvm/keys/host-signer.ed25519` the
+config already names by path, and writes the identity drive before it opens
+disks. The egress policy and the empty secret set are fixed at that call site
+rather than taken from the wire, so nothing crossing it can widen what the
+endpoint serves — and a restored child never inherits the request, since it
+names the parent's VM, socket and identity drive.
 
 ## Pre-existing gaps this uncovered
 

--- a/xtask/src/check_build_egress_callers.rs
+++ b/xtask/src/check_build_egress_callers.rs
@@ -43,12 +43,14 @@ const ALLOWED_CALLERS: &[&str] = &[
     "crates/mvm-runtime/src/builder_runner/runner.rs",
     // The libkrun builder's supervisor config.
     "crates/mvm-build/src/libkrun_builder.rs",
-    // The persistent HVF builder's endpoint, which is the same trusted builder
-    // tier as `runner.rs` above and differs only in lifetime: the session
-    // outlives the command that starts it, so it spawns its own endpoint
-    // rather than inheriting the one-shot runner's. It carries no untrusted
-    // workload — a workload microVM never boots from this policy.
-    "crates/mvm-runtime/src/builder_runner/hvf_persistent.rs",
+    // The persistent HVF builder's endpoint. Same trusted builder tier as
+    // `runner.rs` above, and it lives in the *supervisor* rather than a
+    // launcher because a session outlives the command that starts it: the
+    // endpoint self-reaps when orphaned, so only the per-VM supervisor has a
+    // lifetime that matches the VM's. The policy is applied at that call site
+    // and is not taken from the supervisor's wire config, so nothing crossing
+    // that boundary can widen it. No workload microVM boots from this policy.
+    "crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs",
 ];
 
 /// The file that defines the constructor, plus its own tests. Not a "caller"

--- a/xtask/src/check_build_egress_callers.rs
+++ b/xtask/src/check_build_egress_callers.rs
@@ -43,6 +43,12 @@ const ALLOWED_CALLERS: &[&str] = &[
     "crates/mvm-runtime/src/builder_runner/runner.rs",
     // The libkrun builder's supervisor config.
     "crates/mvm-build/src/libkrun_builder.rs",
+    // The persistent HVF builder's endpoint, which is the same trusted builder
+    // tier as `runner.rs` above and differs only in lifetime: the session
+    // outlives the command that starts it, so it spawns its own endpoint
+    // rather than inheriting the one-shot runner's. It carries no untrusted
+    // workload — a workload microVM never boots from this policy.
+    "crates/mvm-runtime/src/builder_runner/hvf_persistent.rs",
 ];
 
 /// The file that defines the constructor, plus its own tests. Not a "caller"

--- a/xtask/src/check_no_virtio_fs.rs
+++ b/xtask/src/check_no_virtio_fs.rs
@@ -7,11 +7,13 @@
 //! mechanism by which a guest addresses host filesystem *structure* rather than
 //! opaque blocks. A block device is a byte array with no protocol to attack.
 //!
-//! No workload tier reaches it any more. What is left is builder-VM plumbing
-//! and the libkrun C FFI, each pinned below with the reason it survives and
-//! what would retire it. This check does not assert the surface is gone — it asserts
-//! nothing has been *added* to it, and that entries disappear from the table as
-//! the code disappears.
+//! No workload tier reaches it any more, and no builder *spec* constructs a
+//! share: both the one-shot and the persistent builder exchange jobs and
+//! artifacts over raw transport disks. What is left is the backend plumbing
+//! that would map a share if one existed, and the libkrun C FFI, each pinned
+//! below with the reason it survives and what would retire it. This check does
+//! not assert the surface is gone — it asserts nothing has been *added* to it,
+//! and that entries disappear from the table as the code disappears.
 //!
 //! The check counts only sites that **attach a device or construct a share**.
 //! Prose mentioning virtio-fs is not counted: ~70 files discuss it, and a gate
@@ -70,14 +72,6 @@ const PINNED: &[(&str, usize, &str)] = &[
          QEMU *workload* driver below; the QEMU builder no longer uses it. \
          Retired with that driver's share arm, which is already unreachable",
     ),
-    // ── builder VM: the trusted tier, still exchanging files as shares ───────
-    (
-        "crates/mvm-runtime/src/builder_runner/spec.rs",
-        1,
-        "the HVF *persistent* builder's work/mvm-bins/job/out shares. Retired by \
-         moving the per-dispatch exchange onto the BuilderDispatch vsock channel \
-         that already exists; the one-shot builder already uses the disk transport",
-    ),
     // ── the seam every backend maps its shares through ───────────────────────
     (
         "crates/mvm-vmm/src/driver/spec.rs",
@@ -87,12 +81,15 @@ const PINNED: &[(&str, usize, &str)] = &[
     (
         "crates/mvm-vmm/src/host/hvf_supervisor.rs",
         1,
-        "HvfVirtioFsShare on the supervisor wire config, builder VMs only",
+        "HvfVirtioFsShare on the supervisor wire config. No spec constructs a \
+         share any more, so nothing populates this field; it goes when the \
+         HVF device model does",
     ),
     (
         "crates/mvm-backends/src/driver/hvf.rs",
         1,
-        "maps spec shares onto the HVF supervisor config",
+        "maps spec shares onto the HVF supervisor config. Every HVF spec now \
+         carries an empty share list, so this maps nothing",
     ),
     (
         "crates/mvm-backends/src/driver/libkrun.rs",
@@ -130,13 +127,14 @@ const PINNED: &[(&str, usize, &str)] = &[
     (
         "crates/mvm-vmm/src/vmm/virtio.rs",
         1,
-        "the VirtioFs MMIO device. Reachable only from a builder VM now that the \
-         dev-tier virtio-fs root is gone",
+        "the VirtioFs MMIO device. No longer reachable: the builder VMs that were \
+         its last callers moved to the disk transport",
     ),
     (
         "crates/mvm-runtime/src/backends/hvf/kernel_boot.rs",
         1,
-        "attaches the builder's shares to the HVF device model",
+        "attaches spec shares to the HVF device model. The builder no longer \
+         declares any, so this attaches nothing",
     ),
 ];
 


### PR DESCRIPTION
Finishes Stage C of `specs/plans/2026-08-31-remove-virtio-fs.md` for the persistent HVF builder. Stacked on #3056 (the gate + the guest half); rebases onto main once that lands.

## What changes

The persistent HVF builder exchanges jobs and artifacts over two raw block devices instead of four virtio-fs shares. `persistent_builder_spec` declares no shares, so `check-no-virtio-fs` **drops `builder_runner/spec.rs` from its pinned table entirely** — the signal the plan names for Stage C working. The gate now ratchets 22 sites across 10 files, none of them a builder spec.

The two builder cmdlines collapse into one: a persistent builder now boots the same contract as a one-shot, `vda`–`vdd` in the same order, so a second copy of the same string is gone rather than maintained.

Per-dispatch lifetime lives in a new `persistent_builder_transport` module. Both dispatch clients use it — `PersistentBuilderVm::run_build` (what `mvmctl build` routes through) and the `persistent-builder submit` verb.

## Three things the plan did not anticipate

**Readiness could not become connect-polling.** The backend binds the host UDS during VM setup, *before* the guest boots, so `connect` succeeds against a guest whose vsock driver is not up. The bridge only closes that connection when the guest kernel answers `OP_RST`, so early in boot a probe neither connects-and-fails nor gets refused — it hangs open and reads as ready, which is the same silent hang the move was meant to remove. It is a round trip instead: `submit_workload_status` for the nil UUID. Any well-formed reply proves the loop is accepting and framing. Existing request, no side effect, no protocol change.

**A fifth coordinated change, and the one that would have shipped broken.** The guest tars `/out` — and only `/out` — onto the output disk, but both host stagers rendered a `cmd.sh` writing to `/job/<job_id>/out`, which under the disk transport is the guest's own input stage, never read back. The four planned changes alone would have produced a build that reported success and emitted nothing.

**The install arm has the same shape and no host-side fix.** It hardcodes `/job/<job_id>/out`. Rather than lose a claim-11 sealed volume's SBOM and CVE sidecars silently, an install dispatch on a disk-backed session is refused with a message naming the missing half.

## Live validation — macOS 26.5.2, Apple Silicon

Proven end to end against a rebuilt builder image: the input disk attaches as `vdc` and the output as `vdd`; the guest binds `/job`, `/work` and `/mvm-bins` off the input disk (Nix evaluated a flake at `path:/work`, only possible if the workspace crossed on that disk); the new readiness path returns with no `dispatch.ready` file anywhere the host can see; and **two dispatches into one live session** each rewrote the input disk, re-staged `/job/<job_id>` off it, and streamed stderr back.

**Not proven: a completed build**, and therefore `read_dispatch_artifacts` against a real output disk (unit-tested only). The blocker is not the transport — the session's `mvm-network-endpoint` dies with the command that spawned it, so the guest loses egress mid-build. The one-shot builder never hits this because its endpoint's lifetime *is* the VM's. Tracked in the plan; it is claim-10 lifecycle design and wants its own change.

## Pre-existing gaps this uncovered

The persistent HVF builder had never booted. Reaching Stage C at all required fixing three things unrelated to virtio-fs, each by calling the helper the one-shot builder already calls: no runtime overlay was resolved, no FlowMux identity drive was minted, and no network endpoint was spawned. A fourth was this branch's own: the input pack must use `stage_filtered_work_input`, or 45 GB of `target/` lands on the input disk and fills the store image mid-extraction.

`trusted_build_egress` gains one allow-listed caller — the same trusted builder tier as the one-shot runner, differing only in lifetime. No workload microVM boots from this policy.

## Verification

`just check-gated`, `cargo nextest run --workspace` (12854 passed), `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all -- --check`, and `cargo run -p xtask -- check-all` (63/63) all clean.