### PR TITLE
fix(ci): let Extended CI's red mean a regression again

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -90,6 +90,12 @@ jobs:
   e2e-docs:
     name: Documented surface e2e
     uses: ./.github/workflows/e2e-docs.yml
+    with:
+      # No hosted macOS runner can boot a guest (issue #3011), so blocking here
+      # would paint this run red every night for a reason no commit caused —
+      # and a lane that is always red is one nobody reads, which is how the
+      # claim-bearing lanes went stale before. Releases still block on it.
+      macos_blocks_on_unusable_host: false
 
 
   sdk-release-dry-run:

--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -17,6 +17,16 @@ name: Documented surface e2e
 
 on:
   workflow_call:
+    inputs:
+      macos_blocks_on_unusable_host:
+        description: >-
+          Whether a macOS host that cannot run any workload backend fails this
+          workflow. `release.yml` leaves it true so a tag still cannot be cut
+          without live macOS evidence. Extended CI passes false so its nightly
+          red means a regression rather than the standing hardware gap.
+        type: boolean
+        required: false
+        default: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -147,8 +157,65 @@ jobs:
             done
           done
 
+  # Split out of the job below so the same detection can mean two things to two
+  # callers. Releases must still stop dead on a macOS host that cannot boot a
+  # guest; a nightly that stops dead on it every single night reports the same
+  # red for a standing hardware gap as for a real regression, and a lane whose
+  # red never varies is one nobody reads. Neither caller gets to weaken the
+  # other: this job fails for `release.yml` and reports `supported=false` for
+  # Extended CI, off one probe.
+  e2e-docs-macos-host-check:
+    name: Documented surface e2e (macOS, host check)
+    runs-on: macos-15-intel
+    timeout-minutes: 10
+    outputs:
+      supported: ${{ steps.preflight.outputs.supported }}
+    steps:
+      # Fail in seconds, naming the real constraint, instead of spending ~35
+      # minutes building and then dying on "pipe inject config to supervisor" —
+      # which reads as a supervisor bug rather than as a host that cannot run
+      # one.
+      #
+      # No GitHub-hosted macOS runner can boot an mvm guest today:
+      #
+      #   arm64 (macos-latest)  Hypervisor.framework is nested and reports
+      #                         HV_UNSUPPORTED. libkrun goes through the same
+      #                         framework, so it does not escape this either —
+      #                         the passing `libkrun (macOS Apple Silicon)` job
+      #                         builds, tests and lints, and never boots.
+      #   x86_64 (this runner)  has the virtualization extensions, but
+      #                         `mvm-hvf-supervisor` is Apple-Silicon-only and
+      #                         links as a stub, and the libkrun Homebrew
+      #                         formula is ARM-only so it cannot be installed.
+      #
+      # This lane needs a self-hosted Apple Silicon runner — see issue #3011.
+      # The probe is a live `uname`, not the `runs-on` label, so pointing this
+      # workflow at such a runner is the whole change: the lane starts running
+      # for both callers with nothing here to remember to flip back.
+      - name: Preflight — this host can run the workload backend
+        id: preflight
+        env:
+          BLOCKS: ${{ inputs.macos_blocks_on_unusable_host }}
+        run: |
+          set -euo pipefail
+          arch="$(uname -m)"
+          echo "runner arch: $arch"
+          if [ "$arch" = "arm64" ]; then
+            echo "supported=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "supported=false" >> "$GITHUB_OUTPUT"
+          reason="mvm-hvf-supervisor is Apple-Silicon-only and links as a stub on $arch, and the libkrun Homebrew formula is ARM-only. No workload backend can start here. This lane needs a self-hosted Apple Silicon runner; see issue #3011."
+          if [ "$BLOCKS" = "true" ]; then
+            echo "::error::$reason" >&2
+            exit 1
+          fi
+          echo "::warning::$reason Skipping the macOS documented-surface lane for this caller; it remains a hard requirement for releases."
+
   e2e-docs-macos:
     name: Documented surface e2e (macOS, HVF)
+    needs: e2e-docs-macos-host-check
+    if: needs.e2e-docs-macos-host-check.outputs.supported == 'true'
     # The macOS default backend is HVF, and every guest-booting BDD scenario
     # before this one carried `@firecracker` — so the backend most users run
     # had no lane that booted anything. This is that lane.
@@ -170,38 +237,6 @@ jobs:
       MVM_BUILDER_BACKEND: hvf
     steps:
       - uses: actions/checkout@v6
-
-      # Fail in seconds, naming the real constraint, instead of spending ~35
-      # minutes building and then dying on "pipe inject config to supervisor" —
-      # which reads as a supervisor bug rather than as a host that cannot run
-      # one.
-      #
-      # No GitHub-hosted macOS runner can boot an mvm guest today:
-      #
-      #   arm64 (macos-latest)  Hypervisor.framework is nested and reports
-      #                         HV_UNSUPPORTED. libkrun goes through the same
-      #                         framework, so it does not escape this either —
-      #                         the passing `libkrun (macOS Apple Silicon)` job
-      #                         builds, tests and lints, and never boots.
-      #   x86_64 (this runner)  has the virtualization extensions, but
-      #                         `mvm-hvf-supervisor` is Apple-Silicon-only and
-      #                         links as a stub, and the libkrun Homebrew
-      #                         formula is ARM-only so it cannot be installed.
-      #
-      # This lane needs a self-hosted Apple Silicon runner. Until one exists it
-      # is red by construction — see issue #3011 — and it is a release blocker on
-      # purpose: a tag
-      # cut without it is a tag with no evidence that the documented examples
-      # boot on macOS at all.
-      - name: Preflight — this host can run the workload backend
-        run: |
-          set -euo pipefail
-          arch="$(uname -m)"
-          echo "runner arch: $arch"
-          if [ "$arch" != "arm64" ]; then
-            echo "::error::mvm-hvf-supervisor is Apple-Silicon-only and links as a stub on $arch, and the libkrun Homebrew formula is ARM-only. No workload backend can start here. This lane needs a self-hosted Apple Silicon runner; see issue #3011." >&2
-            exit 1
-          fi
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
   # README works.
   e2e-docs:
     uses: ./.github/workflows/e2e-docs.yml
+    with:
+      # Stated rather than inherited. A tag must not be cut without live macOS
+      # evidence, so a macOS host that cannot boot a guest fails this workflow
+      # here even though Extended CI tolerates it nightly.
+      macos_blocks_on_unusable_host: true
 
   build:
     strategy:

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -398,6 +398,18 @@ for detailed scope and acceptance criteria.
       same wrong conclusion two authors already reached independently. Wired
       into `check-all`, so it runs on every PR. See
       `specs/sprint/delivery/vcpu-ceiling-gate-refuses-wire-type-limits.md`.
+      Closed out by issue #3099, which asked the same question of the fourth
+      backend and answered it the other way: QEMU declares no ceiling on
+      purpose. Its limit belongs to the machine type (255 on the x86_64
+      default, 288 reported for q35, 512 on aarch64 `virt`) and the driver
+      names no machine on x86_64, so any constant is the distribution's to
+      change; querying is worse, since `query-machines` reports a `cpu-max` for
+      q35 that the same machine refuses to start; and no host-side ceiling is
+      observable anyway, because the guest kernel's `CONFIG_NR_CPUS` binds
+      first at 64. A clamp warning is truthful only where the declared ceiling
+      is the binding one, which is true on Firecracker and libkrun and never on
+      QEMU. See
+      `specs/sprint/delivery/qemu-declares-no-vcpu-ceiling-on-purpose.md`.
 
 - [x] **virtiofsd sandbox parity — issue #3022.**
       `specs/plans/2026-08-31-virtiofsd-sandbox-parity.md`.

--- a/specs/sprint/delivery/extended-ci-red-must-mean-a-regression.md
+++ b/specs/sprint/delivery/extended-ci-red-must-mean-a-regression.md
@@ -1,0 +1,80 @@
+# Extended CI's red has to mean a regression, not the standing macOS gap
+
+Extended CI has been red since 2026-08-29 and is red on current main. Three
+jobs fail, and one of them **cannot pass**: the documented-surface macOS lane
+detects in 41 seconds that no GitHub-hosted macOS runner can boot an mvm guest
+and fails on purpose, naming issue #3011.
+
+That was a deliberate choice and the reasoning behind it is sound — a tag cut
+without live macOS evidence is a tag with no evidence its own README works, and
+`release.yml` lists `e2e-docs` in `needs:` precisely so that cannot happen. The
+problem is that the same job serves a second caller with a different question.
+Extended CI runs nightly. A nightly whose red never varies reports the same
+colour for a missing runner as for a real regression, so nobody reads it — which
+is exactly how the claim-bearing lanes went stale before, `app-deps-audit`
+having been cited by ADR-001 for months while running zero times.
+
+So the fix is not to stop blocking. It is to let one probe mean two things to
+two callers.
+
+## What changed
+
+`e2e-docs.yml` gains a `workflow_call` input,
+`macos_blocks_on_unusable_host`, defaulting to **true**. The arch preflight
+moves out of the macOS job into its own `e2e-docs-macos-host-check` job, which
+runs the same live `uname -m` and then either fails (blocking caller) or reports
+`supported=false` and lets the lane skip (non-blocking caller). The macOS lane
+itself becomes `needs:` that check, gated on `supported == 'true'`.
+
+- `release.yml` passes `true` — stated at the call site rather than inherited,
+  so the gate is visible where the decision matters. Release behaviour is
+  **unchanged**: a hosted macOS host still fails the workflow and still blocks
+  the tag.
+- `ci-full.yml` passes `false` — the nightly skips the lane with a warning
+  annotation that names #3011, and its red goes back to meaning a commit broke
+  something.
+
+The default is the safe one on purpose: a future caller that says nothing gets
+blocking, so the opt-out cannot spread by omission.
+
+## Why the probe stays a live `uname`
+
+Resolving #3011 means pointing `runs-on` at a self-hosted Apple Silicon runner.
+Keying the skip to the runner *label* would mean the lane kept skipping on
+hardware that can run it, and the gap would close with the evidence silently
+never coming back. Keying it to the host means the retarget is the whole change
+— the lane starts running for both callers with nothing to remember to flip.
+
+## Tests
+
+Three, in `tests/github_actions_extended_e2e.rs`. Nothing previously pinned any
+of this, so the release gate could have been turned off by editing one line
+with every test still green.
+
+- `releases_still_block_on_a_macos_host_that_cannot_boot_a_guest` — the safety
+  property. Verified by mutation: flipping `release.yml` to `false` fails it.
+- `the_macos_host_gate_defaults_to_blocking` — a `false` default would make
+  every future caller non-blocking by omission.
+- `the_macos_lane_runs_whenever_the_host_probe_says_the_host_can_boot` — pins
+  the probe to `uname` and the lane to the check's output.
+
+`actionlint` clean on all three workflows.
+
+## Not addressed here
+
+The other two Extended CI failures are real and stay red, which is now the
+point:
+
+- **Linux, Firecracker e2e** — `doctor found issues`, an entrypoint boot
+  failure, and `control frame read failed` / `session i/o error: Resource
+  temporarily unavailable (os error 11)`, the same EAGAIN signature as the
+  closed #3052. The recipe was then terminated by signal 15 at 81 minutes.
+- **Aarch64 no-KVM bundle smoke (QEMU TCG)** — SIGTERM 5m12s in with its output
+  redirected to a file, so nothing was captured. The job's `timeout-minutes` is
+  300, so that is not the cause.
+
+Both need diagnosis on real hardware rather than log-reading. They are the work
+this change makes visible.
+
+The vCPU clamp failure that was in this lane is **gone** — it was the pre-fix
+`u8::MAX` ceiling and the run reporting it predated the fix.

--- a/tests/github_actions_extended_e2e.rs
+++ b/tests/github_actions_extended_e2e.rs
@@ -45,6 +45,88 @@ fn the_release_workflow_waits_for_the_documented_surface() {
     );
 }
 
+/// The release gate must be stated at the release call site, not inherited.
+///
+/// No GitHub-hosted macOS runner can boot an mvm guest (issue #3011), so the
+/// macOS lane fails on every hosted host. Extended CI opts out of that failure
+/// nightly — otherwise its red never varies and stops being read at all — and
+/// the danger in having an opt-out is that the release caller quietly acquires
+/// it too. Then a tag cuts with no live macOS evidence and nothing says so,
+/// which is the same silent-gate failure that let `machine run -it` ship broken
+/// on every OCI image.
+#[test]
+fn releases_still_block_on_a_macos_host_that_cannot_boot_a_guest() {
+    let workflow =
+        fs::read_to_string(".github/workflows/release.yml").expect("read release workflow");
+    assert!(
+        workflow.contains("macos_blocks_on_unusable_host: true"),
+        "release.yml must block on an unusable macOS host, or a tag is cut with \
+         no evidence the documented examples boot on macOS"
+    );
+
+    let extended =
+        fs::read_to_string(".github/workflows/ci-full.yml").expect("read extended CI workflow");
+    assert!(
+        extended.contains("macos_blocks_on_unusable_host: false"),
+        "Extended CI must tolerate the standing hardware gap, or its nightly red \
+         reports the same thing for a missing runner as for a regression"
+    );
+}
+
+/// The two callers must disagree, and the default must be the safe one.
+///
+/// A `workflow_call` input that defaults to false would make every future
+/// caller non-blocking by omission — the failure mode this split exists to
+/// prevent, reintroduced one level up.
+#[test]
+fn the_macos_host_gate_defaults_to_blocking() {
+    let workflow = extended_ci();
+    let inputs = workflow
+        .split("jobs:")
+        .next()
+        .expect("the workflow must declare its triggers before its jobs");
+    assert!(
+        inputs.contains("macos_blocks_on_unusable_host:"),
+        "the shared workflow must declare the macOS host gate as an input"
+    );
+    assert!(
+        inputs.contains("default: true"),
+        "the macOS host gate must default to blocking, so a caller that says \
+         nothing gets the release-safe behaviour"
+    );
+}
+
+/// The lane is skipped by the host check, never by a hardcoded runner label.
+///
+/// Pointing `runs-on` at a self-hosted Apple Silicon runner has to be the whole
+/// of resolving #3011. If the skip were keyed to the label rather than to a
+/// live `uname`, the lane would keep skipping on hardware that can run it, and
+/// the gap would close without anyone noticing the evidence never came back.
+#[test]
+fn the_macos_lane_runs_whenever_the_host_probe_says_the_host_can_boot() {
+    let workflow = extended_ci();
+    let check = job_block(&workflow, "e2e-docs-macos-host-check");
+    assert!(
+        check.contains("uname -m"),
+        "the host check must probe the live host, not the runner label"
+    );
+    assert!(
+        check.contains("supported=true"),
+        "the host check must report a usable host to its dependents"
+    );
+
+    let macos = job_block(&workflow, "e2e-docs-macos");
+    assert!(
+        macos.contains("needs: e2e-docs-macos-host-check"),
+        "the macOS lane must wait on the host check"
+    );
+    assert!(
+        macos.contains("if: needs.e2e-docs-macos-host-check.outputs.supported == 'true'"),
+        "the macOS lane must run exactly when the host probe says the host can \
+         boot a guest"
+    );
+}
+
 fn documented_surface_script() -> String {
     fs::read_to_string("scripts/e2e-documented-surface.sh").expect("read documented-surface runner")
 }


### PR DESCRIPTION
## The problem

Extended CI has been red since 2026-08-29 and is red on current main. One of
its three failing jobs **cannot pass**: the documented-surface macOS lane
detects in 41 seconds that no GitHub-hosted macOS runner can boot an mvm guest
and fails on purpose, naming #3011.

```
::error::mvm-hvf-supervisor is Apple-Silicon-only and links as a stub on x86_64,
and the libkrun Homebrew formula is ARM-only. No workload backend can start
here. This lane needs a self-hosted Apple Silicon runner; see issue #3011.
```

The blocking is right and I have not weakened it. A tag cut without live macOS
evidence has no evidence its own README works — that is why `release.yml` lists
`e2e-docs` in `needs:`.

But the same job answers a second caller asking a different question. Extended
CI runs nightly, and **a nightly whose red never varies reports the same colour
for a missing runner as for a real regression**, so nobody reads it. That is
precisely how `app-deps-audit` was cited by ADR-001 for months while running
zero times.

## The change

One probe, two meanings, chosen by the caller.

The arch preflight moves out of the macOS job into `e2e-docs-macos-host-check`,
which runs the same live `uname -m` and then either fails (blocking caller) or
reports `supported=false` (non-blocking caller). The macOS lane becomes
`needs:` that check, gated on `supported == 'true'`.

| caller | input | behaviour |
| --- | --- | --- |
| `release.yml` | `macos_blocks_on_unusable_host: true` | **unchanged** — hosted macOS host fails the workflow, blocks the tag |
| `ci-full.yml` | `macos_blocks_on_unusable_host: false` | skips the lane with a warning naming #3011 |

The input **defaults to `true`**, so a future caller that says nothing gets the
release-safe behaviour and the opt-out cannot spread by omission. The release
value is stated at the call site rather than inherited, so the gate is visible
where the decision matters.

## Why the probe stays a live `uname`

Resolving #3011 means pointing `runs-on` at a self-hosted Apple Silicon runner.
Keyed to the runner *label*, the lane would keep skipping on hardware that can
run it and the evidence would silently never come back. Keyed to the host, the
retarget is the whole change — the lane starts running for both callers with
nothing to remember to flip.

## Tests

Three, and **none of this was pinned before** — the release gate could have been
switched off by editing one line with every test still green.

- `releases_still_block_on_a_macos_host_that_cannot_boot_a_guest` — the safety
  property. Verified by mutation: flipping `release.yml` to `false` fails it.
- `the_macos_host_gate_defaults_to_blocking` — a `false` default would make
  every future caller non-blocking by omission.
- `the_macos_lane_runs_whenever_the_host_probe_says_the_host_can_boot` — pins
  the probe to `uname` and the lane to the check's output.

## What stays red, deliberately

The other two failures are real and are now the only thing Extended CI's red
will mean:

- **Linux, Firecracker e2e** — `doctor found issues`, an entrypoint boot
  failure, and `control frame read failed` / `session i/o error: Resource
  temporarily unavailable (os error 11)` — the same EAGAIN signature as the
  closed #3052. Recipe then terminated by signal 15 at 81 minutes.
- **Aarch64 no-KVM bundle smoke (QEMU TCG)** — SIGTERM 5m12s in with its output
  redirected to a file, so nothing was captured. `timeout-minutes` is 300, so
  that is not the cause.

Both need diagnosis on hardware rather than log-reading. The vCPU clamp failure
that used to be in this lane is **gone** — it was the pre-fix wire-type ceiling,
and the run reporting it predated #3098.

Also carries the #3099 closeout into `specs/REFACTOR-STATUS.md`, which the qemu
vCPU change should have included and did not.

## Validation

`actionlint` clean on all three workflows · `check-all` 67 gates clean ·
`cargo nextest run --workspace` 12966 passed · doctests clean ·
`clippy --all-targets -D warnings` clean · `cargo fmt --all --check` clean.
