### PR TITLE
docs: point the helper rebuild at the recipe, and finish the crate list

### DIFF
--- a/.agent-memory/notes/hvf-boot-timeout-has-5x-headroom-under-load.md
+++ b/.agent-memory/notes/hvf-boot-timeout-has-5x-headroom-under-load.md
@@ -1,0 +1,60 @@
+---
+title: The 5s HVF PID-file timeout has ~5x headroom even at load 45 — do not raise it
+date: 2026-09-02
+tags: [hvf, boot-latency, timeout, falsification, measurement]
+---
+
+`PID_FILE_TIMEOUT` for HVF is a hardcoded `Duration::from_secs(5)`
+(`crates/mvm-backends/src/driver/hvf_process.rs`), with no env override, against
+QEMU's 10s. A workload boot failed once with `hvf supervisor did not confirm
+boot within 5s` on a machine at load 40, which made the ceiling look marginal
+and the asymmetry with QEMU look like a bug.
+
+**It is not.** 12 consecutive `machine run --image rust` boots on an
+Apple Silicon host at load 40–47 (Cursor, a local model server, a rustc, and
+Spotlight indexing — an ordinary working desktop), measuring the
+`backend_start` phase that contains the supervisor spawn and the PID-file wait:
+
+| | backend_start |
+|---|---|
+| min | 167 ms |
+| median | ~250 ms |
+| mean | 327 ms |
+| max | 1017 ms |
+
+12/12 succeeded. Worst observed sample used **20% of the budget** — 4.9x
+headroom — at a load *higher* than the one where the failure happened. Raising
+the ceiling or making it tunable would buy nothing measurable.
+
+Reproduce with `MVM_PHASE_TIMING=1` and read `backend_start=` off the
+`phase-timing:` line. `MVM_LAUNCH_SAMPLE_JSON` writes the same data as JSON.
+
+## What the single failure probably was
+
+Not steady-state load: that is what the table above was measured under. The one
+plausible correlate is a *burst* — five VM state dirs (`w-dev-console`,
+`w-policy`, `w-raw`, `w-sealed`, `w-wire`) appeared in `~/.mvm/vms` at the same
+minute, so another session was creating five guests at once. A concurrent
+multi-guest burst is a different load shape from a high load average, and it is
+the one shape this measurement does not cover.
+
+If this recurs, measure during a burst before touching the constant. Do not
+infer a systematic problem from a boot failure on a loaded machine — steady
+load is not the cause, and this table is the evidence.
+
+## Two other refuted explanations
+
+Both were plausible and both are wrong, so do not spend time on them again:
+
+- **"A debug-profile supervisor is too slow to boot in 5s."** A debug supervisor
+  boots fine; the samples above are all against a debug build.
+- **"First launch of a freshly built supervisor spends the budget on
+  `codesign --force` and the re-exec."** Forced a fresh unsigned rebuild and the
+  first boot took 2.8s wall, well inside the window. The self-signing path is
+  not expensive enough to matter.
+
+## Incidental
+
+Every sample reported `launch_mode=cold`. A warm claim skips the fresh
+supervisor spawn entirely, so warm and cold boots are different populations and
+must not be pooled when measuring anything about this timeout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ Persistent builder state dirs live under `~/.mvm/cache/builder-vm/vms/`, disting
 
 ### Workspace Structure
 
-17-crate Cargo workspace (Bar-A consolidation took 32→16; `mvm-vmm`, `mvm-backends`, and `mvm-http` were split back out afterwards). Root facade (`src/lib.rs`) re-exports the libraries.
+19-crate Cargo workspace under `crates/` (Bar-A consolidation took 32→16; `mvm-vmm`, `mvm-backends`, and `mvm-http` were split back out afterwards, and `mvm-host-services` was split out of `mvm-sdk`), plus the root `mvmctl` package, `xtask`, and `mvm-conformance` — 22 packages by `cargo metadata`. Root facade (`src/lib.rs`) re-exports the libraries.
 
 **Libraries, low → high:**
 
@@ -160,6 +160,10 @@ Persistent builder state dirs live under `~/.mvm/cache/builder-vm/vms/`, disting
 - `mvm-runtime` -- the big runtime crate (absorbs `mvm` + `mvm-backend` + `mvm-base`): the `VmBackend` trait and the `AnyBackend` dispatch over every backend, VM lifecycle (`vm/` templates + checkpoints), `microvm/` (Firecracker driver), `base/` (shell/ui/linux_env/cow host substrate), `storage/` (dm-thin), `network/` (the TAP/gateway impl behind the `mvm-net` seam). Re-exports the `mvmctl::runtime`/`::backend` contract.
 - `mvm-client` -- the local/remote client facade: `LocalBackend` (default) + `GatewayBackend` (the `remote` feature), the canonical host-wide machine inventory (`inventory`, which backs `mvmctl machine ls` and non-CLI consumers), plus a re-export of `mvm-core`'s `MvmClient` trait and its `stream` reader. There is **no `dyn MvmClient` facade in the CLI** — `mvm-cli` uses `AnyBackend` directly for the backend surface, and the routing-everything-through-the-client refactor has not landed. Say what the code does, not what the plan said.
 - `mvm-cli` -- Clap CLI (the `mvmctl` surface), bootstrap/doctor/build/run/machine commands; `build.rs` embeds the host binaries.
+- `mvm-host-services` -- the in-guest host-services C ABI: one JSON-in/JSON-out entry point over the vsock broker, built as the `libmvm_host_services.so` cdylib every language SDK `dlopen`s. The package name is what makes cargo emit that filename directly. Its closure is deliberately tiny (no C, no async runtime) because it is compiled into every guest — `check-sdk-transport-free` holds that line, and the SDK sidecar's staleness fingerprint watches this crate and its dependencies rather than `mvm-sdk`.
+- `mvm-observability` -- tracing subscriber assembly for the host-side binaries.
+- `mvm-capture` -- project-environment capture frontend.
+- `mvm-mcp` -- bounded stdio MCP adapter over the `MvmClient` facade.
 
 **Top of graph (daemons, SDK, FFI):**
 

--- a/Justfile
+++ b/Justfile
@@ -411,6 +411,9 @@ build-supervisors *ARGS:
 # relinks mvmctl; that is why this is a deliberate step and not part of `build`.
 # Bare, this writes `target/debug/mvmctl` — pass `--release` if the mvmctl you
 # invoke is the release one, or the release binary is left untouched.
+#
+
+# Build an mvmctl carrying the embedded Linux host binaries (--release for a release one)
 embed *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/crates/mvm-vmm/src/host/aux_bin.rs
+++ b/crates/mvm-vmm/src/host/aux_bin.rs
@@ -88,8 +88,8 @@ fn profile_mismatch_warning(bin: &str, mismatch: &ProfileMismatch) -> String {
          Helpers are searched in target/release before target/debug, so a missing helper \
          beside the running binary is answered silently by the other profile's — at \
          whatever revision it was last built. If their config contract has moved since, \
-         {bin} will refuse to start. Build the matching one with `cargo build{flag} \
-         -p mvm-hostd --bins`.",
+         {bin} will refuse to start. Build the matching one with \
+         `just build-supervisors{flag}`.",
         exe = mismatch.exe.as_str(),
         helper = mismatch.helper.as_str(),
         path = mismatch.helper_path.display(),
@@ -423,7 +423,7 @@ mod tests {
             "naming the file is what makes it checkable: {warning}"
         );
         assert!(
-            warning.contains("cargo build --release -p mvm-hostd --bins"),
+            warning.contains("just build-supervisors --release"),
             "the rebuild must name the running binary's profile, not the helper's: {warning}"
         );
     }

--- a/crates/mvm-vmm/src/host/console_capture.rs
+++ b/crates/mvm-vmm/src/host/console_capture.rs
@@ -126,7 +126,7 @@ fn stale_supervisor_hint(stderr_tail: &str) -> String {
 /// they do not use and watch the next launch fail identically.
 fn helper_rebuild_command(profile: Option<crate::host::aux_bin::BuildProfile>) -> String {
     let flag = profile.map_or("", crate::host::aux_bin::BuildProfile::cargo_flag);
-    format!("cargo build{flag} -p mvm-hostd --bins")
+    format!("just build-supervisors{flag}")
 }
 
 #[cfg(test)]
@@ -216,7 +216,7 @@ mod tests {
         .unwrap();
         let detail = supervisor_stderr_detail(dir.path());
         assert!(
-            detail.contains("-p mvm-hostd --bins"),
+            detail.contains("just build-supervisors"),
             "an unknown field must name the rebuild: {detail}"
         );
         assert!(
@@ -235,18 +235,15 @@ mod tests {
 
         assert_eq!(
             helper_rebuild_command(Some(BuildProfile::Release)),
-            "cargo build --release -p mvm-hostd --bins"
+            "just build-supervisors --release"
         );
         assert_eq!(
             helper_rebuild_command(Some(BuildProfile::Debug)),
-            "cargo build -p mvm-hostd --bins"
+            "just build-supervisors"
         );
         // An installed binary, or this very test harness, which sits under
         // `target/<profile>/deps` and so reads as no profile at all.
-        assert_eq!(
-            helper_rebuild_command(None),
-            "cargo build -p mvm-hostd --bins"
-        );
+        assert_eq!(helper_rebuild_command(None), "just build-supervisors");
     }
 
     #[test]
@@ -258,7 +255,7 @@ mod tests {
         )
         .unwrap();
         let detail = supervisor_stderr_detail(dir.path());
-        assert!(!detail.contains("-p mvm-hostd --bins"), "got: {detail}");
+        assert!(!detail.contains("just build-supervisors"), "got: {detail}");
         assert!(detail.contains("HV_ERROR"), "got: {detail}");
     }
 }


### PR DESCRIPTION
Three corrections and a measurement.

## The rebuild command

The cross-profile warning (#3105) and the stale-supervisor hint both named `cargo build -p mvm-hostd --bins`. That was deliberate at the time: the recipe took no arguments and always built debug, so naming it would have handed a release `mvmctl` a command that rebuilds the helper it does not use. #3101 gave it `*ARGS`, so both now name `just build-supervisors{--release}`.

That is also strictly better than the raw cargo line, which silently skipped `mvm-libkrun-supervisor` — it carries `required-features = ["libkrun-sys"]`, and the recipe probes for `libkrun.h` and builds it separately.

## `just --list`

It prints the last comment line before a recipe, so `embed` was advertising itself as:

```
embed *ARGS    # invoke is the release one, or the release binary is left untouched.
```

Now:

```
embed *ARGS    # Build an mvmctl carrying the embedded Linux host binaries (--release for a release one)
```

## The crate list

It said 17 and enumerated 15. `cargo metadata --no-deps` reports 22 packages: 19 under `crates/` plus the root `mvmctl`, `xtask`, and `mvm-conformance`.

The four missing were `mvm-host-services`, `mvm-observability`, `mvm-capture`, and `mvm-mcp`. The first is not incidental — it builds `libmvm_host_services.so`, which this file credited to `mvm-sdk` until #3102. A crate absent from the inventory is one the next reader attributes to whichever neighbour the prose happens to mention, which is exactly how that error survived.

## A refutation worth recording

A workload boot failed once with `hvf supervisor did not confirm boot within 5s`. HVF's `PID_FILE_TIMEOUT` is a hardcoded 5s with no env override, against QEMU's 10s, so the ceiling looked marginal and the asymmetry looked like a bug.

Twelve consecutive `machine run --image rust` boots on an Apple Silicon host at load 40–47 — an ordinary working desktop, not a stressed one — measuring the `backend_start` phase that contains the supervisor spawn and PID-file wait:

| min | median | mean | max |
|---|---|---|---|
| 167 ms | ~250 ms | 327 ms | 1017 ms |

12/12 succeeded. The worst sample used 20% of the budget, at a *higher* load than the one where the failure happened. **The ceiling is fine and should not be raised.**

The note records the numbers, how to reproduce them (`MVM_PHASE_TIMING=1`, read `backend_start=`), the one load shape the measurement does not cover — a concurrent multi-guest burst, which is what the evidence suggests actually happened — and two other explanations that experiment ruled out (debug-profile slowness; first-launch `codesign` cost). Both were plausible; neither survived.

## Verification

`mvm-vmm` 623/623, `github_actions_extended_e2e` 25/25, `cargo fmt --all --check` clean, and `check-agent-notes` / `check-witness-citations` / `check-asserted-absence` all clean.
