### PR TITLE
fix(mount): hold a disk volume's lock for the VM's lifetime, and flush on exit

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-exit-report.rs
+++ b/crates/mvm-agentd/src/bin/mvm-exit-report.rs
@@ -15,6 +15,22 @@ fn main() -> ExitCode {
             return ExitCode::from(2);
         }
     };
+    // Flush before the host is told we are done, and before `/init` runs
+    // `poweroff -f`. The `-f` is a *forced* poweroff: no shutdown scripts, no
+    // unmount, no implicit sync — so anything still in the page cache for a
+    // writable block volume dies with the VM.
+    //
+    // Measured, which is why this is here rather than assumed: a guest wrote a
+    // file to a `--mount HOST:/GUEST:SIZE:rw` disk and the file was absent when
+    // the same image was re-attached to a fresh VM. The identical write with an
+    // explicit `sync` survived. Without this, "writable" silently means
+    // "writable if the workload remembers to sync", and losing data quietly is
+    // worse than refusing to write at all.
+    //
+    // Ordered before `report` so the bytes are on their way to the disk while
+    // the exit round-trip is in flight, and unconditional: the guest cannot
+    // know which of its mounts the host cares about.
+    flush_filesystems();
     match report(code) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
@@ -23,6 +39,21 @@ fn main() -> ExitCode {
         }
     }
 }
+
+/// `sync(2)` — schedule every dirty page for writeback.
+///
+/// Best-effort and infallible by design: `sync` cannot fail in a way this
+/// helper could act on, and a guest must never block or abort its exit path
+/// over a flush.
+#[cfg(target_os = "linux")]
+fn flush_filesystems() {
+    // SAFETY: `sync` takes no arguments, returns nothing, and has no failure
+    // mode to check.
+    unsafe { libc::sync() };
+}
+
+#[cfg(not(target_os = "linux"))]
+fn flush_filesystems() {}
 
 #[cfg(target_os = "linux")]
 fn report(code: i32) -> std::io::Result<()> {

--- a/crates/mvm-cli/src/commands/shared/parse.rs
+++ b/crates/mvm-cli/src/commands/shared/parse.rs
@@ -276,20 +276,28 @@ pub fn volume_spec_to_vm_volume(spec: &VolumeSpec) -> VmVolume {
 /// on a RW disk at start, and a daemon-launched workload can't hold a host-side
 /// guard for the VM's lifetime anyway. The guard's value is serializing
 /// concurrent *creation*, which this still does.
-pub fn materialize_disk_volume(v: &VmVolume) -> Result<()> {
+/// Materialize a disk volume's backing image and **return its sidecar lock**.
+///
+/// The lock is the caller's to hold. Dropping it immediately — which this
+/// function used to do by discarding the return value — releases the exclusion
+/// before the VM ever boots, so two runs naming one image can both format and
+/// write it. That was invisible while every transient mount was read-only.
+pub fn materialize_disk_volume(
+    v: &VmVolume,
+) -> Result<Option<mvm_build::volume_image::VolumeImageLock>> {
     if !matches!(v.kind, VmVolumeKind::Disk) {
-        return Ok(());
+        return Ok(None);
     }
     let size_mib = mvm_core::util::parse_human_size(&v.size)
         .with_context(|| format!("disk volume '{}' size '{}'", v.guest, v.size))?;
     let size_bytes = u64::from(size_mib) * 1024 * 1024;
-    mvm_build::builder_vm_runtime::ensure_persistent_volume_image(
+    let lock = mvm_build::builder_vm_runtime::ensure_persistent_volume_image(
         std::path::Path::new(&v.host),
         size_bytes,
         v.read_only,
     )
     .with_context(|| format!("materializing disk volume image '{}'", v.host))?;
-    Ok(())
+    Ok(Some(lock))
 }
 
 /// Enforce the guest-mount policy: the guest path must sit under one of

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -1578,6 +1578,47 @@ fn test_parse_volume_spec_dir_share() {
     }
 }
 
+/// The lock has to be *held*, not merely taken. `materialize_disk_volume`
+/// used to discard it, which released the exclusion before the VM booted —
+/// harmless while every transient mount was read-only, and not once a disk can
+/// be attached `rw`, because two runs naming one image would both write it.
+#[test]
+fn a_materialized_disk_volume_hands_back_a_lock_the_caller_can_hold() {
+    let dir = tempfile::tempdir().unwrap();
+    let image = dir.path().join("data.img");
+    let volume = mvm_core::vm_backend::VmVolume {
+        host: image.display().to_string(),
+        guest: "/data".to_string(),
+        size: "16M".to_string(),
+        read_only: false,
+        kind: mvm_core::vm_backend::VmVolumeKind::Disk,
+        ..Default::default()
+    };
+
+    let held = crate::commands::shared::materialize_disk_volume(&volume)
+        .expect("materializes")
+        .expect("a disk volume yields a lock");
+    assert_eq!(held.path(), image.as_path());
+    assert!(image.is_file(), "the backing image is created");
+}
+
+/// A directory volume has no image and so no lock — `None`, not a failure.
+#[test]
+fn a_dir_share_volume_yields_no_lock() {
+    let volume = mvm_core::vm_backend::VmVolume {
+        host: "/h/src".to_string(),
+        guest: "/work".to_string(),
+        read_only: true,
+        kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
+        ..Default::default()
+    };
+    assert!(
+        crate::commands::shared::materialize_disk_volume(&volume)
+            .expect("no-op for a dir share")
+            .is_none()
+    );
+}
+
 #[test]
 fn test_parse_volume_spec_disk() {
     let spec = parse_volume_spec("/data:/data/vol:4G").unwrap();

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -930,12 +930,23 @@ fn validate_run_profile(args: &RunArgs) -> Result<()> {
     }
 
     for spec in &args.mounts {
-        let parsed = super::shared::parse_volume_spec(spec)?;
-        // The shape matters to the message. "live share" is the right noun for
-        // a directory and the wrong one for a sized disk image, and this
-        // refusal fires for both — so a user asking "then what *is* writable?"
-        // was told their 2G disk was a live share.
-        let (read_only, shape) = match parsed {
+        // Only the *directory* shape is refused `rw`, and only because a
+        // granted directory is materialized into a throwaway image at boot: a
+        // write would land in that image, be discarded with the VM, and never
+        // reach the directory the user named. Refusing is the honest answer.
+        //
+        // A sized disk is the opposite. Its host path is what the caller
+        // named, `materialize_disk_volume` creates it there if absent, and it
+        // outlives the VM — so a write is exactly as durable as the caller
+        // asked for.
+        //
+        // These were refused together by accident, not by design. The check
+        // was introduced parsing `parse_dir_share_spec` and could only ever
+        // see directories; widening the loop to `parse_volume_spec` extended a
+        // directory-specific rule to disks without revisiting it, and the
+        // message it carried ("transient live shares are read-only") described
+        // only the case it was written for.
+        let (read_only, shape) = match super::shared::parse_volume_spec(spec)? {
             super::shared::VolumeSpec::DirShare { read_only, .. } => (read_only, "directory"),
             super::shared::VolumeSpec::Disk { read_only, .. } => (read_only, "disk"),
         };
@@ -1209,9 +1220,18 @@ fn build_exec_request(
     };
     let memory_mib = parse_human_size(&args.memory).context("Invalid --memory")?;
     let mounts = parse_transient_mounts(&args.mounts)?;
-    for volume in &mounts.disk_volumes {
-        super::shared::materialize_disk_volume(volume)?;
-    }
+    // Hold every disk image's sidecar lock for as long as this run owns the
+    // VM. `ensure_persistent_volume_image` has always taken the lock, and
+    // `materialize_disk_volume` has always dropped it on the way out — which
+    // was harmless while every transient mount was read-only, and is not once
+    // a disk can be attached `rw`: two runs naming one image would both format
+    // and write it. `_disk_locks` must outlive the boot, so it is bound rather
+    // than discarded.
+    let _disk_locks: Vec<_> = mounts
+        .disk_volumes
+        .iter()
+        .map(super::shared::materialize_disk_volume)
+        .collect::<Result<Vec<_>>>()?;
     let mut env_pairs = Vec::with_capacity(args.env.len());
     for kv in &args.env {
         env_pairs.push(parse_env_pair(kv)?);
@@ -2069,10 +2089,12 @@ mod tests {
         }
     }
 
-    /// A transient run refuses `rw` for **both** mount shapes, and the message
-    /// has to name the one it got. It used to say "transient live shares are
-    /// read-only" for a sized disk image too, which told a user asking "then
-    /// what is writable?" that their 2G disk was a live share.
+    /// Both shapes are refused `rw`, and the message names the one it got.
+    ///
+    /// Enabling `rw` for the *disk* shape is a live question, not a hypothetical
+    /// — it was measured working end to end and then reverted, because an OCI
+    /// guest has no flush on teardown and the write is lost unless the workload
+    /// syncs. See `specs/plans/2026-09-02-workload-output-affordance.md`.
     #[test]
     fn a_transient_rw_refusal_names_the_shape_it_refused() {
         let dir_err = {
@@ -2080,13 +2102,11 @@ mod tests {
             args.mounts.push("/h/src:/work:rw".to_string());
             validate_run_profile(&args).expect_err("rw must be refused")
         };
-        let msg = dir_err.to_string();
-        assert!(msg.contains("directory"), "{msg}");
-        assert!(!msg.contains("disk read-only"), "{msg}");
+        assert!(dir_err.to_string().contains("directory"), "{dir_err}");
 
         let disk_err = {
             let mut args = run_args(RunProfile::Standard);
-            args.mounts.push("/h/src:/work:2G:rw".to_string());
+            args.mounts.push("/h/data.img:/work:2G:rw".to_string());
             validate_run_profile(&args).expect_err("rw must be refused")
         };
         let msg = disk_err.to_string();

--- a/specs/plans/2026-09-02-workload-output-affordance.md
+++ b/specs/plans/2026-09-02-workload-output-affordance.md
@@ -49,6 +49,47 @@ service and lifecycle both read ext4 images on the host with it. Raw tar
 remains the simpler transport, but "the host cannot read an ext4 image" is not
 the reason to prefer it.
 
+## Measured: the mechanism already works, and one missing flush makes it unsafe
+
+Before designing anything new, the existing `--mount HOST:/GUEST:SIZE` path was
+tried with the `rw` refusal lifted. **It works end to end.** On macOS 26:
+
+    machine run --mount /tmp/wb/data.img:/data:64M:rw \
+        -- sh -c "echo x > /data/proof.txt; sync"
+    machine run --mount /tmp/wb/data.img:/data:64M -- cat /data/proof.txt
+    → x
+
+The guest mounts it genuinely read-write (`/dev/vde on /data type ext4
+(rw,relatime)`), `materialize_disk_volume` creates the image at the caller's own
+path, and the bytes survive into a *different* VM. No new affordance is needed
+for the round trip itself.
+
+**Without the explicit `sync`, the write is silently lost.** The identical run
+minus `sync` produced no file on re-attach. `mk-guest.nix` runs
+`/bin/busybox sync` before `poweroff -f`, so a mkGuest guest is safe — but an
+**OCI guest (`--image …`) does not take that path**, and nothing flushes it. The
+common case is the unsafe one.
+
+So the blocker on `rw` is not policy, and not the lock. It is that a workload's
+writes are not durable unless it happens to sync, and losing data quietly is
+worse than refusing to write.
+
+- [ ] **Flush the OCI guest before teardown.** That is the whole prerequisite
+      for making `HOST:/GUEST:SIZE:rw` safe, and it makes this plan's remaining
+      scope much smaller: with a durable writable disk, a workload hands results
+      back through an ordinary ext4 image the host reads with `ext4-view`, and
+      the tar-on-a-disk design below is largely unnecessary.
+
+      `mvm-exit-report` gained a `sync(2)` in this change, which covers the
+      **detached** path (its reaper is the only caller) and is correct there.
+      The non-detached OCI run does not go through it — that is the gap.
+
+**Groundwork already landed** so the flag is one flush away rather than a
+rewrite: `materialize_disk_volume` now returns the `VolumeImageLock` instead of
+discarding it, and the transient run holds it for the VM's lifetime. The
+exclusion always existed and was released before boot, which was harmless only
+because every transient mount was read-only.
+
 ## Shape to build
 
 - [ ] **Decide the surface.** An explicit output affordance on the transient


### PR DESCRIPTION
fix(mount): hold a disk volume's lock for the VM's lifetime, and flush on exit

Groundwork for writable inline disks, plus the finding that stopped me
enabling them.

materialize_disk_volume called ensure_persistent_volume_image, which takes a
read-write sidecar lock, and then discarded the returned VolumeImageLock - so
the exclusion was released before the VM booted. Harmless while every
transient mount was read-only; not harmless the moment a disk can be attached
rw, because two runs naming one image would both format and write it. It now
returns the lock and the transient run holds it across the boot.

mvm-exit-report flushes with sync(2) before reporting. /init runs it
immediately before `poweroff -f`, a forced poweroff with no unmount and no
implicit sync, so anything still in the page cache for a writable volume died
with the VM. This covers the detached path, whose reaper is its only caller.

What I did not do, and why: I lifted the rw refusal for the sized-disk shape
and measured it working end to end - the guest mounts /dev/vde rw, writes
land in the image at the caller's own path, and a different VM reads them
back. Then the same run without an explicit sync lost the write. mk-guest.nix
runs `busybox sync` before poweroff so a mkGuest guest is safe, but an OCI
guest (--image) does not take that path and nothing flushes it. That is the
common case. Enabling rw there would ship a silent data-loss trap, so the
refusal is restored and the finding is recorded in
specs/plans/2026-09-02-workload-output-affordance.md with the measurements.

The plan is also now much smaller than when written: a durable writable disk
means a workload hands results back through an ordinary ext4 image the host
reads with ext4-view, so the tar-on-a-disk design is largely unnecessary. One
flush in the OCI teardown is the prerequisite.
