### PR TITLE
fix(xtask): make the kernel-reads gate see hand-rolled cache paths

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -216,6 +216,25 @@ Last updated: 2026-09-01
 
 ## Completed
 
+- [x] **Kernel cache moved out of the Stage 0 blast radius — PR #3038.**
+      `specs/sprint/delivery/kernel-cache-outside-stage0-blast-radius.md`.
+      The workload kernel was cached inside `builder-vm/<arch>`, the directory
+      Stage 0 `remove_dir_all`s on a source-fingerprint change, so promoting a
+      new builder image destroyed a half-hour artifact and the next boot rebuilt
+      it — blowing `just e2e-launch`'s 1800s cap. Entries now live at
+      `<cache>/kernels/<arch>/<variant>/`; `resolve_kernel` adopts an entry left
+      at the old path by renaming it. The layout was hand-rebuilt at nine call
+      sites, all now routed through `kernel_cache_dir`/`cached_kernel_path`. The
+      gate's builder cap is raised to 7200s, matching `ci-full.yml`. Merged
+      after a live macOS 26 `e2e-launch` run confirmed the migration is a rename
+      rather than a rebuild.
+
+- [x] **machine diff handshake retry — issue #3024, PR #3028.**
+      `specs/plans/2026-08-31-machine-diff-handshake-retry.md`.
+      A typed pre-authentication peer hangup gets one fresh connection; an EOF
+      after authentication is never replayed. Focused regressions cover both
+      boundaries and the bounded retry budget.
+
 - [x] **Fleet stream edge delivery handoff.** The edge pump now terminates in
       the bounded, exactly-once guest input route; close carries the scanner's
       withheld tail before EOF. `StreamPlane::subscribe` and

--- a/specs/sprint/delivery/kernel-reads-gate-sees-handrolled-paths.md
+++ b/specs/sprint/delivery/kernel-reads-gate-sees-handrolled-paths.md
@@ -1,0 +1,85 @@
+# The verified-kernel-reads gate now sees hand-rolled paths
+
+`check-verified-kernel-reads` exists to stop a workload kernel booting on an
+`exists()` check instead of a verified digest. It worked, for the callers that
+asked the shared helper where the kernel lives:
+
+```rust
+crate::fs_walk::for_each_file(&workspace.join("crates"), Some("rs"), &mut |path, text| {
+    if text.contains(LOCATION) { ... }   // LOCATION == "cached_kernel_path"
+});
+```
+
+A file that spelled the layout itself never entered that walk. It was not
+examined and found acceptable — it was not examined.
+
+## What that hid
+
+The kernel-cache relocation (PR #3038) found the layout hand-rebuilt at nine
+call sites. Routing them through `kernel_cache_dir` / `cached_kernel_path` made
+two of them visible to this gate for the first time, and one was a genuine
+violation that predates that branch:
+
+```rust
+// crates/mvm-conformance/tests/conformance.rs
+let cached = /* hand-built <cache>/builder-vm/<arch>/kernels/workload/vmlinux */;
+cached.is_file().then_some(cached)
+```
+
+That is the kernel every `@workload_kernel` BDD scenario boots, selected by
+whether a file exists. It is exactly what the gate is for, and the gate could
+not see it for as long as it declined to use the helper.
+
+The incentive was backwards: naming `cached_kernel_path` opted you into
+scrutiny, and hand-rolling the path opted you out. A gate that only inspects
+the disciplined callers is reporting on the population least likely to be wrong.
+
+## What changed
+
+Two checks, ordered so the first makes the second complete.
+
+**One definition of the layout.** `.join("kernels")` outside
+`crates/mvm-build/src/kernel_fetch.rs` is refused. Every caller is therefore
+forced through the helper, which puts every caller inside the verified-read
+check that follows. The allow-list governs that second check only: a staging
+lane may read the location without verifying, but it may not keep its own copy
+of where the location is.
+
+**A drift alarm for shell.** A script cannot call a Rust helper, so it is held
+to the weaker rule: do not name the retired location. This is aimed at one
+concrete failure — the same relocation left
+`e2e-launch-modes.sh` running `find "$E2E_HOME/cache/builder-vm" -name vmlinux`,
+which finds nothing, reports no error, and silently drops the in-process
+`mvm-client` seam from the lane. That was caught only because the script had
+been written to fail loudly on a missing kernel rather than skip. The check
+distinguishes a kernel path from the builder VM's *own* kernel, which still
+lives under `builder-vm/<arch>/vmlinux` legitimately.
+
+## Limits
+
+The one-definition rule is a string match on `.join("kernels")`. A caller
+determined to evade it can build the path from a variable, and the shell check
+knows only the retired name, not the current layout — a script pointed at a
+third location is invisible to both. Neither is a proof; they raise the cost of
+the specific mistake that has now happened twice.
+
+The original co-presence caveat is unchanged and still applies: a file may
+resolve through the seam in one function and use a bare path in another.
+
+## Verification
+
+Eleven gate tests, of which three are new and were red before the change: the
+old gate returned `Ok` for a hand-rolled layout (never walked), `Ok` for an
+allow-listed file with its own copy of the layout, and `Ok` for any shell at all
+(it scanned no shell). `check-all` is green across all 62 gates, with the
+workspace suite, Clippy, doctests and `check-gated`.
+
+## Also in this change
+
+`specs/REFACTOR-STATUS.md` had two entries under **In progress** reading "merge
+delivery remains" for work already on `main` — the kernel cache relocation
+(#3038, `927f25bc29`) and the machine diff handshake retry (#3024/#3028,
+`a22414f5ce`). Both verified merged by commit and moved to **Completed**. The
+staleness is structural rather than anyone's oversight: the file asks to be
+ticked in the same change as the work, and the tick is only true after that
+change merges.

--- a/xtask/src/check_verified_kernel_reads.rs
+++ b/xtask/src/check_verified_kernel_reads.rs
@@ -21,6 +21,21 @@
 //! for diagnostics at exactly the sites that must not boot from it, so the
 //! honest cheap control is to make a bare use visible in review rather than
 //! impossible.
+//!
+//! That check only ever looked at files naming `cached_kernel_path`, which left
+//! it blind to the way the layout was most often written: by hand. Nine call
+//! sites rebuilt `<cache>/kernels/<arch>/<variant>` with their own `join`
+//! chains, and one of them — the BDD harness picking the kernel every
+//! `@workload_kernel` scenario boots — selected it with a bare `is_file()`.
+//! It was invisible here for as long as it spelled the path itself, and became
+//! visible the moment it was routed through the helper. A gate that only sees
+//! the disciplined callers reports on the population least likely to be wrong.
+//!
+//! So there are two checks now, and the second is what makes the first
+//! complete: the layout may be built in exactly one place, which forces every
+//! caller into the seam check above. The third is a drift alarm for shell,
+//! which cannot call a Rust helper and so can only be held to "do not name the
+//! retired location".
 
 use anyhow::{Result, bail};
 use std::path::Path;
@@ -53,19 +68,112 @@ const ALLOWED_UNVERIFIED: &[&str] = &[
     "crates/mvm-conformance/tests/steps/volume.rs",
 ];
 
+/// Building the kernel cache layout rather than asking for it.
+///
+/// The first `join` of the layout is enough: every hand-rolled form starts
+/// here, and matching one component keeps the check from depending on how the
+/// rest of the chain is spelled or wrapped.
+const HANDROLLED_LAYOUT: &str = r#".join("kernels")"#;
+
+/// The retired location. Kernels moved out of the builder-VM cache directory
+/// because Stage 0 replaces that directory wholesale, taking any kernel inside
+/// it with them.
+const RETIRED_LAYOUT: &str = "builder-vm";
+
+/// Shell that legitimately names the current kernel cache location.
+///
+/// Scripts cannot call the Rust helper, so they are held to the weaker rule:
+/// name the current location, never the retired one.
+const SHELL_ROOT: &str = "scripts";
+
+/// Flag `.join("kernels")` outside the module that owns the layout.
+///
+/// The layout has one definition for the same reason a kernel has one digest:
+/// a second copy is a second thing to keep in sync, and the copies drift
+/// silently because each one works.
+fn handrolled_layout_offenders(workspace: &Path) -> Result<Vec<String>> {
+    let mut offenders = Vec::new();
+    crate::fs_walk::for_each_file(&workspace.join("crates"), Some("rs"), &mut |path, text| {
+        let rel = relative(workspace, path);
+        if rel == DEFINING_FILE || !text.contains(HANDROLLED_LAYOUT) {
+            return;
+        }
+        for (i, line) in text.lines().enumerate() {
+            if line.contains(HANDROLLED_LAYOUT) {
+                offenders.push(format!("{rel}:{}: {}", i + 1, line.trim()));
+            }
+        }
+    })?;
+    Ok(offenders)
+}
+
+/// Flag shell that still points at the pre-relocation kernel location.
+///
+/// Narrower than the Rust checks by necessity, and aimed at exactly the failure
+/// it is named for: a relocation that updates the Rust and leaves a script
+/// looking where kernels used to live. That script does not error — it finds
+/// nothing, and a lane quietly stops covering what it claims to.
+fn stale_shell_offenders(workspace: &Path) -> Result<Vec<String>> {
+    let mut offenders = Vec::new();
+    crate::fs_walk::for_each_file(
+        &workspace.join(SHELL_ROOT),
+        Some("sh"),
+        &mut |path, text| {
+            let rel = relative(workspace, path);
+            for (i, line) in text.lines().enumerate() {
+                if line.contains(RETIRED_LAYOUT) && line.contains("kernels") {
+                    offenders.push(format!("{rel}:{}: {}", i + 1, line.trim()));
+                }
+            }
+        },
+    )?;
+    Ok(offenders)
+}
+
+fn relative(workspace: &Path, path: &Path) -> String {
+    path.strip_prefix(workspace)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
 pub fn run(workspace: &Path) -> Result<()> {
+    let handrolled = handrolled_layout_offenders(workspace)?;
+    if !handrolled.is_empty() {
+        for o in &handrolled {
+            eprintln!("[error] {o}");
+        }
+        bail!(
+            "check-verified-kernel-reads: {} site(s) build the kernel cache layout by hand \
+             instead of calling `kernel_cache_dir` / `{LOCATION}`. A hand-rolled path is \
+             invisible to the verified-read check below, which is how an unverified read of the \
+             workload kernel survived in the BDD harness: it spelled the layout itself, so \
+             nothing looked at it. Build the path through {DEFINING_FILE}.",
+            handrolled.len()
+        );
+    }
+
+    let stale_shell = stale_shell_offenders(workspace)?;
+    if !stale_shell.is_empty() {
+        for o in &stale_shell {
+            eprintln!("[error] {o}");
+        }
+        bail!(
+            "check-verified-kernel-reads: {} shell line(s) look for kernels under `{RETIRED_LAYOUT}`, \
+             which is not where they live. Stage 0 replaces that directory wholesale, which is \
+             why they moved out of it. A script pointed there finds nothing and reports no \
+             error, so the lane it feeds silently stops covering what it claims to.",
+            stale_shell.len()
+        );
+    }
+
     let mut offenders: Vec<String> = Vec::new();
     let mut verified_sites = 0usize;
 
     let mut files: Vec<(String, String)> = Vec::new();
     crate::fs_walk::for_each_file(&workspace.join("crates"), Some("rs"), &mut |path, text| {
         if text.contains(LOCATION) {
-            let rel = path
-                .strip_prefix(workspace)
-                .unwrap_or(path)
-                .to_string_lossy()
-                .replace('\\', "/");
-            files.push((rel, text.to_string()));
+            files.push((relative(workspace, path), text.to_string()));
         }
     })?;
 
@@ -176,6 +284,100 @@ mod tests {
             (
                 "crates/mvm-build/src/kernel_fetch.rs",
                 "pub fn cached_kernel_path() {}",
+            ),
+        ]);
+        assert!(run(tmp.path()).is_ok());
+    }
+
+    /// The regression this gate did not catch. Before the layout had one
+    /// definition, this file was invisible: no `cached_kernel_path`, so the
+    /// verified-read check never looked at it, and it booted whatever sat at a
+    /// path it spelled itself.
+    #[test]
+    fn a_handrolled_layout_is_refused_even_without_naming_the_helper() {
+        let tmp = workspace_with(&[
+            verified_reader(),
+            (
+                "crates/mvm-conformance/tests/conformance.rs",
+                "fn k() { let p = cache.join(\"kernels\").join(arch).join(\"workload\"); \
+                 p.is_file().then_some(p) }",
+            ),
+        ]);
+        let err = run(tmp.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("build the kernel cache layout by hand"),
+            "{err}"
+        );
+    }
+
+    /// The allow-list governs the verified-read check, not the one-definition
+    /// rule. A staging lane may read the location without verifying; it may not
+    /// keep its own copy of where that location is.
+    #[test]
+    fn the_allow_list_does_not_excuse_a_handrolled_layout() {
+        let tmp = workspace_with(&[
+            verified_reader(),
+            (
+                "crates/mvm-client/tests/launch_lifecycle_live.rs",
+                "fn seed() { let d = c.join(\"kernels\").join(a).join(\"workload\"); }",
+            ),
+        ]);
+        let err = run(tmp.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("build the kernel cache layout by hand"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn the_module_that_owns_the_layout_may_build_it() {
+        let tmp = workspace_with(&[
+            verified_reader(),
+            (
+                "crates/mvm-build/src/kernel_fetch.rs",
+                "pub fn kernel_cache_dir(c: &Path) -> PathBuf { c.join(\"kernels\") }\n\
+                 pub fn cached_kernel_path() {}",
+            ),
+        ]);
+        assert!(run(tmp.path()).is_ok());
+    }
+
+    /// The other straggler: a shell lane still looking where kernels used to
+    /// live. It finds nothing and says nothing, so the seam it feeds goes dark.
+    #[test]
+    fn shell_pointed_at_the_retired_location_is_refused() {
+        let tmp = workspace_with(&[
+            verified_reader(),
+            (
+                "scripts/e2e-launch-modes.sh",
+                "KERNEL=\"$(find \"$HOME/cache/builder-vm\" -name vmlinux -path '*kernels*')\"",
+            ),
+        ]);
+        let err = run(tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("which is not where they live"), "{err}");
+    }
+
+    #[test]
+    fn shell_naming_the_current_location_passes() {
+        let tmp = workspace_with(&[
+            verified_reader(),
+            (
+                "scripts/e2e-launch-modes.sh",
+                "KERNEL=\"$(find \"$HOME/cache/kernels\" -name vmlinux -path '*workload*')\"",
+            ),
+        ]);
+        assert!(run(tmp.path()).is_ok());
+    }
+
+    /// The builder VM's *own* kernel legitimately lives in that directory, and
+    /// a script naming it is not the failure this looks for.
+    #[test]
+    fn shell_naming_the_builder_vms_own_kernel_is_not_flagged() {
+        let tmp = workspace_with(&[
+            verified_reader(),
+            (
+                "scripts/measure-hvf-density.sh",
+                "seed=\"${CACHE_DIR}/builder-vm/${arch}/vmlinux\"",
             ),
         ]);
         assert!(run(tmp.path()).is_ok());


### PR DESCRIPTION
Recovered from a stale local worktree and pushed so the work is not one `git worktree remove` away from gone.

**Draft on purpose.** This is preserved work-in-progress, not a review request. Nobody has said it is finished.

| | |
|---|---|
| Commits ahead of `main` | 1 |
| Files this branch changes | 3 |
| Of those, still differing from `main` | **1** |
| Behind `main` by | 22 commits |
| Last commit | 2026-08-31 |

### Commits

- \`374c188ece\` fix(xtask): make the kernel-reads gate see hand-rolled cache paths

### Read CI here with care

This branch is **22 commits behind `main`** and has not been rebased or re-run since 2026-08-31.
A red lane is at least as likely to be a stale base as a defect in the change, and a green one
does not say the change still integrates. It needs a rebase before either verdict means anything.
