### PR TITLE
fix(cli): preserve image PATH for mounted PTY runs

### DIFF
--- a/crates/mvm-cli/src/exec/guest_run.rs
+++ b/crates/mvm-cli/src/exec/guest_run.rs
@@ -185,7 +185,7 @@ struct PtyConsoleRequest {
 
 fn pty_console_request(req: &ExecRequest, wrapper: String) -> PtyConsoleRequest {
     match &req.target {
-        ExecTarget::Inline { argv } if direct_pty_inline_argv(argv, req) => PtyConsoleRequest {
+        ExecTarget::Inline { argv } if direct_pty_inline_argv(argv) => PtyConsoleRequest {
             argv: argv.clone(),
             env: req.env.clone(),
         },
@@ -196,8 +196,8 @@ fn pty_console_request(req: &ExecRequest, wrapper: String) -> PtyConsoleRequest 
     }
 }
 
-fn direct_pty_inline_argv(req_argv: &[String], req: &ExecRequest) -> bool {
-    req.dir_shares.is_empty() && req_argv.first().is_some_and(|argv0| argv0.starts_with('/'))
+fn direct_pty_inline_argv(req_argv: &[String]) -> bool {
+    req_argv.first().is_some_and(|argv0| argv0.starts_with('/'))
 }
 
 #[cfg(test)]
@@ -234,6 +234,41 @@ mod tests {
 
         assert_eq!(pty.argv, vec!["/bin/sh"]);
         assert_eq!(pty.env, vec![("TERM".into(), "xterm-256color".into())]);
+    }
+
+    #[test]
+    fn pty_console_request_with_mount_passes_absolute_argv_directly() {
+        let req = ExecRequest {
+            name: None,
+            warm_pool_size: 0,
+            image: ImageSource::Template("t".into()),
+            cpus: 1,
+            memory_mib: 256,
+            mem_initial_mib: None,
+            dir_shares: vec![DirShareSpec {
+                host_dir: "/host/src".into(),
+                guest_mount: "/work/src".into(),
+                read_only: true,
+            }],
+            disk_volumes: Vec::new(),
+            env: vec![("NAME".into(), "ari".into())],
+            target: ExecTarget::Inline {
+                argv: vec!["/bin/bash".into()],
+            },
+            timeout_secs: None,
+            pty: true,
+            network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+            stdin: Vec::new(),
+            healthcheck: None,
+            hypervisor: None,
+            sdk_host_services: Vec::new(),
+            declared_libc: mvm_contract::guest_libc::GuestLibc::Unknown,
+        };
+
+        let pty = pty_console_request(&req, "unused wrapper".to_string());
+
+        assert_eq!(pty.argv, vec!["/bin/bash"]);
+        assert_eq!(pty.env, vec![("NAME".into(), "ari".into())]);
     }
 
     #[test]

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -53,6 +53,19 @@ Feature: every README-documented CLI launch mode boots a real guest
     And the guest printed "console-ok"
     And the guest control plane came up
 
+  # A host-directory mount used to route an otherwise absolute PTY command
+  # through `/bin/sh -lc`. The image's `/etc/profile` then replaced its OCI
+  # PATH before bash started, hiding tools such as Rust's cargo even though the
+  # binaries were present in the rootfs.
+  @live @dir_share
+  Scenario: an interactive mounted run preserves the image environment
+    When I launch "machine run --image rust --env NAME=ari --mount .:/work -it -- /bin/bash -c 'tty; command -v cargo; printf NAME=%s $NAME; test -f /work/README.md'" on a terminal
+    Then the launch succeeds
+    And the guest console is a pseudo-terminal
+    And the guest printed "/usr/local/cargo/bin/cargo"
+    And the guest printed "NAME=ari"
+    And the guest control plane came up
+
   # The same defect stated as the mount it actually is, on the non-interactive
   # path so it runs on a host with no terminal to give — a CI runner, or this
   # suite under `just bdd`. devtmpfs supplies /dev/ptmx and the image supplies

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -26,6 +26,13 @@ Last updated: 2026-09-01
       workspace validation and the release embed witness are green; no live VM
       command was run outside the builder VM.
 
+- [ ] **Mounted PTY image environment.**
+      `specs/plans/2026-09-01-mounted-pty-image-environment.md`.
+      Mounted absolute PTY commands now reach the guest console directly, so
+      an image login profile cannot erase the OCI-declared `PATH`. Focused,
+      workspace, Clippy, gated-target, formatting, and non-live BDD checks are
+      green; the live Rust directory-share witness and merge remain.
+
 - [ ] **Extended CI residual regressions — issues #3051 and #3052.**
       `specs/plans/2026-08-28-extended-ci-red-repair.md`.
       Persistent launches clamp vCPUs before admission, authenticated frame

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,15 @@
 
 ## In progress
 
+- [ ] **Mounted PTY image environment.**
+      `specs/plans/2026-09-01-mounted-pty-image-environment.md`.
+      Absolute PTY commands now bypass the login-shell wrapper even when the
+      launch carries `--mount`, preserving the OCI image environment and its
+      declared `PATH`. A focused dispatch regression is green, and a live Rust
+      scenario covers the PTY, mount, CLI env, and Cargo path together.
+      Workspace, Clippy, gated-target, formatting, and non-live BDD validation
+      are green; merge delivery remains.
+
 - [x] **Signed caller commitment — issue #3070, PR #3076.**
       `specs/plans/2026-09-01-signed-caller-commitment.md`.
       One typed opaque 32-byte commitment now reaches the signed execution

--- a/specs/plans/2026-09-01-mounted-pty-image-environment.md
+++ b/specs/plans/2026-09-01-mounted-pty-image-environment.md
@@ -1,0 +1,25 @@
+Backing: shipped-source
+Validation: check-sprint-append
+
+# Mounted PTY image environment
+
+An absolute command passed to `machine run -it` normally reaches the guest
+console directly, preserving the OCI image environment assembled by the guest
+agent. Adding `--mount` incorrectly disabled that direct path and introduced a
+`/bin/sh -lc` wrapper. The image's login profile could then replace its declared
+`PATH`; `rust` still contained Cargo under `/usr/local/cargo/bin`, but an
+interactive Bash session could not resolve it.
+
+## Delivery
+
+- [x] Reproduce the mounted absolute-command dispatch through the login-shell
+      wrapper with a focused failing regression.
+- [x] Keep mounted absolute PTY commands on the direct console path while
+      retaining shell lookup for relative commands.
+- [x] Add a live Rust-image scenario covering the PTY, host mount, CLI
+      environment, and image-declared Cargo path together.
+- [x] Pass formatting, workspace tests, zero-warning Clippy, gated-target, and
+      non-live BDD validation; leave the hardware-backed scenario to the opted-in
+      live lane.
+- [x] Record the completed repair in the sprint and refactor rollup.
+- [ ] Merge the repair through the queue.

--- a/specs/sprint/delivery/mounted-pty-image-environment.md
+++ b/specs/sprint/delivery/mounted-pty-image-environment.md
@@ -1,0 +1,29 @@
+Backing: shipped-source
+Validation: check-sprint-append
+
+# Mounted PTY image environment
+
+`mvmctl machine run --image rust --mount ... -it -- /bin/bash` booted the
+correct image and carried Cargo at `/usr/local/cargo/bin/cargo`, but `cargo`
+was absent from command lookup. The mount left a directory share on the
+request, which made PTY dispatch replace the absolute Bash argv with
+`/bin/sh -lc <wrapper>`. Debian's login profile then replaced the OCI `PATH`
+before Bash started.
+
+Absolute interactive commands now go directly to the guest console whether or
+not the launch also carries host-directory shares. The guest agent therefore
+applies the image runtime environment once and execs the requested command
+without a login shell rewriting it. Relative commands retain the wrapper they
+need for shell path lookup.
+
+The focused regression first demonstrated the mounted request lowering to the
+login wrapper, then passed with `/bin/bash` and the caller environment preserved
+on the direct request. A live `@dir_share` scenario mirrors the reported Rust
+launch and jointly checks a real PTY, mounted content, `NAME=ari`, and Cargo at
+the image-declared path. The regular BDD run compiles and discovers that
+scenario; execution remains with the opted-in hardware lane.
+
+Validation completed with the focused PTY dispatch tests, the workspace test
+suite, `mvm-build` doc tests, full all-target/all-feature Clippy with warnings
+denied, Linux and BDD gated-target checks, formatting, and the 243-scenario
+non-live BDD suite (242 passed, one capability scenario skipped).


### PR DESCRIPTION
## Summary

- preserve OCI image environment for mounted absolute PTY commands by dispatching argv directly
- retain the shell wrapper for relative commands
- add unit and live Rust-image regression coverage plus delivery documentation

## Validation

- `cargo test --workspace --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `just check-gated`
- `just bdd` (242 passed, 1 existing capability skip; opt-in live scenarios discovered but not run)
- `cargo run -p xtask -- check-all` (66 gates)