### PR TITLE
fix(just): strip supervisor binaries on macOS again

### DIFF
--- a/.agent-memory/notes/dyld-vars-are-stripped-across-the-rustc-wrapper.md
+++ b/.agent-memory/notes/dyld-vars-are-stripped-across-the-rustc-wrapper.md
@@ -1,0 +1,37 @@
+---
+title: SIP strips DYLD_* before the rustc wrapper runs, so the loader path must be re-derived
+date: 2026-09-02
+tags: [macos, toolchain, build, justfile, falsification]
+---
+
+Some pinned macOS nightlies ship `rust-objcopy` with `LC_RPATH` of
+`@loader_path/../lib`, resolving to `lib/rustlib/aarch64-apple-darwin/lib`,
+while `libLLVM.dylib` actually lives at the sysroot's `lib/`. rustc's strip step
+spawns it, dyld aborts with SIGABRT, and rustc only *warns* — so the build
+succeeds and silently emits unstripped binaries.
+
+Measured on this host (nightly-2026-08-25): `rust-objcopy --version` fails
+bare and succeeds under either `DYLD_FALLBACK_LIBRARY_PATH=$sysroot/lib` or
+`DYLD_LIBRARY_PATH=$sysroot/lib`. The library is present; only the search path
+is wrong.
+
+**Exporting the variable from the calling shell does nothing.** SIP strips every
+`DYLD_*` variable across an exec of a protected binary, and
+`scripts/rustc-macos-loader.sh` starts with `#!/usr/bin/env bash` — `/usr/bin/env`
+is protected. Probed directly with a logging `RUSTC_WRAPPER`: a parent that
+exported the path was observed as `UNSET` in all seven wrapper invocations. That
+is *why* the wrapper re-derives the sysroot itself instead of trusting what it
+inherits; the parent export covers build scripts, which Cargo launches as
+siblings of rustc rather than children. Neither half is redundant.
+
+Do not try to reproduce this in a scratch crate. A one-file `cargo new` with
+`strip = true` on the release profile emits zero warnings with and without the
+wrapper — the strip path that shells out to `rust-objcopy` is not reached. A/B
+against a real workspace crate instead: `-p libkrun-sys --release` into an empty
+`CARGO_TARGET_DIR` gives 2 warnings without the repair and 0 with it.
+
+Reading the warnings is its own trap: Cargo replays cached diagnostic text from
+units it did not rebuild. Two consecutive runs "after the fix" both showed
+warnings that had already been emitted by an earlier build. The `dyld[PID]` in
+the note line is the only way to tell — a repeated PID is a replay, a new PID is
+a live failure. Compare PIDs before concluding anything about a fix.

--- a/Justfile
+++ b/Justfile
@@ -385,6 +385,9 @@ bdd-live-ci:
 build-supervisors *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
+    # This recipe links the same `mvm-hostd` binaries `embed` does and needs the
+    # same rust-objcopy repair; without it every supervisor ships unstripped.
+    source "{{justfile_directory()}}/scripts/macos-objcopy-env.sh" "{{justfile_directory()}}"
     ./scripts/cargo-fast.sh build -p mvm-hostd --bins {{ARGS}}
     header="${MVM_LIBKRUN_HEADER:-}"
     if [[ -z "$header" ]]; then
@@ -417,24 +420,9 @@ build-supervisors *ARGS:
 embed *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Some pinned macOS nightlies ship rust-objcopy with an RPATH relative to
-    # its rustlib bin directory even though libLLVM lives at the sysroot's lib
-    # directory. cargo-zigbuild only warns when stripping then continues with
-    # larger unstripped payloads, so make the library visible explicitly.
-    if [[ "$(uname -s)" == "Darwin" ]]; then
-      # Build scripts are sibling processes launched by Cargo, while compiler
-      # helpers inherit from rustc. Seed the parent for the first case and use
-      # the wrapper for the second; either half alone leaves some rust-objcopy
-      # invocations unable to load libLLVM.
-      rust_channel="$(sed -n 's/^channel = "\([^"]*\)"$/\1/p' rust-toolchain.toml)"
-      rust_sysroot="$(rustup run "$rust_channel" rustc --print sysroot)"
-      if [[ -n "${DYLD_FALLBACK_LIBRARY_PATH:-}" ]]; then
-        export DYLD_FALLBACK_LIBRARY_PATH="$rust_sysroot/lib:$DYLD_FALLBACK_LIBRARY_PATH"
-      else
-        export DYLD_FALLBACK_LIBRARY_PATH="$rust_sysroot/lib"
-      fi
-      export RUSTC_WRAPPER="{{justfile_directory()}}/scripts/rustc-macos-loader.sh"
-    fi
+    # Make rust-objcopy able to load libLLVM, or the strip step aborts and every
+    # binary this recipe links is emitted unstripped.
+    source "{{justfile_directory()}}/scripts/macos-objcopy-env.sh" "{{justfile_directory()}}"
     # `mvmctl` and these `[[bin]]` targets live in different packages, so
     # building one does not cause Cargo to build the others. Forward the same
     # profile arguments (`--release`, `--profile ...`) so runtime's adjacent-

--- a/crates/mvm-cli/tests/embed_recipe.rs
+++ b/crates/mvm-cli/tests/embed_recipe.rs
@@ -1,34 +1,58 @@
 //! Contributor embedding is an explicit workflow. Keep its macOS LLVM loader
-//! repair in the recipe contributors actually run.
+//! repair reachable from every recipe that links host binaries.
 
+const JUSTFILE: &str = include_str!("../../../Justfile");
+
+/// The body of `name`, up to the recipe that follows it. Recipe bodies are the
+/// unit these guards assert over, and slicing them by hand three times over is
+/// how one of them ends up bounded by the wrong marker.
+fn recipe_body(name: &str, next: &str) -> &'static str {
+    JUSTFILE
+        .split(name)
+        .nth(1)
+        .unwrap_or_else(|| panic!("{name} recipe"))
+        .split(next)
+        .next()
+        .unwrap_or_else(|| panic!("{name} recipe body"))
+}
+
+/// The repair moved out of `embed` and into a shared script so a second recipe
+/// could reuse it. Assert the reference, not the mechanism — the mechanism is
+/// asserted once, against the script, below.
 #[test]
 fn embed_recipe_exposes_the_pinned_rust_sysroot_to_macos_llvm_tools() {
-    let justfile = include_str!("../../../Justfile");
-    let recipe = justfile
-        .split("embed *ARGS:")
-        .nth(1)
-        .expect("embed recipe")
-        .split("embed-refresh:")
-        .next()
-        .expect("embed recipe body");
+    let recipe = recipe_body("embed *ARGS:", "embed-refresh:");
+    assert!(recipe.contains("scripts/macos-objcopy-env.sh"), "{recipe}");
+}
 
-    assert!(recipe.contains("scripts/rustc-macos-loader.sh"), "{recipe}");
-    assert!(recipe.contains("RUSTC_WRAPPER"), "{recipe}");
-    assert!(recipe.contains("rustc --print sysroot"), "{recipe}");
-    assert!(recipe.contains("DYLD_FALLBACK_LIBRARY_PATH"), "{recipe}");
-    assert!(recipe.contains("$rust_sysroot/lib"), "{recipe}");
+/// `build-supervisors` links the same `mvm-hostd` binaries `embed` does. It
+/// went without this repair and shipped every supervisor unstripped, which is
+/// what this guard exists to catch a second time.
+#[test]
+fn build_supervisors_recipe_exposes_the_pinned_rust_sysroot_too() {
+    let recipe = recipe_body("build-supervisors *ARGS:", "\nembed *ARGS:");
+    assert!(recipe.contains("scripts/macos-objcopy-env.sh"), "{recipe}");
+    assert!(
+        recipe.contains("build -p mvm-hostd --bins {{ARGS}}"),
+        "{recipe}"
+    );
+}
+
+#[test]
+fn macos_objcopy_env_seeds_the_loader_path_and_the_rustc_wrapper() {
+    let env = include_str!("../../../scripts/macos-objcopy-env.sh");
+    assert!(env.contains("rustc --print sysroot"), "{env}");
+    assert!(env.contains("DYLD_FALLBACK_LIBRARY_PATH"), "{env}");
+    assert!(env.contains("${_mvm_rust_sysroot}/lib"), "{env}");
+    assert!(env.contains("scripts/rustc-macos-loader.sh"), "{env}");
+    assert!(env.contains("RUSTC_WRAPPER"), "{env}");
+    // A no-op off Darwin, or every Linux contributor inherits a macOS repair.
+    assert!(env.contains(r#""$(uname -s)" != "Darwin""#), "{env}");
 }
 
 #[test]
 fn embed_recipe_builds_native_vm_helpers_in_the_requested_profile() {
-    let justfile = include_str!("../../../Justfile");
-    let recipe = justfile
-        .split("embed *ARGS:")
-        .nth(1)
-        .expect("embed recipe")
-        .split("embed-refresh:")
-        .next()
-        .expect("embed recipe body");
+    let recipe = recipe_body("embed *ARGS:", "embed-refresh:");
 
     let helper_build = recipe
         .find("build -p mvm-hostd --bins {{ARGS}}")

--- a/scripts/macos-objcopy-env.sh
+++ b/scripts/macos-objcopy-env.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Source this (do not execute it) before a cargo build that links binaries on
+# macOS. Takes the workspace root as $1.
+#
+# Some pinned macOS nightlies ship rust-objcopy with an RPATH relative to its
+# rustlib bin directory even though libLLVM lives at the sysroot's lib
+# directory. rustc's strip step then aborts with SIGABRT and only warns, so the
+# build succeeds while emitting larger, unstripped binaries behind a wall of
+# "Library not loaded: @rpath/libLLVM.dylib" noise.
+#
+# Exporting the loader path from the calling shell is not enough on its own:
+# SIP strips every DYLD_* variable across an exec of a protected binary, and
+# the wrapper's own `#!/usr/bin/env bash` shebang is one. That is why the
+# wrapper re-derives the path itself rather than trusting what it inherits.
+# Build scripts are sibling processes launched by Cargo, while compiler helpers
+# inherit from rustc, so seed the parent for the first case and use the wrapper
+# for the second; either half alone leaves some rust-objcopy invocations unable
+# to load libLLVM.
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+_mvm_workspace_root="$1"
+_mvm_rust_channel="$(sed -n 's/^channel = "\([^"]*\)"$/\1/p' "${_mvm_workspace_root}/rust-toolchain.toml")"
+_mvm_rust_sysroot="$(rustup run "${_mvm_rust_channel}" rustc --print sysroot)"
+if [[ -n "${DYLD_FALLBACK_LIBRARY_PATH:-}" ]]; then
+  export DYLD_FALLBACK_LIBRARY_PATH="${_mvm_rust_sysroot}/lib:${DYLD_FALLBACK_LIBRARY_PATH}"
+else
+  export DYLD_FALLBACK_LIBRARY_PATH="${_mvm_rust_sysroot}/lib"
+fi
+export RUSTC_WRAPPER="${_mvm_workspace_root}/scripts/rustc-macos-loader.sh"
+unset _mvm_workspace_root _mvm_rust_channel _mvm_rust_sysroot

--- a/specs/sprint/delivery/build-supervisors-strips-its-binaries.md
+++ b/specs/sprint/delivery/build-supervisors-strips-its-binaries.md
@@ -1,0 +1,23 @@
+# `just build-supervisors` strips its binaries again
+
+`just embed` carried a macOS-only repair for a broken `rust-objcopy` RPATH in
+the pinned nightly. `just build-supervisors` links the same `mvm-hostd`
+binaries and did not, so every supervisor it produced was emitted unstripped
+behind a page of `Library not loaded: @rpath/libLLVM.dylib` warnings.
+
+The repair is now one sourceable script, `scripts/macos-objcopy-env.sh`, used
+by both recipes. It is a no-op off Darwin. The prose that used to live inline
+in `embed` moved into the script, along with the reason the two halves (parent
+export for build scripts, `RUSTC_WRAPPER` for compiler helpers) are both
+needed: SIP strips `DYLD_*` across the wrapper's own `#!/usr/bin/env bash`
+shebang, so the wrapper has to re-derive the sysroot rather than inherit it.
+
+Verified by A/B on identical cold builds into an empty `CARGO_TARGET_DIR`:
+`-p libkrun-sys --release` emits 2 `libLLVM.dylib` warnings without the repair
+and 0 with it, and a full `just build-supervisors --release` is clean.
+
+Not changed, and worth a follow-up decision: `release-build` and
+`release-build-target` are plain `cargo build --release` and hit the same
+defect on a macOS host. They were left alone because setting `RUSTC_WRAPPER`
+there displaces a globally configured `sccache`, which is a trade the release
+lanes should make deliberately rather than inherit from this fix.


### PR DESCRIPTION
## Problem

`just embed` carries a repair for a broken `rust-objcopy` RPATH in the pinned macOS nightly. `just build-supervisors` links the same `mvm-hostd` binaries and did not, so it emitted every supervisor unstripped behind a page of `Library not loaded: @rpath/libLLVM.dylib` warnings.

That is not cosmetic. Same binary, same profile, with and without the repair:

| | `mvm-hvf-supervisor` |
|---|---|
| unrepaired | 4545 symbols, 3.16 MB |
| repaired | 184 symbols, 2.38 MB |

## Change

The repair moves into `scripts/macos-objcopy-env.sh`, sourced by both recipes. No-op off Darwin.

The comment moves with it, plus the part that was missing before: SIP strips every `DYLD_*` variable across an exec of a protected binary, and the wrapper's own `#!/usr/bin/env bash` shebang is one. Probed with a logging `RUSTC_WRAPPER`, a parent that exported the path is `UNSET` in all seven wrapper invocations. That is why the wrapper re-derives the sysroot rather than inheriting it, and why the parent export is still needed separately — it covers build scripts, which Cargo launches as siblings of rustc rather than children. Neither half is redundant.

## Verification

A/B on identical cold builds into an empty `CARGO_TARGET_DIR`:

- `-p libkrun-sys --release` — 2 `libLLVM.dylib` warnings without the repair, 0 with it.
- Full cold `just build-supervisors --release` — 0 warnings across both legs.
- `check-agent-notes`, `check-fast-cargo`, and the 38 Justfile-sensitive tests in `dev_env_isolation` / `github_actions_extended_e2e` / `github_actions_bdd_gate` pass.

## Not changed

`release-build` and `release-build-target` are plain `cargo build --release` and hit the same defect on a macOS host. Left alone deliberately: setting `RUSTC_WRAPPER` there displaces a globally configured `sccache`, which the release lanes should opt into rather than inherit from this fix.

Two traps worth knowing, recorded in `.agent-memory/notes/dyld-vars-are-stripped-across-the-rustc-wrapper.md`:

- A scratch `cargo new` crate with `strip = true` does **not** reproduce this — it emits zero warnings either way. A/B against a real workspace crate.
- Cargo replays cached warning text from units it did not rebuild. The `dyld[PID]` is the only way to tell a live failure from a replay; a repeated PID is a replay.