### PR TITLE
fix(guest): name the missing device-mapper instead of the missing file

### DIFF
--- a/crates/mvm-agentd/src/guest_mount.rs
+++ b/crates/mvm-agentd/src/guest_mount.rs
@@ -1272,13 +1272,43 @@ fn chown(path: &str, uid: u32, gid: u32) -> Result<()> {
 // dm-verity helpers (Linux only)
 // ---------------------------------------------------------------------------
 
+/// Open the device-mapper control node, distinguishing "this kernel has no
+/// device-mapper" from every other way the open can fail.
+///
+/// The bare syscall error was unactionable. A guest booted on a kernel built
+/// without `CONFIG_BLK_DEV_DM` reported `open /dev/mapper/control: No such
+/// file or directory`, which reads as a missing mount or a verity bug — and
+/// sent a real investigation through the guest's early-mount ordering, the
+/// kernel's devtmpfs config, and the published kernel artifact before landing
+/// on the kernel that was actually booted. devtmpfs creates this node when
+/// device-mapper registers its misc device; no device-mapper, no node, and
+/// nothing about the mount is wrong.
 #[cfg(target_os = "linux")]
 fn open_dm_control() -> Result<std::fs::File> {
     std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .open("/dev/mapper/control")
-        .map_err(|e| MountError::syscall("open /dev/mapper/control", e))
+        .map_err(dm_control_open_error)
+}
+
+/// Classify a failed `/dev/mapper/control` open.
+///
+/// Split out so the message is reachable from a test: the host running the
+/// suite has a working control node, so the only way to pin what a guest
+/// without device-mapper reports is to call this directly.
+#[cfg(target_os = "linux")]
+fn dm_control_open_error(e: std::io::Error) -> MountError {
+    if e.kind() == std::io::ErrorKind::NotFound {
+        return MountError::VeritySetup(format!(
+            "/dev/mapper/control is absent, so this guest kernel has no device-mapper and \
+             cannot bring up a dm-verity target. devtmpfs creates the node when device-mapper \
+             registers, so this is the kernel's configuration (CONFIG_BLK_DEV_DM), not a \
+             missing mount. A kernel built by a user flake rather than by nix/images/kernel/ \
+             is the usual way to get here. ({e})"
+        ));
+    }
+    MountError::syscall("open /dev/mapper/control", e)
 }
 
 #[cfg(target_os = "linux")]
@@ -1596,6 +1626,61 @@ mod tests {
     use std::io::{Seek, SeekFrom, Write};
 
     const FAKE_HASH: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    /// A guest kernel without device-mapper says so, rather than reporting a
+    /// missing file.
+    ///
+    /// The bare `open /dev/mapper/control: No such file or directory` sent a
+    /// real investigation through the guest's early-mount ordering, the
+    /// kernel's devtmpfs config and the published kernel artifact before
+    /// reaching the kernel that had actually booted — which was a user flake's
+    /// own, built without `CONFIG_BLK_DEV_DM`. The node is absent *because*
+    /// there is no device-mapper to register it, and nothing about the mount
+    /// is wrong.
+    ///
+    /// Asserted on the rendered message because that string is the whole
+    /// deliverable: this is the only place a guest can explain the condition,
+    /// and the host sees nothing but this text.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_kernel_without_device_mapper_is_named_as_the_cause() {
+        let rendered =
+            dm_control_open_error(std::io::Error::from(std::io::ErrorKind::NotFound)).to_string();
+
+        assert!(
+            rendered.contains("no device-mapper"),
+            "the message must name the missing subsystem: {rendered}"
+        );
+        assert!(
+            rendered.contains("CONFIG_BLK_DEV_DM"),
+            "the message must name the config that fixes it: {rendered}"
+        );
+        assert!(
+            rendered.contains("not a missing mount"),
+            "the message must rule out the reading it previously invited: {rendered}"
+        );
+    }
+
+    /// Every other failure keeps the plain syscall shape.
+    ///
+    /// The NotFound arm is a claim about the kernel's configuration. Making it
+    /// on a permission error or a busy device would be a confident wrong
+    /// answer, which is worse than the unhelpful one it replaces.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_non_missing_dm_control_failure_stays_a_syscall_error() {
+        let rendered =
+            dm_control_open_error(std::io::Error::from_raw_os_error(libc::EACCES)).to_string();
+
+        assert!(
+            !rendered.contains("no device-mapper"),
+            "a permission failure is not a kernel-configuration claim: {rendered}"
+        );
+        assert!(
+            rendered.contains("open /dev/mapper/control"),
+            "it must still say which syscall failed: {rendered}"
+        );
+    }
 
     #[test]
     fn syscall_error_display_includes_os_error() {

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -412,8 +412,14 @@ warm_launch_artifacts() {
   # older checkout. A plain file-existence check bypasses that validation and
   # can boot stale guest-agent behavior while testing a new host binary.
   echo "    validating the source-matched universal initramfs"
+  # Captured, not discarded. This went to /dev/null, and a warm-up that failed
+  # in seconds was indistinguishable from one that succeeded in seconds: a
+  # nightly reported `warm-up done (10s)` for a step that cannot build an
+  # initramfs in ten seconds, then ran the whole suite against whatever was
+  # already cached. The budget below is not the only way this ends early.
+  local warm_log="${TMPDIR:-/tmp}/mvm-e2e-warmup.$$.log"
   MVM_HOME="$E2E_HOME" "$MVMCTL" machine run --name bdd-warmup --image alpine \
-    -- /bin/true >/dev/null 2>&1 &
+    -- /bin/true >"$warm_log" 2>&1 &
   local warm_pid=$! waited=0
   while kill -0 "$warm_pid" 2>/dev/null; do
     if (( waited >= ${MVM_E2E_WARMUP_SECS:-900} )); then
@@ -429,8 +435,19 @@ warm_launch_artifacts() {
       echo "    ... still warming (${waited}s)"
     fi
   done
-  wait "$warm_pid" 2>/dev/null || true
-  echo "    warm-up done (${waited}s)"
+  local warm_status=0
+  wait "$warm_pid" 2>/dev/null || warm_status=$?
+  if (( warm_status != 0 )); then
+    # Still non-fatal — this is a warm-up, and the scenarios that need the
+    # artifact will fail on their own terms. But it says so now, with the
+    # reason, instead of reporting a duration that reads like success.
+    echo "    warm-up FAILED (exit ${warm_status}, ${waited}s) — scenarios will run against"
+    echo "    whatever is already cached. Last lines:"
+    sed 's/^/      /' <"$warm_log" | tail -20
+  else
+    echo "    warm-up done (${waited}s)"
+  fi
+  rm -f "$warm_log"
 }
 warm_launch_artifacts
 

--- a/specs/sprint/delivery/a-guest-kernel-without-device-mapper-now-says-so.md
+++ b/specs/sprint/delivery/a-guest-kernel-without-device-mapper-now-says-so.md
@@ -1,0 +1,86 @@
+# A guest kernel without device-mapper now says so
+
+`mvmctl machine run --entrypoint --flake examples/exit_code` fails during
+guest activation:
+
+```
+1: activate workload after boot
+2: guest activation failed: syscall failed: open /dev/mapper/control: No such file or directory
+```
+
+Reproduced on the x86_64 KVM box against current main, so this is a product
+defect rather than CI state. It is one of the two failures that had kept the
+nightly documented-surface lane red.
+
+## What the error was actually about
+
+The guest kernel has no device-mapper, so nothing ever registers the control
+node that dm-verity opens. devtmpfs *was* mounted and the mount path was
+entirely correct — the message pointed at the one part of the system that was
+working.
+
+The session VM boots a flake-built kernel out of the template:
+
+```
+kernel_image_path: ~/.mvm/templates/<hash>/artifacts/revisions/.../vmlinux.elf
+```
+
+| kernel | "device-mapper" strings | `dm_ioctl` / `dm_table` |
+| --- | --- | --- |
+| shared workload kernel (`nix/images/kernel/`) | 149 | present |
+| flake-built template kernel | **0** | **absent** |
+
+`vm::template::lifecycle::artifacts::slot_kernel_source` returns a flake-built
+`vmlinux` unconditionally when one exists, and `nix/lib/mk-guest.nix` does not
+reference the shared kernel definition at all — only `default-tenant` and
+`builder-vm` do. So a user flake gets a stock kernel where device-mapper is a
+module rather than built in. That function's own comment concedes the
+dependency ("AArch64 guests need the workload kernel's platform and dm-verity
+support"), but the built-kernel branch runs ahead of that reasoning on every
+arch.
+
+## What this change does, and does not
+
+It does **not** change which kernel boots. Making user-flake images boot a
+dm-capable kernel is a decision about what a user flake produces — either
+`mkGuest` builds from the shared kernel definition, or `slot_kernel_source`
+refuses a built kernel that lacks device-mapper — and neither belongs in a
+diagnosability fix. The root cause is filed with the evidence above.
+
+What it changes is that the next person to hit this is told what happened.
+
+**The error names the cause.** A missing control node is now reported as "this
+guest kernel has no device-mapper", naming `CONFIG_BLK_DEV_DM` and explicitly
+ruling out the mount reading. The bare `No such file or directory` sent this
+investigation through the guest's early-mount ordering, the in-tree kernel
+config, and the published kernel artifact — three wrong answers, each of which
+had to be measured to be discarded — before reaching the kernel that had
+actually booted.
+
+Only `NotFound` is classified. A permission or busy failure keeps the plain
+syscall shape, because a confident wrong answer is worse than the unhelpful one
+it replaces, and there is a test for that.
+
+**The e2e warm-up stops reporting failure as success.** It printed
+`warm-up done (10s)` for a step that cannot build a universal initramfs in ten
+seconds: the command's output went to `/dev/null`, so a warm-up that failed in
+seconds was indistinguishable from one that succeeded in seconds, and the suite
+then ran every scenario against whatever happened to be cached. It now reports
+the exit code and the last twenty lines, and stays non-fatal — the scenarios
+still fail on their own terms.
+
+## A test that was rewritten before it landed
+
+The first version of the error test asserted against a copy of the message it
+had built itself, so it would have passed with the production path deleted.
+`dm_control_open_error` is split out so the test calls the real function.
+Both are `cfg(target_os = "linux")` and therefore invisible to a macOS `cargo
+test`; they were run on the Linux box to confirm they execute rather than
+silently compile out.
+
+## Validation
+
+67 gates clean · `cargo nextest run --workspace` 12979 passed · doctests clean ·
+`clippy --all-targets -D warnings` clean · `fmt --all --check` clean ·
+`check-gated` clean with `RUSTFLAGS=-D warnings` · both new tests confirmed
+passing on Linux · `bash -n` clean on the harness change.


### PR DESCRIPTION
`mvmctl machine run --entrypoint --flake examples/exit_code` fails guest
activation with a message about the one part of the system that was working:

```
2: guest activation failed: syscall failed: open /dev/mapper/control: No such file or directory
```

Reproduced on the x86_64 KVM box against current main — a product defect, not CI
state. It is the remaining failure keeping the nightly documented-surface lane
red.

## What it was actually about

The guest kernel has no device-mapper, so nothing registers the control node
dm-verity opens. devtmpfs *was* mounted and the mount path was entirely correct.

The session VM boots a flake-built kernel out of the template:

| kernel | "device-mapper" strings | `dm_ioctl` / `dm_table` |
| --- | --- | --- |
| shared workload kernel (`nix/images/kernel/`) | 149 | present |
| flake-built template kernel | **0** | **absent** |

`slot_kernel_source` returns a flake-built `vmlinux` unconditionally when one
exists, and `nix/lib/mk-guest.nix` never references the shared kernel definition
— only `default-tenant` and `builder-vm` do. So a user flake gets a stock kernel
with dm as a module.

## Scope: this does not change which kernel boots

Making user-flake images boot a dm-capable kernel is a decision about what a
user flake *produces* — either `mkGuest` builds from the shared kernel
definition, or `slot_kernel_source` refuses a built kernel without
device-mapper. That changes the contract of `mkGuest` and does not belong in a
diagnosability fix. Filed separately with the full evidence.

What changes here is that the next person to hit this is told what happened.

## The two fixes

**The error names the cause.** A missing control node now reports "this guest
kernel has no device-mapper", names `CONFIG_BLK_DEV_DM`, and explicitly rules
out the mount reading. The bare ENOENT sent this investigation through the
guest's early-mount ordering, the in-tree kernel config, and the published
kernel artifact — three wrong answers, each of which had to be *measured* to be
discarded — before reaching the kernel that had actually booted.

Only `NotFound` is classified. A permission or busy failure keeps the plain
syscall shape, because a confident wrong answer is worse than the unhelpful one
it replaces, and there is a test for that.

**The e2e warm-up stops reporting failure as success.** It printed
`warm-up done (10s)` for a step that cannot build a universal initramfs in ten
seconds — its output went to `/dev/null`, so a warm-up that failed in seconds
was indistinguishable from one that succeeded in seconds, and the suite then ran
every scenario against whatever happened to be cached. It now reports the exit
code and the last twenty lines, and stays non-fatal.

## A test rewritten before it landed

The first version of the error test asserted against a copy of the message it
had built itself — it would have passed with the production path deleted.
`dm_control_open_error` is split out so the test calls the real function.

Both new tests are `cfg(target_os = "linux")` and therefore invisible to a macOS
`cargo test`; they were run on the Linux box to confirm they execute rather than
silently compile out.

## Validation

67 gates clean · `cargo nextest run --workspace` **12979 passed** · doctests
clean · `clippy --all-targets -D warnings` clean · `fmt --all --check` clean ·
`check-gated` clean with `RUSTFLAGS=-D warnings` · both new tests confirmed
running on Linux · `bash -n` clean on the harness change.
