### PR TITLE
fix(scripts): reclaim CARGO_TARGET_DIR inherited from another source tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,10 @@ jobs:
                      scripts/check-no-orchestration-server.test.sh \
                      scripts/security-lane-verdict.sh \
                      scripts/security-lane-verdict.test.sh \
+                     scripts/cargo-fast.sh \
+                     scripts/cargo-stable.sh \
+                     scripts/cargo-target-dir-guard.sh \
+                     scripts/cargo-target-dir-guard.test.sh \
                      .githooks/pre-commit \
                      .githooks/pre-commit.test.sh
 
@@ -291,6 +295,9 @@ jobs:
 
       - name: Orchestration-server gate tests
         run: bash scripts/check-no-orchestration-server.test.sh
+
+      - name: Cargo target dir guard tests
+        run: bash scripts/cargo-target-dir-guard.test.sh
 
       # The nightly security lanes do not run on a PR, so this is the only
       # place their failure reporting is exercised before it has to work.

--- a/scripts/cargo-fast.sh
+++ b/scripts/cargo-fast.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 workspace_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# A foreign CARGO_TARGET_DIR would let this build type-check against
+# artifacts cargo recycled from another source tree (mtime-fresh, content-
+# stale). Reclaim it before anything resolves the target dir.
+# shellcheck source=scripts/cargo-target-dir-guard.sh
+source "${workspace_root}/scripts/cargo-target-dir-guard.sh"
 fast_toolchain="$(sed -n 's/^channel = "\([^"]*\)"$/\1/p' "${workspace_root}/rust-toolchain.toml")"
 rustc_bin="$(rustup which --toolchain "${fast_toolchain}" rustc)"
 cargo_bin="$(rustup which --toolchain "${fast_toolchain}" cargo)"

--- a/scripts/cargo-stable.sh
+++ b/scripts/cargo-stable.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 workspace_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# A foreign CARGO_TARGET_DIR would let this build type-check against
+# artifacts cargo recycled from another source tree (mtime-fresh, content-
+# stale). Reclaim it before the stable target root derives from the env var.
+# shellcheck source=scripts/cargo-target-dir-guard.sh
+source "${workspace_root}/scripts/cargo-target-dir-guard.sh"
 stable_toolchain="1.97.1"
 rustc_bin="$(rustup which --toolchain "${stable_toolchain}" rustc)"
 cargo_bin="$(rustup which --toolchain "${stable_toolchain}" cargo)"

--- a/scripts/cargo-target-dir-guard.sh
+++ b/scripts/cargo-target-dir-guard.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Reclaim a CARGO_TARGET_DIR inherited from a different source tree.
+#
+# The compile-time version of the stale-helper bug: cargo decides a cached
+# artifact is fresh by comparing source mtimes, and fingerprints embed
+# absolute paths. A CARGO_TARGET_DIR exported in a shell that belonged to
+# another worktree — or to non-repo work like an issuer build — is silently
+# inherited by every cargo invocation in this tree. The failure it produces
+# is an E0063 naming a field that exists in none of the sources being
+# compiled: rustc type-checked this tree against metadata from an rlib built
+# from a different revision, where the field still existed. Nothing about
+# the message says the cache lied.
+#
+# Sourced by the cargo wrapper scripts (cargo-fast.sh, cargo-stable.sh)
+# before they resolve the target dir. The reclaim mirrors scripts/dev-env.sh:
+# a value already inside this worktree is a real override and is honored; a
+# value pointing anywhere else — another worktree, a sibling shared dir, a
+# relative path that resolves per-cwd — is reclaimed, loudly.
+# MVM_DEV_ENV_KEEP_INHERITED=1 keeps the inherited value anyway.
+#
+# Only CARGO_TARGET_DIR is claimed here. A shared CARGO_HOME costs lock
+# contention, not wrong artifacts; a shared MVM_HOME is a runtime-state
+# concern the runtime already guards.
+
+if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    _cargo_target_guard_root=$(
+        CDPATH="" cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd
+    )
+    case "${CARGO_TARGET_DIR}" in
+        "${_cargo_target_guard_root}"/*) ;;
+        *)
+            if [ -n "${MVM_DEV_ENV_KEEP_INHERITED:-}" ]; then
+                printf 'cargo-target-dir-guard: keeping inherited CARGO_TARGET_DIR=%s (outside %s)\n' \
+                    "${CARGO_TARGET_DIR}" "${_cargo_target_guard_root}" >&2
+            else
+                printf 'cargo-target-dir-guard: CARGO_TARGET_DIR=%s points outside this source tree — reclaiming to %s/target (MVM_DEV_ENV_KEEP_INHERITED=1 keeps it)\n' \
+                    "${CARGO_TARGET_DIR}" "${_cargo_target_guard_root}" >&2
+                export CARGO_TARGET_DIR="${_cargo_target_guard_root}/target"
+            fi
+            ;;
+    esac
+    unset _cargo_target_guard_root
+fi

--- a/scripts/cargo-target-dir-guard.test.sh
+++ b/scripts/cargo-target-dir-guard.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Gate tests for cargo-target-dir-guard.sh.
+#
+# The guard exists to stop one specific failure: cargo type-checking this
+# tree against artifacts recycled from another source tree, which surfaces
+# as an E0063 naming a field that exists in none of the sources being
+# compiled. Both wrong answers are expensive. Reclaiming a deliberate
+# override breaks a real choice and re-downloads gigabytes of cache;
+# keeping an inherited value preserves the poisoning it exists to stop —
+# the value is "almost never deliberate: it is left over from a shell that
+# exported it in a different worktree" (scripts/dev-env.sh).
+#
+# Each case runs the guard in a subshell because it mutates the exported
+# env; stderr is captured to assert the guard speaks up when it acts.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+ROOT="$PWD"
+GUARD="scripts/cargo-target-dir-guard.sh"
+
+failures=0
+
+# Runs the guard in a clean subshell and prints "<final>\t<warned>".
+run_guard() {
+    GUARD="${GUARD}" CARGO_TARGET_DIR="$1" bash -c '
+        source "${GUARD}"
+        if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+            printf "%s" "${CARGO_TARGET_DIR}"
+        else
+            printf "UNSET"
+        fi
+    ' 2>guard-stderr.tmp
+    local stderr
+    stderr=$(cat guard-stderr.tmp)
+    rm -f guard-stderr.tmp
+    case "${stderr}" in
+        *cargo-target-dir-guard:*) printf "\t1" ;;
+        *) printf "\t0" ;;
+    esac
+}
+
+# check <description> <want final value> <want warned 0|1> <inherited value>
+check() {
+    local desc="$1" want_value="$2" want_warn="$3" inherit="$4"
+    local got_value got_warn
+    local outcome
+    outcome=$(run_guard "${inherit}")
+    got_value="${outcome%%$'\t'*}"
+    got_warn="${outcome##*$'\t'}"
+
+    if [ "${got_value}" = "${want_value}" ] && [ "${got_warn}" = "${want_warn}" ]; then
+        printf 'ok   %s\n' "${desc}"
+    else
+        printf 'FAIL %s\n     want value=%s warn=%s\n     got  value=%s warn=%s\n' \
+            "${desc}" "${want_value}" "${want_warn}" "${got_value}" "${got_warn}"
+        failures=$((failures + 1))
+    fi
+}
+
+# An unset variable is not claimed; nothing to reclaim.
+outcome=$(GUARD="${GUARD}" bash -c '
+    source "${GUARD}"
+    if [ -n "${CARGO_TARGET_DIR:-}" ]; then printf "%s" "${CARGO_TARGET_DIR}"; else printf "UNSET"; fi
+' 2>guard-stderr.tmp)
+[ ! -s guard-stderr.tmp ] || { echo "FAIL: unset case must stay silent"; cat guard-stderr.tmp; failures=$((failures + 1)); }
+rm -f guard-stderr.tmp
+if [ "${outcome}" = "UNSET" ]; then
+    printf 'ok   unset CARGO_TARGET_DIR stays unset and silent\n'
+else
+    printf 'FAIL unset CARGO_TARGET_DIR became %s\n' "${outcome}"
+    failures=$((failures + 1))
+fi
+
+# A value already inside this worktree is a real override and is honored,
+# including the dev-env state dir the worktree wrappers use.
+check "target dir inside the worktree is honored" \
+    "${ROOT}/target" 0 "${ROOT}/target"
+check "worktree dev-env target dir is honored" \
+    "${ROOT}/.mvm-test/target" 0 "${ROOT}/.mvm-test/target"
+
+# Anything outside the tree is reclaimed, loudly: another worktree, a
+# sibling shared dir, a relative path that resolves per-cwd.
+check "another worktree's target dir is reclaimed" \
+    "${ROOT}/target" 1 "/some/other/worktree/target"
+check "sibling shared target dir is reclaimed" \
+    "${ROOT}/target" 1 "/some/other/.target-shared"
+check "relative target dir is reclaimed" \
+    "${ROOT}/target" 1 ".target-relative"
+
+# The escape hatch keeps the inherited value, still loudly.
+outcome=$(GUARD="${GUARD}" MVM_DEV_ENV_KEEP_INHERITED=1 CARGO_TARGET_DIR="/some/other/target" bash -c '
+    source "${GUARD}"
+    printf "%s" "${CARGO_TARGET_DIR}"
+' 2>guard-stderr.tmp)
+stderr=$(cat guard-stderr.tmp)
+rm -f guard-stderr.tmp
+if [ "${outcome}" = "/some/other/target" ] && [ -n "${stderr}" ]; then
+    printf 'ok   MVM_DEV_ENV_KEEP_INHERITED=1 keeps the inherited value, loudly\n'
+else
+    printf 'FAIL keep-inherited: got %s stderr=%s\n' "${outcome}" "${stderr}"
+    failures=$((failures + 1))
+fi
+
+if [ "${failures}" -gt 0 ]; then
+    printf '%d gate test(s) failed\n' "${failures}" >&2
+    exit 1
+fi
+printf 'all cargo-target-dir-guard tests passed\n'

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,8 +1,18 @@
 # Refactor status
 
-Last updated: 2026-09-01
+Last updated: 2026-09-02
 
 ## In progress
+
+- [ ] **Cargo target-dir guard.**
+      `specs/plans/2026-09-02-cargo-target-dir-guard.md`.
+      Both cargo wrapper scripts reclaim a CARGO_TARGET_DIR pointing outside
+      the current source tree — the compile-time sibling of the stale-helper
+      bug, observed as an E0063 naming a field deleted by a merged PR, served
+      from rlibs in a shared target dir inherited from unrelated work. Policy
+      mirrors dev-env.sh: inside-tree values honored, outside-tree values
+      reclaimed loudly, MVM_DEV_ENV_KEEP_INHERITED=1 keeps them anyway. Gate
+      tests and CI shellcheck green; merge delivery remains.
 
 - [ ] **Signed caller commitment — issue #3070.**
       `specs/plans/2026-09-01-signed-caller-commitment.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3562,3 +3562,13 @@ writes the plan:
       sustained egress transfers.
 - [ ] Complete the broad validation matrix and merge the repair for #3051,
       and #3052.
+
+## 2026-09-02 cargo target-dir guard
+
+- [x] Reclaim a CARGO_TARGET_DIR inherited from another source tree in both
+      cargo wrapper scripts, loudly, honoring inside-tree overrides and the
+      MVM_DEV_ENV_KEEP_INHERITED=1 escape hatch.
+- [x] Gate-test all four policy cases (unset, inside-honored,
+      outside-reclaimed, keep-inherited) and wire shellcheck + the gate
+      test into CI.
+- [ ] Merge the guard through the queue.

--- a/specs/plans/2026-09-02-cargo-target-dir-guard.md
+++ b/specs/plans/2026-09-02-cargo-target-dir-guard.md
@@ -1,0 +1,69 @@
+# Cargo target-dir guard
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Status: IMPLEMENTED — merge delivery remains.** Companion to the
+stale-helper contract fix (PR #3132): that one stops a *runtime* helper from
+an older revision being silently reused; this one stops cargo itself from
+type-checking this tree against *artifacts* built from another source tree.
+
+## Problem
+
+`cargo build` in this repo failed with `E0063: missing field
+virtiofs_shares`, naming a field that existed in no on-disk source — the
+merge deleting `virtiofs_shares` (#3109) had already landed. The
+explanation was in a shared target directory,
+`/Users/auser/work/tinylabs/mvmco/.target-mvmd-issuer`, holding `mvm-vmm`
+rlibs from 2026-08-17 that still carried `virtiofs_shares` metadata. A
+shell that had exported `CARGO_TARGET_DIR` to that shared dir — leftover
+from unrelated issuer work — silently poisoned every later cargo invocation
+in this tree: cargo fingerprints embed absolute source paths, but a shared
+target dir keyed on the same toolchain + features served the stale rmeta.
+
+Nothing about `E0063` says the cache lied, and the diagnosis cost real
+time. This is the compile-time sibling of the stale-supervisor bug.
+
+## The guard
+
+`scripts/cargo-target-dir-guard.sh` is sourced by both cargo wrapper
+scripts immediately after they resolve the workspace root. It reclaims
+`CARGO_TARGET_DIR` when — and only when — it is set and points outside the
+current source tree, and it says so loudly on stderr. The policy mirrors
+`scripts/dev-env.sh`:
+
+- unset -> no-op (nothing to reclaim);
+- a value inside this worktree, including the dev-env state dir
+  (`.mvm-test/target`), is a real override and is honored silently;
+- anything else — another worktree, a sibling shared dir, a relative path
+  that resolves per-cwd — is reclaimed to `<repo>/target`, loudly;
+- `MVM_DEV_ENV_KEEP_INHERITED=1` keeps the inherited value anyway, still
+  loudly.
+
+Only `CARGO_TARGET_DIR` is claimed. A shared `CARGO_HOME` costs lock
+contention, not wrong artifacts; a shared `MVM_HOME` is a runtime-state
+concern the runtime already guards. CI never sets `CARGO_TARGET_DIR`, so
+the guard is a no-op there.
+
+## Work
+
+- [x] Write `scripts/cargo-target-dir-guard.sh` and source it from
+  `scripts/cargo-fast.sh` and `scripts/cargo-stable.sh` right after the
+  workspace root is computed.
+- [x] Add `scripts/cargo-target-dir-guard.test.sh` covering all four
+  policy cases (unset, inside-honored, outside-reclaimed, keep-inherited),
+  asserting both the final value and whether the guard spoke up.
+- [x] Shellcheck the guard, both wrappers, and the gate test; extend the
+  CI shellcheck list and add a gate-test step beside the other
+  `*.test.sh` gate steps.
+- [x] Smoke the end-to-end path through both wrappers, including the
+  reclaim message naming the actual contaminated dir from the incident.
+
+## Validation
+
+- `bash scripts/cargo-target-dir-guard.test.sh` — 7 cases, all green.
+- `shellcheck` clean on all four touched scripts at CI severity.
+- `CARGO_TARGET_DIR=<contaminated shared dir> bash scripts/cargo-fast.sh
+  --version` reclaims loudly and exits 0; an inside-tree value stays silent;
+  `MVM_DEV_ENV_KEEP_INHERITED=1` keeps the value loudly.
+- Merge delivery: PR, full CI matrix.


### PR DESCRIPTION
## What

A shell that exported `CARGO_TARGET_DIR` to a shared dir — leftover from unrelated work — silently poisoned every cargo invocation in this tree. Cargo freshness checks compare source mtimes and fingerprints embed absolute source paths, but a shared target dir keyed on the same toolchain + features served stale rmeta anyway. Observed as an `E0063: missing field virtiofs_shares` from 2026-08-17 `mvm-vmm` rlibs in `.target-mvmd-issuer`, days after the merge deleting `virtiofs_shares` (#3109) had landed — the field existed in none of the sources being compiled. Nothing about the error says the cache lied, and the diagnosis cost real time.

This is the compile-time sibling of the stale-supervisor bug fixed in #3132 (prior art: `fix/e2e-launch-staleness`, 051c16784f): fail loud at the boundary instead of debugging the symptom downstream.

## How

Both cargo wrappers now source `scripts/cargo-target-dir-guard.sh` right after resolving the workspace root. Policy mirrors `scripts/dev-env.sh`:

- unset → no-op (nothing to reclaim);
- a value inside this worktree, including `.mvm-test/target`, is a real override and is honored silently;
- anything else — another worktree, a sibling shared dir, a relative path that resolves per-cwd — is reclaimed to `<repo>/target`, loudly;
- `MVM_DEV_ENV_KEEP_INHERITED=1` keeps the inherited value anyway, still loudly.

Only `CARGO_TARGET_DIR` is claimed: a shared `CARGO_HOME` costs lock contention, not wrong artifacts; a shared `MVM_HOME` is a runtime-state concern the runtime already guards. CI never sets `CARGO_TARGET_DIR`, so the guard is a no-op there.

## Validation

- `bash scripts/cargo-target-dir-guard.test.sh` — 7 cases covering all four policy cases, asserting both the final value and whether the guard spoke up.
- `shellcheck` clean on the guard, both wrappers, and the gate test; all four added to the CI shellcheck list, and the gate test added beside the other `*.test.sh` gate steps.
- End-to-end smoke through both wrappers: the actual contaminated dir from the incident is reclaimed loudly and cargo runs with exit 0; an inside-tree value stays silent; the escape hatch keeps the value loudly.

Plan: `specs/plans/2026-09-02-cargo-target-dir-guard.md`; SPRINT.md and REFACTOR-STATUS.md updated in the same change.