### PR TITLE
feat(builder): carry the libkrun seeded closure on the input disk

### DIFF
--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -1154,9 +1154,7 @@ impl LibkrunBuilderVm {
                     src: work_staging.path(),
                 },
             ],
-            // The closure seed is still attached below as a virtio-fs share on
-            // this path, so it must not also ride the input disk.
-            None,
+            self.closure_nar.as_deref(),
             u64::from(BUILDER_OUTPUT_DISK_MIB) << 20,
         )?;
 
@@ -1184,12 +1182,8 @@ impl LibkrunBuilderVm {
                 attachment.read_only,
             );
         }
-        if let Some(share_dir) = self.closure_seed_share(&vm_state_dir)? {
-            krun = krun.add_virtio_fs(
-                CLOSURE_SEED_TAG,
-                path_to_str(&share_dir, "closure_seed_dir")?,
-            );
-        }
+        // No closure-seed share: the NAR rides the input disk above, landing at
+        // the same `/closure-seed/<CLOSURE_FILE>` the guest imports either way.
 
         for disk in &job.extra_disks {
             krun = krun.add_disk(
@@ -1683,9 +1677,7 @@ impl BuilderVm for LibkrunBuilderVm {
                     src: &mounts.host_bin_dir,
                 },
             ],
-            // The closure seed is still attached below as a virtio-fs share on
-            // this path, so it must not also ride the input disk.
-            None,
+            self.closure_nar.as_deref(),
             u64::from(BUILDER_OUTPUT_DISK_MIB) << 20,
         )?;
         let mut krun = krun_context_for_image(&vm_name, &image)?
@@ -1712,12 +1704,9 @@ impl BuilderVm for LibkrunBuilderVm {
                 attachment.read_only,
             );
         }
-        if let Some(share_dir) = self.closure_seed_share(&vm_state_dir)? {
-            krun = krun.add_virtio_fs(
-                CLOSURE_SEED_TAG,
-                path_to_str(&share_dir, "closure_seed_dir")?,
-            );
-        }
+        // No closure-seed share: the NAR rides the input disk above, landing at
+        // the same `/closure-seed/<CLOSURE_FILE>` the guest imports either way.
+
         // Builder VMs are NIC-less: egress goes over the vsock relay below, so
         // the libkrun networking mode must be the disconnected sink — the
         // supervisor rejects anything else. Matches the Stage 0 path.
@@ -5607,6 +5596,49 @@ mod tests {
             std::fs::read_to_string(dest.join("work/crates/mvm-build/src/lib.rs")).unwrap(),
             "// real source"
         );
+    }
+
+    /// The seeded closure reaches the guest at `/closure-seed/<CLOSURE_FILE>`
+    /// whether it arrived as a virtio-fs share or on the input disk — the guest
+    /// imports a fixed path and does not care which transport populated it.
+    /// This pins the disk arm, which is what the one-shot builders now use.
+    ///
+    /// The source file is deliberately named something else: `pack_input_disk`
+    /// renames to `CLOSURE_FILE` on the way in, and a differently-named source
+    /// silently landing under its own name would make the guest import a no-op.
+    #[test]
+    fn prepare_transport_disks_lands_the_closure_under_its_fixed_name() {
+        let vm_state_dir = tempfile::TempDir::new().unwrap();
+        let scratch = tempfile::TempDir::new().unwrap();
+        let job = scratch.path().join("job");
+        std::fs::create_dir_all(&job).unwrap();
+        std::fs::write(job.join("cmd.sh"), b"#!/bin/sh\n").unwrap();
+        let nar = scratch.path().join("some-other-name.nar");
+        std::fs::write(&nar, b"closure-bytes").unwrap();
+
+        let (input_disk, _output_disk) = prepare_builder_transport_disks(
+            vm_state_dir.path(),
+            &[InputTree {
+                name: "job",
+                src: &job,
+            }],
+            Some(nar.as_path()),
+            1 << 20,
+        )
+        .unwrap();
+
+        let dest = scratch.path().join("unpacked");
+        read_output_disk(&input_disk, &dest).unwrap();
+        assert_eq!(
+            std::fs::read(
+                dest.join(CLOSURE_SEED_TAG)
+                    .join(crate::builder_pack::CLOSURE_FILE)
+            )
+            .unwrap(),
+            b"closure-bytes"
+        );
+        // And nothing was staged as a share directory for it.
+        assert!(!vm_state_dir.path().join(CLOSURE_SEED_TAG).exists());
     }
 
     #[test]

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -181,15 +181,25 @@ order and asks for no shares). What is left is narrower than "the builder VM":
 
 - [x] `work`, `job`, `mvm-bins` — inbound. Done for the one-shot builder via
       the disk transport; `work` was already done on Stage 0.
-- [ ] **The closure seed is not done, and this box used to claim it was.** It is
-      the one inbound tree still on virtio-fs in the one-shot libkrun builder:
-      `libkrun_builder.rs` calls `closure_seed_share` +
-      `add_virtio_fs(CLOSURE_SEED_TAG, …)` at both transport sites, while
-      `prepare_builder_transport_disks` passed a hardcoded `None`. The helper now
-      takes a real `closure_nar` — the QEMU builder uses it — so flipping libkrun
-      is two tokens. Held back only because it changes the macOS default builder
-      and the QEMU work was validated on Linux/KVM; it needs its own live
-      libkrun run.
+- [x] **The closure seed is done now.** This box used to claim it was done while
+      `prepare_builder_transport_disks` passed a hardcoded `None` and both
+      transport sites attached the NAR over virtio-fs a few lines later. Both
+      now pass `self.closure_nar.as_deref()` and attach no share, so the
+      one-shot libkrun builder boots with an empty `virtio_fs_mounts` list —
+      verified against the supervisor config a live `--builder libkrun` run
+      wrote, not just its exit status.
+
+      `run_stage0_impl` keeps its share deliberately: Stage 0 boots a virtio-fs
+      *root* and has no transport disks, so it predates this seam rather than
+      lagging it.
+
+      **The live run could not exercise the closure-carrying arm.** No builder
+      pack on the dev host emits a `nix-closure.nar`, so
+      `closure_nar_for_host_arch()` is `None` and old and new code produce
+      identical bytes. That arm is unit-tested instead
+      (`prepare_transport_disks_lands_the_closure_under_its_fixed_name`), which
+      also pins the rename to `CLOSURE_FILE` — a differently-named source
+      landing under its own name would make the guest's import a silent no-op.
 **The guest is already most of the way there.** `mvm-host-vm-init` has a
 complete disk-transport mode, selected by `mvm.builder_transport=disk` with
 `mvm.builder_input=` / `mvm.builder_output=` naming the devices:

--- a/specs/sprint/delivery/libkrun-closure-on-disk.md
+++ b/specs/sprint/delivery/libkrun-closure-on-disk.md
@@ -1,0 +1,67 @@
+# The libkrun seeded closure rides the input disk
+
+Stage C of `specs/plans/2026-08-31-remove-virtio-fs.md`, libkrun half. Both
+one-shot libkrun transport paths (`run_shell_script`, `run_build`) now pass the
+seeded Nix store closure to `prepare_builder_transport_disks` instead of
+attaching it as a separate virtio-fs share.
+
+This closes a box the plan had marked done and wasn't. The plan's `[x]` on
+"`work`, `job`, `mvm-bins`, closure seed — Done for the one-shot builder via the
+disk transport" was false for the closure: `prepare_builder_transport_disks`
+passed a hardcoded `None` while both call sites attached the NAR over virtio-fs
+a few lines later. The QEMU migration gave the helper a real `closure_nar`
+parameter; this uses it.
+
+## What stays
+
+`run_stage0_impl` keeps its closure-seed share, deliberately. Stage 0 boots a
+virtio-fs *root* (`krun_set_root`) and has no transport disks at all, so it
+predates this seam rather than lagging it. `closure_seed_share` and its two unit
+tests stay for that one caller.
+
+## Live validation
+
+`mvmctl machine build --builder libkrun` on macOS 26.5.2 / arm64 against
+`examples/sleeper`, warm builder-image cache:
+
+    [mvm] Step 2/2: Build complete
+    [mvm]   Slot: 2ab4f258887f2a9aed72961b42675a68993c5e841fd6e51188daff7ea364e65f
+
+The proof is in the supervisor config the run wrote, not just the exit status:
+
+    virtio_fs_mounts = []
+    extra_disks = [nix-store, input, output, runtime-overlay, …]
+
+The libkrun one-shot builder now boots with **zero** virtio-fs devices, and no
+`closure-seed/` staging directory was created under the VM state dir.
+
+**What this run does not prove, stated rather than glossed.** This host's
+builder-image cache carries no `nix-closure.nar`, so `closure_nar_for_host_arch()`
+returns `None` — with no closure to carry, old and new code produce identical
+bytes and the live run is a regression check on the surrounding transport path
+rather than a test of the closure moving onto the disk.
+
+That arm is covered by
+`prepare_transport_disks_lands_the_closure_under_its_fixed_name`, which packs a
+deliberately misnamed source NAR and asserts it lands at
+`closure-seed/nix-closure.nar`. The rename is the part worth pinning: the guest
+imports a fixed path, so a differently-named source landing under its own name
+would make `import_seeded_closure` a silent no-op rather than an error.
+
+Planting a synthetic NAR to force the live path was considered and rejected —
+`import_seeded_closure` returns `Err` when `nix-store --import` fails, so a
+bogus file would fail the build for an artificial reason and say nothing about
+the transport.
+
+## Gate
+
+`check-no-virtio-fs`: 54 sites across 15 files → **52 across 15**, and
+`libkrun_builder.rs`'s pin reason is now accurate — its remaining 11 sites are
+the Stage 0 RootDir path, not the transport paths.
+
+## Verification
+
+`cargo fmt --all --check`, `just check-gated`, `cargo clippy --workspace
+--all-targets -D warnings`, `cargo nextest run --workspace` (12,890 passed),
+`cargo test --workspace --doc`, `cargo run -p xtask -- check-all` (63 gates) —
+all clean.

--- a/xtask/src/check_no_virtio_fs.rs
+++ b/xtask/src/check_no_virtio_fs.rs
@@ -115,11 +115,11 @@ const PINNED: &[(&str, usize, &str)] = &[
     // ── builder VM: our own trusted build engine ────────────────────────────
     (
         "crates/mvm-build/src/libkrun_builder.rs",
-        13,
-        "the libkrun builder's work/out/job/mvm-bins shares on the paths that \
-         predate the disk transport, plus the seeded-closure share the \
-         one-shot transport paths still attach. Retired by passing the NAR to \
-         `prepare_builder_transport_disks`, which now takes it",
+        11,
+        "the libkrun builder's work/out/job/mvm-bins shares on the Stage 0 \
+         RootDir path, which boots a virtio-fs root and so predates the disk \
+         transport entirely. The one-shot transport paths carry nothing over \
+         virtio-fs now that the seeded closure rides the input disk",
     ),
     (
         "crates/mvm-backends/src/driver/fc.rs",


### PR DESCRIPTION
# The libkrun seeded closure rides the input disk

Stage C of `specs/plans/2026-08-31-remove-virtio-fs.md`, libkrun half. Both
one-shot libkrun transport paths (`run_shell_script`, `run_build`) now pass the
seeded Nix store closure to `prepare_builder_transport_disks` instead of
attaching it as a separate virtio-fs share.

This closes a box the plan had marked done and wasn't. The plan's `[x]` on
"`work`, `job`, `mvm-bins`, closure seed — Done for the one-shot builder via the
disk transport" was false for the closure: `prepare_builder_transport_disks`
passed a hardcoded `None` while both call sites attached the NAR over virtio-fs
a few lines later. The QEMU migration gave the helper a real `closure_nar`
parameter; this uses it.

## What stays

`run_stage0_impl` keeps its closure-seed share, deliberately. Stage 0 boots a
virtio-fs *root* (`krun_set_root`) and has no transport disks at all, so it
predates this seam rather than lagging it. `closure_seed_share` and its two unit
tests stay for that one caller.

## Live validation

`mvmctl machine build --builder libkrun` on macOS 26.5.2 / arm64 against
`examples/sleeper`, warm builder-image cache:

    [mvm] Step 2/2: Build complete
    [mvm]   Slot: 2ab4f258887f2a9aed72961b42675a68993c5e841fd6e51188daff7ea364e65f

The proof is in the supervisor config the run wrote, not just the exit status:

    virtio_fs_mounts = []
    extra_disks = [nix-store, input, output, runtime-overlay, …]

The libkrun one-shot builder now boots with **zero** virtio-fs devices, and no
`closure-seed/` staging directory was created under the VM state dir.

**What this run does not prove, stated rather than glossed.** This host's
builder-image cache carries no `nix-closure.nar`, so `closure_nar_for_host_arch()`
returns `None` — with no closure to carry, old and new code produce identical
bytes and the live run is a regression check on the surrounding transport path
rather than a test of the closure moving onto the disk.

That arm is covered by
`prepare_transport_disks_lands_the_closure_under_its_fixed_name`, which packs a
deliberately misnamed source NAR and asserts it lands at
`closure-seed/nix-closure.nar`. The rename is the part worth pinning: the guest
imports a fixed path, so a differently-named source landing under its own name
would make `import_seeded_closure` a silent no-op rather than an error.

Planting a synthetic NAR to force the live path was considered and rejected —
`import_seeded_closure` returns `Err` when `nix-store --import` fails, so a
bogus file would fail the build for an artificial reason and say nothing about
the transport.

## Gate

`check-no-virtio-fs`: 54 sites across 15 files → **52 across 15**, and
`libkrun_builder.rs`'s pin reason is now accurate — its remaining 11 sites are
the Stage 0 RootDir path, not the transport paths.

## Verification

`cargo fmt --all --check`, `just check-gated`, `cargo clippy --workspace
--all-targets -D warnings`, `cargo nextest run --workspace` (12,890 passed),
`cargo test --workspace --doc`, `cargo run -p xtask -- check-all` (63 gates) —
all clean.
