### PR TITLE
fix(template): boot a workload guest on the workload kernel, on x86_64 too

### DIFF
--- a/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
+++ b/crates/mvm-runtime/src/vm/template/lifecycle/artifacts.rs
@@ -35,27 +35,27 @@ pub(super) fn slot_kernel_source(
         | mvm_build::kernel_fetch::KernelResolution::NeedsFetch(_) => None,
     };
 
-    // AArch64 guests need the workload kernel's platform and dm-verity support.
-    // The x86_64 builder kernel is the established persistent-machine kernel;
-    // keep it first there so an unrelated cached workload kernel cannot change
-    // a previously working boot path.
-    match arch {
-        GuestArch::Aarch64 => {
-            if let Some(workload_kernel) = verified_workload_kernel() {
-                return Ok(workload_kernel);
-            }
-            if builder_kernel.is_file() {
-                return Ok(builder_kernel);
-            }
-        }
-        GuestArch::X86_64 => {
-            if builder_kernel.is_file() {
-                return Ok(builder_kernel);
-            }
-            if let Some(workload_kernel) = verified_workload_kernel() {
-                return Ok(workload_kernel);
-            }
-        }
+    // A workload guest needs the workload kernel, on every arch.
+    //
+    // The builder kernel has no device-mapper, and not by accident:
+    // `nix/images/kernel/builder.nix` lists `BLK_DEV_DM` and `DM_VERITY` among
+    // the options it force-drops, because the builder VM boots `ro` with no
+    // roothash and never opens a dm device — "verified boot is a
+    // workload-kernel concern", in its words. So a workload booted on it dies
+    // in activation the moment dm-verity reaches for /dev/mapper/control, which
+    // is a device its kernel was deliberately built without.
+    //
+    // AArch64 already preferred the workload kernel and said dm-verity was why.
+    // x86_64 preferred the builder kernel to avoid disturbing an established
+    // boot path — but the path it protected cannot mount a sealed rootfs, so
+    // what it preserved was the failure. The builder kernel stays as the
+    // fallback: a host with no workload kernel cached is better served booting
+    // something than refusing, and an unsealed guest never opens dm at all.
+    if let Some(workload_kernel) = verified_workload_kernel() {
+        return Ok(workload_kernel);
+    }
+    if builder_kernel.is_file() {
+        return Ok(builder_kernel);
     }
     let workload_path =
         mvm_build::kernel_fetch::cached_kernel_path(cache_root, &arch_str, "workload");
@@ -512,8 +512,22 @@ mod tests {
         assert_eq!(selected, workload);
     }
 
+    /// x86_64 takes the workload kernel over the builder kernel, same as
+    /// aarch64.
+    ///
+    /// This test asserted the opposite, and the behaviour it pinned is the
+    /// bug: `nix/images/kernel/builder.nix` force-drops `BLK_DEV_DM` and
+    /// `DM_VERITY` because the builder VM boots `ro` with no roothash and
+    /// never opens a dm device — "verified boot is a workload-kernel concern".
+    /// So a sealed workload booted on the builder kernel died in activation on
+    /// `open /dev/mapper/control: No such file or directory`, a device its
+    /// kernel was deliberately built without, and the nightly
+    /// documented-surface lane was red on it.
+    ///
+    /// The preference existed to avoid disturbing an established boot path.
+    /// What it preserved was the failure.
     #[test]
-    fn slot_kernel_source_prefers_builder_kernel_for_x86_64() {
+    fn slot_kernel_source_prefers_the_workload_kernel_on_x86_64_too() {
         let tmp = tempfile::tempdir().unwrap();
         let built = tmp.path().join("build").join("vmlinux");
         let cache = tmp.path().join("cache");
@@ -524,6 +538,29 @@ mod tests {
         std::fs::create_dir_all(workload.parent().unwrap()).unwrap();
         std::fs::write(&workload, b"workload-kernel").unwrap();
         mvm_build::kernel_fetch::record_kernel_digest(&workload).unwrap();
+
+        let selected = slot_kernel_source(&built, &cache, GuestArch::X86_64).unwrap();
+
+        assert_eq!(
+            selected, workload,
+            "a workload guest needs the kernel that carries device-mapper"
+        );
+    }
+
+    /// The builder kernel remains the fallback when no workload kernel is
+    /// cached.
+    ///
+    /// Refusing outright would strand a host that can still boot an unsealed
+    /// guest, which never opens a dm device at all. The ordering is a
+    /// preference, not a requirement.
+    #[test]
+    fn slot_kernel_source_falls_back_to_the_builder_kernel_when_no_workload_kernel_is_cached() {
+        let tmp = tempfile::tempdir().unwrap();
+        let built = tmp.path().join("build").join("vmlinux");
+        let cache = tmp.path().join("cache");
+        let builder = cache.join("builder-vm").join("x86_64").join("vmlinux");
+        std::fs::create_dir_all(builder.parent().unwrap()).unwrap();
+        std::fs::write(&builder, b"builder-kernel").unwrap();
 
         let selected = slot_kernel_source(&built, &cache, GuestArch::X86_64).unwrap();
 

--- a/specs/sprint/delivery/a-workload-guest-needs-the-workload-kernel.md
+++ b/specs/sprint/delivery/a-workload-guest-needs-the-workload-kernel.md
@@ -1,0 +1,78 @@
+# A workload guest needs the workload kernel, on every arch
+
+`mvmctl machine run --entrypoint --flake examples/exit_code` died in guest
+activation:
+
+```
+guest activation failed: syscall failed: open /dev/mapper/control: No such file or directory
+```
+
+This was the last failure keeping the nightly documented-surface lane red
+(`features/suites/s29_doc_examples/documented_build_live.feature:27`), present
+in both recent runs and reproducible on the x86_64 KVM box.
+
+## The kernel it booted had no device-mapper, deliberately
+
+The flake build produces no kernel, so `slot_kernel_source` falls through to its
+arch branch — and on x86_64 that branch preferred the **builder** kernel:
+
+```
+template revision vmlinux              sha256: abd7ed4d1faeae03…
+~/.mvm/cache/builder-vm/x86_64/vmlinux sha256: abd7ed4d1faeae03…
+```
+
+Byte-identical, and matching the revision's own `vmlinux.elf.src` sidecar.
+
+`nix/images/kernel/builder.nix` force-drops `MD`, `BLK_DEV_DM` and `DM_VERITY`,
+and states the reason: the builder VM boots `ro` with no roothash and never
+opens a dm device, so *"verified boot is a workload-kernel concern."* A sealed
+workload booted on that kernel reaches for a device its kernel was built
+without.
+
+## The fix is the rule aarch64 already followed
+
+`slot_kernel_source` preferred the workload kernel on aarch64 and gave
+dm-verity as the reason. x86_64 preferred the builder kernel to avoid
+disturbing "a previously working boot path" — but that path cannot mount a
+sealed rootfs. What the preference preserved was the failure.
+
+x86_64 now prefers the workload kernel too. The builder kernel stays as the
+fallback: a host with no workload kernel cached is better served booting an
+unsealed guest, which never opens a dm device, than refusing outright. The
+ordering is a preference, not a requirement.
+
+Nothing about `mkGuest` or what user flakes produce changes.
+
+## The test pinned the bug
+
+`slot_kernel_source_prefers_builder_kernel_for_x86_64` asserted the broken
+preference, which is why no test caught this. It is rewritten to state the rule
+with its reason, and joined by one asserting the builder kernel remains the
+fallback when no workload kernel is cached — the behaviour that keeps the
+change from turning a working unsealed boot into a refusal.
+
+## An analysis that was wrong first
+
+The first diagnosis held that a user flake built its own stock kernel via
+`mkGuest`, and proposed either rewiring `mkGuest` to the shared kernel
+definition or having the host reject a dm-less built kernel. Both rested on a
+misreading: the `MD`/`BLK_DEV_DM`/`DM_VERITY` line in `builder.nix` is in its
+*disables* list, not its enables, and the template kernel was not built by the
+flake at all — the matching sha256 above is what settled it. Recorded because
+the wrong version was plausible enough to survive a first pass, and the thing
+that refuted it was a hash comparison rather than more reading.
+
+## Live verification
+
+Same command, same host, on the scenario that was failing:
+
+```
+before: EXIT=1   guest activation failed: open /dev/mapper/control: No such file or directory
+after:  EXIT=7   the sealed workload's own exit code, which is what the scenario asserts
+```
+
+## Validation
+
+68 gates clean · `cargo nextest run --workspace` · `clippy --all-targets
+-D warnings` clean · `fmt --all --check` clean · `check-gated` clean with
+`RUSTFLAGS=-D warnings` · live witness above.


### PR DESCRIPTION
Closes #3128.

`mvmctl machine run --entrypoint --flake examples/exit_code` died in guest
activation with `open /dev/mapper/control: No such file or directory` — the last
failure keeping the nightly documented-surface lane red, present in both recent
runs and reproducible on the KVM box.

## The kernel it booted had no device-mapper, deliberately

The flake build produces **no kernel**, so `slot_kernel_source` falls through to
its arch branch — and on x86_64 that branch preferred the **builder** kernel:

```
template revision vmlinux               sha256: abd7ed4d1faeae03…
~/.mvm/cache/builder-vm/x86_64/vmlinux  sha256: abd7ed4d1faeae03…
```

Byte-identical, matching the revision's own `vmlinux.elf.src` sidecar.

`nix/images/kernel/builder.nix` force-drops `MD`, `BLK_DEV_DM` and `DM_VERITY`,
and says why:

> the builder boots `ro` with no roothash and never opens a dm device
> (veritysetup only `format`s in userspace); **verified boot is a
> workload-kernel concern**

So a sealed workload booted on that kernel reaches for a device its kernel was
built without.

## The fix is the rule aarch64 already followed

`slot_kernel_source` preferred the workload kernel on aarch64 and gave dm-verity
as the reason. x86_64 preferred the builder kernel to avoid disturbing "a
previously working boot path" — **but that path cannot mount a sealed rootfs**.
What the preference preserved was the failure.

Both arches now prefer the workload kernel. The builder kernel stays the
fallback: a host with no workload kernel cached is better served booting an
unsealed guest — which never opens a dm device — than refusing outright.

Nothing about `mkGuest`, or what user flakes produce, changes.

## The test pinned the bug

`slot_kernel_source_prefers_builder_kernel_for_x86_64` asserted the broken
preference, which is why nothing caught this. It now states the rule with its
reason, joined by one pinning the builder kernel as the fallback — the
behaviour that keeps this from turning a working unsealed boot into a refusal.

## An analysis that was wrong first

My first diagnosis (in #3128, since corrected) held that a user flake built its
own stock kernel via `mkGuest`, and proposed either rewiring `mkGuest` to the
shared kernel definition or having the host reject a dm-less built kernel. Both
rested on reading `builder.nix`'s **disables** list as enables, and on assuming
the template kernel came from the flake. The matching sha256 above is what
refuted it — a hash comparison, not more reading.

## Live verification

Same command, same host, on the scenario that was failing:

| | result |
| --- | --- |
| before | `EXIT=1` — `guest activation failed: open /dev/mapper/control` |
| after | `EXIT=7` — the sealed workload's own exit code, which is what the scenario asserts |

## Validation

68 gates clean · `cargo nextest run --workspace` **12960 passed** · doctests
clean · `clippy --all-targets -D warnings` clean · `fmt --all --check` clean ·
`check-gated` clean with `RUSTFLAGS=-D warnings` · live witness above.
