### PR TITLE
fix(mount): say what a transient run will and will not attach

### DIFF
--- a/crates/mvm-cli/src/commands/machine/runtime.rs
+++ b/crates/mvm-cli/src/commands/machine/runtime.rs
@@ -229,6 +229,42 @@ fn attach_to_output(name: &str) -> Result<()> {
     }
 }
 
+/// Say so when a transient run's name carries volume registrations it will not
+/// attach.
+///
+/// `mvmctl machine volume mount <NAME> …` registers against a VM name, but only
+/// the *persistent* start path consumes the registry (`start_machine` →
+/// `start_persistent_oci_machine` → `merge_registered_volumes_for_launch`). A
+/// transient `machine run --name <NAME>` with the same name ignores it.
+///
+/// Defensible — a transient VM has no `machine stop` to release the exclusive
+/// attachment lease with — but it was entirely silent. Measured on macOS 26: a
+/// registered mount at `/data/probe` still listed by `machine volume ls`
+/// produced `ls: /data/probe: No such file or directory` inside a guest that
+/// booted cleanly, with no diagnostic on either side.
+///
+/// A warning rather than a refusal: attaching would take a lease this run
+/// cannot release, and refusing would break a run whose registrations are
+/// simply irrelevant to it. Best-effort — a registry that cannot be read must
+/// not fail a boot that never depended on it.
+fn warn_registered_volumes_are_not_attached(name: Option<&str>) {
+    let Some(name) = name else {
+        return;
+    };
+    let Ok(records) = crate::commands::vm::volume::list_registered_attachments(name) else {
+        return;
+    };
+    if records.is_empty() {
+        return;
+    }
+    mvm_runtime::base::ui::warn(&format!(
+        "machine {name:?} has {n} registered volume mount(s) that a transient run does not \
+         attach — those apply to `mvmctl machine start`. Use `--mount` to attach one here, or \
+         `mvmctl machine volume ls {name}` to list them.",
+        n = records.len(),
+    ));
+}
+
 fn apply_machine_ttl(name: &str, dur_str: &str) -> Result<()> {
     // Duration parsing stays a CLI concern; the facade's `set_ttl` applies the
     // resolved `expires_at` to the host registry (same op the `set-ttl` verb
@@ -427,6 +463,7 @@ pub(super) fn run_dispatch(cli: &Cli, mut args: MachineRunArgs, cfg: &MvmConfig)
     tracing::debug!(?mode, warm_pool_size, "machine run warm-pool eligibility");
     match mode {
         MachineRunMode::Transient => {
+            warn_registered_volumes_are_not_attached(args.name.as_deref());
             if let Some(slot) = resolved_flake_slot {
                 args.run.manifest = Some(slot);
             }

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -931,12 +931,21 @@ fn validate_run_profile(args: &RunArgs) -> Result<()> {
 
     for spec in &args.mounts {
         let parsed = super::shared::parse_volume_spec(spec)?;
-        let read_only = match parsed {
-            super::shared::VolumeSpec::DirShare { read_only, .. }
-            | super::shared::VolumeSpec::Disk { read_only, .. } => read_only,
+        // The shape matters to the message. "live share" is the right noun for
+        // a directory and the wrong one for a sized disk image, and this
+        // refusal fires for both — so a user asking "then what *is* writable?"
+        // was told their 2G disk was a live share.
+        let (read_only, shape) = match parsed {
+            super::shared::VolumeSpec::DirShare { read_only, .. } => (read_only, "directory"),
+            super::shared::VolumeSpec::Disk { read_only, .. } => (read_only, "disk"),
         };
         if !read_only {
-            anyhow::bail!("--mount '{spec}' requests rw, but transient live shares are read-only");
+            anyhow::bail!(
+                "--mount '{spec}' requests rw, but a transient run attaches every {shape} \
+                 read-only. Nothing a transient guest writes reaches the host. For a writable \
+                 volume, register one with `mvmctl machine volume mount` and boot the machine \
+                 with `mvmctl machine start`."
+            );
         }
     }
 
@@ -2058,6 +2067,45 @@ mod tests {
                 profile.as_str()
             );
         }
+    }
+
+    /// A transient run refuses `rw` for **both** mount shapes, and the message
+    /// has to name the one it got. It used to say "transient live shares are
+    /// read-only" for a sized disk image too, which told a user asking "then
+    /// what is writable?" that their 2G disk was a live share.
+    #[test]
+    fn a_transient_rw_refusal_names_the_shape_it_refused() {
+        let dir_err = {
+            let mut args = run_args(RunProfile::Standard);
+            args.mounts.push("/h/src:/work:rw".to_string());
+            validate_run_profile(&args).expect_err("rw must be refused")
+        };
+        let msg = dir_err.to_string();
+        assert!(msg.contains("directory"), "{msg}");
+        assert!(!msg.contains("disk read-only"), "{msg}");
+
+        let disk_err = {
+            let mut args = run_args(RunProfile::Standard);
+            args.mounts.push("/h/src:/work:2G:rw".to_string());
+            validate_run_profile(&args).expect_err("rw must be refused")
+        };
+        let msg = disk_err.to_string();
+        assert!(msg.contains("disk"), "{msg}");
+        assert!(
+            !msg.contains("live share"),
+            "a sized disk is not a live share: {msg}"
+        );
+    }
+
+    /// The refusal is a dead end unless it says where writable volumes live.
+    #[test]
+    fn the_rw_refusal_points_at_the_path_that_can_write() {
+        let mut args = run_args(RunProfile::Standard);
+        args.mounts.push("/h/src:/work:rw".to_string());
+        let msg = validate_run_profile(&args)
+            .expect_err("rw must be refused")
+            .to_string();
+        assert!(msg.contains("machine start"), "{msg}");
     }
 
     /// `Default` is hand-written, so it can drift from the `default_value`

--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -447,6 +447,18 @@ pub(super) type PreparedLaunchVolumes = mvm_client::volume::LaunchPreparation;
 
 /// Merge persisted local registrations into the volume list used to construct
 /// both signed admission grants and the backend launch configuration.
+/// The attachments registered against `vm_name`, without taking a lease.
+///
+/// Distinct from [`merge_registered_volumes_for_launch`], which acquires the
+/// exclusive launch lease. This is for callers that only need to *know*
+/// registrations exist — a transient run that will not attach them, for
+/// instance — and must not disturb a persistent machine that holds them.
+pub(crate) fn list_registered_attachments(
+    vm_name: &str,
+) -> Result<Vec<mvm_client::volume::AttachmentRecord>> {
+    service().list_attachments(vm_name)
+}
+
 pub(super) fn merge_registered_volumes_for_launch(
     vm_name: &str,
     explicit: &[mvm_runtime::image::RuntimeVolume],

--- a/crates/mvm-cli/src/exec/mounts.rs
+++ b/crates/mvm-cli/src/exec/mounts.rs
@@ -81,9 +81,13 @@ pub(crate) fn materialize_mount_volumes(
 /// # What a caller loses
 ///
 /// The image is a snapshot taken now. Host edits during the run are not
-/// visible to the guest. `--mount` was already read-only — the CLI refuses
-/// `rw` with "transient live shares are read-only" — so mid-run visibility is
-/// the only property that goes.
+/// visible to the guest. `--mount` was already read-only — a transient run
+/// refuses `rw` for every shape, directory and sized disk alike — so mid-run
+/// visibility is the only property that goes.
+///
+/// Nothing a transient guest writes reaches the host either, in any shape. A
+/// workload that has to hand results back needs a registered volume and
+/// `mvmctl machine start`, not this path.
 pub(crate) fn materialize_mount_image(
     share: &DirShareSpec,
     state_dir: &std::path::Path,

--- a/specs/plans/2026-09-02-workload-output-affordance.md
+++ b/specs/plans/2026-09-02-workload-output-affordance.md
@@ -1,0 +1,91 @@
+# A workload needs a way to hand results back
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Status: NOT STARTED — design only.**
+
+## The gap, measured
+
+A transient workload cannot write anything a host or a later microVM can read.
+Not "writes are snapshotted" — nothing is writable at all:
+
+    mvmctl machine run --image alpine --mount /tmp/x:/data:rw    -- …
+    → --mount requests rw, but a transient run attaches every directory read-only
+
+    mvmctl machine run --image alpine --mount /tmp/x:/data:2G:rw -- …
+    → …attaches every disk read-only
+
+Both shapes refused. So a fleet workload that computes something has no
+supported way to return it on the `machine run` path. The persistent path
+(`machine start` + a registered volume) can, but that is a different lifecycle:
+a named machine you start and stop, not a job you run.
+
+## Why the obvious fix is the wrong one
+
+Making a share writable puts a guest-driven FUSE parser back on the host — the
+thing `specs/plans/2026-08-31-remove-virtio-fs.md` removed, and the reason
+claim 1 can now rest on the guest having *no* channel to host filesystem
+structure rather than on virtio-fs behaving. The vsock-only data plane is also
+what makes claims 10 and 13 and the audit chain enforceable. A writable host
+directory would quietly cost all of that.
+
+## The mechanism already exists
+
+The builder does exactly this today, and both builders were migrated onto it
+this cycle: **a raw tar written straight onto a block device**, no filesystem
+on the transport disk. The guest packs its artifacts; the host `tar x`es them.
+Both sides only ever run `tar`, which is why it works on a macOS host that can
+neither format nor mount an ext4 (`mvm_build::builder_disk_transport`).
+
+The guest half is already general: `mvm-host-vm-init` collects `/out` onto the
+output disk. The host half is `read_output_disk`.
+
+**Correction to an earlier claim in the virtio-fs plan** (and to something I
+repeated): "needs a host-side ext4 *reader*, which `mvm-fs` does not have" is
+false as a general statement. `ext4-view` is a workspace dependency used by
+`mvm-fs`, `mvm-client`, `mvm-runtime` and `mvm-cli` — `mvm-client`'s volume
+service and lifecycle both read ext4 images on the host with it. Raw tar
+remains the simpler transport, but "the host cannot read an ext4 image" is not
+the reason to prefer it.
+
+## Shape to build
+
+- [ ] **Decide the surface.** An explicit output affordance on the transient
+      path, e.g. `--output <guest-dir>:<host-dir>`, materialized as an output
+      disk the guest writes and the host extracts after exit. Deliberately not
+      a mode of `--mount`: the direction is the whole point, and overloading
+      `--mount` is what made its two shapes confusing enough to need the
+      message fix that preceded this plan.
+- [ ] **Reuse `builder_disk_transport`, do not fork it.** `create_output_disk`
+      and `read_output_disk` are the host half. If they need widening beyond
+      `mvm-build`, widen them — a second raw-tar codec would drift from the
+      first.
+- [ ] **Decide what writes the tar in a workload guest.** The builder's guest
+      init does it today. A workload guest runs `mvm-guest-agent`, not
+      `mvm-host-vm-init`, so this is the real work: the agent needs an
+      equivalent collect-and-pack step, and it needs to run after the workload
+      exits but before teardown.
+- [ ] **Bound it.** The output disk is fixed-size at boot; decide the failure
+      mode when a workload produces more than fits. The builder's
+      `repack_input_disk_in_place` refuses rather than truncating, on the
+      grounds that refusing is the only way the failure is visible. Same
+      reasoning applies.
+- [ ] **Say what it is in the audit record.** A workload that can emit bytes to
+      the host is a grant. It should appear in the signed plan the way a
+      directory grant does, not arrive as an unrecorded side channel.
+
+## What this does not need
+
+A writable directory share, a second network path, or any change to the
+vsock-only funnel. The output disk is an opaque byte array: the guest writes
+bytes, the host decides what they mean, and there is no protocol for a guest to
+drive.
+
+## Adjacent, already recorded
+
+`specs/plans/2026-09-02-retire-dirshare.md` covers the read direction and the
+`DirShare` grant record. Its open question — a registered volume that the
+transient path silently ignores — is now a warning rather than silence, but the
+underlying asymmetry (registrations apply to `machine start` only) is the same
+lifecycle split this plan runs into.


### PR DESCRIPTION
fix(mount): say what a transient run will and will not attach

Two diagnostics for the same defect class: a mount that is silently or
misleadingly wrong.

A transient run refuses rw for both mount shapes, and said "transient live
shares are read-only" for each. That noun is right for a directory and wrong
for a sized disk image, so a user asking which shape *is* writable was told
their 2G disk was a live share. The message now names the shape it refused,
states plainly that nothing a transient guest writes reaches the host, and
points at the path that can write - register a volume and boot with
`mvmctl machine start`. Two tests pin the shape-specific wording and the
pointer, because a message nobody asserts is a message that drifts.

`mvmctl machine volume mount <NAME>` registers against a VM name, but only the
persistent start path consumes the registry: start_machine ->
start_persistent_oci_machine -> merge_registered_volumes_for_launch. A
transient `machine run --name <NAME>` with the same name ignored it in
silence. Measured on macOS 26: a registered mount at /data/probe, still listed
by `machine volume ls`, produced "ls: /data/probe: No such file or directory"
inside a guest that booted cleanly, with no diagnostic anywhere.

That is now a warning rather than silence. Not a refusal: attaching would take
the exclusive lease `machine stop` releases, and a transient run has no stop to
pair with it; refusing would break a run whose registrations are irrelevant to
it. Best-effort - a registry that cannot be read must not fail a boot that
never depended on it. list_registered_attachments is a read-only accessor that
takes no lease, distinct from the launch merge which does.

The doc comment on materialize_mount_image quoted the old wording and is
corrected with it.

## Also here: the plan for the gap this exposed

`specs/plans/2026-09-02-workload-output-affordance.md`. A transient workload cannot write anything a host or a later microVM can read — both mount shapes refuse `rw`, measured. Making a share writable is the wrong fix; the builder already solved this with a raw tar on a block device, and both builders were migrated onto it this cycle. The real work is that a workload guest runs `mvm-guest-agent`, not `mvm-host-vm-init`, so the collect-and-pack step has no equivalent there yet.

The plan also corrects a claim it inherited: the host **does** have an ext4 reader. `ext4-view` is a workspace dependency and `mvm-client`'s volume service and lifecycle both read images with it.
