### PR TITLE
fix(lifecycle): dispatch pause and resume through VM owner

### DIFF
--- a/crates/mvm-client/src/local.rs
+++ b/crates/mvm-client/src/local.rs
@@ -104,24 +104,36 @@ impl LocalBackend {
         infos.into_iter().map(|i| to_state(i, None)).collect()
     }
 
-    /// Whether this client drives the hermetic in-memory mock backend. The mock
-    /// has no live Firecracker socket and no guest agent, so the snapshot path
-    /// swaps in canned bytes and skips the guest-facing signals.
-    fn is_mock(&self) -> bool {
-        self.backend.kind() == BackendKind::Mock
+    /// Resolve an existing machine's owning backend from its live marker. A
+    /// marker-less machine falls back to the backend explicitly carried by this
+    /// client, preserving the hermetic mock path and explicit CLI overrides.
+    fn lifecycle_backend_for(&self, vm_name: &str) -> AnyBackend {
+        AnyBackend::for_started_vm(vm_name)
+            .unwrap_or_else(|| AnyBackend::from_hypervisor(self.backend.name()))
     }
 
-    /// Pick the `SnapshotIO` matching this client's backend. The mock writes
+    /// Firecracker and the hermetic mock use the sealed snapshot lifecycle.
+    /// Other backends own their pause/resume mechanics directly.
+    fn uses_sealed_snapshot(backend: &AnyBackend) -> bool {
+        matches!(backend.kind(), BackendKind::Firecracker | BackendKind::Mock)
+    }
+
+    fn is_mock_backend(backend: &AnyBackend) -> bool {
+        backend.kind() == BackendKind::Mock
+    }
+
+    /// Pick the `SnapshotIO` matching the resolved machine owner. The mock writes
     /// deterministic `CannedIO` stub bytes so the seal/verify round-trip runs
     /// without a real Firecracker socket; every other backend drives
-    /// `FirecrackerIO` against the running VM's UDS control socket. The mock
+    /// `FirecrackerIO` against the running Firecracker VM's UDS control socket.
+    /// Backend-native lifecycle paths never call this helper. The mock
     /// arm is gated behind `test-support` along with `is_mock()`'s only
     /// possible `true` outcome — outside that feature `AnyBackend::Mock`
     /// doesn't exist, so `is_mock()` is always `false` and this falls
     /// straight through to the real Firecracker path.
-    fn snapshot_io_for(&self, vm_name: &str) -> Result<Box<dyn SnapshotIO>> {
+    fn snapshot_io_for(&self, backend: &AnyBackend, vm_name: &str) -> Result<Box<dyn SnapshotIO>> {
         #[cfg(feature = "test-support")]
-        if self.is_mock() {
+        if Self::is_mock_backend(backend) {
             let dir = mvm_runtime::MockBackend::vm_dir(vm_name);
             if !dir.exists() {
                 return Err(backend_err(format!(
@@ -134,6 +146,11 @@ impl LocalBackend {
                 b"mock-mem".to_vec(),
             )));
         }
+        debug_assert_eq!(
+            backend.kind(),
+            BackendKind::Firecracker,
+            "only Firecracker reaches the production sealed-snapshot transport"
+        );
         let vm_dir = mvm_runtime::microvm::resolve_running_vm_dir(vm_name)
             .map_err(|e| backend_err(format!("VM {vm_name:?} is not running: {e:#}")))?;
         Ok(Box::new(FirecrackerIO::new(firecracker_socket(&vm_dir))))
@@ -143,15 +160,12 @@ impl LocalBackend {
     /// fresh VMGenID, load + resume live memory, reseed. Fails closed with the
     /// typed `WarmStartError::Unsupported` recovery hint on a disk-only backend
     /// rather than silently cold-booting.
-    fn warm_resume(&self, name: &str) -> Result<ResumeOutcome> {
+    fn warm_resume(&self, backend: &AnyBackend, name: &str) -> Result<ResumeOutcome> {
         let config = VmStartConfig {
             name: name.to_string(),
             ..Default::default()
         };
-        match self
-            .backend
-            .warm_start(&config, SnapshotCapability::LiveMemory)
-        {
+        match backend.warm_start(&config, SnapshotCapability::LiveMemory) {
             Ok(outcome) => {
                 // FC keeps its pid across pause/resume, so the marker must be
                 // cleared explicitly on a successful warm resume.
@@ -175,8 +189,16 @@ impl LocalBackend {
     /// older-epoch snapshot** — load it back and resume vCPUs, then finish
     /// bringing the guest back with a fresh-VMGenID PostRestore (skipped for the
     /// mock, which has no guest agent).
-    fn plain_resume(&self, name: &str) -> Result<ResumeOutcome> {
-        let io = self.snapshot_io_for(name)?;
+    fn plain_resume(&self, backend: &AnyBackend, name: &str) -> Result<ResumeOutcome> {
+        if !Self::uses_sealed_snapshot(backend) {
+            backend
+                .resume(&VmId(name.to_string()))
+                .map_err(|e| backend_err(format!("resuming VM {name:?}: {e:#}")))?;
+            set_registry_resumed(name);
+            return Ok(ResumeOutcome::default());
+        }
+
+        let io = self.snapshot_io_for(backend, name)?;
         // The replay-refusal gate: `verify_and_resume` rejects a snapshot whose
         // epoch is below the persisted high-water mark before restoring anything.
         // Called unchanged — this is the security property of resume.
@@ -192,7 +214,7 @@ impl LocalBackend {
         // simply re-run resume.
         set_registry_resumed(name);
 
-        if !self.is_mock() {
+        if !Self::is_mock_backend(backend) {
             signal_guest_post_restore(name)?;
         }
         // Report the verified snapshot's epoch + artifact lengths so the caller's
@@ -777,11 +799,12 @@ impl MvmClient for LocalBackend {
 
     async fn pause_machine(&self, id: &MachineId, opts: PauseOpts) -> Result<PauseOutcome> {
         let name = &id.0;
+        let backend = self.lifecycle_backend_for(name);
 
         // Opt-in warm-base barrier: wait for the workload to signal "primed"
         // before sealing. Fails closed — a timeout propagates so no half-warmed
         // snapshot is sealed. Skipped for the mock (no guest agent to answer).
-        if let Some(timeout) = primed_barrier_timeout(&opts, self.is_mock()) {
+        if let Some(timeout) = primed_barrier_timeout(&opts, Self::is_mock_backend(&backend)) {
             let source = VsockPrimedSignalSource {
                 vm_name: name.clone(),
                 poll_interval: std::time::Duration::from_millis(500),
@@ -790,7 +813,15 @@ impl MvmClient for LocalBackend {
                 .map_err(|e| backend_err(format!("primed barrier for VM {name:?}: {e:#}")))?;
         }
 
-        let io = self.snapshot_io_for(name)?;
+        if !Self::uses_sealed_snapshot(&backend) {
+            backend
+                .pause(&VmId(name.clone()))
+                .map_err(|e| backend_err(format!("pausing VM {name:?}: {e:#}")))?;
+            set_registry_paused(name, true);
+            return Ok(PauseOutcome::default());
+        }
+
+        let io = self.snapshot_io_for(&backend, name)?;
         let sidecar = pause_and_seal(name, &*io)
             .map_err(|e| backend_err(format!("pausing VM {name:?}: {e:#}")))?;
 
@@ -805,13 +836,14 @@ impl MvmClient for LocalBackend {
     }
 
     async fn resume_machine(&self, id: &MachineId, opts: ResumeOpts) -> Result<ResumeOutcome> {
+        let backend = self.lifecycle_backend_for(&id.0);
         // `warm` routes through the backend's live-memory warm-start path (fails
         // closed on a disk-only backend); the default plain path verifies +
         // restores the sealed snapshot and signals the guest.
         if opts.warm {
-            self.warm_resume(&id.0)
+            self.warm_resume(&backend, &id.0)
         } else {
-            self.plain_resume(&id.0)
+            self.plain_resume(&backend, &id.0)
         }
     }
 
@@ -1436,6 +1468,33 @@ mod tests {
             firecracker_socket("/tmp/vms/web"),
             std::path::PathBuf::from("/tmp/vms/web/fc.socket")
         );
+    }
+
+    #[test]
+    #[cfg(feature = "test-support")]
+    fn lifecycle_backend_prefers_the_started_vm_marker() {
+        let _data = IsolatedDataDir::new();
+        let state_dir = mvm_core::config::vm_state_dir("hvf-owned");
+        std::fs::create_dir_all(&state_dir).expect("create VM state directory");
+        std::fs::write(state_dir.join("hvf.pid"), "123").expect("write HVF owner marker");
+
+        let firecracker_client = LocalBackend::with_hypervisor("firecracker");
+        let owner = firecracker_client.lifecycle_backend_for("hvf-owned");
+
+        assert_eq!(owner.kind(), BackendKind::Hvf);
+        assert!(!LocalBackend::uses_sealed_snapshot(&owner));
+    }
+
+    #[test]
+    #[cfg(feature = "test-support")]
+    fn lifecycle_backend_falls_back_to_the_explicit_test_backend_without_a_marker() {
+        let _data = IsolatedDataDir::new();
+        let mock_client = LocalBackend::with_hypervisor("mock");
+
+        let owner = mock_client.lifecycle_backend_for("marker-less");
+
+        assert_eq!(owner.kind(), BackendKind::Mock);
+        assert!(LocalBackend::uses_sealed_snapshot(&owner));
     }
 
     #[tokio::test]

--- a/crates/mvm-core/src/client/dto.rs
+++ b/crates/mvm-core/src/client/dto.rs
@@ -415,18 +415,20 @@ impl Default for PauseOpts {
     }
 }
 
-/// The outcome of a successful `pause_machine`: the sealed snapshot's replay
-/// epoch and the byte lengths of the sealed vmstate + memory artifacts. Plain
-/// data the caller renders in its success line and audit entry.
+/// The outcome of a successful `pause_machine`. A sealed-snapshot backend
+/// reports its replay epoch and artifact lengths; a backend-native vCPU pause
+/// reports zeroes because it creates no sealed artifacts. Plain data the caller
+/// renders in its success line and audit entry.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PauseOutcome {
     /// Monotonic replay-defence counter stamped into the sealed envelope; a
     /// resume refuses any snapshot whose epoch is below the high-water mark.
+    /// Zero for a backend-native pause that creates no sealed snapshot.
     pub epoch: u64,
-    /// Length in bytes of the sealed `vmstate.bin`.
+    /// Length in bytes of the sealed `vmstate.bin`; zero for backend-native pause.
     pub vmstate_len: u64,
-    /// Length in bytes of the sealed `mem.bin`.
+    /// Length in bytes of the sealed `mem.bin`; zero for backend-native pause.
     pub mem_len: u64,
 }
 
@@ -448,8 +450,8 @@ pub struct ResumeOpts {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResumeOutcome {
-    /// The verified snapshot's epoch (plain resume). `0` for a warm resume,
-    /// which restores live memory rather than a sealed snapshot.
+    /// The verified snapshot's epoch (plain resume). `0` for a warm resume or
+    /// backend-native vCPU resume, neither of which restores a sealed snapshot.
     #[serde(default)]
     pub epoch: u64,
     /// Length in bytes of the restored `vmstate.bin` (plain resume); `0` for warm.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,8 +1,14 @@
 # Refactor status
 
-Last updated: 2026-08-26
+Last updated: 2026-08-27
 
 ## In progress
+
+- [ ] **Recorded-backend pause and resume — issue #2929.**
+      `specs/plans/2026-08-27-recorded-backend-pause-resume.md`.
+      Pause/resume now resolves the live machine's owner before dispatch while
+      retaining Firecracker's sealed snapshot path and explicit marker-less
+      backend fallback. Validation and merge-queue delivery remain.
 
 - [ ] **SDK surface contract repairs — issues #2902 and #2906.**
       `specs/plans/2026-08-26-sdk-surface-contract-repairs.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,14 @@
 
 ## In progress
 
+- [ ] **Recorded-backend pause and resume — issue #2929.**
+      `specs/plans/2026-08-27-recorded-backend-pause-resume.md`.
+      Existing-machine lifecycle operations resolve the VMM that owns the live
+      state marker instead of trusting the CLI's Firecracker default. The
+      Firecracker sealed-snapshot replay gate and marker-less mock fallback stay
+      intact; focused and workspace validation remain before merge-queue
+      delivery.
+
 - [ ] **Admission cache durability boundary.**
       `specs/plans/2026-08-26-admission-cache-durability.md`.
       Preserve the chain-signed admission record's fail-closed durability

--- a/specs/plans/2026-08-27-recorded-backend-pause-resume.md
+++ b/specs/plans/2026-08-27-recorded-backend-pause-resume.md
@@ -1,0 +1,29 @@
+# Recorded-backend pause and resume
+
+**Status: IN PROGRESS**
+
+## Problem
+
+`machine pause` and `machine resume` construct a local client from the CLI's
+`--hypervisor` default. An existing machine may have been launched by a
+different backend, so a lifecycle operation can be sent to Firecracker even
+when the machine's live marker records HVF as its owner.
+
+## Scope
+
+- Resolve the backend that owns an existing machine from its live state marker.
+- Preserve the explicit backend as the fallback for marker-less machines and
+  the hermetic mock test path.
+- Preserve Firecracker's sealed snapshot and replay-refusal lifecycle.
+- Dispatch non-Firecracker pause/resume operations through the owning backend's
+  native lifecycle implementation.
+
+## Acceptance
+
+- [ ] Regression coverage proves a live backend marker wins over the client's
+      default and that a marker-less mock remains hermetic.
+- [ ] Pause and resume dispatch through the resolved owner without weakening
+      Firecracker snapshot verification.
+- [ ] Focused tests, workspace tests/check, Clippy, and gated target checks pass.
+- [ ] Sprint and refactor rollups describe the delivered behavior.
+


### PR DESCRIPTION
Recovered from a stale local worktree and pushed so the work is not one `git worktree remove` away from gone.

**Draft on purpose.** This is preserved work-in-progress, not a review request. Nobody has said it is finished.

| | |
|---|---|
| Commits ahead of `main` | 1 |
| Files this branch changes | 5 |
| Of those, still differing from `main` | **4** |
| Behind `main` by | 107 commits |
| Last commit | 2026-08-27 |

### Commits

- \`8137a7ac4f\` fix(lifecycle): dispatch pause and resume through VM owner

### Read CI here with care

This branch is **107 commits behind `main`** and has not been rebased or re-run since 2026-08-27.
A red lane is at least as likely to be a stale base as a defect in the change, and a green one
does not say the change still integrates. It needs a rebase before either verdict means anything.
