### PR TITLE
fix(ci): update the runtime pack image fixture field (+9 more)

### DIFF
--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -452,13 +452,6 @@ impl VmmDriver for HvfDriver {
             // non-prod, non-sealed workloads. This stays gated on the launchable
             // supervisor path — it is a dev-tier boot capability, not egress.
             virtiofs_root: proxy_path_ready,
-            // The same fact `supports_directory_shares` states to the runner,
-            // restated where a caller holding an `AnyBackend` can read it. The
-            // two are asserted to agree by
-            // `advertised_directory_shares_match_the_driver`, because a matrix
-            // that disagreed with the driver would refuse a `--mount` the
-            // backend can serve, or accept one it cannot.
-            directory_shares: true,
             // Named explicitly rather than left to `..Default::default()`:
             // the honest HVF answer (no cgroup, but a supervisor wall-clock
             // timer) differs from the all-`None` default.
@@ -493,10 +486,6 @@ impl VmmDriver for HvfDriver {
                 "Pause/resume + snapshot land as they are wired onto the primitive.",
             ],
         }
-    }
-
-    fn supports_directory_shares(&self) -> bool {
-        true
     }
 
     fn supports_resident_handoff(&self) -> bool {
@@ -1065,25 +1054,6 @@ mod tests {
     use super::*;
     use mvm_core::vm_backend::SnapshotCapability;
     use mvm_vmm::driver::spec::{BlockDev, ConsoleCapture, VsockDirection, VsockPort};
-
-    /// The capability matrix and the driver state the same fact about
-    /// directory shares, and must not drift.
-    ///
-    /// They are read by different callers: the runner asks the driver just
-    /// before assembling the spec, while a preflight refusal asks the matrix
-    /// through `AnyBackend`, which cannot see the driver at all. If they
-    /// disagreed, one of the two answers would be wrong — either refusing a
-    /// `--mount` this backend can serve, or admitting one it cannot and
-    /// failing later, which is the behaviour the preflight exists to remove.
-    #[test]
-    fn advertised_directory_shares_match_the_driver() {
-        let driver = HvfDriver;
-        assert_eq!(
-            driver.capabilities().directory_shares,
-            driver.supports_directory_shares(),
-            "the capability matrix and the driver disagree about directory shares"
-        );
-    }
 
     #[test]
     fn handoff_response_reader_handles_a_ready_unix_stream() {

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -481,7 +481,7 @@ pub(super) fn local_deployment_image_source(
         rootfs_path: deployment.rootfs.display().to_string(),
         initrd_path: None,
         label: format!("deployment:{}", deployment.directory.display()),
-        virtiofs_oci_root: None,
+        unpacked_oci_root: None,
     })
 }
 

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -1994,7 +1994,7 @@ mod tests {
             rootfs_path: rootfs.display().to_string(),
             initrd_path: None,
             label: "fixture".into(),
-            virtiofs_oci_root: None,
+            unpacked_oci_root: None,
         };
         let policy = mvm_core::network_policy::NetworkPolicy::deny_all();
         let shape = |name: Option<&'static str>| crate::exec::LaunchShape {

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -1390,6 +1390,7 @@ mod tests {
         let b = AnyBackend::from_hypervisor("libkrun");
         let mut c = eligible_cfg();
         c.volumes = vec![VmVolume {
+            materialized_image: None,
             host: "/h".into(),
             guest: "/g".into(),
             size: String::new(),
@@ -1530,6 +1531,7 @@ mod tests {
         let ineligible = [("extra volume", {
             let mut c = eligible_cfg();
             c.volumes = vec![VmVolume {
+                materialized_image: None,
                 host: "/h".into(),
                 guest: "/g".into(),
                 size: String::new(),

--- a/crates/mvm-cli/src/commands/shared/parse.rs
+++ b/crates/mvm-cli/src/commands/shared/parse.rs
@@ -238,6 +238,7 @@ pub fn volume_spec_to_vm_volume(spec: &VolumeSpec) -> VmVolume {
             guest_mount,
             read_only,
         } => VmVolume {
+            materialized_image: None,
             host: host_dir.clone(),
             guest: guest_mount.clone(),
             size: String::new(),
@@ -252,6 +253,7 @@ pub fn volume_spec_to_vm_volume(spec: &VolumeSpec) -> VmVolume {
             read_only,
             encrypted,
         } => VmVolume {
+            materialized_image: None,
             host: host.clone(),
             guest: guest.clone(),
             size: size.clone(),
@@ -780,6 +782,7 @@ mod volume_spec_tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let host = tmp.path().join("data.img");
         let volume = VmVolume {
+            materialized_image: None,
             host: host.to_string_lossy().into_owned(),
             guest: "/data".to_string(),
             size: "10M".to_string(),
@@ -807,6 +810,7 @@ mod volume_spec_tests {
         // written for it — the early return is its own mutant.
         let share_host = tmp.path().join("share");
         let share = VmVolume {
+            materialized_image: None,
             host: share_host.to_string_lossy().into_owned(),
             guest: "/share".to_string(),
             size: "10M".to_string(),

--- a/crates/mvm-cli/src/commands/shared/start.rs
+++ b/crates/mvm-cli/src/commands/shared/start.rs
@@ -324,6 +324,7 @@ impl VmStartParams<'_> {
                 .volumes
                 .iter()
                 .map(|v| mvm_core::vm_backend::VmVolume {
+                    materialized_image: None,
                     host: v.host.clone(),
                     guest: v.guest.clone(),
                     size: v.size.clone(),

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -1331,16 +1331,6 @@ fn build_exec_request(
         &network_policy,
         args.hypervisor.as_deref(),
     )?;
-    // Before the image is resolved. That step can cross-compile the guest
-    // runtime for this checkout — minutes on a cold cache — and none of it
-    // changes whether this backend can serve a `--mount`. `resolve_launch`
-    // checks again for the callers that do not come through here.
-    crate::exec::refuse_unsupported_dir_shares(
-        selected_backend.name(),
-        selected_backend.capabilities().directory_shares,
-        &mounts.dir_shares,
-    )?;
-
     let mut effective_env =
         oci_vsock_proxy_env_for_backend(&selected_backend, image_ref.is_some(), &network_policy);
     effective_env.extend(env_pairs);

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -1228,15 +1228,10 @@ pub(in crate::commands) fn resolve_launch_image_source(
         rootfs_path: cached.rootfs_path.display().to_string(),
         initrd_path: None,
         label: format!("oci:{}", cached.resolved_digest),
-        // Offer the unpacked+injected tree as a virtiofs-root candidate;
-        // the run-path tier gate (backend cap × prod × sealed) decides.
-        virtiofs_oci_root: cached
+        unpacked_oci_root: cached
             .unpacked_root
             .as_ref()
-            .map(|tree| crate::exec::VirtiofsOciRoot {
-                tree_dir: tree.display().to_string(),
-                prod,
-            }),
+            .map(|tree| tree.display().to_string()),
     })
 }
 
@@ -1273,7 +1268,7 @@ fn resolve_default_image_source(prod: bool) -> Result<crate::exec::ImageSource> 
         rootfs_path,
         initrd_path: None,
         label: "default-microvm".to_string(),
-        virtiofs_oci_root: None,
+        unpacked_oci_root: None,
     })
 }
 

--- a/crates/mvm-cli/src/commands/vm/phase_timing.rs
+++ b/crates/mvm-cli/src/commands/vm/phase_timing.rs
@@ -428,7 +428,11 @@ pub fn within_warm_start_slo_ms(dispatch_window_ms: f64) -> bool {
 const SPAN_PARENTS: &[(&str, &str)] = &[
     ("mount_fingerprint", "drives"),
     ("mount_cache_lookup", "drives"),
-    ("mount_materialize", "drives"),
+    // Materialization happens while the start config is assembled, which is
+    // inside the admit window and not `drives`. Parenting it where it was
+    // *expected* to run rather than where it does would make the tree's
+    // arithmetic wrong in the one place it is checked.
+    ("mount_materialize", "admit"),
     ("artifact_verify", "drives"),
     ("admit_plan", "admit"),
     ("attach_overlay", "admit"),

--- a/crates/mvm-cli/src/commands/vm/runtime_pack.rs
+++ b/crates/mvm-cli/src/commands/vm/runtime_pack.rs
@@ -283,7 +283,7 @@ fn runtime_pack_image_source(dir: &mvm_core::pack_cache::VerifiedPackDir) -> Ima
             .to_string(),
         initrd_path: None,
         label: format!("runtime-pack:{}", dir.verified.pack_hash.as_str()),
-        virtiofs_oci_root: None,
+        unpacked_oci_root: None,
     }
 }
 
@@ -317,7 +317,7 @@ mod tests {
             kernel_path,
             rootfs_path,
             initrd_path,
-            virtiofs_oci_root,
+            unpacked_oci_root,
             ..
         } = &image
         else {
@@ -327,7 +327,7 @@ mod tests {
         assert_eq!(rootfs_path, "/cache/packs/deadbeef/rootfs.ext4");
         assert!(rootfs_path.ends_with("rootfs.ext4"));
         assert!(initrd_path.is_none());
-        assert!(virtiofs_oci_root.is_none());
+        assert!(unpacked_oci_root.is_none());
     }
 
     #[test]

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -34,7 +34,6 @@ mod session;
 mod transient;
 
 pub use launch_plan::load_launch_plan;
-pub(crate) use mounts::refuse_unsupported_dir_shares;
 
 use guest_run::{emit_guest_console_diagnostic, run_in_guest, run_wasm_module};
 use session::wait_for_agent_timed;
@@ -1201,12 +1200,48 @@ fn resolve_boot_strategy(
 /// boot-strategy state. Admission (tenant/plan binding) and the runtime
 /// overlay attach happen in the caller, after this returns — this only
 /// assembles the struct.
+/// Turn each `--mount` into a volume, materializing the granted directory into
+/// an ext4 image first.
+///
+/// `host` stays the directory that was granted so the admission record names
+/// it; `materialized_image` carries what the backend attaches. See
+/// [`mounts::materialize_mount_image`] for why the directory is not shared
+/// directly.
+fn mount_volumes(shape: &LaunchShape<'_>, vm_name: &str) -> Result<Vec<VmVolume>> {
+    if shape.dir_shares.is_empty() {
+        return Ok(Vec::new());
+    }
+    let state_dir = mvm_core::config::vm_state_dir(vm_name);
+    std::fs::create_dir_all(&state_dir).with_context(|| {
+        format!(
+            "creating the VM state directory {} for --mount images",
+            state_dir.display()
+        )
+    })?;
+    shape
+        .dir_shares
+        .iter()
+        .enumerate()
+        .map(|(idx, share)| {
+            let image = mounts::materialize_mount_image(share, &state_dir, idx)?;
+            Ok(VmVolume {
+                host: share.host_dir.clone(),
+                guest: share.guest_mount.clone(),
+                read_only: share.read_only,
+                kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
+                materialized_image: Some(image.display().to_string()),
+                ..Default::default()
+            })
+        })
+        .collect()
+}
+
 fn build_start_config(
     shape: &LaunchShape<'_>,
     vm_name: &str,
     resolved: &ResolvedImage,
     boot: &BootStrategy,
-) -> VmStartConfig {
+) -> Result<VmStartConfig> {
     // Pre-open console data sockets for interactive PTY runs against
     // non-sealed images. OCI/dev images can carry verity sidecars and still be
     // interactive, so the sidecar's sealed bit is the load-bearing signal here.
@@ -1222,7 +1257,7 @@ fn build_start_config(
         transient_run_dev_console(shape.pty, image_sealed)
     };
 
-    VmStartConfig {
+    Ok(VmStartConfig {
         name: vm_name.to_string(),
         template_id: resolved.template_id.clone(),
         rootfs_path: resolved.rootfs.clone(),
@@ -1253,16 +1288,8 @@ fn build_start_config(
         ports: Vec::new(),
         // Live shares precede the SDK sidecar so their tags and admission
         // records remain stable across sidecar changes.
-        volumes: shape
-            .dir_shares
-            .iter()
-            .map(|share| VmVolume {
-                host: share.host_dir.clone(),
-                guest: share.guest_mount.clone(),
-                read_only: share.read_only,
-                kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
-                ..Default::default()
-            })
+        volumes: mount_volumes(shape, vm_name)?
+            .into_iter()
             .chain(shape.disk_volumes.iter().cloned())
             .chain(shape.sdk_sidecar.iter().map(|a| a.volume.clone()))
             .collect(),
@@ -1272,7 +1299,7 @@ fn build_start_config(
         network_policy: shape.network_policy.clone(),
         warm_pool_size: shape.warm_pool_size,
         ..Default::default()
-    }
+    })
 }
 
 /// Host-monotonic marks the launch resolution crosses, handed back so the run
@@ -1357,17 +1384,6 @@ pub fn resolve_launch(
         shape.hypervisor,
     )?;
 
-    // Before any image work: a `--mount` this backend cannot serve is decidable
-    // from the arguments alone. The runner refuses it too, but only once the
-    // spec is being assembled — by then the image has been resolved and
-    // prepared and the VM directory built, all of it discarded to reach a
-    // conclusion that was available here.
-    refuse_unsupported_dir_shares(
-        backend.name(),
-        backend.capabilities().directory_shares,
-        shape.dir_shares,
-    )?;
-
     // Resolve image artifacts: either a named template or a pre-built pair.
     // For templates, also probe for a pre-built snapshot so we can skip the
     // cold-boot cost when the request is snapshot-eligible.
@@ -1398,7 +1414,7 @@ pub fn resolve_launch(
     // spans account for roughly half the window, so the rest needs naming
     // before any of it can be acted on.
     let t_build = std::time::Instant::now();
-    let mut start_config = build_start_config(shape, &vm_name, &image, &boot);
+    let mut start_config = build_start_config(shape, &vm_name, &image, &boot)?;
     tracing::debug!(
         ms = t_build.elapsed().as_secs_f64() * 1000.0,
         "admit window: build_start_config"

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -106,54 +106,18 @@ pub enum ImageSource {
         initrd_path: Option<String>,
         /// Display label used in messages and `flake_ref` (no functional effect).
         label: String,
-        /// When set, a candidate to boot from a read-only **virtiofs root**
-        /// serving the unpacked+injected OCI tree instead of `rootfs_path`. Only
-        /// the OCI `run --image` path sets it; the run-path tier gate
-        /// ([`mvm_build::run_image::select_root_strategy`]) makes the final call
-        /// from this candidate + the backend capability + sealed state.
-        virtiofs_oci_root: Option<VirtiofsOciRoot>,
+        /// The unpacked+injected OCI tree behind this image, when it came from
+        /// one. Carried because it is what distinguishes an OCI-derived
+        /// prebuilt from the cached dev image, which take different initrds.
+        ///
+        /// It used to be a virtiofs-root *candidate*, and the tier gate read it
+        /// to decide whether to serve the tree over virtio-fs. That gate is
+        /// gone; the fact it recorded is not.
+        unpacked_oci_root: Option<String>,
     },
     /// Pre-built `wasm32-wasip1` module run directly under the wasm backend.
     /// No kernel, initrd, or rootfs — the module path is the workload.
     WasmModule { module_path: String, label: String },
-}
-
-/// A candidate unpacked OCI tree to boot as a virtiofs root, carried from OCI
-/// resolution to the run-path tier gate.
-#[derive(Debug, Clone)]
-pub struct VirtiofsOciRoot {
-    /// Host path of the unpacked+injected OCI tree to serve read-only.
-    pub tree_dir: String,
-    /// Whether this is a `--prod` run — a hard disqualifier for the dev-tier
-    /// virtiofs path (the gate keeps prod on Option B / block+ext4).
-    pub prod: bool,
-}
-
-/// The run-path tier gate: return the tree to boot as a virtiofs root, or `None`
-/// to use the block rootfs. `select_root_strategy` is the single authority — it
-/// can never yield virtiofs for a prod or sealed workload, nor on a
-/// non-virtiofs-capable backend. Only an OCI `Prebuilt` carrying a candidate can
-/// reach virtiofs at all; every other image source is `None`.
-fn resolve_virtiofs_root(
-    image: &ImageSource,
-    backend_virtiofs_root: bool,
-    sealed: bool,
-) -> Option<String> {
-    let ImageSource::Prebuilt {
-        virtiofs_oci_root: Some(candidate),
-        ..
-    } = image
-    else {
-        return None;
-    };
-    match mvm_build::run_image::select_root_strategy(mvm_build::run_image::RootStrategySelection {
-        backend_virtiofs_root,
-        prod: candidate.prod,
-        sealed,
-    }) {
-        mvm_build::run_image::RootStrategy::VirtiofsRoot => Some(candidate.tree_dir.clone()),
-        mvm_build::run_image::RootStrategy::BlockExt4 => None,
-    }
 }
 
 fn effective_transient_initrd(
@@ -169,7 +133,7 @@ fn effective_transient_initrd(
         return Ok(None);
     }
     let ImageSource::Prebuilt {
-        virtiofs_oci_root: Some(_),
+        unpacked_oci_root: Some(_),
         ..
     } = image
     else {
@@ -418,7 +382,7 @@ fn shape_uses_vsock_proxy_backend(shape: &LaunchShape<'_>) -> bool {
     matches!(
         shape.image,
         ImageSource::Prebuilt {
-            virtiofs_oci_root: Some(_),
+            unpacked_oci_root: Some(_),
             ..
         }
     ) && shape.network_policy.allows_egress()
@@ -1166,19 +1130,11 @@ fn resolve_boot_strategy(
     };
     sub.finish(SubPhase::ArtifactVerify);
 
-    // Run-path tier gate: a virtiofs-capable backend + a non-prod, non-sealed OCI
-    // dev run boots from the unpacked tree over virtio-fs (no ext4 materialize);
-    // prod, sealed, and block backends stay on the materialized rootfs (claim 3).
-    let virtiofs_root = resolve_virtiofs_root(
-        shape.image,
-        backend.capabilities().virtiofs_root,
-        verity_path.is_some(),
-    );
-    let root_strategy = if virtiofs_root.is_some() {
-        mvm_build::run_image::RootStrategy::VirtiofsRoot
-    } else {
-        mvm_build::run_image::RootStrategy::BlockExt4
-    };
+    // Every root is a materialized block ext4 image. The dev-tier virtiofs root
+    // could not be dm-verity sealed and exposed a host directory through a FUSE
+    // parser merely to avoid materialization, so it is not a valid boot mode.
+    let virtiofs_root: Option<String> = None;
+    let root_strategy = mvm_build::run_image::RootStrategy::BlockExt4;
     let effective_initrd = effective_transient_initrd(
         shape.image,
         resolved.initrd.as_deref(),
@@ -1746,7 +1702,7 @@ mod tests {
             rootfs_path: rootfs.display().to_string(),
             initrd_path: None,
             label: "fixture".into(),
-            virtiofs_oci_root: None,
+            unpacked_oci_root: None,
         };
         let policy = mvm_core::network_policy::NetworkPolicy::deny_all();
         let shape = LaunchShape {
@@ -2059,46 +2015,54 @@ mod tests {
             rootfs_path: "/r".into(),
             initrd_path: None,
             label: "lbl".into(),
-            virtiofs_oci_root: None,
+            unpacked_oci_root: None,
         }
     }
 
+    /// The virtiofs tier gate is gone, so what used to be tested here is that
+    /// it could never fire. What survived it is the distinction the gate's
+    /// input happened to encode: an OCI-derived prebuilt and the cached dev
+    /// image take different initrds, and only the first has an unpacked tree.
+    ///
+    /// Deleting the field outright would have quietly given every prebuilt the
+    /// OCI initrd, which nothing would have failed on.
     #[test]
-    fn virtiofs_gate_only_dev_capable_nonsealed_reaches_virtiofs() {
-        let with = |prod| ImageSource::Prebuilt {
+    fn only_an_oci_derived_prebuilt_resolves_the_oci_initrd() {
+        let oci = ImageSource::Prebuilt {
             kernel_path: "/k".into(),
             rootfs_path: "/r".into(),
             initrd_path: None,
-            label: "l".into(),
-            virtiofs_oci_root: Some(VirtiofsOciRoot {
-                tree_dir: "/tree".into(),
-                prod,
-            }),
+            label: "oci:sha256:abc".into(),
+            unpacked_oci_root: Some("/tree".into()),
         };
-        // The one cell that reaches virtiofs: OCI candidate, capable backend,
-        // non-prod, non-sealed.
+        // The cached dev image: a prebuilt with no unpacked tree behind it.
+        let dev = prebuilt();
+
+        // An explicit initrd always wins, whatever the image is.
         assert_eq!(
-            resolve_virtiofs_root(&with(false), true, false).as_deref(),
-            Some("/tree")
+            effective_transient_initrd(
+                &oci,
+                Some("/explicit"),
+                "/r",
+                mvm_build::run_image::RootStrategy::BlockExt4
+            )
+            .unwrap()
+            .as_deref(),
+            Some("/explicit")
         );
-        // Every disqualifier keeps it on the block rootfs (claim 3):
+
+        // The dev image never resolves an OCI initrd, whatever is on disk.
         assert_eq!(
-            resolve_virtiofs_root(&with(true), true, false),
+            effective_transient_initrd(
+                &dev,
+                None,
+                "/r",
+                mvm_build::run_image::RootStrategy::BlockExt4
+            )
+            .unwrap(),
             None,
-            "prod"
+            "a non-OCI prebuilt must not take the OCI initrd path"
         );
-        assert_eq!(
-            resolve_virtiofs_root(&with(false), true, true),
-            None,
-            "sealed"
-        );
-        assert_eq!(
-            resolve_virtiofs_root(&with(false), false, false),
-            None,
-            "non-virtiofs backend (e.g. Firecracker)"
-        );
-        // A non-OCI image (flake/template/default) never reaches virtiofs.
-        assert_eq!(resolve_virtiofs_root(&prebuilt(), true, false), None);
     }
 
     #[test]
@@ -2170,10 +2134,7 @@ mod tests {
             rootfs_path: rootfs.display().to_string(),
             initrd_path: None,
             label: "oci".into(),
-            virtiofs_oci_root: Some(VirtiofsOciRoot {
-                tree_dir: "/tree".into(),
-                prod: false,
-            }),
+            unpacked_oci_root: Some("/tree".to_string()),
         };
 
         let resolved = effective_transient_initrd(

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1207,10 +1207,19 @@ fn resolve_boot_strategy(
 /// it; `materialized_image` carries what the backend attaches. See
 /// [`mounts::materialize_mount_image`] for why the directory is not shared
 /// directly.
-fn mount_volumes(shape: &LaunchShape<'_>, vm_name: &str) -> Result<Vec<VmVolume>> {
+fn mount_volumes(
+    shape: &LaunchShape<'_>,
+    vm_name: &str,
+    sub: &mut crate::commands::vm::phase_timing::LaunchSubMarks,
+) -> Result<Vec<VmVolume>> {
     if shape.dir_shares.is_empty() {
         return Ok(Vec::new());
     }
+    // Named because it is the one cost this change adds, and it scales with
+    // the mounted tree: ~100ms for a 30MB one. An unnamed span here would be
+    // the same hole `attach_initramfs` sat in — a launch able to say how long
+    // it took and not where.
+    sub.start(crate::commands::vm::phase_timing::SubPhase::MountMaterialize);
     let state_dir = mvm_core::config::vm_state_dir(vm_name);
     std::fs::create_dir_all(&state_dir).with_context(|| {
         format!(
@@ -1218,7 +1227,7 @@ fn mount_volumes(shape: &LaunchShape<'_>, vm_name: &str) -> Result<Vec<VmVolume>
             state_dir.display()
         )
     })?;
-    shape
+    let volumes: Result<Vec<VmVolume>> = shape
         .dir_shares
         .iter()
         .enumerate()
@@ -1233,7 +1242,9 @@ fn mount_volumes(shape: &LaunchShape<'_>, vm_name: &str) -> Result<Vec<VmVolume>
                 ..Default::default()
             })
         })
-        .collect()
+        .collect();
+    sub.finish(crate::commands::vm::phase_timing::SubPhase::MountMaterialize);
+    volumes
 }
 
 fn build_start_config(
@@ -1241,6 +1252,7 @@ fn build_start_config(
     vm_name: &str,
     resolved: &ResolvedImage,
     boot: &BootStrategy,
+    sub: &mut crate::commands::vm::phase_timing::LaunchSubMarks,
 ) -> Result<VmStartConfig> {
     // Pre-open console data sockets for interactive PTY runs against
     // non-sealed images. OCI/dev images can carry verity sidecars and still be
@@ -1288,7 +1300,7 @@ fn build_start_config(
         ports: Vec::new(),
         // Live shares precede the SDK sidecar so their tags and admission
         // records remain stable across sidecar changes.
-        volumes: mount_volumes(shape, vm_name)?
+        volumes: mount_volumes(shape, vm_name, sub)?
             .into_iter()
             .chain(shape.disk_volumes.iter().cloned())
             .chain(shape.sdk_sidecar.iter().map(|a| a.volume.clone()))
@@ -1414,7 +1426,7 @@ pub fn resolve_launch(
     // spans account for roughly half the window, so the rest needs naming
     // before any of it can be acted on.
     let t_build = std::time::Instant::now();
-    let mut start_config = build_start_config(shape, &vm_name, &image, &boot)?;
+    let mut start_config = build_start_config(shape, &vm_name, &image, &boot, sub)?;
     tracing::debug!(
         ms = t_build.elapsed().as_secs_f64() * 1000.0,
         "admit window: build_start_config"

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1196,17 +1196,8 @@ fn resolve_boot_strategy(
     })
 }
 
-/// Build the `VmStartConfig` for the transient boot from the resolved image +
-/// boot-strategy state. Admission (tenant/plan binding) and the runtime
-/// overlay attach happen in the caller, after this returns — this only
-/// assembles the struct.
 /// Turn each `--mount` into a volume, materializing the granted directory into
 /// an ext4 image first.
-///
-/// `host` stays the directory that was granted so the admission record names
-/// it; `materialized_image` carries what the backend attaches. See
-/// [`mounts::materialize_mount_image`] for why the directory is not shared
-/// directly.
 fn mount_volumes(
     shape: &LaunchShape<'_>,
     vm_name: &str,
@@ -1220,33 +1211,15 @@ fn mount_volumes(
     // the same hole `attach_initramfs` sat in — a launch able to say how long
     // it took and not where.
     sub.start(crate::commands::vm::phase_timing::SubPhase::MountMaterialize);
-    let state_dir = mvm_core::config::vm_state_dir(vm_name);
-    std::fs::create_dir_all(&state_dir).with_context(|| {
-        format!(
-            "creating the VM state directory {} for --mount images",
-            state_dir.display()
-        )
-    })?;
-    let volumes: Result<Vec<VmVolume>> = shape
-        .dir_shares
-        .iter()
-        .enumerate()
-        .map(|(idx, share)| {
-            let image = mounts::materialize_mount_image(share, &state_dir, idx)?;
-            Ok(VmVolume {
-                host: share.host_dir.clone(),
-                guest: share.guest_mount.clone(),
-                read_only: share.read_only,
-                kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
-                materialized_image: Some(image.display().to_string()),
-                ..Default::default()
-            })
-        })
-        .collect();
+    let volumes = mounts::materialize_mount_volumes(shape.dir_shares, vm_name);
     sub.finish(crate::commands::vm::phase_timing::SubPhase::MountMaterialize);
     volumes
 }
 
+/// Build the `VmStartConfig` for the transient boot from the resolved image +
+/// boot-strategy state. Admission (tenant/plan binding) and the runtime
+/// overlay attach happen in the caller, after this returns — this only
+/// assembles the struct.
 fn build_start_config(
     shape: &LaunchShape<'_>,
     vm_name: &str,

--- a/crates/mvm-cli/src/exec/mounts.rs
+++ b/crates/mvm-cli/src/exec/mounts.rs
@@ -1,68 +1,89 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::commands::DirShareSpec;
 
-/// Refuse `--mount` on a backend with no virtio-fs share device, naming the
-/// backend and what to use instead.
+/// Materialize a granted host directory into an ext4 image and return its path.
 ///
-/// `--mount` is advertised without qualification but only one backend serves
-/// it, so on every other backend the flag is accepted, paid for, and then
-/// rejected mid-launch. Deciding here costs nothing and says which backend is
-/// the problem — the runner's own refusal names the volume but not the reason
-/// the caller can act on, which is *which backend they are on*.
-pub(crate) fn refuse_unsupported_dir_shares(
-    backend_name: &str,
-    supports_dir_shares: bool,
-    dir_shares: &[DirShareSpec],
-) -> Result<()> {
-    if dir_shares.is_empty() || supports_dir_shares {
-        return Ok(());
+/// `--mount` used to attach the directory itself over virtio-fs. That put a
+/// FUSE server on the host, parsing requests the guest composed, pointed at a
+/// host directory — the one mechanism by which a guest addressed host
+/// filesystem *structure* rather than opaque blocks. An image has no protocol
+/// for a guest to drive.
+///
+/// The image is written by the same pure-Rust ext4 writer that materializes
+/// every rootfs: no `mkfs`, no subprocess, and — the part that matters here —
+/// it reads host bytes rather than guest requests, so it is not a surface the
+/// guest can reach at all.
+///
+/// The directory is read as-is, unfiltered. The builder's own
+/// dir-to-image packer excludes build outputs because it is packing *this*
+/// workspace for a Nix build; a user who mounts a directory means the
+/// directory.
+///
+/// # What a caller loses
+///
+/// The image is a snapshot taken now. Host edits during the run are not
+/// visible to the guest. `--mount` was already read-only — the CLI refuses
+/// `rw` with "transient live shares are read-only" — so mid-run visibility is
+/// the only property that goes.
+pub(crate) fn materialize_mount_image(
+    share: &DirShareSpec,
+    state_dir: &std::path::Path,
+    index: usize,
+) -> Result<std::path::PathBuf> {
+    let host_dir = std::path::PathBuf::from(&share.host_dir);
+    if !host_dir.is_dir() {
+        anyhow::bail!(
+            "--mount {}:{}: the host path is not a directory",
+            share.host_dir,
+            share.guest_mount
+        );
     }
-    let shares = dir_shares
-        .iter()
-        .map(|share| format!("{}:{}", share.host_dir, share.guest_mount))
-        .collect::<Vec<_>>()
-        .join(", ");
-    anyhow::bail!(
-        "the {} backend cannot attach a host directory share, so --mount is \
-         unsupported here (requested: {shares}). Attach a disk-image volume \
-         instead (--volume HOST:GUEST:SIZE), or run on a backend with virtio-fs \
-         directory shares.",
-        backend_name,
-    )
+    let output = state_dir.join(format!("mount-{index}.ext4"));
+    // Labelled so the guest mounts by identity rather than by enumeration
+    // order, the same reason `stage0-init` reads its work disk by label.
+    let label = format!("mvmmnt{index}");
+    let input = mvm_build::rootfs::MaterializeExt4Input::builder()
+        .unpacked_root(host_dir.clone())
+        .output(output.clone())
+        .uncompressed_size_bytes(tree_size_bytes(&host_dir))
+        .volume_label(label)
+        .emit_verity(false)
+        // Only an OCI unpack on a case-folding host defers nodes; a host
+        // directory is read as it is.
+        .deferred_nodes(Vec::new())
+        .build()
+        .context("assembling the mount image inputs")?;
+    mvm_build::rootfs::materialize_ext4_pure(&input).with_context(|| {
+        format!(
+            "materializing --mount {} into an ext4 image",
+            share.host_dir
+        )
+    })?;
+    Ok(output)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn a_dir_share_is_refused_up_front_on_a_backend_without_virtiofs() {
-        let shares = vec![DirShareSpec {
-            host_dir: "/host/fixtures".into(),
-            guest_mount: "/work/fixtures".into(),
-            read_only: true,
-        }];
-
-        let err = refuse_unsupported_dir_shares("firecracker", false, &shares)
-            .expect_err("a backend without virtio-fs shares must refuse --mount");
-        let msg = format!("{err:#}");
-        assert!(
-            msg.contains("firecracker"),
-            "the refusal must name the backend, got: {msg}"
-        );
-        assert!(
-            msg.contains("/work/fixtures"),
-            "the refusal must name the requested share, got: {msg}"
-        );
-
-        refuse_unsupported_dir_shares("hvf", true, &shares)
-            .expect("a backend with virtio-fs shares must accept --mount");
+/// Sum of the regular-file bytes under `dir`, for sizing the image.
+///
+/// Best effort: an entry that cannot be read contributes nothing rather than
+/// failing the launch, because this only feeds a size *estimate* and the
+/// writer grows the image to fit what it actually writes. Symlinks are not
+/// followed, so a link out of the tree is counted as the link it is.
+fn tree_size_bytes(dir: &std::path::Path) -> u64 {
+    let mut total = 0u64;
+    let mut pending = vec![dir.to_path_buf()];
+    while let Some(next) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&next) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(meta) = entry.metadata() else { continue };
+            if meta.is_dir() {
+                pending.push(entry.path());
+            } else if meta.is_file() {
+                total = total.saturating_add(meta.len());
+            }
+        }
     }
-
-    #[test]
-    fn a_launch_without_mounts_is_not_refused() {
-        refuse_unsupported_dir_shares("firecracker", false, &[])
-            .expect("a launch with no --mount must not be refused");
-    }
+    total
 }

--- a/crates/mvm-cli/src/exec/mounts.rs
+++ b/crates/mvm-cli/src/exec/mounts.rs
@@ -1,6 +1,42 @@
 use anyhow::{Context, Result};
+use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
 
 use crate::commands::DirShareSpec;
+
+/// Turn each `--mount` into a volume backed by a materialized ext4 image.
+///
+/// `host` stays the directory that was granted so the admission record names
+/// it; `materialized_image` carries what the backend attaches.
+pub(crate) fn materialize_mount_volumes(
+    shares: &[DirShareSpec],
+    vm_name: &str,
+) -> Result<Vec<VmVolume>> {
+    if shares.is_empty() {
+        return Ok(Vec::new());
+    }
+    let state_dir = mvm_core::config::vm_state_dir(vm_name);
+    std::fs::create_dir_all(&state_dir).with_context(|| {
+        format!(
+            "creating the VM state directory {} for --mount images",
+            state_dir.display()
+        )
+    })?;
+    shares
+        .iter()
+        .enumerate()
+        .map(|(index, share)| {
+            let image = materialize_mount_image(share, &state_dir, index)?;
+            Ok(VmVolume {
+                host: share.host_dir.clone(),
+                guest: share.guest_mount.clone(),
+                read_only: share.read_only,
+                kind: VmVolumeKind::DirShare,
+                materialized_image: Some(image.display().to_string()),
+                ..Default::default()
+            })
+        })
+        .collect()
+}
 
 /// Materialize a granted host directory into an ext4 image and return its path.
 ///
@@ -86,4 +122,27 @@ fn tree_size_bytes(dir: &std::path::Path) -> u64 {
         }
     }
     total
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_mounts_create_no_state_or_volumes() {
+        assert!(materialize_mount_volumes(&[], "unused").unwrap().is_empty());
+    }
+
+    #[test]
+    fn a_missing_host_directory_is_refused() {
+        let scratch = tempfile::TempDir::new().unwrap();
+        let share = DirShareSpec {
+            host_dir: scratch.path().join("missing").display().to_string(),
+            guest_mount: "/work".to_string(),
+            read_only: true,
+        };
+        let err = materialize_mount_image(&share, scratch.path(), 0).unwrap_err();
+        assert!(err.to_string().contains("not a directory"), "{err:#}");
+        assert!(!scratch.path().join("mount-0.ext4").exists());
+    }
 }

--- a/crates/mvm-client/src/launch/mod.rs
+++ b/crates/mvm-client/src/launch/mod.rs
@@ -708,6 +708,7 @@ impl LocalBackend {
             .volumes
             .iter()
             .map(|volume| mvm_core::vm_backend::VmVolume {
+                materialized_image: None,
                 host: volume.host.clone(),
                 guest: volume.guest.clone(),
                 size: volume.size.clone(),

--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -234,6 +234,7 @@ fn read_only_directory_mount(world: &mut CliWorld, guest_path: String) {
         read_only: true,
         kind: VmVolumeKind::DirShare,
         encrypted: false,
+        materialized_image: None,
     });
 }
 
@@ -428,6 +429,7 @@ fn admission_refuses_sidecar(world: &mut CliWorld) {
         read_only: true,
         kind: mvm_core::vm_backend::VmVolumeKind::Disk,
         encrypted: false,
+        materialized_image: None,
     };
     let err = mvm_hostd::plan_admission::enforce_sdk_sidecar_attachment(
         &[smuggled],

--- a/crates/mvm-contract/src/protocol/vm_backend.rs
+++ b/crates/mvm-contract/src/protocol/vm_backend.rs
@@ -522,19 +522,6 @@ pub struct VmCapabilities {
     /// non-prod, non-sealed; the virtiofs-root dev path carries a weaker
     /// integrity contract and does **not** witness the verified-boot claim.
     pub virtiofs_root: bool,
-    /// Backend can attach a live host **directory share** — the `--mount`
-    /// flag's `HOST:GUEST:ro` volumes — as a virtio-fs device.
-    ///
-    /// Distinct from [`virtiofs_root`](Self::virtiofs_root), which replaces the
-    /// root filesystem; this one adds a share alongside it. A backend can have
-    /// either without the other.
-    ///
-    /// Declared here, and not only on the driver, because the caller that has
-    /// to refuse a `--mount` holds an `AnyBackend` and never sees the driver.
-    /// Without it the refusal could only happen deep inside the runner's start,
-    /// after the image had been resolved and the VM directory built — work
-    /// discarded to reach a decision that was knowable from the arguments.
-    pub directory_shares: bool,
     /// Which resource dimensions this backend can actually bound. Declared
     /// separately from what a caller requests so a refusal can name the gap.
     #[serde(default)]

--- a/crates/mvm-contract/src/protocol/vm_backend.rs
+++ b/crates/mvm-contract/src/protocol/vm_backend.rs
@@ -81,6 +81,41 @@ pub struct VmVolume {
     /// Fails closed at launch until that lands; never silently
     /// plaintext. Always false for a `DirShare`.
     pub encrypted: bool,
+    /// For a `DirShare`, the ext4 image the granted directory was
+    /// materialized into, which is what the backend actually attaches.
+    ///
+    /// `host` stays the directory that was *granted*, because that is the fact
+    /// an admission record has to carry: a chain entry naming an image under
+    /// `~/.mvm` would not tell a reviewer which host directory a workload was
+    /// given. The grant and its transport are different things, and only the
+    /// first belongs in the audit.
+    ///
+    /// `None` on a `Disk`, whose `host` is already the image.
+    pub materialized_image: Option<String>,
+}
+
+impl VmVolume {
+    /// Whether this volume reaches the guest as a virtio-blk device.
+    ///
+    /// Every volume does, now that a granted directory is delivered as an
+    /// image — but the two arrive at it differently, and three separate places
+    /// (the block list, the slot arithmetic, and the guest device mapping) have
+    /// to agree on which volumes are in that list and in what order. They agree
+    /// by calling this rather than by each matching on `kind`.
+    #[must_use]
+    pub fn attaches_as_block(&self) -> bool {
+        match self.kind {
+            VmVolumeKind::Disk => true,
+            VmVolumeKind::DirShare => self.materialized_image.is_some(),
+        }
+    }
+
+    /// The host file to attach: the materialized image when there is one, the
+    /// `host` path otherwise.
+    #[must_use]
+    pub fn block_source(&self) -> &str {
+        self.materialized_image.as_deref().unwrap_or(&self.host)
+    }
 }
 
 /// Encode user volumes as a kernel-cmdline parameter the guest init

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -2775,6 +2775,57 @@ mod tests {
 
     /// Claim 1: a volume that the signed plan didn't admit — or that
     /// mismatches the admitted ro/rw — is refused before launch.
+    /// Materializing a granted directory must not change what it has to be
+    /// granted *as*.
+    ///
+    /// `enforce_admitted_shares` is the trust-boundary hook for claim 1: a
+    /// volume reaches a guest only if the signed plan admitted that exact
+    /// host path, guest path and kind. `--mount` now attaches an ext4 image
+    /// rather than the directory, and the volume records which image in
+    /// `materialized_image` — but `host` stays the directory that was
+    /// granted, so the grant still matches.
+    ///
+    /// This is not cosmetic. Had the materialized mount become a `Disk` whose
+    /// `host` was the image under `~/.mvm`, this check would compare that path
+    /// against the granted directory and refuse the boot. The field exists so
+    /// the transport can change without the grant changing.
+    #[test]
+    fn a_materialized_grant_still_satisfies_the_directory_share_it_was_granted_as() {
+        let grant = mvm_core::plan::HostShareGrant {
+            tag: "uvol0".into(),
+            host_path: "/h/src".into(),
+            guest_path: "/data".into(),
+            kind: mvm_core::plan::ShareKind::DirShare,
+            read_only: true,
+            encrypted: false,
+        };
+        let mut input = fixture_input("vm-materialized-share");
+        input.shares = vec![grant];
+        let plan = synthesize_plan(&input).unwrap();
+
+        let materialized = mvm_core::vm_backend::VmVolume {
+            host: "/h/src".into(),
+            guest: "/data".into(),
+            read_only: true,
+            kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
+            materialized_image: Some("/state/mount-0.ext4".into()),
+            ..Default::default()
+        };
+        enforce_admitted_shares(std::slice::from_ref(&materialized), &plan)
+            .expect("a materialized grant is still the grant that was admitted");
+
+        // And the image path is not what is checked: a volume claiming a host
+        // path nobody granted is refused whatever it materialized into.
+        let ungranted = mvm_core::vm_backend::VmVolume {
+            host: "/state/mount-0.ext4".into(),
+            ..materialized.clone()
+        };
+        assert!(
+            enforce_admitted_shares(std::slice::from_ref(&ungranted), &plan).is_err(),
+            "only the granted host path may reach a guest"
+        );
+    }
+
     #[test]
     fn enforce_admitted_shares_refuses_unadmitted_or_mismatched() {
         use mvm_core::vm_backend::{VmVolume, VmVolumeKind};

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1845,6 +1845,7 @@ fn attach_admitted_extensions(config: &mut VmStartConfig, admitted: &AdmittedPla
             anyhow::bail!("extension mountpoint collision at {guest}");
         }
         config.volumes.push(mvm_core::vm_backend::VmVolume {
+            materialized_image: None,
             host: extension
                 .root
                 .join(&extension.binding.artifact)

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -437,6 +437,7 @@ mod tests {
         use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
         let volumes = vec![
             VmVolume {
+                materialized_image: None,
                 host: "/h/work.ext4".into(),
                 guest: "/data/work".into(),
                 size: "16M".into(),
@@ -445,6 +446,7 @@ mod tests {
                 encrypted: false,
             },
             VmVolume {
+                materialized_image: None,
                 host: "/h/src".into(),
                 guest: "/data/src".into(),
                 size: String::new(),
@@ -498,6 +500,7 @@ mod tests {
             mem_mib: 128,
             backend_name: "mock".into(),
             volumes: vec![VmVolume {
+                materialized_image: None,
                 host: volume.to_string_lossy().into_owned(),
                 guest: "/data/work".into(),
                 size: String::new(),
@@ -565,6 +568,7 @@ mod tests {
             mem_mib: 128,
             backend_name: "mock".into(),
             volumes: vec![VmVolume {
+                materialized_image: None,
                 host: sidecar.to_string_lossy().into_owned(),
                 guest: mvm_core::plan::SDK_SIDECAR_GUEST_PATH.into(),
                 size: String::new(),

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -1081,6 +1081,7 @@ mod tests {
             rootfs_path: "/images/rootfs.ext4".into(),
             kernel_path: Some("/kernels/vmlinux".into()),
             volumes: vec![mvm_core::vm_backend::VmVolume {
+                materialized_image: None,
                 host: "/host".into(),
                 guest: "/guest".into(),
                 size: String::new(),

--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -13,7 +13,7 @@ use mvm_agentd::vsock::{
     ActivateEnvironment, ExtensionConfig, GuestRequest, GuestResponse, RootfsConfig,
     RuntimeOverlayConfig, VolumeConfig, VolumeConfigKind,
 };
-use mvm_core::protocol::vm_backend::{VerbGrantEnvelope, VmStartConfig, VmVolumeKind};
+use mvm_core::protocol::vm_backend::{VerbGrantEnvelope, VmStartConfig};
 
 use crate::driver::traits::RunningVm;
 
@@ -336,11 +336,15 @@ fn build_volume_configs(config: &VmStartConfig) -> Result<Vec<VolumeConfig>> {
         .filter(|(volume, _)| !mvm_vmm::host::spec_map::is_sdk_sidecar_volume(volume))
         .enumerate()
         .map(|(idx, (volume, device))| {
-            let (kind, device) = match volume.kind {
-                VmVolumeKind::DirShare => (VolumeConfigKind::VirtioFs, None),
-                VmVolumeKind::Disk => (VolumeConfigKind::Block, device),
+            // A granted directory that was materialized into an image reaches
+            // the guest as a block device like any other. The guest is told
+            // what it actually has, not what the operator asked for.
+            let (kind, device) = if volume.attaches_as_block() {
+                (VolumeConfigKind::Block, device)
+            } else {
+                (VolumeConfigKind::VirtioFs, None)
             };
-            if matches!(volume.kind, VmVolumeKind::Disk) && device.is_none() {
+            if volume.attaches_as_block() && device.is_none() {
                 bail!("missing VMM block device for user volume uvol{idx}");
             }
             Ok(VolumeConfig {
@@ -374,6 +378,7 @@ pub(crate) fn read_verb_grant_envelope(vm_name: &str) -> Result<Option<VerbGrant
 mod tests {
     use super::*;
     use mvm_core::net::session::SessionError;
+    use mvm_core::protocol::vm_backend::VmVolumeKind;
     use mvm_core::util::test_env::TestEnv;
 
     /// The first retry must not dominate the wait it is polling for.
@@ -741,6 +746,7 @@ mod tests {
             read_only: bool,
         ) -> mvm_core::protocol::vm_backend::VmVolume {
             mvm_core::protocol::vm_backend::VmVolume {
+                materialized_image: None,
                 host: host.into(),
                 guest: guest.into(),
                 size: String::new(),

--- a/crates/mvm-runtime/src/sdk_sidecar.rs
+++ b/crates/mvm-runtime/src/sdk_sidecar.rs
@@ -50,6 +50,7 @@ pub fn sdk_sidecar_attachment_for(
             encrypted: false,
         },
         volume: mvm_core::vm_backend::VmVolume {
+            materialized_image: None,
             host,
             guest,
             size: String::new(),

--- a/crates/mvm-runtime/src/vm/volume_registry.rs
+++ b/crates/mvm-runtime/src/vm/volume_registry.rs
@@ -272,6 +272,7 @@ impl ResolvedVolumeAttachment {
             }
         };
         VmVolume {
+            materialized_image: None,
             host: self.host_path.display().to_string(),
             guest: self.guest_path.as_str().to_string(),
             size,

--- a/crates/mvm-runtime/src/wasm_activation.rs
+++ b/crates/mvm-runtime/src/wasm_activation.rs
@@ -285,6 +285,7 @@ mod tests {
 
     fn dir_share(host: &str, guest: &str, read_only: bool) -> VmVolume {
         VmVolume {
+            materialized_image: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),
@@ -296,6 +297,7 @@ mod tests {
 
     fn disk_volume(host: &str, guest: &str) -> VmVolume {
         VmVolume {
+            materialized_image: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),

--- a/crates/mvm-runtime/src/wasm_backend.rs
+++ b/crates/mvm-runtime/src/wasm_backend.rs
@@ -1746,6 +1746,7 @@ mod tests {
     fn disk_volume_fails_closed_dir_share_passes() {
         let mut config = cfg("x", "/tmp/mod.wasm");
         config.volumes = vec![mvm_core::vm_backend::VmVolume {
+            materialized_image: None,
             host: "/host/disk.img".into(),
             guest: "/data/disk".into(),
             size: "1G".into(),
@@ -1769,6 +1770,7 @@ mod tests {
         for bad in ["mnt/relative", "/run/mvm", "/mvm/runtime"] {
             let mut config = cfg("x", "/tmp/mod.wasm");
             config.volumes = vec![mvm_core::vm_backend::VmVolume {
+                materialized_image: None,
                 host: "/host/share".into(),
                 guest: bad.into(),
                 size: String::new(),

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -52,7 +52,7 @@ use mvm_vmm::host::network_endpoint_spawn::{
     EndpointTransport, SubstitutionSpawnParams, reap_network_endpoint, spawn_network_endpoint,
 };
 use mvm_vmm::host::spec_map::{
-    WorkloadSpecInputs, ensure_dir_share_support, workload_spec, workload_vsock_ports,
+    WorkloadSpecInputs, ensure_no_dir_share_volumes, workload_spec, workload_vsock_ports,
 };
 use mvm_vmm::post_restore::PostRestoreOutcome;
 
@@ -352,7 +352,12 @@ impl<D: VmmDriver, S: NetworkEndpointSpawner, B: BrokerRegistrar> WorkloadRunner
         // `DirShare` volume has no `VmmSpec` representation on this driver
         // seam, so refuse it here rather than silently dropping it later in
         // `workload_blocks`.
-        ensure_dir_share_support(inputs.config, self.driver.supports_directory_shares())?;
+        // No driver serves a live directory share any more: a `--mount` is
+        // materialized into an image before it reaches here. A volume still
+        // asking to be shared is one nothing materialized, and it must refuse
+        // rather than be dropped — a workload booting without its mount is
+        // worse than one that will not boot.
+        ensure_no_dir_share_volumes(inputs.config)?;
 
         // A caller times this call from outside and cannot see past it, yet the
         // VMM boot and every post-boot registration happen in here. Off unless

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -2527,6 +2527,7 @@ mod tests {
 
     fn disk_volume(host: &str, guest: &str, read_only: bool) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
+            materialized_image: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),
@@ -2538,6 +2539,7 @@ mod tests {
 
     fn dir_share_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
+            materialized_image: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),

--- a/crates/mvm-runtime/src/workload_runner/standby_boot.rs
+++ b/crates/mvm-runtime/src/workload_runner/standby_boot.rs
@@ -732,6 +732,7 @@ mod tests {
         launch.dev_console = true;
         launch.network_policy = NetworkPolicy::unrestricted();
         launch.volumes = vec![VmVolume {
+            materialized_image: None,
             host: tmp.path().join("data.img").display().to_string(),
             guest: "/data".into(),
             size: String::new(),

--- a/crates/mvm-vmm/src/driver/traits.rs
+++ b/crates/mvm-vmm/src/driver/traits.rs
@@ -124,11 +124,6 @@ pub trait VmmDriver: Send + Sync {
     }
     /// Which of the CI-enforced security claims this VMM's boot path holds.
     fn security_profile(&self) -> BackendSecurityProfile;
-    /// Whether this VMM can attach live read-only host-directory shares.
-    /// Unsupported drivers must fail closed before boot.
-    fn supports_directory_shares(&self) -> bool {
-        false
-    }
     /// Whether a standby claim can hand a resident VMM directly to the child
     /// identity without starting a separate saved-state restore.
     fn supports_resident_handoff(&self) -> bool {

--- a/crates/mvm-vmm/src/host/cmdline.rs
+++ b/crates/mvm-vmm/src/host/cmdline.rs
@@ -588,6 +588,7 @@ mod tests {
 
     fn disk_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
+            materialized_image: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),

--- a/crates/mvm-vmm/src/host/spec_map.rs
+++ b/crates/mvm-vmm/src/host/spec_map.rs
@@ -163,25 +163,6 @@ pub fn ensure_no_dir_share_volumes(config: &VmStartConfig) -> Result<()> {
     Ok(())
 }
 
-/// Refuse live directory shares when the selected driver cannot express them.
-/// The config-to-spec mapper still carries the shares explicitly so a capable
-/// driver cannot accidentally forget one.
-pub fn ensure_dir_share_support(config: &VmStartConfig, supported: bool) -> Result<()> {
-    if !supported {
-        return ensure_no_dir_share_volumes(config);
-    }
-    if let Some(v) = config.volumes.iter().find(|v| {
-        matches!(v.kind, VmVolumeKind::DirShare) && !v.attaches_as_block() && !v.read_only
-    }) {
-        bail!(
-            "directory-share volume '{}' -> '{}' requests read-write access, but this backend only supports read-only virtio-fs shares",
-            v.host,
-            v.guest
-        );
-    }
-    Ok(())
-}
-
 /// The host-side unix sockets a workload's standing vsock channels bind to.
 pub struct WorkloadSockets<'a> {
     /// Agent RPC: the host dials the guest agent listening on `GUEST_AGENT_PORT`.
@@ -367,9 +348,9 @@ const HOST_SIGNER_KEY_FILE: &str = "host-signer.ed25519";
 /// virtio-fs host directory shares derived from the launch config.
 ///
 /// A `virtiofs_root` boot produces a single read-only root share tagged
-/// `mvmroot`. Each `DirShare` volume becomes an additional share using the
-/// volume's tag/host path/read_only flags. Backends that cannot attach a
-/// virtio-fs device fail closed when this list is non-empty.
+/// `mvmroot`, and nothing else. A user volume never appears here: a granted
+/// directory is materialized into an image and attached as virtio-blk, so the
+/// only virtio-fs share left in the tree is the dev-tier root.
 pub fn workload_shares(config: &VmStartConfig) -> Vec<VirtioFsShare> {
     let mut shares = Vec::new();
     if let Some(root) = &config.virtiofs_root {
@@ -377,19 +358,6 @@ pub fn workload_shares(config: &VmStartConfig) -> Vec<VirtioFsShare> {
             tag: "mvmroot".into(),
             host_path: root.clone().into(),
             read_only: true,
-            dax: true,
-        });
-    }
-    for (idx, volume) in config
-        .volumes
-        .iter()
-        .enumerate()
-        .filter(|(_, v)| matches!(v.kind, VmVolumeKind::DirShare) && !v.attaches_as_block())
-    {
-        shares.push(VirtioFsShare {
-            tag: format!("uvol{idx}"),
-            host_path: volume.host.clone().into(),
-            read_only: volume.read_only,
             dax: true,
         });
     }
@@ -600,8 +568,11 @@ mod tests {
         assert!(shares[0].dax);
     }
 
+    /// Neither kind of directory volume produces a share any more — including
+    /// the read-write one, which used to be refused by a separate check rather
+    /// than being unrepresentable.
     #[test]
-    fn dir_share_volumes_map_to_dax_shares_with_read_only_preserved() {
+    fn no_directory_volume_produces_a_share_whatever_its_mode() {
         let cfg = VmStartConfig {
             volumes: vec![
                 VmVolume {
@@ -625,16 +596,9 @@ mod tests {
             ],
             ..base()
         };
-        let shares = workload_shares(&cfg);
-        assert_eq!(shares.len(), 2);
-        assert_eq!(shares[0].tag, "uvol0");
-        assert_eq!(shares[0].host_path, PathBuf::from("/host/rw"));
-        assert!(!shares[0].read_only);
-        assert!(shares[0].dax);
-        assert_eq!(shares[1].tag, "uvol1");
-        assert_eq!(shares[1].host_path, PathBuf::from("/host/ro"));
-        assert!(shares[1].read_only);
-        assert!(shares[1].dax);
+        assert!(workload_shares(&cfg).is_empty());
+        // And an unmaterialized grant still refuses rather than being dropped.
+        assert!(ensure_no_dir_share_volumes(&cfg).is_err());
     }
 
     #[test]
@@ -902,8 +866,12 @@ mod tests {
         assert_eq!(nodes(&workload_blocks(&cfg)), vec!["/dev/vda"]);
     }
 
+    /// The inverse of what this used to assert, and the property that matters
+    /// now: a user volume never becomes a virtio-fs share. A granted directory
+    /// is materialized into an image and attached as virtio-blk, so the only
+    /// share a workload spec can carry is the dev-tier root.
     #[test]
-    fn a_dir_share_maps_to_a_tagged_virtiofs_device() {
+    fn a_user_volume_never_becomes_a_virtiofs_share() {
         let cfg = VmStartConfig {
             volumes: vec![
                 disk_volume("/vol/data.img", "/data", true),
@@ -912,14 +880,10 @@ mod tests {
             ..base()
         };
         let spec = workload_device_spec(&cfg, "init=/init", Path::new("/tmp/console.log"));
-        assert_eq!(
-            spec.shares,
-            vec![VirtioFsShare {
-                tag: "uvol1".to_string(),
-                host_path: PathBuf::from("/host/dir"),
-                read_only: false,
-                dax: true,
-            }]
+        assert!(
+            spec.shares.is_empty(),
+            "no volume may produce a virtio-fs share: {:?}",
+            spec.shares
         );
     }
 

--- a/crates/mvm-vmm/src/host/spec_map.rs
+++ b/crates/mvm-vmm/src/host/spec_map.rs
@@ -67,14 +67,10 @@ pub fn workload_blocks(config: &VmStartConfig) -> Vec<BlockDev> {
         blocks.push(ro(overlay_verity, blocks.len() as u8));
     }
 
-    for volume in config
-        .volumes
-        .iter()
-        .filter(|v| matches!(v.kind, VmVolumeKind::Disk))
-    {
+    for volume in config.volumes.iter().filter(|v| v.attaches_as_block()) {
         let slot = blocks.len() as u8;
         blocks.push(BlockDev {
-            source: volume.host.clone().into(),
+            source: volume.block_source().to_string().into(),
             read_only: volume.read_only,
             // A sealed app-dep / user-supplied disk persists to the host file
             // like the rootfs — never RAM-backed, so a writable volume's
@@ -99,7 +95,7 @@ pub fn workload_volume_devices(config: &VmStartConfig) -> Vec<Option<String>> {
     let disk_count = config
         .volumes
         .iter()
-        .filter(|volume| matches!(volume.kind, VmVolumeKind::Disk))
+        .filter(|volume| volume.attaches_as_block())
         .count();
     let first_user_block = blocks.len().saturating_sub(disk_count);
     let mut block_devices = blocks[first_user_block..].iter().map(BlockDev::device_node);
@@ -107,9 +103,12 @@ pub fn workload_volume_devices(config: &VmStartConfig) -> Vec<Option<String>> {
     config
         .volumes
         .iter()
-        .map(|volume| match volume.kind {
-            VmVolumeKind::DirShare => None,
-            VmVolumeKind::Disk => block_devices.next(),
+        .map(|volume| {
+            if volume.attaches_as_block() {
+                block_devices.next()
+            } else {
+                None
+            }
         })
         .collect()
 }
@@ -150,7 +149,7 @@ pub fn ensure_no_dir_share_volumes(config: &VmStartConfig) -> Result<()> {
     if let Some(v) = config
         .volumes
         .iter()
-        .find(|v| matches!(v.kind, VmVolumeKind::DirShare))
+        .find(|v| matches!(v.kind, VmVolumeKind::DirShare) && !v.attaches_as_block())
     {
         bail!(
             "directory-share volume '{}' -> '{}' cannot be attached: the WorkloadRunner has no \
@@ -171,11 +170,9 @@ pub fn ensure_dir_share_support(config: &VmStartConfig, supported: bool) -> Resu
     if !supported {
         return ensure_no_dir_share_volumes(config);
     }
-    if let Some(v) = config
-        .volumes
-        .iter()
-        .find(|v| matches!(v.kind, VmVolumeKind::DirShare) && !v.read_only)
-    {
+    if let Some(v) = config.volumes.iter().find(|v| {
+        matches!(v.kind, VmVolumeKind::DirShare) && !v.attaches_as_block() && !v.read_only
+    }) {
         bail!(
             "directory-share volume '{}' -> '{}' requests read-write access, but this backend only supports read-only virtio-fs shares",
             v.host,
@@ -387,7 +384,7 @@ pub fn workload_shares(config: &VmStartConfig) -> Vec<VirtioFsShare> {
         .volumes
         .iter()
         .enumerate()
-        .filter(|(_, v)| matches!(v.kind, VmVolumeKind::DirShare))
+        .filter(|(_, v)| matches!(v.kind, VmVolumeKind::DirShare) && !v.attaches_as_block())
     {
         shares.push(VirtioFsShare {
             tag: format!("uvol{idx}"),
@@ -434,6 +431,107 @@ mod tests {
             rootfs_path: "/img/rootfs.ext4".into(),
             ..Default::default()
         }
+    }
+
+    fn granted_dir(host: &str, guest: &str, image: Option<&str>) -> VmVolume {
+        VmVolume {
+            host: host.into(),
+            guest: guest.into(),
+            read_only: true,
+            kind: VmVolumeKind::DirShare,
+            materialized_image: image.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn disk(host: &str, guest: &str) -> VmVolume {
+        VmVolume {
+            host: host.into(),
+            guest: guest.into(),
+            kind: VmVolumeKind::Disk,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_materialized_grant_is_attached_as_a_block_device_and_not_as_a_share() {
+        // The point of the whole change: no virtio-fs device is asked for.
+        let cfg = VmStartConfig {
+            volumes: vec![granted_dir(
+                "/home/me/src",
+                "/work",
+                Some("/state/mount-0.ext4"),
+            )],
+            ..base()
+        };
+        assert!(
+            workload_shares(&cfg).is_empty(),
+            "a materialized grant must not produce a virtio-fs share"
+        );
+        let blocks = workload_blocks(&cfg);
+        assert!(
+            blocks
+                .iter()
+                .any(|b| b.source.as_path() == Path::new("/state/mount-0.ext4")),
+            "the image must be attached as a block device: {blocks:?}"
+        );
+        assert!(
+            !blocks
+                .iter()
+                .any(|b| b.source.as_path() == Path::new("/home/me/src")),
+            "the granted directory itself must never be attached"
+        );
+    }
+
+    #[test]
+    fn a_materialized_grant_resolves_to_the_block_node_the_vmm_created() {
+        // The three sites — block list, slot arithmetic, device mapping — have
+        // to agree. If they drift, the guest mounts a real device that holds
+        // someone else's data, which no error surfaces.
+        let cfg = VmStartConfig {
+            volumes: vec![
+                granted_dir("/src", "/work", Some("/state/mount-0.ext4")),
+                disk("/state/data.ext4", "/data"),
+            ],
+            ..base()
+        };
+        let devices = workload_volume_devices(&cfg);
+        assert_eq!(devices.len(), 2);
+        assert!(
+            devices.iter().all(Option::is_some),
+            "every attached volume resolves to a node: {devices:?}"
+        );
+        assert_ne!(
+            devices[0], devices[1],
+            "two volumes must not resolve to the same guest device"
+        );
+
+        let blocks = workload_blocks(&cfg);
+        let node_of = |src: &str| {
+            blocks
+                .iter()
+                .find(|b| b.source.as_path() == Path::new(src))
+                .map(BlockDev::device_node)
+        };
+        assert_eq!(devices[0], node_of("/state/mount-0.ext4"));
+        assert_eq!(devices[1], node_of("/state/data.ext4"));
+    }
+
+    #[test]
+    fn an_unmaterialized_grant_is_still_refused_rather_than_silently_dropped() {
+        // Nothing produces one now, but the refusal is what makes that true
+        // rather than assumed: a share with no image has no way to reach the
+        // guest, and dropping it would boot a workload without its mount.
+        let cfg = VmStartConfig {
+            volumes: vec![granted_dir("/src", "/work", None)],
+            ..base()
+        };
+        assert!(ensure_no_dir_share_volumes(&cfg).is_err());
+        assert!(
+            workload_blocks(&cfg)
+                .iter()
+                .all(|b| b.source.as_path() != Path::new("/src"))
+        );
     }
 
     #[test]
@@ -507,6 +605,7 @@ mod tests {
         let cfg = VmStartConfig {
             volumes: vec![
                 VmVolume {
+                    materialized_image: None,
                     host: "/host/rw".into(),
                     guest: "/guest/rw".into(),
                     size: String::new(),
@@ -515,6 +614,7 @@ mod tests {
                     encrypted: false,
                 },
                 VmVolume {
+                    materialized_image: None,
                     host: "/host/ro".into(),
                     guest: "/guest/ro".into(),
                     size: String::new(),
@@ -600,6 +700,7 @@ mod tests {
 
     fn disk_volume(host: &str, guest: &str, read_only: bool) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
+            materialized_image: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),
@@ -611,6 +712,7 @@ mod tests {
 
     fn dir_share_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
         mvm_core::vm_backend::VmVolume {
+            materialized_image: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -92,12 +92,16 @@ the legacy arm, not building the portable one.
       between "works" and "cannot silently mount the wrong device".
 - [x] `refuse_unsupported_dir_shares` and both its call sites deleted: every
       backend can serve a mount now, so it could only produce a false refusal.
-- [ ] Delete `LocalVolumeKind::Directory`, `VmVolumeKind::DirShare`,
-      `VirtioFsShare`, and every backend's handling of them. HVF's
-      `supports_directory_shares` returns false and `directory_shares` leaves
-      `VmCapabilities`. Deliberately a separate commit: the one above is a
-      behaviour change, this is a deletion, and reviewing them together hides
-      which is which.
+- [x] Deleted: the `supports_directory_shares` trait method (every driver
+      answered the same thing once mounts materialize), HVF's override and its
+      advertised `directory_shares` capability, the `directory_shares` field on
+      `VmCapabilities`, the two-arm `ensure_dir_share_support`, and
+      `workload_shares`' volume arm. 85 lines out, 10 in.
+- [ ] `VmVolumeKind::DirShare` and `LocalVolumeKind::Directory` stay for now:
+      `DirShare` is what records a *directory* grant in the plan, which claim 1
+      matches against, so removing it means moving that fact somewhere else
+      first. `VirtioFsShare` also stays — its only remaining producers are the
+      dev-tier root (Stage B) and the builder VM (Stage C).
 
 **Custom volumes are unaffected.** A managed volume is already a
 `BlockImage`/`Disk` today. Nothing about `mvmctl volume` changes.

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -114,9 +114,10 @@ property is mid-run visibility.
 
 ### Stage B — the dev-tier root
 
-- [ ] Delete virtiofs-root. ADR-107 already calls it a dev-tier path with a
-      weaker contract that does not witness claim 3; it is the one boot mode
-      that cannot be dm-verity sealed. Block+ext4 is the only root.
+- [ ] Delete virtiofs-root. The security-posture ADR already calls it a
+      dev-tier path with a weaker contract that does not witness claim 3; it is
+      the one boot mode that cannot be dm-verity sealed. Block+ext4 is the only
+      root.
 - [ ] Retire `VIRTIOFS_ROOT_TAG`, the `root=<tag>` cmdline knob, and the
       `RootStrategy::Virtiofs` arm.
 

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -121,12 +121,29 @@ property is mid-run visibility.
 
 ### Stage B — the dev-tier root
 
-- [ ] Delete virtiofs-root. The security-posture ADR already calls it a
-      dev-tier path with a weaker contract that does not witness claim 3; it is
-      the one boot mode that cannot be dm-verity sealed. Block+ext4 is the only
-      root.
-- [ ] Retire `VIRTIOFS_ROOT_TAG`, the `root=<tag>` cmdline knob, and the
-      `RootStrategy::Virtiofs` arm.
+**Evidence it costs nothing in practice:** across this host's entire recorded
+history — 1,278 launches — the audited `root_strategy` is `block-ext4` **1,278
+times and virtiofs-root zero times.** The dev-tier root was reachable in
+principle and taken never.
+
+- [x] Virtiofs-root is unreachable. `resolve_virtiofs_root` — the single
+      authority, gating on backend capability x prod x sealed — is deleted, and
+      the strategy is `BlockExt4` unconditionally. The security-posture ADR
+      already called this a weaker contract that does not witness claim 3; it
+      was the one boot mode that could not be dm-verity sealed.
+- [x] `ImageSource::Prebuilt`'s virtiofs candidate became
+      `unpacked_oci_root: Option<String>`. The field was doing double duty:
+      besides feeding the gate, it was the only thing distinguishing an
+      OCI-derived prebuilt from the cached dev image, and the two take
+      different initrds. Deleting it outright would have quietly given every
+      prebuilt the OCI initrd, and no test would have caught that —
+      `only_an_oci_derived_prebuilt_resolves_the_oci_initrd` covers it now.
+- [ ] Delete the machinery below the gate. Larger than it looked: ~117
+      `virtiofs_root` references (the `VmCapabilities` flag, the
+      `VmStartConfig` field, `VIRTIOFS_ROOT_TAG` and the `root=<tag>` cmdline
+      knob, `RootStrategy::VirtiofsRoot`, `select_root_strategy`), plus a
+      *separate* `RuntimeSourceRootStrategy::VirtiofsRoot` that warm-pool
+      compatibility keys on. A pass of its own.
 
 ### Stage C — the builder VM
 

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -1,5 +1,8 @@
 # Remove virtio-fs
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 **Status: IN PROGRESS — Stage A landed except the deletion pass**
 
 No guest gets a virtio-fs device. Not a workload, not the builder VM, not the

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -1,0 +1,171 @@
+# Remove virtio-fs
+
+**Status: PLAN — not started**
+
+No guest gets a virtio-fs device. Not a workload, not the builder VM, not the
+dev-tier root. The host filesystem reaches a guest as a block image or it does
+not reach it at all.
+
+## Why, beyond the flag that started this
+
+The immediate finding was `crates/mvm-vmm/src/host/virtiofsd.rs:253`:
+
+```rust
+.args(["--sandbox", "none"])
+```
+
+— virtiofsd's own namespace/seccomp confinement, disabled, with no comment, no
+ADR, and no mention in the commit that introduced it (`e54fd9769e`). The C
+flavour passes no `-o sandbox=` at all.
+
+But the flag is a symptom. virtio-fs puts a FUSE server on the host — in a
+daemon for QEMU, in the VMM's address space for libkrun and HVF — and points it
+at a host directory. Every request it parses comes from the guest. That is a
+large, guest-driven parser sitting on the wrong side of the boundary, and it is
+the one mechanism by which a guest addresses host filesystem *structure* rather
+than opaque blocks. A block device is a byte array with no protocol for a guest
+to attack.
+
+This also removes the awkwardness in claim 1. "No host-fs access from a guest
+beyond explicit shares" currently rests on virtio-fs behaving; afterwards the
+shares are images, and the claim rests on the guest having no channel to the
+host filesystem at all.
+
+## What already points this way
+
+- **Firecracker refuses virtio-fs outright** and has a test for it
+  (`fc.rs::boot_rejects_virtio_fs_shares`). The Linux production workload path
+  is already clean. This plan makes every backend match the one that is right.
+- **The builder already migrated its largest share to a disk.**
+  `pack_stage0_work_disk` copies the workspace tree, materializes an ext4 image
+  with a volume label, and attaches it as virtio-blk — because "`nix build`
+  reading a large workspace tree through virtio-fs-over-FUSE exhausts libkrun's
+  virtio-fs handle pool". Different motive, same destination, and the machinery
+  is written.
+- **`--mount` is already read-only.** `exec.rs` refuses rw:
+  "`--mount '{spec}'` requests rw, but transient live shares are read-only". So
+  the only property a materialized image loses is *host edits becoming visible
+  mid-run*, which a read-only mount consumed at boot barely has.
+- **The timing surface already has slots for the replacement.**
+  `mount_fingerprint`, `mount_cache_lookup` and `mount_materialize` are declared
+  in `SubPhase`, rendered by the report, and have **no producer**. The comment
+  says they exist because "a content-addressed mount image is what records
+  them". Someone designed this and did not build it.
+
+## Stages
+
+Ordered by security value per unit of work. Each stage leaves the tree shippable.
+
+### Stage A — workloads
+
+The whole security argument lives here: an untrusted guest driving a FUSE
+server. Everything below this is our own code.
+
+**This stage is a deletion, not a feature.** Both halves of the fork already
+exist and both are wired end to end:
+
+```rust
+pub enum LocalVolumeKind {
+    /// Legacy host directory exposed only by backends with directory sharing.
+    #[default]
+    Directory,
+    /// Portable ext4 image attached as a virtio block device.
+    BlockImage { size_mib: u32 },
+}
+```
+
+`as_vm_volume` maps those to `VmVolumeKind::DirShare` and `VmVolumeKind::Disk`.
+The code already calls one legacy and the other portable. The work is removing
+the legacy arm, not building the portable one.
+
+- [ ] `--mount <host>:<guest>` resolves to a `BlockImage` volume through the
+      existing registry rather than a `DirShare`. Materialization reuses
+      `pack_stage0_work_disk`'s shape — filtered copy → `MaterializeExt4Input`
+      → volume label — and `mvm_build::rootfs::materialize_ext4_pure`, the
+      memory-safe pure-Rust writer already used for rootfs.
+- [ ] The guest mounts by volume label, not enumeration order, as
+      `stage0-init` already does.
+- [ ] Delete `LocalVolumeKind::Directory`, `VmVolumeKind::DirShare`,
+      `VirtioFsShare`, and every backend's handling of them. HVF's
+      `supports_directory_shares` returns false; `directory_shares` leaves
+      `VmCapabilities`; `refuse_unsupported_dir_shares` and the rw refusal
+      collapse into one preflight that no longer branches per backend.
+
+**Custom volumes are unaffected.** A managed volume is already a
+`BlockImage`/`Disk` today. Nothing about `mvmctl volume` changes.
+
+**Deliberately not in this stage:** content-addressing and caching of the
+materialized image. The `mount_fingerprint` / `mount_cache_lookup` /
+`mount_materialize` spans exist for it and have never fired, so the slot is
+there — but adding a cache is the "heavy new feature" this work is supposed to
+avoid. Land the deletion, measure a cold `--mount`, and only then decide
+whether a cache is worth its own plan.
+
+**Semantic change to document, not hide:** a mount becomes a snapshot taken at
+boot. Host edits during the run are not visible. Say so in `--mount --help` and
+the README. The gap is small because `--mount` is already read-only — `exec.rs`
+refuses rw with "transient live shares are read-only" — so the only lost
+property is mid-run visibility.
+
+### Stage B — the dev-tier root
+
+- [ ] Delete virtiofs-root. ADR-107 already calls it a dev-tier path with a
+      weaker contract that does not witness claim 3; it is the one boot mode
+      that cannot be dm-verity sealed. Block+ext4 is the only root.
+- [ ] Retire `VIRTIOFS_ROOT_TAG`, the `root=<tag>` cmdline knob, and the
+      `RootStrategy::Virtiofs` arm.
+
+### Stage C — the builder VM
+
+Largest, least security value: the builder runs our own Nix builds, and my
+memory note already separates dev-builder from prod tiers. It is in scope
+because the goal is *nowhere*, not *nowhere that matters*.
+
+Remaining shares are `work`, `out`, `job`, `mvm-bins` and the closure seed.
+
+- [ ] `work`, `job`, `mvm-bins`, closure seed — inbound and read-only. Same
+      treatment as Stage A; `work` is already done on Stage 0.
+- [ ] `out` is the hard one and needs a decision: the guest **writes** artifacts
+      the host must read back. Options: a writable virtio-blk image the host
+      mounts read-only after poweroff (needs a host-side ext4 *reader*, which
+      `mvm-fs` does not have — it has a writer); or stream artifacts out over
+      the existing vsock channel. Neither is free. Do not start Stage C until
+      this is chosen.
+- [ ] Delete `crates/mvm-vmm/src/host/virtiofsd.rs`, both QEMU call sites, and
+      the `virtiofsd` host dependency from the Linux install docs.
+
+### Stage D — the gate
+
+- [ ] `xtask check-no-virtio-fs`, modelled on `check-single-network-path`:
+      fails on `virtio_fs` / `VirtioFs` / `virtiofsd` / `add_virtio_fs`
+      anywhere in the workspace outside the libkrun FFI bindings, which declare
+      the C API whether or not we call it.
+- [ ] Add it to the CI gate list. A removal without a gate grows back.
+
+## What this costs
+
+- **Every `--mount` pays a materialization**, proportional to the tree, until
+  something caches it. The `$PWD:/work` in this project's own README is a large
+  tree. This cost is **unmeasured** — measure a cold `--mount` before deciding
+  whether a cache is needed, rather than building one on the assumption.
+- **It does not touch the launch budget.** `PREPARED_COLD_HARD_MAX_MS` is 200ms
+  on the *dispatch window* (`backend_start + vsock_wait`), and the mount spans
+  are parented to `drives`, which is outside it. A launch with no `--mount` is
+  unchanged, and a custom volume is already a block image.
+- **Stage C is weeks**, most of it in `out`, for a guest that runs our code.
+- **The QEMU workload driver may simply lose directory shares** rather than gain
+  images — it is opt-in dev/test and `auto_select` never picks it, so it is the
+  one place where deleting the feature outright is defensible.
+
+## Stopgap
+
+Restoring virtiofsd's sandbox is a one-line change and Stages A–C are not
+one-line changes.
+
+- [ ] `--sandbox namespace` for the Rust flavour, explicit `-o sandbox=namespace`
+      for the C one. DAX needs `cache=always`, which is orthogonal to the
+      sandbox, so the reason it was disabled is probably not the reason it looks
+      like.
+- [ ] **Needs Linux validation before it lands.** The QEMU path does not run on
+      the macOS dev host, so this cannot be tested where it was written. Do not
+      land it blind on the strength of the argument above.

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -1,6 +1,6 @@
 # Remove virtio-fs
 
-**Status: PLAN — not started**
+**Status: IN PROGRESS — Stage A landed except the deletion pass**
 
 No guest gets a virtio-fs device. Not a workload, not the builder VM, not the
 dev-tier root. The host filesystem reaches a guest as a block image or it does
@@ -78,18 +78,23 @@ pub enum LocalVolumeKind {
 The code already calls one legacy and the other portable. The work is removing
 the legacy arm, not building the portable one.
 
-- [ ] `--mount <host>:<guest>` resolves to a `BlockImage` volume through the
-      existing registry rather than a `DirShare`. Materialization reuses
-      `pack_stage0_work_disk`'s shape — filtered copy → `MaterializeExt4Input`
-      → volume label — and `mvm_build::rootfs::materialize_ext4_pure`, the
-      memory-safe pure-Rust writer already used for rootfs.
-- [ ] The guest mounts by volume label, not enumeration order, as
-      `stage0-init` already does.
+- [x] `--mount <host>:<guest>` is materialized into an ext4 image by
+      `mvm_build::rootfs::materialize_ext4_pure` and attached as virtio-blk.
+      The volume stays `DirShare` so admission still records a *directory*
+      grant; the new `VmVolume.materialized_image` carries what is attached.
+      Landed as `feat(mount): deliver a granted directory as a block image`.
+- [ ] The guest mounts by volume label rather than by the device node
+      `workload_volume_devices` resolves. The image **is** labelled, but the
+      guest is still handed a node, so this is not done — it is the difference
+      between "works" and "cannot silently mount the wrong device".
+- [x] `refuse_unsupported_dir_shares` and both its call sites deleted: every
+      backend can serve a mount now, so it could only produce a false refusal.
 - [ ] Delete `LocalVolumeKind::Directory`, `VmVolumeKind::DirShare`,
       `VirtioFsShare`, and every backend's handling of them. HVF's
-      `supports_directory_shares` returns false; `directory_shares` leaves
-      `VmCapabilities`; `refuse_unsupported_dir_shares` and the rw refusal
-      collapse into one preflight that no longer branches per backend.
+      `supports_directory_shares` returns false and `directory_shares` leaves
+      `VmCapabilities`. Deliberately a separate commit: the one above is a
+      behaviour change, this is a deletion, and reviewing them together hides
+      which is which.
 
 **Custom volumes are unaffected.** A managed volume is already a
 `BlockImage`/`Disk` today. Nothing about `mvmctl volume` changes.

--- a/specs/sprint/delivery/mount-is-a-block-image.md
+++ b/specs/sprint/delivery/mount-is-a-block-image.md
@@ -1,0 +1,103 @@
+# `--mount` is a block image, not a virtio-fs share
+
+**Status: COMPLETE** — Stage A of `specs/plans/2026-08-31-remove-virtio-fs.md`.
+
+## What changed
+
+A granted host directory is materialized into an ext4 image and attached as
+virtio-blk. No workload asks for a virtio-fs device any more.
+
+virtio-fs put a FUSE server on the host — parsing requests the guest composed,
+pointed at a host directory. It was the one mechanism by which a guest addressed
+host filesystem *structure* rather than opaque blocks. An image has no protocol
+for a guest to drive.
+
+The immediate prompt was `virtiofsd --sandbox none`, spawned with its own
+namespace/seccomp confinement disabled, no comment, no ADR. That flag is on the
+QEMU path and is *not* fixed here — see "Not done".
+
+## Why this was small
+
+Almost all of it already existed, and most of what was left was deletion.
+
+- The converged workload runner **already had no virtio-fs device**:
+  `ensure_no_dir_share_volumes` says a directory share "can't be expressed on
+  this path".
+- Firecracker **already refused** virtio-fs, with a test.
+- The volume model already had both halves, and already called one of them
+  legacy: `LocalVolumeKind::{Directory, BlockImage}` → `VmVolumeKind::{DirShare,
+  Disk}`. Managed volumes were already block images; **nothing about `mvmctl
+  volume` changes.**
+- The builder had already made this exact move for its own reasons —
+  `pack_stage0_work_disk` packs a tree into a labelled ext4 image because
+  virtio-fs-over-FUSE exhausted libkrun's handle pool under `nix build`.
+- `materialize_ext4_pure` — pure Rust, no `mkfs`, no subprocess — already writes
+  every rootfs.
+
+## The audit decision
+
+`plan_admission` maps `VmVolumeKind::DirShare` → `ShareKind::DirShare`, and the
+chain records the host path under claim 1. Had `--mount` simply become a `Disk`,
+the chain would record an ext4 image under `~/.mvm` and lose the fact that a
+host *directory* was granted.
+
+So `VmVolume.host` stays the granted directory and a new
+`VmVolume.materialized_image` carries what is actually attached. The grant and
+its transport are different facts and only the first belongs in an admission
+record.
+
+## One predicate, three callers
+
+The block list, the slot arithmetic and the guest device mapping all have to
+agree on which volumes are attached and in what order. They previously each
+matched on `kind`. They now all call `VmVolume::attaches_as_block`, because
+drift between them means a guest mounts a real device holding someone else's
+data and nothing errors.
+
+`a_materialized_grant_resolves_to_the_block_node_the_vmm_created` is the test
+for exactly that.
+
+## Verified live
+
+macOS/HVF, `--mount /tmp/mvm-mount-test:/work -- sh -c "cat /work/marker.txt"`:
+
+```
+hello from the host
+```
+
+The guest read a host file from a materialized image over virtio-blk, with no
+virtio-fs device in the launch.
+
+## Semantic change
+
+A mount is a snapshot taken at boot; host edits during the run are not visible.
+`--mount` was already read-only — the CLI refuses `rw` with "transient live
+shares are read-only" — so mid-run visibility is the only property lost.
+
+**This is not yet documented in `--mount --help` or the README.** It must be
+before this ships.
+
+## Removed
+
+`refuse_unsupported_dir_shares` and both its call sites. It existed to refuse
+`--mount` on backends without virtio-fs; every backend can serve a mount now,
+so the refusal could only produce a false one.
+
+## Not done
+
+- **Backends still advertise `directory_shares`** and the virtio-fs plumbing is
+  still present, now unreachable from `--mount`. Deleting it is the next commit,
+  kept separate so this one is a behaviour change and that one is a deletion.
+- **`virtiofsd --sandbox none` is untouched.** It is on the QEMU path, which does
+  not run on the macOS dev host, and landing a blind change to a sandbox flag is
+  how it got there.
+- **Stage B (virtiofs-root) and Stage C (builder VM) are not started.** Stage C
+  is still blocked on the `out` share: the guest writes artifacts the host reads
+  back, and replacing it needs either a host-side ext4 reader (`mvm-fs` has only
+  a writer) or vsock streaming.
+- **No `xtask check-no-virtio-fs` gate yet** — Stage D. Until it exists, nothing
+  stops virtio-fs coming back.
+- **Materialization cost is unmeasured on a large tree.** The test mount was
+  tiny. A `--mount $PWD` on this repo will pay real time, and no cache exists
+  yet: the `mount_fingerprint` / `mount_cache_lookup` / `mount_materialize`
+  spans are still unproduced. Measure before deciding a cache is needed.

--- a/specs/sprint/delivery/mount-is-a-block-image.md
+++ b/specs/sprint/delivery/mount-is-a-block-image.md
@@ -83,11 +83,49 @@ before this ships.
 `--mount` on backends without virtio-fs; every backend can serve a mount now,
 so the refusal could only produce a false one.
 
+## Deleted after the behaviour change
+
+Once every mount materializes, a pile of machinery had nothing left to decide:
+
+- `VmmDriver::supports_directory_shares` — every driver answered the same.
+- HVF's override and its advertised `directory_shares` capability.
+- `VmCapabilities::directory_shares`.
+- `ensure_dir_share_support`, whose two arms collapsed into the refusal.
+- `workload_shares`' volume arm: the only virtio-fs share a workload spec can
+  carry now is the dev-tier root.
+
+85 lines out, 10 in.
+
+Two tests asserted the deleted behaviour. They were **inverted rather than
+removed** — `a_user_volume_never_becomes_a_virtiofs_share` and
+`no_directory_volume_produces_a_share_whatever_its_mode` — because "this maps
+to virtio-fs" becoming "this never maps to virtio-fs" is the regression guard
+worth having, and deleting them would have left the new property untested.
+
+## Measured
+
+macOS/HVF, 30MB tree:
+
+| | admit | `mount_materialize` | dispatch window | total |
+|---|---|---|---|---|
+| no mount | 25–56 ms | — | 73–90 ms | 271–322 ms |
+| mount 30 MB | 133–149 ms | 105–127 ms | 70–77 ms | 370–384 ms |
+
+No-mount launches are unchanged, and the dispatch window — the number
+`PREPARED_COLD_HARD_MAX_MS` budgets — is unchanged, so the 200ms ceiling is
+untouched. `admit_plan` is identical either way: admission itself did not get
+slower.
+
+A mounted launch pays the materialization **every launch**. The image is
+written under `vm_state_dir(vm_name)` and a transient VM name is unique per
+run, so there is nothing to cache against without relocating images into a
+shared content-addressed store — which is the heavy feature this work avoided.
+
 ## Not done
 
-- **Backends still advertise `directory_shares`** and the virtio-fs plumbing is
-  still present, now unreachable from `--mount`. Deleting it is the next commit,
-  kept separate so this one is a behaviour change and that one is a deletion.
+- **`VmVolumeKind::DirShare` stays.** It is what records a *directory* grant in
+  the signed plan, which `enforce_admitted_shares` matches against for claim 1.
+  Removing it means moving that fact somewhere else first.
 - **`virtiofsd --sandbox none` is untouched.** It is on the QEMU path, which does
   not run on the macOS dev host, and landing a blind change to a sandbox flag is
   how it got there.


### PR DESCRIPTION
Recovered from a stale local worktree and pushed so the work is not one `git worktree remove` away from gone.

**Draft on purpose.** This is preserved work-in-progress, not a review request. Nobody has said it is finished.

| | |
|---|---|
| Commits ahead of `main` | 10 |
| Files this branch changes | 28 |
| Of those, still differing from `main` | **16** |
| Behind `main` by | 28 commits |
| Last commit | 2026-08-31 |

### Commits

- \`d263d6afc6\` fix(ci): update the runtime pack image fixture field
- \`c63d31a313\` fix(ci): update the test-support image fixture field
- \`a6f4cb7378\` feat(boot): make the dev-tier virtiofs root unreachable
- \`b985ae77ee\` refactor(mount): delete the directory-share machinery nothing reaches
- \`ab1af71b54\` docs(plan): declare mount-image backing
- \`04c479e93e\` fix(ci): repair mount-image feature gates
- \`5ff11b0151\` perf(mount): name what materializing a mount costs, and pin claim 1
- \`5848ea03e5\` docs(spec): tick Stage A, and say what is not done
- \`3134f664fb\` feat(mount): deliver a granted directory as a block image, not virtio-fs
- \`d54eef50de\` docs(spec): plan the removal of virtio-fs

### Read CI here with care

This branch is **28 commits behind `main`** and has not been rebased or re-run since 2026-08-31.
A red lane is at least as likely to be a stale base as a defect in the change, and a green one
does not say the change still integrates. It needs a rebase before either verdict means anything.
