### PR TITLE
feat(xtask): refuse a vCPU ceiling derived from a wire type

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -348,6 +348,11 @@ for detailed scope and acceptance criteria.
       reporting clamp stays a single call site above the backends.
       Live-witnessed on x86_64 Linux/KVM. See
       `specs/sprint/delivery/vcpu-ceilings-are-the-vmms-not-the-wires.md`.
+      Followed by `xtask check-vcpu-ceilings`, which refuses a `max_vcpus`
+      derived from an integer type's `MAX` so a fourth backend cannot reach the
+      same wrong conclusion two authors already reached independently. Wired
+      into `check-all`, so it runs on every PR. See
+      `specs/sprint/delivery/vcpu-ceiling-gate-refuses-wire-type-limits.md`.
 
 - [x] **virtiofsd sandbox parity — issue #3022.**
       `specs/plans/2026-08-31-virtiofsd-sandbox-parity.md`.

--- a/specs/sprint/delivery/vcpu-ceiling-gate-refuses-wire-type-limits.md
+++ b/specs/sprint/delivery/vcpu-ceiling-gate-refuses-wire-type-limits.md
@@ -1,0 +1,94 @@
+# A gate for the vCPU ceiling, because the mistake was made twice
+
+Firecracker and libkrun each declared `max_vcpus: Some(u32::from(u8::MAX))`,
+independently, for the same reason: the vCPU count is a byte on the wire, so
+255 is the largest value the call can carry. True of both, and the limit of
+neither — `/machine-config` refuses anything above 32, and libkrun's
+`krun_set_vm_config` accepts all 255 and then aborts inside `krun_start_enter`
+at 65. The clamp above the backends faithfully granted a count that would not
+boot, so `--cpus 9999` failed on both while succeeding on HVF, whose ceiling is
+asked of the host. Both were fixed under #3051 and #3065.
+
+Two independent authors reaching the same wrong conclusion is the argument for
+a gate rather than a third careful review. Nothing stopped a fourth backend
+from declaring the same thing tomorrow, and the failure is invisible until
+someone boots a guest with an absurd `--cpus` on that specific backend — which
+is how both of these survived: the number was wrong the whole time, and the
+tests that existed asserted it.
+
+`xtask check-vcpu-ceilings` refuses a `max_vcpus` declaration derived from an
+integer type's `MAX`. It is registered in `check-all`, which `ci.yml` runs on
+every PR.
+
+## What it does and does not say
+
+The rule is narrow on purpose. *How* a backend obtains a real ceiling is its
+own business: a measured constant (`Some(MAX_VCPUS)`) and a host query
+(`hvf_max_vcpus()`) are both fine and the gate prefers neither. What it refuses
+is the one derivation that cannot be right, because the width of a field says
+nothing about what the VMM behind it accepts.
+
+It matches any width and both signednesses rather than `u8::MAX` alone: the
+reasoning that produced the bug — "the field is N bits wide, so its ceiling is
+what N bits hold" — is not specific to a byte, and a backend whose count
+travels as a `u16` would repeat it verbatim.
+
+Test code is scanned too, since a declaration in a fixture binds as much as one
+in a driver — but note what that does *not* buy. `mvm-client`'s clamp test read
+`assert_eq!(..., Some(u32::from(u8::MAX)))`, pinning the defect as the
+contract, and this gate walks straight past it: that is an `assert_eq!`
+argument, not a `max_vcpus` declaration. Reaching it would mean flagging a
+wire-type `MAX` anywhere near vCPU text, which immediately hits honest uses —
+the libkrun driver's
+`u8::try_from(spec.vcpus.clamp(1, MAX_VCPUS)).unwrap_or(u8::MAX)` is an
+infallible-conversion fallback on an already-clamped value, on a line that says
+`vcpus`. A gate that cried wolf there would be switched off. So the rule stays
+narrow, and the wrong assertion stays CI's job — which is how that one was
+actually caught: it went red the moment the ceiling was corrected.
+
+Comments and strings are blanked first through the shared
+`xtask::rust_source` scanner rather than a second copy of that handling — the
+gate's own explanation says `u8::MAX` several times, and a scanner that read
+comments as code would fail the gate on its own prose.
+
+A declaration floor (`MINIMUM_DECLARATIONS`) is the other half: a gate that
+passes because every ceiling has been deleted has stopped noticing that
+ceilings used to be declared. Same failure `check-backend-resource-controls`
+guards with its matrix floor.
+
+## Witness
+
+Both halves were checked by hand against the real code rather than inferred:
+reintroducing the declaration defect in `fc.rs` fails the gate, and
+reintroducing the assertion defect in `mvm-client` does *not* — which is the
+boundary described above, confirmed rather than assumed.
+
+The gate's unit tests cover the spellings it must catch (`Some(u8::MAX)`,
+`Some(u32::from(u8::MAX))`, `Some(u16::MAX)`, `Some(std::u8::MAX)`), the ones
+it must not (`Some(MAX_VCPUS)`, a host query, a bare literal, `None`), the
+near-misses that would make it noisy (`MAX_VCPUS` and `FALLBACK_u8::MAX` end in
+`MAX` but name no primitive), and that it passes on the tree that ships it.
+
+Checked against the real thing rather than only its fixtures: reintroducing the
+original defect in `fc.rs` fails the gate with the file, the line, the spelling,
+and what to do instead —
+
+```
+crates/mvm-backends/src/driver/fc.rs:666: `max_vcpus` is derived from `u8::MAX`
+— that is the width of the wire field, not a count the VMM boots. Declare what
+the backend will actually start (a measured constant, or a value queried from
+the host/library) so the clamp above the backends grants a request that runs.
+```
+
+## What it does not cover
+
+qemu declares no ceiling at all, so this gate has nothing to check there and
+the reporting clamp stays silent on that backend. Measured while writing this:
+QEMU reports its own limit (`Invalid SMP CPUs 256. The max CPUs supported by
+machine 'pc-i440fx-noble-v2' is 255`), and 255 is exactly what the qemu driver
+already clamps to — so x86_64 is correct today by coincidence rather than by
+derivation. The number is machine-type and version dependent, so a constant
+would be wrong and a probe means spawning QEMU from `capabilities()`. Left
+alone: qemu is a dev/test backend that carries no workload, is never
+auto-selected, and does not fail — the residue is a missing warning, not a
+broken launch.

--- a/xtask/src/check_all.rs
+++ b/xtask/src/check_all.rs
@@ -219,6 +219,7 @@ pub const GATES: &[Gate] = &[
         "check-backend-resource-controls",
         crate::check_backend_resource_controls::run,
     ),
+    ("check-vcpu-ceilings", crate::check_vcpu_ceilings::run),
     (
         "check-single-fixture-corpus",
         crate::check_single_fixture_corpus::run,

--- a/xtask/src/check_vcpu_ceilings.rs
+++ b/xtask/src/check_vcpu_ceilings.rs
@@ -1,0 +1,270 @@
+//! `xtask check-vcpu-ceilings`
+//!
+//! A backend's declared `VmCapabilities::max_vcpus` is the number the clamp
+//! above the backends grants an over-large `--cpus` request. It must therefore
+//! be a count the VMM will *boot*, and this gate fails a declaration derived
+//! from an integer type's `MAX`.
+//!
+//! That is the exact defect this gate exists for, made twice. Firecracker and
+//! libkrun both declared `Some(u32::from(u8::MAX))`, each reasoning that the
+//! vCPU count is a byte on the wire — true of both, and the limit of neither.
+//! `/machine-config` refuses anything above 32; libkrun's `krun_set_vm_config`
+//! accepts all 255 and then aborts inside `krun_start_enter` at 65. So the
+//! clamp faithfully produced a count that would not run, and `--cpus 9999`
+//! failed on both while succeeding on HVF, whose ceiling is asked of the host.
+//!
+//! The rule is narrow on purpose: *how* a real ceiling is obtained is the
+//! backend's business — a measured constant (`Some(MAX_VCPUS)`) and a host
+//! query (`hvf_max_vcpus()`) are both fine, and this gate deliberately does
+//! not prefer one. What it refuses is the one derivation that cannot be right,
+//! because the width of a field says nothing about what the VMM behind it will
+//! accept.
+//!
+//! What this does **not** reach: an assertion that names the wrong number
+//! without declaring it. `mvm-client`'s clamp test read `assert_eq!(...,
+//! Some(u32::from(u8::MAX)))`, pinning the defect as the expected behaviour —
+//! and that is an `assert_eq!` argument, not a `max_vcpus` declaration, so
+//! this gate walks past it. Catching it would mean flagging a wire-type `MAX`
+//! anywhere *near* vCPU text, which immediately hits honest uses: the libkrun
+//! driver's `u8::try_from(spec.vcpus.clamp(1, MAX_VCPUS)).unwrap_or(u8::MAX)`
+//! is an infallible-conversion fallback on an already-clamped value, on a line
+//! that says `vcpus`. A gate that cried wolf there would be turned off, so the
+//! rule stays narrow and the wrong assertion stays CI's job — which is how
+//! that one was in fact caught, by going red the moment the ceiling was fixed.
+//!
+//! Test code is still scanned, since a *declaration* in a fixture is as
+//! binding as one in a driver.
+//!
+//! Comments and string literals are blanked first via the shared
+//! [`crate::rust_source`] scanner — this file's own prose says `u8::MAX`
+//! several times, and a scanner that reads comments as code would fail the
+//! gate on its own explanation.
+
+use anyhow::{Result, bail};
+use std::path::Path;
+
+/// Trees that declare or assert a backend vCPU ceiling.
+const SCANNED_DIRS: &[&str] = &[
+    "crates/mvm-backends/src",
+    "crates/mvm-client/src",
+    "crates/mvm-runtime/src",
+];
+
+/// The struct field whose value this gate governs.
+const FIELD: &str = "max_vcpus";
+
+/// Declarations that must exist. A gate that passes because every ceiling has
+/// been deleted has stopped noticing that ceilings used to be declared — the
+/// same failure `check-backend-resource-controls` guards with its matrix floor.
+/// Two of the three microVM backends declare a constant and one queries the
+/// host; this floor keeps at least the constants honest.
+const MINIMUM_DECLARATIONS: usize = 2;
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mut findings: Vec<String> = Vec::new();
+    let mut declarations = 0usize;
+
+    for dir in SCANNED_DIRS {
+        let root = workspace.join(dir);
+        if !root.is_dir() {
+            bail!("{dir} is not a directory; check-vcpu-ceilings is scanning a stale path");
+        }
+        for file in rust_files(&root)? {
+            let raw = std::fs::read_to_string(&file)
+                .map_err(|e| anyhow::anyhow!("reading {}: {e}", file.display()))?;
+            let body = crate::rust_source::blank_comments_and_strings(&raw);
+            let relative = file
+                .strip_prefix(workspace)
+                .unwrap_or(&file)
+                .display()
+                .to_string();
+
+            for (line_no, line) in body.lines().enumerate() {
+                let Some(value) = ceiling_value(line) else {
+                    continue;
+                };
+                declarations += 1;
+                if let Some(spelling) = wire_type_max(value) {
+                    findings.push(format!(
+                        "{relative}:{}: `{FIELD}` is derived from `{spelling}` — that is the \
+                         width of the wire field, not a count the VMM boots. Declare what the \
+                         backend will actually start (a measured constant, or a value queried \
+                         from the host/library) so the clamp above the backends grants a \
+                         request that runs.",
+                        line_no + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    if !findings.is_empty() {
+        bail!(
+            "vCPU ceilings derived from a wire type:\n\n{}\n",
+            findings.join("\n\n")
+        );
+    }
+
+    if declarations < MINIMUM_DECLARATIONS {
+        bail!(
+            "expected at least {MINIMUM_DECLARATIONS} `{FIELD}` declarations across {:?}; \
+             found {declarations}. Ceilings that have all disappeared is a question, not a pass.",
+            SCANNED_DIRS
+        );
+    }
+
+    println!(
+        "check-vcpu-ceilings: {declarations} ceiling declarations, none derived from a wire type"
+    );
+    Ok(())
+}
+
+/// The value assigned to `max_vcpus:` on this line, if it is an assignment.
+///
+/// A read (`caps.max_vcpus`) or the field's own declaration in the struct
+/// (`pub max_vcpus: Option<u32>`) is not an assignment and is left alone: only
+/// the value a backend *declares* is this gate's business. The type-annotation
+/// form is told apart by its leading visibility/binding keyword rather than by
+/// guessing at the value, so a field renamed or re-typed does not slip past.
+fn ceiling_value(line: &str) -> Option<&str> {
+    // An assignment starts the line with the field itself. `pub max_vcpus:` is
+    // the struct's own declaration and never gets past this, and a read
+    // (`caps.max_vcpus`) has the field mid-line rather than at its head.
+    let value = line
+        .trim()
+        .strip_prefix(FIELD)?
+        .strip_prefix(':')?
+        .trim()
+        .trim_end_matches(',');
+    // `max_vcpus: Option<u32>` is the struct's own field declaration, and
+    // `max_vcpus: u32` its display mirror — neither declares a ceiling.
+    if value.starts_with("Option<") || value.starts_with("u32") || value.is_empty() {
+        return None;
+    }
+    Some(value)
+}
+
+/// The integer-type `MAX` this expression is built from, if any.
+///
+/// Matches any width and both signednesses rather than `u8::MAX` alone: the
+/// reasoning that produced the bug — "the field is N bits wide, so its ceiling
+/// is what N bits hold" — is not specific to a byte, and a future backend
+/// whose count travels as a `u16` would repeat it verbatim.
+fn wire_type_max(value: &str) -> Option<String> {
+    let bytes: Vec<char> = value.chars().collect();
+    for (i, _) in bytes.iter().enumerate() {
+        if !bytes[i..].starts_with(&[':', ':', 'M', 'A', 'X']) {
+            continue;
+        }
+        // Walk back over the digits and the leading `u`/`i` of the type name.
+        let mut start = i;
+        while start > 0 && bytes[start - 1].is_ascii_digit() {
+            start -= 1;
+        }
+        if start == i {
+            continue; // `::MAX` with no width in front — not an integer type.
+        }
+        if start == 0 || !matches!(bytes[start - 1], 'u' | 'i') {
+            continue;
+        }
+        start -= 1;
+        // A qualified path (`std::u8::MAX`) still ends in the type, but a
+        // longer identifier (`FOO_u8::MAX`) does not name a primitive.
+        if start > 0 && (bytes[start - 1].is_alphanumeric() || bytes[start - 1] == '_') {
+            continue;
+        }
+        return Some(bytes[start..i + 5].iter().collect());
+    }
+    None
+}
+
+fn rust_files(root: &Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir)
+            .map_err(|e| anyhow::anyhow!("reading {}: {e}", dir.display()))?
+        {
+            let path = entry
+                .map_err(|e| anyhow::anyhow!("reading an entry of {}: {e}", dir.display()))?
+                .path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wire_type_ceiling_is_caught_however_it_is_spelled() {
+        for value in [
+            "Some(u8::MAX)",
+            "Some(u32::from(u8::MAX))",
+            "Some(u16::MAX)",
+            "Some(std::u8::MAX)",
+            "Some(u32::from(i8::MAX))",
+        ] {
+            assert!(
+                wire_type_max(value).is_some(),
+                "{value} derives a ceiling from a wire type and must be refused"
+            );
+        }
+    }
+
+    /// A real ceiling is not flagged, whichever way the backend got it. The
+    /// gate governs the derivation, not the mechanism — a measured constant
+    /// and a host query are equally acceptable answers.
+    #[test]
+    fn a_measured_or_queried_ceiling_passes() {
+        for value in [
+            "Some(MAX_VCPUS)",
+            "hvf_backend::hvf_max_vcpus()",
+            "Some(32)",
+            "None",
+        ] {
+            assert_eq!(
+                wire_type_max(value),
+                None,
+                "{value} is a real ceiling and must pass"
+            );
+        }
+    }
+
+    /// `MAX_VCPUS` ends in `MAX` but names no integer type, and a constant
+    /// whose identifier merely ends in one is not a primitive path either.
+    #[test]
+    fn an_identifier_ending_in_max_is_not_a_wire_type() {
+        assert_eq!(wire_type_max("Some(MAX_VCPUS)"), None);
+        assert_eq!(wire_type_max("Some(FALLBACK_u8::MAX)"), None);
+        assert_eq!(wire_type_max("Some(SELF::MAX)"), None);
+    }
+
+    #[test]
+    fn only_assignments_are_read_not_reads_or_field_declarations() {
+        assert_eq!(
+            ceiling_value("            max_vcpus: Some(MAX_VCPUS),"),
+            Some("Some(MAX_VCPUS)")
+        );
+        assert_eq!(ceiling_value("    pub max_vcpus: Option<u32>,"), None);
+        assert_eq!(ceiling_value("    pub max_vcpus: u32,"), None);
+        assert_eq!(ceiling_value("        let c = caps.max_vcpus;"), None);
+    }
+
+    /// The gate must pass on the tree that ships it.
+    #[test]
+    fn passes_on_this_workspace() {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("xtask has a parent workspace")
+            .to_path_buf();
+        run(&workspace).expect("this workspace declares no wire-type vCPU ceiling");
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -75,6 +75,7 @@ mod check_stream_redaction_seam;
 mod check_test_home_isolation;
 mod check_trust_gradient;
 mod check_two_surfaces;
+mod check_vcpu_ceilings;
 mod check_verified_kernel_reads;
 mod check_witness_citations;
 mod check_workflow_paths;
@@ -369,6 +370,10 @@ fn main() -> Result<()> {
             let workspace = workspace_root();
             check_single_network_path::run(&workspace)
         }
+        Some("check-vcpu-ceilings") => {
+            let workspace = workspace_root();
+            check_vcpu_ceilings::run(&workspace)
+        }
         Some("check-guest-init-parity") => {
             let workspace = workspace_root();
             check_guest_init_parity::run(&workspace)
@@ -438,7 +443,7 @@ fn main() -> Result<()> {
             check_all::run_all(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-sdk-transport-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-asserted-absence, check-agent-notes, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-virtio-fs, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-sdk-transport-free, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-asserted-absence, check-agent-notes, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-virtio-fs, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, check-vcpu-ceilings, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -587,6 +592,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-single-network-path              assert one endpoint, one NetworkFlow channel, no guest NIC/L3 path, and one workload socket owner"
+            );
+            eprintln!(
+                "  check-vcpu-ceilings                    assert no backend derives its declared vCPU ceiling from a wire type's MAX"
             );
             println!(
                 "  check-no-virtio-fs                     ratchet the virtio-fs attach surface: builder VM and FFI only, may shrink but never grow"


### PR DESCRIPTION
Follow-on to #3064, which corrected the vCPU ceilings that #3051 and #3065
reported. This adds the gate so the class cannot come back.

## Why a gate and not a code review

Firecracker and libkrun each declared `max_vcpus: Some(u32::from(u8::MAX))`,
**independently**, for the same reason: the vCPU count is a byte on the wire, so
255 is the largest value the call can carry. True of both, and the limit of
neither — `/machine-config` refuses anything above 32, and libkrun's
`krun_set_vm_config` accepts all 255 and then aborts inside `krun_start_enter`
at 65. The clamp above the backends faithfully granted a count that would not
boot.

Two authors reaching the same wrong conclusion is the argument for a gate rather
than a third careful review. Nothing stopped a fourth backend declaring the same
thing, and the failure stays invisible until someone boots a guest with an
absurd `--cpus` on that specific backend — which is how both survived: the
number was wrong the whole time, and the tests asserted it.

## The rule

`xtask check-vcpu-ceilings` refuses a `max_vcpus` declaration derived from an
integer type's `MAX`. Any width, either signedness — the reasoning that produced
the bug ("the field is N bits wide, so its ceiling is what N bits hold") is not
specific to a byte, and a backend whose count travels as a `u16` would repeat it
verbatim.

It is deliberately agnostic about *how* a real ceiling is obtained: a measured
constant (`Some(MAX_VCPUS)`) and a host query (`hvf_max_vcpus()`) both pass. What
it refuses is the one derivation that cannot be right, because the width of a
field says nothing about what the VMM behind it accepts.

Registered in `check-all`, which `ci.yml` runs on every PR — a gate nothing
invokes is worse than no gate.

## What it deliberately does not reach

An assertion that names the wrong number without declaring it. `mvm-client`'s
clamp test read `assert_eq!(..., Some(u32::from(u8::MAX)))` — pinning the defect
as the contract, green for as long as the bug lived — and this gate walks past
it, because that is an `assert_eq!` argument rather than a `max_vcpus`
declaration.

Widening the rule to reach it means flagging a wire-type `MAX` anywhere *near*
vCPU text, which immediately hits honest uses: the libkrun driver's
`u8::try_from(spec.vcpus.clamp(1, MAX_VCPUS)).unwrap_or(u8::MAX)` is an
infallible-conversion fallback on an already-clamped value, on a line that says
`vcpus`. A gate that cried wolf there would be switched off, so the rule stays
narrow and the wrong assertion stays CI's job — which is how that one was in
fact caught, by going red the moment the ceiling was corrected.

## Witness

Both halves of that boundary were checked against the real code rather than
inferred:

- reintroducing the declaration defect in `fc.rs` **fails** the gate:
  ```
  crates/mvm-backends/src/driver/fc.rs:666: `max_vcpus` is derived from `u8::MAX`
  — that is the width of the wire field, not a count the VMM boots. Declare what
  the backend will actually start (a measured constant, or a value queried from
  the host/library) so the clamp above the backends grants a request that runs.
  ```
- reintroducing the assertion defect in `mvm-client` **does not** — the
  documented limit, confirmed rather than assumed.

Unit tests cover the spellings it must catch (`Some(u8::MAX)`,
`Some(u32::from(u8::MAX))`, `Some(u16::MAX)`, `Some(std::u8::MAX)`), the ones it
must not (`Some(MAX_VCPUS)`, a host query, a bare literal, `None`), the
near-misses that would make it noisy (`MAX_VCPUS` and `FALLBACK_u8::MAX` end in
`MAX` but name no primitive), and that it passes on the tree that ships it.

Comments and strings are blanked through the shared `xtask::rust_source` scanner
rather than a second copy — this gate's own prose names `u8::MAX` several times,
and a scanner reading comments as code would fail the gate on its own
explanation. A declaration floor is the other half: a gate that passes because
every ceiling has been deleted has stopped noticing ceilings used to exist.

## qemu, measured and deliberately left

qemu declares no ceiling, so the gate has nothing to check there and the
reporting clamp stays silent on that backend. Measured while writing this: QEMU
reports its own limit (`Invalid SMP CPUs 256. The max CPUs supported by machine
'pc-i440fx-noble-v2' is 255`), and 255 is exactly what the qemu driver already
clamps to — so x86_64 is correct today by coincidence rather than derivation.
The number is machine-type and version dependent, so a constant would be wrong
and a probe means spawning QEMU from `capabilities()`. Left alone: qemu is a
dev/test backend that carries no workload, is never auto-selected, and does not
fail. The residue is a missing warning, not a broken launch.

## Gates

`cargo fmt --all -- --check`, `cargo run -p xtask -- check-all` (66 gates clean),
`cargo nextest run --workspace` (12916 passed), `cargo nextest run -p xtask` (694
passed), `cargo test --workspace --doc`,
`cargo clippy --workspace --all-targets -- -D warnings`, `just check-gated`.
