### PR TITLE
fix(vmm): verify the host-helper contract before spawn

### DIFF
--- a/crates/mvm-backends/src/driver/hvf.rs
+++ b/crates/mvm-backends/src/driver/hvf.rs
@@ -26,6 +26,7 @@ use mvm_vmm::hvf_handoff::HvfHandoffRequest;
 
 use crate::driver::hvf_process::{
     self as hvf_backend, PID_FILE_NAME, PID_FILE_TIMEOUT, resolve_supervisor_path,
+    resolve_supervisor_path_verified,
 };
 use mvm_contract::grants::CpuGrant;
 use mvm_core::checkpoint::{DeviceAnchors, HVF_FRAME_BLOB};
@@ -327,7 +328,7 @@ fn boot_with_handoff(
     .map_err(|e| anyhow!("write supervisor config {}: {e}", config_path.display()))?;
     let json =
         serde_json::to_string(&cfg).map_err(|e| anyhow!("serialize HvfSupervisorConfig: {e}"))?;
-    let supervisor = resolve_supervisor_path()?;
+    let supervisor = resolve_supervisor_path_verified()?;
     let mut child = bounded_supervisor_command(&supervisor, spec, &paths.state_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())

--- a/crates/mvm-backends/src/driver/hvf_process.rs
+++ b/crates/mvm-backends/src/driver/hvf_process.rs
@@ -152,13 +152,24 @@ pub(crate) fn wait_for_pause_state(path: &Path, paused: bool) -> Result<()> {
     }
 }
 
-/// Locate the per-VM HVF supervisor binary. Compiled by mvmctl's build script;
-/// see [`mvm_vmm::host::aux_bin`] for the search order.
+/// Locate the per-VM HVF supervisor binary without verifying its freshness —
+/// for availability probes and codesign enumeration, not for spawning.
 pub fn resolve_supervisor_path() -> Result<PathBuf> {
-    mvm_vmm::host::aux_bin::resolve(&mvm_vmm::host::aux_bin::AuxBin {
+    mvm_vmm::host::aux_bin::resolve(&hvf_supervisor_spec())
+}
+
+/// Locate the supervisor and refuse a stale one: the spawn path must not hand
+/// a moved-on config contract to a helper built from an older revision.
+pub fn resolve_supervisor_path_verified() -> Result<PathBuf> {
+    mvm_vmm::host::aux_bin::resolve_verified(&hvf_supervisor_spec())
+}
+
+fn hvf_supervisor_spec() -> mvm_vmm::host::aux_bin::AuxBin<'static> {
+    mvm_vmm::host::aux_bin::AuxBin {
         bin: "mvm-hvf-supervisor",
         env_var: "MVM_HVF_SUPERVISOR_PATH",
-    })
+        rebuild_package: "mvm-hostd",
+    }
 }
 
 pub fn vms_root() -> PathBuf {

--- a/crates/mvm-backends/src/driver/hvf_restore.rs
+++ b/crates/mvm-backends/src/driver/hvf_restore.rs
@@ -31,7 +31,7 @@ use mvm_core::checkpoint::{
 use mvm_vmm::host::hvf_supervisor::{HvfDisk, HvfSupervisorConfig};
 
 use crate::driver::hvf_process::{
-    PID_FILE_NAME, PID_FILE_TIMEOUT, read_pid, resolve_supervisor_path,
+    PID_FILE_NAME, PID_FILE_TIMEOUT, read_pid, resolve_supervisor_path_verified,
 };
 
 /// A materialized HVF checkpoint about to be booted under a fresh identity.
@@ -269,7 +269,7 @@ pub fn restore_hvf_vm(req: &HvfRestoreRequest<'_>) -> Result<RestoredHvfVm> {
 
     prepare_child_state_dir(req, &cfg)?;
 
-    let supervisor = resolve_supervisor_path()?;
+    let supervisor = resolve_supervisor_path_verified()?;
     let json = serde_json::to_string(&cfg).context("serializing HvfSupervisorConfig")?;
     let mut child = bounded_restore_command(&supervisor, req)
         .stdin(Stdio::piped())

--- a/crates/mvm-backends/src/driver/libkrun.rs
+++ b/crates/mvm-backends/src/driver/libkrun.rs
@@ -406,7 +406,7 @@ impl VmmDriver for LibkrunDriver {
         let json = serde_json::to_string(&cfg)
             .map_err(|e| anyhow!("serialize libkrun SupervisorConfig: {e}"))?;
 
-        let supervisor = crate::driver::libkrun_process::resolve_supervisor_path()?;
+        let supervisor = crate::driver::libkrun_process::resolve_supervisor_path_verified()?;
         let stdout = mvm_vmm::host::console_capture::open_console_capture(&console_log)
             .map(Stdio::from)
             .unwrap_or_else(|_| Stdio::null());

--- a/crates/mvm-backends/src/driver/libkrun_process.rs
+++ b/crates/mvm-backends/src/driver/libkrun_process.rs
@@ -633,13 +633,25 @@ pub fn libkrun_startup_diagnostics(state_dir: &Path) -> String {
 
 // ─── helpers ───────────────────────────────────────────────────────
 
-/// Resolve the absolute path to the `mvm-libkrun-supervisor` binary. Compiled
-/// by mvmctl's build script; see [`mvm_vmm::host::aux_bin`] for the search order.
+/// Resolve the absolute path to the `mvm-libkrun-supervisor` binary without
+/// verifying its freshness — for availability probes and codesign enumeration,
+/// not for spawning.
 pub fn resolve_supervisor_path() -> Result<PathBuf> {
-    mvm_vmm::host::aux_bin::resolve(&mvm_vmm::host::aux_bin::AuxBin {
+    mvm_vmm::host::aux_bin::resolve(&libkrun_supervisor_spec())
+}
+
+/// Resolve the supervisor and refuse a stale one: the spawn path must not
+/// hand a moved-on config contract to a helper built from an older revision.
+pub fn resolve_supervisor_path_verified() -> Result<PathBuf> {
+    mvm_vmm::host::aux_bin::resolve_verified(&libkrun_supervisor_spec())
+}
+
+fn libkrun_supervisor_spec() -> mvm_vmm::host::aux_bin::AuxBin<'static> {
+    mvm_vmm::host::aux_bin::AuxBin {
         bin: "mvm-libkrun-supervisor",
         env_var: "MVM_LIBKRUN_SUPERVISOR_PATH",
-    })
+        rebuild_package: "mvm-hostd",
+    }
 }
 
 pub(crate) fn read_pid(path: &Path) -> Option<libc::pid_t> {

--- a/crates/mvm-backends/src/driver/qemu_process.rs
+++ b/crates/mvm-backends/src/driver/qemu_process.rs
@@ -527,9 +527,12 @@ pub(crate) fn cleanup_vsock_bridge_sockets(state_dir: &Path) {
 }
 
 pub fn resolve_bridge_executable() -> Result<PathBuf> {
-    mvm_vmm::host::aux_bin::resolve(&mvm_vmm::host::aux_bin::AuxBin {
+    // Verified even though the bridge is a re-exec of mvmctl itself: the
+    // resolved copy can be the other profile's binary, built whenever.
+    mvm_vmm::host::aux_bin::resolve_verified(&mvm_vmm::host::aux_bin::AuxBin {
         bin: "mvmctl",
         env_var: "MVM_QEMU_BRIDGE_PATH",
+        rebuild_package: "mvmctl",
     })
 }
 

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -280,6 +280,10 @@ pub fn cli_command() -> clap::Command {
 }
 
 pub fn run() -> Result<()> {
+    // The qemu vsock bridge re-execs this binary as a per-VM host helper, so
+    // mvmctl answers the host-helper contract probe like every other helper —
+    // before clap sees the unknown flag.
+    mvm_vmm::host::helper_contract::exit_with_probe_answer_if_requested("mvmctl");
     let result = run_command();
     // Emitted after the command settles so the profile covers teardown as well.
     // A no-op unless MVM_SPAN_TIMINGS is set.

--- a/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-hvf-supervisor.rs
@@ -9,6 +9,7 @@
 
 #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
 fn main() {
+    mvm_vmm::host::helper_contract::exit_with_probe_answer_if_requested("mvm-hvf-supervisor");
     eprintln!(
         "mvm-hvf-supervisor runs only on macOS / Apple silicon (Hypervisor.framework); \
          this is a stub build"
@@ -216,6 +217,7 @@ fn main() -> anyhow::Result<()> {
     use anyhow::Context;
     use mvm_vmm::host::hvf_supervisor::{HvfShutdownTimingRecord, HvfSupervisorConfig};
 
+    mvm_vmm::host::helper_contract::exit_with_probe_answer_if_requested("mvm-hvf-supervisor");
     // Sign + re-exec before anything else (preserves the stdin config pipe).
     ensure_self_signed();
 

--- a/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
+++ b/crates/mvm-hostd/src/bin/mvm-libkrun-supervisor.rs
@@ -86,6 +86,7 @@ struct PrelaunchEnvelope {
 }
 
 fn main() -> ExitCode {
+    mvm_vmm::host::helper_contract::exit_with_probe_answer_if_requested("mvm-libkrun-supervisor");
     // First statement in the process: a panic before this line would
     // print its payload unredacted.
     mvm_hostd::panic_hook::install("libkrun-supervisor");

--- a/crates/mvm-hostd/src/bin/mvm-network-endpoint.rs
+++ b/crates/mvm-hostd/src/bin/mvm-network-endpoint.rs
@@ -49,6 +49,7 @@ fn read_stdin_blocking() -> Result<Vec<u8>> {
 }
 
 fn main() -> Result<()> {
+    mvm_vmm::host::helper_contract::exit_with_probe_answer_if_requested("mvm-network-endpoint");
     // First statement in the process: a panic before this line would
     // print its payload unredacted.
     mvm_hostd::panic_hook::install("substitution-endpoint");

--- a/crates/mvm-runtime/src/builder_runner/inject.rs
+++ b/crates/mvm-runtime/src/builder_runner/inject.rs
@@ -16,7 +16,7 @@ use anyhow::{Context, Result, bail};
 use mvm_build::rootfs_inject::{InjectBinary, build_inject_initramfs};
 use mvm_vmm::host::hvf_supervisor::{HvfDisk, HvfSupervisorConfig};
 
-use mvm_backends::driver::hvf_process::resolve_supervisor_path;
+use mvm_backends::driver::hvf_process::resolve_supervisor_path_verified;
 
 /// A rootfs-injection request.
 pub struct InjectRequest<'a> {
@@ -110,7 +110,7 @@ pub fn inject_host_binaries(req: &InjectRequest<'_>) -> Result<()> {
     };
     let json = serde_json::to_string(&cfg).context("serialize inject supervisor config")?;
 
-    let supervisor = resolve_supervisor_path()?;
+    let supervisor = resolve_supervisor_path_verified()?;
     let mut child = Command::new(&supervisor)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())

--- a/crates/mvm-runtime/src/builder_runner/runner.rs
+++ b/crates/mvm-runtime/src/builder_runner/runner.rs
@@ -266,7 +266,15 @@ mod tests {
         let stub = tmp.path().join("stub-endpoint.sh");
         std::fs::write(
             &stub,
-            "#!/bin/sh\ncat >/dev/null\necho '{\"env\":[],\"input_fingerprints\":[]}'\nsleep 30\n",
+            // The stub runs through the verified resolver before it can
+            // play its role, so it answers the contract probe first.
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = \"{flag}\" ]; then echo '{answer}'; exit 0; fi\n\
+                 cat >/dev/null\necho '{{\"env\":[],\"input_fingerprints\":[]}}'\nsleep 30\n",
+                flag = mvm_vmm::host::helper_contract::CONTRACT_PROBE_FLAG,
+                answer = mvm_vmm::host::helper_contract::probe_response("mvm-network-endpoint")
+                    .trim_end(),
+            ),
         )
         .unwrap();
         {

--- a/crates/mvm-vmm/src/host/aux_bin.rs
+++ b/crates/mvm-vmm/src/host/aux_bin.rs
@@ -661,9 +661,12 @@ mod tests {
 
         // Resolution order inside a checkout is release before debug, so the
         // rebuilt helper must win over the stale debug one.
+        // Explicit scratch dirs, not workspace_target_dirs_for: that helper
+        // also honors the process CARGO_TARGET_DIR, and under the per-worktree
+        // isolation env it would let a real helper shadow the fixture.
         let lookup = Lookup {
             override_path: None,
-            dirs: workspace_target_dirs_for(&root),
+            dirs: vec![root.join("target/release"), root.join("target/debug")],
         };
         let got = resolve_verified_in(&hvf_spec(), &lookup, &env).unwrap();
         assert_eq!(got, root.join("target/release/mvm-hvf-supervisor"));
@@ -683,9 +686,12 @@ mod tests {
 
         let mut env = test_env(Some(root.clone()));
         env.cargo = cargo;
+        // Explicit scratch dirs, not workspace_target_dirs_for: that helper
+        // also honors the process CARGO_TARGET_DIR, and under the per-worktree
+        // isolation env it would let a real helper shadow the fixture.
         let lookup = Lookup {
             override_path: None,
-            dirs: workspace_target_dirs_for(&root),
+            dirs: vec![root.join("target/release"), root.join("target/debug")],
         };
         let err = resolve_verified_in(&hvf_spec(), &lookup, &env)
             .unwrap_err()
@@ -710,9 +716,12 @@ mod tests {
 
         let mut env = test_env(Some(root.clone()));
         env.cargo = cargo;
+        // Explicit scratch dirs, not workspace_target_dirs_for: that helper
+        // also honors the process CARGO_TARGET_DIR, and under the per-worktree
+        // isolation env it would let a real helper shadow the fixture.
         let lookup = Lookup {
             override_path: None,
-            dirs: workspace_target_dirs_for(&root),
+            dirs: vec![root.join("target/release"), root.join("target/debug")],
         };
         let err = resolve_verified_in(&hvf_spec(), &lookup, &env)
             .unwrap_err()

--- a/crates/mvm-vmm/src/host/aux_bin.rs
+++ b/crates/mvm-vmm/src/host/aux_bin.rs
@@ -1,175 +1,367 @@
 //! Resolver for the per-VM host helper binaries `mvmctl` spawns — the backend
-//! supervisors (`mvm-hvf-supervisor`, `mvm-libkrun-supervisor`) and the
-//! substitution endpoint. Each is a separate `[[bin]]` of `mvm-hostd`, produced
-//! by an ordinary workspace `cargo build` into `target/<profile>/`.
+//! supervisors (`mvm-hvf-supervisor`, `mvm-libkrun-supervisor`), the
+//! substitution endpoint, and the qemu bridge (a re-exec of `mvmctl`
+//! itself). Each is an ordinary workspace `[[bin]]`, produced by `cargo
+//! build` into `target/<profile>/`.
 //!
-//! Resolution order (first existing file wins): `$<ENV_VAR>` override →
-//! `$MVM_AUX_BIN_DIR` (a directory override, for a packaged helper set) →
-//! alongside the current exe (a downloaded release ships them there) →
-//! workspace `target/{release,debug}`.
+//! Path resolution (first existing file wins) is [`resolve`]:
+//! `$<ENV_VAR>` override → `$MVM_AUX_BIN_DIR` → alongside the current exe →
+//! workspace `target/{release,debug}`. That order spans build profiles on
+//! purpose, and cargo never rebuilds a helper because the other profile's
+//! binary is about to run it — so a release `mvmctl` with no release helper
+//! beside it is answered by whichever debug helper was built last, at
+//! whatever revision. When the config contract has moved since, the helper
+//! refuses to start with a JSON parse error deep into a `machine run`.
 //!
-//! Freshness is cargo's, not ours. `mvm-cli`'s build script used to compile
-//! these into a private target dir so that `cargo run -p mvm-cli` — which
-//! builds no sibling `[[bin]]`s — would produce them, and then had to mark the
-//! ones it reused so a stale supervisor could be refused at spawn. That cost a
-//! duplicate build of `mvm-hostd`'s whole closure per worktree and made
-//! staleness representable in the first place. Letting the workspace build own
-//! them removes both: cargo rebuilds a helper when its sources change.
-//!
-//! That holds *within* a profile and not across one, which this resolver spans
-//! by design — `target/release` then `target/debug`. Cargo never rebuilds a
-//! debug helper because a release binary is about to run it, so a release
-//! `mvmctl` with no release helper beside it is answered by whichever debug
-//! helper was built last, at whatever revision. When the config contract has
-//! moved since, the helper refuses to start and says only that it does not
-//! recognise a field. [`profile_mismatch`] is what makes that attributable.
+//! [`resolve_verified`] closes that hole. Every helper compiled from this
+//! tree answers the `--contract-version` probe with
+//! [`helper_contract::HOST_HELPER_CONTRACT_VERSION`]; a helper that answers
+//! differently — or not at all, since pre-probe binaries exit non-zero — is
+//! stale. A stale helper found inside this checkout's own `target/`
+//! directories is rebuilt automatically in the running binary's profile;
+//! anything else (an installed layout, an exe-dir copy, an env override) is
+//! a hard error naming both sides and the exact command that fixes it. A
+//! stale helper is never returned.
 
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
 
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
 
-/// A per-VM helper binary and its path-override env var.
+use crate::host::helper_contract;
+
+/// A per-VM helper binary, its path-override env var, and the cargo package
+/// that builds it (used when an automatic rebuild is required).
 pub struct AuxBin<'a> {
     /// Binary/file name, e.g. `mvm-hvf-supervisor`.
     pub bin: &'a str,
     /// Path-override env var, e.g. `MVM_HVF_SUPERVISOR_PATH`.
     pub env_var: &'a str,
+    /// Cargo package whose build produces this helper, e.g. `mvm-hostd`.
+    pub rebuild_package: &'a str,
 }
 
-/// Resolve `spec` to an on-disk binary. Never builds — a missing one is a hard
-/// error with a recovery hint.
+/// Resolve `spec` to an on-disk binary. Never builds — a missing one is a
+/// hard error with a recovery hint. Availability probes (doctor, backend
+/// selection) use this; everything that is about to *spawn* the helper must
+/// use [`resolve_verified`].
 pub fn resolve(spec: &AuxBin) -> Result<PathBuf> {
-    let resolved = resolve_from(
-        spec,
-        &Lookup {
-            override_path: std::env::var_os(spec.env_var).map(PathBuf::from),
-            dirs: assemble_candidate_dirs(
-                current_exe_dir(),
-                aux_bin_dir_from_env(),
-                workspace_target_dirs(),
-            ),
-        },
-    )?;
-    warn_once_on_profile_mismatch(spec, &resolved);
-    Ok(resolved)
+    resolve_from(spec, &lookup_from_env(spec))
 }
 
-/// Say once per process that a helper came from the other build profile.
-///
-/// Once, not once per helper: a process that picks one helper cross-profile
-/// picks all of them that way, because the cause is which profile was built
-/// rather than anything about the individual binary. Repeating it per spawn
-/// would bury the line that matters under two identical ones.
-///
-/// A warning and not a refusal. A cross-profile helper is wrong-looking, not
-/// necessarily broken — it works whenever the config contract has not moved —
-/// and refusing here would break a working setup for a mismatch that is only
-/// sometimes fatal. The failure it precedes is already loud; what was missing
-/// is the attribution, so that is what this adds.
-fn warn_once_on_profile_mismatch(spec: &AuxBin, resolved: &Path) {
-    static SAID: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+/// Resolve `spec` and refuse to return a helper that does not provably speak
+/// this build's config contract. See the module doc.
+pub fn resolve_verified(spec: &AuxBin) -> Result<PathBuf> {
+    resolve_verified_in(spec, &lookup_from_env(spec), &VerifyEnv::from_process())
+}
 
-    let exe = std::env::current_exe().ok();
-    let Some(mismatch) = profile_mismatch(exe.as_deref(), resolved) else {
-        return;
+pub(crate) fn resolve_verified_in(
+    spec: &AuxBin,
+    lookup: &Lookup,
+    env: &VerifyEnv,
+) -> Result<PathBuf> {
+    let resolved = resolve_from(spec, lookup)?;
+    match probe_contract(&resolved, env.probe_timeout) {
+        ProbeOutcome::Answered(version)
+            if version == helper_contract::HOST_HELPER_CONTRACT_VERSION =>
+        {
+            Ok(resolved)
+        }
+        stale => recover_stale_helper(spec, lookup, env, &resolved, &stale),
+    }
+}
+
+/// How a helper answered (or failed to answer) the contract probe.
+enum ProbeOutcome {
+    /// It printed a parseable contract version.
+    Answered(u32),
+    /// It ran but the answer was unreadable — or it predates the probe flag
+    /// and exited non-zero on the unexpected argument.
+    Refused {
+        /// What the probe observed, for error attribution.
+        detail: String,
+    },
+    /// It did not finish within the deadline.
+    TimedOut,
+}
+
+/// Deadline for one contract probe. Helpers answer instantly (the probe is
+/// handled before anything else in their `main`); a helper that exceeds this
+/// is pathological.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Run `helper --contract-version` and classify the answer.
+fn probe_contract(helper: &Path, timeout: Duration) -> ProbeOutcome {
+    let child = match Command::new(helper)
+        .arg(helper_contract::CONTRACT_PROBE_FLAG)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) => {
+            return ProbeOutcome::Refused {
+                detail: format!("could not execute it: {e}"),
+            };
+        }
     };
-    if SAID.swap(true, std::sync::atomic::Ordering::Relaxed) {
-        return;
-    }
-    crate::host::ui::warn(&profile_mismatch_warning(spec.bin, &mismatch));
-}
-
-/// The text for a cross-profile pick, split out so it is assertable without
-/// capturing stderr.
-fn profile_mismatch_warning(bin: &str, mismatch: &ProfileMismatch) -> String {
-    format!(
-        "this mvmctl is the {exe} build but {bin} resolved to the {helper} one ({path}). \
-         Helpers are searched in target/release before target/debug, so a missing helper \
-         beside the running binary is answered silently by the other profile's — at \
-         whatever revision it was last built. If their config contract has moved since, \
-         {bin} will refuse to start. Build the matching one with \
-         `just build-supervisors{flag}`.",
-        exe = mismatch.exe.as_str(),
-        helper = mismatch.helper.as_str(),
-        path = mismatch.helper_path.display(),
-        flag = mismatch.exe.cargo_flag(),
-    )
-}
-
-/// The cargo build profile a binary was produced under.
-///
-/// Only the two cargo emits without a custom profile. A custom one lands in
-/// `target/<name>/` and reads as [`None`] rather than being guessed at: this
-/// type exists to compare two binaries, and an unrecognised name on either side
-/// would manufacture a mismatch out of no information.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BuildProfile {
-    /// `target/debug`.
-    Debug,
-    /// `target/release`.
-    Release,
-}
-
-impl BuildProfile {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Debug => "debug",
-            Self::Release => "release",
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        // On a timeout the outcome is decided without this result; the
+        // thread still reaps the child when it eventually exits.
+        let _ = tx.send(child.wait_with_output());
+    });
+    let output = match rx.recv_timeout(timeout) {
+        Ok(Ok(output)) => output,
+        Ok(Err(e)) => {
+            return ProbeOutcome::Refused {
+                detail: format!("waiting on it failed: {e}"),
+            };
         }
-    }
-
-    /// The cargo flag that selects this profile, ready to interpolate after
-    /// `cargo build`. Empty for debug, which is cargo's default.
-    pub fn cargo_flag(self) -> &'static str {
-        match self {
-            Self::Debug => "",
-            Self::Release => " --release",
+        Err(mpsc::RecvTimeoutError::Timeout) => return ProbeOutcome::TimedOut,
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            return ProbeOutcome::Refused {
+                detail: "the probe observer died".to_string(),
+            };
+        }
+    };
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        match helper_contract::parse_probe_version(&stdout) {
+            Some(version) => ProbeOutcome::Answered(version),
+            None => ProbeOutcome::Refused {
+                detail: format!("unrecognized probe answer {stdout:?}"),
+            },
+        }
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let tail = stderr
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .rev()
+            .take(3)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join(" ");
+        ProbeOutcome::Refused {
+            detail: format!("probe exited with {}: {}", output.status, tail.trim()),
         }
     }
 }
 
-/// A helper resolved from a different build profile than the running binary.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProfileMismatch {
-    /// The running executable's profile.
-    pub exe: BuildProfile,
-    /// The resolved helper's profile.
-    pub helper: BuildProfile,
-    /// Where the helper was found.
-    pub helper_path: PathBuf,
-}
-
-/// Which profile a binary sits under, read from its parent directory name.
-pub fn build_profile_of(path: &Path) -> Option<BuildProfile> {
-    match path.parent()?.file_name()?.to_str()? {
-        "debug" => Some(BuildProfile::Debug),
-        "release" => Some(BuildProfile::Release),
-        _ => None,
+/// One-sentence description of a stale probe, grammatically fit for both
+/// "helper at path {detail}" messages.
+fn stale_detail(stale: &ProbeOutcome) -> String {
+    match stale {
+        ProbeOutcome::Answered(version) => format!("speaks contract version {version}"),
+        ProbeOutcome::Refused { detail } => {
+            format!("does not answer the contract probe ({detail})")
+        }
+        ProbeOutcome::TimedOut => {
+            "did not answer the contract probe within the deadline".to_string()
+        }
     }
 }
 
-/// Describe a cross-profile pick, or [`None`] when there is nothing to say.
-///
-/// Silent unless *both* sides are recognisable and they differ, so an installed
-/// binary — a downloaded release in `~/.local/bin` with its helpers beside it,
-/// neither under a cargo target dir — is never accused of a mismatch it cannot
-/// have.
-pub fn profile_mismatch(exe: Option<&Path>, helper: &Path) -> Option<ProfileMismatch> {
-    let exe_profile = build_profile_of(exe?)?;
-    let helper_profile = build_profile_of(helper)?;
-    (exe_profile != helper_profile).then(|| ProfileMismatch {
-        exe: exe_profile,
-        helper: helper_profile,
-        helper_path: helper.to_path_buf(),
-    })
+/// Everything [`resolve_verified_in`] reads from the process, gathered into
+/// one struct so the verification rules are testable without mutating
+/// process-global env or invoking a real cargo build.
+pub(crate) struct VerifyEnv {
+    /// Root of the source checkout this binary was built from, when that
+    /// root still looks like a checkout (a workspace `Cargo.toml` present).
+    workspace_root: Option<PathBuf>,
+    /// Build profile of the running exe, when its path reveals one.
+    exe_profile: Option<BuildProfile>,
+    /// `cargo` used for an automatic rebuild.
+    cargo: PathBuf,
+    probe_timeout: Duration,
 }
 
-/// Everything `resolve` reads from the environment, gathered so the resolution
-/// rules are testable without mutating process-global env.
+impl VerifyEnv {
+    fn from_process() -> Self {
+        let workspace_root =
+            workspace_root_from_manifest_dir().filter(|root| root.join("Cargo.toml").is_file());
+        Self {
+            workspace_root,
+            exe_profile: std::env::current_exe()
+                .ok()
+                .as_deref()
+                .and_then(build_profile_of),
+            cargo: PathBuf::from("cargo"),
+            probe_timeout: PROBE_TIMEOUT,
+        }
+    }
+}
+
+fn recover_stale_helper(
+    spec: &AuxBin,
+    lookup: &Lookup,
+    env: &VerifyEnv,
+    resolved: &Path,
+    stale: &ProbeOutcome,
+) -> Result<PathBuf> {
+    let Some(plan) = RebuildPlan::new(spec, resolved, env) else {
+        let command = manual_rebuild_command(spec, env.exe_profile);
+        let mut advice = format!("Rebuild the matching helper with `{command}`.");
+        if lookup.override_path.is_some() {
+            advice = format!(
+                "{env_var} overrides helper resolution; point it at a matching build or \
+                 unset it. Then rebuild with `{command}` if needed.",
+                env_var = spec.env_var,
+            );
+        }
+        bail!(
+            "{bin} at {path} {detail}, but this mvmctl requires contract version \
+             {required}. {advice}",
+            bin = spec.bin,
+            path = resolved.display(),
+            detail = stale_detail(stale),
+            required = helper_contract::HOST_HELPER_CONTRACT_VERSION,
+        );
+    };
+
+    crate::host::ui::warn(&format!(
+        "{bin} at {path} {detail}; rebuilding with `{command}` …",
+        bin = spec.bin,
+        path = resolved.display(),
+        detail = stale_detail(stale),
+        command = plan.command_line(),
+    ));
+    plan.run(env)?;
+    let rebuilt = resolve_from(spec, lookup)?;
+    match probe_contract(&rebuilt, env.probe_timeout) {
+        ProbeOutcome::Answered(version)
+            if version == helper_contract::HOST_HELPER_CONTRACT_VERSION =>
+        {
+            Ok(rebuilt)
+        }
+        still_stale => bail!(
+            "rebuilt {bin} at {path} {detail}; the rebuild did not produce a helper \
+             speaking contract version {required}. Run `{command}` yourself and check \
+             its output.",
+            bin = spec.bin,
+            path = rebuilt.display(),
+            detail = stale_detail(&still_stale),
+            required = helper_contract::HOST_HELPER_CONTRACT_VERSION,
+            command = plan.command_line(),
+        ),
+    }
+}
+
+/// The build command a person can run by hand: the package that produces the
+/// helper, in the running binary's profile when it is known (advising a bare
+/// `cargo build` from a release `mvmctl` rebuilds the debug helper the
+/// release one does not use, so the command appears to succeed and the next
+/// launch fails identically).
+fn manual_rebuild_command(spec: &AuxBin, exe_profile: Option<BuildProfile>) -> String {
+    let flag = exe_profile.map_or("", BuildProfile::cargo_flag);
+    format!("cargo build{flag} -p {} --bins", spec.rebuild_package)
+}
+
+/// One automatic rebuild of a stale helper.
+#[derive(Debug, PartialEq, Eq)]
+struct RebuildPlan {
+    root: PathBuf,
+    args: Vec<String>,
+}
+
+impl RebuildPlan {
+    /// A rebuild can fix `resolved` only when the helper lives in this
+    /// checkout's own `target/` directories — rebuilding the workspace is
+    /// what changes what resolution picks there. An installed helper, an
+    /// exe-dir copy, or an env-pointed one is outside cargo's reach, and no
+    /// plan is the honest answer.
+    fn new(spec: &AuxBin, resolved: &Path, env: &VerifyEnv) -> Option<Self> {
+        let root = env.workspace_root.as_ref()?;
+        let parent = resolved.parent()?;
+        if !workspace_target_dirs_for(root)
+            .iter()
+            .any(|dir| dir == parent)
+        {
+            return None;
+        }
+        let profile = env.exe_profile.or_else(|| build_profile_of(resolved))?;
+        let mut args = vec!["build".to_string()];
+        if profile == BuildProfile::Release {
+            args.push("--release".to_string());
+        }
+        args.push("-p".to_string());
+        args.push(spec.rebuild_package.to_string());
+        args.push("--bins".to_string());
+        Some(Self {
+            root: root.clone(),
+            args,
+        })
+    }
+
+    fn command_line(&self) -> String {
+        format!("cargo {}", self.args.join(" "))
+    }
+
+    fn run(&self, env: &VerifyEnv) -> Result<()> {
+        let output = Command::new(&env.cargo)
+            .args(&self.args)
+            .current_dir(&self.root)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| {
+                anyhow!(
+                    "could not run `{}` ({e}); run it yourself from {}",
+                    self.command_line(),
+                    self.root.display(),
+                )
+            })?;
+        if output.status.success() {
+            return Ok(());
+        }
+        let tail = [output.stdout, output.stderr]
+            .iter()
+            .map(|bytes| String::from_utf8_lossy(bytes).to_string())
+            .collect::<Vec<_>>()
+            .concat();
+        let tail = tail
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .rev()
+            .take(5)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join("\n");
+        bail!(
+            "`{}` failed ({}) with:\n{tail}\nrun it yourself from {} and fix the errors",
+            self.command_line(),
+            output.status,
+            self.root.display(),
+        )
+    }
+}
+
+/// Everything `resolve` reads from the environment, gathered so the
+/// resolution rules are testable without mutating process-global env.
 pub(crate) struct Lookup {
     pub(crate) override_path: Option<PathBuf>,
     pub(crate) dirs: Vec<PathBuf>,
+}
+
+fn lookup_from_env(spec: &AuxBin) -> Lookup {
+    Lookup {
+        override_path: std::env::var_os(spec.env_var).map(PathBuf::from),
+        dirs: assemble_candidate_dirs(
+            current_exe_dir(),
+            aux_bin_dir_from_env(),
+            workspace_target_dirs(),
+        ),
+    }
 }
 
 fn resolve_from(spec: &AuxBin, lookup: &Lookup) -> Result<PathBuf> {
@@ -187,10 +379,11 @@ fn resolve_from(spec: &AuxBin, lookup: &Lookup) -> Result<PathBuf> {
         return Ok(found);
     }
     bail!(
-        "{bin} not found. It is a per-VM host helper `[[bin]]` of mvm-hostd; on \
+        "{bin} not found. It is a per-VM host helper `[[bin]]` of {pkg}; on \
          a source checkout run `cargo build --bins` (or `just \
          build-supervisors`), or set {env}=<path>.{hint}",
         bin = spec.bin,
+        pkg = spec.rebuild_package,
         env = spec.env_var,
         hint = missing_hint(spec.bin),
     )
@@ -247,11 +440,13 @@ fn workspace_root_from_manifest_dir() -> Option<PathBuf> {
 /// `target/{release,debug}` under each workspace target dir (default plus a
 /// `CARGO_TARGET_DIR` override), the fallback for `just build-supervisors`.
 fn workspace_target_dirs() -> Vec<PathBuf> {
-    let Some(root) = workspace_root_from_manifest_dir() else {
-        return Vec::new();
-    };
+    workspace_root_from_manifest_dir()
+        .map_or_else(Vec::new, |root| workspace_target_dirs_for(&root))
+}
+
+fn workspace_target_dirs_for(root: &Path) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
-    for base in source_checkout_target_dirs(&root) {
+    for base in source_checkout_target_dirs(root) {
         dirs.push(base.join("release"));
         dirs.push(base.join("debug"));
     }
@@ -287,103 +482,420 @@ fn cargo_target_dir_from_env(workspace_root: &Path, target_dir: Option<OsString>
     }
 }
 
+/// The cargo build profile a binary was produced under.
+///
+/// Only the two cargo emits without a custom profile. A custom one lands in
+/// `target/<name>/` and reads as [`None`] rather than being guessed at: this
+/// type exists to pick a rebuild profile, and an unrecognised name would
+/// manufacture a choice out of no information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildProfile {
+    /// `target/debug`.
+    Debug,
+    /// `target/release`.
+    Release,
+}
+
+impl BuildProfile {
+    /// The cargo flag that selects this profile, ready to interpolate after
+    /// `cargo build`. Empty for debug, which is cargo's default.
+    pub fn cargo_flag(self) -> &'static str {
+        match self {
+            Self::Debug => "",
+            Self::Release => " --release",
+        }
+    }
+}
+
+/// Which profile a binary sits under, read from its parent directory name.
+pub fn build_profile_of(path: &Path) -> Option<BuildProfile> {
+    match path.parent()?.file_name()?.to_str()? {
+        "debug" => Some(BuildProfile::Debug),
+        "release" => Some(BuildProfile::Release),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::os::unix::fs::PermissionsExt;
+
     use super::*;
 
-    /// The failure this exists to attribute: a release `mvmctl` whose own
-    /// directory has no helper is answered by `target/debug`, because the
-    /// search spans profiles and cargo never rebuilds across one. It works
-    /// until the config contract moves, and then the supervisor refuses with a
-    /// message about a JSON field.
-    #[test]
-    fn a_release_exe_answered_by_a_debug_helper_is_a_mismatch() {
-        let mismatch = profile_mismatch(
-            Some(Path::new("/repo/target/release/mvmctl")),
-            Path::new("/repo/target/debug/mvm-hvf-supervisor"),
-        )
-        .expect("crossing profiles must be reported");
+    fn hvf_spec() -> AuxBin<'static> {
+        AuxBin {
+            bin: "mvm-hvf-supervisor",
+            env_var: "MVM_HVF_SUPERVISOR_PATH",
+            rebuild_package: "mvm-hostd",
+        }
+    }
 
-        assert_eq!(mismatch.exe, BuildProfile::Release);
-        assert_eq!(mismatch.helper, BuildProfile::Debug);
-        assert_eq!(
-            mismatch.helper_path,
-            Path::new("/repo/target/debug/mvm-hvf-supervisor")
+    fn write_exe(path: &Path, body: &str) {
+        std::fs::write(path, body).unwrap();
+        let mut perms = std::fs::metadata(path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(path, perms).unwrap();
+    }
+
+    /// A helper script that answers the probe with `version`.
+    fn answering_helper(bin: &str, version: u32) -> String {
+        format!("#!/bin/sh\nprintf '%s\\n' '{bin} contract-version={version}'\n")
+    }
+
+    /// A stand-in for `cargo` that rebuilds every requested host helper as a
+    /// probe-answering script under `target/<profile>/`, relative to its cwd
+    /// (the workspace root the resolver sets).
+    fn fixing_cargo(bin: &str) -> String {
+        format!(
+            "#!/bin/sh\n\
+             profile=debug\n\
+             for arg in \"$@\"; do\n\
+             \x20   if [ \"$arg\" = \"--release\" ]; then profile=release; fi\n\
+             done\n\
+             mkdir -p \"target/$profile\"\n\
+             cat > \"target/$profile/{bin}\" <<'PROBE_EOF'\n\
+             #!/bin/sh\n\
+             printf '%s\\n' '{bin} contract-version={current}'\n\
+             PROBE_EOF\n\
+             chmod +x \"target/$profile/{bin}\"\n",
+            current = helper_contract::HOST_HELPER_CONTRACT_VERSION,
+        )
+    }
+
+    /// A stand-in for `cargo` that succeeds without producing anything —
+    /// the rebuild-that-doesn't-fix case.
+    fn no_op_cargo() -> String {
+        "#!/bin/sh\nexit 0\n".to_string()
+    }
+
+    /// A stand-in for `cargo` that leaves a marker file when run, so tests
+    /// can assert no rebuild was attempted.
+    fn marker_cargo(marker: &Path) -> String {
+        format!("#!/bin/sh\ntouch '{}'\nexit 0\n", marker.display())
+    }
+
+    fn test_env(workspace_root: Option<PathBuf>) -> VerifyEnv {
+        VerifyEnv {
+            workspace_root,
+            exe_profile: None,
+            cargo: PathBuf::from("cargo"),
+            probe_timeout: PROBE_TIMEOUT,
+        }
+    }
+
+    /// A scratch workspace: a `Cargo.toml` plus `target/{release,debug}/`.
+    fn scratch_checkout(tmp: &Path) -> PathBuf {
+        let root = tmp.join("ws");
+        std::fs::create_dir_all(root.join("target/release")).unwrap();
+        std::fs::create_dir_all(root.join("target/debug")).unwrap();
+        std::fs::write(root.join("Cargo.toml"), "[workspace]\n").unwrap();
+        root
+    }
+
+    #[test]
+    fn verified_resolve_accepts_a_helper_with_the_current_contract() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("mvm-hvf-supervisor");
+        write_exe(
+            &bin,
+            &answering_helper(
+                "mvm-hvf-supervisor",
+                helper_contract::HOST_HELPER_CONTRACT_VERSION,
+            ),
         );
-    }
 
-    /// Both directions, because the resolver searches `release` before `debug`
-    /// but the exe's own directory before either — so which way the fallthrough
-    /// runs depends on which helper is missing, not on a fixed precedence.
-    #[test]
-    fn a_debug_exe_answered_by_a_release_helper_is_also_a_mismatch() {
-        let mismatch = profile_mismatch(
-            Some(Path::new("/repo/target/debug/mvmctl")),
-            Path::new("/repo/target/release/mvm-libkrun-supervisor"),
+        let got = resolve_verified_in(
+            &hvf_spec(),
+            &Lookup {
+                override_path: None,
+                dirs: vec![tmp.path().to_path_buf()],
+            },
+            &test_env(None),
         )
-        .expect("crossing profiles must be reported in either direction");
-
-        assert_eq!(mismatch.exe, BuildProfile::Debug);
-        assert_eq!(mismatch.helper, BuildProfile::Release);
+        .unwrap();
+        assert_eq!(got, bin);
     }
 
     #[test]
-    fn matching_profiles_are_not_a_mismatch() {
-        for profile in ["debug", "release"] {
+    fn verified_resolve_rejects_an_older_contract_without_a_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_exe(
+            &tmp.path().join("mvm-hvf-supervisor"),
+            &answering_helper("mvm-hvf-supervisor", 0),
+        );
+
+        let err = resolve_verified_in(
+            &hvf_spec(),
+            &Lookup {
+                override_path: None,
+                dirs: vec![tmp.path().to_path_buf()],
+            },
+            &test_env(None),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("contract version 0"), "{err}");
+        assert!(
+            err.contains(&format!(
+                "requires contract version {}",
+                helper_contract::HOST_HELPER_CONTRACT_VERSION
+            )),
+            "{err}"
+        );
+        assert!(err.contains("cargo build -p mvm-hostd --bins"), "{err}");
+    }
+
+    #[test]
+    fn verified_resolve_rebuilds_a_stale_helper_inside_the_checkout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = scratch_checkout(tmp.path());
+        let stale = root.join("target/debug/mvm-hvf-supervisor");
+        write_exe(&stale, &answering_helper("mvm-hvf-supervisor", 0));
+
+        let cargo = tmp.path().join("cargo");
+        write_exe(&cargo, &fixing_cargo("mvm-hvf-supervisor"));
+
+        let mut env = test_env(Some(root.clone()));
+        env.exe_profile = Some(BuildProfile::Release);
+        env.cargo = cargo;
+
+        // Resolution order inside a checkout is release before debug, so the
+        // rebuilt helper must win over the stale debug one.
+        let lookup = Lookup {
+            override_path: None,
+            dirs: workspace_target_dirs_for(&root),
+        };
+        let got = resolve_verified_in(&hvf_spec(), &lookup, &env).unwrap();
+        assert_eq!(got, root.join("target/release/mvm-hvf-supervisor"));
+        assert_ne!(got, stale);
+    }
+
+    #[test]
+    fn verified_resolve_bails_when_the_rebuild_does_not_fix_the_helper() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = scratch_checkout(tmp.path());
+        write_exe(
+            &root.join("target/debug/mvm-hvf-supervisor"),
+            &answering_helper("mvm-hvf-supervisor", 0),
+        );
+        let cargo = tmp.path().join("cargo");
+        write_exe(&cargo, &no_op_cargo());
+
+        let mut env = test_env(Some(root.clone()));
+        env.cargo = cargo;
+        let lookup = Lookup {
+            override_path: None,
+            dirs: workspace_target_dirs_for(&root),
+        };
+        let err = resolve_verified_in(&hvf_spec(), &lookup, &env)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("did not produce a helper"), "{err}");
+        assert!(err.contains("cargo build -p mvm-hostd --bins"), "{err}");
+    }
+
+    #[test]
+    fn verified_resolve_reports_a_failed_rebuild_with_cargo_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = scratch_checkout(tmp.path());
+        write_exe(
+            &root.join("target/debug/mvm-hvf-supervisor"),
+            &answering_helper("mvm-hvf-supervisor", 0),
+        );
+        let cargo = tmp.path().join("cargo");
+        write_exe(
+            &cargo,
+            "#!/bin/sh\necho 'error: broken workspace' >&2\nexit 1\n",
+        );
+
+        let mut env = test_env(Some(root.clone()));
+        env.cargo = cargo;
+        let lookup = Lookup {
+            override_path: None,
+            dirs: workspace_target_dirs_for(&root),
+        };
+        let err = resolve_verified_in(&hvf_spec(), &lookup, &env)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("broken workspace"), "{err}");
+        assert!(err.contains("cargo build -p mvm-hostd --bins"), "{err}");
+    }
+
+    #[test]
+    fn verified_resolve_never_rebuilds_a_helper_outside_the_checkout_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = scratch_checkout(tmp.path());
+        let plain = tmp.path().join("plain");
+        std::fs::create_dir_all(&plain).unwrap();
+        write_exe(
+            &plain.join("mvm-hvf-supervisor"),
+            &answering_helper("mvm-hvf-supervisor", 0),
+        );
+        let marker = tmp.path().join("ran");
+        let cargo = tmp.path().join("cargo");
+        write_exe(&cargo, &marker_cargo(&marker));
+
+        let mut env = test_env(Some(root));
+        env.cargo = cargo;
+        let err = resolve_verified_in(
+            &hvf_spec(),
+            &Lookup {
+                override_path: None,
+                dirs: vec![plain],
+            },
+            &env,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(!marker.exists(), "no rebuild may be attempted: {err}");
+        assert!(err.contains("requires contract version"), "{err}");
+    }
+
+    #[test]
+    fn verified_resolve_never_rebuilds_an_env_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = scratch_checkout(tmp.path());
+        let override_path = tmp.path().join("elsewhere");
+        std::fs::create_dir_all(&override_path).unwrap();
+        write_exe(
+            &override_path.join("mvm-hvf-supervisor"),
+            &answering_helper("mvm-hvf-supervisor", 0),
+        );
+        let marker = tmp.path().join("ran");
+        let cargo = tmp.path().join("cargo");
+        write_exe(&cargo, &marker_cargo(&marker));
+
+        let mut env = test_env(Some(root));
+        env.cargo = cargo;
+        let err = resolve_verified_in(
+            &hvf_spec(),
+            &Lookup {
+                override_path: Some(override_path.join("mvm-hvf-supervisor")),
+                dirs: vec![],
+            },
+            &env,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(!marker.exists(), "no rebuild may be attempted: {err}");
+        assert!(err.contains("MVM_HVF_SUPERVISOR_PATH"), "{err}");
+    }
+
+    #[test]
+    fn a_helper_that_exits_without_answering_is_treated_as_stale() {
+        // Pre-probe helpers fail reading their stdin config instead of
+        // answering — the resolver must read that as "stale", never as a
+        // usable helper.
+        let tmp = tempfile::tempdir().unwrap();
+        write_exe(
+            &tmp.path().join("mvm-hvf-supervisor"),
+            "#!/bin/sh\nexit 1\n",
+        );
+
+        let err = resolve_verified_in(
+            &hvf_spec(),
+            &Lookup {
+                override_path: None,
+                dirs: vec![tmp.path().to_path_buf()],
+            },
+            &test_env(None),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("does not answer the contract probe"), "{err}");
+    }
+
+    #[test]
+    fn a_probe_that_times_out_is_treated_as_stale() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_exe(
+            &tmp.path().join("mvm-hvf-supervisor"),
+            "#!/bin/sh\nsleep 60\n",
+        );
+
+        let mut env = test_env(None);
+        env.probe_timeout = Duration::from_millis(100);
+        let err = resolve_verified_in(
+            &hvf_spec(),
+            &Lookup {
+                override_path: None,
+                dirs: vec![tmp.path().to_path_buf()],
+            },
+            &env,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("within the deadline"), "{err}");
+    }
+
+    #[test]
+    fn rebuild_plan_matches_the_running_exes_profile() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = scratch_checkout(tmp.path());
+        let helper = root.join("target/debug/mvm-hvf-supervisor");
+        write_exe(&helper, "#!/bin/sh\n");
+
+        for (exe_profile, expect_release) in [(Some(BuildProfile::Release), true), (None, false)] {
+            let env = VerifyEnv {
+                workspace_root: Some(root.clone()),
+                exe_profile,
+                cargo: PathBuf::from("cargo"),
+                probe_timeout: PROBE_TIMEOUT,
+            };
+            let plan = RebuildPlan::new(&hvf_spec(), &helper, &env)
+                .unwrap_or_else(|| panic!("plan must exist for {exe_profile:?}"));
+            assert_eq!(plan.args.contains(&"--release".to_string()), expect_release);
             assert_eq!(
-                profile_mismatch(
-                    Some(&PathBuf::from(format!("/repo/target/{profile}/mvmctl"))),
-                    &PathBuf::from(format!("/repo/target/{profile}/mvm-hvf-supervisor")),
-                ),
-                None,
-                "{profile} against itself is the ordinary case"
+                plan.command_line(),
+                if expect_release {
+                    "cargo build --release -p mvm-hostd --bins"
+                } else {
+                    "cargo build -p mvm-hostd --bins"
+                }
             );
         }
     }
 
-    /// A downloaded release ships its helpers beside the binary, and neither
-    /// side sits under a cargo target dir. Accusing that layout of a mismatch
-    /// would put a rebuild instruction in front of someone with no checkout to
-    /// run it in, so an unreadable profile on either side stays silent.
     #[test]
-    fn an_installed_binary_is_never_accused_of_a_mismatch() {
-        assert_eq!(
-            profile_mismatch(
-                Some(Path::new("/usr/local/bin/mvmctl")),
-                Path::new("/usr/local/bin/mvm-hvf-supervisor"),
-            ),
-            None
-        );
-        // One side recognisable is still not enough to conclude anything.
-        assert_eq!(
-            profile_mismatch(
-                Some(Path::new("/usr/local/bin/mvmctl")),
-                Path::new("/repo/target/debug/mvm-hvf-supervisor"),
-            ),
-            None
-        );
-        assert_eq!(
-            profile_mismatch(
-                Some(Path::new("/repo/target/release/mvmctl")),
-                Path::new("/usr/local/bin/mvm-hvf-supervisor"),
-            ),
-            None
-        );
+    fn rebuild_plan_exists_only_for_checkout_target_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = scratch_checkout(tmp.path());
+        let env = VerifyEnv {
+            workspace_root: Some(root.clone()),
+            exe_profile: None,
+            cargo: PathBuf::from("cargo"),
+            probe_timeout: PROBE_TIMEOUT,
+        };
+
+        let in_checkout = root.join("target/release/mvm-hvf-supervisor");
+        write_exe(&in_checkout, "#!/bin/sh\n");
+        assert!(RebuildPlan::new(&hvf_spec(), &in_checkout, &env).is_some());
+
+        let elsewhere = tmp.path().join("plain").join("mvm-hvf-supervisor");
+        std::fs::create_dir_all(elsewhere.parent().unwrap()).unwrap();
+        write_exe(&elsewhere, "#!/bin/sh\n");
+        assert_eq!(RebuildPlan::new(&hvf_spec(), &elsewhere, &env), None);
+
+        let no_root = VerifyEnv {
+            workspace_root: None,
+            ..env
+        };
+        assert_eq!(RebuildPlan::new(&hvf_spec(), &in_checkout, &no_root), None);
     }
 
-    /// `current_exe()` can fail, and a diagnostic that cannot read one side has
-    /// nothing to compare rather than something to report.
     #[test]
-    fn an_unknown_exe_yields_no_mismatch() {
-        assert_eq!(
-            profile_mismatch(None, Path::new("/repo/target/debug/mvm-hvf-supervisor")),
-            None
-        );
+    fn build_profile_of_reads_the_parent_dir_name() {
+        for (profile, expected) in [
+            ("debug", BuildProfile::Debug),
+            ("release", BuildProfile::Release),
+        ] {
+            assert_eq!(
+                build_profile_of(&PathBuf::from(format!("/repo/target/{profile}/mvmctl"))),
+                Some(expected)
+            );
+        }
     }
 
-    /// A custom cargo profile lands in `target/<name>/`, and a test binary in
-    /// `target/<profile>/deps/`. Neither is one of the two names, and guessing
-    /// at them would manufacture a mismatch out of no information.
     #[test]
     fn only_the_two_cargo_profiles_are_recognised() {
         assert_eq!(
@@ -401,30 +913,6 @@ mod tests {
         assert_eq!(
             build_profile_of(Path::new("/repo/target/debug/deps/mvm_vmm-abc123")),
             None
-        );
-    }
-
-    /// The warning has to carry the path, both profiles, and a rebuild whose
-    /// flag follows the *running* binary rather than the helper that was found.
-    #[test]
-    fn the_warning_names_both_profiles_and_a_profile_correct_rebuild() {
-        let mismatch = profile_mismatch(
-            Some(Path::new("/repo/target/release/mvmctl")),
-            Path::new("/repo/target/debug/mvm-hvf-supervisor"),
-        )
-        .unwrap();
-        let warning = profile_mismatch_warning("mvm-hvf-supervisor", &mismatch);
-
-        assert!(warning.contains("mvm-hvf-supervisor"), "{warning}");
-        assert!(warning.contains("release build"), "{warning}");
-        assert!(warning.contains("the debug one"), "{warning}");
-        assert!(
-            warning.contains("/repo/target/debug/mvm-hvf-supervisor"),
-            "naming the file is what makes it checkable: {warning}"
-        );
-        assert!(
-            warning.contains("just build-supervisors --release"),
-            "the rebuild must name the running binary's profile, not the helper's: {warning}"
         );
     }
 
@@ -474,13 +962,6 @@ mod tests {
             first_existing_bin("mvm-hvf-supervisor", &[tmp.path().to_path_buf()]),
             None
         );
-    }
-
-    fn hvf_spec() -> AuxBin<'static> {
-        AuxBin {
-            bin: "mvm-hvf-supervisor",
-            env_var: "MVM_HVF_SUPERVISOR_PATH",
-        }
     }
 
     #[test]

--- a/crates/mvm-vmm/src/host/helper_contract.rs
+++ b/crates/mvm-vmm/src/host/helper_contract.rs
@@ -1,0 +1,174 @@
+//! Compile-time contract between `mvmctl` and the per-VM host helper
+//! binaries it spawns (`mvm-hvf-supervisor`, `mvm-libkrun-supervisor`,
+//! `mvm-network-endpoint`, and `mvmctl` itself when the qemu bridge re-execs
+//! it).
+//!
+//! Both sides of every host↔helper config pipe are compiled from the same
+//! source tree, so each binary carries the same
+//! [`HOST_HELPER_CONTRACT_VERSION`]. A binary built from an older revision —
+//! or from the other cargo profile, which cargo never rebuilds across —
+//! carries a different one. `aux_bin::resolve_verified` asks the resolved
+//! helper for its version before spawning it, so a stale helper is rebuilt
+//! or refused instead of failing mid-boot with a JSON parse error.
+//!
+//! Bump [`HOST_HELPER_CONTRACT_VERSION`] whenever any host↔helper config
+//! contract changes incompatibly. The shape-pin tests (one per strict config
+//! type, e.g. `HvfSupervisorConfig`) force that bump: they hash the
+//! serialized struct and compare against a pin stored in this file, so a
+//! contract change without a version bump fails the test suite.
+
+/// Version of the host↔helper config contract this build speaks.
+///
+/// Helpers compiled from the same tree answer the
+/// [`CONTRACT_PROBE_FLAG`] probe with this value; `mvmctl` refuses to spawn
+/// a helper that answers differently.
+pub const HOST_HELPER_CONTRACT_VERSION: u32 = 1;
+
+/// CLI flag every host helper answers by printing its contract version and
+/// exiting 0. Binaries built before the probe existed exit non-zero instead,
+/// which the resolver reads as "stale" — that is the whole point.
+pub const CONTRACT_PROBE_FLAG: &str = "--contract-version";
+
+/// Response body a helper prints for [`CONTRACT_PROBE_FLAG`]:
+/// `<bin> contract-version=<N>` followed by a newline.
+pub fn probe_response(bin: &str) -> String {
+    format!("{bin} {CONTRACT_PROBE_KEY}={HOST_HELPER_CONTRACT_VERSION}\n")
+}
+
+const CONTRACT_PROBE_KEY: &str = "contract-version";
+
+/// Whether an argv (including argv\[0\]) requests the contract probe, so a
+/// helper's `main` can answer it before doing anything else.
+pub fn probe_requested(mut args: impl Iterator<Item = String>) -> bool {
+    args.next();
+    args.any(|arg| arg == CONTRACT_PROBE_FLAG)
+}
+
+/// Answer the contract probe and exit 0 when it was requested; do nothing
+/// otherwise. Every host helper's `main` calls this as its first statement,
+/// before panic hooks, self-signing, or config reads — the probe must stay
+/// cheap and side-effect-free so `aux_bin::resolve_verified` can run it on
+/// every spawn.
+pub fn exit_with_probe_answer_if_requested(bin: &str) {
+    if probe_requested(std::env::args()) {
+        print!("{}", probe_response(bin));
+        std::process::exit(0);
+    }
+}
+
+/// Parse the version out of a helper's probe stdout.
+///
+/// Strict on purpose: exactly `<anything> contract-version=<u32>` on the
+/// first line. A looser parse would let an unrelated crash banner read as a
+/// version answer.
+pub fn parse_probe_version(stdout: &str) -> Option<u32> {
+    let line = stdout.lines().next()?.trim_end();
+    let (name, rest) = line.split_once(' ')?;
+    if name.is_empty() {
+        return None;
+    }
+    rest.strip_prefix(CONTRACT_PROBE_KEY)?
+        .strip_prefix('=')?
+        .parse()
+        .ok()
+}
+
+/// FNV-1a over the canonical JSON of a fully populated
+/// [`crate::host::hvf_supervisor::HvfSupervisorConfig`]. The shape-pin test
+/// in that module recomputes this and compares — changing the struct's
+/// fields without updating this pin (and bumping the contract version)
+/// fails the test suite. Test-only because it exists solely for that test.
+#[cfg(test)]
+pub(crate) const HVF_CONFIG_SHAPE_HASH: u64 = 0x319f_4039_b7ab_fb40;
+
+/// 64-bit FNV-1a, implemented inline so the shape pins have no dependency.
+#[cfg(test)]
+pub(crate) fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET_BASIS;
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_response_round_trips_through_the_parser() {
+        let response = probe_response("mvm-hvf-supervisor");
+        assert_eq!(
+            parse_probe_version(&response),
+            Some(HOST_HELPER_CONTRACT_VERSION)
+        );
+    }
+
+    #[test]
+    fn parser_accepts_any_binary_name() {
+        assert_eq!(parse_probe_version("mvmctl contract-version=7\n"), Some(7));
+    }
+
+    #[test]
+    fn parser_rejects_garbage() {
+        for stdout in [
+            "",
+            "\n",
+            "mvm-hvf-supervisor\n",
+            "contract-version=1\n",
+            "mvm-hvf-supervisor contract-version=\n",
+            "mvm-hvf-supervisor contract-version=1 extra\n",
+            "mvm-hvf-supervisor contract-version=1x\n",
+            "mvm-hvf-supervisor contract-version=-1\n",
+            "mvm-hvf-supervisor contract-version= 1\n",
+            "panic: something broke contract-version=3\n",
+        ] {
+            assert_eq!(parse_probe_version(stdout), None, "input: {stdout:?}");
+        }
+    }
+
+    #[test]
+    fn parser_reads_only_the_first_line() {
+        assert_eq!(
+            parse_probe_version("mvm-hvf-supervisor contract-version=2\nnoise\n"),
+            Some(2)
+        );
+        assert_eq!(parse_probe_version("noise\nmvm contract-version=2\n"), None);
+    }
+
+    #[test]
+    fn probe_requested_finds_the_flag_anywhere_after_argv0() {
+        assert!(probe_requested(
+            [
+                "mvm-hvf-supervisor".to_string(),
+                "--contract-version".to_string()
+            ]
+            .into_iter()
+        ));
+        assert!(probe_requested(
+            [
+                "mvmctl".to_string(),
+                "__qemu-vsock-bridge".to_string(),
+                "--contract-version".to_string()
+            ]
+            .into_iter()
+        ));
+        assert!(!probe_requested(
+            ["mvm-hvf-supervisor".to_string()].into_iter()
+        ));
+        assert!(!probe_requested(
+            ["mvm-hvf-supervisor".to_string(), "--verbose".to_string()].into_iter()
+        ));
+    }
+
+    #[test]
+    fn fnv1a_matches_the_reference_value() {
+        // Published FNV-1a test vector (from the FNV reference page).
+        assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(fnv1a_64(b"a"), 0xaf63_dc4c_8601_ec8c);
+        assert_eq!(fnv1a_64(b"foobar"), 0x8594_4171_f739_67e8);
+    }
+}

--- a/crates/mvm-vmm/src/host/hvf_supervisor.rs
+++ b/crates/mvm-vmm/src/host/hvf_supervisor.rs
@@ -284,9 +284,9 @@ pub struct HvfSupervisorConfig {
 mod tests {
     use super::*;
 
-    #[test]
-    fn json_roundtrip_with_all_fields() {
-        let cfg = HvfSupervisorConfig {
+    /// Every field populated, so the shape pin below sees the whole schema.
+    fn full_config_fixture() -> HvfSupervisorConfig {
+        HvfSupervisorConfig {
             kernel: "/k/Image".into(),
             cmdline: Some("console=ttyAMA0 root=/dev/vda ro init=/sbin/mvm-host-vm-init".into()),
             memory_mib: 8192,
@@ -332,11 +332,34 @@ mod tests {
             handoff_verify_key: Some("11".repeat(32)),
             cpu_millicores: Some(500),
             quota_record: Some("/state/quota.json".into()),
-        };
+        }
+    }
+
+    #[test]
+    fn json_roundtrip_with_all_fields() {
+        let cfg = full_config_fixture();
         let json = serde_json::to_string(&cfg).unwrap();
         assert_eq!(
             serde_json::from_str::<HvfSupervisorConfig>(&json).unwrap(),
             cfg
+        );
+    }
+
+    /// The config contract is version-stamped (see `host::helper_contract`),
+    /// and this pin forces the stamp to move with the schema: serializing
+    /// the full fixture must hash to the pinned value, so adding, renaming,
+    /// or retyping a field fails here until the contract version and the pin
+    /// are updated together. Without it a same-tree config change could keep
+    /// the old version number and an older helper would be probed as current
+    /// while still refusing the new field at spawn.
+    #[test]
+    fn config_shape_matches_the_pinned_hash() {
+        let json = serde_json::to_string(&full_config_fixture()).unwrap();
+        let hash = crate::host::helper_contract::fnv1a_64(json.as_bytes());
+        assert_eq!(
+            hash,
+            crate::host::helper_contract::HVF_CONFIG_SHAPE_HASH,
+            "HvfSupervisorConfig's shape changed: bump              HOST_HELPER_CONTRACT_VERSION in host::helper_contract and update              HVF_CONFIG_SHAPE_HASH to 0x{hash:016x}"
         );
     }
 

--- a/crates/mvm-vmm/src/host/mod.rs
+++ b/crates/mvm-vmm/src/host/mod.rs
@@ -16,6 +16,7 @@ pub mod egress_redirect;
 pub mod egress_shared;
 pub mod fc_kernel;
 pub mod flowmux_identity;
+pub mod helper_contract;
 pub mod host_agent_spawn;
 pub mod hvf_supervisor;
 pub mod linux_env;

--- a/crates/mvm-vmm/src/host/network_endpoint_spawn.rs
+++ b/crates/mvm-vmm/src/host/network_endpoint_spawn.rs
@@ -415,12 +415,14 @@ fn stderr_tail(path: &Path, max_bytes: usize) -> Option<String> {
     (!collapsed.is_empty()).then_some(collapsed)
 }
 
-/// Locate the `mvm-network-endpoint` binary. Compiled by mvmctl's build
-/// script; see [`mvm_vmm::host::aux_bin`] for the search order.
+/// Locate the `mvm-network-endpoint` binary and refuse a stale one — the
+/// endpoint holds the workload's substituted secrets, so a moved-on config
+/// contract failing mid-boot is the worst place to discover the mismatch.
 fn resolve_network_endpoint_path() -> Result<PathBuf> {
-    crate::host::aux_bin::resolve(&crate::host::aux_bin::AuxBin {
+    crate::host::aux_bin::resolve_verified(&crate::host::aux_bin::AuxBin {
         bin: "mvm-network-endpoint",
         env_var: "MVM_SUBSTITUTION_ENDPOINT_PATH",
+        rebuild_package: "mvm-hostd",
     })
 }
 
@@ -1199,6 +1201,19 @@ fn kill(pid: libc::pid_t, sig: libc::c_int) {
 #[cfg(test)]
 mod tests {
 
+    /// Stub endpoint scripts run through the verified resolver before they
+    /// can play their role, so every stub answers the contract probe first.
+    /// Generated from the real response so a contract bump rewrites the
+    /// stubs instead of breaking them.
+    fn stub_preamble() -> String {
+        format!(
+            "#!/bin/sh\nif [ \"$1\" = \"{flag}\" ]; then echo '{answer}'; exit 0; fi\n",
+            flag = crate::host::helper_contract::CONTRACT_PROBE_FLAG,
+            answer =
+                crate::host::helper_contract::probe_response("mvm-network-endpoint").trim_end(),
+        )
+    }
+
     /// A launch whose endpoint never carried a session must fail, and say
     /// which of the two ways it failed.
     #[test]
@@ -1951,7 +1966,8 @@ mod tests {
         std::fs::write(
             &stub,
             format!(
-                "#!/bin/sh\ncat > {}\necho '{}'\n",
+                "{}cat > {}\necho '{}'\n",
+                stub_preamble(),
                 cfg_out.display(),
                 READY_HANDSHAKE
             ),
@@ -2017,7 +2033,10 @@ mod tests {
         let stub = dir.join("stub-endpoint.sh");
         std::fs::write(
             &stub,
-            format!("#!/bin/sh\ncat >/dev/null\necho '{READY_HANDSHAKE}'\n"),
+            format!(
+                "{}cat >/dev/null\necho '{READY_HANDSHAKE}'\n",
+                stub_preamble()
+            ),
         )
         .unwrap();
         {
@@ -2091,7 +2110,14 @@ mod tests {
         env.set("MVM_HOME", &dir);
 
         let stub = dir.join("stub-endpoint.sh");
-        std::fs::write(&stub, "#!/bin/sh\ncat >/dev/null\necho 'ready handshake'\n").unwrap();
+        std::fs::write(
+            &stub,
+            format!(
+                "{}cat >/dev/null\necho 'ready handshake'\n",
+                stub_preamble()
+            ),
+        )
+        .unwrap();
         {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
@@ -2154,7 +2180,8 @@ mod tests {
         std::fs::write(
             &stub,
             format!(
-                "#!/bin/sh\ncat >/dev/null\necho $$ > {}\ntrap 'echo stopped > {}; exit 0' TERM\necho '{}'\nwhile :; do sleep 1; done\n",
+                "{}cat >/dev/null\necho $$ > {}\ntrap 'echo stopped > {}; exit 0' TERM\necho '{}'\nwhile :; do sleep 1; done\n",
+                stub_preamble(),
                 pid_capture.display(),
                 stopped.display(),
                 READY_HANDSHAKE

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -13,6 +13,17 @@ Last updated: 2026-09-02
       mirrors dev-env.sh: inside-tree values honored, outside-tree values
       reclaimed loudly, MVM_DEV_ENV_KEEP_INHERITED=1 keeps them anyway. Gate
       tests and CI shellcheck green; merged via #3135.
+- [ ] **Aux host-helper contract verification.**
+      `specs/plans/2026-09-02-aux-helper-contract.md`.
+      Host helpers answer a `--contract-version` probe and `mvmctl` verifies
+      the answer before spawning: a stale helper in a source checkout is
+      rebuilt in the running binary's profile, and any other stale pick is a
+      hard error naming both contract versions and the rebuild command,
+      replacing the recurring silent cross-profile fallback that surfaced as
+      an "unknown field" spawn failure. A `HvfSupervisorConfig` shape pin
+      forces the contract version to bump with the schema. Focused
+      regressions, affected crate suites, zero-warning Clippy, and Linux/BDD
+      gated compilation are green; merge delivery remains.
 
 - [ ] **Signed caller commitment — issue #3070.**
       `specs/plans/2026-09-01-signed-caller-commitment.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -27,6 +27,19 @@
       ledger with a BDD suite (`s33_content_addressed_assets`, 4 scenarios).
       Workspace check, host tests, gated Linux cross-check, clippy, fmt, and
       the claim/CLI lint gates are green. Merge delivery remains.
+- [ ] **Aux host-helper contract verification.**
+      `specs/plans/2026-09-02-aux-helper-contract.md`.
+      Host helpers now carry a compiled-in contract version and answer a
+      `--contract-version` probe; `mvmctl` probes before spawn and never
+      hands a moved-on config contract to a helper built from an older
+      revision or the other cargo profile. A stale helper inside a source
+      checkout is rebuilt automatically in the running binary's profile;
+      anything else is a hard error naming both versions and the exact
+      rebuild command. A shape pin on `HvfSupervisorConfig` forces the
+      contract version to move with the schema. Focused resolver, probe, and
+      spawn-path regressions, the mvm-vmm / mvm-backends / mvm-hostd /
+      mvm-runtime suites, zero-warning Clippy, and Linux/BDD gated
+      compilation are green; merge delivery remains.
 
 - [ ] **Mounted PTY image environment.**
       `specs/plans/2026-09-01-mounted-pty-image-environment.md`.

--- a/specs/plans/2026-09-02-aux-helper-contract.md
+++ b/specs/plans/2026-09-02-aux-helper-contract.md
@@ -35,4 +35,4 @@ silent fallback is gone.
 - [x] Profile-mismatch warning machinery removed (subsumed by verification).
 - [x] Tests green on host; workspace clippy and gated-target checks green in
       the builder VM.
-- [ ] `specs/SPRINT.md` updated; PR opened from the worktree branch.
+- [x] `specs/SPRINT.md` updated; PR opened from the worktree branch.

--- a/specs/plans/2026-09-02-aux-helper-contract.md
+++ b/specs/plans/2026-09-02-aux-helper-contract.md
@@ -1,0 +1,38 @@
+# Aux host-helper contract verification
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** recurring "unknown field" spawn failure when a release `mvmctl` is
+answered by a stale helper binary from the other cargo profile
+(`target/debug/mvm-hvf-supervisor`), or by any helper built from an older
+revision. The failure surfaced only at supervisor spawn — after the guest
+runtime build — and earlier mitigation only improved the error message.
+
+## Outcome
+
+A host helper is never spawned unless it provably speaks the same config
+contract as the running `mvmctl`. Helpers carry a compiled-in contract version
+and answer a `--contract-version` probe. `mvmctl` probes before spawn: a
+matching helper runs; a stale helper found in a source checkout is rebuilt
+automatically in the running binary's profile; anything else fails immediately
+with an error naming both versions and the exact rebuild command. Cross-profile
+silent fallback is gone.
+
+## Delivery checklist
+
+- [x] `mvm-vmm::host::helper_contract`: `HOST_HELPER_CONTRACT_VERSION`, probe
+      flag, response emission, and strict response parsing.
+- [x] All host helpers answer the probe: `mvm-hvf-supervisor`,
+      `mvm-libkrun-supervisor`, `mvm-network-endpoint`, and `mvmctl` itself
+      (the qemu bridge re-execs the `mvmctl` binary).
+- [x] `aux_bin::resolve_verified`: probe, compare, auto-rebuild in checkout,
+      hard error elsewhere; stale picks are never returned.
+- [x] Spawn call sites use the verified resolver; availability probes and
+      codesign enumeration keep the pure resolver.
+- [x] Config-shape hash pin next to the version const forces a version bump
+      when `HvfSupervisorConfig` changes.
+- [x] Profile-mismatch warning machinery removed (subsumed by verification).
+- [x] Tests green on host; workspace clippy and gated-target checks green in
+      the builder VM.
+- [ ] `specs/SPRINT.md` updated; PR opened from the worktree branch.


### PR DESCRIPTION
## Problem

A release `mvmctl` with no release helper beside it is answered silently by whichever helper the other cargo profile last built, at whatever revision — cargo never rebuilds across profiles. When the config contract has moved since, the stale helper refuses the config **at spawn time**, after the guest runtime build, with a JSON `unknown field` error. This failure has recurred; previous mitigation only improved the error message (`console_capture::stale_supervisor_hint`) or added a once-per-process warning (`aux_bin::warn_once_on_profile_mismatch`). Nothing prevented the stale pick.

## Fix

Make a stale helper impossible to spawn:

- **`HOST_HELPER_CONTRACT_VERSION`** (new `mvm-vmm::host::helper_contract`) is compiled into `mvmctl` and every helper from the same tree.
- **Every helper answers `--contract-version`** (`mvm-hvf-supervisor`, `mvm-libkrun-supervisor`, `mvm-network-endpoint`, and `mvmctl` itself for the qemu bridge re-exec) as the first statement of `main`, before panic hooks, self-signing, or config reads. Pre-probe binaries exit non-zero on the flag, which reads as "stale" — that is the point.
- **`aux_bin::resolve_verified`** probes the resolved helper before any spawn:
  - version matches → run;
  - stale helper inside this checkout's own `target/` dirs → automatic one-shot rebuild in the running binary's profile (`cargo build[ --release] -p <pkg> --bins`), then re-resolve and re-probe;
  - anything else (installed layout, exe-dir copy, env override) → hard error naming the helper path, both contract versions, and the exact rebuild command.
- **A shape pin on `HvfSupervisorConfig`** (FNV-1a hash of the fully-populated fixture, stored beside the version const) fails the test suite when the schema changes without bumping the contract version — closing the "forgot to bump" hole that a plain version number leaves.
- Spawn call sites (HVF boot + restore, libkrun boot, qemu bridge, network endpoint, rootfs-inject helper VM) use the verified resolver; availability probes and codesign enumeration keep the pure `resolve`.
- The profile-mismatch warning machinery is removed: verification subsumes it, and a cross-profile helper at the same revision is a legitimate pick that should not warn.

## Validation

- New unit coverage: probe parsing strictness, verified resolution against fake helper scripts (accept, rebuild-in-checkout, rebuild-doesn't-fix, no-rebuild-outside-checkout, env-override, timeout, pre-probe exit), rebuild-plan profile/command selection, contract probe round-trip on every helper, and the config shape pin.
- `cargo test -p mvm-vmm` (607), `-p mvm-backends` (192), `-p mvm-hostd` (1825+), `-p mvm-runtime --lib` (882), `-p mvm-cli --lib` (1994): green.
- `just check-gated` (Linux cross-compile + BDD-featured conformance): green.
- `just clippy` (workspace `--all-targets`, `-D warnings`) + pre-commit fmt/clippy: green.
- Live probe smoke: built `mvmctl`, `mvm-hvf-supervisor`, `mvm-network-endpoint` all answer `--contract-version` with the expected response.

Plan: `specs/plans/2026-09-02-aux-helper-contract.md`; sprint/refactor-status entries updated in this change.
