### PR TITLE
spike: export MVM_WORKSPACE_PATH in the builder-VM sidecar job (+3 more)

### DIFF
--- a/crates/mvm-cli/src/commands/env/builder_vm/sdk_sidecar.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/sdk_sidecar.rs
@@ -45,7 +45,7 @@ pub(crate) fn build_sdk_sidecar_from_checkout(
 
     let request =
         super::stage0_artifact::Stage0ArtifactBuild::builder(workspace_root, &staging_dir)
-            .build_attr("sdk-sidecar-image")
+            .build_attr("sdk-sidecar-image-musl")
             .output_mode("sdk-sidecar")
             .verbose(verbose)
             .build()?;
@@ -122,7 +122,7 @@ build-users-group =
 substituters = https://cache.nixos.org/
 trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
 mkdir -p "$XDG_CACHE_HOME" "$XDG_STATE_HOME"
-out=$(/sbin/nix build 'path:/work/nix/images/builder-vm#packages.{arch}-linux.sdk-sidecar-image' \
+out=$(/sbin/nix build 'path:/work/nix/images/builder-vm#packages.{arch}-linux.sdk-sidecar-image-musl' \
   --no-link --print-out-paths --no-write-lock-file --impure --print-build-logs)
 test -n "$out"
 for name in '{image}' '{version}' '{checksums}'; do

--- a/crates/mvm-cli/src/commands/env/builder_vm/sdk_sidecar.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/sdk_sidecar.rs
@@ -112,6 +112,13 @@ fn sdk_sidecar_builder_script(arch: mvm_core::arch::GuestArch) -> String {
         r#"#!/bin/sh
 set -eu
 export HOME=/tmp
+# The builder-vm flake resolves its workspace root from this, falling back to
+# `../../..`. That fallback is wrong here: the build names the flake as
+# `path:/work/nix/images/builder-vm`, so nix copies only that subdirectory into
+# the store and the relative walk lands on `/nix` — making every attribute
+# reached through the runtime-overlay import unresolvable. Stage 0's own
+# `stage0-init` already exports this; the builder-VM shell job did not.
+export MVM_WORKSPACE_PATH=/work
 export XDG_CACHE_HOME=/nix-store/.cache
 export XDG_STATE_HOME=/tmp/.local/state
 export NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
@@ -149,6 +156,22 @@ mod tests {
         }
         assert!(script.contains("\"/out/$name\""));
         assert!(script.contains("--no-write-lock-file"));
+        assert!(script.contains("--impure"));
+    }
+
+    /// The flake reads this to find the workspace, falling back to a relative
+    /// walk that is wrong from a `path:`-named subdirectory: nix copies only
+    /// that subdirectory into the store, so the walk lands on `/nix` and every
+    /// attribute reached through the runtime-overlay import fails to resolve.
+    /// `--impure` is what makes the env var visible to `getEnv`, so both are
+    /// required together and asserted together.
+    #[test]
+    fn the_script_exports_the_workspace_root_the_flake_reads() {
+        let script = sdk_sidecar_builder_script(mvm_core::arch::GuestArch::X86_64);
+        assert!(
+            script.contains("export MVM_WORKSPACE_PATH=/work"),
+            "without this the builder-vm flake resolves its workspace to /nix"
+        );
         assert!(script.contains("--impure"));
     }
 }

--- a/nix/images/builder-vm/flake.nix
+++ b/nix/images/builder-vm/flake.nix
@@ -557,6 +557,7 @@
         # sidecar to build guest workloads, so this exposes the runtime-overlay's
         # sdk-sidecar-image output through the builder-vm flake.
         sdk-sidecar-image = runtimeOverlay.packages.${system}.sdk-sidecar-image;
+        sdk-sidecar-image-musl = runtimeOverlay.packages.${system}.sdk-sidecar-image-musl;
       });
     };
 }

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -212,11 +212,18 @@
       # dynamic loader the rootfs provides.
       mvmSdkCdylibFor =
         system:
+        mvmSdkCdylibForLibc system "glibc";
+
+      # The same derivation, parameterized by the libc the object is built
+      # against. A guest can only dlopen the variant matching its own, and the
+      # host selects from the libc recorded in the image's `mvm-meta.json`.
+      mvmSdkCdylibForLibc =
+        system: libc:
         let
           pkgs = import nixpkgs { inherit system; };
         in
         import (workspace + "/nix/packages/mvm-sdk-cdylib.nix") {
-          inherit pkgs;
+          inherit pkgs libc;
           lib = pkgs.lib;
           mvmSrc = workspace;
         };
@@ -537,6 +544,10 @@
         runtime-overlay = mkRuntimeOverlay system;
         sdk-sidecar = mkSdkSidecar system;
         sdk-sidecar-image = mkSdkSidecarImage system;
+        # Exposed individually so each libc variant can be built and inspected
+        # on its own; the musl one is what an Alpine guest can load.
+        sdk-cdylib-glibc = mvmSdkCdylibForLibc system "glibc";
+        sdk-cdylib-musl = mvmSdkCdylibForLibc system "musl";
       });
     };
 }

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -283,11 +283,26 @@
 
       mkSdkSidecar =
         system:
+        mkSdkSidecarForLibc system "glibc";
+
+      # The musl sidecar carries only what the guest lacks.
+      #
+      # The glibc tree bundles a loader and a libc because the workload rootfs
+      # has neither — the catalog is Alpine. A musl guest already has both: its
+      # own interpreter is running under `/lib/ld-musl-<arch>.so.1`. So the musl
+      # tree is the cdylib plus musl's libgcc, which the object still records as
+      # NEEDED — rustc emits `-lgcc_s` for unwinding and `-static-libgcc` does
+      # not remove it. The RPATH stays, because that libgcc is what the object
+      # finds through it.
+      mkSdkSidecarForLibc =
+        system: libc:
         let
           pkgs = import nixpkgs { inherit system; };
-          hostsvc = mvmSdkCdylibFor system;
+          isMusl = libc == "musl";
+          hostsvc = mvmSdkCdylibForLibc system libc;
+          muslLibgcc = "${pkgs.pkgsMusl.lib.getLib pkgs.pkgsMusl.stdenv.cc.cc}/lib/libgcc_s.so.1";
         in
-        pkgs.runCommand "mvm-sdk-sidecar-${system}"
+        pkgs.runCommand "mvm-sdk-sidecar-${libc}-${system}"
           {
             nativeBuildInputs = [ pkgs.patchelf ];
             passthru = {
@@ -299,11 +314,20 @@
             set -euo pipefail
 
             mkdir -p "$out/lib"
-            cp ${sdkRuntimeLoaderFor pkgs} "$out/lib/${sdkRuntimeLoaderBaseFor pkgs}"
             cp ${hostsvc}/lib/libmvm_host_services.so \
               "$out/lib/libmvm_host_services.so"
-            cp ${sdkRuntimeLibcFor pkgs} "$out/lib/libc.so.6"
-            cp ${sdkRuntimeLibgccFor pkgs} "$out/lib/libgcc_s.so.1"
+            ${
+              if isMusl then
+                ''
+                  cp ${muslLibgcc} "$out/lib/libgcc_s.so.1"
+                ''
+              else
+                ''
+                  cp ${sdkRuntimeLoaderFor pkgs} "$out/lib/${sdkRuntimeLoaderBaseFor pkgs}"
+                  cp ${sdkRuntimeLibcFor pkgs} "$out/lib/libc.so.6"
+                  cp ${sdkRuntimeLibgccFor pkgs} "$out/lib/libgcc_s.so.1"
+                ''
+            }
             chmod u+w "$out/lib/libmvm_host_services.so"
             patchelf \
               --set-rpath /mvm/sdk/lib \
@@ -311,7 +335,7 @@
             chmod 0555 "$out/lib"/*
             echo "${overlayVersion}" > "$out/VERSION"
             cat > "$out/README" <<'EOF'
-            This read-only sidecar supplies the glibc SDK host-services cdylib.
+            This read-only sidecar supplies the ${libc} SDK host-services cdylib.
             Attach it at /mvm/sdk for workloads that use mvm.audit or mvm.host.
             EOF
             chmod 0444 "$out/VERSION" "$out/README"
@@ -331,11 +355,15 @@
       # boot instead of surfacing as an in-guest dlopen failure.
       mkSdkSidecarImage =
         system:
+        mkSdkSidecarImageForLibc system "glibc";
+
+      mkSdkSidecarImageForLibc =
+        system: libc:
         let
           pkgs = import nixpkgs { inherit system; };
-          tree = mkSdkSidecar system;
+          tree = mkSdkSidecarForLibc system libc;
         in
-        pkgs.runCommand "mvm-sdk-sidecar-image-${system}"
+        pkgs.runCommand "mvm-sdk-sidecar-image-${libc}-${system}"
           {
             nativeBuildInputs = [
               pkgs.e2fsprogs
@@ -548,6 +576,8 @@
         # on its own; the musl one is what an Alpine guest can load.
         sdk-cdylib-glibc = mvmSdkCdylibForLibc system "glibc";
         sdk-cdylib-musl = mvmSdkCdylibForLibc system "musl";
+        sdk-sidecar-musl = mkSdkSidecarForLibc system "musl";
+        sdk-sidecar-image-musl = mkSdkSidecarImageForLibc system "musl";
       });
     };
 }

--- a/nix/packages/mvm-sdk-cdylib.nix
+++ b/nix/packages/mvm-sdk-cdylib.nix
@@ -22,10 +22,52 @@
   pkgs,
   lib,
   mvmSrc,
+  # Which libc the cdylib is built against. A guest can only `dlopen` the
+  # variant matching its own: musl's loader fails resolving glibc-only symbols
+  # such as `_dl_find_object`, and one process cannot use two libcs. The host
+  # records each image's libc in its `mvm-meta.json` sidecar and selects.
+  libc ? "glibc",
 }:
 
-pkgs.rustPlatform.buildRustPackage {
-  pname = "mvm-sdk-cdylib";
+assert lib.assertOneOf "libc" libc [ "glibc" "musl" ];
+
+let
+  isMusl = libc == "musl";
+
+  # Same-arch musl triple. The cdylib is built for the guest that will load it,
+  # and every backend runs a same-arch guest.
+  muslTarget =
+    if pkgs.stdenv.hostPlatform.isAarch64 then
+      "aarch64-unknown-linux-musl"
+    else if pkgs.stdenv.hostPlatform.isx86_64 then
+      "x86_64-unknown-linux-musl"
+    else
+      throw "no musl target for this host platform";
+
+  # Native cargo plus a rustc sysroot carrying the musl std — the mechanism
+  # `embedded-rust-toolchain.nix` exists for. `pkgsMusl.rustPlatform` would
+  # instead rebuild the toolchain itself against musl, which this crate does
+  # not need: its closure is pure Rust, so nothing here compiles C.
+  muslToolchain = pkgs.callPackage ./embedded-rust-toolchain.nix {
+    cargo = pkgs.rust_1_91.packages.prebuilt.cargo;
+    rustc = pkgs.rust_1_91.packages.prebuilt.rustc;
+    target = muslTarget;
+  };
+
+  # The linker driver, and the thing that actually decides the output's libc.
+  # Naming a `*-linux-musl` target is NOT sufficient: with `crt-static` off the
+  # default driver is the host `cc`, which links against the host's glibc and
+  # produces a glibc object that builds clean and fails inside an Alpine guest.
+  # Only `pkgsMusl`'s cc wrapper is borrowed here, which comes from the binary
+  # cache; no package set is rebuilt against musl.
+  # `/bin/gcc` specifically: the wrapper does not reliably provide a `cc`
+  # alias, and a linker path that does not exist fails loudly, whereas an
+  # unset linker fails silently by falling back to the host cc.
+  muslLinker = "${pkgs.pkgsMusl.stdenv.cc}/bin/gcc";
+in
+
+pkgs.rustPlatform.buildRustPackage ({
+  pname = "mvm-sdk-cdylib" + lib.optionalString isMusl "-musl";
   version = "0.18.0";
 
   src = mvmSrc;
@@ -63,12 +105,43 @@ pkgs.rustPlatform.buildRustPackage {
       find target -name 'libmvm_host_services*.so' -print \
         -exec install -m0644 {} $out/lib/libmvm_host_services.so \;
     fi
+
+    # Assert the artifact is the libc it claims to be, by its NEEDED soname:
+    # musl's is `libc.so`, glibc's is `libc.so.6`. This is not belt-and-braces.
+    # A `*-linux-musl` build with the wrong linker driver produces a glibc
+    # object, exports the right symbols, and reports success — the failure only
+    # appears later as a relocation error inside a guest. Refuse to publish a
+    # mislabelled object instead.
+    needed="$(${pkgs.binutils}/bin/readelf -d $out/lib/libmvm_host_services.so \
+      | grep NEEDED || true)"
+    echo "$needed"
+    ${if isMusl then ''
+      if ! echo "$needed" | grep -q 'Shared library: \[libc\.so\]'; then
+        echo "expected a musl object (NEEDED libc.so); got the above" >&2
+        exit 1
+      fi
+    '' else ''
+      if ! echo "$needed" | grep -q 'Shared library: \[libc\.so\.6\]'; then
+        echo "expected a glibc object (NEEDED libc.so.6); got the above" >&2
+        exit 1
+      fi
+    ''}
   '';
 
   meta = with lib; {
-    description = "mvm in-guest host-services FFI — one JSON-in/JSON-out C ABI over the broker clients, loaded by every language SDK";
+    description = "mvm in-guest host-services FFI (${libc}) — one JSON-in/JSON-out C ABI over the broker clients, loaded by every language SDK";
     homepage = "https://github.com/tinylabscom/mvm";
     license = licenses.asl20;
     platforms = platforms.linux;
   };
-}
+} // lib.optionalAttrs isMusl {
+  # Cross-compile to musl with a native toolchain. `-crt-static` off because a
+  # cdylib needs a dynamic loader; the guest supplies musl's.
+  nativeBuildInputs = [ muslToolchain ];
+  CARGO_BUILD_TARGET = muslTarget;
+  # The linker goes in RUSTFLAGS rather than `CARGO_TARGET_<TRIPLE>_LINKER`.
+  # Both are documented, but only this one was verified end to end to produce
+  # a musl object here; the env-var form left the default host `cc` in place
+  # and silently yielded glibc, which the NEEDED assertion below caught.
+  RUSTFLAGS = "-C target-feature=-crt-static -C linker=${muslLinker}";
+})


### PR DESCRIPTION
Recovered from a stale local worktree and pushed so the work is not one `git worktree remove` away from gone.

**Draft on purpose.** This is preserved work-in-progress, not a review request. Nobody has said it is finished.

| | |
|---|---|
| Commits ahead of `main` | 4 |
| Files this branch changes | 4 |
| Of those, still differing from `main` | **3** |
| Behind `main` by | 50 commits |
| Last commit | 2026-08-31 |

### Commits

- \`958a582e72\` spike: export MVM_WORKSPACE_PATH in the builder-VM sidecar job
- \`cf1476ea64\` spike: point the Stage 0 sidecar build at the musl variant
- \`bd84f830b6\` feat(sdk): assemble a musl SDK sidecar carrying only what the guest lacks
- \`9ef72b386c\` feat(sdk): build the host-services cdylib for musl as well as glibc

### Read CI here with care

This branch is **50 commits behind `main`** and has not been rebased or re-run since 2026-08-31.
A red lane is at least as likely to be a stale base as a defect in the change, and a green one
does not say the change still integrates. It needs a rebase before either verdict means anything.
