### PR TITLE
fix(build): bootstrap SDK sidecars from unembedded CLI

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -2489,6 +2489,34 @@ fn auto_bootstrap_builder_vm_image(arch_dir: &Path) -> Result<bool, BuilderVmErr
 }
 
 pub fn maybe_reexec_builder_vm_bootstrap_helper() -> Result<bool, BuilderVmError> {
+    maybe_reexec_builder_vm_helper(BuilderVmHelperCommand::Bootstrap)
+}
+
+pub fn maybe_reexec_builder_vm_sdk_sidecar_helper(force: bool) -> Result<bool, BuilderVmError> {
+    maybe_reexec_builder_vm_helper(BuilderVmHelperCommand::SdkSidecarBuild { force })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BuilderVmHelperCommand {
+    Bootstrap,
+    SdkSidecarBuild { force: bool },
+}
+
+impl BuilderVmHelperCommand {
+    fn args(self) -> Vec<&'static str> {
+        match self {
+            Self::Bootstrap => vec!["__builder-vm-bootstrap"],
+            Self::SdkSidecarBuild { force: false } => {
+                vec!["build", "sdk-sidecar", "build"]
+            }
+            Self::SdkSidecarBuild { force: true } => {
+                vec!["build", "sdk-sidecar", "build", "--force"]
+            }
+        }
+    }
+}
+
+fn maybe_reexec_builder_vm_helper(command: BuilderVmHelperCommand) -> Result<bool, BuilderVmError> {
     let Some(workspace_root) = builder_vm_source_checkout_root() else {
         return Ok(false);
     };
@@ -2499,8 +2527,7 @@ pub fn maybe_reexec_builder_vm_bootstrap_helper() -> Result<bool, BuilderVmError
     }
 
     let mut cmd = Command::new(&bootstrap_bin);
-    cmd.current_dir(&workspace_root)
-        .arg("__builder-vm-bootstrap");
+    cmd.current_dir(&workspace_root).args(command.args());
     #[cfg(target_os = "linux")]
     if std::env::var_os(crate::builder_backend_select::MVM_BUILDER_BACKEND_ENV).is_none() {
         cmd.env(
@@ -2510,13 +2537,13 @@ pub fn maybe_reexec_builder_vm_bootstrap_helper() -> Result<bool, BuilderVmError
     }
     let status = cmd.status().map_err(|e| {
         BuilderVmError::ExtractionFailed(format!(
-            "spawn explicit builder VM bootstrap helper {}: {e}",
+            "spawn embedded builder VM helper {}: {e}",
             bootstrap_bin.display()
         ))
     })?;
     if !status.success() {
         return Err(BuilderVmError::ExtractionFailed(format!(
-            "explicit builder VM bootstrap helper {} exited with {}",
+            "embedded builder VM helper {} exited with {}",
             bootstrap_bin.display(),
             status.code().unwrap_or(-1),
         )));
@@ -2590,7 +2617,14 @@ fn builder_vm_bootstrap_helper_build_command(
     let mut cmd = Command::new(cargo);
     cmd.current_dir(workspace_root)
         .env("CARGO_TARGET_DIR", helper_target_dir)
-        .args(["build", "-q", "--bin", "mvmctl"]);
+        .args([
+            "build",
+            "-q",
+            "--bin",
+            "mvmctl",
+            "--features",
+            "embed-host-bins",
+        ]);
     cmd
 }
 
@@ -6325,7 +6359,17 @@ mod tests {
             .get_args()
             .map(|arg| arg.to_string_lossy().into_owned())
             .collect::<Vec<_>>();
-        assert_eq!(args, vec!["build", "-q", "--bin", "mvmctl"]);
+        assert_eq!(
+            args,
+            vec![
+                "build",
+                "-q",
+                "--bin",
+                "mvmctl",
+                "--features",
+                "embed-host-bins"
+            ]
+        );
 
         let envs = cmd
             .get_envs()
@@ -6339,6 +6383,22 @@ mod tests {
         assert_eq!(
             envs.get("CARGO_TARGET_DIR"),
             Some(&Some("/tmp/helper-target".to_string()))
+        );
+    }
+
+    #[test]
+    fn builder_vm_helper_commands_are_closed_and_preserve_force() {
+        assert_eq!(
+            BuilderVmHelperCommand::Bootstrap.args(),
+            ["__builder-vm-bootstrap"]
+        );
+        assert_eq!(
+            BuilderVmHelperCommand::SdkSidecarBuild { force: false }.args(),
+            ["build", "sdk-sidecar", "build"]
+        );
+        assert_eq!(
+            BuilderVmHelperCommand::SdkSidecarBuild { force: true }.args(),
+            ["build", "sdk-sidecar", "build", "--force"]
         );
     }
 

--- a/crates/mvm-cli/src/commands/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/bootstrap.rs
@@ -37,10 +37,6 @@ pub(in crate::commands) fn run_builder_vm_bootstrap(
     _args: BuilderVmBootstrapArgs,
     _cfg: &MvmConfig,
 ) -> Result<()> {
-    #[cfg(feature = "builder-vm")]
-    if mvm_build::libkrun_builder::maybe_reexec_builder_vm_bootstrap_helper()? {
-        return Ok(());
-    }
     super::env::builder_vm::bootstrap_builder_vm_image()
 }
 

--- a/crates/mvm-cli/src/commands/build/sdk_sidecar.rs
+++ b/crates/mvm-cli/src/commands/build/sdk_sidecar.rs
@@ -46,6 +46,12 @@ fn run_build(args: BuildArgs) -> Result<()> {
             "SDK sidecar source build requires a source checkout with nix/images/runtime-overlay/flake.nix"
         )
     })?;
+
+    #[cfg(feature = "builder-vm")]
+    if mvm_build::libkrun_builder::maybe_reexec_builder_vm_sdk_sidecar_helper(args.force)? {
+        return Ok(());
+    }
+
     let cache_root = std::path::PathBuf::from(mvm_core::config::mvm_cache_dir());
     let version = env!("CARGO_PKG_VERSION");
     let arch = GuestArch::host();

--- a/crates/mvm-cli/src/commands/env/builder_vm/bootstrap.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/bootstrap.rs
@@ -154,6 +154,31 @@ pub(super) fn stage0_locked_input_sources(
 }
 
 pub(in crate::commands) fn bootstrap_builder_vm_image() -> Result<()> {
+    #[cfg(feature = "builder-vm")]
+    return bootstrap_builder_vm_image_with(
+        || {
+            mvm_build::libkrun_builder::maybe_reexec_builder_vm_bootstrap_helper()
+                .map_err(anyhow::Error::from)
+        },
+        bootstrap_builder_vm_image_in_process,
+    );
+
+    #[cfg(not(feature = "builder-vm"))]
+    bootstrap_builder_vm_image_in_process()
+}
+
+#[cfg(feature = "builder-vm")]
+fn bootstrap_builder_vm_image_with(
+    maybe_reexec: impl FnOnce() -> Result<bool>,
+    bootstrap_in_process: impl FnOnce() -> Result<()>,
+) -> Result<()> {
+    if maybe_reexec()? {
+        return Ok(());
+    }
+    bootstrap_in_process()
+}
+
+fn bootstrap_builder_vm_image_in_process() -> Result<()> {
     let arch = builder_vm_host_arch();
     let out_dir = format!("{}/builder-vm/{arch}", mvm_core::config::mvm_cache_dir());
     let out_dir_path = std::path::Path::new(&out_dir);
@@ -229,6 +254,61 @@ pub(in crate::commands) fn bootstrap_builder_vm_image() -> Result<()> {
         BuilderVmBootstrapAction::DownloadPublished => {
             perform_builder_vm_download_published(arch, &out_dir)
         }
+    }
+}
+
+#[cfg(all(test, feature = "builder-vm"))]
+mod bootstrap_helper_routing_tests {
+    use super::bootstrap_builder_vm_image_with;
+    use std::cell::Cell;
+
+    #[test]
+    fn completed_source_helper_skips_in_process_bootstrap() {
+        let called = Cell::new(false);
+
+        bootstrap_builder_vm_image_with(
+            || Ok(true),
+            || {
+                called.set(true);
+                Ok(())
+            },
+        )
+        .expect("completed helper should satisfy bootstrap");
+
+        assert!(!called.get(), "bootstrap must not run twice");
+    }
+
+    #[test]
+    fn matching_source_helper_bootstraps_in_process() {
+        let called = Cell::new(false);
+
+        bootstrap_builder_vm_image_with(
+            || Ok(false),
+            || {
+                called.set(true);
+                Ok(())
+            },
+        )
+        .expect("matching helper should bootstrap in process");
+
+        assert!(called.get(), "matching helper must perform bootstrap");
+    }
+
+    #[test]
+    fn helper_resolution_error_prevents_bootstrap() {
+        let called = Cell::new(false);
+
+        let error = bootstrap_builder_vm_image_with(
+            || anyhow::bail!("helper build failed"),
+            || {
+                called.set(true);
+                Ok(())
+            },
+        )
+        .expect_err("helper errors must fail closed");
+
+        assert!(error.to_string().contains("helper build failed"));
+        assert!(!called.get(), "bootstrap must not bypass a helper error");
     }
 }
 

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -33,6 +33,7 @@ REPO="$PWD"
 E2E_HOME="${MVM_E2E_HOME:-${MVM_HOME:-$HOME/.mvm}}"
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"
+UNEMBEDDED_MVMCTL="$E2E_HOME/mvmctl-unembedded-e2e"
 
 echo "==> e2e documented surface"
 echo "    repo: $REPO"
@@ -232,15 +233,22 @@ just embed-refresh
 # standard compiler/linker path: the nightly fast-codegen wrapper leaves the
 # native aws-lc symbols unresolved. The featureless local path can retain the
 # faster wrapper because it does not link that stack.
-# `embed-host-bins` is appended to both arms rather than left to the caller:
-# this suite boots builder VMs, and without the embedded payload every one of
-# them fails at bootstrap. A caller-supplied MVM_E2E_FEATURES is about which
-# acquisition channel to exercise, not about whether the guest binaries ship.
+# Preserve a feature-off binary first. Its SDK-sidecar warm is the regression
+# for the contributor path: that command must re-exec the isolated embedded
+# helper for the complete HVF/Nix build, not resume in this payload-free parent.
+# The main suite binary is then rebuilt with the payload because later workload
+# launches consume the extracted host helpers directly.
 E2E_FEATURES="${MVM_E2E_FEATURES-}"
 if [[ -n "$E2E_FEATURES" ]]; then
+  echo "==> building unembedded mvmctl (--features $E2E_FEATURES)"
+  cargo build --bin mvmctl --features "$E2E_FEATURES"
+  cp "$MVMCTL" "$UNEMBEDDED_MVMCTL"
   echo "==> building mvmctl (--features $E2E_FEATURES,embed-host-bins)"
   cargo build --bin mvmctl --features "$E2E_FEATURES,embed-host-bins"
 else
+  echo "==> building unembedded mvmctl"
+  ./scripts/cargo-fast.sh build --bin mvmctl
+  cp "$MVMCTL" "$UNEMBEDDED_MVMCTL"
   echo "==> building mvmctl"
   ./scripts/cargo-fast.sh build --bin mvmctl --features embed-host-bins
 fi
@@ -335,6 +343,13 @@ echo "    boot image: $MVM_BOOT_IMAGE"
 # would throw away every result that does not depend on it. The scenarios that do
 # need it then fail on their own, naming themselves.
 echo "==> warming artifacts in $E2E_HOME"
+
+# This is deliberately before the explicit bootstrap. A cold cache proves the
+# unembedded public command can hand the entire source build to its embedded
+# helper, including Stage 0, HVF image baking, and both Nix sidecar variants.
+echo "==> warming source-matched SDK sidecar through unembedded mvmctl"
+MVM_HOME="$E2E_HOME" "$UNEMBEDDED_MVMCTL" build sdk-sidecar build
+
 if ! MVM_HOME="$E2E_HOME" "$MVMCTL" bootstrap; then
   echo
   echo "!!! bootstrap FAILED — the builder VM image is unavailable."
@@ -343,14 +358,6 @@ if ! MVM_HOME="$E2E_HOME" "$MVMCTL" bootstrap; then
   echo
   BOOTSTRAP_FAILED=1
 fi
-
-# SDK host-service scenarios must attach the sidecar built from this checkout.
-# A published sidecar can be version-compatible while still missing the source
-# changes under test, so warming only the general launch artifacts is not
-# enough. Build it once up front and fail here with the explicit prerequisite
-# rather than letting every dependent scenario refuse independently.
-echo "==> warming source-matched SDK sidecar"
-MVM_HOME="$E2E_HOME" "$MVMCTL" build sdk-sidecar build
 
 # ---------------------------------------------------------------------------
 # Warm the launch artifacts, even when bootstrap did not get that far.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -172,8 +172,13 @@ Last updated: 2026-09-01
       `specs/plans/2026-08-27-sdk-sidecar-source-build.md`.
       Source checkouts can explicitly build the guest-facing glibc sidecar
       through the shared Stage 0 artifact runner and atomically bind it to the
-      checkout fingerprint. The full local gates and a live aarch64 Stage 0/Nix
-      artifact build are green; merge delivery remains.
+      checkout fingerprint. An unembedded SDK-sidecar command now re-executes
+      its complete build in the isolated source helper carrying the opt-in
+      embedded Linux payload, and the documented-surface E2E suite exercises
+      that cold-cache handoff. A live aarch64 cold run completed Stage 0/Nix
+      and cached both libc variants through the HVF builder. Focused regressions
+      plus workspace check/tests, formatting, and zero-warning Clippy are green;
+      merge delivery remains.
 
 - [ ] **Issue #2942 — warm-launch gate contract repair.**
       `specs/plans/2026-08-27-warm-launch-gate-contract.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -141,10 +141,15 @@
       `specs/plans/2026-08-27-sdk-sidecar-source-build.md`.
       An explicit builder-VM command now realizes the existing glibc sidecar
       derivation through Stage 0, verifies its artifact contract, and promotes
-      the source fingerprint atomically with the image. Focused and workspace
-      tests, workspace check, gated Linux/BDD compilation, zero-warning Clippy,
-      all policy gates, and a live aarch64 Stage 0/Nix build are green; merge
-      delivery remains.
+      the source fingerprint atomically with the image. The source-checkout
+      SDK-sidecar command now re-executes in a source-checkout helper built with
+      its required embedded Linux host binaries, so a normal unembedded
+      developer `mvmctl` can cold-bootstrap and complete the SDK build. The
+      documented-surface E2E suite preserves that cold-cache path. A live
+      aarch64 cold run completed Stage 0/Nix and cached both glibc and musl
+      sidecars through the HVF builder. Focused regressions, workspace check and
+      tests, formatting, and zero-warning Clippy are green; merge delivery
+      remains.
 
 - [x] **FlowMux HTTPS live-client repair.**
       `specs/plans/2026-08-27-flowmux-https-live-client.md`.

--- a/specs/plans/2026-08-27-sdk-sidecar-source-build.md
+++ b/specs/plans/2026-08-27-sdk-sidecar-source-build.md
@@ -42,4 +42,10 @@ inside Stage 0 through the project builder VM.
 - [x] Prove the Linux Stage 0 tests and Nix evaluation inside the builder VM.
 - [x] Run workspace tests/checks, gated-target checks, zero-warning Clippy, and
       repository policy gates.
+- [x] Repair the opt-in embedded-host-binary regression: an unembedded
+      SDK-sidecar command re-executes in the isolated source-checkout helper,
+      which is built with `embed-host-bins` before it performs Stage 0 and the
+      complete SDK build. Keep this cold-cache handoff in the documented-surface
+      E2E suite. A live aarch64 cold run completed Stage 0/Nix and cached both
+      glibc and musl sidecars through the HVF builder.
 - [ ] Merge the PR and close issue #2941 through the merged PR link.

--- a/tests/github_actions_extended_e2e.rs
+++ b/tests/github_actions_extended_e2e.rs
@@ -278,6 +278,28 @@ fn signature_verifying_build_avoids_the_fast_codegen_link_path() {
 }
 
 #[test]
+fn documented_surface_cold_builds_the_sidecar_through_an_unembedded_cli() {
+    let script = documented_surface_script();
+
+    let unembedded_build = script
+        .find("cargo build --bin mvmctl --features \"$E2E_FEATURES\"")
+        .expect("the release-feature lane must build an unembedded witness");
+    let embedded_build = script
+        .find("cargo build --bin mvmctl --features \"$E2E_FEATURES,embed-host-bins\"")
+        .expect("the live suite must restore its embedded binary");
+    let sidecar_warm = script
+        .find("\"$UNEMBEDDED_MVMCTL\" build sdk-sidecar build")
+        .expect("the sidecar warm must execute the unembedded witness");
+    let explicit_bootstrap = script
+        .find("\"$MVMCTL\" bootstrap")
+        .expect("the suite must retain the explicit bootstrap check");
+
+    assert!(unembedded_build < embedded_build);
+    assert!(embedded_build < sidecar_warm);
+    assert!(sidecar_warm < explicit_bootstrap);
+}
+
+#[test]
 fn documented_surface_jobs_install_the_sdk_codegen_runtime() {
     let workflow = extended_ci();
 
@@ -299,7 +321,7 @@ fn documented_surface_warms_the_source_matched_sdk_sidecar() {
     let script = documented_surface_script();
 
     assert!(
-        script.contains("\"$MVMCTL\" build sdk-sidecar build"),
+        script.contains("\"$UNEMBEDDED_MVMCTL\" build sdk-sidecar build"),
         "the live SDK scenarios must use a sidecar built from the checkout under test"
     );
 }


### PR DESCRIPTION
## Summary

- re-execute the complete SDK-sidecar source build in an isolated helper compiled with `embed-host-bins`
- preserve `--force` across the helper handoff and avoid recursive re-execution
- cover an unembedded developer binary with a cold cache in the documented-surface E2E suite

## Regression

The failure required three changes to line up: #2993 made embedded host binaries opt-in for developer builds, #2997 routed SDK-sidecar builds through the steady-state HVF builder, and #3044 changed the cache layout to include libc. The last change invalidated existing warm entries and exposed the cold-bootstrap assumption.

The previous E2E path used an embedded binary and explicitly bootstrapped before building the sidecar, so it did not cover the failing state combination.

## Validation

- live aarch64 cold-cache run from an unembedded `mvmctl`
- Stage 0/Nix source builder image completed
- steady-state HVF builder cached both glibc and musl SDK sidecars
- `cargo check --workspace`
- `cargo test -p mvm-build --features builder-vm --lib --tests`
- `cargo test -p mvm-build --features builder-vm --doc`
- `cargo test -p mvmctl --test github_actions_extended_e2e`
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all --check`
- repository sprint and source-comment policy gates