### PR TITLE
fix(doctor): ask diskutil about the volume, not the directory

### DIFF
--- a/crates/mvm-cli/src/doctor/security_checks.rs
+++ b/crates/mvm-cli/src/doctor/security_checks.rs
@@ -336,20 +336,63 @@ pub(crate) fn require_local_volume_host_path_encrypted(path: &std::path::Path) -
     )
 }
 
+/// The device node of the volume containing `path`, e.g. `/dev/disk3s5`.
+///
+/// `diskutil info` takes a device or a volume, **not an arbitrary directory**:
+/// `diskutil info /Users/auser` exits 1 with "Could not find disk". Every
+/// caller of the probe passes a directory, so without this resolution the
+/// macOS arm could never succeed — and it reported the tool as unavailable
+/// when the tool had run perfectly and simply rejected its argument.
+#[cfg(target_os = "macos")]
+fn macos_containing_device(path: &std::path::Path) -> Option<String> {
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes()).ok()?;
+    // SAFETY: `c_path` is a valid NUL-terminated string for the duration of the
+    // call, and `buf` is a correctly-sized zeroed `statfs` the kernel fills in.
+    let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statfs(c_path.as_ptr(), &mut buf) } != 0 {
+        return None;
+    }
+    // SAFETY: on success the kernel leaves `f_mntfromname` NUL-terminated.
+    let device = unsafe { std::ffi::CStr::from_ptr(buf.f_mntfromname.as_ptr()) };
+    device
+        .to_str()
+        .ok()
+        .map(str::to_string)
+        .filter(|d| !d.is_empty())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn macos_containing_device(_path: &std::path::Path) -> Option<String> {
+    None
+}
+
 pub(crate) fn detect_host_path_encryption_status(path: &std::path::Path) -> HostFdeStatus {
     let plat = platform::current();
     if matches!(plat, Platform::MacOS) {
+        // Ask about the volume that holds the directory, not the directory.
+        // Falling back to the path itself keeps the old behaviour when the
+        // resolution fails rather than refusing outright.
+        let target = macos_containing_device(path).unwrap_or_else(|| path.display().to_string());
         match std::process::Command::new("diskutil")
             .arg("info")
-            .arg(path)
+            .arg(&target)
             .output()
         {
             Ok(out) if out.status.success() => {
                 let stdout = String::from_utf8_lossy(&out.stdout);
                 parse_macos_diskutil_encryption_status(path, &stdout)
             }
-            _ => HostFdeStatus::not_enabled(format!(
-                "could not determine encryption state for {} (diskutil unavailable)",
+            // Ran, but rejected the argument. Distinct from "could not run it",
+            // and conflating the two is what made this look environmental.
+            Ok(out) => HostFdeStatus::not_enabled(format!(
+                "diskutil could not report on {target} (for {}): {}",
+                path.display(),
+                String::from_utf8_lossy(&out.stderr).trim(),
+            )),
+            Err(e) => HostFdeStatus::not_enabled(format!(
+                "could not run diskutil to check {}: {e}",
                 path.display()
             )),
         }
@@ -1400,6 +1443,33 @@ mod tests {
             status.info.contains("does NOT appear"),
             "expected encrypted-backing refusal, got: {}",
             status.info
+        );
+    }
+
+    /// The bug this guards: `diskutil info` takes a device or a volume, not a
+    /// directory. Every caller passes a directory, so before this resolution
+    /// the probe reported "diskutil unavailable" on every macOS host — for a
+    /// tool that ran fine and rejected its argument. `mvmctl machine volume
+    /// mount` refused every directory as a result.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_directory_resolves_to_the_device_of_its_containing_volume() {
+        // A plain directory that is not itself a mount point is the shape that
+        // failed; `/` is the shape that happened to work and hid it.
+        let device = macos_containing_device(std::path::Path::new("/System/Volumes/Data"))
+            .expect("a real directory resolves to a device");
+        assert!(
+            device.starts_with("/dev/"),
+            "expected a device node, got {device}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn an_unresolvable_path_yields_no_device_rather_than_a_wrong_one() {
+        assert_eq!(
+            macos_containing_device(std::path::Path::new("/no/such/path/anywhere")),
+            None
         );
     }
 

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -20,11 +20,7 @@ target. Two of the four need live hardware to validate.
 The end state is **FFI-only rows, not zero**: 16 of the remaining sites declare
 libkrun's C API, which exports `krun_add_virtiofs` whether or not we call it,
 and three more are the `VirtioFsShare` type plus the QEMU and Firecracker tests
-that assert a share is *refused*.**libkrun's
-Stage 0 still boots a virtio-fs root** — the plan's headline is not yet true of
-that path. The others: the libkrun persistent builder's shares, the guest's
-install arm, and the HVF VirtioFs device + its 1,108-line FuseServer and fuzz
-target. Two of the four need live hardware to validate.**
+that assert a share is *refused*.
 
 No guest gets a virtio-fs device. Not a workload, not the builder VM, not the
 dev-tier root. The host filesystem reaches a guest as a block image or it does

--- a/specs/plans/2026-09-02-retire-dirshare.md
+++ b/specs/plans/2026-09-02-retire-dirshare.md
@@ -75,15 +75,41 @@ So the first question is not about `VmVolumeKind` at all:
 - [ ] **Decide what a managed *directory* volume is.** Either it materializes
       like `--mount` does (and `LocalVolumeKind::Directory` collapses into
       `BlockImage`), or it stays a genuinely different thing and needs its own
-      discriminator. `attaches_as_block()` already returns `false` for it, so
-      today it reaches no backend as a device — worth establishing whether that
-      path boots at all before designing around it.
+      discriminator.
+
+### What live testing established
+
+Run on macOS 26 / arm64, after fixing the encryption probe that was refusing
+every registration (see below):
+
+    mvmctl machine volume mount dirvol-test --volume probevol \
+        --host /tmp/mvm-dirvol2 --guest /data/probe     # registers, ok
+    mvmctl machine run --name dirvol-test --image alpine -- ls /data/probe
+    → ls: /data/probe: No such file or directory        # VM booted fine
+
+So an unmaterialized `DirShare` **does not fail the boot**. It also does not
+reach the guest. `mvmctl machine volume ls dirvol-test` still lists the
+attachment afterwards, so the registration persisted and the transient `run`
+path simply never consumed it.
+
+This **contradicts the code-path reading** that preceded it. `mount_volumes`
+propagates a failed mount with `?`, and a workload has no virtio-fs device, so
+the prediction was a failed boot. The volume never got that far: it is dropped
+before `VolumeConfig` is built, not attached-and-ignored. Recorded because the
+inference was confident and wrong, and only the live run separated the two.
+
+- [ ] **Find the launch path that *does* consume the registry.**
+      `registered_managed_mount_is_consumed_by_launch_resolution`
+      (`mvm-cli/src/commands/vm/volume.rs`) proves one exists; transient
+      `machine run --name` is not it. Until that path is exercised, "can an
+      unmaterialized `DirShare` reach a boot mount" is answered only for the
+      transient case.
+- [ ] **Decide whether silently ignoring a registered volume is acceptable.**
+      A user who registers a mount, sees it in `volume ls`, boots, and finds
+      nothing at the mount point got no error anywhere. That is its own defect
+      independent of this plan, and may be the more urgent one.
 
 ## Ordered work
-
-- [ ] Establish whether an unmaterialized `DirShare` can reach a live boot, and
-      what happens if it does. This is the load-bearing unknown; everything
-      below is contingent on it.
 - [ ] Move the `want_kind` derivation off `VmVolumeKind` and onto
       `materialized_image`, with a test that a plan recording `ShareKind::DirShare`
       still admits a materialized mount, and that a `Disk` plan does not admit
@@ -93,6 +119,25 @@ So the first question is not about `VmVolumeKind` at all:
       is the boot path; a unit test that constructs both sides agrees with
       itself by construction, which is the failure mode this repo has hit
       repeatedly.
+
+## Fixed while scoping: the encryption probe could never succeed
+
+`detect_host_path_encryption_status` ran `diskutil info <path>` on the host
+directory being shared. `diskutil info` takes a device or a volume, **not an
+arbitrary directory** — `diskutil info /Users/auser` exits 1 with "Could not
+find disk", while `diskutil info /` exits 0. Every caller passes a directory,
+so the macOS arm could never succeed, and `require_encrypted` refused every
+`mvmctl machine volume mount` on every macOS host.
+
+The message made it look environmental: both "could not spawn diskutil" and
+"diskutil ran and rejected the argument" collapsed into *"diskutil
+unavailable"*. It read as a missing tool on this machine rather than a bug in
+how it was called.
+
+Fixed in this change: resolve the path to its containing volume's device with
+`statfs`'s `f_mntfromname` before asking `diskutil`, and report the two failure
+modes separately. Registration now succeeds, which is what made the live test
+above possible at all.
 
 ## Found while scoping, not part of this work
 


### PR DESCRIPTION
fix(doctor): ask diskutil about the volume, not the directory

detect_host_path_encryption_status ran `diskutil info <path>` on the host
directory being shared. diskutil info takes a device or a volume, not an
arbitrary directory: `diskutil info /Users/auser` exits 1 with "Could not find
disk", while `diskutil info /` exits 0. Every caller passes a directory, so the
macOS arm could never succeed and require_encrypted refused every
`mvmctl machine volume mount` on every macOS host.

The message hid it. Both "could not spawn diskutil" and "diskutil ran and
rejected its argument" collapsed into "diskutil unavailable", which reads as a
missing tool on this machine rather than a bug in how it is called. Those are
now separate messages, and the second quotes diskutil's own stderr.

The fix resolves the path to its containing volume's device via statfs
f_mntfromname before asking diskutil, falling back to the path itself so a
failed resolution keeps the previous behaviour rather than refusing outright.
The existing parser needed no change: `diskutil info /dev/disk3s5` reports
"FileVault: Yes", which is exactly what it already looks for.

Verified on macOS 26 / arm64: `mvmctl machine volume mount ... --host <dir>`
now registers, where before it failed with the unavailable message regardless
of which directory was given.

Also adds the plan for retiring VmVolumeKind::DirShare, whose first question
this unblocked, updated with what the live run then showed: an unmaterialized
DirShare does not fail the boot and does not reach the guest either - the
transient run path never consumes the registration. That contradicts the
code-path reading that preceded it, which predicted a failed mount, and the
plan records the contradiction rather than the conclusion it replaced.
