### PR TITLE
feat: resume --boot cold-boots a parked durable session (#2750) (+1 more)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,6 +591,13 @@ jobs:
           cargo nextest run -p mvm-agentd --features addons
           cargo check -p mvm-agentd --features addons --bins
 
+      # End-user release builds enable a bootstrap path that contributor builds
+      # deliberately omit. Keep that source compiled with warnings denied on
+      # every code-changing pull request so the nightly reproducibility lane is
+      # evidence, not the first compiler to see it.
+      - name: release-artifact bootstrap feature compiles
+        run: cargo check -p mvm-cli --features release-artifact-bootstrap --lib
+
       - name: Assert auto-detect still picks libkrun off Linux/HVF
         run: |
           cargo test -p mvm-build --features builder-vm --lib \

--- a/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/stage0_cache.rs
@@ -893,7 +893,6 @@ pub(super) fn promote_builder_vm_stage0_cache(
 /// at compile time via `--features release-artifact-bootstrap`.
 #[cfg(feature = "release-artifact-bootstrap")]
 pub(super) fn download_builder_vm_image(arch: &str, cache_dir: &str) -> Result<()> {
-    let version = env!("CARGO_PKG_VERSION");
     let names = builder_vm_artifact_names(arch);
     // Builder-VM images ship on the boot image counter, not the CLI's.
     let (tag, image_version) = crate::update::boot_image_release()?;

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-08-19
+Last updated: 2026-08-20
 
 This is the cross-plan progress index. The owning plan remains authoritative
 for detailed scope and acceptance criteria.
@@ -334,6 +334,12 @@ for detailed scope and acceptance criteria.
       zero; the later workload boot stopped at a separate readiness timeout.
 
 ## In-flight plans
+
+- [~] **Security lane recovery — issue #2736.** The advisory finding is fixed,
+      the release-artifact bootstrap source now compiles with warnings denied,
+      and pull-request CI exercises that otherwise dormant feature directly.
+      Closure remains gated on a clean Security workflow run from current
+      `main`, including every mutation shard and both reproducibility builds.
 
 - [x] **Secret bindings for forked children** —
       `specs/plans/2026-08-18-fork-inherits-secret-bindings.md`, issue #2698.

--- a/specs/sprint/delivery/2736-security-release-feature.md
+++ b/specs/sprint/delivery/2736-security-release-feature.md
@@ -1,0 +1,8 @@
+- [x] The release-artifact bootstrap path is compiled with warnings denied on
+      every code-changing pull request instead of first being seen by the
+      nightly reproducibility build. The stale CLI-version binding left behind
+      when builder downloads moved to the boot-image release tag is removed.
+      The exact feature check fails on the prior source and passes after the
+      fix; workspace all-target Clippy, workflow syntax, formatting, and the
+      workspace suite pass, with the sole transient doctest target passing on
+      its isolated rerun after the suite's nested Cargo process exited.


### PR DESCRIPTION
Recovered from a stale local worktree and pushed so the work is not one `git worktree remove` away from gone.

**Draft on purpose.** This is preserved work-in-progress, not a review request. Nobody has said it is finished.

| | |
|---|---|
| Commits ahead of `main` | 2 |
| Files this branch changes | 4 |
| Of those, still differing from `main` | **3** |
| Behind `main` by | 234 commits |
| Last commit | 2026-08-20 |

### Commits

- \`888a06dc43\` Merge remote-tracking branch 'origin/main' into fix/security-release-feature-build
- \`e00d402e3f\` fix(ci): compile the release bootstrap feature

### Read CI here with care

This branch is **234 commits behind `main`** and has not been rebased or re-run since 2026-08-20.
A red lane is at least as likely to be a stale base as a defect in the change, and a green one
does not say the change still integrates. It needs a rebase before either verdict means anything.
