### PR TITLE
docs(plan): close the two DirShare boxes that are already answered

### DIFF
--- a/specs/plans/2026-09-02-retire-dirshare.md
+++ b/specs/plans/2026-09-02-retire-dirshare.md
@@ -98,16 +98,33 @@ the prediction was a failed boot. The volume never got that far: it is dropped
 before `VolumeConfig` is built, not attached-and-ignored. Recorded because the
 inference was confident and wrong, and only the live run separated the two.
 
-- [ ] **Find the launch path that *does* consume the registry.**
-      `registered_managed_mount_is_consumed_by_launch_resolution`
-      (`mvm-cli/src/commands/vm/volume.rs`) proves one exists; transient
-      `machine run --name` is not it. Until that path is exercised, "can an
-      unmaterialized `DirShare` reach a boot mount" is answered only for the
-      transient case.
-- [ ] **Decide whether silently ignoring a registered volume is acceptable.**
-      A user who registers a mount, sees it in `volume ls`, boots, and finds
-      nothing at the mount point got no error anywhere. That is its own defect
-      independent of this plan, and may be the more urgent one.
+- [x] **Find the launch path that *does* consume the registry.** It is
+      `start_machine` → `start_persistent_oci_machine` →
+      `merge_registered_volumes_for_launch`, i.e. `mvmctl machine start`. That
+      is the only production caller; transient `machine run --name` never
+      reaches it.
+
+      So the split is by *lifecycle*, not by volume kind: registrations belong
+      to a persistent named machine you start and stop, and a transient run is
+      a job. Nothing said so, which is what made it look like a bug rather than
+      a boundary.
+
+      **"Can an unmaterialized `DirShare` reach a boot mount" therefore remains
+      open for the persistent case.** The transient answer (it does not — the
+      volume is dropped before `VolumeConfig` is built) does not generalise,
+      because the persistent path resolves through a different function that
+      returns `VmVolumeKind::Disk` for a managed volume. Exercising
+      `machine start` with a *directory*-kind registration is what would settle
+      it, and it is the remaining prerequisite for the `want_kind` change below.
+- [x] **Decide whether silently ignoring a registered volume is acceptable.**
+      Decided: no, but a warning rather than a refusal, landed in
+      `fix(mount): say what a transient run will and will not attach`.
+
+      Not a refusal because attaching would take the exclusive attachment lease
+      that `machine stop` releases, and a transient run has no stop to pair with
+      it; and refusing outright would break a run whose registrations are simply
+      irrelevant to it. Best-effort, too — a registry that cannot be read must
+      not fail a boot that never depended on it.
 
 ## Ordered work
 - [ ] Move the `want_kind` derivation off `VmVolumeKind` and onto


### PR DESCRIPTION
docs(plan): close the two DirShare boxes that are already answered

Both were answered while building the transient-run warning, and the plan
merged before that work did - so it shipped asking questions whose answers
were already in the tree. That is the stale-plan failure this plan set was
written to correct, so leaving it would be the wrong kind of irony.

The launch path that consumes the volume registry is start_machine ->
start_persistent_oci_machine -> merge_registered_volumes_for_launch, i.e.
`mvmctl machine start`, and it is the only production caller. The split is by
lifecycle rather than by volume kind: registrations belong to a persistent
named machine, and a transient run is a job. Nothing said so, which is what
made it read as a bug rather than a boundary.

One consequence is recorded rather than glossed: "can an unmaterialized
DirShare reach a boot mount" stays open for the persistent case. The transient
answer does not generalise, because the persistent path resolves through a
different function that returns VmVolumeKind::Disk for a managed volume.
Exercising machine start with a directory-kind registration is what settles
it, and it gates the want_kind change.

Silently ignoring a registered volume was decided as a warning rather than a
refusal, and landed already. Not a refusal because attaching would take the
exclusive lease machine stop releases and a transient run has no stop, and
because refusing would break a run whose registrations are irrelevant to it.
