### PR TITLE
fix(build): stop a plain cargo build from un-embedding mvmctl

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,19 +43,30 @@ binaries (`mvm-host-vm-init`, `mvm-egress-proxy`) as static
 See Plan 115 / ADR-004.
 
 That cross-compile is **opt-in**, behind the `embed-host-bins` feature, and is
-the only work `build.rs` still does. A plain `cargo build` skips it: the build
-script then watches four files and writes an empty table, so cargo runs it once
-per fingerprint and never again on the inner loop. Build with the payload when
-you are about to boot a VM:
+the only work `build.rs` still does. Run it when you are about to boot a VM:
 
 ```sh
 just embed          # cargo build --features embed-host-bins
 ```
 
-Without it `mvmctl` runs every host-side verb but cannot bootstrap a builder
-VM — `host_binaries::extract` refuses and names this recipe rather than
+A plain `cargo build` never cross-compiles, but it does **restore** the payload
+from the content store at `~/.cache/mvm/embed` when the store holds bytes keyed
+to this tree — the same key (dependency closure + `Cargo.lock` + pinned
+toolchain) the embedding arm trusts when it skips a rebuild. That matters
+because both variants write the same `target/<profile>/mvmctl`: the last cargo
+invocation owns the file, and a cached zero-compile build is enough to swap it.
+Restoring means one `just embed` sticks. On a miss (fresh clone, an edit to the
+payload's own sources, `MVM_EMBED_NO_CACHE=1`) the arm writes the empty table as
+before — it compiles nothing, so a payload it cannot prove is one it does not
+ship.
+
+Bare `just embed` builds the **debug** profile; use `just embed --release` for a
+release binary, or the release one is left untouched. Without a payload `mvmctl`
+runs every host-side verb but cannot bootstrap a builder VM —
+`host_binaries::extract` refuses with the profile-correct rebuild rather than
 extracting an empty directory. The tag-push release workflow always turns the
-feature on, so a downloaded binary is self-sufficient.
+feature on, so a downloaded binary is self-sufficient; `just release-build`
+carries it too.
 
 Provision it with one command — it installs the exact pinned zig (from the
 `ziglang` PyPI package, read out of `[workspace.metadata.mvm.toolchain]`) plus

--- a/Justfile
+++ b/Justfile
@@ -399,6 +399,8 @@ build-supervisors:
 # `target/<profile>/mvmctl` under different feature sets, so alternating the two
 
 # relinks mvmctl; that is why this is a deliberate step and not part of `build`.
+# Bare, this writes `target/debug/mvmctl` — pass `--release` if the mvmctl you
+# invoke is the release one, or the release binary is left untouched.
 embed *ARGS:
     ./scripts/cargo-fast.sh build --features embed-host-bins {{ARGS}}
 
@@ -620,13 +622,17 @@ release-tag VERSION:
     git push origin "v$V"
     echo "==> Pushed tag v$V — the release pipeline will build + publish."
 
-# Build optimized release binary
+# Build optimized release binary. `embed-host-bins` matches the release
+# workflow's `MVMCTL_RELEASE_FEATURES`; without it this produces the one build
+# that looks finished and cannot bootstrap a builder VM. `release-channel` is
+# deliberately absent — it would resolve artifacts from the published channel
+# rather than this checkout.
 release-build:
-    cargo build --release --features host,user,template-registry-s3,release-artifact-bootstrap
+    cargo build --release --features host,user,template-registry-s3,release-artifact-bootstrap,embed-host-bins
 
 # Cross-compile release binary for a target
 release-build-target TARGET:
-    cargo build --release --target {{ TARGET }} --features host,user,template-registry-s3,release-artifact-bootstrap
+    cargo build --release --target {{ TARGET }} --features host,user,template-registry-s3,release-artifact-bootstrap,embed-host-bins
 
 # Dry-run crates.io publish (all crates in dependency order)
 publish-dry-run:

--- a/crates/mvm-cli/build.rs
+++ b/crates/mvm-cli/build.rs
@@ -149,11 +149,11 @@ fn main() {
 
     emit_pinned_toolchain_env(&workspace_root);
 
-    // The cross-compile is opt-in. Off, this script watches four files and does
-    // nothing else, so cargo runs it once per fingerprint and never again on
-    // the inner loop — the point of the feature. On, it produces the real set.
+    // The cross-compile is opt-in. Off, this script never compiles anything —
+    // it only restores a payload the content store can already prove belongs to
+    // this tree. On, it produces the real set.
     if !embedding_requested() {
-        write_unembedded_table(&out_dir);
+        write_unembedded_table(&workspace_root, &out_dir);
         return;
     }
     embed_host_binaries(&workspace_root, &out_dir);
@@ -182,20 +182,127 @@ fn emit_pinned_toolchain_env(workspace_root: &Path) {
     println!("cargo:rustc-env=MVM_PINNED_TARGET={}", pin.target);
 }
 
-/// The unembedded arm: an empty `EMBEDDED` table plus the minimum watch set.
+/// The unembedded arm. It never cross-compiles — but it does reuse a payload
+/// the content store can prove belongs to this source tree.
 ///
-/// At least one `rerun-if-*` line is mandatory here. Emitting none does not
-/// mean "never re-run" — it restores cargo's default, which re-runs the script
-/// on *any* change to the package, i.e. every edit to `mvm-cli`'s 251 files.
-/// That is the opposite of what this arm is for. The four inputs below are the
-/// only ones that can change what it writes.
-fn write_unembedded_table(out_dir: &Path) {
-    std::fs::write(out_dir.join("embedded.rs"), render_embedded_rs(&[])).unwrap();
-    println!("cargo:rustc-env=MVM_EMBEDDED_BINS_REUSED=0");
+/// Both feature variants write the same `target/<profile>/mvmctl`, so whichever
+/// cargo invocation ran last decides whether the binary on `PATH` carries the
+/// payload. A cached, zero-compile `cargo build` is enough to take it away,
+/// which is why an unembedded `mvmctl` kept coming back after a `just embed`
+/// that had genuinely worked. Restoring here closes that: the key covers each
+/// binary's dependency closure, `Cargo.lock` and the pinned toolchain, so a hit
+/// is exactly the bytes this tree produces — the same proof the embedding arm
+/// relies on when it skips a rebuild.
+///
+/// A miss, an unreachable store, or `MVM_EMBED_NO_CACHE=1` writes the empty
+/// table as before. This arm compiles nothing, so a payload it cannot prove is
+/// one it does not ship.
+///
+/// At least one `rerun-if-*` line is mandatory. Emitting none does not mean
+/// "never re-run" — it restores cargo's default, which re-runs the script on
+/// *any* change to the package, i.e. every edit to `mvm-cli`'s 251 files.
+fn write_unembedded_table(workspace_root: &Path, out_dir: &Path) {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=build_support.rs");
     println!("cargo:rerun-if-changed=build_embed_cache.rs");
     println!("cargo:rerun-if-changed=src/host_binaries/manifest.rs");
+    println!("cargo:rerun-if-env-changed=MVM_EMBED_NO_CACHE");
+    println!("cargo:rerun-if-env-changed=MVM_EMBED_CACHE_DIR");
+
+    let entries = restore_embedded_from_store(workspace_root, out_dir);
+    std::fs::write(out_dir.join("embedded.rs"), render_embedded_rs(&entries)).unwrap();
+    println!(
+        "cargo:rustc-env=MVM_EMBEDDED_BINS_REUSED={}",
+        if entries.is_empty() { "0" } else { "1" }
+    );
+}
+
+/// Restore the whole embedded set from the content store, or nothing.
+///
+/// All-or-nothing on purpose: extraction verifies the table as a unit, and a
+/// builder VM missing one binary fails later and somewhere else, which reads as
+/// a corrupted cache rather than as a partial restore.
+fn restore_embedded_from_store(
+    workspace_root: &Path,
+    out_dir: &Path,
+) -> Vec<(String, PathBuf, String)> {
+    let mut cache = EmbedCache::discover(workspace_root);
+    let Some(store_root) = cache.root.clone() else {
+        return Vec::new();
+    };
+    // Watch the store itself, not just the sources. Publishing from a
+    // `just embed` changes no file this unit already watches, so without this
+    // the restore below would never re-run and the next plain build would keep
+    // shipping the empty table it cached — the exact swap this arm exists to
+    // stop. Created when absent so the watch is a stable directory rather than
+    // a missing path, which cargo treats as permanently dirty.
+    let _ = std::fs::create_dir_all(&store_root);
+    println!("cargo:rerun-if-changed={}", store_root.display());
+
+    let pin = read_pinned_toolchain(workspace_root);
+    let bins_out = out_dir.join("mvm-host-bins");
+    let mut entries = Vec::new();
+    for binary in read_embedded_manifest(workspace_root) {
+        let out_file = bins_out.join(&binary.name);
+        let key = artifact_key_for(&mut cache, &binary, &pin);
+        if !cache.restore(key.as_deref(), &binary.name, &out_file) {
+            // Watch the closure anyway: a later edit has to be able to bring
+            // this unit back for another look once the store carries the
+            // matching bytes.
+            cache.emit_rerun();
+            return Vec::new();
+        }
+        let sha = sha256_hex(&out_file);
+        entries.push((binary.name.clone(), out_file, sha));
+    }
+    // Editing any source the payload is built from must invalidate the restore,
+    // or this arm would keep serving bytes that no longer match the tree.
+    cache.emit_rerun();
+    eprintln!(
+        "[build.rs] embedded host binaries restored from the content store \
+         without `embed-host-bins` ({} binaries)",
+        entries.len()
+    );
+    entries
+}
+
+/// Every binary that gets cross-compiled and embedded.
+///
+/// `HOST_BINARIES` (installed into the builder/dev VM rootfs) and
+/// `SEED_BINARIES` (host-side only, e.g. the Stage 0 nix-seed's `/init`) are
+/// both `mvm-build` `[[bin]]`s; the bootstrap support list carries its own
+/// package names, so it cannot assume one.
+fn read_embedded_manifest(workspace_root: &Path) -> Vec<EmbeddedSourceBinary> {
+    let mut manifest: Vec<EmbeddedSourceBinary> = read_rust_manifest(workspace_root)
+        .into_iter()
+        .chain(read_seed_binaries(workspace_root))
+        .map(|name| EmbeddedSourceBinary {
+            package: "mvm-build".to_string(),
+            name,
+            features: String::new(),
+        })
+        .collect();
+    manifest.extend(read_bootstrap_support_binaries(workspace_root));
+    manifest
+}
+
+/// The content-store key for one embedded binary under the pinned toolchain.
+fn artifact_key_for(
+    cache: &mut EmbedCache,
+    binary: &EmbeddedSourceBinary,
+    pin: &Pin,
+) -> Option<String> {
+    cache.key_for(&KeyRequest {
+        package: &binary.package,
+        binary: &binary.name,
+        features: &binary.features,
+        target: &pin.target,
+        toolchain: &format!(
+            "rust={} zig={} zigbuild={}",
+            pin.rust, pin.zig, pin.cargo_zigbuild
+        ),
+        flavor: "musl-static",
+    })
 }
 
 fn embed_host_binaries(workspace_root: &Path, out_dir: &Path) {
@@ -224,21 +331,7 @@ fn embed_host_binaries(workspace_root: &Path, out_dir: &Path) {
     println!("cargo:rerun-if-env-changed=MVM_EMBED_ZIG");
     println!("cargo:rerun-if-env-changed=MVM_EMBED_NO_CACHE");
 
-    // HOST_BINARIES (installed into the builder/dev VM rootfs), SEED_BINARIES
-    // (host-side only, e.g. the Stage 0 nix-seed's /init), and bootstrap
-    // support binaries all get cross-compiled + embedded. The support list
-    // includes binaries owned by crates other than mvm-build, so retain the
-    // package name alongside each binary instead of assuming one package.
-    let mut manifest: Vec<EmbeddedSourceBinary> = read_rust_manifest(&workspace_root)
-        .into_iter()
-        .chain(read_seed_binaries(&workspace_root))
-        .map(|name| EmbeddedSourceBinary {
-            package: "mvm-build".to_string(),
-            name,
-            features: String::new(),
-        })
-        .collect();
-    manifest.extend(read_bootstrap_support_binaries(&workspace_root));
+    let manifest = read_embedded_manifest(&workspace_root);
     let mut entries = Vec::new();
 
     // The host-vm bins are statically musl-linked and embedded for the host
@@ -290,17 +383,7 @@ fn embed_host_binaries(workspace_root: &Path, out_dir: &Path) {
             .join(strip_glibc(&pin.target))
             .join("release")
             .join(&binary.name);
-        let key = cache.key_for(&KeyRequest {
-            package: &binary.package,
-            binary: &binary.name,
-            features: &binary.features,
-            target: &pin.target,
-            toolchain: &format!(
-                "rust={} zig={} zigbuild={}",
-                pin.rust, pin.zig, pin.cargo_zigbuild
-            ),
-            flavor: "musl-static",
-        });
+        let key = artifact_key_for(&mut cache, binary, &pin);
 
         if cache.restore(key.as_deref(), &binary.name, &out_file) {
             eprintln!(

--- a/crates/mvm-cli/src/host_binaries/extract.rs
+++ b/crates/mvm-cli/src/host_binaries/extract.rs
@@ -15,17 +15,30 @@ use super::embedded::EMBEDDED;
 /// Without this the empty table extracts an empty directory and every caller
 /// fails later, somewhere else, as a missing file — the failure would be read
 /// as a corrupted cache rather than as a build that was never asked to embed
-/// anything. Named here so the message can say which build produced it.
+/// anything.
 fn require_embedded_payload() -> std::io::Result<()> {
     if !EMBEDDED.is_empty() {
         return Ok(());
     }
-    Err(std::io::Error::other(
+    Err(std::io::Error::other(no_payload_message(cfg!(
+        debug_assertions
+    ))))
+}
+
+/// The refusal, naming the rebuild for *this* binary's profile.
+///
+/// Bare `just embed` writes `target/debug/mvmctl`, so a release-profile binary
+/// sent to it is never replaced — and a `PATH` carrying `target/release` ahead
+/// of `target/debug` keeps resolving to the one that refused. The profile has
+/// to travel with the instruction or the instruction cannot work.
+fn no_payload_message(debug_profile: bool) -> String {
+    let profile = if debug_profile { "" } else { " --release" };
+    format!(
         "this mvmctl was built without the embedded Linux host binaries, so it \
-         cannot bootstrap a builder VM. Rebuild with `just embed` (or \
-         `cargo build --features embed-host-bins`); official release binaries \
-         always carry them.",
-    ))
+         cannot bootstrap a builder VM. Rebuild with `just embed{profile}` (or \
+         `cargo build{profile} --features embed-host-bins`); official release \
+         binaries always carry them."
+    )
 }
 
 pub fn ensure_extracted(cache_root: &Path) -> std::io::Result<PathBuf> {
@@ -107,12 +120,32 @@ fn rand_suffix() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::combined_hash_hex;
+    use super::{combined_hash_hex, no_payload_message};
 
     #[test]
     fn combined_hash_is_sha256_hex() {
         let hash = combined_hash_hex();
         assert_eq!(hash.len(), 64);
         assert!(hash.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    /// A release-profile binary told to run bare `just embed` gets a *debug*
+    /// binary, which never replaces the one that refused — so the same refusal
+    /// returns forever.
+    #[test]
+    fn a_release_build_is_told_to_rebuild_the_release_profile() {
+        let msg = no_payload_message(false);
+        assert!(msg.contains("just embed --release"), "{msg}");
+        assert!(
+            msg.contains("cargo build --release --features embed-host-bins"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn a_debug_build_is_told_to_rebuild_the_debug_profile() {
+        let msg = no_payload_message(true);
+        assert!(msg.contains("just embed"), "{msg}");
+        assert!(!msg.contains("--release"), "{msg}");
     }
 }

--- a/crates/mvm-cli/tests/unembedded_host_binaries.rs
+++ b/crates/mvm-cli/tests/unembedded_host_binaries.rs
@@ -1,50 +1,80 @@
-//! The default build carries no Linux host-binary payload. These assert that
-//! it *says so* rather than quietly behaving as if it had one.
+//! A build without `embed-host-bins` never cross-compiles the Linux host
+//! binaries. What it *ships* is whatever the content store could prove belongs
+//! to this tree: nothing on a cold machine, the restored set once a `just
+//! embed` has published one.
 //!
-//! Gating `embedded_binaries.rs` on the feature without this file would leave
-//! the default configuration — the one nearly every `cargo test` run uses —
-//! asserting nothing at all about the embedded set.
+//! Both states have a contract and this file asserts both, in one test rather
+//! than two that skip past each other — the empty arm must refuse and say so,
+//! the restored arm must be complete. Gating `embedded_binaries.rs` on the
+//! feature without this would leave the default configuration — the one nearly
+//! every `cargo test` run uses — asserting nothing at all about the payload.
 #![cfg(not(feature = "embed-host-bins"))]
 
 use mvm_cli::host_binaries::embedded::EMBEDDED;
 use mvm_cli::host_binaries::extract::{ensure_boot_host_binaries, ensure_extracted};
+use mvm_cli::host_binaries::manifest::{BOOTSTRAP_SUPPORT_BINARIES, HOST_BINARIES, SEED_BINARIES};
 
-#[test]
-fn the_default_build_embeds_nothing() {
-    assert!(
-        EMBEDDED.is_empty(),
-        "a build without `embed-host-bins` must carry no payload, found {} entries",
-        EMBEDDED.len()
-    );
-}
-
-/// The refusal has to name the command that fixes it. An empty extract dir
-/// would otherwise surface later as a missing file and read as a corrupted
-/// cache rather than as a build that was never asked to embed anything.
-#[test]
-fn extraction_refuses_and_names_the_rebuild_command() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let err = ensure_extracted(tmp.path()).unwrap_err().to_string();
-    assert!(err.contains("embed-host-bins"), "{err}");
-    assert!(err.contains("just embed"), "{err}");
+/// Every binary `build.rs` embeds, whichever arm produced the table.
+fn expected_payload_len() -> usize {
+    HOST_BINARIES.len() + SEED_BINARIES.len() + BOOTSTRAP_SUPPORT_BINARIES.len()
 }
 
 #[test]
-fn boot_binary_extraction_refuses_too() {
-    let tmp = tempfile::TempDir::new().unwrap();
-    let err = match ensure_boot_host_binaries(tmp.path()) {
-        Ok(_) => panic!("an unembedded build must not produce boot host binaries"),
-        Err(err) => err.to_string(),
-    };
-    assert!(err.contains("embed-host-bins"), "{err}");
-}
-
-/// Refusing before any filesystem work matters: a half-populated cache
-/// directory is what the next run would take as a valid extraction.
-#[test]
-fn refusal_leaves_no_cache_directory_behind() {
+fn the_default_build_ships_only_a_payload_the_store_could_prove() {
     let tmp = tempfile::TempDir::new().unwrap();
     let root = tmp.path().join("host-bins");
-    assert!(ensure_extracted(&root).is_err());
-    assert!(!root.exists(), "refusal must not create {}", root.display());
+
+    match ensure_extracted(&root) {
+        // Cold: nothing proven, so nothing shipped. The refusal has to name the
+        // command that fixes it, and refuse before any filesystem work — a
+        // half-populated cache directory is what the next run would take as a
+        // valid extraction.
+        Err(err) => {
+            let err = err.to_string();
+            assert!(
+                EMBEDDED.is_empty(),
+                "extraction refused while carrying {} entries",
+                EMBEDDED.len()
+            );
+            assert!(err.contains("embed-host-bins"), "{err}");
+            assert!(err.contains("just embed"), "{err}");
+            assert!(!root.exists(), "refusal must not create {}", root.display());
+        }
+        // Warm: restored from the content store. A restore is all-or-nothing,
+        // because extraction verifies the table as a unit and a builder VM
+        // missing one binary fails later and elsewhere.
+        Ok(dir) => {
+            assert_eq!(
+                EMBEDDED.len(),
+                expected_payload_len(),
+                "a restored payload must be the whole manifest, not a subset"
+            );
+            for bin in EMBEDDED {
+                assert!(
+                    dir.join(bin.name).is_file(),
+                    "{} missing from the extraction",
+                    bin.name
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn boot_binary_extraction_agrees_with_the_table() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    match ensure_boot_host_binaries(tmp.path()) {
+        Ok(boot) => {
+            assert!(
+                !EMBEDDED.is_empty(),
+                "boot binaries produced from an empty table"
+            );
+            assert!(!boot.stage0_init.is_empty(), "stage0-init must have bytes");
+        }
+        Err(err) => {
+            let err = err.to_string();
+            assert!(EMBEDDED.is_empty(), "refused while carrying a payload");
+            assert!(err.contains("embed-host-bins"), "{err}");
+        }
+    }
 }

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -52,9 +52,15 @@ cargo run --features embed-host-bins -- bootstrap
 > it is off by default so it stays off the edit/check/test loop. A plain
 > `cargo build` gives you an `mvmctl` with every host-side verb; it just cannot
 > bootstrap a builder VM, and says so with this recipe named. The two write the
-> same `target/debug/mvmctl` under different feature sets, so alternating them
-> relinks `mvmctl` — run `just embed` when you are about to boot a VM, not as
-> part of the inner loop. Released binaries always carry the payload.
+> same `target/<profile>/mvmctl` under different feature sets, so alternating
+> them relinks `mvmctl` — run `just embed` when you are about to boot a VM, not
+> as part of the inner loop. Released binaries always carry the payload.
+>
+> Two things follow. Bare `just embed` builds the **debug** profile, so use
+> `just embed --release` if that is the binary you invoke. And a plain
+> `cargo build` restores the payload from `~/.cache/mvm/embed` when the store
+> has bytes keyed to this tree, so one `just embed` is not undone by the next
+> ordinary build.
 
 > **Note — after a toolchain-version change.** `rust-toolchain.toml` pins an
 > exact Rust version, and rustup keys installed cross-targets per toolchain

--- a/specs/plans/2026-08-28-embedded-host-binaries-are-opt-in.md
+++ b/specs/plans/2026-08-28-embedded-host-binaries-are-opt-in.md
@@ -1,7 +1,7 @@
 # Take `mvm-cli`'s build script off the inner loop entirely
 
 Backing: shipped-source
-Validation: the_default_build_embeds_nothing
+Validation: the_default_build_ships_only_a_payload_the_store_could_prove
 
 **Status:** DELIVERED
 **Date:** 2026-08-28
@@ -20,6 +20,12 @@ feature off the script writes an empty `EMBEDDED` table, watches four files, and
 returns — so cargo runs it once per fingerprint and never again on the inner
 loop. `just embed` and the tag-push release workflow turn it on.
 
+Amended 2026-09-01 — see "Follow-up" below: the unembedded arm still never
+cross-compiles, but it now *restores* a payload the content store can prove
+belongs to this tree, because writing an empty table unconditionally turned an
+ordinary `cargo build` into something that silently un-embedded the binary on
+`PATH`.
+
 The argument is not wall time; at 0.13s there was little left to win. It is that
 a dev build should not carry hidden work, and that the one place a shipped
 artifact gets its payload should be a named, reviewable line in the release
@@ -37,7 +43,10 @@ it writes.
 
 Verified: with the feature off, `touch crates/mvm-core/src/lib.rs` followed by
 `cargo build -p mvmctl --bin mvmctl -vv` shows zero `build-script-build`
-executions.
+executions. The follow-up widens this: when the store can serve a payload the
+arm also watches that payload's dependency closure, so an edit to
+`mvm-core/src` does re-run the script. It still compiles nothing — it recomputes
+the key and either restores or writes the empty table.
 
 ## What an unembedded binary does
 
@@ -45,7 +54,14 @@ Every host-side verb works. What it cannot do is bootstrap a builder VM, so
 `host_binaries::extract::ensure_extracted` refuses up front:
 
 > this mvmctl was built without the embedded Linux host binaries, so it cannot
-> bootstrap a builder VM. Rebuild with `just embed` …
+> bootstrap a builder VM. Rebuild with `just embed --release` (or
+> `cargo build --release --features embed-host-bins`) …
+
+The rebuild command is profile-correct. Bare `just embed` writes
+`target/debug/mvmctl`, so a release-profile binary sent to it is never replaced
+— and a checkout carrying `target/release` ahead of `target/debug` on `PATH`
+keeps resolving to the stale one, which made the refusal recur for as long as
+the operator followed the instruction.
 
 It refuses *before* creating the cache directory. An empty extract would
 otherwise surface later as a missing file and read as a corrupted cache rather
@@ -57,9 +73,12 @@ Gating `embedded_binaries.rs` and `host_binaries_extract.rs` on the feature
 would leave the default configuration — the one nearly every `cargo test` uses —
 asserting nothing whatsoever about the embedded set. So the gating is paired:
 
-- `tests/unembedded_host_binaries.rs` (`#![cfg(not(feature = ...))]`) asserts the
-  table is empty, that both extraction entry points refuse, that the message
-  names the fix, and that no cache directory is left behind.
+- `tests/unembedded_host_binaries.rs` (`#![cfg(not(feature = ...))]`) asserts
+  whichever state the store left this build in: the cold arm must refuse from
+  both extraction entry points, name the fix and the binary it came from, and
+  leave no cache directory behind; the warm arm must carry the complete
+  manifest. It cannot assert the table is empty any more — after a `just embed`
+  on the same machine, it is not.
 - `tests/embedded_binaries.rs` + `tests/host_binaries_extract.rs`
   (`#![cfg(feature = ...)]`) keep the payload assertions.
 - In `host_binaries_manifest.rs` only the one payload test is gated; the three
@@ -140,3 +159,28 @@ while its hermetic job drops one it never needed.
   miss costing "~17.8s of nested `cargo build` on the aux-helper leg". That leg
   no longer exists, so the insurance the raise was buying is obsolete — a host
   config decision, not a repo one.
+
+## Follow-up (2026-09-01): the unembedded arm restores from the store
+
+Both variants write the same `target/<profile>/mvmctl`, so the last cargo
+invocation owns the file. Measured: 32,395,744 bytes with the feature,
+27,012,528 without, and the swap took 0.26s with **nothing compiled** — so a
+script, a test harness or another session could un-embed the binary on `PATH`
+between a `just embed` and the next command.
+
+`write_unembedded_table` now calls `restore_embedded_from_store`. It still
+compiles nothing; it asks the same store the embedding arm uses, under the same
+key, so a hit is proven to be the bytes this tree produces. All-or-nothing,
+because extraction verifies the table as a unit. A miss, `MVM_EMBED_NO_CACHE=1`
+or an unreachable store writes the empty table as before.
+
+The store root is watched, and created when absent so the watch is a stable
+directory rather than a permanently-dirty missing path. Without it a `just
+embed` changes no file this unit watches, so it would never re-run and the next
+plain build would keep serving its cached empty table.
+
+`tests/unembedded_host_binaries.rs` can no longer assert `EMBEDDED.is_empty()`
+— on a machine that has run `just embed` it is not. It matches on the extraction
+result and asserts the contract of whichever state it finds: cold must refuse,
+name the rebuild and leave no cache directory; warm must be the complete
+manifest. One test, no skip, both arms real.

--- a/specs/sprint/delivery/embed-refusal-names-the-binary-and-profile.md
+++ b/specs/sprint/delivery/embed-refusal-names-the-binary-and-profile.md
@@ -1,0 +1,34 @@
+# One `just embed` now sticks
+
+Plan: `specs/plans/2026-08-28-embedded-host-binaries-are-opt-in.md` (follow-up)
+
+An unembedded `mvmctl` kept coming back after a `just embed` that had genuinely
+worked. Three causes, one root.
+
+The root: both feature variants write the same `target/<profile>/mvmctl`, so the
+last cargo invocation owns the file. Measured 2026-09-01 — `--features
+embed-host-bins` uplifts 32,395,744 bytes, a plain `cargo build --release --bin
+mvmctl` puts back 27,012,528 **in 0.26s with nothing compiled**. Any script,
+test harness or parallel session was enough to un-embed the binary on `PATH`.
+The unembedded build-script arm now restores the payload from the content store
+instead of unconditionally writing an empty table: same store, same key
+(dependency closure + `Cargo.lock` + pinned toolchain) the embedding arm trusts
+when it skips a rebuild, so a hit is proven to be this tree's bytes. It still
+cross-compiles nothing. All-or-nothing, because extraction verifies the table as
+a unit. A miss, `MVM_EMBED_NO_CACHE=1` or an unreachable store writes the empty
+table exactly as before.
+
+The other two were what made it inescapable. `just embed` builds the **debug**
+profile, so a release-profile binary told to run it is never replaced — the
+refusal is now profile-correct. And `just release-build` had never carried
+`embed-host-bins` though `release.yml`'s `MVMCTL_RELEASE_FEATURES` has since the
+opt-in landed, so the recipe named "Build optimized release binary" produced the
+one build that looks finished and cannot boot anything. `release-channel` stays
+out of it: that would resolve artifacts from the published channel rather than
+the checkout.
+
+`tests/unembedded_host_binaries.rs` changed shape — it cannot assert
+`EMBEDDED.is_empty()` on a machine that has run `just embed`. It matches on the
+extraction result and asserts whichever state it finds, in one test with no
+skip. Both arms were run: 2042 pass warm, and the binary passes cold under
+`MVM_EMBED_NO_CACHE=1`.


### PR DESCRIPTION
## The bug

An unembedded `mvmctl` kept coming back after a `just embed` that had genuinely
worked, refusing at builder-VM bootstrap with "Rebuild with `just embed`" — the
command that had just been run.

## Root cause

Both feature variants write the same `target/<profile>/mvmctl`, so the last
cargo invocation owns the file. Measured on this tree:

```
cargo build --release --bin mvmctl --features embed-host-bins  → 32,395,744 bytes
cargo build --release --bin mvmctl                             → 27,012,528 bytes, 0.26s
```

The second one **compiled nothing**. A cached no-op is enough, so a script, a
test harness or a parallel session could un-embed the binary on `PATH` between
a `just embed` and the next command.

Two things made it inescapable. `just embed` builds the **debug** profile, so a
release-profile binary told to run it is never replaced — and a checkout with
`target/release` ahead of `target/debug` on `PATH` keeps resolving to the one
that refused. And `just release-build` never carried `embed-host-bins`, though
`release.yml`'s `MVMCTL_RELEASE_FEATURES` has since the opt-in landed, so the
recipe named "Build optimized release binary" produced the one build that looks
finished and cannot boot anything.

## Fix

The unembedded build-script arm restores the payload from the content store
instead of unconditionally writing an empty table. It still cross-compiles
nothing — it asks the same store the embedding arm uses, under the same key
(dependency closure + `Cargo.lock` + pinned toolchain), so a hit is proven to be
this tree's bytes. All-or-nothing, since extraction verifies the table as a
unit. A miss, `MVM_EMBED_NO_CACHE=1` or an unreachable store writes the empty
table exactly as before, so the inner-loop win from the opt-in plan is intact.

The store root is watched, and created when absent so the watch is a stable
directory rather than a permanently-dirty missing path — a `just embed`
otherwise changes no file this unit watches, and the next plain build would keep
serving its cached empty table.

The refusal is profile-correct, and `release-build` / `release-build-target`
carry the feature. `release-channel` stays out: it would resolve artifacts from
the published channel rather than the checkout.

## Tests

`tests/unembedded_host_binaries.rs` can no longer assert `EMBEDDED.is_empty()` —
on a machine that has run `just embed` it is not. It matches on the extraction
result and asserts the contract of whichever state it finds, with no skip: cold
must refuse, name the rebuild and leave no cache directory; warm must be the
complete manifest.

Both arms exercised. `cargo nextest run --workspace` 12862 passed; the two-test
binary passes cold under `MVM_EMBED_NO_CACHE=1`; `xtask check-all` 63 gates
clean; workspace clippy and `cargo fmt --all` green.

CI is unaffected — no workflow caches `~/.cache/mvm/embed`, so every lane keeps
taking the empty-table arm.
