### PR TITLE
fix(hooks): stop the pre-commit hook reporting a non-member package as a clippy failure

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -55,6 +55,36 @@ owning_package() {
     fi
 }
 
+# Package names `cargo -p` can address from this workspace root: the root
+# package plus every path in the root manifest's `members` list.
+#
+# `owning_package` walks up to the nearest Cargo.toml, and several real
+# packages in this tree are not workspace members — `web/mvm-demo/` declares
+# `mvm-demo-web`, and each detached fuzz crate declares its own name. For any
+# of those `cargo clippy -p <name>` exits with "did not match any packages",
+# and this hook reported that as **"clippy failed"** — the one thing a lint
+# hook must never say when lint is fine. Any merge commit carrying changes
+# under `web/` hit it.
+#
+# Deliberately not "every Cargo.toml under the tree": that glob matches the
+# fuzz crates and `mvm-hostd-ebpf`, which is the same mistake in a new place.
+workspace_members() {
+    [ -f Cargo.toml ] || return 0
+    sed -n 's/^name[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' Cargo.toml | head -1
+    sed -n '/^members[[:space:]]*=[[:space:]]*\[/,/^\]/p' Cargo.toml \
+        | sed -n 's/^[[:space:]]*"\([^"]*\)".*/\1/p' \
+        | while IFS= read -r dir; do
+            [ -f "$dir/Cargo.toml" ] || continue
+            sed -n 's/^name[[:space:]]*=[[:space:]]*"\(.*\)".*/\1/p' \
+                "$dir/Cargo.toml" | head -1
+        done
+}
+
+# True when $1 is one of the names workspace_members prints.
+is_workspace_member() {
+    printf '%s\n' "$WORKSPACE_MEMBERS" | grep -qxF "$1"
+}
+
 # True when no other manifest in the tree declares $1 as a dependency.
 #
 # This is the whole basis for narrowing clippy's scope: changing a crate
@@ -162,11 +192,18 @@ if [ "$has_rust" -eq 1 ]; then
         else
             pkgs=""
             unresolved=0
+            unresolved_reason="a staged Rust file belongs to no package"
+            WORKSPACE_MEMBERS="$(workspace_members)"
             while IFS= read -r f; do
                 [ -z "$f" ] && continue
                 pkg="$(owning_package "$f")"
                 if [ -z "$pkg" ]; then
                     unresolved=1
+                    break
+                fi
+                if ! is_workspace_member "$pkg"; then
+                    unresolved=1
+                    unresolved_reason="$pkg is not a workspace member, so -p cannot address it"
                     break
                 fi
                 case " $pkgs " in
@@ -176,7 +213,7 @@ if [ "$has_rust" -eq 1 ]; then
             done <<< "$staged_rust"
 
             if [ "$unresolved" -eq 1 ]; then
-                scope_reason="a staged Rust file belongs to no package"
+                scope_reason="$unresolved_reason"
             else
                 all_leaf=1
                 for pkg in $pkgs; do

--- a/.githooks/pre-commit.test.sh
+++ b/.githooks/pre-commit.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Tests the pre-commit hook's clippy-scoping decision.
+#
+# The hook narrows `cargo clippy` to the packages owning the staged files. That
+# is only sound when cargo can address those packages with `-p`, and several
+# real packages in this tree cannot be: `web/mvm-demo/` and every detached fuzz
+# crate declare a package name that is not a workspace member. Passing one to
+# `cargo -p` exits with "did not match any packages", which the hook reported
+# as "clippy failed" — a lint hook claiming a lint failure when lint is fine.
+#
+# These tests pin the decision, not the clippy run: a fixture workspace, the
+# hook's own helper functions, and an assertion on which packages it would
+# scope to.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+hook="$repo_root/.githooks/pre-commit"
+fixture="$(mktemp -d)"
+trap 'rm -rf "$fixture"' EXIT
+
+# Source the hook's helpers without running it. Everything above the
+# "Bail out early" guard is definitions; the guard is the first statement that
+# acts. If that marker moves, this extraction fails loudly rather than
+# silently testing nothing.
+fns="$fixture/fns.sh"
+sed -n '1,/^# Bail out early/p' "$hook" | sed '$d' > "$fns"
+if ! grep -q '^workspace_members()' "$fns"; then
+  echo "extraction missed workspace_members — has the 'Bail out early' marker moved?" >&2
+  exit 1
+fi
+if ! grep -q '^owning_package()' "$fns"; then
+  echo "extraction missed owning_package" >&2
+  exit 1
+fi
+
+# A workspace with one member, one non-member sibling, and a detached fuzz
+# crate under a member — the three shapes that matter.
+mkdir -p "$fixture/ws/crates/real/src" \
+         "$fixture/ws/crates/real/fuzz/fuzz_targets" \
+         "$fixture/ws/web/demo/src" \
+         "$fixture/ws/src"
+cat > "$fixture/ws/Cargo.toml" <<'TOML'
+[package]
+name = "rootpkg"
+
+[workspace]
+members = [
+    # a comment naming "crates/decoy" must not be read as a member
+    "crates/real",
+]
+TOML
+printf '[package]\nname = "realpkg"\n' > "$fixture/ws/crates/real/Cargo.toml"
+printf '[package]\nname = "realpkg-fuzz"\n' > "$fixture/ws/crates/real/fuzz/Cargo.toml"
+printf '[package]\nname = "demo-web"\n' > "$fixture/ws/web/demo/Cargo.toml"
+
+cd "$fixture/ws"
+# shellcheck source=/dev/null
+source "$fns"
+WORKSPACE_MEMBERS="$(workspace_members)"
+
+expect_member() {
+  local file="$1" want_pkg="$2" want_member="$3" pkg verdict
+  pkg="$(owning_package "$file")"
+  if [ "$pkg" != "$want_pkg" ]; then
+    echo "FAIL $file: owning_package said '$pkg', expected '$want_pkg'" >&2
+    exit 1
+  fi
+  if is_workspace_member "$pkg"; then verdict=yes; else verdict=no; fi
+  if [ "$verdict" != "$want_member" ]; then
+    echo "FAIL $file: is_workspace_member($pkg) said $verdict, expected $want_member" >&2
+    exit 1
+  fi
+  echo "  ok  $file -> $pkg (member: $verdict)"
+}
+
+echo "workspace_members:"
+printf '%s\n' "$WORKSPACE_MEMBERS" | sed 's/^/  /'
+
+# The root package is addressable even though it is not in `members`.
+expect_member "src/lib.rs" "rootpkg" "yes"
+# A declared member scopes, which is the whole point of the narrowing.
+expect_member "crates/real/src/lib.rs" "realpkg" "yes"
+# The two shapes that must widen instead of being handed to `cargo -p`.
+expect_member "web/demo/src/lib.rs" "demo-web" "no"
+expect_member "crates/real/fuzz/fuzz_targets/t.rs" "realpkg-fuzz" "no"
+
+# A path inside a member but below no nearer manifest still resolves upward.
+expect_member "crates/real/src/deep/nested.rs" "realpkg" "yes"
+
+# A member name must not be inferred from a commented-out path.
+if is_workspace_member "decoypkg"; then
+  echo "FAIL: a name only mentioned in a comment was treated as a member" >&2
+  exit 1
+fi
+echo "  ok  a commented member path is not a member"
+
+echo "pre-commit scoping tests passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,19 @@ jobs:
                      scripts/check-no-orchestration-server.sh \
                      scripts/check-no-orchestration-server.test.sh \
                      scripts/security-lane-verdict.sh \
-                     scripts/security-lane-verdict.test.sh
+                     scripts/security-lane-verdict.test.sh \
+                     .githooks/pre-commit \
+                     .githooks/pre-commit.test.sh
 
       - name: Release-asset verifier gate tests
         run: bash nix/packaging/release/verify-release-assets.test.sh
+
+      # The hook narrows clippy to the packages owning the staged files. When
+      # it picked a package cargo cannot address with `-p`, it reported that as
+      # "clippy failed" while clippy was fine. These tests pin the scoping
+      # decision; they do not run clippy.
+      - name: Pre-commit hook scoping tests
+        run: bash .githooks/pre-commit.test.sh
 
 
       - name: Clippy

--- a/specs/sprint/delivery/precommit-non-member-packages.md
+++ b/specs/sprint/delivery/precommit-non-member-packages.md
@@ -1,0 +1,59 @@
+# The pre-commit hook said "clippy failed" when clippy was fine
+
+## What was wrong
+
+The hook narrows `cargo clippy` to the packages owning the staged files. It
+finds them with `owning_package`, which walks up to the nearest `Cargo.toml`
+and reads its `name`. Several real packages in this tree are not workspace
+members, so `cargo -p` cannot address them:
+
+- `web/mvm-demo/` declares `mvm-demo-web`
+- each detached fuzz crate declares its own name (`mvm-agentd-fuzz`, …)
+- `mvm-hostd-ebpf`
+
+For any of those, clippy exits with `error: package ID specification
+'mvm-demo-web' did not match any packages`, and the hook reported it as:
+
+```
+  clippy failed. CI gates on the same '-D warnings' rule, so
+  this commit will fail on push.
+```
+
+Clippy had not failed. The commit was refused, and the advice — fix your lints
+— pointed at nothing. Any merge commit carrying main's changes under `web/`
+hits it; it blocked three separate merges during one afternoon of queue work
+(#3072, #3075, #3096), each time costing a manual verification of the scope the
+hook wanted, by hand, before using its own `MVM_SKIP_CLIPPY=1` escape.
+
+A lint hook that cries wolf gets bypassed, and a bypassed hook gates nothing.
+
+## The fix
+
+`workspace_members` derives the addressable set from the root manifest — the
+root package plus every path in its `members` list — and `is_workspace_member`
+checks against it. A staged file owned by anything else takes the widen-to
+`--workspace` path the hook already had for unresolvable files, with a reason
+that says what happened:
+
+```
+pre-commit: clippy covering the whole workspace — mvm-demo-web is not a
+workspace member, so -p cannot address it
+```
+
+Deliberately **not** "every `Cargo.toml` under the tree". That glob also
+matches the fuzz crates and `mvm-hostd-ebpf`, which is the same mistake
+relocated: it would accept `-p mvm-agentd-fuzz` and fail exactly as before.
+
+## Tests
+
+`.githooks/pre-commit.test.sh`, in the established `*.test.sh` shape: a fixture
+workspace with a member, a non-member sibling, and a detached fuzz crate under
+a member. It pins the scoping decision, not the clippy run.
+
+Verified to bite: against `main`'s hook the suite fails rather than passing.
+Verified not to over-widen: a staged `xtask` file still produces
+`--workspace, then -p xtask --all-targets`, and a staged `web/` file now widens
+end-to-end instead of failing.
+
+Wired into `ci.yml` alongside the other shell-tool tests, and shellchecked with
+them.


### PR DESCRIPTION
The hook narrows `cargo clippy` to the packages owning the staged files, finding
them by walking up to the nearest `Cargo.toml`. Several real packages in this
tree are **not workspace members**, so `cargo -p` cannot address them:

- `web/mvm-demo/` → `mvm-demo-web`
- every detached fuzz crate → `mvm-agentd-fuzz`, `mvm-core-fuzz`, …
- `mvm-hostd-ebpf`

For any of those, clippy exits with:

```
error: package ID specification `mvm-demo-web` did not match any packages
```

and the hook printed:

```
  clippy failed. CI gates on the same '-D warnings' rule, so
  this commit will fail on push.
```

**Clippy had not failed.** The commit was refused and the advice — go fix your
lints — pointed at nothing.

Any merge commit carrying main's changes under `web/` hits this. It blocked
#3072, #3075 and #3096 in a single afternoon of merge-queue work; each one cost
running the scope the hook wanted by hand to confirm clippy was actually clean,
then falling back to the hook's own `MVM_SKIP_CLIPPY=1`.

A lint hook that cries wolf gets bypassed, and a bypassed hook gates nothing.

## The fix

`workspace_members` derives the addressable set from the root manifest — the
root package plus every path in its `members` list. A staged file owned by
anything else takes the widen-to-`--workspace` path the hook already had for
unresolvable files, and says why:

```
pre-commit: clippy covering the whole workspace — mvm-demo-web is not a
workspace member, so -p cannot address it
```

Deliberately **not** "every `Cargo.toml` under the tree". That glob also matches
the fuzz crates and `mvm-hostd-ebpf` — it would accept `-p mvm-agentd-fuzz` and
fail in exactly the same way, which is the same bug in a new place.

## Tests

`.githooks/pre-commit.test.sh`, in the established `*.test.sh` shape: a fixture
workspace with a member, a non-member sibling, and a detached fuzz crate under a
member. It pins the scoping decision and does not run clippy.

| Check | Result |
|---|---|
| Fails against `main`'s hook | yes — it is not a test that would pass either way |
| Staged `web/` file, end to end | widens to `--workspace` instead of failing |
| Staged `xtask` file, end to end | still `--workspace, then -p xtask --all-targets` — narrowing is not lost |
| A member path mentioned only in a comment | not treated as a member |

Shellchecked and run in `ci.yml` beside the other shell-tool tests.

## Gates

`cargo nextest run --workspace` → **12963 pass** (the workflow-structure tests
pin job locations, so the `ci.yml` edit needed the full suite).
`check-workflow-paths` clean. `shellcheck` clean on both files.

`check-stubs` and `check-ir-parity` fail locally for want of `uv` and `tsx`;
they fail identically on an untouched `main` checkout.
