### PR TITLE
feat(mount): find a materialized mount by label rather than by slot

### DIFF
--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -388,7 +388,26 @@ fn ensure_volume_mount_target(
     }
 }
 
-fn resolve_volume_mount_source(volume: &VolumeConfig) -> Result<(&str, &'static str)> {
+/// Find the attached block device whose ext4 label is `label`.
+///
+/// Delegates to `flowmux_drive`, which already solved this for the FlowMux
+/// identity disk: it enumerates from `/sys/class/block` rather than guessing a
+/// `/dev/vd[a-z]` range, checks the ext4 magic before trusting the label field,
+/// and is the same decoder the writer's stamp is tested against. A second
+/// superblock parser here would be a second thing to keep in sync with the
+/// on-disk format.
+fn device_for_label(label: &str) -> Result<String> {
+    crate::flowmux_drive::find_labeled_ext4_disk_among(
+        crate::flowmux_drive::virtio_block_devices(),
+        label,
+    )
+    .map(|path| path.to_string_lossy().into_owned())
+    .ok_or_else(|| {
+        MountError::InvalidConfig(format!("no block device carries volume label {label:?}"))
+    })
+}
+
+fn resolve_volume_mount_source(volume: &VolumeConfig) -> Result<(String, &'static str)> {
     if volume.tag.is_empty() {
         return Err(MountError::InvalidConfig(
             "volume tag must not be empty".to_string(),
@@ -402,7 +421,13 @@ fn resolve_volume_mount_source(volume: &VolumeConfig) -> Result<(&str, &'static 
                     volume.tag
                 )));
             }
-            Ok((&volume.tag, "virtiofs"))
+            if volume.label.is_some() {
+                return Err(MountError::InvalidConfig(format!(
+                    "virtio-fs volume {:?} must not carry a volume label",
+                    volume.tag
+                )));
+            }
+            Ok((volume.tag.clone(), "virtiofs"))
         }
         VolumeConfigKind::Block => {
             let device = volume.device.as_deref().ok_or_else(|| {
@@ -412,7 +437,14 @@ fn resolve_volume_mount_source(volume: &VolumeConfig) -> Result<(&str, &'static 
                 ))
             })?;
             validate_virtio_block_device(device, "block volume")?;
-            Ok((device, "ext4"))
+            // A label, when the host wrote one, wins over the node. Resolution
+            // failure is fatal rather than a fallback to `device`: the host
+            // asserted an identity, and mounting the slot anyway would be
+            // exactly the silent wrong-image mount the label exists to stop.
+            match volume.label.as_deref() {
+                Some(label) => Ok((device_for_label(label)?, "ext4")),
+                None => Ok((device.to_string(), "ext4")),
+            }
         }
     }
 }
@@ -450,7 +482,7 @@ pub fn mount_volumes(volumes: &[VolumeConfig], root: &Path) -> Result<()> {
         #[cfg(target_os = "linux")]
         {
             let flags = if vol.read_only { libc::MS_RDONLY } else { 0 };
-            mount(source, &target.to_string_lossy(), filesystem, flags, "")?;
+            mount(&source, &target.to_string_lossy(), filesystem, flags, "")?;
             if let Some((uid, gid)) = writable_block_volume_owner(vol) {
                 chown(&target.to_string_lossy(), uid, gid)?;
             }
@@ -2017,6 +2049,41 @@ tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0
     }
 
     #[test]
+    fn a_virtiofs_volume_may_not_carry_a_volume_label() {
+        // A share is addressed by tag and has no filesystem to read a label
+        // from, so a label here means the host built a contradictory config.
+        let volume = VolumeConfig {
+            tag: "uvol0".to_string(),
+            mountpoint: "/mnt/data".to_string(),
+            read_only: true,
+            kind: VolumeConfigKind::VirtioFs,
+            device: None,
+            label: Some("mvmmnt0".to_string()),
+        };
+        assert!(resolve_volume_mount_source(&volume).is_err());
+    }
+
+    #[test]
+    fn a_labelled_block_volume_that_matches_no_device_refuses() {
+        // Fail closed. Falling back to the device node would mount whatever
+        // landed in that slot, which is the failure the label prevents.
+        let volume = VolumeConfig {
+            tag: "uvol0".to_string(),
+            mountpoint: "/mnt/data".to_string(),
+            read_only: true,
+            kind: VolumeConfigKind::Block,
+            device: Some("/dev/vdb".to_string()),
+            label: Some("mvm-no-such-label".to_string()),
+        };
+        let err = resolve_volume_mount_source(&volume)
+            .expect_err("an unmatched label must refuse rather than fall back");
+        assert!(
+            err.to_string().contains("mvm-no-such-label"),
+            "error should name the label: {err}"
+        );
+    }
+
+    #[test]
     fn volume_mount_source_distinguishes_virtiofs_and_block() {
         let share = VolumeConfig {
             tag: "uvol0".to_string(),
@@ -2024,10 +2091,11 @@ tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0
             read_only: true,
             kind: crate::vsock::VolumeConfigKind::VirtioFs,
             device: None,
+            label: None,
         };
         assert_eq!(
             resolve_volume_mount_source(&share).unwrap(),
-            ("uvol0", "virtiofs")
+            ("uvol0".to_string(), "virtiofs")
         );
 
         let block = VolumeConfig {
@@ -2036,10 +2104,11 @@ tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0
             read_only: false,
             kind: crate::vsock::VolumeConfigKind::Block,
             device: Some("/dev/vdb".to_string()),
+            label: None,
         };
         assert_eq!(
             resolve_volume_mount_source(&block).unwrap(),
-            ("/dev/vdb", "ext4")
+            ("/dev/vdb".to_string(), "ext4")
         );
     }
 
@@ -2051,6 +2120,7 @@ tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0
             read_only: false,
             kind: crate::vsock::VolumeConfigKind::VirtioFs,
             device: Some("/dev/vdb".to_string()),
+            label: None,
         };
         assert!(resolve_volume_mount_source(&share_with_device).is_err());
 
@@ -2060,6 +2130,7 @@ tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0
             read_only: false,
             kind: crate::vsock::VolumeConfigKind::Block,
             device: Some("/dev/sda".to_string()),
+            label: None,
         };
         assert!(resolve_volume_mount_source(&invalid_block).is_err());
     }
@@ -2080,6 +2151,7 @@ tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0
             read_only: false,
             kind: crate::vsock::VolumeConfigKind::Block,
             device: Some("/dev/vdb".to_string()),
+            label: None,
         };
 
         assert_eq!(
@@ -2096,6 +2168,7 @@ tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0
             read_only: true,
             kind: crate::vsock::VolumeConfigKind::Block,
             device: Some("/dev/vdb".to_string()),
+            label: None,
         };
         let writable_share = VolumeConfig {
             tag: "uvol1".to_string(),
@@ -2103,6 +2176,7 @@ tmpfs /tmp tmpfs rw,nosuid,nodev,relatime 0 0
             read_only: false,
             kind: crate::vsock::VolumeConfigKind::VirtioFs,
             device: None,
+            label: None,
         };
 
         assert_eq!(writable_block_volume_owner(&read_only_block), None);

--- a/crates/mvm-agentd/src/vsock/activation.rs
+++ b/crates/mvm-agentd/src/vsock/activation.rs
@@ -193,6 +193,14 @@ pub struct VolumeConfig {
     /// virtio-fs and is validated against the bounded `/dev/vd[a-z]` range.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub device: Option<String>,
+    /// ext4 volume label on the attached image, when the host wrote one.
+    ///
+    /// Preferred over [`Self::device`] for a block volume: a device node names
+    /// whichever image landed in that slot, so a slot-order change mounts the
+    /// wrong one and succeeds. Matching the label proves the guest mounted the
+    /// image the host meant. `None` falls back to the node.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 #[cfg(test)]
@@ -220,6 +228,7 @@ mod tests {
                 read_only: true,
                 kind: VolumeConfigKind::VirtioFs,
                 device: None,
+                label: None,
             }],
             extensions: Vec::new(),
             verb_grant_envelope: None,

--- a/crates/mvm-agentd/src/vsock/request_policy.rs
+++ b/crates/mvm-agentd/src/vsock/request_policy.rs
@@ -673,6 +673,7 @@ mod tests {
                 read_only: false,
                 kind: crate::vsock::VolumeConfigKind::VirtioFs,
                 device: None,
+                label: None,
             }],
             extensions: Vec::new(),
             verb_grant_envelope: None,

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -1401,6 +1401,7 @@ mod tests {
         let mut c = eligible_cfg();
         c.volumes = vec![VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: "/h".into(),
             guest: "/g".into(),
             size: String::new(),
@@ -1558,6 +1559,7 @@ mod tests {
             let mut c = eligible_cfg();
             c.volumes = vec![VmVolume {
                 materialized_image: None,
+                volume_label: None,
                 host: "/h".into(),
                 guest: "/g".into(),
                 size: String::new(),

--- a/crates/mvm-cli/src/commands/shared/parse.rs
+++ b/crates/mvm-cli/src/commands/shared/parse.rs
@@ -239,6 +239,7 @@ pub fn volume_spec_to_vm_volume(spec: &VolumeSpec) -> VmVolume {
             read_only,
         } => VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host_dir.clone(),
             guest: guest_mount.clone(),
             size: String::new(),
@@ -254,6 +255,7 @@ pub fn volume_spec_to_vm_volume(spec: &VolumeSpec) -> VmVolume {
             encrypted,
         } => VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host.clone(),
             guest: guest.clone(),
             size: size.clone(),
@@ -783,6 +785,7 @@ mod volume_spec_tests {
         let host = tmp.path().join("data.img");
         let volume = VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host.to_string_lossy().into_owned(),
             guest: "/data".to_string(),
             size: "10M".to_string(),
@@ -811,6 +814,7 @@ mod volume_spec_tests {
         let share_host = tmp.path().join("share");
         let share = VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: share_host.to_string_lossy().into_owned(),
             guest: "/share".to_string(),
             size: "10M".to_string(),

--- a/crates/mvm-cli/src/commands/shared/start.rs
+++ b/crates/mvm-cli/src/commands/shared/start.rs
@@ -325,6 +325,7 @@ impl VmStartParams<'_> {
                 .iter()
                 .map(|v| mvm_core::vm_backend::VmVolume {
                     materialized_image: None,
+                    volume_label: None,
                     host: v.host.clone(),
                     guest: v.guest.clone(),
                     size: v.size.clone(),

--- a/crates/mvm-cli/src/exec/mounts.rs
+++ b/crates/mvm-cli/src/exec/mounts.rs
@@ -3,6 +3,19 @@ use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
 
 use crate::commands::DirShareSpec;
 
+/// The ext4 volume label for the `index`-th `--mount` image.
+///
+/// One authority, called both when the image is written and when the volume
+/// that describes it is built: if those two disagreed the guest would look for
+/// a label that is not on the bytes and fall back to the device node, silently
+/// losing the identity check this exists to provide.
+///
+/// ext4 caps a volume label at 16 bytes; `mvmmnt` plus a `usize` stays inside
+/// that for any plausible mount count.
+pub(crate) fn mount_volume_label(index: usize) -> String {
+    format!("mvmmnt{index}")
+}
+
 /// Turn each `--mount` into a volume backed by a materialized ext4 image.
 ///
 /// `host` stays the directory that was granted so the admission record names
@@ -32,6 +45,9 @@ pub(crate) fn materialize_mount_volumes(
                 read_only: share.read_only,
                 kind: VmVolumeKind::DirShare,
                 materialized_image: Some(image.display().to_string()),
+                // Same authority the image was written with, so the guest
+                // mounts the label that is actually on the bytes.
+                volume_label: Some(mount_volume_label(index)),
                 ..Default::default()
             })
         })
@@ -78,7 +94,7 @@ pub(crate) fn materialize_mount_image(
     let output = state_dir.join(format!("mount-{index}.ext4"));
     // Labelled so the guest mounts by identity rather than by enumeration
     // order, the same reason `stage0-init` reads its work disk by label.
-    let label = format!("mvmmnt{index}");
+    let label = mount_volume_label(index);
     let input = mvm_build::rootfs::MaterializeExt4Input::builder()
         .unpacked_root(host_dir.clone())
         .output(output.clone())

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -709,6 +709,7 @@ impl LocalBackend {
             .iter()
             .map(|volume| mvm_core::vm_backend::VmVolume {
                 materialized_image: None,
+                volume_label: None,
                 host: volume.host.clone(),
                 guest: volume.guest.clone(),
                 size: volume.size.clone(),

--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -259,6 +259,7 @@ fn read_only_directory_mount(world: &mut CliWorld, guest_path: String) {
         kind: VmVolumeKind::DirShare,
         encrypted: false,
         materialized_image: None,
+        volume_label: None,
     });
 }
 
@@ -455,6 +456,7 @@ fn admission_refuses_sidecar(world: &mut CliWorld) {
         kind: mvm_core::vm_backend::VmVolumeKind::Disk,
         encrypted: false,
         materialized_image: None,
+        volume_label: None,
     };
     let err = mvm_hostd::plan_admission::enforce_sdk_sidecar_attachment(
         &[smuggled],

--- a/crates/mvm-contract/src/protocol/vm_backend.rs
+++ b/crates/mvm-contract/src/protocol/vm_backend.rs
@@ -92,6 +92,15 @@ pub struct VmVolume {
     ///
     /// `None` on a `Disk`, whose `host` is already the image.
     pub materialized_image: Option<String>,
+    /// ext4 volume label written into the attached image, when the host set
+    /// one, so the guest can mount by identity rather than by enumeration
+    /// order.
+    ///
+    /// A device node is positional: it names whichever disk landed in that
+    /// slot, so a slot-order change mounts the wrong image and succeeds. A
+    /// label travels with the bytes. `None` for an image the host did not
+    /// label, which still mounts by node.
+    pub volume_label: Option<String>,
 }
 
 impl VmVolume {

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1867,6 +1867,7 @@ fn attach_admitted_extensions(config: &mut VmStartConfig, admitted: &AdmittedPla
         }
         config.volumes.push(mvm_core::vm_backend::VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: extension
                 .root
                 .join(&extension.binding.artifact)
@@ -2933,6 +2934,7 @@ mod tests {
             read_only: true,
             kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
             materialized_image: Some("/state/mount-0.ext4".into()),
+            volume_label: None,
             ..Default::default()
         };
         enforce_admitted_shares(std::slice::from_ref(&materialized), &plan)

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -438,6 +438,7 @@ mod tests {
         let volumes = vec![
             VmVolume {
                 materialized_image: None,
+                volume_label: None,
                 host: "/h/work.ext4".into(),
                 guest: "/data/work".into(),
                 size: "16M".into(),
@@ -447,6 +448,7 @@ mod tests {
             },
             VmVolume {
                 materialized_image: None,
+                volume_label: None,
                 host: "/h/src".into(),
                 guest: "/data/src".into(),
                 size: String::new(),
@@ -501,6 +503,7 @@ mod tests {
             backend_name: "mock".into(),
             volumes: vec![VmVolume {
                 materialized_image: None,
+                volume_label: None,
                 host: volume.to_string_lossy().into_owned(),
                 guest: "/data/work".into(),
                 size: String::new(),
@@ -569,6 +572,7 @@ mod tests {
             backend_name: "mock".into(),
             volumes: vec![VmVolume {
                 materialized_image: None,
+                volume_label: None,
                 host: sidecar.to_string_lossy().into_owned(),
                 guest: mvm_core::plan::SDK_SIDECAR_GUEST_PATH.into(),
                 size: String::new(),

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -1082,6 +1082,7 @@ mod tests {
             kernel_path: Some("/kernels/vmlinux".into()),
             volumes: vec![mvm_core::vm_backend::VmVolume {
                 materialized_image: None,
+                volume_label: None,
                 host: "/host".into(),
                 guest: "/guest".into(),
                 size: String::new(),

--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -341,6 +341,13 @@ fn build_volume_configs(config: &VmStartConfig) -> Result<Vec<VolumeConfig>> {
                 read_only: volume.read_only,
                 kind,
                 device,
+                // Only a block volume can be found by label; a virtio-fs share
+                // is addressed by tag and has no filesystem the guest reads a
+                // label from.
+                label: volume
+                    .attaches_as_block()
+                    .then(|| volume.volume_label.clone())
+                    .flatten(),
             })
         })
         .collect()
@@ -736,6 +743,7 @@ mod tests {
         ) -> mvm_core::protocol::vm_backend::VmVolume {
             mvm_core::protocol::vm_backend::VmVolume {
                 materialized_image: None,
+                volume_label: None,
                 host: host.into(),
                 guest: guest.into(),
                 size: String::new(),

--- a/crates/mvm-runtime/src/sdk_sidecar.rs
+++ b/crates/mvm-runtime/src/sdk_sidecar.rs
@@ -51,6 +51,7 @@ pub fn sdk_sidecar_attachment_for(
         },
         volume: mvm_core::vm_backend::VmVolume {
             materialized_image: None,
+            volume_label: None,
             host,
             guest,
             size: String::new(),

--- a/crates/mvm-runtime/src/vm/volume_registry.rs
+++ b/crates/mvm-runtime/src/vm/volume_registry.rs
@@ -273,6 +273,7 @@ impl ResolvedVolumeAttachment {
         };
         VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: self.host_path.display().to_string(),
             guest: self.guest_path.as_str().to_string(),
             size,

--- a/crates/mvm-runtime/src/wasm_activation.rs
+++ b/crates/mvm-runtime/src/wasm_activation.rs
@@ -286,6 +286,7 @@ mod tests {
     fn dir_share(host: &str, guest: &str, read_only: bool) -> VmVolume {
         VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),
@@ -298,6 +299,7 @@ mod tests {
     fn disk_volume(host: &str, guest: &str) -> VmVolume {
         VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),

--- a/crates/mvm-runtime/src/wasm_backend.rs
+++ b/crates/mvm-runtime/src/wasm_backend.rs
@@ -1747,6 +1747,7 @@ mod tests {
         let mut config = cfg("x", "/tmp/mod.wasm");
         config.volumes = vec![mvm_core::vm_backend::VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: "/host/disk.img".into(),
             guest: "/data/disk".into(),
             size: "1G".into(),
@@ -1771,6 +1772,7 @@ mod tests {
             let mut config = cfg("x", "/tmp/mod.wasm");
             config.volumes = vec![mvm_core::vm_backend::VmVolume {
                 materialized_image: None,
+                volume_label: None,
                 host: "/host/share".into(),
                 guest: bad.into(),
                 size: String::new(),

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -2533,6 +2533,7 @@ mod tests {
     fn disk_volume(host: &str, guest: &str, read_only: bool) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),
@@ -2545,6 +2546,7 @@ mod tests {
     fn dir_share_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -721,6 +721,7 @@ mod tests {
         launch.network_policy = NetworkPolicy::unrestricted();
         launch.volumes = vec![VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: tmp.path().join("data.img").display().to_string(),
             guest: "/data".into(),
             size: String::new(),

--- a/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_protocol/protocol.py
@@ -1665,6 +1665,7 @@ class VolumeConfig:
     tag: str
     device: Optional[str] = None
     kind: Optional[VolumeConfigKind] = 'virtio_fs'
+    label: Optional[str] = None
     read_only: Optional[bool] = False
 
 

--- a/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/protocol/protocol.ts
@@ -901,6 +901,12 @@ device?: (string | null)
  */
 kind?: (VolumeConfigKind & string)
 /**
+ * ext4 volume label on the attached image, when the host wrote one.
+ * 
+ * Preferred over [`Self::device`] for a block volume: a device node names whichever image landed in that slot, so a slot-order change mounts the wrong one and succeeds. Matching the label proves the guest mounted the image the host meant. `None` falls back to the node.
+ */
+label?: (string | null)
+/**
  * Absolute guest mountpoint.  Must pass `MountPathPolicy`.
  */
 mountpoint: string

--- a/crates/mvm-vmm/src/host/cmdline.rs
+++ b/crates/mvm-vmm/src/host/cmdline.rs
@@ -590,6 +590,7 @@ mod tests {
     fn disk_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),

--- a/crates/mvm-vmm/src/host/spec_map.rs
+++ b/crates/mvm-vmm/src/host/spec_map.rs
@@ -392,6 +392,7 @@ mod tests {
             read_only: true,
             kind: VmVolumeKind::DirShare,
             materialized_image: image.map(str::to_string),
+            volume_label: None,
             ..Default::default()
         }
     }
@@ -547,6 +548,7 @@ mod tests {
             volumes: vec![
                 VmVolume {
                     materialized_image: None,
+                    volume_label: None,
                     host: "/host/rw".into(),
                     guest: "/guest/rw".into(),
                     size: String::new(),
@@ -556,6 +558,7 @@ mod tests {
                 },
                 VmVolume {
                     materialized_image: None,
+                    volume_label: None,
                     host: "/host/ro".into(),
                     guest: "/guest/ro".into(),
                     size: String::new(),
@@ -634,6 +637,7 @@ mod tests {
     fn disk_volume(host: &str, guest: &str, read_only: bool) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),
@@ -646,6 +650,7 @@ mod tests {
     fn dir_share_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
             materialized_image: None,
+            volume_label: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),

--- a/schema/protocol-v0.json
+++ b/schema/protocol-v0.json
@@ -4407,6 +4407,13 @@
             }
           ]
         },
+        "label": {
+          "description": "ext4 volume label on the attached image, when the host wrote one.\n\nPreferred over [`Self::device`] for a block volume: a device node names whichever image landed in that slot, so a slot-order change mounts the wrong one and succeeds. Matching the label proves the guest mounted the image the host meant. `None` falls back to the node.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "mountpoint": {
           "description": "Absolute guest mountpoint.  Must pass `MountPathPolicy`.",
           "type": "string"

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -90,10 +90,24 @@ the legacy arm, not building the portable one.
       The volume stays `DirShare` so admission still records a *directory*
       grant; the new `VmVolume.materialized_image` carries what is attached.
       Landed as `feat(mount): deliver a granted directory as a block image`.
-- [ ] The guest mounts by volume label rather than by the device node
-      `workload_volume_devices` resolves. The image **is** labelled, but the
-      guest is still handed a node, so this is not done — it is the difference
-      between "works" and "cannot silently mount the wrong device".
+- [x] The guest mounts by volume label rather than by the device node
+      `workload_volume_devices` resolves. `VmVolume.volume_label` is set from
+      the same authority that stamps the image, carried to the guest on
+      `VolumeConfig`, and preferred over the node — with resolution failure
+      **fatal rather than a fallback**, since falling back to the slot is the
+      silent wrong-device mount this exists to stop.
+
+      The resolver is `flowmux_drive`'s, not a new one: it already enumerated
+      from `/sys/class/block`, checked the ext4 magic before trusting the label
+      field, and was the decoder the writer's stamp is tested against. The first
+      draft of this change hand-rolled a second superblock parser over a guessed
+      `/dev/vd[a-z]` range and was replaced.
+
+      Only `--mount` images are labelled, so only they mount by label; managed
+      volumes carry `None` and keep the node path explicitly. Live-validated on
+      macOS 26 by reading `s_volume_name` off the image while the VM ran
+      (`magic 53ef`, `label mvmmnt0`) — a passing mount alone would not have
+      shown which path ran.
 - [x] `refuse_unsupported_dir_shares` and both its call sites deleted: every
       backend can serve a mount now, so it could only produce a false refusal.
 - [x] Deleted: the `supports_directory_shares` trait method (every driver

--- a/specs/sprint/delivery/mount-by-volume-label.md
+++ b/specs/sprint/delivery/mount-by-volume-label.md
@@ -1,0 +1,84 @@
+# A materialized mount is found by label, not by slot
+
+Stage A of `specs/plans/2026-08-31-remove-virtio-fs.md`, the box that read:
+*"The guest mounts by volume label rather than by the device node
+`workload_volume_devices` resolves. The image **is** labelled, but the guest is
+still handed a node… the difference between 'works' and 'cannot silently mount
+the wrong device'."*
+
+## What changed
+
+`VmVolume` gains `volume_label`, set by `materialize_mount_volumes` from the
+same authority that stamps the image (`mount_volume_label`, extracted so the
+writer and the volume description cannot drift apart). `VolumeConfig` carries it
+to the guest, and `resolve_volume_mount_source` prefers it over the node.
+
+Resolution failure is **fatal, not a fallback**. Falling back to the device node
+would mount whatever landed in that slot, which is precisely the failure the
+label exists to prevent. A virtio-fs volume carrying a label is also refused —
+a share has no filesystem to read one from, so its presence means the host built
+a contradictory config.
+
+## Reusing the resolver that already existed
+
+The first version of this change hand-rolled a superblock parser and scanned a
+guessed `/dev/vd[a-z]` range. `mvm-agentd` already had the whole thing:
+`flowmux_drive::{read_ext4_volume_label, find_labeled_ext4_disk_among,
+virtio_block_devices}`, written for the FlowMux identity disk.
+
+The existing one is better in three concrete ways, which is the argument for the
+rule rather than just the rule: it enumerates from `/sys/class/block` instead of
+guessing a letter range, it checks the ext4 magic before trusting the label
+field, and it is the decoder the writer's stamp is already tested against. The
+duplicate is gone.
+
+## Live validation
+
+`mvmctl machine run --image alpine --mount /tmp/…:/work:ro -- cat /work/marker.txt`
+on macOS 26.5.2 / arm64 printed the payload, before and after the dedup.
+
+A passing mount alone would not prove the label path ran, so the image was read
+while the VM was alive:
+
+    magic@1080 = 53ef        (ext4)
+    label@1144 = b'mvmmnt0\x00…'
+
+That is `s_volume_name` at `1024 + 0x78`. Combined with the guest failing closed
+on an unresolvable label, a successful mount means the label resolved.
+
+**A measurement bug worth recording.** The first read of that offset returned
+empty and looked like "the writer never stamped a label". It was `dd` reading a
+path that had already been reaped when the transient VM exited, with `2>/dev/null`
+hiding the missing-file error. Empty output read as absence. The rerun held the
+VM open with a `sleep` and confirmed the file existed before reading it.
+
+## Scope
+
+Only `--mount` images are labelled today, so only they mount by label. Managed
+volumes (`mvmctl volume`) keep mounting by node: their images are created
+elsewhere and this change does not assume they carry labels. `volume_label` is
+`None` for them, which selects the node path explicitly rather than by accident.
+
+This is a guest-side change in `mvm-agentd`, baked into workload rootfs images,
+so it takes effect for an image once that image is rebuilt. An image carrying an
+older agent ignores the unknown field via `#[serde(default)]` and mounts by node
+exactly as before — it does not fail.
+
+## Not done: retiring `DirShare`
+
+The sibling box (`VmVolumeKind::DirShare` / `LocalVolumeKind::Directory`) stays
+open. `DirShare` is what records a *directory* grant in the plan, which claim 1
+matches against, so removing it means relocating a claim-bearing fact through
+the admission path. That is a security-model change, not cleanup, and does not
+belong bundled with a mount-resolution fix.
+
+## Verification
+
+`cargo fmt --all --check`, `just check-gated`, `cargo clippy --workspace
+--all-targets -D warnings`, `cargo nextest run --workspace` (12,891 passed),
+`cargo test --workspace --doc`, `cargo run -p xtask -- check-all` (63 gates).
+
+`check-gated` earned its keep twice here: it caught a `&str`/`String` mismatch in
+the `cfg(target_os = "linux")` mount call and two exhaustive `VmVolume`
+constructions in `mvm-conformance`, both invisible to `--all-targets` on macOS.
+`check-stubs` caught the generated SDK stubs going stale from the new field.


### PR DESCRIPTION
# A materialized mount is found by label, not by slot

Stage A of `specs/plans/2026-08-31-remove-virtio-fs.md`, the box that read:
*"The guest mounts by volume label rather than by the device node
`workload_volume_devices` resolves. The image **is** labelled, but the guest is
still handed a node… the difference between 'works' and 'cannot silently mount
the wrong device'."*

## What changed

`VmVolume` gains `volume_label`, set by `materialize_mount_volumes` from the
same authority that stamps the image (`mount_volume_label`, extracted so the
writer and the volume description cannot drift apart). `VolumeConfig` carries it
to the guest, and `resolve_volume_mount_source` prefers it over the node.

Resolution failure is **fatal, not a fallback**. Falling back to the device node
would mount whatever landed in that slot, which is precisely the failure the
label exists to prevent. A virtio-fs volume carrying a label is also refused —
a share has no filesystem to read one from, so its presence means the host built
a contradictory config.

## Reusing the resolver that already existed

The first version of this change hand-rolled a superblock parser and scanned a
guessed `/dev/vd[a-z]` range. `mvm-agentd` already had the whole thing:
`flowmux_drive::{read_ext4_volume_label, find_labeled_ext4_disk_among,
virtio_block_devices}`, written for the FlowMux identity disk.

The existing one is better in three concrete ways, which is the argument for the
rule rather than just the rule: it enumerates from `/sys/class/block` instead of
guessing a letter range, it checks the ext4 magic before trusting the label
field, and it is the decoder the writer's stamp is already tested against. The
duplicate is gone.

## Live validation

`mvmctl machine run --image alpine --mount /tmp/…:/work:ro -- cat /work/marker.txt`
on macOS 26.5.2 / arm64 printed the payload, before and after the dedup.

A passing mount alone would not prove the label path ran, so the image was read
while the VM was alive:

    magic@1080 = 53ef        (ext4)
    label@1144 = b'mvmmnt0\x00…'

That is `s_volume_name` at `1024 + 0x78`. Combined with the guest failing closed
on an unresolvable label, a successful mount means the label resolved.

**A measurement bug worth recording.** The first read of that offset returned
empty and looked like "the writer never stamped a label". It was `dd` reading a
path that had already been reaped when the transient VM exited, with `2>/dev/null`
hiding the missing-file error. Empty output read as absence. The rerun held the
VM open with a `sleep` and confirmed the file existed before reading it.

## Scope

Only `--mount` images are labelled today, so only they mount by label. Managed
volumes (`mvmctl volume`) keep mounting by node: their images are created
elsewhere and this change does not assume they carry labels. `volume_label` is
`None` for them, which selects the node path explicitly rather than by accident.

This is a guest-side change in `mvm-agentd`, baked into workload rootfs images,
so it takes effect for an image once that image is rebuilt. An image carrying an
older agent ignores the unknown field via `#[serde(default)]` and mounts by node
exactly as before — it does not fail.

## Not done: retiring `DirShare`

The sibling box (`VmVolumeKind::DirShare` / `LocalVolumeKind::Directory`) stays
open. `DirShare` is what records a *directory* grant in the plan, which claim 1
matches against, so removing it means relocating a claim-bearing fact through
the admission path. That is a security-model change, not cleanup, and does not
belong bundled with a mount-resolution fix.

## Verification

`cargo fmt --all --check`, `just check-gated`, `cargo clippy --workspace
--all-targets -D warnings`, `cargo nextest run --workspace` (12,891 passed),
`cargo test --workspace --doc`, `cargo run -p xtask -- check-all` (63 gates).

`check-gated` earned its keep twice here: it caught a `&str`/`String` mismatch in
the `cfg(target_os = "linux")` mount call and two exhaustive `VmVolume`
constructions in `mvm-conformance`, both invisible to `--all-targets` on macOS.
`check-stubs` caught the generated SDK stubs going stale from the new field.
