### PR TITLE
fix(build): the typed persistent route read back an empty export

### DIFF
--- a/crates/mvm-build/src/pipeline/dev_build.rs
+++ b/crates/mvm-build/src/pipeline/dev_build.rs
@@ -657,6 +657,26 @@ fn try_typed_persistent_build(
     use crate::builder_vm::host_system_linux;
     use crate::libkrun_builder::GUEST_WORK_DIR;
 
+    // This route reaches its artifacts through the `/job` share: it stages into
+    // a host directory and tells the daemon to export to the guest path the
+    // share backs. A disk-transport session has no such share — the record's
+    // own `job_dir` doc says the guest never sees that path — and the transport
+    // collects `/out`, not `/job/<id>/out`. Running anyway stages into a
+    // directory nothing writes to and reads it back empty.
+    //
+    // Fall through to the single-shot builder rather than refusing outright:
+    // unlike the install arm, which fails closed because a claim-11 sealed
+    // volume would silently lose its SBOM and CVE sidecars, this route has a
+    // safety net and taking it costs build time rather than correctness.
+    if record.disk_transport.is_some() {
+        tracing::warn!(
+            session_id = %record.session_id,
+            "persistent session uses the disk transport, which does not read back \
+             /job/<id>/out; falling through to the single-shot builder"
+        );
+        return None;
+    }
+
     let system = host_system_linux();
     let attr_path = match profile {
         Some(p) if p != "default" => format!("packages.{system}.tenant-{p}"),
@@ -750,12 +770,26 @@ fn finalize_typed_persistent_build(
 
 #[cfg(feature = "builder-vm")]
 fn copy_staged_artifacts(staging: &str, final_dir: &str) -> Result<()> {
+    let mut copied = 0usize;
     for entry in
         std::fs::read_dir(staging).with_context(|| format!("reading staging dir {staging}"))?
     {
         let entry = entry?;
         let dst = std::path::Path::new(final_dir).join(entry.file_name());
         copy_staged_artifact(&entry.path(), &dst)?;
+        copied += 1;
+    }
+    // An empty export is a failed build that looked like a successful one. The
+    // loop above simply does not run, so this returned `Ok` and the caller went
+    // on to build `vmlinux`/`rootfs.ext4` paths for files that were never
+    // written, log "build complete", and hand back a `DevBuildResult` — with the
+    // real failure surfacing much later, at boot, far from its cause. Refusing
+    // here also keeps it out of the persistent route's fallback, which only
+    // triggers on an `Err`.
+    if copied == 0 {
+        anyhow::bail!(
+            "the builder exported no artifacts to {staging}; the build produced nothing to copy"
+        );
     }
     Ok(())
 }
@@ -926,6 +960,45 @@ fn nix_system() -> &'static str {
         "aarch64-linux"
     } else {
         "x86_64-linux"
+    }
+}
+
+#[cfg(all(test, feature = "builder-vm"))]
+mod typed_export_tests {
+    use super::*;
+
+    #[test]
+    fn an_empty_export_is_an_error_rather_than_an_empty_success() {
+        // The regression this guards: the copy loop over an empty directory
+        // does not run, so it used to return Ok and the caller went on to
+        // report a complete build whose vmlinux and rootfs paths named files
+        // that were never written.
+        let scratch = tempfile::tempdir().unwrap();
+        let staging = scratch.path().join("out");
+        let final_dir = scratch.path().join("final");
+        std::fs::create_dir_all(&staging).unwrap();
+        std::fs::create_dir_all(&final_dir).unwrap();
+
+        let err = copy_staged_artifacts(staging.to_str().unwrap(), final_dir.to_str().unwrap())
+            .expect_err("an empty export must not look like a successful build");
+        assert!(
+            err.to_string().contains("exported no artifacts"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn a_populated_export_still_copies() {
+        let scratch = tempfile::tempdir().unwrap();
+        let staging = scratch.path().join("out");
+        let final_dir = scratch.path().join("final");
+        std::fs::create_dir_all(&staging).unwrap();
+        std::fs::create_dir_all(&final_dir).unwrap();
+        std::fs::write(staging.join("vmlinux"), b"kernel").unwrap();
+
+        copy_staged_artifacts(staging.to_str().unwrap(), final_dir.to_str().unwrap())
+            .expect("a populated export copies");
+        assert_eq!(std::fs::read(final_dir.join("vmlinux")).unwrap(), b"kernel");
     }
 }
 

--- a/specs/sprint/delivery/typed-build-disk-transport-gap.md
+++ b/specs/sprint/delivery/typed-build-disk-transport-gap.md
@@ -1,0 +1,60 @@
+# The typed persistent route reads back an empty export
+
+`/job` had two consumers and #3061 migrated one of them.
+
+`persistent_builder_spec` now declares no shares, so a persistent HVF session
+exchanges everything over the transport disks. The CLI dispatch path was updated
+with it (`repack_dispatch_input` / `read_dispatch_artifacts`), and the install
+arm was made to refuse outright, because the transport collects `/out` and not
+`/job/<job_id>/out`.
+
+`dev_build.rs` was not touched, and it is the other consumer.
+`try_typed_persistent_build` still creates `<job_dir>/<uuid>/out` on the host and
+tells `mvm-builderd` to export to the guest path `/job/<uuid>/out` — a path the
+session record's own field doc now describes as one "the guest never sees" when
+`disk_transport` is set.
+
+## Why it failed silently rather than loudly
+
+`copy_staged_artifacts` iterates the export directory. Over an empty directory
+the loop body never runs and it returned `Ok(())`. `finalize_typed_persistent_build`
+then composed `vmlinux` and `rootfs.ext4` paths as strings without checking they
+exist, logged "Builder VM build complete (typed)", and returned a
+`DevBuildResult`.
+
+Two consequences, and the second is the worse one:
+
+- The failure surfaced later, at boot, far from its cause.
+- Returning `Ok` **bypassed the single-shot fallback**, which only triggers on an
+  `Err`. The safety net was there and could not fire.
+
+## The fix, in two parts
+
+**Fall through when the session uses the transport.** `try_typed_persistent_build`
+returns `None` — the "no typed route available" signal — with a warning naming
+the reason. Falling through rather than refusing is deliberate and differs from
+the install arm: that one fails closed because a claim-11 sealed volume would
+silently lose its SBOM and CVE sidecars, whereas this route has a working
+single-shot fallback and taking it costs build time, not correctness.
+
+**Make an empty export an error everywhere.** `copy_staged_artifacts` counts what
+it copied and bails on zero. This is the part that matters beyond this bug: any
+future path that exports nothing now fails loudly at the point of failure instead
+of producing a `DevBuildResult` naming files that were never written.
+
+## Scope and what is not claimed
+
+Found by reading, not by reproducing. Confirming it live means starting a
+persistent HVF session and running a build through it, which needs the hidden
+`mvmctl persistent-builder` subcommand; the reasoning is `disk_transport.is_some()`
+on one side and no writer for `host_out` on the other, both verifiable in the
+tree. The empty-export half is directly unit-tested.
+
+The persistent route is opt-in, hidden, and falls back, so the blast radius is
+build time on an explicitly-started session — not a broken default build.
+
+## Verification
+
+`cargo fmt --all --check`, `just check-gated`, `cargo clippy --workspace
+--all-targets -D warnings`, `cargo nextest run --workspace` (12,965 passed),
+`cargo test --workspace --doc`, `cargo run -p xtask -- check-all` (67 gates).


### PR DESCRIPTION
# The typed persistent route reads back an empty export

`/job` had two consumers and #3061 migrated one of them.

`persistent_builder_spec` now declares no shares, so a persistent HVF session
exchanges everything over the transport disks. The CLI dispatch path was updated
with it (`repack_dispatch_input` / `read_dispatch_artifacts`), and the install
arm was made to refuse outright, because the transport collects `/out` and not
`/job/<job_id>/out`.

`dev_build.rs` was not touched, and it is the other consumer.
`try_typed_persistent_build` still creates `<job_dir>/<uuid>/out` on the host and
tells `mvm-builderd` to export to the guest path `/job/<uuid>/out` — a path the
session record's own field doc now describes as one "the guest never sees" when
`disk_transport` is set.

## Why it failed silently rather than loudly

`copy_staged_artifacts` iterates the export directory. Over an empty directory
the loop body never runs and it returned `Ok(())`. `finalize_typed_persistent_build`
then composed `vmlinux` and `rootfs.ext4` paths as strings without checking they
exist, logged "Builder VM build complete (typed)", and returned a
`DevBuildResult`.

Two consequences, and the second is the worse one:

- The failure surfaced later, at boot, far from its cause.
- Returning `Ok` **bypassed the single-shot fallback**, which only triggers on an
  `Err`. The safety net was there and could not fire.

## The fix, in two parts

**Fall through when the session uses the transport.** `try_typed_persistent_build`
returns `None` — the "no typed route available" signal — with a warning naming
the reason. Falling through rather than refusing is deliberate and differs from
the install arm: that one fails closed because a claim-11 sealed volume would
silently lose its SBOM and CVE sidecars, whereas this route has a working
single-shot fallback and taking it costs build time, not correctness.

**Make an empty export an error everywhere.** `copy_staged_artifacts` counts what
it copied and bails on zero. This is the part that matters beyond this bug: any
future path that exports nothing now fails loudly at the point of failure instead
of producing a `DevBuildResult` naming files that were never written.

## Scope and what is not claimed

Found by reading, not by reproducing. Confirming it live means starting a
persistent HVF session and running a build through it, which needs the hidden
`mvmctl persistent-builder` subcommand; the reasoning is `disk_transport.is_some()`
on one side and no writer for `host_out` on the other, both verifiable in the
tree. The empty-export half is directly unit-tested.

The persistent route is opt-in, hidden, and falls back, so the blast radius is
build time on an explicitly-started session — not a broken default build.

## Verification

`cargo fmt --all --check`, `just check-gated`, `cargo clippy --workspace
--all-targets -D warnings`, `cargo nextest run --workspace` (12,965 passed),
`cargo test --workspace --doc`, `cargo run -p xtask -- check-all` (67 gates).
