### PR TITLE
docs(status): file the sidecar libc selection as landed

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -10,18 +10,6 @@ Last updated: 2026-09-01
       reads preserve retryable I/O sources. Focused regressions are green;
       broad validation and merge delivery remain.
 
-- [ ] **SDK sidecar selection from the image's own libc — issue #2969.**
-      `specs/sprint/delivery/sdk-sidecar-image-libc-selection.md`.
-      Closes the half #3044 named as remaining: the variant is chosen from the
-      libc the image recorded at materialization rather than from a catalogued
-      runtime's declaration, so an arbitrary `--image` selects correctly instead
-      of being refused as unknown. One resolution still feeds both the plan
-      grant and the attached volume, now through `AdmitInputs`. The declaration
-      keeps a job as a cross-check against the observed value, and the resolver
-      proves a cached artifact's libc from its own `DT_NEEDED` rather than from
-      the path it was filed under. Workspace tests, gated targets, Clippy and
-      the live `host.kv.v1` witness are green; merge delivery remains.
-
 - [ ] **Warm claim authenticated readiness — issue #3039.**
       `specs/plans/2026-08-31-warm-claim-authenticated-readiness.md`.
       A restored child advances only after an authenticated Ping proves its
@@ -260,6 +248,19 @@ Last updated: 2026-09-01
       delivery remains.
 
 ## Completed
+
+- [x] **SDK sidecar selection from the image's own libc — issue #2969, PR #3060.**
+      `specs/sprint/delivery/sdk-sidecar-image-libc-selection.md`.
+      Closes the half #3044 named as remaining: the variant is chosen from the
+      libc the image recorded at materialization rather than from a catalogued
+      runtime's declaration, so an arbitrary `--image` selects correctly instead
+      of being refused as unknown. One resolution still feeds both the plan
+      grant and the attached volume, now through `AdmitInputs`. The declaration
+      keeps a job as a cross-check against the observed value, and the resolver
+      proves a cached artifact's libc from its own `DT_NEEDED` rather than from
+      the path it was filed under. Workspace tests, gated targets, Clippy and
+      the live `host.kv.v1` witness were green before merge. Landed on main as
+      `e79b366c98`.
 
 - [x] **Kernel cache moved out of the Stage 0 blast radius — PR #3038.**
       `specs/sprint/delivery/kernel-cache-outside-stage0-blast-radius.md`.


### PR DESCRIPTION
#3060 merged as `e79b366c98`. Its `REFACTOR-STATUS.md` entry still sat under **In progress** ending "merge delivery remains", which is no longer true.

Moves it to **Completed**, ticked and carrying the PR number, matching the neighbouring entries. Moved rather than copied — leaving the original in place is how this file accumulates duplicate entries across a rebase.

Docs only; no code change.