### PR TITLE
Close caller commitment delivery records

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,14 +4,6 @@ Last updated: 2026-09-01
 
 ## In progress
 
-- [ ] **Signed caller commitment — issue #3070.**
-      `specs/plans/2026-09-01-signed-caller-commitment.md`.
-      Replaces reliance on overwriteable free-form audit labels with one typed,
-      opaque 32-byte commitment covered by the plan identity/signature and
-      copied into chain-signed audit entries. Workspace tests, zero-warning
-      Clippy, Linux/BDD gated checks, frozen-wire compatibility, and the full
-      non-live BDD suite are green; merge delivery remains.
-
 - [ ] **Extended CI residual regressions — issues #3051 and #3052.**
       `specs/plans/2026-08-28-extended-ci-red-repair.md`.
       Persistent launches clamp vCPUs before admission, authenticated frame
@@ -264,6 +256,15 @@ Last updated: 2026-09-01
       delivery remains.
 
 ## Completed
+
+- [x] **Signed caller commitment — issue #3070, PR #3076.**
+      `specs/plans/2026-09-01-signed-caller-commitment.md`.
+      Replaces reliance on overwriteable free-form audit labels with one typed,
+      opaque 32-byte commitment covered by the plan identity/signature and
+      copied into chain-signed audit entries. Workspace tests, zero-warning
+      Clippy, Linux/BDD gated checks, frozen-wire compatibility, and the full
+      non-live BDD suite were green before merge. Landed on main as
+      `8623950746`; issue #3070 is closed.
 
 - [x] **SDK sidecar selection from the image's own libc — issue #2969, PR #3060.**
       `specs/sprint/delivery/sdk-sidecar-image-libc-selection.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,13 +10,14 @@
 
 ## In progress
 
-- [ ] **Signed caller commitment — issue #3070.**
+- [x] **Signed caller commitment — issue #3070, PR #3076.**
       `specs/plans/2026-09-01-signed-caller-commitment.md`.
       One typed opaque 32-byte commitment now reaches the signed execution
       plan and every chain-signed plan audit entry from `run` and `machine
       run`, including persistent-machine restarts. Workspace tests, Clippy,
       Linux/BDD gated checks, formatting, frozen-wire compatibility, and the
-      243-scenario non-live BDD suite are green; merge delivery remains.
+      243-scenario non-live BDD suite were green before merge. Landed on main
+      as `8623950746`; issue #3070 is closed.
 
 - [ ] **Warm claim authenticated readiness — issue #3039.**
       `specs/plans/2026-08-31-warm-claim-authenticated-readiness.md`.

--- a/specs/plans/2026-09-01-signed-caller-commitment.md
+++ b/specs/plans/2026-09-01-signed-caller-commitment.md
@@ -3,7 +3,7 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status: IMPLEMENTED AND VALIDATED — MERGE DELIVERY REMAINS**
+**Status: COMPLETE — LANDED IN PR #3076**
 
 Issue #3070 asks whether an external settlement or escrow verifier can bind a
 pre-agreed task-spec digest to the exact execution MVM admits. `audit_labels`
@@ -43,4 +43,4 @@ and accepted by the user-facing launch commands.
 - [x] Run workspace tests/check, gated-target checks, formatting, and
       zero-warning workspace Clippy.
 - [x] Update the sprint delivery record and refactor rollup.
-- [ ] Merge through the queue and close #3070 from landed evidence.
+- [x] Merge through the queue and close #3070 from landed evidence.

--- a/specs/sprint/delivery/3070-signed-caller-commitment.md
+++ b/specs/sprint/delivery/3070-signed-caller-commitment.md
@@ -30,4 +30,5 @@ Validation completed on 2026-09-01:
   one existing unsupported Docker block-attachment scenario skipped), including
   an end-to-end caller-commitment audit-chain verification scenario.
 
-Merge delivery and closing #3070 remain.
+Landed through the merge queue in PR #3076 as `8623950746` on 2026-09-01;
+issue #3070 closed from the landed evidence.


### PR DESCRIPTION
Summary:
- mark the signed caller commitment plan complete after PR #3076 landed
- move the refactor rollup entry to Completed and record the merge commit
- update the sprint and delivery note with issue #3070 closure evidence

Validation:
- cargo run -p xtask -- check-sprint-append
- cargo run -p xtask -- check-plan-names
- cargo run -p xtask -- check-declared-backing
- git diff --check