### PR TITLE
fix(sdk): slim the host-services cdylib closure

### DIFF
--- a/crates/mvm-cli/Cargo.toml
+++ b/crates/mvm-cli/Cargo.toml
@@ -29,7 +29,7 @@ mvm-client.workspace = true
 mvm-mcp.workspace = true
 # `mvmctl compile` reads the Workload IR (mvm_contract::ir, re-exported from
 # mvm_contract::ir) and routes it through the compile pipeline.
-mvm-sdk.workspace = true
+mvm-sdk = { workspace = true, features = ["remote-deploy"] }
 mvm-capture.workspace = true
 # Direct IR access (`mvm_contract::ir::…`) for the command surfaces that
 # only need the DTOs, not the rest of the SDK's build-time tooling.

--- a/crates/mvm-sdk/Cargo.toml
+++ b/crates/mvm-sdk/Cargo.toml
@@ -35,7 +35,7 @@ mvm-contract.workspace = true
 async-trait = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-mvm-http.workspace = true
+mvm-http = { workspace = true, optional = true }
 thiserror.workspace = true
 
 # Runtime record mode encodes `Sandbox.files.write` bytes
@@ -66,6 +66,10 @@ tree-sitter-typescript = { workspace = true }
 [features]
 default = []
 client-facade = ["dep:async-trait", "mvm-core/client"]
+# Authenticated host-side deployment transport. The default library is also
+# built as the in-guest host-services cdylib, whose synchronous vsock C ABI
+# must not inherit HTTP, TLS, or async-runtime dependencies.
+remote-deploy = ["dep:mvm-http"]
 # Derive `schemars::JsonSchema` on the addon-manifest and runtime-record types
 # and forward to the IR's own derives, for the three schema-emitter bins below.
 # Off by default: nothing on the `mvmctl` runtime path reads a JSON Schema, and

--- a/crates/mvm-sdk/src/deploy.rs
+++ b/crates/mvm-sdk/src/deploy.rs
@@ -23,6 +23,7 @@
 //! is the additional sidecar the receiver reads to make scheduling
 //! decisions without unpacking the rest.
 
+#[cfg(feature = "remote-deploy")]
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -621,17 +622,20 @@ pub struct RemoteArtifact {
 }
 
 #[derive(Debug, Deserialize)]
+#[cfg(feature = "remote-deploy")]
 struct RemoteResponse {
     data: RemoteArtifact,
 }
 
 /// Authenticated remote artifact client.
+#[cfg(feature = "remote-deploy")]
 pub struct MvmdClient {
     /// The configured mvmd endpoint.
     pub base_url: String,
     api_key: String,
 }
 
+#[cfg(feature = "remote-deploy")]
 impl MvmdClient {
     /// Construct a new client for `base_url` with a bearer credential.
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
@@ -694,6 +698,7 @@ impl MvmdClient {
     }
 }
 
+#[cfg(feature = "remote-deploy")]
 fn deploy_multipart_body(record_json: &str, bundle_bytes: &[u8]) -> (String, Vec<u8>) {
     let boundary = format!("mvm-deploy-{}", blake3::hash(bundle_bytes).to_hex());
     let mut body = Vec::with_capacity(record_json.len() + bundle_bytes.len() + 512);
@@ -712,6 +717,7 @@ fn deploy_multipart_body(record_json: &str, bundle_bytes: &[u8]) -> (String, Vec
     (format!("multipart/form-data; boundary={boundary}"), body)
 }
 
+#[cfg(feature = "remote-deploy")]
 fn remote_upload_endpoint(base_url: &str) -> Result<String, DeployError> {
     let parsed = mvm_http::Url::parse(base_url).map_err(|error| DeployError::RemoteProtocol {
         base_url: base_url.to_string(),
@@ -730,6 +736,7 @@ fn remote_upload_endpoint(base_url: &str) -> Result<String, DeployError> {
     ))
 }
 
+#[cfg(feature = "remote-deploy")]
 fn is_loopback_url(url: &mvm_http::Url) -> bool {
     match url.host_str() {
         Some("localhost") => true,
@@ -1034,6 +1041,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "remote-deploy")]
     fn remote_client_fails_closed_for_unreachable_transport() {
         let client = MvmdClient::new("http://127.0.0.1:1", "test-token");
         let tmp = tempfile::tempdir().unwrap();
@@ -1075,6 +1083,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "remote-deploy")]
     fn remote_endpoint_rejects_cleartext_non_loopback() {
         let error = remote_upload_endpoint("http://mvmd.example").unwrap_err();
         assert!(matches!(
@@ -1084,6 +1093,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "remote-deploy")]
     fn deploy_multipart_body_contains_record_and_bundle_parts() {
         let (content_type, body) = deploy_multipart_body(r#"{"workload_id":"demo"}"#, b"bundle");
         let body = String::from_utf8(body).expect("multipart test body is UTF-8");

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,14 @@ Last updated: 2026-08-28
 
 ## In progress
 
+- [ ] **SDK cdylib dependency surface — issue #2978.**
+      `specs/plans/2026-08-28-sdk-cdylib-dependency-surface.md`.
+      Authenticated remote deployment is now an explicit `mvm-sdk` feature
+      enabled by `mvm-cli`; the default guest-facing cdylib closure excludes
+      `mvm-http`, `rustls`, `ring`, `tokio`, and `tokio-rustls`. Focused SDK
+      and gate tests plus package Clippy are green; latest-main validation and
+      merge delivery remain.
+
 - [ ] **HVF machine restore dispatch — issue #2961.**
       `specs/plans/2026-08-27-hvf-machine-restore-dispatch.md`.
       The `machine` fork/restore surfaces now share the backend-origin

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3297,3 +3297,15 @@ writes the plan:
 - [x] Record why the 224.5 ms sample is inside the warm hard ceiling without
       relabeling it as a prepared-cold percentile result.
 - [ ] Merge the repair through the queue and close issue #2942.
+
+## 2026-08-28 SDK cdylib dependency surface — issue #2978
+
+- [x] Reproduce the default `mvm-sdk` dependency leak and add an exact-name
+      Cargo-tree regression for host HTTP, TLS, and async crates.
+- [x] Put authenticated remote deployment behind the off-by-default
+      `remote-deploy` feature while keeping `mvm-cli` opted in.
+- [x] Pass default and remote-feature SDK tests, focused xtask tests, and
+      package all-target/all-feature Clippy.
+- [ ] Rebase on the latest merged queue head and pass full workspace and
+      repository gates.
+- [ ] Merge the repair and let the linked PR close issue #2978.

--- a/specs/plans/2026-08-28-sdk-cdylib-dependency-surface.md
+++ b/specs/plans/2026-08-28-sdk-cdylib-dependency-surface.md
@@ -1,0 +1,32 @@
+# SDK cdylib dependency surface
+
+Issue: #2978
+
+## Goal
+
+Keep the default `mvm-sdk` library closure used by
+`libmvm_host_services.so` free of the host-only HTTP, TLS, and async stack,
+without removing authenticated remote deployment from `mvmctl`.
+
+## Work
+
+- [x] Reproduce the dependency leak with `cargo tree` and add a regression
+      gate that fails on `mvm-http`, `rustls`, `ring`, `tokio`, or
+      `tokio-rustls` in the default non-dev closure.
+- [x] Make `mvm-http` optional and put the remote deployment client behind an
+      off-by-default `remote-deploy` feature.
+- [x] Keep `mvmctl deploy` functional by enabling `remote-deploy` at the
+      `mvm-cli` dependency boundary.
+- [x] Verify default and feature-enabled `mvm-sdk` tests plus focused xtask
+      tests and zero-warning package Clippy.
+- [ ] Rebase on the latest merged queue head and pass workspace tests,
+      workspace Clippy, formatting, and repository policy gates.
+- [ ] Merge the repair through the queue and confirm issue #2978 closes from
+      the merged PR.
+
+## Security boundary
+
+The shipping client remains fail-closed and authenticated when explicitly
+enabled. The default guest-facing library stops compiling unreachable host
+transport code and its native TLS dependency; the synchronous broker C ABI is
+unchanged.

--- a/specs/sprint/delivery/2978-sdk-cdylib-dependency-surface.md
+++ b/specs/sprint/delivery/2978-sdk-cdylib-dependency-surface.md
@@ -1,0 +1,24 @@
+# Issue #2978 — SDK cdylib dependency surface
+
+## Outcome
+
+The default `mvm-sdk` non-dev dependency closure no longer contains
+`mvm-http`, `rustls`, `ring`, `tokio`, or `tokio-rustls`. Authenticated remote
+deployment remains available to `mvm-cli` through the explicit
+`remote-deploy` feature.
+
+## Witnesses
+
+- `xtask check-sdk-cdylib-deps` resolves the exact default Cargo feature tree
+  and rejects the host transport stack by exact crate name.
+- The gate was observed failing before the feature split and passing after it.
+- Default `mvm-sdk` tests pass with the remote client excluded.
+- `mvm-sdk --features remote-deploy` tests pass with the client and its
+  fail-closed transport tests enabled.
+- Package-wide all-target/all-feature Clippy is warning-free for `mvm-sdk`
+  and `xtask`.
+
+## Remaining delivery
+
+Rebase on the latest merge-queue head, run the full workspace and repository
+gates, then merge the linked PR so GitHub closes issue #2978.

--- a/xtask/src/check_all.rs
+++ b/xtask/src/check_all.rs
@@ -157,6 +157,7 @@ pub const GATES: &[Gate] = &[
         "check-core-runtime-free",
         crate::check_core_runtime_free::run,
     ),
+    ("check-sdk-cdylib-deps", crate::check_sdk_cdylib_deps::run),
     (
         "check-content-address-determinism",
         crate::check_content_address_determinism::run,

--- a/xtask/src/check_sdk_cdylib_deps.rs
+++ b/xtask/src/check_sdk_cdylib_deps.rs
@@ -1,0 +1,82 @@
+//! `xtask check-sdk-cdylib-deps`
+//!
+//! Keep the default `mvm-sdk` library closure suitable for the in-guest
+//! host-services cdylib. The C ABI is synchronous JSON-over-vsock and must not
+//! inherit the host-side remote deployment transport or its TLS/async stack.
+
+use anyhow::{Context, Result, bail};
+use std::path::Path;
+use std::process::Command;
+
+const FORBIDDEN: &[&str] = &["mvm-http", "ring", "rustls", "tokio", "tokio-rustls"];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let output = Command::new(&cargo)
+        .current_dir(workspace)
+        .env_remove("RUSTC_WRAPPER")
+        .args([
+            "tree",
+            "-p",
+            "mvm-sdk",
+            "-e",
+            "no-dev,no-build",
+            "--prefix",
+            "none",
+            "--locked",
+        ])
+        .output()
+        .context("running `cargo tree -p mvm-sdk -e no-dev,no-build`")?;
+
+    if !output.status.success() {
+        bail!(
+            "cargo tree failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let tree = String::from_utf8_lossy(&output.stdout);
+    let found = forbidden_hits(&tree, FORBIDDEN);
+    if !found.is_empty() {
+        bail!(
+            "check-sdk-cdylib-deps: mvm-sdk's default non-dev closure pulls host-only HTTP/TLS/async dependencies ({}). Keep remote transport behind an off-by-default feature so the host-services cdylib remains cross-compilable without a C TLS stack.",
+            found.join(", ")
+        );
+    }
+
+    eprintln!(
+        "check-sdk-cdylib-deps: clean (mvm-sdk default non-dev closure has no host HTTP/TLS/async stack)"
+    );
+    Ok(())
+}
+
+fn forbidden_hits<'a>(tree: &'a str, forbidden: &[&str]) -> Vec<&'a str> {
+    let mut found: Vec<&str> = tree
+        .lines()
+        .filter_map(|line| line.split_whitespace().next())
+        .filter(|name| forbidden.contains(name))
+        .collect();
+    found.sort_unstable();
+    found.dedup();
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forbidden_transport_stack_is_reported_once_per_crate() {
+        let tree = "mvm-sdk v0.18.0\nmvm-http v0.18.0\nrustls v0.23.0\nring v0.17.0\ntokio v1.52.0\ntokio v1.52.0 (*)\n";
+        assert_eq!(
+            forbidden_hits(tree, FORBIDDEN),
+            vec!["mvm-http", "ring", "rustls", "tokio"]
+        );
+    }
+
+    #[test]
+    fn similarly_named_crates_do_not_false_positive() {
+        let tree = "mvm-sdk v0.18.0\nrustls-pemfile v2.0.0\ntokio-util v0.7.0\n";
+        assert!(forbidden_hits(tree, FORBIDDEN).is_empty());
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -59,6 +59,7 @@ mod check_per_vm_host_binaries_sync;
 mod check_plan_names;
 mod check_require_grant_token_allowlist;
 mod check_runtime_overlay_version;
+mod check_sdk_cdylib_deps;
 mod check_single_exec_secs_writer;
 mod check_single_fixture_corpus;
 mod check_single_grants_projection;
@@ -151,6 +152,10 @@ fn main() -> Result<()> {
         Some("check-core-runtime-free") => {
             let workspace = workspace_root();
             check_core_runtime_free::run(&workspace)
+        }
+        Some("check-sdk-cdylib-deps") => {
+            let workspace = workspace_root();
+            check_sdk_cdylib_deps::run(&workspace)
         }
         Some("check-content-address-determinism") => {
             let workspace = workspace_root();
@@ -449,6 +454,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-core-runtime-free                 Plan 126 B5: assert mvm-core's default build pulls no tokio"
+            );
+            eprintln!(
+                "  check-sdk-cdylib-deps                  assert mvm-sdk's default cdylib closure excludes host HTTP/TLS/async dependencies"
             );
             eprintln!(
                 "  check-content-address-determinism       Assert serde_json in mvm-core/mvm-contract has no preserve_order (stable key order → deterministic plan_id/checkpoint digests)"


### PR DESCRIPTION
Recovered from a stale local worktree and pushed so the work is not one `git worktree remove` away from gone.

**Draft on purpose.** This is preserved work-in-progress, not a review request. Nobody has said it is finished.

| | |
|---|---|
| Commits ahead of `main` | 1 |
| Files this branch changes | 10 |
| Of those, still differing from `main` | **10** |
| Behind `main` by | 70 commits |
| Last commit | 2026-08-28 |

### Commits

- \`6962128506\` fix(sdk): slim the host-services cdylib closure

### Read CI here with care

This branch is **70 commits behind `main`** and has not been rebased or re-run since 2026-08-28.
A red lane is at least as likely to be a stale base as a defect in the change, and a green one
does not say the change still integrates. It needs a rebase before either verdict means anything.
