### PR TITLE
docs(qemu): record why this backend declares no vCPU ceiling

### DIFF
--- a/.agent-memory/notes/qemu-has-no-vcpu-ceiling-worth-declaring.md
+++ b/.agent-memory/notes/qemu-has-no-vcpu-ceiling-worth-declaring.md
@@ -1,0 +1,68 @@
+---
+title: QEMU has no vCPU ceiling worth declaring, and the guest kernel caps at 64 regardless
+date: 2026-09-01
+tags: [qemu, vcpu, capabilities, backends, falsification]
+---
+
+The QEMU driver declares no `VmCapabilities::max_vcpus`, so the reporting clamp
+never fires and `--cpus 9999` boots with no warning. That was left open after
+the Firecracker (32) and libkrun (64) ceilings were fixed. It is now closed as
+working as intended, and the reason is not "QEMU is a dev backend" — it is that
+**every candidate ceiling is either wrong or invisible**.
+
+Measured on the Hetzner x86_64 KVM box, QEMU 8.2.2 (Debian
+`1:8.2.2+ds-0ubuntu1.17`), against `mvmctl machine run --hypervisor qemu`:
+
+| probe | result |
+| --- | --- |
+| `--cpus 100`, guest `nproc` | **64**, exit 0 |
+| `--cpus 300`, guest `nproc` | **64**, exit 0 |
+| guest dmesg | `CPU topo: Allowing 64 present CPUs plus 0 hotplug CPUs` |
+| guest `/sys/devices/system/cpu/kernel_max` | `63` |
+| `qemu-system-x86_64 -smp 9999` (no `-machine`) | refuses; max for `pc-i440fx-noble-v2` is **255** |
+| `qemu-system-x86_64 -machine help` | default machine is `pc-i440fx-noble-v2` |
+| QMP `query-machines` | `pc-i440fx-*` → `cpu-max` **255**; `pc-q35-5.2`+ → **288**; `pc-q35-2.7`/`-xenial` → 255 |
+| `qemu-system-x86_64 -M q35 -smp 256` | **fails**: `apic initialization failed. APIC ID 255 is invalid` |
+| `qemu-system-aarch64 -M virt -smp 513` | refuses; max for `virt-8.2` is **512** (512 accepted) |
+
+Three findings, in increasing order of how much they settle the question.
+
+**A constant would be right by coincidence.** One host and one binary give
+three different answers depending on machine type and version. `mvm` passes
+`-machine virt` on aarch64 and *no* `-machine` at all on x86_64
+(`mvm_vmm::qemu_arch::machine_for_arch`), so the x86_64 number is a property of
+whichever machine the distribution shipped as its default. It moves without mvm
+moving. That 255 happens to equal `u8::MAX` is luck, not derivation.
+
+**Querying returns the wrong number — this is the part that was not known.**
+QMP `query-machines` reports `cpu-max: 288` for `pc-q35-noble`, and that machine
+refuses to start at `-smp 256`. So a cached subprocess in `capabilities()`
+would not merely cost a spawn on a path every launch and `mvmctl doctor` walk —
+it would hand the clamp a count 33 above what the machine boots, recreating the
+exact #3051 defect (a granted count that will not run) with a more expensive
+mechanism. The only oracle that tells the truth is the boot attempt, and the
+contract forbids making an over-large `--cpus` fatal.
+
+**No host-side ceiling is the number the caller observes.** `--cpus 100`
+passes QEMU's check (100 < 255), boots, and yields 64. The binding limit is
+`CONFIG_NR_CPUS` in the guest kernel, which `nix/images/kernel/` does not set —
+it is nixpkgs' arch-dependent default, inherited and unpinned. A clamp warning
+is only truthful when the *declared* ceiling is the *binding* one. On
+Firecracker (32) and libkrun (64) it is, so those warnings are honest. On QEMU
+it never is: every candidate sits above 64, so any warning would name a count
+four times the machine the caller got. **Today's silence is more accurate than
+the warning would be.**
+
+Do not re-derive this, and in particular do not "finish" it by declaring
+`Some(255)`. The `-smp` floor in `qemu_boot_argv_for_arch` stays — it is what
+keeps an absurd request non-fatal, since raw QEMU refuses `-smp 9999` — but it
+is a floor, not a ceiling claim, and `check-vcpu-ceilings` correctly does not
+see it as a declaration.
+
+Loose end, not a defect in this backend: `--cpus 100` silently delivering 64 is
+a *granted ≠ delivered* gap that exists on every backend and is only hidden on
+the others by their lower declared ceilings. Closing it means reporting the
+guest's real count after boot, which is a different mechanism from a host-side
+clamp. Not built here.
+
+Related: [[a-citation-can-resolve-to-its-own-test-fixture]].

--- a/crates/mvm-backends/src/driver/qemu.rs
+++ b/crates/mvm-backends/src/driver/qemu.rs
@@ -127,6 +127,32 @@ fn qemu_boot_argv_for_arch(
     let mut args: Vec<String> = Vec::new();
     args.push("-m".into());
     args.push(spec.memory_mib.to_string());
+    // A floor that keeps an absurd `--cpus` from being fatal, deliberately not
+    // a claim about how many vCPUs QEMU will start. This backend therefore
+    // declares no `max_vcpus` in `capabilities()`, and the reporting clamp
+    // above the backends stays quiet on it.
+    //
+    // Nothing reachable from here knows the real number. QEMU's ceiling is a
+    // property of the machine type, and the machine type on x86_64 is whichever
+    // one the distribution packaged as its default -- omitted from this argv on
+    // purpose, so it moves without mvm moving. One host, one 8.2.2 binary:
+    // `pc-i440fx-noble-v2` (that default) stops at 255, every `pc-q35` from 5.2
+    // on reports 288, and `virt-8.2` on aarch64 stops at 512.
+    //
+    // Asking does not help either, which is the part worth writing down. QMP
+    // `query-machines` reports `cpu-max: 288` for q35, and that machine refuses
+    // `-smp 256` with `apic initialization failed. APIC ID 255 is invalid`.
+    // A probe would spend a subprocess on every launch to obtain a count 33
+    // above the one the machine boots -- the failure a declared ceiling exists
+    // to prevent, bought at a higher price.
+    //
+    // And no host-side number is the one the caller observes: the guest kernel
+    // binds first. `--cpus 100` and `--cpus 300` both pass QEMU's check, boot,
+    // and report 64 (`CPU topo: Allowing 64 present CPUs`) -- `CONFIG_NR_CPUS`,
+    // which `nix/images/kernel/` does not set, so it is nixpkgs' arch-dependent
+    // default. A warning naming any ceiling above 64 would misdescribe the
+    // machine the caller got, which is why silence here is the accurate answer
+    // rather than the unfinished one.
     let vcpus = spec.vcpus.clamp(1, u32::from(u8::MAX));
     args.push("-smp".into());
     args.push(vcpus.to_string());
@@ -991,6 +1017,57 @@ mod tests {
         let append = argvalue(&argv, "-append").expect("append");
         assert!(append.contains("console=ttyAMA0"), "got: {append}");
         assert!(!append.contains("console=ttyS0"), "got: {append}");
+    }
+
+    /// This backend declares no vCPU ceiling, and that is the answer rather
+    /// than a gap left for someone to fill in.
+    ///
+    /// The other backends declare one because they have one to declare:
+    /// Firecracker's API refuses above 32, libkrun aborts at 65, HVF asks the
+    /// host. QEMU's limit belongs to the machine type -- 255 on the x86_64
+    /// default, 288 reported for q35, 512 on aarch64 `virt` -- and this driver
+    /// names no machine on x86_64, so the number is the distribution's to
+    /// change. Asking QEMU is worse than not asking: `query-machines` reports
+    /// 288 for a q35 that will not start at 256.
+    ///
+    /// The measurement that settles it is on the other side. `--cpus 100` and
+    /// `--cpus 300` both boot and both report 64 vCPUs, because the guest
+    /// kernel's `CONFIG_NR_CPUS` binds well under any of those ceilings. A
+    /// declared ceiling exists to make the clamp warning truthful, and here
+    /// every candidate would make it name a count four times what the caller
+    /// got.
+    ///
+    /// So the contract still holds -- an over-large `--cpus` boots rather than
+    /// failing -- and it is `-smp` that holds it, not a declaration.
+    #[test]
+    fn no_vcpu_ceiling_is_declared_and_an_oversized_request_still_boots() {
+        assert_eq!(
+            QemuDriver::new().capabilities().max_vcpus,
+            None,
+            "a ceiling declared here would be a guess about the host's QEMU \
+             package, and would still sit above the guest kernel's own limit"
+        );
+
+        // The floor in the argv is what keeps the request non-fatal. QEMU
+        // refuses `-smp 9999` outright, so an unclamped value would turn an
+        // over-large request into a failed launch on this backend alone.
+        for (requested, expected) in [(9999, "255"), (300, "255"), (100, "100"), (0, "1")] {
+            let mut spec = spec_with(KernelImage::Path("/img/vmlinux".into()), vec![], vec![]);
+            spec.vcpus = requested;
+            let argv = qemu_boot_argv_for_arch(
+                &spec,
+                Path::new("/img/vmlinux"),
+                3,
+                true,
+                Path::new("/state/w/qemu.pid"),
+                "x86_64",
+            );
+            assert_eq!(
+                argvalue(&argv, "-smp"),
+                Some(expected),
+                "{requested} vCPUs requested"
+            );
+        }
     }
 
     #[test]

--- a/specs/sprint/delivery/qemu-declares-no-vcpu-ceiling-on-purpose.md
+++ b/specs/sprint/delivery/qemu-declares-no-vcpu-ceiling-on-purpose.md
@@ -1,0 +1,78 @@
+# The QEMU backend declares no vCPU ceiling, and that is the answer
+
+After the Firecracker (32) and libkrun (64) ceilings were corrected, QEMU was
+the one backend left declaring nothing: `capabilities().max_vcpus` is `None`,
+so the reporting clamp above the backends never fires and `--cpus 9999` boots
+silently. That was recorded as unmeasured and deliberately left open.
+
+It is now measured, and the outcome is that QEMU is **working as intended**.
+No probe, no constant. The deliverable is the reasoning, pinned by a test so it
+cannot be quietly "finished" by someone declaring a plausible number.
+
+## Why this was not a matter of picking a number
+
+Measured on the Hetzner x86_64 KVM box, QEMU 8.2.2
+(`1:8.2.2+ds-0ubuntu1.17`). Nothing below is inferred.
+
+| probe | result |
+| --- | --- |
+| `mvmctl machine run --hypervisor qemu --cpus 100`, guest `nproc` | **64**, exit 0 |
+| `mvmctl machine run --hypervisor qemu --cpus 300`, guest `nproc` | **64**, exit 0 |
+| guest dmesg | `CPU topo: Allowing 64 present CPUs plus 0 hotplug CPUs` |
+| guest `/sys/devices/system/cpu/kernel_max` | `63` |
+| `qemu-system-x86_64 -smp 9999`, no `-machine` | refuses; max for `pc-i440fx-noble-v2` is 255 |
+| `qemu-system-x86_64 -machine help` | default machine is `pc-i440fx-noble-v2` |
+| QMP `query-machines` | `pc-i440fx-*` → `cpu-max` 255; `pc-q35-5.2`+ → 288; `pc-q35-2.7`/`-xenial` → 255 |
+| `qemu-system-x86_64 -M q35 -smp 256` | **fails**: `apic initialization failed. APIC ID 255 is invalid` |
+| `qemu-system-aarch64 -M virt -smp 513` | refuses; max for `virt-8.2` is 512 (512 accepted) |
+
+**A constant is wrong.** One host, one binary, three answers, chosen by machine
+type and version. This driver names no machine on x86_64
+(`mvm_vmm::qemu_arch::machine_for_arch` returns `None` there), so that 255 is a
+fact about the distribution's packaging, not about mvm — it changes without mvm
+changing. That it coincides with `u8::MAX` is luck. Writing it down would
+reproduce the defect `xtask check-vcpu-ceilings` exists to refuse, in a form the
+gate cannot see because the literal would no longer name a type.
+
+**A query is wrong, which is the finding that decides it.** The obvious
+objection to a probe was cost: `capabilities()` is called on every launch and by
+`mvmctl doctor`, so an honest answer would need a cached subprocess. The real
+problem is worse. QMP `query-machines` reports `cpu-max: 288` for
+`pc-q35-noble`, and that machine will not start at `-smp 256`. A probe would
+spend the subprocess to obtain a count 33 above the one the machine boots —
+handing the clamp a granted-but-unbootable number, which is precisely the #3051
+failure, bought at a higher price. The only oracle that tells the truth is the
+boot attempt, and the contract forbids letting an over-large `--cpus` be fatal.
+
+**And no host-side number is the one the caller observes.** `--cpus 100` clears
+QEMU's check and still yields a 64-CPU guest. The binding limit is
+`CONFIG_NR_CPUS` in the guest kernel, which `nix/images/kernel/` does not set —
+so it is nixpkgs' arch-dependent default, inherited and unpinned. A clamp
+warning is only truthful when the declared ceiling is the binding one. On
+Firecracker (32) and libkrun (64) it is, which is why those warnings are honest.
+On QEMU it never is: every candidate ceiling sits above 64, so any warning would
+name a count four times the machine the caller actually got. Silence is the
+accurate answer here, not the unfinished one.
+
+## What landed
+
+- `crates/mvm-backends/src/driver/qemu.rs` — the `-smp` bound is documented as
+  a **floor** that keeps an absurd request non-fatal (raw QEMU refuses
+  `-smp 9999`), explicitly not a claim about how many vCPUs QEMU starts, with
+  the measurements above recorded where the next reader will look.
+- `no_vcpu_ceiling_is_declared_and_an_oversized_request_still_boots` — asserts
+  `max_vcpus` is `None` and that 9999/300/100/0 reach `-smp` as 255/255/100/1,
+  so the contract (granted, never refused) stays pinned to the mechanism that
+  actually holds it.
+- `.agent-memory/notes/qemu-has-no-vcpu-ceiling-worth-declaring.md` — the
+  measurements, so this costs one read rather than four guest boots.
+
+No behaviour change: `--cpus 9999` booted before and boots now.
+
+## Deliberately not done
+
+`--cpus 100` silently delivering 64 is a *granted ≠ delivered* gap that exists
+on every backend and is merely hidden on the others by their lower declared
+ceilings. Closing it means reporting the guest's real CPU count after boot,
+which is a different mechanism from a host-side clamp and a different decision.
+Not in scope here.


### PR DESCRIPTION
## Decision

QEMU was the one backend declaring no `capabilities().max_vcpus`, so the
reporting clamp never fires and `--cpus 9999` boots with no warning — the one
place the documented contract ("granted the maximum, with a warning") is not
observable. Left open as unmeasured after #3051 / #3065 fixed Firecracker (32)
and libkrun (64).

Measured now. **There is no number worth declaring, and the backend is working
as intended.** No probe, no constant. The deliverable is the reasoning, pinned
by a test.

## Why not a constant

One host, one 8.2.2 binary, three answers — chosen by machine type and version:

| machine | max |
| --- | --- |
| `pc-i440fx-noble-v2` (the x86_64 default) | 255 |
| `pc-q35-5.2` and newer | 288 reported |
| `virt-8.2` (aarch64) | 512 |

This driver passes `-machine virt` on aarch64 and **no `-machine` at all** on
x86_64, so that 255 is a fact about the distribution's QEMU package. It moves
without mvm moving. That it equals the byte width is luck, not derivation.

## Why not a probe — the finding that decides it

The objection to a probe was cost: `capabilities()` runs on every launch and
every `doctor` walk, so an honest answer needs a cached subprocess. The real
problem is that **the answer is wrong**:

```
$ qemu-system-x86_64 -machine none -qmp stdio   # query-machines
  "name": "pc-q35-noble"    "cpu-max": 288

$ qemu-system-x86_64 -M q35 -smp 256
qemu-system-x86_64: apic initialization failed. APIC ID 255 is invalid
```

QEMU reports a `cpu-max` 33 above what the machine will start. A probe would
spend the subprocess to hand the clamp a granted-but-unbootable count — the
exact #3051 defect, at a higher price. The only oracle that tells the truth is
the boot attempt, and the contract forbids making an over-large `--cpus` fatal.

## Why no host-side ceiling would be honest anyway

```
$ mvmctl machine run --hypervisor qemu --cpus 100 -- nproc   → 64   (exit 0)
$ mvmctl machine run --hypervisor qemu --cpus 300 -- nproc   → 64   (exit 0)
guest dmesg: CPU topo: Allowing 64 present CPUs plus 0 hotplug CPUs
guest /sys/devices/system/cpu/kernel_max: 63
```

`--cpus 100` clears QEMU's check and still yields a 64-CPU guest. The binding
limit is `CONFIG_NR_CPUS` in the guest kernel, which `nix/images/kernel/` does
not set — nixpkgs' arch-dependent default, inherited and unpinned.

A clamp warning is truthful only when the **declared** ceiling is the **binding**
one. On Firecracker (32) and libkrun (64) it is, which is why those warnings are
honest. On QEMU it never is: every candidate sits above 64, so any warning would
name a count four times the machine the caller got. Silence here is the accurate
answer, not the unfinished one.

## What changed

No behaviour change — `--cpus 9999` booted before and boots now.

- The `-smp` bound is documented as a **floor** that keeps an absurd request
  non-fatal (raw QEMU refuses `-smp 9999` outright), explicitly not a claim
  about how many vCPUs QEMU starts. `check-vcpu-ceilings` correctly does not
  read it as a declaration.
- `no_vcpu_ceiling_is_declared_and_an_oversized_request_still_boots` asserts
  `max_vcpus` is `None` and that 9999/300/100/0 reach `-smp` as 255/255/100/1,
  so the contract stays pinned to the mechanism that actually holds it and the
  decision cannot be quietly finished by declaring a plausible number.
- Delivery record + `.agent-memory` note carrying the measurements, so this
  costs one read rather than four guest boots.

## Not done, deliberately

`--cpus 100` silently delivering 64 is a *granted ≠ delivered* gap present on
every backend, merely hidden on the others by their lower declared ceilings.
Closing it means reporting the guest's real CPU count after boot — a different
mechanism from a host-side clamp, and a separate decision.

## Validation

Linux behaviour measured on the Hetzner x86_64 KVM box (QEMU 8.2.2,
`1:8.2.2+ds-0ubuntu1.17`), not inferred. Locally: `check-all` 66 gates clean,
`cargo nextest run --workspace` 12940 passed, `--doc` clean, `clippy -D
warnings` clean, `check-gated` clean with `RUSTFLAGS=-D warnings`.
