### PR TITLE
feat(builder): move the QEMU builder onto the disk transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ mvmctl machine run --image alpine -- sh -c "echo hello from a microVM && uname -
 mvmctl machine run --image python:3.12 -- python -c "print(2 + 2)"
 
 # Run a Python file from the host checkout (the mount is read-only).
-# Repeat --mount for additional host directories.
-# --mount needs a backend serving a virtio-fs directory share (libkrun, HVF).
-# Firecracker (the Linux default) has none and refuses before boot: pass a
-# disk-image volume instead, --volume HOST:/GUEST:SIZE.
+# Repeat --mount for additional host directories. Every backend serves it:
+# the directory is materialized into an ext4 image and attached as a block
+# device, so there is no virtio-fs requirement and Firecracker takes it too.
+# The image is a snapshot taken at boot — host edits mid-run are not visible.
+# For a sized disk instead of a directory, --volume HOST:/GUEST:SIZE.
 mvmctl machine run --image python:3.12 \
   --mount "$PWD:/work:ro" -- python /work/app.py
 

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -630,14 +630,30 @@ fn kill_pid(pid: libc::pid_t, sig: libc::c_int) {
     }
 }
 
-fn prepare_builder_transport_disks(
+/// Pack the inbound trees onto an input disk and create the output disk the
+/// guest writes its artifact tar onto — the host half of the disk transport,
+/// shared by every one-shot builder VMM.
+///
+/// `closure_nar` is the resolved builder image's optional seeded Nix store
+/// closure: a single file that rides the same input disk at
+/// `closure-seed/<CLOSURE_FILE>`. The guest imports that fixed path and does
+/// not care which transport populated it, so a caller still attaching the
+/// closure as a virtio-fs share passes `None` here instead.
+pub(crate) fn prepare_builder_transport_disks(
     vm_state_dir: &Path,
     input_trees: &[InputTree<'_>],
+    closure_nar: Option<&Path>,
     output_size: u64,
 ) -> Result<(PathBuf, PathBuf), BuilderVmError> {
     let input_disk = vm_state_dir.join("input.img");
     let output_disk = vm_state_dir.join("output.img");
-    pack_input_disk(input_trees, None, &input_disk, BUILDER_INPUT_DISK_MIN).map_err(|e| {
+    pack_input_disk(
+        input_trees,
+        closure_nar,
+        &input_disk,
+        BUILDER_INPUT_DISK_MIN,
+    )
+    .map_err(|e| {
         BuilderVmError::ExtractionFailed(format!(
             "pack builder input disk {}: {e}",
             input_disk.display()
@@ -652,7 +668,7 @@ fn prepare_builder_transport_disks(
     Ok((input_disk, output_disk))
 }
 
-fn extract_builder_transport_output(
+pub(crate) fn extract_builder_transport_output(
     output_disk: &Path,
     artifact_out: &Path,
     job_dir: &Path,
@@ -1138,6 +1154,9 @@ impl LibkrunBuilderVm {
                     src: work_staging.path(),
                 },
             ],
+            // The closure seed is still attached below as a virtio-fs share on
+            // this path, so it must not also ride the input disk.
+            None,
             u64::from(BUILDER_OUTPUT_DISK_MIB) << 20,
         )?;
 
@@ -1664,6 +1683,9 @@ impl BuilderVm for LibkrunBuilderVm {
                     src: &mounts.host_bin_dir,
                 },
             ],
+            // The closure seed is still attached below as a virtio-fs share on
+            // this path, so it must not also ride the input disk.
+            None,
             u64::from(BUILDER_OUTPUT_DISK_MIB) << 20,
         )?;
         let mut krun = krun_context_for_image(&vm_name, &image)?

--- a/crates/mvm-build/src/qemu_builder.rs
+++ b/crates/mvm-build/src/qemu_builder.rs
@@ -25,13 +25,14 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::builder_vm::{BuilderArtifacts, BuilderJob, BuilderMounts, BuilderVm, BuilderVmError};
 #[cfg(feature = "builder-vm")]
-use crate::builder_vm_runtime::{CLOSURE_SEED_TAG, acquire_nix_store_image_lock_named};
+use crate::builder_vm_runtime::acquire_nix_store_image_lock_named;
 #[cfg(feature = "builder-vm")]
 use crate::libkrun_builder::{
     BuilderEndpointTransport, BuilderRuntimeOverlayAttachment, BuilderShellJob, BuilderShellResult,
     BuilderVmImage, BuilderVsockEgressEndpoint, DEFAULT_NIX_STORE_MIB,
-    builder_virtiofs_runtime_overlay_attachment, builder_vm_cache_dir,
-    prepopulate_stage0_nix_store_image, require_runtime_overlay_ext4, stage0_nix_store_image_name,
+    builder_runtime_overlay_attachment, builder_vm_cache_dir, extract_builder_transport_output,
+    prepare_builder_transport_disks, prepopulate_stage0_nix_store_image,
+    require_runtime_overlay_ext4, stage0_nix_store_image_name,
 };
 use mvm_core::config::DEFAULT_MVM_HOME_DIR_NAME;
 use mvm_fs::overlay::CHECKSUM_MANIFEST_FILE;
@@ -906,7 +907,9 @@ fn io_err(ctx: &str, path: &Path, e: std::io::Error) -> BuilderVmError {
 // Devices, matched to what the unchanged guest expects:
 //   - vda  virtio-blk  the builder `rootfs.ext4` (mounted `ro`)
 //   - vdb  virtio-blk  the persistent nix-store image (`/nix` overlay upper)
-//   - virtio-fs tags `work` `out` `job` `mvm-bins` over vhost-user/virtiofsd
+//   - vdc  virtio-blk  the input tar: `job` `work` `mvm-bins` + closure seed
+//   - vdd  virtio-blk  the output tar the guest writes its artifacts onto
+//   - vde  virtio-blk  the runtime overlay
 //   - virtio-net-pci + user-mode (slirp); slirp's DHCP feeds the guest's
 //     `udhcpc -i eth0` (we force `net.ifnames=0` so the NIC comes up `eth0`)
 //
@@ -934,23 +937,20 @@ fn run_build_qemu(
 
 #[cfg(feature = "builder-vm")]
 fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, BuilderVmError> {
+    use crate::builder_disk_transport::InputTree;
     use crate::builder_vm_runtime::{
         acquire_nix_store_image_lock, builder_vm_timeout, read_job_result_with_diagnostics,
-        shell_job_exit_error, stage_closure_seed_dir, stage_shell_job_dir,
+        shell_job_exit_error, stage_filtered_work_input, stage_shell_job_dir,
     };
     use crate::libkrun_builder::{
         BuilderVmImage, DEFAULT_NIX_STORE_MIB, builder_vm_cache_dir, ensure_builder_vm_image,
         host_arch_tag, unique_job_id,
     };
+    use crate::pipeline::build::BUILDER_OUTPUT_DISK_MIB;
 
     validate_shell_job(job)?;
 
     let qemu_bin = locate_qemu()?;
-    let (virtiofsd_bin, virtiofsd_flavor) =
-        crate::virtiofsd::locate_virtiofsd().map_err(|e| BuilderVmError::VmmUnavailable {
-            requested: "virtiofsd".to_string(),
-            reason: format!("{e:#}"),
-        })?;
     let (kernel, rootfs, image_cmdline) = match ensure_builder_vm_image()? {
         BuilderVmImage::Rootfs {
             kernel_path,
@@ -992,43 +992,33 @@ fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, Bu
         );
     }
 
-    // Attach the resolved builder image's seeded closure NAR, when it
-    // carries one, as a fourth read-only share — the same per-arch cache
-    // dir `ensure_builder_vm_image` just read the kernel/rootfs from.
+    // The resolved builder image's seeded closure NAR, when it carries one,
+    // rides the input disk at `closure-seed/<CLOSURE_FILE>` — the same
+    // per-arch cache dir `ensure_builder_vm_image` just read kernel/rootfs
+    // from. The guest imports that fixed path either way.
     let closure_nar =
         crate::builder_pack::closure_nar_path(&builder_vm_cache_dir().join(host_arch_tag()));
-    let closure_share_dir = closure_nar
-        .as_deref()
-        .map(|nar| stage_closure_seed_dir(nar, &vm_state_dir))
-        .transpose()?;
 
-    let shares = qemu_shares_with_closure_seed(
-        vec![
-            ("work", job.work_dir.as_path()),
-            ("out", job.artifact_out.as_path()),
-            ("job", job_dir.as_path()),
+    // `job.work_dir` can be the repo root on a source checkout. A share
+    // tolerated that; a tar does not — `target/`, `.git/` and `.worktrees/`
+    // would overflow the guest's RAM-capped extraction tmpfs. `work_staging`
+    // must outlive the QEMU run.
+    let work_staging = stage_filtered_work_input(&job.work_dir)?;
+    let (input_disk, output_disk) = prepare_builder_transport_disks(
+        &vm_state_dir,
+        &[
+            InputTree {
+                name: "job",
+                src: &job_dir,
+            },
+            InputTree {
+                name: "work",
+                src: work_staging.path(),
+            },
         ],
-        closure_share_dir.as_deref(),
-    );
-    let mut virtiofsd = crate::virtiofsd::VirtiofsdGuard::default();
-    for (tag, dir) in shares.iter().copied() {
-        let sock = qemu_virtiofs_socket_path(&job_id, tag);
-        virtiofsd
-            .spawn(
-                crate::virtiofsd::SpawnParams::new(
-                    &virtiofsd_bin,
-                    virtiofsd_flavor,
-                    tag,
-                    &sock,
-                    dir,
-                )
-                .read_only(false),
-            )
-            .map_err(|e| BuilderVmError::VmmUnavailable {
-                requested: "virtiofsd".to_string(),
-                reason: format!("{e:#}"),
-            })?;
-    }
+        closure_nar.as_deref(),
+        u64::from(BUILDER_OUTPUT_DISK_MIB) << 20,
+    )?;
 
     // The QEMU builder is always a lean Rootfs builder, so the runtime overlay
     // is required — fail closed rather than booting a builder whose guest agent
@@ -1070,11 +1060,23 @@ fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, Bu
         crate::builder_cmdline::checked_builder_cmdline(cmdline.clone())
             .map_err(BuilderVmError::NixBuildFailed)?,
     );
+    // Slot order is the guest's contract, not a preference: the cmdline names
+    // `/dev/vdc` and `/dev/vdd` for the transport pair and `/dev/vde` for the
+    // runtime overlay, so these four must be attached in exactly this order.
+    // vda rootfs, vdb nix-store, vdc input, vdd output, vde overlay.
     cmd.arg("-drive")
         .arg(format!("file={},if=virtio,format=raw", rootfs.display()));
     cmd.arg("-drive").arg(format!(
         "file={},if=virtio,format=raw",
         nix_store_lock.path().display()
+    ));
+    cmd.arg("-drive").arg(format!(
+        "file={},if=virtio,format=raw,readonly=on",
+        input_disk.display()
+    ));
+    cmd.arg("-drive").arg(format!(
+        "file={},if=virtio,format=raw",
+        output_disk.display()
     ));
     cmd.arg("-drive").arg(format!(
         "file={},if=virtio,format=raw,readonly=on",
@@ -1085,20 +1087,6 @@ fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, Bu
         cmd.arg("-drive").arg(format!(
             "file={},if=virtio,format=raw{read_only}",
             disk.path.display()
-        ));
-    }
-    cmd.args([
-        "-object",
-        &format!("memory-backend-memfd,id=mem,size={mem_arg},share=on"),
-        "-numa",
-        "node,memdev=mem",
-    ]);
-    for (tag, _) in shares.iter().copied() {
-        let sock = qemu_virtiofs_socket_path(&job_id, tag);
-        cmd.arg("-chardev")
-            .arg(format!("socket,id=vfs-{tag},path={}", sock.display()));
-        cmd.arg("-device").arg(format!(
-            "vhost-user-fs-pci,queue-size=1024,chardev=vfs-{tag},tag={tag}"
         ));
     }
     let (identity_material, identity_drive) =
@@ -1123,7 +1111,6 @@ fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, Bu
         .status()
         .map_err(|e| BuilderVmError::NixBuildFailed(format!("spawning qemu ({qemu_bin}): {e}")))?;
     drop(egress_endpoint);
-    drop(virtiofsd);
 
     if !status.success() && status.code() == Some(124) {
         return Err(BuilderVmError::NixBuildFailed(format!(
@@ -1138,6 +1125,13 @@ fn run_shell_script_qemu(job: &BuilderShellJob) -> Result<BuilderShellResult, Bu
             console_log.display()
         )));
     }
+
+    // The guest wrote its artifacts onto the output disk rather than into a
+    // shared `/out`, so the host has to extract before anything reads them —
+    // `read_job_result_with_diagnostics` looks for `result` in `job_dir`, which
+    // the extraction populates.
+    extract_builder_transport_output(&output_disk, &job.artifact_out, &job_dir)?;
+    drop(work_staging);
 
     let result = read_job_result_with_diagnostics(&job_dir, &vm_state_dir)?;
     if result.exit_code != 0 {
@@ -1186,14 +1180,16 @@ fn run_build_qemu(
     job: &BuilderJob,
     mounts: &BuilderMounts,
 ) -> Result<BuilderArtifacts, BuilderVmError> {
+    use crate::builder_disk_transport::InputTree;
     use crate::builder_vm_runtime::{
         acquire_nix_store_image_lock, builder_vm_timeout, finalize_flake_job, finalize_install_job,
-        stage_closure_seed_dir, stage_job_dir,
+        stage_filtered_work_input, stage_job_dir,
     };
     use crate::libkrun_builder::{
         BuilderVmImage, DEFAULT_NIX_STORE_MIB, builder_vm_cache_dir, ensure_builder_vm_image,
         host_arch_tag, unique_job_id,
     };
+    use crate::pipeline::build::BUILDER_OUTPUT_DISK_MIB;
 
     // 1. Validate caller inputs early — clearer than a QEMU launch failure.
     validate_build_mounts(mounts)?;
@@ -1201,11 +1197,6 @@ fn run_build_qemu(
 
     // 2. Locate the host tooling up front.
     let qemu_bin = locate_qemu()?;
-    let (virtiofsd_bin, virtiofsd_flavor) =
-        crate::virtiofsd::locate_virtiofsd().map_err(|e| BuilderVmError::VmmUnavailable {
-            requested: "virtiofsd".to_string(),
-            reason: format!("{e:#}"),
-        })?;
 
     // 3. Resolve the cached builder image (kernel + rootfs + cmdline) the
     //    Stage 0 path promoted. `run_build` never takes the RootDir shape.
@@ -1262,48 +1253,38 @@ fn run_build_qemu(
         eprintln!("[mvm] QEMU running unaccelerated (TCG) — no /dev/kvm; this build will be slow.");
     }
 
-    // 8. Bring up one virtiofsd per share BEFORE QEMU (QEMU connects to
-    //    their sockets as a client at launch, so they must be ready). The
-    //    guest mounts each by tag; `work`/`mvm-bins` are inputs it mounts
-    //    read-only (`virtiofs_tag_is_read_only`), `out`/`job` read-write.
-    // Attach the resolved builder image's seeded closure NAR, when it
-    // carries one, as a fifth read-only share — the same per-arch cache
-    // dir `ensure_builder_vm_image` just read the kernel/rootfs from.
+    // 8. Pack the inbound trees onto the input disk and create the output
+    //    disk. The resolved builder image's seeded closure NAR, when it
+    //    carries one, rides the same input disk at
+    //    `closure-seed/<CLOSURE_FILE>` — the per-arch cache dir
+    //    `ensure_builder_vm_image` just read the kernel/rootfs from.
     let closure_nar =
         crate::builder_pack::closure_nar_path(&builder_vm_cache_dir().join(host_arch_tag()));
-    let closure_share_dir = closure_nar
-        .as_deref()
-        .map(|nar| stage_closure_seed_dir(nar, &vm_state_dir))
-        .transpose()?;
 
-    let shares = qemu_shares_with_closure_seed(
-        vec![
-            ("work", mounts.flake_src.as_path()),
-            ("out", mounts.artifact_out.as_path()),
-            ("job", job_dir.as_path()),
-            ("mvm-bins", mounts.host_bin_dir.as_path()),
+    // `mounts.flake_src` is the repo root itself on a source checkout. A share
+    // tolerated that; a tar does not — `target/`, `.git/` and `.worktrees/`
+    // would overflow the guest's RAM-capped extraction tmpfs. `work_staging`
+    // must outlive the QEMU run.
+    let work_staging = stage_filtered_work_input(&mounts.flake_src)?;
+    let (input_disk, output_disk) = prepare_builder_transport_disks(
+        &vm_state_dir,
+        &[
+            InputTree {
+                name: "job",
+                src: &job_dir,
+            },
+            InputTree {
+                name: "work",
+                src: work_staging.path(),
+            },
+            InputTree {
+                name: "mvm-bins",
+                src: &mounts.host_bin_dir,
+            },
         ],
-        closure_share_dir.as_deref(),
-    );
-    let mut virtiofsd = crate::virtiofsd::VirtiofsdGuard::default();
-    for (tag, dir) in shares.iter().copied() {
-        let sock = qemu_virtiofs_socket_path(&job_id, tag);
-        virtiofsd
-            .spawn(
-                crate::virtiofsd::SpawnParams::new(
-                    &virtiofsd_bin,
-                    virtiofsd_flavor,
-                    tag,
-                    &sock,
-                    dir,
-                )
-                .read_only(false),
-            )
-            .map_err(|e| BuilderVmError::VmmUnavailable {
-                requested: "virtiofsd".to_string(),
-                reason: format!("{e:#}"),
-            })?;
-    }
+        closure_nar.as_deref(),
+        u64::from(BUILDER_OUTPUT_DISK_MIB) << 20,
+    )?;
 
     // 9. Build the QEMU cmdline from the image's (swap hvc0 for the native
     //    QEMU serial console, force eth0, mark the backend); `root=/dev/vda ro
@@ -1350,10 +1331,13 @@ fn run_build_qemu(
         crate::builder_cmdline::checked_builder_cmdline(cmdline.clone())
             .map_err(BuilderVmError::NixBuildFailed)?,
     );
-    // Root disk (vda) + persistent nix store (vdb). The guest mounts vda
-    // `ro`, so the cached `rootfs.ext4` stays pristine across builds even
-    // though the block device is attached writable (mirrors libkrun). vdb
-    // lands at `/dev/vdb`, exactly where mvm-host-vm-init expects it.
+    // Slot order is the guest's contract, not a preference: the cmdline names
+    // `/dev/vdc` and `/dev/vdd` for the transport pair and `/dev/vde` for the
+    // runtime overlay, so these five must be attached in exactly this order.
+    // The guest mounts vda `ro`, so the cached `rootfs.ext4` stays pristine
+    // across builds even though the block device is attached writable
+    // (mirrors libkrun).
+    //   vda rootfs, vdb nix-store, vdc input, vdd output, vde overlay.
     cmd.arg("-drive")
         .arg(format!("file={},if=virtio,format=raw", rootfs.display()));
     cmd.arg("-drive").arg(format!(
@@ -1362,24 +1346,16 @@ fn run_build_qemu(
     ));
     cmd.arg("-drive").arg(format!(
         "file={},if=virtio,format=raw,readonly=on",
+        input_disk.display()
+    ));
+    cmd.arg("-drive").arg(format!(
+        "file={},if=virtio,format=raw",
+        output_disk.display()
+    ));
+    cmd.arg("-drive").arg(format!(
+        "file={},if=virtio,format=raw,readonly=on",
         runtime_overlay.display()
     ));
-    // Shared memory backend required by vhost-user-fs (virtiofs). Its size
-    // MUST equal `-m`.
-    cmd.args([
-        "-object",
-        &format!("memory-backend-memfd,id=mem,size={mem_arg},share=on"),
-        "-numa",
-        "node,memdev=mem",
-    ]);
-    for (tag, _) in shares.iter().copied() {
-        let sock = qemu_virtiofs_socket_path(&job_id, tag);
-        cmd.arg("-chardev")
-            .arg(format!("socket,id=vfs-{tag},path={}", sock.display()));
-        cmd.arg("-device").arg(format!(
-            "vhost-user-fs-pci,queue-size=1024,chardev=vfs-{tag},tag={tag}"
-        ));
-    }
     let (identity_material, identity_drive) =
         crate::libkrun_builder::stage_builder_flowmux_identity(&vm_state_dir)?;
     let egress_endpoint = BuilderVsockEgressEndpoint::spawn_with_transport(
@@ -1403,9 +1379,6 @@ fn run_build_qemu(
         .map_err(|e| BuilderVmError::NixBuildFailed(format!("spawning qemu ({qemu_bin}): {e}")))?;
     drop(egress_endpoint);
 
-    // 11. virtiofsd is no longer needed once QEMU has exited.
-    drop(virtiofsd);
-
     if !status.success() && status.code() == Some(124) {
         return Err(BuilderVmError::NixBuildFailed(format!(
             "QEMU builder VM timed out after {timeout_secs}s; console at {}",
@@ -1413,7 +1386,12 @@ fn run_build_qemu(
         )));
     }
 
-    // 12. Per-variant finalize via the shared job protocol — identical to
+    // 12. The guest wrote its artifacts onto the output disk rather than into
+    //     a shared `/out`, so extract before finalize reads them.
+    extract_builder_transport_output(&output_disk, &mounts.artifact_out, &job_dir)?;
+    drop(work_staging);
+
+    // 13. Per-variant finalize via the shared job protocol — identical to
     //     the libkrun/HVF paths, so the BuilderArtifacts is byte-identical
     //     regardless of VMM. Flake reads /job/result + validates
     //     /out/rootfs.ext4; Install reads /out/result.json.
@@ -1423,30 +1401,6 @@ fn run_build_qemu(
     }?;
     drop(nix_store_lock);
     Ok(artifacts)
-}
-
-#[cfg(feature = "builder-vm")]
-fn qemu_virtiofs_socket_path(job_id: &str, tag: &str) -> PathBuf {
-    // AF_UNIX paths cap at ~108 bytes on Linux. Cache roots can be deeply
-    // nested in worktrees, so keep QEMU virtiofs sockets under /tmp and rely
-    // on VirtiofsdGuard to remove them.
-    PathBuf::from(format!("/tmp/mvm-vfs-{job_id}-{tag}.sock"))
-}
-
-/// Append the closure-seed share to `base` iff `closure_share_dir` is
-/// `Some`, mirroring the libkrun path's `closure_seed_share`. Pulled out as
-/// its own pure step (no qemu/virtiofsd spawn) so the "attach a share iff
-/// the resolved image carries a closure" decision is unit-testable without
-/// booting anything.
-#[cfg(feature = "builder-vm")]
-fn qemu_shares_with_closure_seed<'a>(
-    mut base: Vec<(&'a str, &'a Path)>,
-    closure_share_dir: Option<&'a Path>,
-) -> Vec<(&'a str, &'a Path)> {
-    if let Some(dir) = closure_share_dir {
-        base.push((CLOSURE_SEED_TAG, dir));
-    }
-    base
 }
 
 /// Validate the caller's mount paths before launching QEMU. Mirrors
@@ -1524,7 +1478,11 @@ fn qemu_runtime_overlay_attachment<'a>(
     image: &'a BuilderVmImage,
     runtime_overlay: Option<&'a Path>,
 ) -> Option<BuilderRuntimeOverlayAttachment<'a>> {
-    builder_virtiofs_runtime_overlay_attachment(image, runtime_overlay)
+    // The disk-transport flavour, which is what pins the overlay to `/dev/vde`
+    // and emits `mvm.builder_transport=disk` plus the input/output device
+    // tokens. The device is a consequence of the slot order below: the two
+    // transport disks take vdc and vdd, so the overlay follows them.
+    builder_runtime_overlay_attachment(image, runtime_overlay)
 }
 
 /// Adapt the cached builder-image kernel cmdline for a QEMU boot. The
@@ -1583,9 +1541,13 @@ mod vsock_module_tests {
     #[cfg(feature = "builder-vm")]
     use crate::libkrun_builder::{BuilderExtraDisk, BuilderShellJob};
 
+    /// The overlay device and the transport tokens are one decision, not two:
+    /// the input/output disks take vdc and vdd, so the overlay must be named
+    /// vde. A cmdline that says vdc while the disks are attached in the new
+    /// order points the guest's runtime overlay at the input tar.
     #[cfg(feature = "builder-vm")]
     #[test]
-    fn qemu_runtime_overlay_keeps_virtiofs_transport() {
+    fn qemu_runtime_overlay_rides_the_disk_transport_at_vde() {
         let image = BuilderVmImage::new(
             PathBuf::from("/img/Image"),
             PathBuf::from("/img/rootfs.ext4"),
@@ -1597,34 +1559,11 @@ mod vsock_module_tests {
 
         assert_eq!(attachment.disk_path, overlay);
         assert!(attachment.read_only);
-        assert!(attachment.cmdline.contains("mvm.runtime_data=/dev/vdc"));
-        assert!(!attachment.cmdline.contains("mvm.builder_transport=disk"));
-        assert!(!attachment.cmdline.contains("mvm.builder_input="));
-        assert!(!attachment.cmdline.contains("mvm.builder_output="));
-    }
-
-    #[cfg(feature = "builder-vm")]
-    #[test]
-    fn qemu_shares_omit_closure_seed_when_absent() {
-        let base = vec![("work", Path::new("/w")), ("out", Path::new("/o"))];
-        let shares = qemu_shares_with_closure_seed(base.clone(), None);
-        assert_eq!(shares, base);
-    }
-
-    #[cfg(feature = "builder-vm")]
-    #[test]
-    fn qemu_shares_append_closure_seed_when_present() {
-        let base = vec![("work", Path::new("/w")), ("out", Path::new("/o"))];
-        let closure_dir = Path::new("/vm-state/closure-seed");
-        let shares = qemu_shares_with_closure_seed(base, Some(closure_dir));
-        assert_eq!(
-            shares,
-            vec![
-                ("work", Path::new("/w")),
-                ("out", Path::new("/o")),
-                (CLOSURE_SEED_TAG, closure_dir),
-            ]
-        );
+        assert!(attachment.cmdline.contains("mvm.runtime_data=/dev/vde"));
+        assert!(!attachment.cmdline.contains("mvm.runtime_data=/dev/vdc"));
+        assert!(attachment.cmdline.contains("mvm.builder_transport=disk"));
+        assert!(attachment.cmdline.contains("mvm.builder_input=/dev/vdc"));
+        assert!(attachment.cmdline.contains("mvm.builder_output=/dev/vdd"));
     }
 
     #[test]
@@ -1749,14 +1688,40 @@ mod vsock_module_tests {
         );
     }
 
-    #[cfg(feature = "builder-vm")]
+    /// The seeded closure reaches the guest at the same fixed path it always
+    /// did — `closure-seed/<CLOSURE_FILE>` — but on the input disk rather than
+    /// as its own share, so the QEMU builder needs no staging directory for it.
     #[test]
-    fn virtiofs_socket_path_stays_below_linux_unix_socket_limit() {
-        let path = qemu_virtiofs_socket_path("1781841830517-1343691", "work");
-        let rendered = path.to_string_lossy();
+    fn closure_nar_rides_the_input_disk_under_its_fixed_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let job = dir.path().join("job");
+        std::fs::create_dir_all(&job).unwrap();
+        std::fs::write(job.join("cmd.sh"), b"#!/bin/sh\n").unwrap();
+        let nar = dir.path().join("some-other-name.nar");
+        std::fs::write(&nar, b"nar-bytes").unwrap();
 
-        assert!(rendered.starts_with("/tmp/mvm-vfs-"), "{rendered}");
-        assert!(rendered.len() < 108, "{rendered}");
+        let image = dir.path().join("input.img");
+        crate::builder_disk_transport::pack_input_disk(
+            &[crate::builder_disk_transport::InputTree {
+                name: "job",
+                src: &job,
+            }],
+            Some(nar.as_path()),
+            &image,
+            0,
+        )
+        .unwrap();
+
+        let out = dir.path().join("extracted");
+        crate::builder_disk_transport::read_output_disk(&image, &out).unwrap();
+        assert_eq!(
+            std::fs::read(
+                out.join("closure-seed")
+                    .join(crate::builder_pack::CLOSURE_FILE)
+            )
+            .unwrap(),
+            b"nar-bytes"
+        );
     }
 
     #[cfg(feature = "builder-vm")]

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -294,8 +294,23 @@ pub(in crate::commands) struct RunArgs {
     /// Select a security profile.
     #[arg(long, value_enum, default_value = "standard")]
     pub profile: RunProfile,
-    /// Attach a read-only host directory (needs virtio-fs, repeatable).
-    #[arg(long = "mount", visible_alias = "volume", value_name = "HOST:GUEST:ro")]
+    // One flag, two shapes, dispatched by `parse_volume_spec`:
+    // `HOST:/GUEST[:ro]` materializes the directory into an ext4 image and
+    // attaches it as a block device — every backend serves it, and the image is
+    // a snapshot taken at boot, so host edits mid-run are not visible.
+    // `HOST:/GUEST:SIZE[:ro][:enc]` attaches a disk instead, which is what the
+    // `--volume` spelling reads naturally as. A transient run is read-only
+    // either way.
+    //
+    // Deliberately a plain comment, not a doc comment: clap derives `long_help`
+    // from doc comments and `machine_run_option_summaries_stay_short` caps that
+    // at 64 characters too, so the detail belongs in the CLI reference.
+    /// Attach a host directory snapshot or a sized disk image.
+    #[arg(
+        long = "mount",
+        visible_alias = "volume",
+        value_name = "HOST:GUEST[:ro|SIZE]"
+    )]
     pub mounts: Vec<String>,
     /// Not a flag: the libc of the image this run will boot, when it is known
     /// before the rootfs exists. A catalogued `--runtime` pins its image, so

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -378,9 +378,9 @@ shell).
 | `mvmctl run --profile standard -- <cmd>`             | Default profile on both `run` and `machine run`: explicit env is allowed; host shares must be read-only                                                                                                                            |
 | `mvmctl run --profile dev -- <cmd>`                  | Dev tier: as standard, plus a writable (`:rw`) host share on a persistent machine and the dev guest profile for a sealed-image entrypoint run                                                                                      |
 | `mvmctl run --profile restrictive -- <cmd>`          | No env injection and no host directory shares                                                                                                                                                                                      |
-| `mvmctl run --mount .:/work:ro -- <cmd>`             | Attach a live read-only host-directory share (needs a virtio-fs backend)                                                                                                                                                                                       |
+| `mvmctl run --mount .:/work:ro -- <cmd>`             | Attach a read-only host directory, materialized into an ext4 image at boot (a snapshot, not a live share)                                                                                                                                                                                       |
 | `mvmctl run --profile permissive -- <cmd>`           | Escape hatch; requires `MVM_ACK_PERMISSIVE_RUN=1`                                                                                                                                                                                  |
-| `mvmctl run --mount HOST:GUEST:ro -- <cmd>`          | Attach a live read-only host-directory share (needs a virtio-fs backend)                                                                                                                                                                                       |
+| `mvmctl run --mount HOST:GUEST:ro -- <cmd>`          | Attach a read-only host directory, materialized into an ext4 image at boot (a snapshot, not a live share)                                                                                                                                                                                       |
 | `mvmctl run --env KEY=VAL -- <cmd>`                  | Inject an explicit environment variable. Repeatable; disabled by `--profile restrictive`                                                                                                                                           |
 | `mvmctl run --cpus <n> --memory <size> -- <cmd>`     | Resize the transient VM                                                                                                                                                                                                            |
 | `mvmctl run --timeout <secs> -- <cmd>`               | Per-command timeout                                                                                                                                                                                                                |
@@ -945,7 +945,7 @@ host endpoint.
 ```bash
 mvmctl run -- uname -a                                # default image
 mvmctl run --manifest minimal -- /bin/true            # named template
-mvmctl run --mount .:/work:ro -- ls /work            # share current dir, RO (virtio-fs backends only)
+mvmctl run --mount .:/work:ro -- ls /work            # snapshot current dir into an image, RO
 mvmctl run -e DEBUG=1 -- env | grep DEBUG             # env var injection
 mvmctl run --launch-plan ./launch.json                # launch-plan entrypoint
 ```

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -68,9 +68,17 @@ Last updated: 2026-09-01
       dev-tier virtio-fs root is deleted end to end — the tier gate, the
       capability, the launch-config field, the driver bootargs arm, and the HVF
       device model's root channel including the `MVM_HVF_VIRTIOFS_ROOT` env hook
-      that bypassed the gate. Stage C (the builder VM's `work`/`job`/`out`/
-      `mvm-bins` shares) is unstarted and blocked on deciding how `out` returns
-      artifacts; Stage D (`xtask check-no-virtio-fs`) follows it.
+      that bypassed the gate. Stage D (`xtask check-no-virtio-fs`) landed early
+      as a ratchet rather than last. Stage C was never blocked on how `out`
+      returns artifacts — `builder_disk_transport` had already solved it as a
+      raw tar on a disk, needing no host-side ext4 reader — and its QEMU half
+      has landed: both one-shot QEMU builder sites carry job and artifacts over
+      that transport, with the `virtiofsd` spawn loops, the shared memory
+      backend and the `vhost-user-fs-pci` devices deleted. Widening the gate's
+      pattern to the `add_virtio_fs` spelling and the `virtiofsd` spawn side
+      took it from 23 pinned sites to 54. Remaining: the persistent HVF builder
+      (needs live Apple Silicon) and libkrun's seeded closure, which is still a
+      virtio-fs share the transport helper can now carry.
 
 - [ ] **Warm standby image claim repair — issue #3002.**
       `specs/plans/2026-08-28-warm-standby-image-claim.md`.

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -3,9 +3,11 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status: IN PROGRESS — Stages A, B and D landed. No workload tier reaches
-virtio-fs, and a ratchet gate keeps it that way. Stage C is down to one path:
-the persistent HVF builder, which needs live Apple Silicon validation.**
+**Status: IN PROGRESS — Stages A, B and D landed, and Stage C's QEMU builder
+with them. No workload tier reaches virtio-fs, and a ratchet gate keeps it that
+way. Stage C is down to two paths: the persistent HVF builder, which needs live
+Apple Silicon validation, and libkrun's seeded closure, which is two tokens once
+someone can run a live libkrun build.**
 
 No guest gets a virtio-fs device. Not a workload, not the builder VM, not the
 dev-tier root. The host filesystem reaches a guest as a block image or it does
@@ -177,8 +179,17 @@ zero padding, so a fixed-size disk carrying a shorter archive round-trips.
 disk and reads the output disk; `builder_spec` lays out four disks in vda–vdd
 order and asks for no shares). What is left is narrower than "the builder VM":
 
-- [x] `work`, `job`, `mvm-bins`, closure seed — inbound. Done for the one-shot
-      builder via the disk transport; `work` was already done on Stage 0.
+- [x] `work`, `job`, `mvm-bins` — inbound. Done for the one-shot builder via
+      the disk transport; `work` was already done on Stage 0.
+- [ ] **The closure seed is not done, and this box used to claim it was.** It is
+      the one inbound tree still on virtio-fs in the one-shot libkrun builder:
+      `libkrun_builder.rs` calls `closure_seed_share` +
+      `add_virtio_fs(CLOSURE_SEED_TAG, …)` at both transport sites, while
+      `prepare_builder_transport_disks` passed a hardcoded `None`. The helper now
+      takes a real `closure_nar` — the QEMU builder uses it — so flipping libkrun
+      is two tokens. Held back only because it changes the macOS default builder
+      and the QEMU work was validated on Linux/KVM; it needs its own live
+      libkrun run.
 **The guest is already most of the way there.** `mvm-host-vm-init` has a
 complete disk-transport mode, selected by `mvm.builder_transport=disk` with
 `mvm.builder_input=` / `mvm.builder_output=` naming the devices:
@@ -270,7 +281,33 @@ Five coordinated changes, host and guest:
       makes it separately validatable and removes version skew from the host
       flip. Flipping the host first against an old baked guest hangs the
       dispatch loop with no useful error.
-- [ ] **The QEMU builder needs the same migration, and the plan missed it.**
+- [x] **The QEMU builder needs the same migration, and the plan missed it.**
+      **Landed.** Both one-shot sites are on the disk transport; the `virtiofsd`
+      spawn loops, the `memory-backend-memfd` + `-numa` object and the
+      `vhost-user-fs-pci` loops are gone, along with `qemu_shares_with_closure_seed`
+      and `qemu_virtiofs_socket_path`. Three things the recipe below did not
+      predict, recorded because each would have cost a debugging session:
+
+      1. **The cmdline half is one delegate swap.**
+         `qemu_runtime_overlay_attachment` forwarded to
+         `builder_virtiofs_runtime_overlay_attachment`; pointing it at
+         `builder_runtime_overlay_attachment` emits `mvm.runtime_data=/dev/vde`
+         *and* all three transport tokens, because
+         `builder_runtime_overlay_cmdline` wraps `builder_disk_transport_cmdline`.
+         The vde move and the transport tokens are the same edit, not two.
+      2. **`work` has to go through `stage_filtered_work_input` first.** QEMU
+         shared `job.work_dir` / `mounts.flake_src` directly, which on a source
+         checkout is the repo root. A share tolerates that; a tar does not —
+         libkrun stages a filtered copy precisely because `target/` + `.git/` +
+         `.worktrees/` overflow the guest's RAM-capped extraction tmpfs.
+      3. **A test asserted the trap.** `qemu_runtime_overlay_keeps_virtiofs_transport`
+         asserted `mvm.runtime_data=/dev/vdc` and the *absence* of the transport
+         tokens — it would have stayed green while the guest mounted the input
+         tar as its runtime overlay. Now
+         `qemu_runtime_overlay_rides_the_disk_transport_at_vde`, asserting the
+         vde token and the absence of the vdc one.
+
+      Original entry, for the record:
       `qemu_builder.rs` serves `work` / `out` / `job` / `mvm-bins` over
       vhost-user/virtiofsd — not the disk transport — and QEMU is the *Linux
       auto-detect default builder*. So this is not the "opt-in dev/test backend
@@ -305,12 +342,29 @@ Five coordinated changes, host and guest:
       from `qemu_runtime_overlay_attachment` to match. The identity drive is
       found by ext4 label, not slot, so it is unaffected.
 
-      **One open question**: QEMU carries `closure_share_dir`, a *directory*
-      share. The disk transport's closure support takes a NAR *file*
-      (`pack_input_disk`'s `closure_nar`, archived at
-      `closure-seed/<CLOSURE_FILE>`). libkrun passes `None` there, so the
-      existing helper has no closure path to copy. Resolve how
-      `closure_share_dir` is built before assuming it maps straight across.
+      **The open closure-seed question, answered: it maps straight across, with
+      a step removed rather than added.** `closure_share_dir` is not a share of
+      anything durable. `stage_closure_seed_dir` copies a single file into
+      `<vm_state_dir>/closure-seed/<CLOSURE_FILE>` and returns the wrapper
+      directory; the wrapper exists only because virtio-fs shares directories
+      and not files, which its own doc comment says. The source is already a
+      file — `builder_pack::closure_nar_path(cache/<arch>)`, which QEMU computed
+      *before* staging — and that is exactly what `pack_input_disk`'s
+      `closure_nar` takes, archiving it at the same fixed
+      `closure-seed/<CLOSURE_FILE>`. So the QEMU path passes the NAR straight to
+      the transport and drops both `stage_closure_seed_dir` and
+      `qemu_shares_with_closure_seed`.
+
+      **The premise above was wrong, and the wrong part matters more than the
+      question.** libkrun does not pass `None` because it has no closure:
+      `builder_backend_select.rs` gives every libkrun builder
+      `with_closure_nar(closure_nar_for_host_arch())`.
+      `prepare_builder_transport_disks` hardcoded `None` because the closure was
+      **left on virtio-fs** — the one-shot transport paths still call
+      `closure_seed_share` and `add_virtio_fs(CLOSURE_SEED_TAG, …)` alongside
+      their transport disks. The helper now takes a real `closure_nar` and
+      libkrun's two sites pass `None` explicitly, with a comment saying why.
+      See the corrected checkbox at the top of this stage.
 
 - [ ] The QEMU **workload** driver's share arm is a different matter and *is*
       free: workload specs carry `shares: Vec::new()` unconditionally since
@@ -336,7 +390,20 @@ exactly as long as it took to finish — and the finishing is the slow part.
       originally described would have fired on ~70 files that merely discuss
       virtio-fs, and could have been satisfied by rewording a comment instead of
       deleting code.
-- [x] Pinned at **23 sites across 11 files**, each row carrying why it survives
+- [x] **The first pattern was blind to two spellings, and the QEMU builder
+      migration lowered no count because of it.** The libkrun C symbol is
+      `krun_add_virtiofs`, but the safe wrapper is `add_virtio_fs` — with an
+      underscore — so a pattern written for the C name walked past all 21 Rust
+      call sites in `context.rs`, `libkrun_builder.rs` and `libkrun_process.rs`.
+      Worse, the QEMU *builder* attached its shares through neither: it spawned
+      `virtiofsd` and passed a `vhost-user-fs-pci` device, so `qemu_builder.rs`
+      was not in the table at all and deleting ~60 lines of its wiring moved
+      nothing. The device name is a string literal, which
+      `blank_comments_and_strings` blanks before matching, so the spawn side is
+      caught by `VirtiofsdGuard` / `locate_virtiofsd` instead. Widening took the
+      gate from 23 sites across 11 files to **54 across 15** — 31 attach sites
+      it could not see, including every one this stage is removing.
+- [x] Pinned at **54 sites across 15 files**, each row carrying why it survives
       and what retires it. The count must match exactly: a new site fails as
       growth, and a *removed* one fails as a stale pin, so the table can only
       shrink and cannot drift into a ceiling nobody maintains. Four rows from

--- a/specs/sprint/delivery/qemu-builder-disk-transport.md
+++ b/specs/sprint/delivery/qemu-builder-disk-transport.md
@@ -1,0 +1,94 @@
+# QEMU builder on the disk transport
+
+Stage C of `specs/plans/2026-08-31-remove-virtio-fs.md`, QEMU half. Both
+one-shot QEMU builder sites (`run_shell_script_qemu`, `run_build_qemu`) now move
+their job in and their artifacts out over the raw-tar-on-a-disk transport the
+libkrun and HVF one-shot builders already use, instead of four
+vhost-user/virtiofsd shares.
+
+## Why this one first
+
+QEMU is the Linux auto-detect default builder, so this is not the "opt-in
+dev/test backend we can delete the feature from" the plan originally filed it
+as — deleting its shares without a replacement breaks every Linux build. It is
+also the half that is separately validatable, on the Linux/KVM box, which the
+persistent HVF builder is not.
+
+## What moved
+
+- `prepare_builder_transport_disks` / `extract_builder_transport_output` are
+  `pub(crate)`, and the former takes a real `closure_nar: Option<&Path>` rather
+  than a hardcoded `None`.
+- `qemu_runtime_overlay_attachment` delegates to
+  `builder_runtime_overlay_attachment` instead of the `virtiofs` flavour.
+- Both sites pack `[job, work, mvm-bins]` plus the seeded closure NAR onto the
+  input disk and extract the output disk after QEMU exits.
+- Drives are attached vda rootfs / vdb nix-store / vdc input / vdd output /
+  vde overlay, extra disks, identity last.
+- Deleted: two `virtiofsd` spawn loops, two `memory-backend-memfd` + `-numa`
+  objects, two `vhost-user-fs-pci` device loops,
+  `qemu_shares_with_closure_seed`, `qemu_virtiofs_socket_path`.
+
+No guest change and no builder-image rebuild: `mvm-host-vm-init`'s
+disk-transport mode is what libkrun's one-shot builder already boots, so QEMU
+inherits it. That is also the first thing to confirm on a live run.
+
+## Four things worth keeping
+
+**The closure seed maps across with a step removed.** `stage_closure_seed_dir`
+copies one file into `<vm_state_dir>/closure-seed/<CLOSURE_FILE>` and returns
+the wrapper directory; the wrapper exists only because virtio-fs shares
+directories and not files. The source is already a file, and
+`pack_input_disk`'s `closure_nar` archives it at the same fixed name. The plan's
+stated reason for the open question — "libkrun passes `None` there, so the
+helper has no closure path to copy" — was wrong: libkrun has a closure and left
+it on virtio-fs. That makes the plan's `[x]` on "closure seed — done for the
+one-shot builder" false, and it is now corrected to an open box.
+
+**The overlay device and the transport tokens are one decision.**
+`builder_runtime_overlay_cmdline` wraps `builder_disk_transport_cmdline`, so
+swapping the delegate emits `mvm.runtime_data=/dev/vde` *and*
+`mvm.builder_transport=disk` + the input/output device tokens together. Treating
+them as two edits is how you end up with a guest mounting the input tar as its
+runtime overlay.
+
+**`work` needed filtered staging that the recipe did not mention.** QEMU shared
+`job.work_dir` / `mounts.flake_src` directly, which on a source checkout is the
+repo root. A share tolerates that; a tar does not — `stage_filtered_work_input`
+exists because `target/` + `.git/` + `.worktrees/` overflow the guest's
+RAM-capped extraction tmpfs.
+
+**The ratchet gate could not see any of this.** `check-no-virtio-fs`'s pattern
+matched the libkrun C symbol `krun_add_virtiofs` but not the safe wrapper
+`add_virtio_fs` — underscore — missing 21 Rust call sites. And the QEMU builder
+attached shares through neither, spawning `virtiofsd` and passing a
+`vhost-user-fs-pci` device, so `qemu_builder.rs` was never in the pinned table
+and this deletion lowered no count. The device name is a string literal, which
+the checker blanks before matching, so the spawn side is now caught by
+`VirtiofsdGuard` / `locate_virtiofsd`. The gate went from 23 sites across 11
+files to 54 across 15.
+
+## Also in this change
+
+`--mount`'s user-facing text was wrong in four places since Stage A: `exec.rs`,
+`README.md`, and two rows plus an example in the CLI reference all said it needs
+a virtio-fs backend and serves a *live* share. Neither is true — the directory
+is materialized into an ext4 image and attached as a block device, which every
+backend serves, and the image is a snapshot taken at boot. The README went
+further and told users Firecracker "refuses before boot", which stopped being
+true when materialization landed.
+
+`--volume` stays. It reads as a redundant alias of `--mount`, but the flag takes
+two shapes through `parse_volume_spec` — `host:/guest[:ro]` for a directory and
+`host:/guest:SIZE[:ro][:enc]` for a disk — and `--volume` is the natural
+spelling for the second. Removing it would leave `--mount …:4G` as the only way
+to say it.
+
+## Validation
+
+Gates green on macOS: `just check-gated`, the workspace suite, doctests,
+`clippy --workspace --all-targets -D warnings`, `xtask check-all`.
+
+The behaviour itself is not CI-testable — no hosted runner boots a guest — so it
+requires a live `mvmctl build --builder qemu` on the Linux/KVM box before merge.
+Record the result here rather than assuming it.

--- a/specs/sprint/delivery/qemu-builder-disk-transport.md
+++ b/specs/sprint/delivery/qemu-builder-disk-transport.md
@@ -90,5 +90,33 @@ Gates green on macOS: `just check-gated`, the workspace suite, doctests,
 `clippy --workspace --all-targets -D warnings`, `xtask check-all`.
 
 The behaviour itself is not CI-testable — no hosted runner boots a guest — so it
-requires a live `mvmctl build --builder qemu` on the Linux/KVM box before merge.
-Record the result here rather than assuming it.
+was validated with a live `mvmctl machine build --builder qemu` on the
+Linux/KVM box, from a cold `MVM_HOME` so Stage 0 built the builder image too.
+It completed:
+
+    [mvm] Step 2/2: Build complete
+    [mvm]   Slot:     032e844447f7d53080ec7f9f8c32fe9184498db09ba2a61ddb0564cce891242a
+
+A green build is not on its own proof that the new path ran, so four things were
+checked directly rather than inferred:
+
+- The guest booted with all four tokens — `mvm.builder_transport=disk`,
+  `mvm.builder_input=/dev/vdc`, `mvm.builder_output=/dev/vdd` and
+  `mvm.runtime_data=/dev/vde` — confirming the delegate swap emits the vde move
+  and the transport tokens together.
+- The guest enumerated the devices in the intended order: `vdc` 613 MB (the
+  input tar), `vdd` 8.00 GiB (the output disk), `vde` 10.7 MiB mounted `ro`
+  (the runtime overlay). Had the order been wrong, `vde` would have carried the
+  input tar rather than an ext4 the guest could mount.
+- `virtiofsd`, `vhost-user-fs` and `memory-backend-memfd` appear **zero** times
+  in the run log.
+- The input disk is 613 MB, not tens of GB, so `stage_filtered_work_input`
+  pruned `target/`, `.git/` and `.worktrees/` as intended — the failure mode
+  this migration was most exposed to.
+
+Reproducing it needs two things that are easy to lose an hour to. The bootstrap
+helper must be pinned with `MVM_BUILDER_VM_BOOTSTRAP_BIN` at a binary built
+`--features embed-host-bins`, because the helper mvmctl builds for itself
+carries no embedded host binaries and cannot bootstrap (issue #3067). And the
+process needs `/usr/sbin` on `PATH`, or Stage 0 reports `mkfs.ext4` missing when
+it is installed.

--- a/xtask/src/check_no_virtio_fs.rs
+++ b/xtask/src/check_no_virtio_fs.rs
@@ -28,7 +28,15 @@ use crate::rust_source::blank_comments_and_strings;
 
 /// Sites that attach a virtio-fs device to a guest, or build the share value
 /// that becomes one. Deliberately narrow — see the module comment.
-const ATTACH_PATTERN: &str = r"add_virtiofs[0-9]?\(|VirtioFs::(new|with_tag)|VirtioFsShare\s*\{|HvfVirtioFsShare\s*\{|krun_add_virtiofs";
+/// Two spellings are easy to miss and were both missed at first. The libkrun
+/// C symbol is `krun_add_virtiofs`, but the safe wrapper around it is
+/// `add_virtio_fs` — with an underscore — so a pattern written for the C name
+/// walks straight past every Rust call site. And the QEMU builder attaches its
+/// shares through neither: it spawns `virtiofsd` and passes a
+/// `vhost-user-fs-pci` device, which is a process and a string, not a method.
+/// `blank_comments_and_strings` blanks the device string before matching, so
+/// the spawn side has to be caught by its host-side types instead.
+const ATTACH_PATTERN: &str = r"add_virtiofs[0-9]?\(|add_virtio_fs(_full)?\(|VirtioFs::(new|with_tag)|VirtioFsShare\s*\{|HvfVirtioFsShare\s*\{|krun_add_virtiofs|VirtiofsdGuard|locate_virtiofsd";
 
 /// The pinned surface: `(path, count, why it is still here)`.
 ///
@@ -48,6 +56,19 @@ const PINNED: &[(&str, usize, &str)] = &[
         "crates/deps/libkrun-sys/src/start.rs",
         3,
         "maps SupervisorConfig mounts onto the libkrun C API for the builder VM",
+    ),
+    (
+        "crates/deps/libkrun-sys/src/context.rs",
+        7,
+        "the safe `add_virtio_fs` wrapper over the C symbol above, plus its tests",
+    ),
+    // ── the host-side virtiofsd daemon ──────────────────────────────────────
+    (
+        "crates/mvm-vmm/src/host/virtiofsd.rs",
+        4,
+        "the virtiofsd spawn/supervise module itself. Its last consumer is the \
+         QEMU *workload* driver below; the QEMU builder no longer uses it. \
+         Retired with that driver's share arm, which is already unreachable",
     ),
     // ── builder VM: the trusted tier, still exchanging files as shares ───────
     (
@@ -75,15 +96,30 @@ const PINNED: &[(&str, usize, &str)] = &[
     ),
     (
         "crates/mvm-backends/src/driver/libkrun.rs",
-        5,
+        6,
         "one mapper plus tests asserting a workload spec carries no shares",
     ),
     (
+        "crates/mvm-backends/src/driver/libkrun_process.rs",
+        1,
+        "the out-of-process libkrun driver's share mapper, same seam as above",
+    ),
+    (
         "crates/mvm-backends/src/driver/qemu.rs",
-        2,
-        "QEMU's vhost-user/virtiofsd wiring. Opt-in dev/test only — auto_select \
-         never returns it and it carries no untrusted workload, so this is the \
-         one backend where deleting the feature outright is defensible",
+        7,
+        "QEMU's vhost-user/virtiofsd wiring for *workloads*. Opt-in dev/test \
+         only — auto_select never returns it, and workload specs have carried \
+         `shares: Vec::new()` since Stage A, so this arm is already \
+         unreachable and can be deleted outright rather than migrated",
+    ),
+    // ── builder VM: our own trusted build engine ────────────────────────────
+    (
+        "crates/mvm-build/src/libkrun_builder.rs",
+        13,
+        "the libkrun builder's work/out/job/mvm-bins shares on the paths that \
+         predate the disk transport, plus the seeded-closure share the \
+         one-shot transport paths still attach. Retired by passing the NAR to \
+         `prepare_builder_transport_disks`, which now takes it",
     ),
     (
         "crates/mvm-backends/src/driver/fc.rs",


### PR DESCRIPTION
Stage C of `specs/plans/2026-08-31-remove-virtio-fs.md`, QEMU half. Both one-shot QEMU builder sites now move the job in and the artifacts out over the raw-tar-on-a-disk transport the libkrun and HVF one-shot builders already use, instead of four vhost-user/virtiofsd shares.

QEMU is the Linux auto-detect default builder, so its shares could not simply be deleted the way the QEMU *workload* driver's can — deleting them without a replacement breaks every Linux build.

## What moved

- `prepare_builder_transport_disks` / `extract_builder_transport_output` are `pub(crate)`, and the former takes a real `closure_nar: Option<&Path>` rather than a hardcoded `None`.
- `qemu_runtime_overlay_attachment` delegates to `builder_runtime_overlay_attachment` instead of the `virtiofs` flavour.
- Both sites pack `[job, work, mvm-bins]` plus the seeded closure NAR onto the input disk, and extract the output disk after QEMU exits.
- Drives: vda rootfs, vdb nix-store, vdc input, vdd output, vde overlay, extra disks, identity last.
- Deleted: two virtiofsd spawn loops, two `memory-backend-memfd` + `-numa` objects, two `vhost-user-fs-pci` device loops, `qemu_shares_with_closure_seed`, `qemu_virtiofs_socket_path`.

No guest change and no builder-image rebuild: `mvm-host-vm-init`'s disk-transport mode is what libkrun's one-shot builder already boots, so QEMU inherits it.

## The closure-seed question, answered

The plan held Stage C on it. It resolves with a step *removed*: `stage_closure_seed_dir` copies one file into `<vm_state_dir>/closure-seed/<CLOSURE_FILE>` and returns the wrapper directory, and that wrapper exists only because virtio-fs shares directories and not files. The source is already a file, and `pack_input_disk`'s `closure_nar` archives it at the same fixed name.

The plan's stated reason was wrong in a way worth recording: *"libkrun passes `None` there, so the helper has no closure path to copy."* libkrun has a closure — `builder_backend_select.rs` gives every libkrun builder `with_closure_nar(...)` — and left it on virtio-fs, attaching it via `closure_seed_share` alongside its transport disks. That makes the plan's `[x]` on "closure seed — done for the one-shot builder" false; it is now an open box with the evidence.

## Three things the recipe did not predict

1. **The cmdline half is one delegate swap.** `builder_runtime_overlay_cmdline` wraps `builder_disk_transport_cmdline`, so the swap emits `mvm.runtime_data=/dev/vde` *and* the three transport tokens together. The vde move and the transport tokens are one edit, not two.
2. **`work` needs `stage_filtered_work_input`.** QEMU shared `job.work_dir` / `mounts.flake_src` directly, which on a source checkout is the repo root. A share tolerates that; a tar does not — `target/` + `.git/` + `.worktrees/` overflow the guest's RAM-capped extraction tmpfs.
3. **A test asserted the trap.** `qemu_runtime_overlay_keeps_virtiofs_transport` asserted `mvm.runtime_data=/dev/vdc` and the *absence* of the transport tokens — green while the guest mounted the input tar as its runtime overlay. Now `qemu_runtime_overlay_rides_the_disk_transport_at_vde`.

## The ratchet gate could not see any of this

Running the pre-existing `check-no-virtio-fs` against this branch reported `clean (23 sites across 11 files)` — the ~60-line deletion moved no count. Two blind spots:

- The libkrun C symbol is `krun_add_virtiofs`, but the safe wrapper is `add_virtio_fs` — with an underscore — so the pattern walked past 21 Rust call sites.
- The QEMU builder attached shares through neither, spawning `virtiofsd` and passing a `vhost-user-fs-pci` device, so `qemu_builder.rs` was never in the pinned table. The device name is a string literal that `blank_comments_and_strings` blanks before matching, so the spawn side is caught by `VirtiofsdGuard` / `locate_virtiofsd` instead.

Widened: **23 sites across 11 files → 54 across 15.**

## Also here: `--mount`'s user-facing text

Wrong in four places since the Stage A materialization landed — `exec.rs`, `README.md`, and two rows plus an example in the CLI reference. It needs no virtio-fs backend, every backend serves it, and it is a snapshot taken at boot rather than a live share. The README additionally told users Firecracker "refuses before boot", which stopped being true when materialization landed.

`--volume` stays. It reads as a redundant alias, but `parse_volume_spec` takes two shapes — `host:/guest[:ro]` for a directory and `host:/guest:SIZE[:ro][:enc]` for a disk — and `--volume` is the natural spelling for the second.

## Verification

`cargo fmt --all --check`, `just check-gated`, `cargo clippy --workspace --all-targets -D warnings`, `cargo nextest run --workspace` (12,858 passed), `cargo test --workspace --doc`, `cargo run -p xtask -- check-all` (63 gates) — all clean.

Live `mvmctl machine build --builder qemu` on the Linux/KVM box is in progress; this PR should not merge until it reports.

## Filed separately, not fixed here

`builder_vm_bootstrap_helper_build_command` builds the bootstrap helper with `["build", "-q", "--bin", "mvmctl"]` — no `--features embed-host-bins` — so on a cold builder-image cache the helper is structurally unable to do the job it is spawned for, refusing at `host_binaries::extract`. This is on `main` verbatim (`libkrun_builder.rs:2593`) with a test pinning the argument list, and is unrelated to the disk transport.
