### PR TITLE
fix(vsock): stop the exec stream inheriting a connect timeout

### DIFF
--- a/crates/mvm-agentd/src/vsock/rpc.rs
+++ b/crates/mvm-agentd/src/vsock/rpc.rs
@@ -409,12 +409,18 @@ where
     send_run_entrypoint_while(stream, call, on_event, || true)
 }
 
-/// How long a silent entrypoint stream is left alone before the caller's
+/// How long a silent response stream is left alone before the caller's
 /// liveness check is consulted.
 ///
 /// Not a timeout on the workload: a build or a test run is legitimately quiet
 /// for minutes. It is only how often "is the guest still there" gets asked.
-const ENTRYPOINT_LIVENESS_POLL: std::time::Duration = std::time::Duration::from_secs(5);
+///
+/// Every streaming read sets this for itself and restores what it found,
+/// because the value it would otherwise inherit is a *connect* budget.
+/// `connect_vsock_uds` arms `set_read_timeout` to bound the agent handshake
+/// and never disarms it, so without this a quiet gap in a long transfer
+/// surfaces as `EAGAIN` on a frame boundary and reads as a transport failure.
+const STREAM_LIVENESS_POLL: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// [`send_run_entrypoint`], but giving up when the guest is gone.
 ///
@@ -426,7 +432,7 @@ const ENTRYPOINT_LIVENESS_POLL: std::time::Duration = std::time::Duration::from_
 /// that never runs one is never bounded at all.
 ///
 /// `still_alive` is polled only when the stream has been quiet for
-/// [`ENTRYPOINT_LIVENESS_POLL`], so a long silent workload is unaffected: the
+/// [`STREAM_LIVENESS_POLL`], so a long silent workload is unaffected: the
 /// check costs nothing while output flows, and only decides the case where
 /// nothing is coming because nothing is left to send it.
 pub fn send_run_entrypoint_while<F, L>(
@@ -459,7 +465,7 @@ where
     // read timeout left behind would turn its next blocking read into a
     // spurious failure.
     let previous_timeout = stream.read_timeout().ok().flatten();
-    let _ = stream.set_read_timeout(Some(ENTRYPOINT_LIVENESS_POLL));
+    let _ = stream.set_read_timeout(Some(STREAM_LIVENESS_POLL));
 
     let outcome = loop {
         let resp: GuestResponse = match session.read(stream) {
@@ -654,8 +660,45 @@ fn read_exec_stream_with_session<F>(
 where
     F: FnMut(&ExecEvent),
 {
+    // Poll on our own budget and restore what we found, exactly as the
+    // entrypoint stream does.
+    //
+    // Without this the stream keeps whatever `connect_vsock_uds` armed to bound
+    // the agent handshake, and a gap longer than that connect budget — routine
+    // between two multi-megabyte wheels on one `pip install` — arrives as
+    // `EAGAIN` on a frame boundary. The read below then treated it as a
+    // transport failure and aborted a transfer that was working: the first
+    // 11 MB wheel completed, the second died partway.
+    //
+    // The classifier this relies on already existed and was already correct;
+    // what was missing is that only the entrypoint loop ever consulted it. An
+    // exec stream is quiet for exactly the same reasons and had none.
+    let previous_timeout = stream.read_timeout().ok().flatten();
+    let _ = stream.set_read_timeout(Some(STREAM_LIVENESS_POLL));
+    let outcome = read_exec_stream_frames(stream, session, &mut on_event);
+    let _ = stream.set_read_timeout(previous_timeout);
+    outcome
+}
+
+/// The frame loop itself, so the timeout above is restored on every exit.
+fn read_exec_stream_frames<F>(
+    stream: &mut UnixStream,
+    session: &mut RpcSession,
+    on_event: &mut F,
+) -> Result<ExecEvent>
+where
+    F: FnMut(&ExecEvent),
+{
     loop {
-        let resp: GuestResponse = session.read(stream)?;
+        let resp: GuestResponse = match session.read(stream) {
+            Ok(resp) => resp,
+            // Quiet, not broken. A guest that is actually gone fails the read
+            // with a hangup rather than a timeout, so this cannot spin on a
+            // dead peer; and the command's own `timeout_secs` bounds it inside
+            // the guest.
+            Err(error) if is_read_timeout(&error) => continue,
+            Err(error) => return Err(error),
+        };
         let event = match resp {
             GuestResponse::ExecEvent(e) => e,
             GuestResponse::Error { message } => bail!("guest exec error: {message}"),
@@ -1313,6 +1356,110 @@ mod tests {
         assert_eq!(got.len(), 1);
         assert!(matches!(got[0], ExecEvent::Stderr { ref chunk } if chunk == b"e"));
         assert!(matches!(term, ExecEvent::Exit { code: 2 }));
+    }
+
+    /// A gap between frames longer than the inherited read timeout must not
+    /// end the stream.
+    ///
+    /// This is the shape of a real failure, not a hypothetical. `pip install
+    /// pandas` over admitted egress finished an 11 MB wheel, went quiet while
+    /// the next 16.7 MB one was fetched, and died with `control frame read
+    /// failed: Resource temporarily unavailable (os error 11)` — a transfer
+    /// that was working, aborted on a quiet frame boundary.
+    ///
+    /// The timeout is not something the exec path asks for. `connect_vsock_uds`
+    /// arms `set_read_timeout` to bound the agent handshake and never disarms
+    /// it, so every later read inherits a *connect* budget. The entrypoint
+    /// stream had always overridden it with its own poll and retried; the exec
+    /// stream inherited it and treated it as fatal.
+    ///
+    /// This covers the *override*: the inherited 50 ms budget is replaced by
+    /// the stream's own poll, so a 400 ms gap never reaches the retry at all.
+    /// That is the half which fixes the reported failure, where the gap
+    /// between two wheels is well under the poll interval.
+    /// `a_gap_longer_than_the_liveness_poll_is_retried_not_failed` covers the
+    /// other half — deleting the retry does **not** fail this test, and a
+    /// mutation run says so.
+    #[test]
+    fn a_quiet_gap_between_exec_frames_does_not_end_the_stream() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        // What a caller inherits from the connect helper: short, and never
+        // meant to bound the response stream.
+        host.set_read_timeout(Some(Duration::from_millis(50)))
+            .unwrap();
+
+        let guest_handle = std::thread::spawn(move || {
+            write_frame(
+                &mut guest,
+                &GuestResponse::ExecEvent(ExecEvent::Stdout {
+                    chunk: b"first wheel".to_vec(),
+                }),
+            )
+            .unwrap();
+            // Several times the inherited budget — a download, not a hang.
+            std::thread::sleep(Duration::from_millis(400));
+            write_frame(
+                &mut guest,
+                &GuestResponse::ExecEvent(ExecEvent::Exit { code: 0 }),
+            )
+            .unwrap();
+        });
+
+        let mut got = Vec::new();
+        let term = read_exec_stream(&mut host, |e| got.push(e.clone()))
+            .expect("a quiet gap is not a transport failure");
+        guest_handle.join().unwrap();
+
+        assert_eq!(got.len(), 1, "the pre-gap chunk must still arrive");
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }));
+    }
+
+    /// A gap longer than the liveness poll is retried, not failed.
+    ///
+    /// Drives the frame loop directly, because the wrapper replaces the read
+    /// timeout with `STREAM_LIVENESS_POLL` and a test that went through it
+    /// would have to sleep past five seconds to reach the retry. Here the
+    /// timeout stays short, so every gap times out underneath and only the
+    /// retry can carry the stream to its terminal frame.
+    ///
+    /// Written after the sibling test above was found to pass with the retry
+    /// deleted: the override alone was carrying it, and the assertion that it
+    /// covered EAGAIN handling was false.
+    #[test]
+    fn a_gap_longer_than_the_liveness_poll_is_retried_not_failed() {
+        let (mut host, mut guest) = UnixStream::pair().unwrap();
+        host.set_read_timeout(Some(Duration::from_millis(20)))
+            .unwrap();
+
+        let guest_handle = std::thread::spawn(move || {
+            for _ in 0..3 {
+                std::thread::sleep(Duration::from_millis(60));
+                write_frame(
+                    &mut guest,
+                    &GuestResponse::ExecEvent(ExecEvent::Stdout {
+                        chunk: b"chunk".to_vec(),
+                    }),
+                )
+                .unwrap();
+            }
+            std::thread::sleep(Duration::from_millis(60));
+            write_frame(
+                &mut guest,
+                &GuestResponse::ExecEvent(ExecEvent::Exit { code: 0 }),
+            )
+            .unwrap();
+        });
+
+        let mut session = RpcSession::open(&mut host).unwrap();
+        let mut got = Vec::new();
+        let term = read_exec_stream_frames(&mut host, &mut session, &mut |e: &ExecEvent| {
+            got.push(e.clone())
+        })
+        .expect("each quiet gap must be retried, not treated as a transport failure");
+        guest_handle.join().unwrap();
+
+        assert_eq!(got.len(), 3, "every chunk across the gaps must arrive");
+        assert!(matches!(term, ExecEvent::Exit { code: 0 }));
     }
 
     #[test]

--- a/specs/sprint/delivery/exec-stream-inherits-a-connect-timeout.md
+++ b/specs/sprint/delivery/exec-stream-inherits-a-connect-timeout.md
@@ -1,0 +1,98 @@
+# A large egress transfer died because the exec stream inherited a connect timeout
+
+`mvmctl machine run --image python:3.12 --allow-host pypi.org:443 -- pip
+install pandas` finished the 11 MB pandas wheel, went quiet while the 16.7 MB
+numpy wheel was fetched, and died:
+
+```
+Error: control frame read failed
+  0: session i/o error: Resource temporarily unavailable (os error 11)
+```
+
+Reproduced on the Hetzner x86_64 KVM box against current main, so this was
+neither environment nor collateral from the runner shutdown that ended the same
+nightly run.
+
+## Root cause
+
+`connect_vsock_uds` arms `set_read_timeout` to bound the agent handshake and
+never disarms it. Every later read on that stream therefore inherits a
+*connect* budget, and a quiet gap longer than it — routine between two
+multi-megabyte wheels on one `pip install` — arrives as `EAGAIN` on a frame
+boundary. `read_exec_stream_with_session` had no timeout handling, so a
+transfer that was working was aborted as a transport failure.
+
+The backtrace named it exactly:
+
+```
+5: read_exec_stream_with_session   crates/mvm-agentd/src/vsock/rpc.rs:658
+6: send_exec_streaming             crates/mvm-agentd/src/vsock/rpc.rs:583
+7: run_in_guest                    crates/mvm-cli/src/exec/guest_run.rs:92
+```
+
+## Why the earlier fix did not cover it
+
+This is the same symptom as a previously closed issue, whose fix preserved the
+typed I/O source so a caller could recognise `EAGAIN`, and taught the
+*entrypoint* stream to retry against a liveness probe. Both halves were
+correct. Neither reached the exec stream, which is quiet for exactly the same
+reasons and consulted neither: it inherited the connect timeout and treated it
+as fatal.
+
+So the classifier was never wrong. What was missing is that only one of the two
+streaming paths ever called it.
+
+## The change
+
+`read_exec_stream_with_session` now does what the entrypoint stream already
+did: install its own poll, restore whatever it found on the way out, and treat
+a timeout as "quiet" rather than "broken". The frame loop moved into
+`read_exec_stream_frames` so the timeout is restored on every exit path, and
+`ENTRYPOINT_LIVENESS_POLL` became `STREAM_LIVENESS_POLL` now that two streams
+share it.
+
+Retrying cannot spin on a dead peer: a guest that is actually gone fails the
+read with a hangup, not a timeout, and the command's own `timeout_secs` bounds
+it inside the guest.
+
+## Tests, and one that was wrong
+
+Two, because the fix has two halves and they are not both exercised by the same
+gap:
+
+- `a_quiet_gap_between_exec_frames_does_not_end_the_stream` — the **override**.
+  A 400 ms gap beats the inherited 50 ms budget but never reaches the retry,
+  because the poll replaced it. This is the half that fixes the reported
+  failure.
+- `a_gap_longer_than_the_liveness_poll_is_retried_not_failed` — the **retry**.
+  Drives the frame loop directly with a short timeout so every gap times out
+  underneath, and only the retry can carry the stream to its terminal frame.
+
+The first test was written alone and claimed to cover EAGAIN handling. It does
+not: deleting the retry leaves it green, which a mutation run showed. The
+second test exists because of that, is mutation-verified, and the first one's
+doc comment now says plainly what it does not cover. Worth recording, because
+a single test here would have looked like proof and been none.
+
+## Live verification
+
+Same command, same host, with the fix applied and rebuilt:
+
+```
+Downloading numpy-2.5.2 (16.7 MB)  ━━━━ 16.7/16.7 MB 1.5 MB/s
+Successfully installed numpy-2.5.2 pandas-3.0.5 python-dateutil-2.9.0 six-1.17.0
+EXIT=0
+```
+
+## Not in scope
+
+The other live failure in that nightly is untouched: guest activation dies on
+`open /dev/mapper/control: No such file or directory`. It is inside the guest,
+not on the host, and appears in both recent nightly runs, so it is persistent
+and separate.
+
+## Validation
+
+67 gates clean · `cargo nextest run --workspace` 12981 passed · doctests clean ·
+`clippy --all-targets -D warnings` clean · `fmt --all --check` clean ·
+`check-gated` clean with `RUSTFLAGS=-D warnings` · live witness above.


### PR DESCRIPTION
Reopens and fixes the failure #3052 described. That issue was closed by a fix
that was correct but did not reach this code path.

## The failure, reproduced

```
$ mvmctl machine run --image python:3.12 --allow-host pypi.org:443 \
    --allow-host files.pythonhosted.org:443 -- pip install --no-cache-dir pandas

Downloading pandas-3.0.5 (11.0 MB)   ━━━━ 11.0/11.0 MB 1.5 MB/s   ✓
Downloading numpy-2.5.2 (16.7 MB)
Error: control frame read failed
  0: session i/o error: Resource temporarily unavailable (os error 11)
EXIT=1
```

Reproduced on the x86_64 KVM box against current main — so it is neither
environment nor collateral from the runner shutdown that ended the same nightly
run. It finishes the first wheel and dies on the second.

## Root cause

`connect_vsock_uds` arms `set_read_timeout` to bound the agent handshake and
**never disarms it**. Every later read on that stream inherits a *connect*
budget. A gap longer than it — routine between two multi-megabyte wheels on one
`pip install` — arrives as `EAGAIN` on a frame boundary, and
`read_exec_stream_with_session` had no timeout handling, so a transfer that was
working was aborted as a transport failure.

The backtrace named it exactly:

```
5: read_exec_stream_with_session   crates/mvm-agentd/src/vsock/rpc.rs:658
6: send_exec_streaming             crates/mvm-agentd/src/vsock/rpc.rs:583
7: run_in_guest                    crates/mvm-cli/src/exec/guest_run.rs:92
```

## Why #3057 did not cover it

That fix preserved the typed I/O source so a caller could recognise `EAGAIN`,
and taught the **entrypoint** stream to retry against a liveness probe. Both
halves were correct. Neither reached the **exec** stream, which goes quiet for
exactly the same reasons and consulted neither — it inherited the connect
timeout and treated it as fatal.

The classifier was never wrong. What was missing is that only one of the two
streaming paths ever called it.

## The change

The exec stream now does what the entrypoint stream already did: install its
own poll, restore whatever it found on the way out, and treat a timeout as
*quiet* rather than *broken*. The frame loop moved into
`read_exec_stream_frames` so the timeout is restored on every exit path, and
`ENTRYPOINT_LIVENESS_POLL` became `STREAM_LIVENESS_POLL` now that two streams
share it.

Retrying cannot spin on a dead peer: a guest that is actually gone fails the
read with a hangup, not a timeout, and the command's own `timeout_secs` bounds
it inside the guest.

## Tests — and one of them was wrong

Two, because the fix has two halves and one gap does not exercise both:

- `a_quiet_gap_between_exec_frames_does_not_end_the_stream` — the **override**.
  A 400 ms gap beats the inherited 50 ms budget but never reaches the retry.
  This is the half that fixes the reported failure.
- `a_gap_longer_than_the_liveness_poll_is_retried_not_failed` — the **retry**.
  Drives the frame loop directly with a short timeout so every gap times out
  underneath, and only the retry can carry the stream to its terminal frame.

The first was written alone and claimed to cover EAGAIN handling. **It does
not** — deleting the retry leaves it green, which a mutation run showed. The
second exists because of that and is mutation-verified; the first one's doc now
states plainly what it does not cover. Flagging it because a single test here
would have looked like proof and been none.

## Live verification

Same command, same host, fix applied and rebuilt:

```
Downloading numpy-2.5.2 (16.7 MB)  ━━━━ 16.7/16.7 MB 1.5 MB/s
Successfully installed numpy-2.5.2 pandas-3.0.5 python-dateutil-2.9.0 six-1.17.0
EXIT=0
```

## Not in scope

The other live failure in that nightly is untouched: guest activation dies on
`open /dev/mapper/control: No such file or directory`. That is inside the
guest, not on the host, and appears in both recent nightly runs — persistent,
and a separate fix.

## Validation

67 gates clean · `cargo nextest run --workspace` **12981 passed** · doctests
clean · `clippy --all-targets -D warnings` clean · `fmt --all --check` clean ·
`check-gated` clean with `RUSTFLAGS=-D warnings` · live witness above.
