### PR TITLE
chore: measure the witness-reachability gate, refuse it, and fix what it found

### DIFF
--- a/.agent-memory/notes/witness-reachability-gate-measured-and-refuted.md
+++ b/.agent-memory/notes/witness-reachability-gate-measured-and-refuted.md
@@ -1,0 +1,75 @@
+---
+title: A witness-reachability gate was measured over all 84 fn: witnesses and found nothing — do not build it
+date: 2026-09-01
+tags: [gates, claims-ledger, xtask, falsification, dead-code]
+---
+
+`CLAUDE.md` names the hole plainly: the claim gate "proves a named witness
+*exists*, never that anything calls the code it tests". Claim 13's old witness
+round-tripped an encoder no backend builds and no guest parses, so the hole is
+real and it has cost us once. The obvious fix is a gate that refuses a witness
+whose subject has no production caller.
+
+**Measured before building. It finds nothing, and it cannot be made to.**
+
+Method: `check-dormant-controls`' exact caller rule — production `.rs` under
+`crates/` excluding `target`/`tests`/`fuzz`/`benches`, `#[cfg(test)]` modules
+brace-stripped, `use` and `pub use` lines dropped, the defining file excluded —
+applied to every `fn:` witness in the ADR-001 ledger. Subjects for a test-defined
+witness were inferred as the workspace `fn` names appearing in its body.
+
+## Results over 84 witnesses
+
+| | count |
+|---|---|
+| Not found anywhere | **0** — `check-claim-catalog` is doing its job |
+| Defined in production source | 10 |
+| Defined only in test context | 74 |
+| Production-defined with no caller | 1 |
+| Test-defined with ≥1 dead subject | 20 |
+| **Survivors after removing the two noise classes** | **4** |
+| **Genuine findings after reading all six survivor symbols** | **0** |
+
+## Why every hit was false, and why that is structural
+
+- **The defining-file exclusion dominates.** A symbol used inside its own
+  module reads as dead. `set_no_new_privs` — claim 2's witness — is called at
+  `mvm-seccomp-apply.rs:98`, twelve lines above where it is defined, and the
+  rule cannot see it. Same for `read_scope_unit`, `virtiofs_mount_flags`,
+  `host_cpu_mechanism_gap`, `emit_dns_query`, `validate_guest_mount`.
+  `check-dormant-controls` escapes this only because a human hand-picks each
+  control, and picks cross-module ones.
+- **Trait dispatch is invisible to text.** `teardown_paused` is a trait method
+  called as `io.teardown_paused()`; no text rule connects that to the impl.
+- **Name collisions merge distinct symbols.** Two `tier_for_vm` definitions in
+  different modules become one name, and one definition's caller sits in the
+  other's file.
+- **Test support deliberately lives in production source.** A cross-crate test
+  helper has to be `pub` and outside `#[cfg(test)]` to be visible from another
+  crate. `pretend_mechanism_present`, `rendered_argv`, and the `CannedIO`
+  builder `with_network_interfaces` are all correct as written and all read as
+  dead.
+
+Inferring the subject is the part that cannot be fixed. Every hit needed a
+human to read six lines and say "no", which is what the gate was supposed to
+replace.
+
+## Also refuted: blanking comments in the caller haystack
+
+`check-dormant-controls` documents the limit "a symbol named in a comment
+counts as a caller", and blanking comments looked like a free improvement —
+it is the same fix that closed
+[[a-citation-can-resolve-to-its-own-test-fixture]]. Measured on this
+population: **zero witnesses change verdict**. Not one symbol's only caller was
+a comment. It may still be worth doing for the hand-declared controls in
+`xtask/dormant-controls.toml`, but it is not the lever it looked like.
+
+## What would actually close the hole
+
+Not text analysis. Either a real call graph, or — cheaper and in this
+repository's existing idiom — the ledger declaring each witness's subject
+explicitly, the way `dormant-controls.toml` declares a control and its defining
+file. That is 84 hand-written declarations and a decision about who maintains
+them, which is a different and much larger piece of work than a gate.
+
+Until then the hole stays open and stays documented. That is the honest state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,8 +316,9 @@ ADR-001 §"Appendix: Cardoso minimum-viable-policy checklist".
 
    <!-- absent:end -->
 
-   is named only by five stale doc comments across `mvm-core`, `mvm-cli`,
-   `mvm-build` and `xtask`, and defines nothing. The real pipeline is
+   defines nothing and never did; the five doc comments that named it were
+   corrected on 2026-09-01, along with a second fabricated name they carried.
+   The real pipeline is
    `fetch_expected_hashes` + `verify_artifact_hash`
    (`crates/mvm-cli/src/commands/env/artifact_verify.rs`), which fetch
    the per-arch `*-checksums-sha256.txt` manifest, stream the

--- a/crates/mvm-build/src/runtime_overlay.rs
+++ b/crates/mvm-build/src/runtime_overlay.rs
@@ -895,9 +895,8 @@ const DEFAULT_RELEASE_BASE: &str = "https://github.com/tinylabscom/mvm/releases/
 
 /// Documented escape hatch — bypass the SHA-256
 /// integrity check when an emergency rotation requires it. Never set
-/// in CI. Matches the env var name used by `download_dev_image` and
-/// `download_builder_vm_image` so the operator runbook covers all
-/// three.
+/// in CI. Matches the env var name honoured by `verify_artifact_hash` on the
+/// CLI's download path, so the operator runbook covers both.
 pub(crate) const SKIP_HASH_VERIFY_ENV: &str = "MVM_SKIP_HASH_VERIFY";
 
 /// Construct the per-version release base URL the four artifacts
@@ -917,8 +916,8 @@ pub fn release_base_url(version: &str) -> String {
 /// `checksums-sha256.txt`, and install into `cache_root` under the canonical layout
 /// `<cache_root>/runtime-overlay/<version>/<arch>/`.
 ///
-/// Mirrors the integrity pattern of `download_dev_image` /
-/// `download_builder_vm_image`: fetch the archive checksum first; reject
+/// Mirrors the integrity pattern of `download_builder_vm_image`: fetch the
+/// archive checksum first; reject
 /// downloads whose hash isn't pre-committed there; honor
 /// `MVM_SKIP_HASH_VERIFY=1` only as a documented emergency
 /// rotation escape (never set in CI).

--- a/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
@@ -879,9 +879,9 @@ pub(super) fn promote_builder_vm_stage0_cache(
 /// `builder-vm-image` release-workflow job into the local cache dir,
 /// SHA-256-verified.
 ///
-/// Mirrors `download_dev_image_inner` for the interactive image: the checksum
-/// manifest is signature-verified before it is parsed, and every artifact is
-/// then held to the digest it pins. The required artifacts are `vmlinux`,
+/// Uses the shared verification pipeline: `fetch_expected_hashes` reads the
+/// checksum manifest, and `verify_artifact_hash` then holds every artifact to
+/// the digest that manifest pins. The required artifacts are `vmlinux`,
 /// `rootfs.ext4`, `cmdline.txt`, and `manifest.json`; the runtime
 /// builder-image loader rejects caches that do not carry the full
 /// contract.

--- a/crates/mvm-core/src/observability/metrics.rs
+++ b/crates/mvm-core/src/observability/metrics.rs
@@ -54,9 +54,10 @@ pub struct Metrics {
 
     // ── Dev/builder image verification ──────────────────────────────
     // One counter per outcome of the cosign-signed manifest +
-    // SHA-256 verification pipeline at builder_vm.rs::download_dev_image.
-    // The duration gauge is the last observed wall-clock from
-    // try_fetch_signed_manifest entry through verify_artifact_hash exit.
+    // SHA-256 verification pipeline in
+    // mvm-cli/src/commands/env/artifact_verify.rs. The duration gauge is
+    // the last observed wall-clock from fetch_expected_hashes entry
+    // through verify_artifact_hash exit.
     // mvmd reads these via the prometheus exposition to alert
     // on attack-shaped failure spikes (sig_invalid / digest_mismatch).
     pub dev_image_verify_ok: AtomicU64,

--- a/specs/plans/2026-09-01-committed-agent-notes-and-asserted-absence.md
+++ b/specs/plans/2026-09-01-committed-agent-notes-and-asserted-absence.md
@@ -106,21 +106,37 @@ gate that cries wolf gets deleted. Tracked below, not built here.
 
 ## Follow-on
 
-- [ ] Extend `check-dormant-controls` to the `fn:` witnesses in the claims
-      ledger. It already implements the rule — a caller is a mention in
-      production Rust outside the defining file and outside any `#[cfg(test)]`
-      module or `tests/` tree, declared per symbol in
-      `xtask/dormant-controls.toml`, on a list that may only shrink. Pointing
-      it at the 86 ledger witnesses is a smaller change than a new gate, and it
-      keeps one definition of "reachable" rather than two. Measure against the
-      current ledger before turning it on.
-- [ ] Blank comments and literals in `check-dormant-controls`' haystack. Its
-      own docs record the limit — "a symbol named in a comment counts as a
-      caller" — and that is the same defect this change fixed in the citation
-      resolver, with the same one-line answer
-      (`rust_source::blank_comments_and_strings`). A control whose only
-      "caller" is a doc comment is precisely the dormant control it hunts.
-- [ ] Fix the five doc comments in `mvm-core`, `mvm-cli`, `mvm-build` and
-      `xtask` that reference `download_dev_image`, a function that does not
-      exist. Surfaced by this change; left out of it to keep the diff to one
-      concern.
+- [x] Fix the doc comments in `mvm-core`, `mvm-cli`, `mvm-build` and `xtask`
+      that reference `download_dev_image`, a function that does not exist.
+      Surfaced by this change; done separately to keep the diff to one concern.
+
+### Measured and refused
+
+Both reachability follow-ons were measured over all 84 `fn:` witnesses before
+being built, using `check-dormant-controls`' exact caller rule. Neither is worth
+building. Full method and numbers in
+`.agent-memory/notes/witness-reachability-gate-measured-and-refuted.md`.
+
+- ~~Extend `check-dormant-controls` to the ledger's `fn:` witnesses.~~ Zero
+  genuine findings. Of 84 witnesses, 21 flagged, 4 survived removing the two
+  dominant noise classes, and reading all six survivor symbols found every one
+  correct as written. The failures are structural, not tunable: the
+  defining-file exclusion hides a caller twelve lines above the definition
+  (`set_no_new_privs`, claim 2's own witness), trait dispatch is invisible to a
+  text rule (`teardown_paused`), name collisions merge distinct symbols
+  (`tier_for_vm`), and cross-crate test helpers must be `pub` and outside
+  `#[cfg(test)]` to be visible at all. Inferring a witness's *subject* is the
+  part that cannot be fixed by tightening. `check-dormant-controls` escapes all
+  of this only because a human hand-picks each control.
+- ~~Blank comments in that gate's haystack.~~ Its docs record the limit "a
+  symbol named in a comment counts as a caller", and the fix is the same one
+  that closed the citation-resolver defect. On this population it changes
+  **zero** verdicts — no witness's only caller was a comment. Possibly still
+  worth doing for the hand-declared controls in `xtask/dormant-controls.toml`;
+  it is not the lever it looked like.
+
+What would close the hole is a real call graph, or the ledger declaring each
+witness's subject the way `dormant-controls.toml` declares a control and its
+defining file — 84 hand-written declarations and an owner for them. That is a
+different and much larger piece of work. Until it is done the hole stays open,
+and `CLAUDE.md` continues to say so.

--- a/specs/sprint/delivery/witness-liveness-measured-and-refused.md
+++ b/specs/sprint/delivery/witness-liveness-measured-and-refused.md
@@ -1,0 +1,61 @@
+# Witness reachability: measured, refused, and the doc comments it surfaced
+
+Plan: `specs/plans/2026-09-01-committed-agent-notes-and-asserted-absence.md`
+
+## Outcome
+
+The two reachability follow-ons recorded in that plan were **measured before
+being built, and both are refused.** No gate ships. The measurement and its
+reasoning are recorded in
+`.agent-memory/notes/witness-reachability-gate-measured-and-refuted.md` — the
+first use of the committed-notes mechanism for the thing it exists for.
+
+Method: `check-dormant-controls`' exact caller rule, applied to all 84 `fn:`
+witnesses in the ADR-001 ledger.
+
+| | count |
+|---|---|
+| Witness names not found anywhere | 0 |
+| Production-defined witnesses with no production caller | 1 |
+| Test-defined witnesses with ≥1 dead subject | 20 |
+| Survivors after removing the two dominant noise classes | 4 |
+| **Genuine findings after reading all six survivor symbols** | **0** |
+
+The failure modes are structural rather than tunable. The defining-file
+exclusion hides a caller twelve lines above the definition — `set_no_new_privs`
+is claim 2's own witness and reads as dead. Trait dispatch is invisible to a
+text rule (`teardown_paused`). Name collisions merge distinct symbols
+(`tier_for_vm`). And a cross-crate test helper must be `pub` and outside
+`#[cfg(test)]` to be visible at all, so `pretend_mechanism_present`,
+`rendered_argv` and `CannedIO::with_network_interfaces` are correct as written
+and all read as dead. `check-dormant-controls` escapes every one of these only
+because a human hand-picks each control it tracks.
+
+Blanking comments in that gate's haystack — its own documented limit, and the
+same fix that closed the citation-resolver defect last week — changes **zero**
+verdicts on this population. Not one symbol's only caller was a comment.
+
+The hole `CLAUDE.md` names stays open, and `CLAUDE.md` continues to say so.
+Closing it needs a real call graph, or the ledger declaring each witness's
+subject the way `dormant-controls.toml` declares a control — 84 declarations
+and an owner for them.
+
+## Shipped
+
+Six stale doc comments corrected. `download_dev_image` was named by five
+comments across `mvm-core`, `mvm-cli`, `mvm-build` and `xtask` and defines
+nothing; `crates/mvm-core/src/observability/metrics.rs` additionally named
+`try_fetch_signed_manifest`, whose only occurrence in the whole tree was that
+comment. Both now name the real pipeline —
+`fetch_expected_hashes` / `verify_artifact_hash` in
+`crates/mvm-cli/src/commands/env/artifact_verify.rs`, and
+`download_builder_vm_image` where a sibling download path was meant.
+
+`CLAUDE.md`'s claim-6 absence region keeps `download_dev_image` under gate; only
+the sentence describing the stale comments changed, since they are no longer
+stale.
+
+## Gates
+
+`check-all` 65 clean · `nextest --workspace` 12911 pass · workspace clippy,
+`--doc`, `fmt --all --check`, `just check-gated` all clean.

--- a/xtask/src/build_dev_image.rs
+++ b/xtask/src/build_dev_image.rs
@@ -70,8 +70,8 @@ Prerequisites:
 ";
 
 /// Map the host arch to the matching Linux-system identifier used by
-/// `mvmctl`'s download path (`download_dev_image` uses the same mapping
-/// at `apple_container.rs`).
+/// `mvmctl`'s download path — the same `arch` string
+/// `download_builder_vm_image` threads into `builder_vm_artifact_names`.
 fn host_arch_for_linux() -> &'static str {
     if cfg!(target_arch = "aarch64") {
         "aarch64"


### PR DESCRIPTION
`CLAUDE.md` names the hole directly: the claim gate "proves a named witness
*exists*, never that anything calls the code it tests". Claim 13's old witness
round-tripped an encoder that no backend builds and no guest parses, so the
hole is real and it has cost us once. #3071 recorded two follow-ons to close
it. **Both were measured before being built, and both are refused. No gate
ships here.**

## The measurement

`check-dormant-controls`' exact caller rule — production `.rs` under `crates/`
excluding `target`/`tests`/`fuzz`/`benches`, `#[cfg(test)]` modules
brace-stripped, `use` and `pub use` dropped, defining file excluded — applied
to all 84 `fn:` witnesses in the ADR-001 ledger.

| | count |
|---|---|
| Witness names not found anywhere | **0** — `check-claim-catalog` is doing its job |
| Production-defined witnesses with no production caller | 1 |
| Test-defined witnesses with ≥1 dead subject | 20 |
| Survivors after removing the two dominant noise classes | 4 |
| **Genuine findings after reading all six survivor symbols** | **0** |

## Why it cannot be tightened into working

- **The defining-file exclusion dominates.** `set_no_new_privs` — claim 2's own
  witness — is called twelve lines above where it is defined, and the rule
  cannot see it. Same for `read_scope_unit`, `virtiofs_mount_flags`,
  `host_cpu_mechanism_gap`, `emit_dns_query`, `validate_guest_mount`.
- **Trait dispatch is invisible to text.** `teardown_paused` is called as
  `io.teardown_paused()`; nothing textual connects that to the impl.
- **Name collisions merge distinct symbols.** Two `tier_for_vm` definitions
  become one name, and one definition's caller sits in the other's file.
- **Test support deliberately lives in production source.** A cross-crate
  helper must be `pub` and outside `#[cfg(test)]` to be visible at all, so
  `pretend_mechanism_present`, `rendered_argv` and
  `CannedIO::with_network_interfaces` are all correct as written and all read
  as dead.

Inferring a witness's *subject* is the part that cannot be fixed by tightening.
Every hit needed a human to read six lines and say "no" — which is exactly the
work the gate was supposed to replace. `check-dormant-controls` escapes all of
this only because a human hand-picks each control it tracks.

**The comment-blanking follow-on is also refuted.** That gate documents the
limit "a symbol named in a comment counts as a caller", and blanking is the
same one-line fix that closed the citation-resolver defect in #3071. On this
population it changes **zero** verdicts — not one symbol's only caller was a
comment. Possibly still worth doing for the hand-declared controls in
`dormant-controls.toml`; it is not the lever it looked like.

The hole stays open and `CLAUDE.md` continues to say so. Closing it needs a
real call graph, or the ledger declaring each witness's subject the way
`dormant-controls.toml` declares a control — 84 declarations and an owner for
them, which is a much larger piece of work than a gate.

## What it did find

Six stale doc comments. `download_dev_image` is named by five across
`mvm-core`, `mvm-cli`, `mvm-build` and `xtask` and defines nothing;
`observability/metrics.rs` additionally named `try_fetch_signed_manifest`,
whose only occurrence in the entire tree was that comment. Both now name the
real pipeline — `fetch_expected_hashes` / `verify_artifact_hash` in
`commands/env/artifact_verify.rs`, and `download_builder_vm_image` where a
sibling download path was meant.

`CLAUDE.md`'s claim-6 absence region still holds `download_dev_image` under
gate; only the sentence describing the comments changed, since they are no
longer stale.

## Where the reasoning lives

`.agent-memory/notes/witness-reachability-gate-measured-and-refuted.md` — the
first real use of the committed-notes mechanism for the thing it exists for.
The next person to have this idea will find the numbers instead of re-running
them. The plan's follow-on section is struck with the same result.

## Gates

`check-all` 65 clean · `nextest --workspace` 12911 pass · workspace clippy,
`--doc`, `fmt --all --check`, `just check-gated` all clean.
