### PR TITLE
feat(vmm): attribute a helper resolved from the other build profile

### DIFF
--- a/crates/mvm-vmm/src/host/aux_bin.rs
+++ b/crates/mvm-vmm/src/host/aux_bin.rs
@@ -14,8 +14,15 @@
 //! ones it reused so a stale supervisor could be refused at spawn. That cost a
 //! duplicate build of `mvm-hostd`'s whole closure per worktree and made
 //! staleness representable in the first place. Letting the workspace build own
-//! them removes both: cargo rebuilds a helper when its sources change, so there
-//! is no stale state left to detect.
+//! them removes both: cargo rebuilds a helper when its sources change.
+//!
+//! That holds *within* a profile and not across one, which this resolver spans
+//! by design — `target/release` then `target/debug`. Cargo never rebuilds a
+//! debug helper because a release binary is about to run it, so a release
+//! `mvmctl` with no release helper beside it is answered by whichever debug
+//! helper was built last, at whatever revision. When the config contract has
+//! moved since, the helper refuses to start and says only that it does not
+//! recognise a field. [`profile_mismatch`] is what makes that attributable.
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -33,7 +40,7 @@ pub struct AuxBin<'a> {
 /// Resolve `spec` to an on-disk binary. Never builds — a missing one is a hard
 /// error with a recovery hint.
 pub fn resolve(spec: &AuxBin) -> Result<PathBuf> {
-    resolve_from(
+    let resolved = resolve_from(
         spec,
         &Lookup {
             override_path: std::env::var_os(spec.env_var).map(PathBuf::from),
@@ -43,7 +50,119 @@ pub fn resolve(spec: &AuxBin) -> Result<PathBuf> {
                 workspace_target_dirs(),
             ),
         },
+    )?;
+    warn_once_on_profile_mismatch(spec, &resolved);
+    Ok(resolved)
+}
+
+/// Say once per process that a helper came from the other build profile.
+///
+/// Once, not once per helper: a process that picks one helper cross-profile
+/// picks all of them that way, because the cause is which profile was built
+/// rather than anything about the individual binary. Repeating it per spawn
+/// would bury the line that matters under two identical ones.
+///
+/// A warning and not a refusal. A cross-profile helper is wrong-looking, not
+/// necessarily broken — it works whenever the config contract has not moved —
+/// and refusing here would break a working setup for a mismatch that is only
+/// sometimes fatal. The failure it precedes is already loud; what was missing
+/// is the attribution, so that is what this adds.
+fn warn_once_on_profile_mismatch(spec: &AuxBin, resolved: &Path) {
+    static SAID: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+    let exe = std::env::current_exe().ok();
+    let Some(mismatch) = profile_mismatch(exe.as_deref(), resolved) else {
+        return;
+    };
+    if SAID.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+    crate::host::ui::warn(&profile_mismatch_warning(spec.bin, &mismatch));
+}
+
+/// The text for a cross-profile pick, split out so it is assertable without
+/// capturing stderr.
+fn profile_mismatch_warning(bin: &str, mismatch: &ProfileMismatch) -> String {
+    format!(
+        "this mvmctl is the {exe} build but {bin} resolved to the {helper} one ({path}). \
+         Helpers are searched in target/release before target/debug, so a missing helper \
+         beside the running binary is answered silently by the other profile's — at \
+         whatever revision it was last built. If their config contract has moved since, \
+         {bin} will refuse to start. Build the matching one with `cargo build{flag} \
+         -p mvm-hostd --bins`.",
+        exe = mismatch.exe.as_str(),
+        helper = mismatch.helper.as_str(),
+        path = mismatch.helper_path.display(),
+        flag = mismatch.exe.cargo_flag(),
     )
+}
+
+/// The cargo build profile a binary was produced under.
+///
+/// Only the two cargo emits without a custom profile. A custom one lands in
+/// `target/<name>/` and reads as [`None`] rather than being guessed at: this
+/// type exists to compare two binaries, and an unrecognised name on either side
+/// would manufacture a mismatch out of no information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildProfile {
+    /// `target/debug`.
+    Debug,
+    /// `target/release`.
+    Release,
+}
+
+impl BuildProfile {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Debug => "debug",
+            Self::Release => "release",
+        }
+    }
+
+    /// The cargo flag that selects this profile, ready to interpolate after
+    /// `cargo build`. Empty for debug, which is cargo's default.
+    pub fn cargo_flag(self) -> &'static str {
+        match self {
+            Self::Debug => "",
+            Self::Release => " --release",
+        }
+    }
+}
+
+/// A helper resolved from a different build profile than the running binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileMismatch {
+    /// The running executable's profile.
+    pub exe: BuildProfile,
+    /// The resolved helper's profile.
+    pub helper: BuildProfile,
+    /// Where the helper was found.
+    pub helper_path: PathBuf,
+}
+
+/// Which profile a binary sits under, read from its parent directory name.
+pub fn build_profile_of(path: &Path) -> Option<BuildProfile> {
+    match path.parent()?.file_name()?.to_str()? {
+        "debug" => Some(BuildProfile::Debug),
+        "release" => Some(BuildProfile::Release),
+        _ => None,
+    }
+}
+
+/// Describe a cross-profile pick, or [`None`] when there is nothing to say.
+///
+/// Silent unless *both* sides are recognisable and they differ, so an installed
+/// binary — a downloaded release in `~/.local/bin` with its helpers beside it,
+/// neither under a cargo target dir — is never accused of a mismatch it cannot
+/// have.
+pub fn profile_mismatch(exe: Option<&Path>, helper: &Path) -> Option<ProfileMismatch> {
+    let exe_profile = build_profile_of(exe?)?;
+    let helper_profile = build_profile_of(helper)?;
+    (exe_profile != helper_profile).then(|| ProfileMismatch {
+        exe: exe_profile,
+        helper: helper_profile,
+        helper_path: helper.to_path_buf(),
+    })
 }
 
 /// Everything `resolve` reads from the environment, gathered so the resolution
@@ -171,6 +290,143 @@ fn cargo_target_dir_from_env(workspace_root: &Path, target_dir: Option<OsString>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The failure this exists to attribute: a release `mvmctl` whose own
+    /// directory has no helper is answered by `target/debug`, because the
+    /// search spans profiles and cargo never rebuilds across one. It works
+    /// until the config contract moves, and then the supervisor refuses with a
+    /// message about a JSON field.
+    #[test]
+    fn a_release_exe_answered_by_a_debug_helper_is_a_mismatch() {
+        let mismatch = profile_mismatch(
+            Some(Path::new("/repo/target/release/mvmctl")),
+            Path::new("/repo/target/debug/mvm-hvf-supervisor"),
+        )
+        .expect("crossing profiles must be reported");
+
+        assert_eq!(mismatch.exe, BuildProfile::Release);
+        assert_eq!(mismatch.helper, BuildProfile::Debug);
+        assert_eq!(
+            mismatch.helper_path,
+            Path::new("/repo/target/debug/mvm-hvf-supervisor")
+        );
+    }
+
+    /// Both directions, because the resolver searches `release` before `debug`
+    /// but the exe's own directory before either — so which way the fallthrough
+    /// runs depends on which helper is missing, not on a fixed precedence.
+    #[test]
+    fn a_debug_exe_answered_by_a_release_helper_is_also_a_mismatch() {
+        let mismatch = profile_mismatch(
+            Some(Path::new("/repo/target/debug/mvmctl")),
+            Path::new("/repo/target/release/mvm-libkrun-supervisor"),
+        )
+        .expect("crossing profiles must be reported in either direction");
+
+        assert_eq!(mismatch.exe, BuildProfile::Debug);
+        assert_eq!(mismatch.helper, BuildProfile::Release);
+    }
+
+    #[test]
+    fn matching_profiles_are_not_a_mismatch() {
+        for profile in ["debug", "release"] {
+            assert_eq!(
+                profile_mismatch(
+                    Some(&PathBuf::from(format!("/repo/target/{profile}/mvmctl"))),
+                    &PathBuf::from(format!("/repo/target/{profile}/mvm-hvf-supervisor")),
+                ),
+                None,
+                "{profile} against itself is the ordinary case"
+            );
+        }
+    }
+
+    /// A downloaded release ships its helpers beside the binary, and neither
+    /// side sits under a cargo target dir. Accusing that layout of a mismatch
+    /// would put a rebuild instruction in front of someone with no checkout to
+    /// run it in, so an unreadable profile on either side stays silent.
+    #[test]
+    fn an_installed_binary_is_never_accused_of_a_mismatch() {
+        assert_eq!(
+            profile_mismatch(
+                Some(Path::new("/usr/local/bin/mvmctl")),
+                Path::new("/usr/local/bin/mvm-hvf-supervisor"),
+            ),
+            None
+        );
+        // One side recognisable is still not enough to conclude anything.
+        assert_eq!(
+            profile_mismatch(
+                Some(Path::new("/usr/local/bin/mvmctl")),
+                Path::new("/repo/target/debug/mvm-hvf-supervisor"),
+            ),
+            None
+        );
+        assert_eq!(
+            profile_mismatch(
+                Some(Path::new("/repo/target/release/mvmctl")),
+                Path::new("/usr/local/bin/mvm-hvf-supervisor"),
+            ),
+            None
+        );
+    }
+
+    /// `current_exe()` can fail, and a diagnostic that cannot read one side has
+    /// nothing to compare rather than something to report.
+    #[test]
+    fn an_unknown_exe_yields_no_mismatch() {
+        assert_eq!(
+            profile_mismatch(None, Path::new("/repo/target/debug/mvm-hvf-supervisor")),
+            None
+        );
+    }
+
+    /// A custom cargo profile lands in `target/<name>/`, and a test binary in
+    /// `target/<profile>/deps/`. Neither is one of the two names, and guessing
+    /// at them would manufacture a mismatch out of no information.
+    #[test]
+    fn only_the_two_cargo_profiles_are_recognised() {
+        assert_eq!(
+            build_profile_of(Path::new("/repo/target/debug/mvmctl")),
+            Some(BuildProfile::Debug)
+        );
+        assert_eq!(
+            build_profile_of(Path::new("/repo/target/release/mvmctl")),
+            Some(BuildProfile::Release)
+        );
+        assert_eq!(
+            build_profile_of(Path::new("/repo/target/profiling/mvmctl")),
+            None
+        );
+        assert_eq!(
+            build_profile_of(Path::new("/repo/target/debug/deps/mvm_vmm-abc123")),
+            None
+        );
+    }
+
+    /// The warning has to carry the path, both profiles, and a rebuild whose
+    /// flag follows the *running* binary rather than the helper that was found.
+    #[test]
+    fn the_warning_names_both_profiles_and_a_profile_correct_rebuild() {
+        let mismatch = profile_mismatch(
+            Some(Path::new("/repo/target/release/mvmctl")),
+            Path::new("/repo/target/debug/mvm-hvf-supervisor"),
+        )
+        .unwrap();
+        let warning = profile_mismatch_warning("mvm-hvf-supervisor", &mismatch);
+
+        assert!(warning.contains("mvm-hvf-supervisor"), "{warning}");
+        assert!(warning.contains("release build"), "{warning}");
+        assert!(warning.contains("the debug one"), "{warning}");
+        assert!(
+            warning.contains("/repo/target/debug/mvm-hvf-supervisor"),
+            "naming the file is what makes it checkable: {warning}"
+        );
+        assert!(
+            warning.contains("cargo build --release -p mvm-hostd --bins"),
+            "the rebuild must name the running binary's profile, not the helper's: {warning}"
+        );
+    }
 
     #[test]
     fn candidate_order_is_aux_then_exe_then_targets() {

--- a/crates/mvm-vmm/src/host/console_capture.rs
+++ b/crates/mvm-vmm/src/host/console_capture.rs
@@ -90,14 +90,43 @@ pub fn supervisor_stderr_detail(state_dir: &Path) -> String {
 /// supervisor does not recognise means its binary predates the `mvmctl` that
 /// wrote the config — not a bad value. Nothing in the exit status the launch
 /// path sees distinguishes that from any other refusal; only the stderr can.
-fn stale_supervisor_hint(stderr_tail: &str) -> &'static str {
-    if stderr_tail.contains("unknown field") {
-        "\n\nThat supervisor binary is older than this mvmctl: it refused a config field \
-         this build sends. Rebuild it with `just build-supervisors`, then re-sign with \
-         `mvmctl env sign`."
-    } else {
-        ""
+///
+/// The rebuild it names carries the running binary's own profile. Advising a
+/// bare `cargo build` from a release `mvmctl` rebuilds the debug helper the
+/// release one does not use, so the command appears to succeed and the next
+/// launch fails identically.
+///
+/// It no longer advises re-signing. Both supervisors sign themselves on first
+/// launch — `mvm-hvf-supervisor` from its own `main`, `mvm-libkrun-supervisor`
+/// through `codesign::ensure_signed` — so a separate signing step was a fourth
+/// instruction that never had to be followed, in a message read by someone
+/// already several layers from the cause.
+fn stale_supervisor_hint(stderr_tail: &str) -> String {
+    if !stderr_tail.contains("unknown field") {
+        return String::new();
     }
+    let profile = std::env::current_exe()
+        .ok()
+        .as_deref()
+        .and_then(crate::host::aux_bin::build_profile_of);
+    format!(
+        "\n\nThat supervisor binary is older than this mvmctl: it refused a config field \
+         this build sends. Rebuild it with `{}`. It signs itself on first launch, so no \
+         separate signing step is needed.",
+        helper_rebuild_command(profile)
+    )
+}
+
+/// The rebuild command to print, for a running binary of `profile`.
+///
+/// `None` — an installed binary, or a test harness under `target/<p>/deps` —
+/// falls back to cargo's default profile. That is the safe direction: the debug
+/// form is what a contributor most often wants, and naming `--release` to
+/// someone who is not running a release binary would have them rebuild a helper
+/// they do not use and watch the next launch fail identically.
+fn helper_rebuild_command(profile: Option<crate::host::aux_bin::BuildProfile>) -> String {
+    let flag = profile.map_or("", crate::host::aux_bin::BuildProfile::cargo_flag);
+    format!("cargo build{flag} -p mvm-hostd --bins")
 }
 
 #[cfg(test)]
@@ -187,8 +216,36 @@ mod tests {
         .unwrap();
         let detail = supervisor_stderr_detail(dir.path());
         assert!(
-            detail.contains("just build-supervisors"),
+            detail.contains("-p mvm-hostd --bins"),
             "an unknown field must name the rebuild: {detail}"
+        );
+        assert!(
+            !detail.contains("mvmctl env sign"),
+            "both supervisors self-sign; a signing step is an instruction that \
+             never has to be followed: {detail}"
+        );
+    }
+
+    /// A bare `cargo build` run from a release mvmctl rebuilds the debug helper
+    /// the release one does not use: the command succeeds and the next launch
+    /// fails identically. The flag has to follow the binary being run.
+    #[test]
+    fn the_rebuild_command_carries_the_running_binarys_profile() {
+        use crate::host::aux_bin::BuildProfile;
+
+        assert_eq!(
+            helper_rebuild_command(Some(BuildProfile::Release)),
+            "cargo build --release -p mvm-hostd --bins"
+        );
+        assert_eq!(
+            helper_rebuild_command(Some(BuildProfile::Debug)),
+            "cargo build -p mvm-hostd --bins"
+        );
+        // An installed binary, or this very test harness, which sits under
+        // `target/<profile>/deps` and so reads as no profile at all.
+        assert_eq!(
+            helper_rebuild_command(None),
+            "cargo build -p mvm-hostd --bins"
         );
     }
 
@@ -201,7 +258,7 @@ mod tests {
         )
         .unwrap();
         let detail = supervisor_stderr_detail(dir.path());
-        assert!(!detail.contains("just build-supervisors"), "got: {detail}");
+        assert!(!detail.contains("-p mvm-hostd --bins"), "got: {detail}");
         assert!(detail.contains("HV_ERROR"), "got: {detail}");
     }
 }


### PR DESCRIPTION
`aux_bin::resolve` searches `target/release` then `target/debug` and takes the first hit, so a release `mvmctl` whose own directory holds no helper is answered by whichever debug helper was built last, at whatever revision. Cargo does not close this: it rebuilds a helper when its sources change *within* a profile, and never because a binary of the other profile is about to run it.

The module header asserted the opposite:

> Letting the workspace build own them removes both: cargo rebuilds a helper when its sources change, so there is no stale state left to detect.

True within a profile, false across one — which this resolver spans by design. The one state it could not rule out was the one it claimed was gone.

## What it looked like

A release `mvmctl` built after #3061 sending `builder_egress_endpoint` to a debug supervisor built eight hours earlier:

```
Error: parse HvfSupervisorConfig JSON from stdin
Caused by:
    unknown field `builder_egress_endpoint`, expected one of `kernel`, `cmdline`, ...
```

A message about JSON, from a process the reader did not know had been chosen for them.

## What it looks like now

```
[mvm] this mvmctl is the debug build but mvm-libkrun-supervisor resolved to the release one
      (/…/target/release/mvm-libkrun-supervisor). Helpers are searched in target/release
      before target/debug, so a missing helper beside the running binary is answered
      silently by the other profile's — at whatever revision it was last built. If their
      config contract has moved since, mvm-libkrun-supervisor will refuse to start. Build
      the matching one with `cargo build -p mvm-hostd --bins`.
```

That is real output, not a mock — a debug `mvmctl` in a worktree that had release helpers and no debug ones. It appeared once despite three helpers resolving in that run.

## Design notes

**A warning, not a refusal.** A cross-profile helper is wrong-looking rather than broken; it works whenever the config contract has not moved. Refusing would break a working setup for a mismatch that is only sometimes fatal. The failure it precedes is already loud — what was missing was attribution.

**Once per process, not per helper.** A process that picks one helper cross-profile picks all of them that way; the cause is which profile was built, not anything about the individual binary.

**Silent unless both sides are recognisable.** A downloaded release ships its helpers beside the binary, neither under a cargo target dir, so it is never handed a rebuild instruction for a checkout it does not have. Custom profiles (`target/profiling/`) and test binaries (`target/debug/deps/`) read as no profile rather than being guessed at.

## The post-mortem hint

`stale_supervisor_hint` reports the same failure after the fact and gave advice that could not work: a bare `just build-supervisors` run from a release `mvmctl` rebuilds the debug helper the release one does not use, so the command succeeds and the next launch fails identically. It now carries the running binary's profile.

It also no longer advises `mvmctl env sign`. `mvm-hvf-supervisor` self-signs from its own `main` (`ensure_self_signed`), and `mvm-libkrun-supervisor` through `codesign::ensure_signed` — so that was a fourth instruction that never had to be followed, in a message read by someone already several layers from the cause.

## Verification

9 new tests: both mismatch directions, matching profiles, installed binaries (all three one-side-unreadable permutations), unknown exe, the two-profiles-only rule including the `deps/` case, the warning's content, and the rebuild command's flag. Plus the real `doctor` run above.

`mvm-vmm` 623/623. `cargo fmt --all --check`, `clippy -p mvm-vmm -p mvm-backends --all-targets -D warnings`, and `just check-gated` all clean.

Independent of #3101 and #3102 — it names `cargo build` rather than the `just` recipe, so it carries no ordering dependency on either.
