### PR TITLE
fix(ci): fix the two Extended CI failures that were not the product

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -548,6 +548,14 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$MVM_HOME"
+          # Print the captured log on *any* death, not only on a wrong exit
+          # code. The tail used to live inside the `-ne 7` branch, so a run
+          # killed before that branch — which is exactly what happened when
+          # this step was SIGTERMed five minutes in — emitted nothing at all:
+          # the whole boot is redirected to the file, and the file was never
+          # read. The job reported `exit code 143` over an empty step and there
+          # was nothing to diagnose it with.
+          trap 'echo "::group::mvmctl first-boot log (tail)"; tail -250 /tmp/mvmctl-first-boot.log 2>/dev/null || echo "(no log produced)"; echo "::endgroup::"' EXIT
           set +e
           /tmp/mvmctl-source-under-test machine run \
             --flake examples/exit_code \
@@ -560,7 +568,6 @@ jobs:
           set -e
           if [ "$actual" -ne 7 ]; then
             echo "::error::expected guest exit code 7 from first boot, got $actual"
-            tail -250 /tmp/mvmctl-first-boot.log
             exit 1
           fi
           echo "ok: sealed aarch64 workload built and exited $actual under QEMU TCG"

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -31,6 +31,23 @@ REPO="$PWD"
 # That made worktree-based e2e work impossible by construction, so every
 # verification had to run in the main checkout.
 E2E_HOME="${MVM_E2E_HOME:-${MVM_HOME:-$HOME/.mvm}}"
+
+# Create the mvm home the way mvmctl would, not the way a bare mkdir would.
+#
+# With `MVM_E2E_HOME` unset this falls back to the real `$HOME/.mvm`, and
+# creating that under the runner's umask leaves it 0755. That is a live W1.5
+# violation — `~/.mvm` and every child are 0700 — and the suite's own
+# `mvmctl doctor` scenario duly reports `data dir mode: MISSING (expected
+# 0700, got 0755)`. The lane then goes red for a directory this harness made
+# wrong before mvmctl ever saw it.
+#
+# The chmod is unconditional rather than folded into `mkdir -m`, which applies
+# the mode only to directories it actually creates: a home left loose by an
+# earlier run would otherwise keep that mode forever.
+ensure_private_home() {
+  mkdir -p "$1"
+  chmod 700 "$1"
+}
 TARGET_DIR="${CARGO_TARGET_DIR:-target}"
 MVMCTL="$TARGET_DIR/debug/mvmctl"
 UNEMBEDDED_MVMCTL="$E2E_HOME/mvmctl-unembedded-e2e"
@@ -63,7 +80,7 @@ machine_names() {
 }
 
 snapshot_machines() {
-  mkdir -p "$E2E_HOME"
+  ensure_private_home "$E2E_HOME"
   machine_names > "$SNAPSHOT" 2>/dev/null || : > "$SNAPSHOT"
 }
 
@@ -209,7 +226,7 @@ if [[ -f "$LOCK" ]] && kill -0 "$(cat "$LOCK" 2>/dev/null)" 2>/dev/null; then
   trap - EXIT
   exit 1
 fi
-mkdir -p "$E2E_HOME"
+ensure_private_home "$E2E_HOME"
 echo $$ > "$LOCK"
 release_lock() { [[ -f "$LOCK" ]] && [[ "$(cat "$LOCK" 2>/dev/null)" == "$$" ]] && rm -f "$LOCK"; }
 

--- a/specs/sprint/delivery/two-extended-ci-failures-were-the-harness-not-the-product.md
+++ b/specs/sprint/delivery/two-extended-ci-failures-were-the-harness-not-the-product.md
@@ -1,0 +1,83 @@
+# Two of Extended CI's failures were the harness, and one could not be read at all
+
+Extended CI's nightly is red on current main. Splitting the standing macOS
+hardware gap out of the signal left three real failures to look at. Two of them
+turn out not to be product defects, and this fixes both — plus the reason the
+third could not be diagnosed.
+
+## `doctor found issues` — the harness made the directory wrong
+
+```
+data dir mode: MISSING (expected 0700, got 0755 at /home/runner/.mvm)
+```
+
+`scripts/e2e-documented-surface.sh` resolves `E2E_HOME` to
+`${MVM_E2E_HOME:-${MVM_HOME:-$HOME/.mvm}}`. On CI neither override is set, so
+it is the real `$HOME/.mvm` — and the script created it with a bare `mkdir -p`,
+which leaves the runner's umask on it. The suite then runs its own `mvmctl
+doctor` scenario, which correctly reports a W1.5 violation on a directory the
+harness itself had made wrong before mvmctl ever saw it.
+
+The suite now creates it the way mvmctl would. The chmod is unconditional
+rather than folded into `mkdir -m`, which applies a mode only to directories it
+actually creates — a home left loose by an earlier run would otherwise keep
+that mode forever. Verified under `umask 022`: bare creation gives 0755, the
+helper gives 0700.
+
+**This exposed something larger, which is filed as issue #3111 rather than
+fixed here.** A 0755 home survived an entire suite run, through many `mvmctl`
+invocations that wrote into it, because
+`mvm_core::config::ensure_home_dir` — the helper that creates *and repairs* the
+mode — has **no callers anywhere in the workspace**. W1.5 is enforced by
+nothing; it holds only when the directory happens to be made by a path that
+chmods. `cleanup.rs` even documents the repair as something that happens
+("re-established... by whichever command next calls `ensure_home_dir()`"), and
+no command does. Note the shape: `ensure_private_dir` is unit-tested and
+passes, so the mechanism is proven while the wiring is absent — the same defect
+CLAUDE.md records for claim 13, and invisible to a green test run either way.
+Where the call belongs is a real design question (CLI startup writes `~/.mvm`
+on `--help` and during hermetic tests; per-use is a list that rots), so it gets
+its own issue rather than a guess appended to a CI fix.
+
+## The aarch64 smoke printed nothing, so nobody could diagnose it
+
+The job reported `Process completed with exit code 143` over a step with **no
+output whatsoever**. The boot is redirected wholesale to
+`/tmp/mvmctl-first-boot.log`, and the `tail` sat inside the `-ne 7` branch — so
+a run killed before reaching that branch read the file never. Five minutes in,
+SIGTERM, empty step, nothing to go on.
+
+The dump now runs from an `EXIT` trap armed before the boot, so it fires on any
+death. The exit-code assertion is unchanged. This does not fix whatever killed
+the step; it is the prerequisite for finding out, and without it the next
+nightly would have been equally silent.
+
+## What this does not fix
+
+- **The Linux job's termination** was not ours at all:
+  `The runner has received a shutdown signal. This can happen when the runner
+  service is stopped, or a manually started runner is canceled.` GitHub
+  reclaimed the runner 81 minutes in, against a 120-minute job timeout and a
+  3600-second suite watchdog that had not fired. The suite's own trap printed
+  `!!! interrupted — cleaning up`, not `!!! TIMEOUT`.
+- **Two genuine live-VM failures remain**, both needing reproduction on real
+  hardware rather than log-reading:
+  - `documented_build_live.feature:27` — `builder egress endpoint pid=… exited
+    with status signal: 15 (SIGTERM)` then `Error: Booting VM for the
+    entrypoint call`.
+  - `hvf_egress_observable.feature:18` — `Error: control frame read failed`,
+    `session i/o error: Resource temporarily unavailable (os error 11)`. Same
+    EAGAIN signature as the closed #3052.
+
+## Tests
+
+Both fixes are structural and both are pinned, in
+`tests/github_actions_extended_e2e.rs`:
+
+- `the_documented_surface_creates_its_mvm_home_private` — refuses the bare
+  creation and requires the unconditional chmod.
+- `the_aarch64_smoke_prints_its_boot_log_on_any_failure` — requires the dump to
+  be armed *before* the run, since a trap installed after it would have the
+  same blind spot as the branch it replaces.
+
+`actionlint` clean; `bash -n` clean.

--- a/tests/github_actions_extended_e2e.rs
+++ b/tests/github_actions_extended_e2e.rs
@@ -374,3 +374,50 @@ fn supervisor_build_requires_a_detected_libkrun_header() {
         "the libkrun-sys helper must only build after a real header is found"
     );
 }
+
+/// The suite must create the mvm home private, the way `mvmctl` would.
+///
+/// With `MVM_E2E_HOME` unset the home falls back to the real `$HOME/.mvm`, and
+/// creating it under the caller's umask leaves it 0755 on a CI runner. That is
+/// a W1.5 violation the suite's own `doctor` scenario then reports as `data dir
+/// mode: MISSING`, so the lane went red for a directory the harness made wrong
+/// before mvmctl ever saw it. Nothing repairs it either: the `ensure_home_dir`
+/// helper that would has no callers anywhere in the workspace.
+#[test]
+fn the_documented_surface_creates_its_mvm_home_private() {
+    let script = documented_surface_script();
+    assert!(
+        !script.contains("mkdir -p \"$E2E_HOME\""),
+        "the mvm home must not be created bare; the umask makes it 0755 and \
+         doctor fails the lane on it"
+    );
+    assert!(
+        script.contains("chmod 700 \"$1\""),
+        "the mvm home helper must chmod unconditionally — `mkdir -m` applies the \
+         mode only to directories it creates, leaving an already-loose home loose"
+    );
+}
+
+/// The aarch64 smoke must print its captured log however it dies.
+///
+/// The boot is redirected wholesale to a file, and the tail used to sit inside
+/// the wrong-exit-code branch, so a run killed before reaching that branch
+/// printed nothing at all: the job reported `exit code 143` over an empty step
+/// with no way to tell what the guest had been doing. A lane that cannot say
+/// why it failed is one nobody can fix.
+#[test]
+fn the_aarch64_smoke_prints_its_boot_log_on_any_failure() {
+    let workflow =
+        fs::read_to_string(".github/workflows/ci-full.yml").expect("read extended CI workflow");
+    let trap = workflow
+        .find("trap 'echo \"::group::mvmctl first-boot log (tail)\"")
+        .expect("the first-boot step must dump its log from an EXIT trap");
+    let branch = workflow
+        .find("expected guest exit code 7 from first boot")
+        .expect("the first-boot step must still assert the exit code");
+    assert!(
+        trap < branch,
+        "the log dump must be armed before the run, or a death that skips the \
+         exit-code branch still prints nothing"
+    );
+}


### PR DESCRIPTION
Follow-on to #3108, which separated the standing macOS hardware gap from
Extended CI's signal. With that split out, three real failures remained. **Two
were the harness, not the product** — and the third could not be diagnosed at
all, because its step discarded every byte it produced.

## `doctor found issues` — the harness made the directory wrong

```
data dir mode: MISSING (expected 0700, got 0755 at /home/runner/.mvm)
```

`scripts/e2e-documented-surface.sh` resolves `E2E_HOME` to
`${MVM_E2E_HOME:-${MVM_HOME:-$HOME/.mvm}}`. On CI neither override is set, so it
is the real `$HOME/.mvm` — and the script created it bare, leaving the runner's
umask on it. The suite then runs its own `mvmctl doctor` scenario, which
correctly flags a W1.5 violation on a directory **the harness itself made wrong
before mvmctl ever saw it**.

It now creates it the way mvmctl would. The chmod is unconditional rather than
folded into `mkdir -m`, which applies a mode only to directories it actually
creates — a home loosened by an earlier run would otherwise keep that mode
forever. Verified under `umask 022`: bare creation gives 0755, the helper gives
0700.

### This exposed something larger — filed as #3111, not fixed here

A 0755 home survived an *entire suite run*, through many `mvmctl` invocations
that wrote into it. The reason:

```
$ rg 'ensure_home_dir|ensure_cache_dir' --type rust
crates/mvm-core/src/config.rs:145:pub fn ensure_home_dir() ...
crates/mvm-core/src/config.rs:158:pub fn ensure_cache_dir() ...
```

Two definitions, **zero call sites**. The helper that creates *and repairs* the
0700 mode is dead code, so W1.5 is enforced by nothing — it holds only when the
directory happens to be made by a path that chmods. `cleanup.rs:441` even
documents the repair as a thing that happens ("re-established… by whichever
command next calls `ensure_home_dir()`"); no command does.

Note the shape: `ensure_private_dir` is unit-tested and passes, so the mechanism
is proven while the wiring is absent — the same defect CLAUDE.md records for
claim 13, and equally invisible to a green test run. Where the call belongs is a
genuine design question (CLI startup would write `~/.mvm` on `--help` and during
hermetic tests; per-use is a list that rots), so it gets an issue rather than a
guess appended to a CI fix.

## The aarch64 smoke printed nothing at all

The job reported `Process completed with exit code 143` over a step with **zero
output**. The boot is redirected wholesale to `/tmp/mvmctl-first-boot.log`, and
the `tail` sat inside the `-ne 7` branch — so a run killed before reaching that
branch never read the file. Five minutes in, SIGTERM, empty step.

The dump now runs from an `EXIT` trap armed *before* the boot, so it fires
however the step dies. The exit-code assertion is unchanged. This does not fix
whatever killed it — it is the prerequisite for finding out, and without it the
next nightly would be equally silent.

## What this deliberately does not fix

- **The Linux job's termination was not ours.** `The runner has received a
  shutdown signal. This can happen when the runner service is stopped, or a
  manually started runner is canceled.` GitHub reclaimed the runner 81 minutes
  in, against a 120-minute job timeout and a 3600s suite watchdog that never
  fired — the suite's trap printed `!!! interrupted`, not `!!! TIMEOUT`.
- **Two genuine live-VM failures remain**, both needing hardware to reproduce
  rather than more log-reading:
  - `documented_build_live.feature:27` — `builder egress endpoint pid=… exited
    with status signal: 15 (SIGTERM)`, then `Error: Booting VM for the
    entrypoint call`.
  - `hvf_egress_observable.feature:18` — `Error: control frame read failed` /
    `session i/o error: Resource temporarily unavailable (os error 11)`. Same
    EAGAIN signature as the closed #3052.

## Tests

Both fixes are structural and both are pinned in
`tests/github_actions_extended_e2e.rs`:

- `the_documented_surface_creates_its_mvm_home_private` — refuses the bare
  creation and requires the unconditional chmod.
- `the_aarch64_smoke_prints_its_boot_log_on_any_failure` — requires the dump to
  be armed **before** the run; a trap installed after it would have the same
  blind spot as the branch it replaces.

## Validation

`actionlint` clean · `bash -n` clean · `check-all` 67 gates clean ·
`cargo nextest run --workspace` 12965 passed · doctests clean ·
`clippy --all-targets -D warnings` clean · `cargo fmt --all --check` clean.
