### PR TITLE
feat(xtask): gate prose that asserts absence, and commit agent findings

### DIFF
--- a/.agent-memory/README.md
+++ b/.agent-memory/README.md
@@ -1,0 +1,66 @@
+# `.agent-memory` — committed findings
+
+Cross-session memory for the agents and humans working on mvm, kept as plain
+markdown with YAML frontmatter, in the repository, under version control — so a
+finding is **shared with contributors, visible in a PR diff, and present in a
+fresh clone**.
+
+The alternative is what we had: findings in a per-user, per-machine agent
+memory. Invisible in review, absent from a clone, unavailable to a human, and
+gone the moment someone else picks up the work. The expensive ones get
+re-derived. `stop_pid_disappearance` scaling with guest RAM was measured, the
+obvious fix attempted, A/B'd across two guest sizes, and reverted on
+2026-08-30; nothing in the tree recorded that, so nothing stopped it being
+attempted again.
+
+**No database, no embeddings, no service.** Recall is lexical — `rg` over a few
+hundred terse, keyword-dense engineering notes full of function names, env
+flags and commit SHAs. A substring match is faster, has no dependencies, and is
+the right tool at this size. Embeddings earn their cost on large,
+paraphrase-heavy corpora; if this one ever becomes that, the upgrade path is a
+semantic re-rank over the same markdown, which is a later decision and not a
+day-one dependency.
+
+## Layout
+
+- `notes/<slug>.md` — one finding per file. Frontmatter: `title`, `date`,
+  `tags`, optionally `superseded_by: <slug>`.
+- Link related notes with `[[slug]]`. The link must name a note that exists —
+  `xtask check-agent-notes` enforces it.
+
+## Use
+
+```sh
+just recall teardown ram          # ripgrep-ranked recall
+just notes                        # list every note, newest first
+just remember <slug>              # scaffold a new note
+```
+
+## Conventions
+
+- **Project findings go here.** Machine-specific context — host names, fleet
+  layout, ssh targets, local paths — stays in your own global agent memory. It
+  confuses contributors and it is not a finding.
+- **One finding per note, and keep it terse.** Detail goes in the body, not in
+  a long title.
+- **Record _why_ it failed, not that it did.** "The guest memory is released
+  before the supervisor clears its marker, so both strategies wait for the same
+  thing" beats "the marker fix didn't help". The falsifications are the
+  valuable notes: they narrow the search space, and unlike the successes they
+  are nowhere in the diff.
+- **Say what not to retry.** A note that names the refuted causes explicitly is
+  what stops the next session spending a day on them.
+- **Commit the note with the change it explains.** A note plus its code change
+  in one commit is a decision log nobody has to maintain separately.
+- **Supersede rather than delete.** A finding that stops being true gets
+  `superseded_by`; the record of having believed it is itself useful.
+- **Recall before answering.** A note you did not read is a note that did not
+  exist.
+
+## Not a specification
+
+These are observations bound to a date and a measurement. They are not
+authority: `specs/adrs/` owns decisions, `specs/plans/` owns intent, and the
+claims ledger in `specs/adrs/001-microvm-security-posture.md` owns what is
+enforced. A note that contradicts one of those is either stale or a bug report,
+and either way the owner wins.

--- a/.agent-memory/notes/a-citation-can-resolve-to-its-own-test-fixture.md
+++ b/.agent-memory/notes/a-citation-can-resolve-to-its-own-test-fixture.md
@@ -1,0 +1,37 @@
+---
+title: A witness citation resolved because the gate's own test mentioned the name
+date: 2026-09-01
+tags: [gates, docs-drift, xtask, falsification]
+---
+
+`check-witness-citations` decided whether a cited identifier exists by
+substring-matching the raw text of every `.rs` file under `crates/`, `xtask/`
+and `src/`. Raw text includes string literals, and a gate's test fixtures are
+string literals.
+
+`CLAUDE.md` names `audit_chain_carries_no_payload_bytes` in a paragraph whose
+whole point is that the name was never written. It was backticked, so the
+citation gate required it to resolve — and it did, because its only two
+occurrences anywhere in the tree were inside `check-witness-citations`' own
+tests, as literals asserting that the name has the shape the gate inspects. The
+gate was reading its own fixture back as evidence.
+
+Nothing was wrong with the ledger, and nothing went red. The gate reported
+`clean` for a citation that pointed at nothing.
+
+## What changed
+
+The Rust haystack now goes through `blank_comments_and_strings` before
+matching, so a citation resolves to **code** and not to a comment or a literal.
+Each file's path is appended to the haystack as well, so a token naming a file
+resolves against the tree rather than against whatever the file contains.
+
+## What to take from it
+
+A gate whose corpus includes its own fixtures can be fed its own answer. When a
+text gate matches over source, decide explicitly whether comments and literals
+are part of the evidence — for an existence claim they are not.
+
+Same shape as [[legacy-keyword-mostly-mislabels-live-code]]: the artifact
+looked like it denoted something real, and checking what actually backed it was
+the whole finding.

--- a/.agent-memory/notes/admit-outliers-are-cold-initramfs-acquisition.md
+++ b/.agent-memory/notes/admit-outliers-are-cold-initramfs-acquisition.md
@@ -1,0 +1,31 @@
+---
+title: Multi-second admit outliers are a cold initramfs fetch inside the admit window, not the audit chain
+date: 2026-08-30
+tags: [perf, admit, initramfs, cache, falsification]
+---
+
+A `machine run` reporting an `admit` phase of 74s / 138s / 144s / 72s against a
+~25ms steady state is `attach_universal_initramfs_if_cached` acquiring the
+universal initramfs on a cold cache — inside the admit window, emitting nothing
+while it does. Measured 2026-08-30: `admit_plan=64.0ms attach_overlay=0.9ms
+attach_initramfs=72350.7ms`. Warm, that span is 0.2-1.8ms.
+
+The cache goes cold after a build that changes the embedded host binaries the
+initramfs packages, and after a kernel pin bump wipes
+`~/.mvm/cache/builder-vm/<arch>/kernels/`. That is where the misleading "it is
+always the first run after a build" pattern comes from — the trigger is the
+build, but the cost is the fetch.
+
+## Refuted — do not re-test these
+
+- **`F_FULLFSYNC` stalls.** 4-6ms idle, 3-8ms under six concurrent 900MB
+  writers. Two to four orders of magnitude too small.
+- **Audit leaf-cache miss / segment rotation.** ~100ms. Real, and there is a
+  separate genuine admit cost in chain re-verification — do not conflate the
+  two; neither is seconds.
+- **macOS validating a freshly written binary on first exec.** 0.83s vs 0.11s
+  warm. Real, and 166x too small to explain a 72s span.
+
+`MVM_PHASE_TIMING=1` names these spans. Before that they existed only at
+`tracing::debug`, so catching an outlier meant having `RUST_LOG=debug` attached
+in advance — which is why this took as long to find as it did.

--- a/.agent-memory/notes/legacy-keyword-mostly-mislabels-live-code.md
+++ b/.agent-memory/notes/legacy-keyword-mostly-mislabels-live-code.md
@@ -1,0 +1,39 @@
+---
+title: A "legacy" grep is a claim to verify, not a finding — four of six families were live code with a wrong comment
+date: 2026-08-27
+tags: [refactor, dead-code, docs-drift, falsification]
+---
+
+A full "remove all legacy" sweep on 2026-08-27 found six families. **Two were
+real.**
+
+Real:
+
+- `RuntimeSourcePolicy` — staged-rollout scaffolding whose own doc said it
+  changed "no backend behavior yet", with `RootfsOnly` as `#[default]`. It
+  caused the launch failure that started the sweep.
+- The per-rootfs verity initramfs — genuinely superseded by the universal one.
+
+Mislabelled — live code carrying a wrong comment:
+
+- `BuilderRoute::LegacyShell` — its only generic-dispatch site called
+  `resolve_route(false, ..)` with `daemon_reachable` a hardcoded literal, so the
+  "decision" had exactly one reachable answer. The shell-job channel it names is
+  still the **only** channel for a generic builder job.
+- `driver/{hvf,libkrun,qemu}_legacy.rs` — 55 live references, and `qemu.rs`
+  calls `qemu_legacy::locate_qemu()` on every boot. Renamed to `*_process`.
+- Six of ten "back-compat shims" were `#[serde(default)]` on new optional
+  fields — the pattern CLAUDE.md **mandates**. Removing them would have added
+  exactly the ceremony that rule exists to prevent.
+- `template_list_legacy_names` claimed to power a migration banner and a
+  `template list --legacy` flag. Neither exists anywhere in the CLI.
+
+## How to apply
+
+Treat a `legacy` / `back-compat` hit as a claim to verify: does the code have a
+live caller, and does the comment match what it does? Where the code is fine,
+**fix the comment and say why** — otherwise the next sweep re-flags it.
+Deleting working code to satisfy a keyword search is the failure mode here.
+
+Same shape as [[a-citation-can-resolve-to-its-own-test-fixture]]: prose
+describing something that nothing implements.

--- a/.agent-memory/notes/prepared-cold-budget-covers-the-dispatch-window-only.md
+++ b/.agent-memory/notes/prepared-cold-budget-covers-the-dispatch-window-only.md
@@ -1,0 +1,32 @@
+---
+title: The prepared_cold 200ms budget covers backend_start + vsock_wait only — admit, teardown and command are all out of scope
+date: 2026-08-26
+tags: [perf, launch-budget, benchmarks, scope]
+---
+
+`RunPhaseTimings::dispatch_window_ms()`
+(`crates/mvm-cli/src/commands/vm/phase_timing.rs`) is
+**`backend_start_ms + vsock_wait_ms`, nothing else**. That is the entire
+quantity `LaunchLane::PreparedCold` budgets: p50 200ms / p95 250ms / p99 300ms,
+plus `PREPARED_COLD_HARD_MAX_MS`, which requires every single boot to come in
+strictly under 200ms.
+
+**Out of scope entirely:** `admit_ms`, `warm_window_ms`, `command_ms`,
+`teardown_ms`, `resolve_ms`, `drives_ms`. The doc comment reads
+"admitted-plan to command-dispatch", and the window *starts after* admission —
+so a 346ms `admit_ms` does not fail the lane, and neither does a 12.7s
+`teardown_ms`.
+
+Read a sample with that in mind: `warm_window_ms` is approximately
+`backend_start_ms + vsock_wait_ms`, so warm_window is effectively the dispatch
+window under another name.
+
+Separately from the budget, a lane refuses a sample outright when
+`work.performed()` includes any of `image_pull`, `image_build`,
+`mount_materialize`, `warm_claim`, `artifact_hash`, `process_table_scan`. That
+is a **validity** gate, not a budget: a launch can be comfortably under 200ms
+and still produce no number at all, which reads like a missing measurement
+rather than a rejected one.
+
+The practical consequence is that "prepared_cold is green" is a much narrower
+statement than "launch is fast", and quoting it as the latter overstates it.

--- a/.agent-memory/notes/teardown-scales-with-guest-ram.md
+++ b/.agent-memory/notes/teardown-scales-with-guest-ram.md
@@ -1,0 +1,34 @@
+---
+title: Teardown is guest RAM reclamation at ~50ms/GB, and the PID-marker fix does not help
+date: 2026-08-30
+tags: [perf, teardown, hvf, supervisor, falsification]
+---
+
+`stop_pid_disappearance` scales linearly with guest RAM: 26ms at 256MiB, 34-40ms
+at 512MiB, 96-106ms at 2GiB, 204-213ms at 4GiB — roughly **50ms per GB**. That
+is the kernel reclaiming the guest's address space, not the supervisor doing
+work.
+
+The HVF supervisor writes its own shutdown record to
+`<vm_state_dir>/shutdown-timing.json` (read it by racing the transient reaper).
+It totals **~889µs at every guest size**: `watchdog_to_vcpu_exit=91µs`,
+`watchdog_join=2µs`, `io_thread_join=19µs`, `vcpu_destroy=15µs`,
+`vm_destroy=321µs`, `console_write=441µs`. The supervisor is not the cost and
+making it faster cannot help.
+
+## Do not retry the obvious fix
+
+Ending the host's wait on the supervisor's PID-file marker instead of on process
+exit buys nothing. A/B on one binary, both strategies, same guest size:
+
+| guest | marker | process |
+|---|---|---|
+| 512MiB | 168-177ms | 178-204ms |
+| 2048MiB | 402-479ms | 391-472ms |
+
+The guest memory is released *before* the supervisor clears its marker, so both
+strategies wait for the same thing. Attempted and reverted 2026-08-30.
+
+A real fix has to move the marker removal ahead of the guest-memory drop
+*inside* the supervisor, which changes its shutdown ordering and its durability
+guarantees. That is a design change, not a tuning change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,26 @@ prose below is the narrative and the table is the ledger — and when the
 two disagree, **the table is right**: it is gated and the prose is not.
 Do not name a test here without checking it exists (`rg 'fn <name>'`);
 several of the names below were fabricated and survived for months
-precisely because nothing checks this file.
+precisely because nothing checks this file. `check-witness-citations`
+checks it now — a backticked symbol in this file must appear in code,
+and a comment or a string literal mentioning it does not count.
+
+The opposite direction is checked too. Prose recording that a name was
+**never written** goes inside an absence region:
+
+```markdown
+<!-- absent:begin -->
+
+`a_name_that_does_not_exist`
+
+<!-- absent:end -->
+```
+
+`check-asserted-absence` fails if anything in there starts resolving, so
+a correction cannot rot into a stale denial, and it fails on a region
+that names nothing — a region asserting nothing would pass forever.
+Inside a region the citation gate stands down, so the two can never
+demand opposite things of the same name.
 
 Claim lineage:
 
@@ -289,8 +308,16 @@ ADR-001 §"Appendix: Cardoso minimum-viable-policy checklist".
    path, so there is no in-tree caller and no frame for them to parse.
    `specs/adrs/003-hypervisor-egress-policy.md` is written around the
    vsock-only chokepoint.
-6. **Pre-built dev image is hash-verified.** No function named
-   `download_dev_image` exists; the real pipeline is
+6. **Pre-built dev image is hash-verified.** No such function exists —
+
+   <!-- absent:begin -->
+
+   `download_dev_image`
+
+   <!-- absent:end -->
+
+   is named only by five stale doc comments across `mvm-core`, `mvm-cli`,
+   `mvm-build` and `xtask`, and defines nothing. The real pipeline is
    `fetch_expected_hashes` + `verify_artifact_hash`
    (`crates/mvm-cli/src/commands/env/artifact_verify.rs`), which fetch
    the per-arch `*-checksums-sha256.txt` manifest, stream the
@@ -353,9 +380,17 @@ ADR-001 §"Appendix: Cardoso minimum-viable-policy checklist".
     `MVM_ACK_UNRESTRICTED_NETWORK=1`. **None of that exists.** `up` is not a
     dispatched verb — `up::Args` is not a `Commands` variant, so its
     `--network-preset` and `--network-allow` fields are unreachable CLI
-    surface. `MVM_ACK_UNRESTRICTED_NETWORK` is read nowhere in the workspace;
+    surface. The acknowledgement env var is read nowhere in the workspace;
     its only occurrence is a doc comment in `mvm-contract::stream::edge`
-    saying another mechanism is "shaped after" it. There is no unrestricted
+    saying another mechanism is "shaped after" it:
+
+    <!-- absent:begin -->
+
+    `MVM_ACK_UNRESTRICTED_NETWORK`.
+
+    <!-- absent:end -->
+
+    There is no unrestricted
     acknowledgement, so nothing is being bypassed — but nothing warns either,
     and `specs/plans/296` cites the non-existent hatch as prior art for its
     E7 redaction opt-out. Building the acknowledgement is Plan 306 WS5.
@@ -403,15 +438,24 @@ ADR-001 §"Appendix: Cardoso minimum-viable-policy checklist".
     `unbound_service_returns_not_bound` and
     `service_call_rejects_unknown_envelope_fields`.
 
-    Earlier revisions of this bullet named — in quotes rather than
-    backticks, because backticks assert a real identifier and these are
-    names nobody ever wrote —
-    "service_call_denied_when_unbound",
-    "service_call_denied_outside_profile",
-    "audit_chain_contains_service_call_entries",
-    `audit_chain_carries_no_payload_bytes`, a `fuzz_service_call.rs`
-    target, and three `xtask check-handler-*` gates. **None of them
-    exist**, and none ever did on this branch. The ADR-001 row was
+    Earlier revisions of this bullet named four tests, a fuzz target, and
+    three `xtask check-handler-*` gates that **do not exist** and never did
+    on this branch:
+
+    <!-- absent:begin -->
+
+    `service_call_denied_when_unbound`,
+    `service_call_denied_outside_profile`,
+    `audit_chain_contains_service_call_entries`,
+    `audit_chain_carries_no_payload_bytes`, and a
+    `fuzz_service_call.rs` target.
+
+    <!-- absent:end -->
+
+    That list used to be held in quotes rather than backticks, by hand,
+    because backticks assert a real identifier. It is now a gate:
+    `check-asserted-absence` fails if any of those names appears in the
+    tree, so the correction cannot decay into a stale denial. The ADR-001 row was
     always correct, so `check-claim-catalog` never went red — only this
     file was wrong, which is why the ledger and not the narrative is
     authoritative. Payload-freedom for the stream plane's own audit
@@ -431,14 +475,19 @@ ADR-001 §"Appendix: Cardoso minimum-viable-policy checklist".
     cmdline token remains in tree as designed-but-unwired. Note the shape
     of that failure, because `check-claim-catalog` cannot catch it: the
     gate proves a named witness *exists*, never that anything calls the
-    code it tests. The six test names this bullet used to list
-    ("host_secrets_v1_denied_outside_allowed_destinations",
-    "zeroize_drop_zeros_secret_bytes",
-    "handler_inter_call_memory_hygiene",
-    "host_secrets_v1_signed_payload_jcs_roundtrip",
-    "secrets_subprocess_cannot_reach_supervisor_memory",
-    "placeholder_in_outbound_request_dropped_and_audited") do not exist
-    in the tree — same failure as claim 12's.
+    code it tests. The six test names this bullet used to list do not
+    exist in the tree — same failure as claim 12's:
+
+    <!-- absent:begin -->
+
+    `host_secrets_v1_denied_outside_allowed_destinations`,
+    `zeroize_drop_zeros_secret_bytes`,
+    `handler_inter_call_memory_hygiene`,
+    `host_secrets_v1_signed_payload_jcs_roundtrip`,
+    `secrets_subprocess_cannot_reach_supervisor_memory`,
+    `placeholder_in_outbound_request_dropped_and_audited`.
+
+    <!-- absent:end -->
 14. **Every `mvmctl run --image <oci-ref>` admission records the OCI
     image provenance in the chain-signed audit log.** Row 14 of the
     ADR-001 table. Plan 85 Phase E + F wire the user-facing OCI image
@@ -632,6 +681,37 @@ Every new module, type, or function needs test coverage:
 ## Scratch & temporary files
 
 Never write scratch, temporary, or intermediate files anywhere inside the repo working tree — not the root, not a subdirectory, not a hidden dotfile, not a gitignored path. This covers **every** kind of agent-created scratch (analysis lists, command output, intermediate JSON/TSV, logs, ad-hoc scripts, `git merge-file` inputs), not just screenshots/binaries. Write them under `/tmp/` instead. See AGENTS.md §"Screenshots & Temporary Files" for the full rule.
+
+`.agent-memory/notes/` is the one exception, and it is not an exception to the
+rule so much as a different thing: those are committed findings, reviewed in a
+PR like any other file. Scratch is what you produce while working; a note is
+what you learned.
+
+## Committed findings (`.agent-memory/`)
+
+One finding per file under `.agent-memory/notes/<slug>.md`, with `title`,
+`date` and `tags` frontmatter. `just recall <terms>` searches them, `just
+notes` lists them, `just remember <slug>` scaffolds one. `xtask
+check-agent-notes` holds the shape and refuses a `[[link]]` to a note that does
+not exist.
+
+**Recall before you investigate.** A measurement already in there is one you do
+not have to pay for twice.
+
+Write one when you learn something the diff will not say — and especially when
+you learn something is *false*. The falsifications are the notes that earn
+their keep: `teardown-scales-with-guest-ram` records the obvious fix, the A/B
+that refuted it, and why it could not have worked, which is the difference
+between a day spent and a paragraph read. Say what not to retry, and say why.
+Commit the note with the change it explains.
+
+Machine-specific context — host names, fleet layout, ssh targets, local paths —
+does not go here. It belongs in your own agent memory; in the repository it
+just confuses contributors.
+
+These notes are observations, not authority. `specs/adrs/` owns decisions and
+the claims ledger owns what is enforced; where a note disagrees with one of
+those, the owner wins and the note is stale.
 
 ## Build and Run
 

--- a/Justfile
+++ b/Justfile
@@ -474,6 +474,45 @@ honesty:
 deferrals:
     cargo run -p xtask -- check-deferrals
 
+# ── Agent memory (.agent-memory/notes) ───────────────────────────────────
+
+# Recall committed findings. Lexical, because at a few hundred terse,
+# keyword-dense notes a substring match beats anything with a model in it.
+# Terms are OR-ed: `just recall teardown ram` finds notes mentioning either.
+recall +TERMS:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pattern=$(printf '%s' "{{ TERMS }}" | tr ' ' '|')
+    rg -il --sort path -e "$pattern" .agent-memory/notes | while read -r path; do
+        printf '%s\n    %s\n' \
+            "$(basename "$path" .md)" \
+            "$(sed -n 's/^title: //p' "$path")"
+    done
+
+# List every note, newest first.
+notes:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for path in .agent-memory/notes/*.md; do
+        printf '%s  %s — %s\n' \
+            "$(sed -n 's/^date: //p' "$path")" \
+            "$(basename "$path" .md)" \
+            "$(sed -n 's/^title: //p' "$path")"
+    done | sort -r
+
+# Scaffold a note. Fill in the body, then commit it with the change it explains.
+remember SLUG:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    path=".agent-memory/notes/{{ SLUG }}.md"
+    if [ -e "$path" ]; then echo "note {{ SLUG }} already exists" >&2; exit 1; fi
+    printf -- '---\ntitle: \ndate: %s\ntags: []\n---\n\n' "$(date +%F)" > "$path"
+    echo "created $path"
+
+# Committed findings parse, are dated, and link to notes that exist.
+agent-notes:
+    cargo run -p xtask -- check-agent-notes
+
 # ── Lint & Format ────────────────────────────────────────────────────────
 
 # Format all code

--- a/specs/plans/2026-09-01-committed-agent-notes-and-asserted-absence.md
+++ b/specs/plans/2026-09-01-committed-agent-notes-and-asserted-absence.md
@@ -1,0 +1,126 @@
+# Committed agent notes, and a gate for prose that asserts absence
+
+Backing: shipped-source
+Validation: check-asserted-absence
+
+## Why
+
+Two holes, both visible in this repository's own history.
+
+**Findings do not survive the session that produced them.** An agent working
+here accumulates expensive negative results — the fix that was tried and
+reverted, the cause that was measured and refuted — and stores them in a
+per-user, per-machine memory that is invisible in a PR, absent from a fresh
+clone, and unavailable to a human reader. The next session re-derives them.
+`stop_pid_disappearance` scaling with guest RAM was measured, the obvious fix
+attempted, A/B'd, and reverted on 2026-08-30; nothing in the tree records that,
+so nothing stops it being attempted again.
+
+**Prose that asserts something does *not* exist is ungated.** `CLAUDE.md`
+already distinguishes the two directions by hand:
+
+> named — in quotes rather than backticks, because backticks assert a real
+> identifier and these are names nobody ever wrote
+
+`check-witness-citations` enforces the backtick direction: a cited identifier
+must resolve. Nothing enforces the quoted direction. The paragraphs saying
+"none of them exist, and none ever did" are load-bearing — they are the record
+of a months-long fabrication — and they decay silently the moment anyone adds a
+function with one of those names. A claim of absence is a claim.
+
+## What ships
+
+### 1. `.agent-memory/` — committed, diffable findings
+
+One finding per file under `.agent-memory/notes/<slug>.md`, YAML frontmatter
+(`title`, `date`, `tags`, optional `superseded_by`). Recall is `rg` — at a few
+hundred terse, keyword-dense engineering notes, a substring match beats a vector
+model on speed, footprint and dependencies, and the corpus is nowhere near the
+size where paraphrase recall starts to matter.
+
+Two rules carry the value:
+
+- **Record why a thing failed, not that it did.** The falsifications narrow the
+  search space; the successes are already in the diff.
+- **Commit the note with the change it explains.** A note plus its code change
+  in one commit is a decision log nobody has to maintain separately.
+
+Machine-specific context — host names, fleet layout, ssh targets, local paths —
+stays in the agent's own global memory. It confuses contributors and it is not a
+finding.
+
+### 2. `xtask check-agent-notes`
+
+Frontmatter parses; the `title` is present and non-empty; `date` is ISO-8601 and
+not in the future; `tags` is non-empty; `superseded_by` names a note that exists.
+A superseded note may not itself be cited as current by another note's body.
+
+Cheap, and it stops the directory rotting into a folder of undated fragments.
+
+### 3. `xtask check-asserted-absence`
+
+Opt-in regions in governed prose:
+
+```markdown
+<!-- absent:begin -->
+…paragraph naming identifiers that must not exist…
+<!-- absent:end -->
+```
+
+Inside a region, every identifier-shaped token — `snake_case` with at least one
+underscore, or `kebab-case` with at least one dash — written in quotes or
+backticks must resolve to **nothing** in the workspace sources or workflows.
+Outside a region the gate is silent, so ordinary prose cannot trip it.
+
+The resolver is the one `check-witness-citations` already uses, lifted into a
+shared module and called from both. Two resolvers drift, and the drift is
+invisible until one of them is wrong — the same reasoning
+`check-declared-backing` gives for reusing the citation resolver rather than
+growing its own.
+
+Three ways to fail:
+
+| Failure | Why it is a failure |
+|---|---|
+| A named identifier resolves | The absence claim is now false |
+| A region asserts nothing | A region with no identifiers is a marker someone forgot to fill, not a passing check |
+| Unbalanced or nested markers | The region's extent is ambiguous, so what it asserts is unknown |
+
+## Governed prose
+
+`check-asserted-absence` scans the same set `check-witness-citations` does.
+Regions are added to the paragraphs that already assert absence in prose:
+
+- `CLAUDE.md` claim 12 — the five test names and the `fuzz_service_call.rs`
+  target that were never written.
+- `CLAUDE.md` claim 13 — the six test names in the same shape.
+- `CLAUDE.md` claim 10 — `MVM_ACK_UNRESTRICTED_NETWORK`, read nowhere.
+
+## Deliberately not in scope
+
+**Witness reachability.** `CLAUDE.md` states the remaining hole exactly: the
+claim gate "proves a named witness *exists*, never that anything calls the code
+it tests". That is a real gap and it is not this change — it needs call-graph
+analysis over 86 `fn:` witnesses with a false-positive budget near zero, and a
+gate that cries wolf gets deleted. Tracked below, not built here.
+
+## Follow-on
+
+- [ ] Extend `check-dormant-controls` to the `fn:` witnesses in the claims
+      ledger. It already implements the rule — a caller is a mention in
+      production Rust outside the defining file and outside any `#[cfg(test)]`
+      module or `tests/` tree, declared per symbol in
+      `xtask/dormant-controls.toml`, on a list that may only shrink. Pointing
+      it at the 86 ledger witnesses is a smaller change than a new gate, and it
+      keeps one definition of "reachable" rather than two. Measure against the
+      current ledger before turning it on.
+- [ ] Blank comments and literals in `check-dormant-controls`' haystack. Its
+      own docs record the limit — "a symbol named in a comment counts as a
+      caller" — and that is the same defect this change fixed in the citation
+      resolver, with the same one-line answer
+      (`rust_source::blank_comments_and_strings`). A control whose only
+      "caller" is a doc comment is precisely the dormant control it hunts.
+- [ ] Fix the five doc comments in `mvm-core`, `mvm-cli`, `mvm-build` and
+      `xtask` that reference `download_dev_image`, a function that does not
+      exist. Surfaced by this change; left out of it to keep the diff to one
+      concern.

--- a/specs/sprint/delivery/committed-agent-notes-and-asserted-absence.md
+++ b/specs/sprint/delivery/committed-agent-notes-and-asserted-absence.md
@@ -1,0 +1,69 @@
+# Committed agent notes, and a gate for prose that asserts absence
+
+Plan: `specs/plans/2026-09-01-committed-agent-notes-and-asserted-absence.md`
+
+## Delivered
+
+- `.agent-memory/notes/` — committed findings, one per file, seeded with five
+  real ones ported out of per-user agent memory. Four are falsifications: the
+  teardown fix that was A/B'd and reverted, the admit outliers that were not
+  the audit chain, the `prepared_cold` budget that covers far less than it
+  reads as covering, and the `legacy` sweep where four of six families were
+  live code with a wrong comment.
+- `xtask check-agent-notes` — frontmatter parses, dates are real calendar
+  dates, tags are non-empty, `superseded_by` and every `[[link]]` resolve.
+- `xtask check-asserted-absence` — opt-in `<!-- absent:begin -->` regions whose
+  named identifiers must resolve to nothing. Fails on a resolving name, on a
+  region that names nothing checkable, and on unbalanced or nested markers.
+  Markers inside a fenced block are an example, not a region.
+- `xtask/src/prose_citations.rs` — one resolver, shared by the citation gate
+  and the absence gate, so the two cannot demand opposite things of one name.
+- `just recall` / `just notes` / `just remember` / `just agent-notes`.
+- Four absence regions in `CLAUDE.md`: claims 6, 10, 12, 13.
+
+## Defect found and fixed
+
+`check-witness-citations` matched over the **raw** text of every `.rs` file,
+which includes string literals. `CLAUDE.md` backticks
+`audit_chain_carries_no_payload_bytes` in a paragraph stating the name was
+never written; the citation resolved anyway, because its only two occurrences
+in the tree were literals inside that same gate's tests, asserting the name has
+the shape the gate inspects. The gate was reading its own fixture back as
+evidence and reporting `clean`.
+
+The Rust haystack now goes through `rust_source::blank_comments_and_strings`
+first, so a cited symbol must appear as code. That tightening turned up two
+more real misses and one shape defect:
+
+- `download_dev_image` — named by five stale doc comments across `mvm-core`,
+  `mvm-cli`, `mvm-build` and `xtask`, defining nothing. `CLAUDE.md` already
+  said so; it is now in an absence region. **The five comments are still
+  wrong** and are left for a separate change.
+- `python_image` — a real Python SDK entry point that the resolver could not
+  see, because it only walked `.rs`. The resolver now reads the Python SDK too,
+  raw, since there is no Python lexer here.
+- `check-no-spec-refs-in-comments` — a live gate whose kebab spelling exists
+  only as a string literal and a YAML key. Blanking would have reported it as
+  fabricated, so gate and job names resolve against the raw haystack while
+  symbols resolve against the blanked one. Both gates ask one shape-dispatched
+  predicate.
+
+## Gates
+
+`cargo run -p xtask -- check-all` → 65 clean (was 63). `cargo nextest run
+-p xtask` → 689 pass.
+
+## Not delivered
+
+Witness reachability — the hole `CLAUDE.md` names directly, where the claim
+gate proves a witness *exists* but never that anything calls the code it tests.
+`check-dormant-controls` already holds exactly that rule for security-relevant
+symbols — a caller is a mention in production Rust outside the defining file
+and outside any test module, and its list may only shrink — so the follow-on is
+to extend it to `fn:` witnesses rather than build a third mechanism. Recorded
+in the plan.
+
+That gate's own stated limit is also now fixable: its docs say "a symbol named
+in a comment counts as a caller", which is the same defect this change fixed in
+the citation resolver, and `blank_comments_and_strings` is the same answer.
+Also recorded in the plan.

--- a/xtask/src/check_agent_notes.rs
+++ b/xtask/src/check_agent_notes.rs
@@ -1,0 +1,291 @@
+//! `xtask check-agent-notes`
+//!
+//! Keeps `.agent-memory/notes/` from rotting into a folder of undated
+//! fragments.
+//!
+//! The notes are committed so that a finding — especially a *negative* one —
+//! outlives the session that paid for it, travels with the code, and shows up
+//! in a diff. That only works if the corpus stays uniform enough to grep and
+//! honest enough to trust, which is four properties:
+//!
+//! 1. Frontmatter parses, and the slug matches the filename. Recall is
+//!    `rg` over these files; a note whose title and path disagree is found
+//!    under one name and cited under another.
+//! 2. `date` is a real calendar date. A finding without a date is not a
+//!    finding, it is a rumour.
+//! 3. `tags` is non-empty. The tag is the only index there is.
+//! 4. `superseded_by` and every `[[slug]]` link name a note that exists.
+//!    A dangling link in a committed corpus is a dead end for the next
+//!    reader.
+//!
+//! # What it does not check
+//!
+//! Whether the date is in the past. Comparing against the wall clock makes the
+//! gate's verdict depend on when it runs, which is the property that made
+//! `check-claim-witness-freshness` split its PR behaviour from its scheduled
+//! behaviour. A calendar-valid date is the part that can be checked the same
+//! way everywhere.
+//!
+//! It also does not judge content. Nothing here can tell a good finding from a
+//! bad one; the gate holds the shape, and review holds the substance.
+
+use anyhow::{Result, bail};
+use std::collections::BTreeSet;
+use std::path::Path;
+
+/// Where the committed notes live.
+const NOTES_DIR: &str = ".agent-memory/notes";
+
+/// A parsed note.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Note {
+    /// Filename stem, which is the note's slug.
+    pub slug: String,
+    /// One-line summary.
+    pub title: String,
+    /// ISO-8601 calendar date.
+    pub date: String,
+    /// Non-empty tag set.
+    pub tags: Vec<String>,
+    /// Slug of the note that replaces this one, when it has been replaced.
+    pub superseded_by: Option<String>,
+    /// Slugs this note links to with `[[…]]`.
+    pub links: Vec<String>,
+}
+
+/// Split the leading `---` block off a note.
+fn frontmatter(text: &str) -> Option<(&str, &str)> {
+    let rest = text.strip_prefix("---\n")?;
+    let end = rest.find("\n---\n")?;
+    Some((&rest[..end], &rest[end + 5..]))
+}
+
+/// Read `key: value` out of a frontmatter block.
+fn field<'a>(block: &'a str, key: &str) -> Option<&'a str> {
+    block.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        (name.trim() == key).then(|| value.trim())
+    })
+}
+
+/// Parse the inline `[a, b]` list form.
+fn inline_list(value: &str) -> Option<Vec<String>> {
+    let inner = value.strip_prefix('[')?.strip_suffix(']')?;
+    Some(
+        inner
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+    )
+}
+
+/// Whether `s` is a real `YYYY-MM-DD` calendar date.
+#[must_use]
+pub fn is_calendar_date(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('-').collect();
+    let [y, m, d] = parts[..] else { return false };
+    if y.len() != 4 || m.len() != 2 || d.len() != 2 {
+        return false;
+    }
+    let (Ok(year), Ok(month), Ok(day)) = (y.parse::<u32>(), m.parse::<u32>(), d.parse::<u32>())
+    else {
+        return false;
+    };
+    if !(1..=12).contains(&month) || day == 0 {
+        return false;
+    }
+    day <= days_in_month(year, month)
+}
+
+/// Length of `month` in `year`.
+fn days_in_month(year: u32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        _ if year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400)) => {
+            29
+        }
+        _ => 28,
+    }
+}
+
+/// Slugs named by `[[…]]` links in `body`.
+fn wiki_links(body: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = body;
+    while let Some(open) = rest.find("[[") {
+        let after = &rest[open + 2..];
+        let Some(close) = after.find("]]") else { break };
+        out.push(after[..close].trim().to_string());
+        rest = &after[close + 2..];
+    }
+    out
+}
+
+/// Parse one note.
+///
+/// # Errors
+///
+/// When the frontmatter is missing, a required field is absent or empty, or
+/// the date is not a calendar date.
+pub fn parse(slug: &str, text: &str) -> Result<Note> {
+    let Some((block, body)) = frontmatter(text) else {
+        bail!("no `---` frontmatter block");
+    };
+    let title = field(block, "title").unwrap_or_default();
+    if title.is_empty() {
+        bail!("`title` is missing or empty");
+    }
+    let date = field(block, "date").unwrap_or_default();
+    if !is_calendar_date(date) {
+        bail!("`date` is `{date}`, which is not a YYYY-MM-DD calendar date");
+    }
+    let tags = field(block, "tags")
+        .and_then(inline_list)
+        .unwrap_or_default();
+    if tags.is_empty() {
+        bail!("`tags` is missing or empty; the tag is the only index there is");
+    }
+    Ok(Note {
+        slug: slug.to_string(),
+        title: title.to_string(),
+        date: date.to_string(),
+        tags,
+        superseded_by: field(block, "superseded_by")
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        links: wiki_links(body),
+    })
+}
+
+/// Run the gate.
+///
+/// # Errors
+///
+/// When a note fails to parse, or names a note that does not exist.
+pub fn run(root: &Path) -> Result<()> {
+    let dir = root.join(NOTES_DIR);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        println!("check-agent-notes: no {NOTES_DIR} directory; nothing to check");
+        return Ok(());
+    };
+
+    let mut errors = Vec::new();
+    let mut notes = Vec::new();
+
+    let mut paths: Vec<_> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "md"))
+        .collect();
+    paths.sort();
+
+    for path in paths {
+        let slug = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(err) => {
+                errors.push(format!("{NOTES_DIR}/{slug}.md: unreadable: {err}"));
+                continue;
+            }
+        };
+        match parse(&slug, &text) {
+            Ok(note) => notes.push(note),
+            Err(err) => errors.push(format!("{NOTES_DIR}/{slug}.md: {err}")),
+        }
+    }
+
+    let slugs: BTreeSet<&str> = notes.iter().map(|n| n.slug.as_str()).collect();
+    for note in &notes {
+        if let Some(target) = &note.superseded_by {
+            if target == &note.slug {
+                errors.push(format!("{NOTES_DIR}/{}.md: supersedes itself", note.slug));
+            } else if !slugs.contains(target.as_str()) {
+                errors.push(format!(
+                    "{NOTES_DIR}/{}.md: superseded_by names `{target}`, which is not a note",
+                    note.slug
+                ));
+            }
+        }
+        for link in &note.links {
+            if !slugs.contains(link.as_str()) {
+                errors.push(format!(
+                    "{NOTES_DIR}/{}.md: links to [[{link}]], which is not a note. A dangling \
+                     link in a committed corpus is a dead end for the next reader.",
+                    note.slug
+                ));
+            }
+        }
+    }
+
+    if !errors.is_empty() {
+        for err in &errors {
+            eprintln!("[error] {err}");
+        }
+        bail!("check-agent-notes: {} note(s) are malformed", errors.len());
+    }
+
+    println!("check-agent-notes: clean ({} note(s))", notes.len());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOOD: &str = "---\ntitle: A finding\ndate: 2026-09-01\ntags: [perf, hvf]\n---\n\nBody.\n";
+
+    #[test]
+    fn a_well_formed_note_parses() {
+        let note = parse("a-finding", GOOD).expect("parses");
+        assert_eq!(note.title, "A finding");
+        assert_eq!(note.date, "2026-09-01");
+        assert_eq!(note.tags, vec!["perf", "hvf"]);
+        assert_eq!(note.superseded_by, None);
+    }
+
+    #[test]
+    fn a_note_without_frontmatter_is_refused() {
+        let err = parse("x", "just prose\n").unwrap_err().to_string();
+        assert!(err.contains("frontmatter"), "{err}");
+    }
+
+    #[test]
+    fn an_empty_tag_list_is_refused() {
+        let text = GOOD.replace("tags: [perf, hvf]", "tags: []");
+        let err = parse("x", &text).unwrap_err().to_string();
+        assert!(err.contains("tags"), "{err}");
+    }
+
+    #[test]
+    fn a_date_that_is_not_a_calendar_date_is_refused() {
+        assert!(is_calendar_date("2026-02-28"));
+        assert!(is_calendar_date("2024-02-29"));
+        assert!(!is_calendar_date("2026-02-30"));
+        assert!(!is_calendar_date("2026-13-01"));
+        assert!(!is_calendar_date("2026-9-1"));
+        assert!(!is_calendar_date("yesterday"));
+        let text = GOOD.replace("2026-09-01", "2026-02-30");
+        assert!(parse("x", &text).is_err());
+    }
+
+    #[test]
+    fn wiki_links_are_extracted() {
+        assert_eq!(
+            wiki_links("see [[one-note]] and [[two-note]]"),
+            vec!["one-note", "two-note"]
+        );
+        // An unterminated link must not swallow the rest of the note.
+        assert_eq!(wiki_links("see [[unclosed"), Vec::<String>::new());
+    }
+
+    /// The gate must pass on the corpus as it stands.
+    #[test]
+    fn the_committed_notes_are_well_formed() {
+        run(&crate::workspace_root()).expect("committed notes parse and link");
+    }
+}

--- a/xtask/src/check_all.rs
+++ b/xtask/src/check_all.rs
@@ -104,6 +104,8 @@ pub const GATES: &[Gate] = &[
         "check-witness-citations",
         crate::check_witness_citations::run,
     ),
+    ("check-asserted-absence", crate::check_asserted_absence::run),
+    ("check-agent-notes", crate::check_agent_notes::run),
     ("check-dormant-controls", crate::check_dormant_controls::run),
     ("check-conformance", conformance_read_only),
     ("check-deferrals", crate::check_deferrals::run),

--- a/xtask/src/check_asserted_absence.rs
+++ b/xtask/src/check_asserted_absence.rs
@@ -1,0 +1,381 @@
+//! `xtask check-asserted-absence`
+//!
+//! Prose that says a name was never written must stay right about that.
+//!
+//! # Why the other direction needed a gate too
+//!
+//! `check-witness-citations` holds one direction: a cited identifier must
+//! resolve. The opposite direction was doing real work and had nothing behind
+//! it. `CLAUDE.md` carries paragraphs recording that six named tests for claim
+//! 13, and five for claim 12, do not exist and never did — the residue of a
+//! fabrication that survived months precisely because nothing checked this
+//! file. Those paragraphs are the correction. They decay the instant somebody
+//! writes a function with one of those names, and until now nothing would have
+//! noticed.
+//!
+//! The file already states the convention it was following:
+//!
+//! > named — in quotes rather than backticks, because backticks assert a real
+//! > identifier and these are names nobody ever wrote
+//!
+//! A convention held by hand across two paragraphs is a convention that lasts
+//! until the next editor. This makes it mechanical.
+//!
+//! # The regions
+//!
+//! Absence is claimed explicitly, never inferred:
+//!
+//! ```markdown
+//! <!-- absent:begin -->
+//! …paragraph naming identifiers that must not exist…
+//! <!-- absent:end -->
+//! ```
+//!
+//! Inside a region every backticked or quoted token shaped like an identifier
+//! must resolve to nothing. Outside one the gate is silent, so ordinary prose
+//! that happens to quote a word cannot trip it.
+//!
+//! # Three ways to fail
+//!
+//! | Failure | Why |
+//! |---|---|
+//! | A named identifier resolves | The absence claim is now false |
+//! | A region names nothing checkable | An empty region is a marker someone forgot to fill, not a passing check |
+//! | Unbalanced or nested markers | The region's extent is ambiguous, so what it asserts is unknown |
+//!
+//! The middle row is the one that keeps this gate from rotting into
+//! decoration. A region that checks nothing passes trivially, forever.
+
+use anyhow::{Result, bail};
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use crate::prose_citations::{
+    PROSE, Resolver, backticked, ignored_set, is_kebab_job, is_screaming_env, is_snake_ident,
+    quoted, strip_rs_suffix,
+};
+
+/// Opens a region asserting that the names inside it do not exist.
+const BEGIN: &str = "<!-- absent:begin -->";
+
+/// Closes the region opened by [`BEGIN`].
+const END: &str = "<!-- absent:end -->";
+
+/// A span of prose asserting that the identifiers it names do not exist.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Region {
+    /// 1-based line of the opening marker.
+    pub begin: usize,
+    /// 1-based line of the closing marker.
+    pub end: usize,
+    /// The lines between the markers, exclusive.
+    pub body: String,
+}
+
+/// Parse the absence regions in `text`.
+///
+/// # Errors
+///
+/// When a marker is unbalanced or a region opens inside another.
+pub fn regions(text: &str) -> Result<Vec<Region>> {
+    let mut out = Vec::new();
+    let mut open: Option<(usize, Vec<&str>)> = None;
+    let mut in_fence = false;
+
+    for (idx, line) in text.lines().enumerate() {
+        let lineno = idx + 1;
+        // A fenced example showing the markers is documentation, not a live
+        // assertion. Without this, the paragraph in `CLAUDE.md` explaining the
+        // convention would itself be a region, and the placeholder name in it
+        // would be under gate.
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            if let Some((_, body)) = open.as_mut() {
+                body.push(line);
+            }
+            continue;
+        }
+        match line.trim() {
+            BEGIN => {
+                if let Some((start, _)) = open {
+                    bail!("line {lineno}: absent:begin inside the region opened at line {start}");
+                }
+                open = Some((lineno, Vec::new()));
+            }
+            END => {
+                let Some((start, body)) = open.take() else {
+                    bail!("line {lineno}: absent:end with no matching absent:begin");
+                };
+                out.push(Region {
+                    begin: start,
+                    end: lineno,
+                    body: body.join("\n"),
+                });
+            }
+            _ => {
+                if let Some((_, body)) = open.as_mut() {
+                    body.push(line);
+                }
+            }
+        }
+    }
+
+    if let Some((start, _)) = open {
+        bail!("line {start}: absent:begin is never closed");
+    }
+    Ok(out)
+}
+
+/// Every line number covered by an absence region, markers included.
+///
+/// `check-witness-citations` uses this to stand down inside a region: a name
+/// asserted absent there must not simultaneously be required to resolve.
+#[must_use]
+pub fn absent_line_numbers(text: &str) -> BTreeSet<usize> {
+    let mut out = BTreeSet::new();
+    if let Ok(found) = regions(text) {
+        for region in found {
+            out.extend(region.begin..=region.end);
+        }
+    }
+    out
+}
+
+/// The identifier-shaped tokens a region claims do not exist.
+#[must_use]
+pub fn claimed_absent(body: &str) -> Vec<String> {
+    let ignored = ignored_set();
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    for raw in backticked(body).into_iter().chain(quoted(body)) {
+        let token = strip_rs_suffix(raw.trim()).to_string();
+        if ignored.contains(token.as_str()) {
+            continue;
+        }
+        let checkable = is_snake_ident(&token) || is_kebab_job(&token) || is_screaming_env(&token);
+        if checkable && seen.insert(token.clone()) {
+            out.push(token);
+        }
+    }
+    out
+}
+
+/// What one file's regions produced.
+#[derive(Debug, Default)]
+pub struct Outcome {
+    /// One message per failed absence claim or malformed region.
+    pub errors: Vec<String>,
+    /// Names whose absence was confirmed.
+    pub checked: usize,
+    /// Regions seen, well-formed or not.
+    pub regions: usize,
+}
+
+/// Check every absence region in one document.
+///
+/// Split out from [`run`] so the rules can be tested against a real resolver
+/// without needing a document in the tree that violates them — a gate whose
+/// only test is "the tree passes" cannot tell you it would catch anything.
+#[must_use]
+pub fn check_text(rel: &str, text: &str, resolver: &Resolver) -> Outcome {
+    let mut out = Outcome::default();
+    let found = match regions(text) {
+        Ok(found) => found,
+        Err(err) => {
+            out.errors.push(format!("{rel}: {err}"));
+            return out;
+        }
+    };
+    for region in found {
+        out.regions += 1;
+        let names = claimed_absent(&region.body);
+        if names.is_empty() {
+            out.errors.push(format!(
+                "{rel}: the absence region at lines {}-{} names nothing checkable. A region that \
+                 asserts nothing passes forever; fill it or remove it.",
+                region.begin, region.end
+            ));
+            continue;
+        }
+        for token in names {
+            out.checked += 1;
+            if resolver.resolves(&token) {
+                out.errors.push(format!(
+                    "{rel}: lines {}-{} assert that `{token}` does not exist, but it now resolves \
+                     in the tree. Either the prose is stale, or something was written under a \
+                     name this file says nobody ever wrote.",
+                    region.begin, region.end
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// Run the gate.
+///
+/// # Errors
+///
+/// When a name asserted absent resolves, a region names nothing checkable, or
+/// the markers are unbalanced.
+pub fn run(root: &Path) -> Result<()> {
+    let resolver = Resolver::build(root);
+    let mut errors = Vec::new();
+    let mut checked = 0usize;
+    let mut region_count = 0usize;
+
+    for rel in PROSE {
+        let path = root.join(rel);
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let outcome = check_text(rel, &text, &resolver);
+        errors.extend(outcome.errors);
+        checked += outcome.checked;
+        region_count += outcome.regions;
+    }
+
+    if !errors.is_empty() {
+        for err in &errors {
+            eprintln!("[error] {err}");
+        }
+        bail!(
+            "check-asserted-absence: {} absence claim(s) no longer hold",
+            errors.len()
+        );
+    }
+
+    println!(
+        "check-asserted-absence: clean ({checked} name(s) still absent across {region_count} \
+         region(s))"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wrap(body: &str) -> String {
+        format!("intro\n{BEGIN}\n{body}\n{END}\ntail\n")
+    }
+
+    #[test]
+    fn a_region_is_parsed_with_its_bounds_and_body() {
+        let found = regions(&wrap("names `a_symbol_name_here`")).expect("parses");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].begin, 2);
+        assert_eq!(found[0].end, 4);
+        assert_eq!(found[0].body, "names `a_symbol_name_here`");
+    }
+
+    #[test]
+    fn an_unclosed_region_is_refused() {
+        let err = regions(&format!("{BEGIN}\nbody\n"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("never closed"), "{err}");
+    }
+
+    #[test]
+    fn a_close_without_an_open_is_refused() {
+        let err = regions(&format!("body\n{END}\n")).unwrap_err().to_string();
+        assert!(err.contains("no matching"), "{err}");
+    }
+
+    #[test]
+    fn a_nested_region_is_refused() {
+        let err = regions(&format!("{BEGIN}\n{BEGIN}\n{END}\n"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("inside the region"), "{err}");
+    }
+
+    /// The convention has to be documentable without the documentation
+    /// becoming a live claim.
+    #[test]
+    fn markers_inside_a_fence_are_an_example_not_a_region() {
+        let doc = format!("prose\n```markdown\n{BEGIN}\n`x_y_z`\n{END}\n```\nmore\n");
+        assert!(regions(&doc).expect("parses").is_empty());
+    }
+
+    #[test]
+    fn both_quoted_and_backticked_names_are_claimed() {
+        // Backticked spans are collected first, then quoted ones.
+        let names = claimed_absent("\"quoted_symbol_name\" and `backticked_symbol_name`");
+        assert_eq!(names, vec!["backticked_symbol_name", "quoted_symbol_name"]);
+    }
+
+    #[test]
+    fn a_file_named_target_is_claimed_without_its_extension() {
+        assert_eq!(
+            claimed_absent("`fuzz_service_call.rs`"),
+            vec!["fuzz_service_call"]
+        );
+    }
+
+    #[test]
+    fn prose_that_is_not_an_identifier_is_not_claimed() {
+        assert!(claimed_absent("\"none of them exist\" and `plan_id`").is_empty());
+    }
+
+    #[test]
+    fn absent_line_numbers_cover_the_markers_and_the_body() {
+        let lines = absent_line_numbers(&wrap("names `a_symbol_name_here`"));
+        assert_eq!(lines.into_iter().collect::<Vec<_>>(), vec![2, 3, 4]);
+    }
+
+    /// The gate must pass on the tree as it stands.
+    #[test]
+    fn the_absence_claims_in_the_tree_still_hold() {
+        run(&crate::workspace_root()).expect("asserted-absent names are still absent");
+    }
+
+    /// The failure this exists to catch: prose still denying a name that has
+    /// since been written.
+    #[test]
+    fn a_name_that_now_exists_fails_its_absence_claim() {
+        let resolver = Resolver::build(&crate::workspace_root());
+        let out = check_text("fixture.md", &wrap("`verify_audit_chain`"), &resolver);
+        assert_eq!(out.regions, 1);
+        assert_eq!(out.errors.len(), 1, "{:?}", out.errors);
+        assert!(out.errors[0].contains("now resolves"), "{:?}", out.errors);
+    }
+
+    #[test]
+    fn a_name_that_does_not_exist_passes() {
+        let resolver = Resolver::build(&crate::workspace_root());
+        let out = check_text(
+            "fixture.md",
+            &wrap("`no_such_symbol_was_ever_written_here`"),
+            &resolver,
+        );
+        assert!(out.errors.is_empty(), "{:?}", out.errors);
+        assert_eq!(out.checked, 1);
+    }
+
+    /// A region that checks nothing would pass forever; that is decoration,
+    /// not a gate.
+    #[test]
+    fn an_empty_region_is_refused() {
+        let resolver = Resolver::build(&crate::workspace_root());
+        let out = check_text("fixture.md", &wrap("nothing checkable in here"), &resolver);
+        assert_eq!(out.errors.len(), 1, "{:?}", out.errors);
+        assert!(
+            out.errors[0].contains("names nothing checkable"),
+            "{:?}",
+            out.errors
+        );
+    }
+
+    #[test]
+    fn a_malformed_region_is_reported_rather_than_ignored() {
+        let resolver = Resolver::build(&crate::workspace_root());
+        let out = check_text("fixture.md", &format!("{BEGIN}\nbody\n"), &resolver);
+        assert_eq!(out.errors.len(), 1, "{:?}", out.errors);
+        assert!(out.errors[0].contains("never closed"), "{:?}", out.errors);
+    }
+}

--- a/xtask/src/check_witness_citations.rs
+++ b/xtask/src/check_witness_citations.rs
@@ -22,6 +22,10 @@
 //! positives worth the name: a real symbol appears in the tree, and a
 //! fabricated one does not.
 //!
+//! "Appears in the tree" means appears in **code**, not in a comment or a
+//! string literal. See [`crate::prose_citations`] for why that distinction
+//! turned out to be load-bearing rather than fussy.
+//!
 //! ## What it does not catch
 //!
 //! A citation naming a real symbol that is not actually a witness for the
@@ -32,124 +36,9 @@ use anyhow::{Result, bail};
 use std::collections::HashSet;
 use std::path::Path;
 
-/// Prose that makes claims, and is therefore worth holding to its citations.
-const PROSE: &[&str] = &[
-    "CLAUDE.md",
-    "README.md",
-    "AGENTS.md",
-    "specs/adrs/001-microvm-security-posture.md",
-    "specs/adrs/035-workload-stream-plane.md",
-];
-
-/// Minimum length for a citation to be worth checking. Short snake_case words
-/// (`plan_id`, `vm_name`) are field names, not witnesses, and they are common
-/// enough that including them buys noise rather than coverage.
-const MIN_LEN: usize = 12;
-
-/// Words that look like identifiers but are prose, config keys, or paths.
-const IGNORED: &[&str] = &[
-    "cargo-mutants",
-    "workflow_dispatch",
-    "pull_request",
-    "merge_group",
-    "continue-on-error",
-    "ubuntu-latest",
-    "macos-latest",
-    "windows-latest",
-    "actions-rs",
-    "dtolnay-rust-toolchain",
-    "no-default-features",
-    "all-features",
-    "deny-warnings",
-];
-
-/// Whether `s` is shaped like a Rust test name.
-fn is_snake_ident(s: &str) -> bool {
-    s.len() >= MIN_LEN
-        && s.contains('_')
-        && s.chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
-        && !s.starts_with('_')
-        && !s.ends_with('_')
-}
-
-/// Whether `s` is shaped like a CI job name.
-fn is_kebab_job(s: &str) -> bool {
-    s.len() >= MIN_LEN
-        && s.contains('-')
-        && s.chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
-        && !s.starts_with('-')
-        && !s.ends_with('-')
-}
-
-/// Backticked spans in `text`, each with the line it sat on.
-///
-/// The line matters for kebab-case: a job citation says "job" beside it, while
-/// `rust-version` and `cargo-semver-checks` are a manifest key and a tool that
-/// claim no enforcement.
-fn backticked_with_line(text: &str) -> Vec<(String, String)> {
-    let mut out = Vec::new();
-    for line in text.lines() {
-        for token in backticked(line) {
-            out.push((line.to_string(), token));
-        }
-    }
-    out
-}
-
-/// Backticked spans in `text`.
-fn backticked(text: &str) -> Vec<String> {
-    let mut out = Vec::new();
-    let bytes: Vec<char> = text.chars().collect();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == '`' {
-            let start = i + 1;
-            let mut j = start;
-            while j < bytes.len() && bytes[j] != '`' && bytes[j] != '\n' {
-                j += 1;
-            }
-            if j < bytes.len() && bytes[j] == '`' {
-                out.push(bytes[start..j].iter().collect());
-                i = j + 1;
-                continue;
-            }
-        }
-        i += 1;
-    }
-    out
-}
-
-/// Read every file under `dir` with one of `exts` into one haystack.
-fn haystack(root: &Path, dirs: &[&str], exts: &[&str]) -> String {
-    let mut buf = String::new();
-    for dir in dirs {
-        let mut stack = vec![root.join(dir)];
-        while let Some(d) = stack.pop() {
-            let Ok(entries) = std::fs::read_dir(&d) else {
-                continue;
-            };
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    if entry.file_name() == "target" {
-                        continue;
-                    }
-                    stack.push(path);
-                } else if exts
-                    .iter()
-                    .any(|e| path.extension().is_some_and(|x| x == *e))
-                    && let Ok(src) = std::fs::read_to_string(&path)
-                {
-                    buf.push_str(&src);
-                    buf.push('\n');
-                }
-            }
-        }
-    }
-    buf
-}
+use crate::prose_citations::{
+    PROSE, Resolver, backticked_with_line, ignored_set, is_kebab_job, is_snake_ident,
+};
 
 /// Run the gate.
 ///
@@ -158,9 +47,8 @@ fn haystack(root: &Path, dirs: &[&str], exts: &[&str]) -> String {
 /// When a prose file cites a test- or job-shaped name that appears nowhere in
 /// the sources or workflows.
 pub fn run(root: &Path) -> Result<()> {
-    let sources = haystack(root, &["crates", "xtask", "src"], &["rs"]);
-    let workflows = haystack(root, &[".github"], &["yml", "yaml"]);
-    let ignored: HashSet<&str> = IGNORED.iter().copied().collect();
+    let resolver = Resolver::build(root);
+    let ignored = ignored_set();
 
     let mut errors = Vec::new();
     let mut checked = 0usize;
@@ -170,15 +58,22 @@ pub fn run(root: &Path) -> Result<()> {
         let Ok(text) = std::fs::read_to_string(&path) else {
             continue;
         };
+        let absent = crate::check_asserted_absence::absent_line_numbers(&text);
         let mut seen: HashSet<String> = HashSet::new();
-        for (line, token) in backticked_with_line(&text) {
+        for (lineno, line, token) in backticked_with_line(&text) {
+            // A name inside an absence region is asserted *not* to exist.
+            // `check-asserted-absence` owns it; requiring it to resolve here
+            // would make the two gates contradict each other.
+            if absent.contains(&lineno) {
+                continue;
+            }
             let token = token.trim();
             if ignored.contains(token) || !seen.insert(token.to_string()) {
                 continue;
             }
             if is_snake_ident(token) {
                 checked += 1;
-                if !sources.contains(token) {
+                if !resolver.resolves(token) {
                     errors.push(format!(
                         "{rel}: cites `{token}`, which appears nowhere in the Rust sources. If it \
                          is a witness, it does not exist; if it was renamed, the prose still \
@@ -187,7 +82,7 @@ pub fn run(root: &Path) -> Result<()> {
                 }
             } else if is_kebab_job(token) && line.contains("job") {
                 checked += 1;
-                if !workflows.contains(token) && !sources.contains(token) {
+                if !resolver.resolves(token) {
                     errors.push(format!(
                         "{rel}: cites `{token}`, which no workflow defines. A job name that \
                          resolves to nothing reads as enforcement that is not there."
@@ -214,39 +109,6 @@ pub fn run(root: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn shapes_are_recognised() {
-        assert!(is_snake_ident("audit_chain_carries_no_payload_bytes"));
-        assert!(is_kebab_job("prod-agent-runentry-contract"));
-        // Too short to be worth checking: a field, not a witness.
-        assert!(!is_snake_ident("plan_id"));
-        assert!(!is_kebab_job("read-only"));
-        // Mixed case is a type or a path, not a test name.
-        assert!(!is_snake_ident("ExecutionPlan"));
-        assert!(!is_snake_ident("crates/mvm-core"));
-    }
-
-    #[test]
-    fn backticked_spans_are_extracted_without_crossing_lines() {
-        let found = backticked("see `first_symbol_here` and `second-symbol-here`\n`third`");
-        assert_eq!(
-            found,
-            vec!["first_symbol_here", "second-symbol-here", "third"]
-        );
-        // An unterminated backtick must not swallow the rest of the document.
-        assert_eq!(backticked("`unclosed\nnext line"), Vec::<String>::new());
-    }
-
-    /// The exact drift this exists for: a witness name that was cited for
-    /// months and never existed.
-    #[test]
-    fn a_fabricated_witness_name_is_the_shape_that_gets_checked() {
-        assert!(
-            is_snake_ident("audit_chain_carries_no_payload_bytes"),
-            "the name that survived in CLAUDE.md must be one this gate inspects"
-        );
-    }
 
     /// The gate must pass on the tree as it stands.
     #[test]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,7 +11,9 @@ use std::path::Path;
 mod build_dev_image;
 mod check_abi_layout;
 mod check_adr_coverage;
+mod check_agent_notes;
 mod check_all;
+mod check_asserted_absence;
 mod check_audit_positional;
 mod check_backend_resource_controls;
 mod check_binary_size;
@@ -83,6 +85,7 @@ mod gen_sdk_surface;
 mod gen_stubs;
 mod ir_parity;
 mod perf;
+mod prose_citations;
 mod rust_source;
 mod sprint;
 
@@ -281,6 +284,14 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_witness_citations::run(&workspace)
         }
+        Some("check-asserted-absence") => {
+            let workspace = workspace_root();
+            check_asserted_absence::run(&workspace)
+        }
+        Some("check-agent-notes") => {
+            let workspace = workspace_root();
+            check_agent_notes::run(&workspace)
+        }
         Some("check-declared-backing") => {
             let workspace = workspace_root();
             if std::env::args().any(|a| a == "--self-test") {
@@ -427,7 +438,7 @@ fn main() -> Result<()> {
             check_all::run_all(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-sdk-transport-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-virtio-fs, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-sdk-transport-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-asserted-absence, check-agent-notes, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-virtio-fs, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -537,6 +548,12 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-witness-citations                Prose that names a witness must name one that exists"
+            );
+            println!(
+                "  check-asserted-absence                 Prose that says a name was never written must stay right about that"
+            );
+            println!(
+                "  check-agent-notes                      Committed agent findings parse, are dated, and link to notes that exist"
             );
             println!(
                 "  check-declared-backing                 Claim-bearing prose declares what backs it (--self-test)"

--- a/xtask/src/prose_citations.rs
+++ b/xtask/src/prose_citations.rs
@@ -1,0 +1,362 @@
+//! One resolver for the gates that ask whether prose names something real.
+//!
+//! Two gates ask opposite questions about the same tokens.
+//! `check-witness-citations` asks whether a cited identifier exists;
+//! `check-asserted-absence` asks whether a named identifier is still gone.
+//! A separate resolver for each would drift, and the drift would be invisible
+//! until one of them was wrong — the same reasoning `check-declared-backing`
+//! gives for reusing the citation resolver instead of growing its own.
+//!
+//! # What counts as existing
+//!
+//! A token resolves when it appears in workspace **code** or in a workflow —
+//! not when it appears in a comment or inside a string literal. That
+//! distinction is not pedantry. `audit_chain_carries_no_payload_bytes` is a
+//! witness name `CLAUDE.md` says was never written, and it resolved anyway:
+//! its only two occurrences in the tree were string literals inside
+//! `check-witness-citations`' own tests, asserting that the name has the shape
+//! the gate inspects. The gate's fixture was making the citation resolve. A
+//! resolver that reads literals can be fed its own answer.
+//!
+//! So the Rust haystack is run through
+//! [`crate::rust_source::blank_comments_and_strings`] first. Each file's path
+//! is appended as well, so a token naming a file (`fuzz_service_call.rs`)
+//! resolves against the tree rather than against whatever the file happens to
+//! contain.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::rust_source::blank_comments_and_strings;
+
+/// Prose that makes claims, and is therefore worth holding to its citations.
+pub const PROSE: &[&str] = &[
+    "CLAUDE.md",
+    "README.md",
+    "AGENTS.md",
+    "specs/adrs/001-microvm-security-posture.md",
+    "specs/adrs/035-workload-stream-plane.md",
+];
+
+/// Minimum length for a token to be worth checking. Short snake_case words
+/// (`plan_id`, `vm_name`) are field names, not witnesses, and they are common
+/// enough that including them buys noise rather than coverage.
+pub const MIN_LEN: usize = 12;
+
+/// Words that look like identifiers but are prose, config keys, or paths.
+pub const IGNORED: &[&str] = &[
+    "cargo-mutants",
+    "workflow_dispatch",
+    "pull_request",
+    "merge_group",
+    "continue-on-error",
+    "ubuntu-latest",
+    "macos-latest",
+    "windows-latest",
+    "actions-rs",
+    "dtolnay-rust-toolchain",
+    "no-default-features",
+    "all-features",
+    "deny-warnings",
+];
+
+/// Whether `s` is shaped like a Rust test name.
+#[must_use]
+pub fn is_snake_ident(s: &str) -> bool {
+    s.len() >= MIN_LEN
+        && s.contains('_')
+        && s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+        && !s.starts_with('_')
+        && !s.ends_with('_')
+}
+
+/// Whether `s` is shaped like a CI job name.
+#[must_use]
+pub fn is_kebab_job(s: &str) -> bool {
+    s.len() >= MIN_LEN
+        && s.contains('-')
+        && s.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        && !s.starts_with('-')
+        && !s.ends_with('-')
+}
+
+/// Whether `s` is shaped like an environment variable.
+///
+/// Only [`crate::check_asserted_absence`] uses this. The citation gate does
+/// not: requiring every backticked `MVM_*` in prose to resolve is a much wider
+/// rule than "a cited witness exists", and widening it is a separate decision
+/// from making absence claims mechanical.
+#[must_use]
+pub fn is_screaming_env(s: &str) -> bool {
+    s.len() >= MIN_LEN
+        && s.contains('_')
+        && s.starts_with(|c: char| c.is_ascii_uppercase())
+        && s.chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        && !s.ends_with('_')
+}
+
+/// Strip a trailing Rust source extension so a token naming a file is checked
+/// under the same shape rules as a bare identifier.
+///
+/// `fuzz_service_call.rs` is a claim about a target that does or does not
+/// exist, and it is worth the same scrutiny as a function name.
+#[must_use]
+pub fn strip_rs_suffix(token: &str) -> &str {
+    token.strip_suffix(".rs").unwrap_or(token)
+}
+
+/// Spans delimited by `delim` in `text`, never crossing a newline.
+fn delimited(text: &str, delim: char) -> Vec<String> {
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == delim {
+            let start = i + 1;
+            let mut j = start;
+            while j < chars.len() && chars[j] != delim && chars[j] != '\n' {
+                j += 1;
+            }
+            if j < chars.len() && chars[j] == delim {
+                out.push(chars[start..j].iter().collect());
+                i = j + 1;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Backticked spans in `text`.
+#[must_use]
+pub fn backticked(text: &str) -> Vec<String> {
+    delimited(text, '`')
+}
+
+/// Double-quoted spans in `text`.
+///
+/// Prose asserting that a name was never written cannot backtick it —
+/// `CLAUDE.md` says so itself, "because backticks assert a real identifier".
+/// So the absence gate has to read the quoted form too.
+#[must_use]
+pub fn quoted(text: &str) -> Vec<String> {
+    delimited(text, '"')
+}
+
+/// Backticked spans in `text`, each with its 1-based line number and the line
+/// it sat on.
+///
+/// The line matters for kebab-case: a job citation says "job" beside it, while
+/// `rust-version` and `cargo-semver-checks` are a manifest key and a tool that
+/// claim no enforcement. The number matters because a caller has to know
+/// whether the token fell inside an absence region.
+#[must_use]
+pub fn backticked_with_line(text: &str) -> Vec<(usize, String, String)> {
+    let mut out = Vec::new();
+    for (idx, line) in text.lines().enumerate() {
+        for token in backticked(line) {
+            out.push((idx + 1, line.to_string(), token));
+        }
+    }
+    out
+}
+
+/// The haystacks a citation can resolve against.
+///
+/// Two kinds of name need two kinds of evidence, and conflating them is what
+/// produced both of this resolver's failure modes.
+///
+/// A **symbol** — a test or function name — is code. It is declared as
+/// `fn name`, so requiring it in blanked Rust is exactly right, and it is the
+/// rule that stops a gate's own string fixtures answering for it.
+///
+/// A **gate or job name** is not code anywhere. `check-no-spec-refs-in-comments`
+/// is a real gate whose kebab spelling exists only as a string literal in the
+/// dispatch table and as a key in YAML. Holding it to the blanked haystack
+/// would report a live gate as fabricated — the opposite error, and the one
+/// that gets a gate deleted.
+pub struct Resolver {
+    /// Workspace Rust with comments and literals blanked, plus every scanned
+    /// path.
+    rust_code: String,
+    /// Workspace Rust verbatim, plus every scanned path.
+    rust_raw: String,
+    /// Non-Rust workspace source and workflow YAML, verbatim.
+    ///
+    /// The Python SDK is source we ship; `python_image` is one of its public
+    /// entry points and prose cites it. There is no Python lexer here, so
+    /// these are matched raw — a name mentioned only in a docstring resolves,
+    /// which is weaker than the Rust rule and is the price of not writing a
+    /// second lexer.
+    other: String,
+}
+
+impl Resolver {
+    /// Read the workspace once.
+    #[must_use]
+    pub fn build(root: &Path) -> Self {
+        let rust_dirs = ["crates", "xtask", "src"];
+        let mut other = raw_haystack(root, &rust_dirs, &["py"]);
+        other.push_str(&raw_haystack(root, &[".github"], &["yml", "yaml"]));
+        Self {
+            rust_code: code_haystack(root, &rust_dirs),
+            rust_raw: raw_haystack(root, &rust_dirs, &["rs"]),
+            other,
+        }
+    }
+
+    /// Whether `token` appears as code — the rule for a cited symbol.
+    #[must_use]
+    pub fn in_code(&self, token: &str) -> bool {
+        self.rust_code.contains(token) || self.other.contains(token)
+    }
+
+    /// Whether `token` appears anywhere at all, literals and YAML included —
+    /// the rule for a gate or job name.
+    #[must_use]
+    pub fn anywhere(&self, token: &str) -> bool {
+        self.rust_raw.contains(token) || self.other.contains(token)
+    }
+
+    /// Whether `token` denotes anything, choosing the haystack from its shape.
+    ///
+    /// This is the single predicate both gates ask. `check-witness-citations`
+    /// fails when it is false for a cited name; `check-asserted-absence` fails
+    /// when it is true for a name claimed absent. Sharing it is what makes the
+    /// two gates incapable of contradicting each other — with a predicate
+    /// each, a name could be simultaneously required to exist and required
+    /// not to, and nothing would say so.
+    #[must_use]
+    pub fn resolves(&self, token: &str) -> bool {
+        if is_kebab_job(token) {
+            self.anywhere(token)
+        } else {
+            self.in_code(token)
+        }
+    }
+}
+
+/// The set of tokens this module declines to judge.
+#[must_use]
+pub fn ignored_set() -> HashSet<&'static str> {
+    IGNORED.iter().copied().collect()
+}
+
+/// Every `.rs` file under `dirs`, blanked of comments and literals, with each
+/// file's relative path appended.
+fn code_haystack(root: &Path, dirs: &[&str]) -> String {
+    let mut buf = String::new();
+    walk(root, dirs, &["rs"], &mut |rel, src| {
+        buf.push_str(rel);
+        buf.push('\n');
+        buf.push_str(&blank_comments_and_strings(src));
+        buf.push('\n');
+    });
+    buf
+}
+
+/// Every file under `dirs` with one of `exts`, verbatim.
+fn raw_haystack(root: &Path, dirs: &[&str], exts: &[&str]) -> String {
+    let mut buf = String::new();
+    walk(root, dirs, exts, &mut |rel, src| {
+        buf.push_str(rel);
+        buf.push('\n');
+        buf.push_str(src);
+        buf.push('\n');
+    });
+    buf
+}
+
+/// Call `visit` with the root-relative path and contents of every file under
+/// `dirs` carrying one of `exts`.
+fn walk(root: &Path, dirs: &[&str], exts: &[&str], visit: &mut dyn FnMut(&str, &str)) {
+    for dir in dirs {
+        let mut stack = vec![root.join(dir)];
+        while let Some(d) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&d) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    if entry.file_name() == "target" {
+                        continue;
+                    }
+                    stack.push(path);
+                } else if exts
+                    .iter()
+                    .any(|e| path.extension().is_some_and(|x| x == *e))
+                    && let Ok(src) = std::fs::read_to_string(&path)
+                {
+                    let rel = path.strip_prefix(root).unwrap_or(&path);
+                    visit(&rel.to_string_lossy(), &src);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shapes_are_recognised() {
+        assert!(is_snake_ident("audit_chain_carries_no_payload_bytes"));
+        assert!(is_kebab_job("prod-agent-runentry-contract"));
+        // Too short to be worth checking: a field, not a witness.
+        assert!(!is_snake_ident("plan_id"));
+        assert!(!is_kebab_job("read-only"));
+        // Mixed case is a type or a path, not a test name.
+        assert!(!is_snake_ident("ExecutionPlan"));
+        assert!(!is_snake_ident("crates/mvm-core"));
+    }
+
+    #[test]
+    fn backticked_spans_are_extracted_without_crossing_lines() {
+        let found = backticked("see `first_symbol_here` and `second-symbol-here`\n`third`");
+        assert_eq!(
+            found,
+            vec!["first_symbol_here", "second-symbol-here", "third"]
+        );
+        // An unterminated backtick must not swallow the rest of the document.
+        assert_eq!(backticked("`unclosed\nnext line"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn quoted_spans_are_extracted_without_crossing_lines() {
+        assert_eq!(
+            quoted("named \"first_symbol_here\" and \"second_symbol_here\""),
+            vec!["first_symbol_here", "second_symbol_here"]
+        );
+        assert_eq!(quoted("\"unclosed\nnext line"), Vec::<String>::new());
+    }
+
+    #[test]
+    fn a_file_named_token_is_checked_as_an_identifier() {
+        assert!(!is_snake_ident("fuzz_service_call.rs"));
+        assert!(is_snake_ident(strip_rs_suffix("fuzz_service_call.rs")));
+        assert_eq!(strip_rs_suffix("plain_identifier"), "plain_identifier");
+    }
+
+    /// The circularity this resolver exists to break: a name whose only
+    /// occurrences in the tree are string literals in a gate's own test.
+    #[test]
+    fn a_name_that_only_appears_in_a_string_literal_does_not_resolve() {
+        let blanked = blank_comments_and_strings(
+            "fn shape() { assert!(is_snake_ident(\"audit_chain_carries_no_payload_bytes\")); }",
+        );
+        assert!(
+            !blanked.contains("audit_chain_carries_no_payload_bytes"),
+            "a literal must not make a citation resolve"
+        );
+        assert!(
+            blanked.contains("is_snake_ident"),
+            "surrounding code must survive blanking"
+        );
+    }
+}


### PR DESCRIPTION
Two holes with the same shape: a claim nobody checks.

## Absence is a claim

`check-witness-citations` holds one direction — a cited identifier must
resolve. The opposite direction was doing real work with nothing behind it.
`CLAUDE.md` carries paragraphs recording that six named tests for claim 13 and
five for claim 12 do not exist and never did, and it states the convention it
was following by hand:

> named — in quotes rather than backticks, because backticks assert a real
> identifier and these are names nobody ever wrote

That is a convention that lasts until the next editor. Those paragraphs are the
correction to a months-long fabrication, and they decay silently the moment
anyone writes a function with one of those names.

Absence is now claimed explicitly and checked:

```markdown
<!-- absent:begin -->

`a_name_that_does_not_exist`

<!-- absent:end -->
```

A region fails three ways: a name in it resolves; it names nothing checkable (a
region asserting nothing passes forever, which is decoration rather than a
gate); or the markers are unbalanced or nested. Markers inside a fenced block
are an example, not a region — so the convention can be documented without the
documentation becoming a live assertion.

Both gates ask **one** shared, shape-dispatched predicate, and the citation
gate stands down inside a region. With a predicate each, a name could be
simultaneously required to exist and required not to, and nothing would say so.

## The defect this surfaced

The citation resolver matched over the raw text of every `.rs` file. Raw text
includes string literals, and a gate's fixtures are string literals.

`CLAUDE.md` backticks `audit_chain_carries_no_payload_bytes` in a paragraph
whose whole point is that the name was never written. The citation resolved
anyway — its only two occurrences anywhere in the tree were literals inside
`check-witness-citations`' own tests, asserting that the name has the shape the
gate inspects. The gate was reading its own fixture back as evidence and
reporting `clean` for a citation pointing at nothing.

The Rust haystack now goes through `rust_source::blank_comments_and_strings`,
so a cited symbol must appear as **code**. Each file's path is appended too, so
a token naming a file resolves against the tree.

That tightening found two more real misses and one shape defect:

| Name | What it turned out to be |
|---|---|
| `download_dev_image` | Named by five stale doc comments across `mvm-core`, `mvm-cli`, `mvm-build` and `xtask`; defines nothing. `CLAUDE.md` already said so — now in a region. The five comments are still wrong and left for a separate change. |
| `python_image` | A live Python SDK entry point the resolver could not see, because it only walked `.rs`. It now reads the Python SDK too, raw — there is no Python lexer here, and that asymmetry is documented. |
| `check-no-spec-refs-in-comments` | A live gate whose kebab spelling exists only as a string literal and a YAML key. Blanking would have reported it as fabricated, so gate and job names resolve against the raw haystack while symbols resolve against the blanked one. |

## Committed findings

`.agent-memory/notes/` makes a finding survive the session that paid for it:
committed, diffable in review, `rg`-searchable, present in a fresh clone. One
finding per file, `title` / `date` / `tags` frontmatter, `[[slug]]` links.
Recall is lexical — at a few hundred terse, keyword-dense notes a substring
match beats a vector model on speed, footprint and dependencies, and the
upgrade path stays open if that ever stops being true.

Seeded with five ported out of per-user agent memory, four of them
falsifications:

- **`teardown-scales-with-guest-ram`** — ~50ms/GB is kernel address-space
  reclamation; the supervisor totals ~889µs at every guest size. The obvious
  fix (wait on the PID marker instead of process exit) was A/B'd across two
  guest sizes and reverted, because the guest memory is released *before* the
  marker clears, so both strategies wait for the same thing.
- **`admit-outliers-are-cold-initramfs-acquisition`** — 72s inside the admit
  window, with the refuted causes named so nobody re-tests them.
- **`prepared-cold-budget-covers-the-dispatch-window-only`** — the 200ms budget
  is `backend_start + vsock_wait`; `admit`, `teardown` and `command` are out of
  scope entirely.
- **`legacy-keyword-mostly-mislabels-live-code`** — four of six families were
  live code with a wrong comment.
- **`a-citation-can-resolve-to-its-own-test-fixture`** — this PR's own finding,
  committed with the change that fixes it.

Those are the notes that earn their keep. The successes are already in the
diff; the dead ends are nowhere unless someone writes them down.

## Gates

`cargo run -p xtask -- check-all` → 65 clean (was 63). `cargo nextest run
--workspace` → 12908 pass. Workspace clippy, `--doc`, `just check-gated` all
clean.

## Follow-on (in the plan, not here)

- Extend `check-dormant-controls` to the ledger's 86 `fn:` witnesses. It
  already implements the production-caller rule on a shrink-only list, which is
  the hole `CLAUDE.md` names — the claim gate proves a witness *exists*, never
  that anything calls the code it tests.
- Blank comments and literals in that gate's haystack too: its own docs record
  "a symbol named in a comment counts as a caller", which is the same defect
  fixed here with the same one-line answer.
- Fix the five `download_dev_image` doc comments.
