### PR TITLE
fix(just): let build-supervisors target a profile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -371,12 +371,21 @@ bdd-live-ci:
 # `mvm-libkrun-supervisor` needs its own invocation because it carries
 # `required-features = ["libkrun-sys"]`, which a plain `--bins` does not enable,
 # and that feature makes `libkrun-sys`'s build script demand a real `libkrun.h`.
-
 # So it is probed for, on the same three paths that build script checks.
-build-supervisors:
+#
+# Bare, this writes the debug helpers. Pass `--release` if the mvmctl you invoke
+# is the release one: `aux_bin::resolve` searches `target/release` before
+# `target/debug` and takes the first hit, so a release mvmctl with no release
+# helper beside it silently falls through to whichever debug helper was built
+# last. That one is stale as soon as the config contract moves, and a stale
+# helper refuses the config the current mvmctl sends.
+#
+
+# Build the per-VM supervisor bins (--release to match a release mvmctl)
+build-supervisors *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
-    ./scripts/cargo-fast.sh build -p mvm-hostd --bins
+    ./scripts/cargo-fast.sh build -p mvm-hostd --bins {{ARGS}}
     header="${MVM_LIBKRUN_HEADER:-}"
     if [[ -z "$header" ]]; then
       for candidate in /opt/homebrew/include/libkrun.h /usr/local/include/libkrun.h /usr/include/libkrun.h; do
@@ -384,7 +393,7 @@ build-supervisors:
       done
     fi
     if [[ -f "$header" ]]; then
-      ./scripts/cargo-fast.sh build -p mvm-hostd --bin mvm-libkrun-supervisor --features libkrun-sys
+      ./scripts/cargo-fast.sh build -p mvm-hostd --bin mvm-libkrun-supervisor --features libkrun-sys {{ARGS}}
     else
       echo "build-supervisors: no libkrun.h — skipping mvm-libkrun-supervisor."
       echo "  Install it (brew install slp/krun/libkrun) if you need the libkrun backend."

--- a/tests/github_actions_extended_e2e.rs
+++ b/tests/github_actions_extended_e2e.rs
@@ -351,8 +351,11 @@ fn documented_surface_revalidates_the_source_matched_initramfs() {
 #[test]
 fn supervisor_build_requires_a_detected_libkrun_header() {
     let just = justfile();
+    // Anchored on the newline so this finds the recipe header at column 0 and
+    // not the `build-supervisors:` prefix the skip message inside the body
+    // prints, nor the parameter list the header carries.
     let recipe = just
-        .split_once("build-supervisors:")
+        .split_once("\nbuild-supervisors")
         .expect("build-supervisors recipe")
         .1
         .split_once("\n# ")


### PR DESCRIPTION
`aux_bin::resolve` searches `target/release` before `target/debug` and takes the first hit, so a release `mvmctl` with no release helper beside it falls through to whichever debug helper was built last — silently, and across profiles. That is fine until the config contract moves.

It moved in #3061. A release `mvmctl` built after that change sent `builder_egress_endpoint` to a debug supervisor built eight hours earlier; `HvfSupervisorConfig` is `deny_unknown_fields`, so the supervisor exited 1 before writing its PID file:

```
Error: parse HvfSupervisorConfig JSON from stdin
Caused by:
    unknown field `builder_egress_endpoint`, expected one of `kernel`, `cmdline`, ...
```

`build-supervisors` could not fix that, because it took no arguments and always built debug. It now accepts `*ARGS`, so `just build-supervisors --release` works — matching what `embed *ARGS` already does for the same reason. `just build: (build-supervisors)` still resolves with no arguments, so the default path is unchanged.

Also gives the recipe a real one-line doc comment; `just --list` was printing the sentence fragment `# So it is probed for, on the same three paths that build script checks.`

## Test change

`supervisor_build_requires_a_detected_libkrun_header` sliced the recipe with `split_once("build-supervisors:")`. After adding the parameter that string no longer matches the header — it matches the `echo "build-supervisors: no libkrun.h …"` skip message *inside the body*, so the slice no longer contained the line the test asserts on. Re-anchored on `"\nbuild-supervisors"`, which is indifferent to the parameter list.

Confirmed non-vacuous — the old anchor genuinely fails against the new Justfile:

```
anchor 'build-supervisors:'   -> contains_bins_line=False
anchor '\nbuild-supervisors'  -> contains_bins_line=True
```

## Verification

`just build-supervisors --release` runs to completion and produces both release helpers. `scripts/cargo-fast.sh` passes arguments through untouched and `.cargo/fast.toml` pins `[profile.release] codegen-backend = "llvm"`, so `--release` yields an ordinary optimized binary.

20/20 in `tests/github_actions_extended_e2e.rs`, `cargo fmt --all --check` clean, `clippy --workspace` and `-p mvmctl --all-targets -D warnings` clean.
