### PR TITLE
fix(core): enforce the 0700 mvm-home posture at the creation seam

### DIFF
--- a/crates/mvm-cli/src/commands/env/cleanup.rs
+++ b/crates/mvm-cli/src/commands/env/cleanup.rs
@@ -437,8 +437,11 @@ fn selective_plan(data_root: &Path, cache_root: &Path, tier: Tier) -> CleanupPla
 
 /// The `--nuclear` plan: every entry under the mvm root, minus the
 /// identity material `--keep-identity` spares. The root directory
-/// itself survives so its 0700 mode cannot be re-established
-/// wrong by whichever command next calls `ensure_home_dir()`.
+/// itself survives so its 0700 mode cannot be re-established wrong by
+/// whichever command next writes under it. That used to name a helper
+/// which nothing called, so the re-establishment it described never
+/// happened; `mvm_core::config::create_private_dir` is what performs it
+/// now, on the whole chain, from any writer.
 ///
 /// This is deliberately defined by subtraction. The enumerated version
 /// it replaced named thirteen paths and therefore spared every state

--- a/crates/mvm-client/src/volume/lifecycle.rs
+++ b/crates/mvm-client/src/volume/lifecycle.rs
@@ -65,11 +65,16 @@ pub(crate) fn lock_staging_path(ciphertext_path: &Path) -> PathBuf {
     ciphertext_path.with_extension("locking")
 }
 
+/// Create a volume directory with the whole chain under the mvm home private.
+///
+/// A second copy of this used to live here, chmodding only the leaf. That is
+/// the ancestor bug: `create_dir_all` makes every missing parent at the
+/// process umask, so `~/.mvm/volumes/<id>/ciphertext` could arrive with two
+/// world-readable directories above it holding the same encrypted state.
+/// Delegating keeps one implementation of the rule rather than two that drift.
 pub(crate) fn ensure_private_dir(path: &Path) -> Result<()> {
-    fs::create_dir_all(path).with_context(|| format!("creating {}", path.display()))?;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
-        .with_context(|| format!("chmod 0700 {}", path.display()))?;
-    Ok(())
+    mvm_core::config::create_private_dir(path)
+        .with_context(|| format!("creating {} privately", path.display()))
 }
 
 /// Volume-name shape check for creation: the name doubles as the virtio-fs
@@ -273,7 +278,7 @@ pub(crate) fn create_host_backed(
             root.display()
         );
     }
-    fs::create_dir_all(&root)
+    ensure_private_dir(&root)
         .with_context(|| format!("creating managed volume root {}", root.display()))?;
     probe.require_encrypted(&root)?;
 
@@ -284,7 +289,7 @@ pub(crate) fn create_host_backed(
             host_path.display()
         );
     }
-    fs::create_dir_all(&host_path)
+    ensure_private_dir(&host_path)
         .with_context(|| format!("creating managed volume {}", host_path.display()))?;
     probe.require_encrypted(&host_path)?;
 

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -128,43 +128,26 @@ pub fn mvm_home_strict() -> std::io::Result<std::path::PathBuf> {
     Ok(std::path::PathBuf::from(home).join(".mvm"))
 }
 
-/// Create `~/.mvm` (or whatever `mvm_home()` resolves to) with
-/// mode `0700` and return its path. Idempotent: if the dir already
-/// exists with looser perms, chmod it to `0700` so a host that was
-/// created before this lockdown still gets locked down on the next
-/// run.
-///
-/// `~/.mvm` holds the dev VM's GC root, the host-backed Nix store
-/// disk image, the per-VM `vsock.sock` proxy listener path, build
-/// artifacts in `dev/builds/<rev>/`, and (for production microVMs)
-/// any persisted volumes — every secret-shaped piece of state in
-/// the project. Defaulting to umask perms (typ. 0755) means a
-/// same-host other user can read all of it; this is the project's
-/// privacy boundary.
-#[cfg(unix)]
-pub fn ensure_home_dir() -> std::io::Result<String> {
-    let dir = mvm_home();
-    ensure_private_dir(&dir)?;
-    Ok(dir)
-}
+// `~/.mvm` holds the dev VM's GC root, the host-backed Nix store disk image,
+// the per-VM `vsock.sock` proxy listener path, build artifacts, the host
+// signing key, the audit chain, and every persisted volume. Defaulting to
+// umask perms (typically 0755) means a same-host other user can read all of
+// it; 0700 on the whole tree is the project's privacy boundary, and one of
+// the numbered security claims states exactly that.
+//
+// This used to be `ensure_home_dir` and `ensure_cache_dir`, one per root.
+// Both were correct and neither was ever called — two `pub fn`s asserting an
+// invariant that no code path established, while a comment elsewhere
+// described the repair as something that happened on the next command. What
+// replaced them is a single helper called at the seam where directories are
+// actually made, because that is also the only place the *ancestors* can be
+// got right.
 
-/// Create `~/.mvm/cache` (or wherever `mvm_cache_dir()` resolves to)
-/// with mode `0700`. Same rationale as `ensure_home_dir`. The cache
-/// holds the dev image kernel/rootfs, daemon stdout/stderr logs,
-/// and the GC sentinel — none of it is secret on its own, but the
-/// daemon logs *do* capture guest stdout, which can leak whatever
-/// the guest prints. Lock it down by default.
+/// Chmod one directory to `0700`, leaving it alone if it is already
+/// there. Split out so [`create_private_dir`] can walk a chain of them
+/// without re-deciding the policy at each step.
 #[cfg(unix)]
-pub fn ensure_cache_dir() -> std::io::Result<String> {
-    let dir = mvm_cache_dir();
-    ensure_private_dir(&dir)?;
-    Ok(dir)
-}
-
-/// Create `dir` (and parents) and chmod it to mode `0700`. Both the
-/// initial create and the chmod are idempotent.
-#[cfg(unix)]
-fn ensure_private_dir(dir: &str) -> std::io::Result<()> {
+fn chmod_private(dir: &std::path::Path) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt as _;
     std::fs::create_dir_all(dir)?;
     let mut perms = std::fs::metadata(dir)?.permissions();
@@ -173,6 +156,58 @@ fn ensure_private_dir(dir: &str) -> std::io::Result<()> {
         std::fs::set_permissions(dir, perms)?;
     }
     Ok(())
+}
+
+/// Create a directory under the mvm home, with every component from the
+/// home root down to the leaf at mode `0700`.
+///
+/// This is the only correct way to make a directory under `mvm_home()`, and
+/// the reason is `create_dir_all`'s ancestor behaviour: asked for
+/// `~/.mvm/cache/builder-vm/x86_64` it happily creates `cache` and
+/// `builder-vm` at the process umask — typically `0755` — and chmodding
+/// only the leaf leaves two world-readable directories above it holding the
+/// same state. The claimed posture is "`~/.mvm` **and every child**", so the
+/// leaf alone was never the invariant.
+///
+/// Existing components are repaired rather than skipped, which is what makes
+/// this fix a home that arrived loose: created by a bare `mkdir`, restored
+/// from an archive, or left behind by a build of this tree from before the
+/// helper existed. The first command that writes anything puts the whole
+/// chain right, so no separate startup pass — and no write on `--help` — is
+/// needed.
+///
+/// The target itself is always locked, wherever it is. Only the *ancestor*
+/// walk is confined to the home, because above the home the path stops being
+/// ours: chmodding `$HOME` or `/tmp` on the way to a directory inside them
+/// would be a side effect on someone else's property. A keys or audit
+/// directory relocated outside the home by a test seam or an explicit
+/// override is still a directory full of secrets, and gets the same mode it
+/// would have had inside.
+///
+/// This is for state mvm owns. Do not point it at a location the operator
+/// named — an `--out` export target — where quietly tightening the mode would
+/// be a surprise rather than a guarantee.
+#[cfg(unix)]
+pub fn create_private_dir(dir: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+    let dir = dir.as_ref();
+    let home = std::path::PathBuf::from(mvm_home());
+    let Ok(under_home) = dir.strip_prefix(&home) else {
+        return chmod_private(dir);
+    };
+
+    chmod_private(&home)?;
+    let mut walked = home;
+    for component in under_home.components() {
+        walked.push(component);
+        chmod_private(&walked)?;
+    }
+    Ok(())
+}
+
+/// Non-unix hosts get plain creation: there is no mode to set.
+#[cfg(not(unix))]
+pub fn create_private_dir(dir: impl AsRef<std::path::Path>) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)
 }
 
 // ============================================================================
@@ -245,7 +280,7 @@ pub fn mvm_runtime_dir() -> String {
 #[cfg(unix)]
 pub fn ensure_runtime_dir() -> std::io::Result<String> {
     let dir = mvm_runtime_dir();
-    ensure_private_dir(&dir)?;
+    create_private_dir(&dir)?;
     Ok(dir)
 }
 
@@ -1520,18 +1555,27 @@ mod tests {
         assert_eq!(vms_dir(), std::path::PathBuf::from("/home/user/.mvm/vms"));
     }
 
-    /// `ensure_home_dir` / `ensure_cache_dir` create their
-    /// directories with mode 0700, AND chmod existing dirs
-    /// with looser perms down to 0700 — that's the upgrade path
-    /// for hosts created before this change landed.
+    /// Every component from the home root down is 0700, including a root
+    /// that already existed with looser perms.
+    ///
+    /// The ancestor half is the point. `create_dir_all` makes each missing
+    /// parent at the process umask, so a helper that chmodded only the leaf
+    /// left `~/.mvm` and `~/.mvm/audit` world-traversable while the tight
+    /// mode on `<tenant>/` made it look handled — and the leaf is the one
+    /// component the mode does not need to be on, since traversal is denied
+    /// at the first ancestor that refuses it.
+    ///
+    /// The loose-root half is the upgrade path: a home created by a bare
+    /// `mkdir`, restored from an archive, or left by an older build is
+    /// repaired by the first command that writes, which is what replaces the
+    /// startup pass this project never had.
     #[cfg(unix)]
     #[test]
-    fn test_ensure_private_dir_locks_existing_loose_perms() {
+    fn create_private_dir_locks_every_component_including_a_pre_existing_loose_root() {
         use std::os::unix::fs::PermissionsExt as _;
 
-        // Pick a stable temp path; tests share env-var state so we
-        // serialise via a unique-id suffix.
-        let temp = format!(
+        let mut env = TestEnv::new();
+        let home = format!(
             "/tmp/mvm-private-dir-test-{}-{}",
             std::process::id(),
             std::time::SystemTime::now()
@@ -1539,20 +1583,88 @@ mod tests {
                 .map(|d| d.as_nanos())
                 .unwrap_or(0)
         );
-        std::fs::create_dir_all(&temp).expect("create temp");
-        std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o755))
+        env.set("MVM_HOME", &home);
+
+        // The exact starting state the CI runner was in: a home that already
+        // exists, world-readable, made by something that was not us.
+        std::fs::create_dir_all(&home).expect("create home");
+        std::fs::set_permissions(&home, std::fs::Permissions::from_mode(0o755))
             .expect("loosen for setup");
 
-        ensure_private_dir(&temp).expect("ensure_private_dir");
+        let leaf = std::path::Path::new(&home).join("audit").join("acme");
+        create_private_dir(&leaf).expect("create_private_dir");
 
-        let mode = std::fs::metadata(&temp)
-            .expect("temp exists")
-            .permissions()
-            .mode()
-            & 0o777;
-        assert_eq!(mode, 0o700, "expected 0700, got 0{:o}", mode);
+        let mode_of = |p: &std::path::Path| {
+            std::fs::metadata(p)
+                .unwrap_or_else(|e| panic!("stat {}: {e}", p.display()))
+                .permissions()
+                .mode()
+                & 0o777
+        };
 
-        let _ = std::fs::remove_dir_all(&temp);
+        for dir in [
+            std::path::Path::new(&home),
+            &std::path::Path::new(&home).join("audit"),
+            &leaf,
+        ] {
+            assert_eq!(
+                mode_of(dir),
+                0o700,
+                "expected 0700 on {}, got 0{:o}",
+                dir.display(),
+                mode_of(dir)
+            );
+        }
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// A target outside the home is still locked; its ancestors are not.
+    ///
+    /// Both halves matter. A keys or audit directory relocated by a test seam
+    /// or an explicit override is still full of secrets, so skipping the mode
+    /// because the path sits elsewhere would quietly downgrade exactly the
+    /// directories this exists for — which is what a first cut of this did,
+    /// and two mode assertions in `mvm-hostd` caught it. Walking *up* is the
+    /// opposite error: chmodding `/tmp` on the way to a directory inside it
+    /// would be a side effect on something that is not ours.
+    #[cfg(unix)]
+    #[test]
+    fn create_private_dir_locks_a_target_outside_the_home_but_not_its_parents() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let mut env = TestEnv::new();
+        let home = format!("/tmp/mvm-private-home-{}", std::process::id());
+        env.set("MVM_HOME", &home);
+
+        let parent = format!("/tmp/mvm-private-outside-{}", std::process::id());
+        let _ = std::fs::remove_dir_all(&parent);
+        std::fs::create_dir_all(&parent).expect("create parent");
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755))
+            .expect("loosen parent");
+
+        let target = std::path::Path::new(&parent).join("keys");
+        create_private_dir(&target).expect("create_private_dir outside the home");
+
+        let mode_of = |p: &std::path::Path| {
+            std::fs::metadata(p)
+                .unwrap_or_else(|e| panic!("stat {}: {e}", p.display()))
+                .permissions()
+                .mode()
+                & 0o777
+        };
+        assert_eq!(
+            mode_of(&target),
+            0o700,
+            "a secret-bearing directory is locked wherever it lives"
+        );
+        assert_eq!(
+            mode_of(std::path::Path::new(&parent)),
+            0o755,
+            "a directory above the target is not ours to tighten"
+        );
+
+        let _ = std::fs::remove_dir_all(&parent);
     }
 
     #[test]

--- a/crates/mvm-hostd/src/audit/decisions.rs
+++ b/crates/mvm-hostd/src/audit/decisions.rs
@@ -41,19 +41,12 @@ impl DecisionStore {
     /// `decisions_dir`.
     pub fn open(decisions_dir: &Path, tenant: &str) -> Result<Self> {
         let tenant_dir = decisions_dir.join(tenant);
-        std::fs::create_dir_all(&tenant_dir)
-            .with_context(|| format!("creating decision store dir {}", tenant_dir.display()))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o700);
-            std::fs::set_permissions(&tenant_dir, perms).with_context(|| {
-                format!(
-                    "setting 0700 on decision store dir {}",
-                    tenant_dir.display()
-                )
-            })?;
-        }
+        mvm_core::config::create_private_dir(&tenant_dir).with_context(|| {
+            format!(
+                "creating decision store dir {} privately",
+                tenant_dir.display()
+            )
+        })?;
         let lock_path = tenant_dir.join(".lock");
         Ok(Self {
             tenant_dir,

--- a/crates/mvm-hostd/src/audit/emitter.rs
+++ b/crates/mvm-hostd/src/audit/emitter.rs
@@ -333,22 +333,17 @@ impl AuditEmitter {
     /// OS-default umask, but for hard guarantees the caller should
     /// pre-create it.
     pub fn with_dir(signing_key: SigningKey, audit_dir: &Path) -> Result<Self> {
-        // Tighten the audit dir to 0700 if we created it. We use
-        // `create_dir_all` first (idempotent) then `set_permissions`.
-        // The audit chain inherits the same mode-0700 posture as the
-        // rest of ~/.mvm, since its contents bind to plan-signed entries.
-        if !audit_dir.exists() {
-            std::fs::create_dir_all(audit_dir)
-                .with_context(|| format!("creating audit dir at {}", audit_dir.display()))?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let perms = std::fs::Permissions::from_mode(0o700);
-                std::fs::set_permissions(audit_dir, perms).with_context(|| {
-                    format!("setting 0700 on audit dir {}", audit_dir.display())
-                })?;
-            }
-        }
+        // The audit chain inherits the same 0700 posture as the rest of
+        // ~/.mvm, since its contents bind to plan-signed entries.
+        //
+        // Unconditionally, and over the whole chain. The previous version
+        // tightened the directory only `if !audit_dir.exists()` — so a chain
+        // directory that arrived loose, from a bare `mkdir` or an unpacked
+        // archive, was left exactly as found, which is the one case the mode
+        // mattered. It also chmodded this leaf alone while `create_dir_all`
+        // made its ancestors at the umask.
+        mvm_core::config::create_private_dir(audit_dir)
+            .with_context(|| format!("creating audit dir at {} privately", audit_dir.display()))?;
         let signer = Arc::new(
             FileAuditSigner::open(signing_key.clone(), audit_dir)
                 .with_context(|| format!("opening FileAuditSigner at {}", audit_dir.display()))?,
@@ -383,10 +378,8 @@ impl AuditEmitter {
         audit_dir: &Path,
         signer: Arc<FileAuditSigner>,
     ) -> Result<Self> {
-        if !audit_dir.exists() {
-            std::fs::create_dir_all(audit_dir)
-                .with_context(|| format!("creating audit dir at {}", audit_dir.display()))?;
-        }
+        mvm_core::config::create_private_dir(audit_dir)
+            .with_context(|| format!("creating audit dir at {} privately", audit_dir.display()))?;
         Ok(Self {
             signers: vec![signer],
             signing_key,

--- a/crates/mvm-hostd/src/audit/host_keypair.rs
+++ b/crates/mvm-hostd/src/audit/host_keypair.rs
@@ -72,10 +72,10 @@ pub fn host_signer_id() -> String {
 /// Load the host signer, creating both halves on first use.
 ///
 /// Idempotent: a subsequent call reloads from disk. Refuses if the
-/// secret-half file has perms looser than `SECRET_MODE`. Caller is
-/// responsible for ensuring `~/.mvm/` itself is mode `0700` (the
-/// `mvm_core::config::ensure_home_dir` helper handles that already
-/// for the parent).
+/// secret-half file has perms looser than `SECRET_MODE`. The caller is
+/// not responsible for `~/.mvm` itself: `load_or_init_at` locks the whole
+/// chain from the home root down. It used to say the caller was, and
+/// pointed at a helper with no callers, so in practice nobody was.
 pub fn load_or_init() -> Result<HostSigner> {
     load_or_init_at(&default_keys_dir()?)
 }
@@ -83,19 +83,14 @@ pub fn load_or_init() -> Result<HostSigner> {
 /// Same as [`load_or_init`] but accepts an explicit keys directory.
 /// Test seam.
 pub fn load_or_init_at(keys_dir: &Path) -> Result<HostSigner> {
-    std::fs::create_dir_all(keys_dir)
-        .with_context(|| format!("creating {}", keys_dir.display()))?;
-    #[cfg(unix)]
-    {
-        let mut perms = std::fs::metadata(keys_dir)
-            .with_context(|| format!("stat {}", keys_dir.display()))?
-            .permissions();
-        if perms.mode() & 0o777 != 0o700 {
-            perms.set_mode(0o700);
-            std::fs::set_permissions(keys_dir, perms)
-                .with_context(|| format!("chmod 0700 {}", keys_dir.display()))?;
-        }
-    }
+    // Locks the whole chain from the mvm home down, not just this leaf. The
+    // hand-rolled version here chmodded `keys/` and left whatever
+    // `create_dir_all` had made above it at the process umask — so the
+    // directory holding the host signing key could sit inside a
+    // world-traversable `~/.mvm`, with the tight mode on the leaf reading as
+    // though that had been handled.
+    mvm_core::config::create_private_dir(keys_dir)
+        .with_context(|| format!("creating {} privately", keys_dir.display()))?;
 
     let secret_path = keys_dir.join(SECRET_FILENAME);
     let public_path = keys_dir.join(PUBLIC_FILENAME);

--- a/crates/mvm-hostd/src/audit/plan_persist.rs
+++ b/crates/mvm-hostd/src/audit/plan_persist.rs
@@ -52,8 +52,8 @@ pub fn plan_path(vm_name: &str) -> Result<PathBuf> {
 /// wins). Overwrites any prior file.
 pub fn write_plan(vm_name: &str, plan: &ExecutionPlan) -> Result<PathBuf> {
     let dir = vm_state_dir(vm_name)?;
-    std::fs::create_dir_all(&dir)
-        .with_context(|| format!("creating VM state dir {}", dir.display()))?;
+    mvm_core::config::create_private_dir(&dir)
+        .with_context(|| format!("creating VM state dir {} privately", dir.display()))?;
     let path = dir.join(PLAN_FILENAME);
 
     let bytes =

--- a/crates/mvm-hostd/src/audit/receipt_store.rs
+++ b/crates/mvm-hostd/src/audit/receipt_store.rs
@@ -60,15 +60,8 @@ impl ReceiptStore {
     /// `audit_dir`.
     pub fn open(audit_dir: &Path, tenant: &str) -> Result<Self> {
         let tenant_dir = audit_dir.join("receipts").join(tenant);
-        std::fs::create_dir_all(&tenant_dir)
-            .with_context(|| format!("creating receipt dir {}", tenant_dir.display()))?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o700);
-            std::fs::set_permissions(&tenant_dir, perms)
-                .with_context(|| format!("setting 0700 on {}", tenant_dir.display()))?;
-        }
+        mvm_core::config::create_private_dir(&tenant_dir)
+            .with_context(|| format!("creating receipt dir {} privately", tenant_dir.display()))?;
         let lock_path = tenant_dir.join(".lock");
         let head_path = tenant_dir.join("head.json");
         Ok(Self {

--- a/crates/mvm-hostd/src/audit/witness.rs
+++ b/crates/mvm-hostd/src/audit/witness.rs
@@ -98,8 +98,9 @@ impl WitnessSink for FileWitnessSink {
             buf.push(b'\n');
         }
         if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating witness directory {}", parent.display()))?;
+            mvm_core::config::create_private_dir(parent).with_context(|| {
+                format!("creating witness directory {} privately", parent.display())
+            })?;
         }
         let mut file = std::fs::OpenOptions::new()
             .create(true)

--- a/specs/sprint/delivery/private-mvm-dirs-enforced-at-the-creation-seam.md
+++ b/specs/sprint/delivery/private-mvm-dirs-enforced-at-the-creation-seam.md
@@ -1,0 +1,98 @@
+# The 0700 posture on `~/.mvm` is now enforced by code that runs
+
+`mvm_core::config::ensure_home_dir` and `ensure_cache_dir` were `pub`,
+correct, and called by nothing. The claimed posture — `~/.mvm` and every child
+at mode 0700 — was established by no code path at all; it held only when a
+directory happened to be made by something that chmodded, and silently did not
+hold otherwise. A doc comment in the cleanup planner even described the repair
+as something "whichever command next calls `ensure_home_dir()`" performed. No
+command called it.
+
+This surfaced as a red nightly lane — `data dir mode: MISSING (expected 0700,
+got 0755 at /home/runner/.mvm)` — where the proximate cause was the e2e harness
+creating the home bare. That part was fixed separately. The reason a 0755 home
+then *survived an entire suite run*, through many `mvmctl` invocations writing
+into it, is what this change addresses.
+
+## Why not a startup call
+
+The obvious wiring — call it once when the CLI starts — was rejected for two
+reasons. It puts a write side effect on read-only commands, so `mvmctl --help`
+would create `~/.mvm` and hermetic tests that assert no writes would start
+writing. And more importantly it fixes the wrong thing: `create_dir_all` makes
+each *missing ancestor* at the process umask, so a directory created later in
+the same run still arrives with loose parents. The root is not the only
+component, and a startup pass cannot reach the ones that do not exist yet.
+
+## What landed
+
+**One helper at the creation seam.** `config::create_private_dir` creates the
+path and locks every component from the mvm home down to the leaf, repairing
+components that already exist. Any writer therefore repairs a home that arrived
+loose — from a bare `mkdir`, an unpacked archive, an older build — on the first
+command that touches state, which is the property the startup pass was wanted
+for, without the startup pass.
+
+The target itself is locked wherever it lives; only the *ancestor walk* is
+confined to the home, because above the home the path stops being ours and
+chmodding `/tmp` or `$HOME` en route would be a side effect on someone else's
+property.
+
+**A duplicate implementation folded in.** `mvm-client`'s volume module had its
+own `ensure_private_dir` chmodding only the leaf — the same ancestor bug, in a
+second copy. It now delegates.
+
+**Six hand-rolled sites converted**: the host signing key directory, the audit
+chain directory (two constructors), the decision store, the receipt store, the
+per-VM state directory, the witness directory, and the two managed-volume
+roots. Each was `create_dir_all` followed by a `set_permissions(0o700)` on the
+leaf alone — which reads at a glance as though the mode had been handled.
+
+Two of them were worse than that. `AuditEmitter::with_dir` tightened the
+directory only `if !audit_dir.exists()`, so a chain directory that arrived
+loose was left exactly as found — the one case where the mode mattered.
+
+**A gate so it stays fixed.** `xtask check-private-mvm-dirs` refuses
+`create_dir_all` in the modules owning the secret-bearing roots. It found four
+sites I had missed, including both volume roots.
+
+## Deliberately scoped
+
+The gate watches `crates/mvm-hostd/src/audit` and `crates/mvm-client/src/volume`,
+not the workspace. There are ~1000 `create_dir_all` calls in this tree and the
+overwhelming majority are honest — temp dirs, unpacked guest rootfs trees,
+caller-named `--out` targets, build scratch. A rule that flagged those would be
+switched off within a week, which is the failure mode `check-vcpu-ceilings`
+documents at length.
+
+So this does **not** cover a deep path created elsewhere under an
+already-0700 root. That is cosmetic rather than a leak — traversal needs execute
+permission on every ancestor and the root denies it — but it is a real gap
+against the letter of the claim, and it is not closed here.
+
+`emitter/atomic_write.rs` is allowlisted: it creates the parent of a file it is
+about to rename into place, is called with paths both inside and outside the
+home (an operator's export target among them), and the audit roots it touches
+are already created privately by the emitter before any write reaches it.
+
+## Tests
+
+- `create_private_dir_locks_every_component_including_a_pre_existing_loose_root`
+  — starts from exactly the CI runner's state (an existing 0755 home) and
+  asserts root, intermediate and leaf all end 0700. **Verified by mutation**:
+  reverting the helper to a leaf-only chmod fails it.
+- `create_private_dir_locks_a_target_outside_the_home_but_not_its_parents` —
+  both halves of the boundary rule.
+- `check-private-mvm-dirs` carries `passes_on_this_workspace` plus a check that
+  a comment naming the banned call does not trip the gate on its own docs.
+
+A first cut skipped the mode entirely for paths outside the home, on the
+reasoning that they were caller-owned. Two existing mode assertions in
+`mvm-hostd` caught it immediately — a keys directory relocated by a test seam
+is still a keys directory. The rule above is the corrected one.
+
+## Validation
+
+68 gates clean · `cargo nextest run --workspace` 12982 passed · doctests clean ·
+`clippy --all-targets -D warnings` clean · `fmt --all --check` clean ·
+`check-gated` clean with `RUSTFLAGS=-D warnings`.

--- a/xtask/src/check_all.rs
+++ b/xtask/src/check_all.rs
@@ -221,6 +221,7 @@ pub const GATES: &[Gate] = &[
         crate::check_backend_resource_controls::run,
     ),
     ("check-vcpu-ceilings", crate::check_vcpu_ceilings::run),
+    ("check-private-mvm-dirs", crate::check_private_mvm_dirs::run),
     (
         "check-single-fixture-corpus",
         crate::check_single_fixture_corpus::run,

--- a/xtask/src/check_private_mvm_dirs.rs
+++ b/xtask/src/check_private_mvm_dirs.rs
@@ -1,0 +1,166 @@
+//! `xtask check-private-mvm-dirs`
+//!
+//! Every directory that holds secret-shaped state under the mvm home must be
+//! made with [`mvm_core::config::create_private_dir`], never with a bare
+//! `std::fs::create_dir_all`.
+//!
+//! The distinction is not decoration. `create_dir_all` creates each *missing
+//! ancestor* at the process umask — typically 0755 — so asking for
+//! `~/.mvm/audit/<tenant>` when `~/.mvm` does not exist yet produces a
+//! world-traversable home no matter how tightly the leaf is then chmodded. The
+//! sites this gate covers each hand-rolled exactly that: `create_dir_all`
+//! followed by a `set_permissions(0o700)` on the leaf alone, which reads at a
+//! glance as though the mode had been handled.
+//!
+//! The claimed posture is "`~/.mvm` and every child is 0700", enforced by nothing
+//! at all: `ensure_home_dir` and `ensure_cache_dir` were `pub` and correct and
+//! had zero callers, while a comment in the cleanup planner described the
+//! repair as something the next command performed. It did not.
+//!
+//! **Deliberately scoped, not workspace-wide.** There are roughly a thousand
+//! `create_dir_all` calls in this tree and the overwhelming majority are
+//! honest — temp dirs, unpacked guest rootfs trees, caller-named `--out`
+//! directories, build scratch. A rule that flagged those would be turned off
+//! within a week, which is the failure mode `check-vcpu-ceilings` documents at
+//! length. So this gate watches the modules that own the *secret-bearing
+//! roots* — the audit chain, the host signing key, per-VM state, volumes —
+//! where the path is always under the mvm home and the mode always matters.
+//!
+//! What it therefore does **not** reach: a deep path created somewhere else
+//! under an already-0700 root. That is cosmetic rather than a leak, because
+//! traversal requires execute permission on every ancestor and the root denies
+//! it — but it is a real gap in the letter of that claim, and is not covered here.
+//!
+//! Comments and string literals are blanked first via [`crate::rust_source`],
+//! so this file's own prose naming `create_dir_all` cannot fail the gate.
+
+use anyhow::{Result, bail};
+use std::path::Path;
+
+/// Modules owning a secret-bearing root under the mvm home.
+const WATCHED: &[&str] = &["crates/mvm-hostd/src/audit", "crates/mvm-client/src/volume"];
+
+/// The call this gate refuses in those modules.
+const BANNED: &str = "create_dir_all";
+
+/// The helper that must be used instead.
+const REQUIRED: &str = "create_private_dir";
+
+/// Sites that must keep using the raw call, with the reason.
+///
+/// `atomic_write` creates the parent of a file it is about to rename into
+/// place, and is called with paths both inside and outside the mvm home (an
+/// operator's `--out` export target among them). Tightening a directory the
+/// user named is not ours to do, and the audit roots it *does* touch are
+/// already created privately by the emitter before any write reaches it.
+const ALLOWED: &[&str] = &["emitter/atomic_write.rs"];
+
+pub fn run(workspace: &Path) -> Result<()> {
+    let mut findings: Vec<String> = Vec::new();
+    let mut converted = 0usize;
+
+    for dir in WATCHED {
+        let root = workspace.join(dir);
+        if !root.is_dir() {
+            bail!("{dir} is not a directory; check-private-mvm-dirs is scanning a stale path");
+        }
+        for file in rust_files(&root)? {
+            let relative = file
+                .strip_prefix(workspace)
+                .unwrap_or(&file)
+                .display()
+                .to_string();
+            if ALLOWED.iter().any(|a| relative.ends_with(a)) {
+                continue;
+            }
+            let raw = std::fs::read_to_string(&file)
+                .map_err(|e| anyhow::anyhow!("reading {}: {e}", file.display()))?;
+            let body = crate::rust_source::blank_comments_and_strings(&raw);
+
+            for (line_no, line) in body.lines().enumerate() {
+                if line.contains(REQUIRED) {
+                    converted += 1;
+                    continue;
+                }
+                if line.contains(BANNED) {
+                    findings.push(format!(
+                        "{relative}:{}: `{BANNED}` under a secret-bearing mvm root. It creates \
+                         every missing ancestor at the process umask, so chmodding the leaf \
+                         afterwards still leaves a world-traversable directory above it. Use \
+                         `mvm_core::config::{REQUIRED}`, which locks the whole chain from the \
+                         mvm home down and repairs components that already exist.",
+                        line_no + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    if !findings.is_empty() {
+        bail!(
+            "bare directory creation under a secret-bearing mvm root:\n\n{}\n",
+            findings.join("\n\n")
+        );
+    }
+
+    // A gate that passes because every call has been deleted has stopped
+    // watching anything. The same floor `check-vcpu-ceilings` keeps.
+    if converted == 0 {
+        bail!(
+            "expected at least one `{REQUIRED}` call across {WATCHED:?}; found none. Private \
+             directory creation having vanished entirely is a question, not a pass."
+        );
+    }
+
+    println!(
+        "check-private-mvm-dirs: {converted} private-dir call(s), no bare creation under a \
+         secret-bearing root"
+    );
+    Ok(())
+}
+
+fn rust_files(root: &Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir)
+            .map_err(|e| anyhow::anyhow!("reading {}: {e}", dir.display()))?
+        {
+            let path = entry
+                .map_err(|e| anyhow::anyhow!("reading an entry of {}: {e}", dir.display()))?
+                .path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_on_this_workspace() {
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("workspace root")
+            .to_path_buf();
+        run(&workspace).expect("the tree must satisfy its own private-dir rule");
+    }
+
+    #[test]
+    fn a_comment_naming_the_banned_call_does_not_trip_the_gate() {
+        let blanked = crate::rust_source::blank_comments_and_strings(
+            "// create_dir_all is what this replaces\nlet x = create_private_dir(p);\n",
+        );
+        assert!(
+            !blanked.lines().next().expect("first line").contains(BANNED),
+            "the comment scanner must blank a mention in prose, or this gate fails on its own docs"
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -60,6 +60,7 @@ mod check_no_vz;
 mod check_one_guest_protocol;
 mod check_per_vm_host_binaries_sync;
 mod check_plan_names;
+mod check_private_mvm_dirs;
 mod check_require_grant_token_allowlist;
 mod check_runtime_overlay_version;
 mod check_sdk_cdylib_deps;
@@ -378,6 +379,10 @@ fn main() -> Result<()> {
         Some("check-vcpu-ceilings") => {
             let workspace = workspace_root();
             check_vcpu_ceilings::run(&workspace)
+        }
+        Some("check-private-mvm-dirs") => {
+            let workspace = workspace_root();
+            check_private_mvm_dirs::run(&workspace)
         }
         Some("check-guest-init-parity") => {
             let workspace = workspace_root();


### PR DESCRIPTION
Closes #3111.

`mvm_core::config::ensure_home_dir` and `ensure_cache_dir` were `pub`, correct,
and **called by nothing**. The claimed posture — `~/.mvm` and every child at
mode 0700 — was established by no code path at all. It held when a directory
happened to be made by something that chmodded, and silently did not otherwise.
`cleanup.rs` even documented the repair as something "whichever command next
calls `ensure_home_dir()`" performed; no command called it.

## Why not the obvious fix

Wiring that call into CLI startup is the obvious answer and the wrong one:

- It puts a **write side effect on read-only commands** — `mvmctl --help` would
  create `~/.mvm`, and hermetic tests that assert no writes would start writing.
- It **fixes the wrong component.** `create_dir_all` makes each *missing
  ancestor* at the process umask, so a directory created later in the same run
  still arrives with loose parents. A startup pass cannot reach components that
  do not exist yet.

## What this does instead

**One helper at the seam where directories are made.** `create_private_dir`
creates the path and locks every component from the mvm home down to the leaf,
repairing ones that already exist. Any writer therefore repairs a home that
arrived loose — a bare `mkdir`, an unpacked archive, an older build — on the
first command that touches state. That is the property the startup pass was
wanted for, without the startup pass.

The target is locked **wherever it lives**; only the *ancestor walk* is confined
to the home, because above the home the path stops being ours and chmodding
`/tmp` or `$HOME` en route would be a side effect on someone else's property.

**A duplicate folded in.** `mvm-client`'s volume module had its own
`ensure_private_dir` chmodding only the leaf — the same ancestor bug in a second
copy. It now delegates.

**Eight sites converted**: host signing key dir, audit chain dir (both
constructors), decision store, receipt store, per-VM state, witness dir, and
both managed-volume roots. Each was `create_dir_all` + `set_permissions(0o700)`
on the leaf alone, which reads at a glance as though the mode had been handled.

Two were worse than leaf-only: `AuditEmitter::with_dir` tightened the directory
only `if !audit_dir.exists()`, so a chain directory that arrived loose was left
exactly as found — the one case where the mode mattered.

**A gate so it stays fixed.** `xtask check-private-mvm-dirs` refuses
`create_dir_all` in the modules owning the secret-bearing roots. **It found four
sites I had missed**, including both volume roots.

## Deliberately scoped — and what it does not cover

The gate watches `mvm-hostd/src/audit` and `mvm-client/src/volume`, not the
workspace. There are ~1000 `create_dir_all` calls here and the overwhelming
majority are honest — temp dirs, unpacked guest rootfs trees, caller-named
`--out` targets, build scratch. A rule that flagged those would be switched off
within a week, which is the failure mode `check-vcpu-ceilings` documents at
length.

So this does **not** cover a deep path created elsewhere under an already-0700
root. That is cosmetic rather than a leak — traversal needs execute permission
on every ancestor and the root denies it — but it is a real gap against the
letter of the claim, and I am not claiming otherwise.

`emitter/atomic_write.rs` is allowlisted, with the reason in the gate's source.

## Tests

- `create_private_dir_locks_every_component_including_a_pre_existing_loose_root`
  — starts from exactly the CI runner's state (an existing 0755 home) and
  asserts root, intermediate, and leaf all end 0700. **Verified by mutation**:
  reverting the helper to a leaf-only chmod fails it.
- `create_private_dir_locks_a_target_outside_the_home_but_not_its_parents` —
  both halves of the boundary rule.
- The gate carries `passes_on_this_workspace` and a check that a comment naming
  the banned call does not trip it on its own docs.

A first cut skipped the mode entirely for paths outside the home, reasoning they
were caller-owned. Two existing mode assertions in `mvm-hostd` caught it
immediately — a keys directory relocated by a test seam is still a keys
directory. The rule above is the corrected one.

## Validation

68 gates clean · `cargo nextest run --workspace` **12982 passed** · doctests
clean · `clippy --all-targets -D warnings` clean · `fmt --all --check` clean ·
`check-gated` clean with `RUSTFLAGS=-D warnings`.
