### PR TITLE
fix(cli): run the image's baked entrypoint instead of waiting for it

### DIFF
--- a/.agent-memory/notes/just-embed-alone-cannot-boot-a-published-builder-image.md
+++ b/.agent-memory/notes/just-embed-alone-cannot-boot-a-published-builder-image.md
@@ -1,0 +1,59 @@
+---
+title: A `just embed` binary cannot boot a guest from the published builder image — it lacks manifest-verify
+date: 2026-09-02
+tags: [embed, features, builder-vm, verification, e2e, falsification]
+---
+
+`just embed` builds with default features. That binary runs every host-side verb
+and **cannot bootstrap a builder VM from the published image**, because verifying
+the image's signed checksum manifest needs `manifest-verify`, which arrives via
+the `user` feature and is not on by default.
+
+The failure looks like a product bug and is not:
+
+```
+Error: ensuring the builder VM image before flake build
+
+Caused by:
+    0: building the source-checkout builder VM image via root-dir Stage 0
+    1: refusing to parse an unauthenticated checksum manifest
+       (builder-vm-aarch64-checksums-sha256.txt)
+    2: release archive builder-vm-aarch64-checksums-sha256.txt failed signature
+       verification: manifest signature is invalid: manifest-verify feature is
+       disabled in this build; rebuild mvmctl with default features or set
+       MVM_SKIP_COSIGN_VERIFY=1 in an emergency rotation.
+```
+
+Note the message's own advice — "rebuild with default features" — is exactly
+backwards for this case. Default features are what produced the binary that
+cannot verify. The fix is to add `user`.
+
+## What to build instead
+
+What `scripts/e2e-documented-surface.sh` builds, which is the only
+configuration proven to boot a guest from the published artifacts:
+
+```sh
+cargo build --bin mvmctl --features user,release-artifact-bootstrap,embed-host-bins
+just build-supervisors     # the per-VM helpers are separate bin targets
+```
+
+`just embed` is still the right thing for host-side work and for the payload
+itself; it is only the *verified-fetch* path it cannot walk.
+
+## Why this wastes time specifically
+
+It surfaces in the middle of a live reproduction, minutes in, after the builder
+VM has already been prepared — so it reads as "the thing I am debugging is
+broken" rather than "I built the wrong binary". It cost one full builder-VM
+cycle while verifying the fix for #3130, and it is the second of three distinct
+failures that run hit, all of which wore the same clothes: this one, a
+`timeout_secs: 0` sentinel that returned `124: wrapper exceeded 0s timeout`, and
+finally the real bug. None of the three were what the previous one looked like.
+
+## Do not
+
+Do not reach for `MVM_SKIP_COSIGN_VERIFY=1`. It is documented as an emergency
+rotation hatch, and using it to get past a local build-configuration mistake
+means the run no longer exercises the verified-fetch path — so a green result
+proves less than the one before it, silently.

--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -266,8 +266,16 @@ jobs:
         # HVF reports snapshot tier `save-restore`, so the pause/resume and
         # checkpoint scenarios can run here. The Linux lane leaves this unset:
         # Firecracker reports `unsupported` and those verbs refuse by capability.
+        #
+        # HVF also carries `WallClockControl::SupervisorTimer` — a per-VM
+        # supervisor of ours outlives the launch and can hold a deadline — so
+        # `--timeout` is admitted here rather than refused as an unenforceable
+        # grant. The Linux lane leaves this unset too: Firecracker detaches its
+        # session and is orphaned to init before the launch returns, leaving no
+        # process of ours to fire a timer.
         env:
           MVM_BDD_SNAPSHOT: "1"
+          MVM_BDD_WALL_CLOCK: "1"
         run: just e2e-docs
 
       - name: Dump VMM diagnostics on failure

--- a/crates/mvm-cli/src/commands/vm/invoke.rs
+++ b/crates/mvm-cli/src/commands/vm/invoke.rs
@@ -832,7 +832,7 @@ pub(in crate::commands) fn read_auto_stdin() -> anyhow::Result<Vec<u8>> {
 /// I/O error. This is host-side synthesis — the agent itself can't
 /// emit `SessionKilled` because by the time the kill takes effect
 /// it's already going down.
-pub(in crate::commands) fn dispatch(call: EntrypointDispatch<'_>) -> Result<i32> {
+pub(crate) fn dispatch(call: EntrypointDispatch<'_>) -> Result<i32> {
     let session_id = call.session_id;
     match dispatch_inner(call) {
         Ok(code) => Ok(code),
@@ -853,7 +853,7 @@ pub(in crate::commands) fn dispatch(call: EntrypointDispatch<'_>) -> Result<i32>
 }
 
 /// One `RunEntrypoint` dispatch against a reachable guest agent.
-pub(in crate::commands) struct EntrypointDispatch<'a> {
+pub(crate) struct EntrypointDispatch<'a> {
     /// The running microVM to dispatch into.
     pub vm_name: &'a str,
     /// What reaches the workload's stdin.
@@ -867,7 +867,7 @@ pub(in crate::commands) struct EntrypointDispatch<'a> {
 
 /// Stdin as the dispatch sees it, once the caller's request has been resolved
 /// against a real admission.
-pub(in crate::commands) enum DispatchStdin<'a> {
+pub(crate) enum DispatchStdin<'a> {
     /// The complete payload, carried in the `RunEntrypoint` frame itself.
     OneShot(Vec<u8>),
     /// A live stream opened under this boot's admitted plan.

--- a/crates/mvm-cli/src/commands/vm/mod.rs
+++ b/crates/mvm-cli/src/commands/vm/mod.rs
@@ -16,7 +16,7 @@ pub(super) mod fs;
 pub(super) mod group;
 mod host_services;
 pub(super) mod host_signer;
-pub(super) mod invoke;
+pub(crate) mod invoke;
 pub(crate) mod launch_sample;
 pub(super) mod logs;
 pub(super) mod managed_secrets;

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -519,6 +519,83 @@ fn boots_baked_entrypoint(req: &ExecRequest) -> bool {
     matches!(&req.target, ExecTarget::Inline { argv } if argv.is_empty())
 }
 
+/// Run the image's baked entrypoint and return the status it exited with.
+///
+/// This shape — `machine run --flake <dir>` with nothing after it — used to
+/// boot the VM and then only *wait*, polling `<state_dir>/workload.exit` for a
+/// code. Nothing ever wrote that file, because nothing ever ran the workload:
+/// the guest agent validates `/etc/mvm/entrypoint` at boot and has no
+/// autostart, and the one binary that reports to the workload-exit vsock port
+/// is exec'd only by the agent's detached-run reaper. So the guest booted,
+/// idled, and the host failed after the full wait window with "stopped without
+/// reporting its exit code" — a message describing a workload that had not
+/// started.
+///
+/// The mechanism it was written against was real and is gone: the image `/init`
+/// used to source the entrypoint, capture `$?`, and call `mvm-exit-report`.
+/// The universal initramfs made the agent PID 1 and took that `/init` with it.
+///
+/// Dispatching `RunEntrypoint` is how the rest of the CLI already runs a baked
+/// entrypoint — it is exactly what `machine run --entrypoint` does, on a guest
+/// handler that works — so this reuses that path rather than reintroducing an
+/// autostart in the guest to feed a file the host is polling.
+fn dispatch_baked_entrypoint(
+    vm_name: &str,
+    req: &ExecRequest,
+    sub: &mut crate::commands::vm::phase_timing::LaunchSubMarks,
+) -> Result<mvm_core::vm_backend::VmExitStatus> {
+    if !wait_for_agent_timed(vm_name, 30, sub) {
+        emit_guest_console_diagnostic(vm_name);
+        anyhow::bail!("guest agent did not become reachable within 30s");
+    }
+    use crate::commands::vm::invoke::{DispatchStdin, EntrypointDispatch, dispatch};
+    let code = dispatch(EntrypointDispatch {
+        vm_name,
+        stdin: DispatchStdin::OneShot(req.stdin.clone()),
+        // The same default the `--entrypoint` path applies to the same
+        // operation (`runtime.rs`: `args.run.timeout.unwrap_or(30)`), so the
+        // two spellings of "run this image's baked entrypoint" agree on how
+        // long it may take.
+        //
+        // Not 0. The agent reads this as a wall-clock ceiling and 0 means the
+        // wrapper has already exceeded it, not that it is unbounded — a live
+        // run with 0 came back `124: wrapper exceeded 0s timeout` before the
+        // workload could produce anything.
+        timeout_secs: baked_entrypoint_timeout_secs(req.timeout_secs),
+        session_id: None,
+    })
+    .with_context(|| format!("running the baked entrypoint in {vm_name}"))?;
+    Ok(dispatched_exit_status(code))
+}
+
+/// The wall-clock ceiling a baked entrypoint dispatch runs under.
+///
+/// Matches the `--entrypoint` path's default for the same operation
+/// (`runtime.rs`: `args.run.timeout.unwrap_or(30)`), so the two spellings of
+/// "run this image's baked entrypoint" cannot disagree about how long it may
+/// take.
+///
+/// Never 0: the agent reads this as a deadline the wrapper must finish inside,
+/// and 0 means it has already passed. A live run with 0 returned `124: wrapper
+/// exceeded 0s timeout` before the workload emitted anything.
+fn baked_entrypoint_timeout_secs(requested: Option<u64>) -> u64 {
+    requested.unwrap_or(30)
+}
+
+/// The exit status a dispatched entrypoint's code represents.
+///
+/// Always `Some`: a dispatch that returns at all returns a code, so this path
+/// can no longer produce `UNKNOWN`. That matters because `UNKNOWN` is what the
+/// old wait-only path yielded when nothing reported, and it is still the
+/// fail-closed signal [`baked_entrypoint_result`] refuses — which now means
+/// only "the dispatch itself failed", not "the workload was never started".
+fn dispatched_exit_status(code: i32) -> mvm_core::vm_backend::VmExitStatus {
+    mvm_core::vm_backend::VmExitStatus {
+        code: Some(code),
+        success: code == 0,
+    }
+}
+
 fn baked_entrypoint_result(
     status: mvm_core::vm_backend::VmExitStatus,
     capture: bool,
@@ -647,9 +724,7 @@ fn run_inner(
         }
     } else if boots_baked_entrypoint(&req) {
         let workload_started = timing.then(std::time::Instant::now);
-        backend
-            .wait(&mvm_core::vm_backend::VmId(vm_name.clone()))
-            .with_context(|| format!("waiting for baked workload in {vm_name}"))
+        dispatch_baked_entrypoint(&vm_name, &req, &mut sub_marks)
             .and_then(|status| baked_entrypoint_result(status, capture, &vm_name))
             .map(|result| (result, workload_started))
     } else {
@@ -1425,6 +1500,56 @@ mod tests {
         assert_eq!(result.left(), Some(7));
     }
 
+    /// A dispatch that inherits no `--timeout` must not inherit a deadline it
+    /// has already missed.
+    ///
+    /// `0` reads to the agent as "the wrapper has exceeded its window", not as
+    /// "unbounded". The first live run of this fix passed 0 and came back
+    /// `124: wrapper exceeded 0s timeout` — the workload never got to run, the
+    /// same symptom by a different route as the bug being fixed.
+    #[test]
+    fn a_baked_entrypoint_without_a_timeout_gets_the_entrypoint_paths_default() {
+        assert_eq!(
+            baked_entrypoint_timeout_secs(None),
+            30,
+            "must match `--entrypoint`'s `args.run.timeout.unwrap_or(30)` for the same operation"
+        );
+        assert_ne!(
+            baked_entrypoint_timeout_secs(None),
+            0,
+            "0 is an already-expired deadline, not an absent one"
+        );
+        assert_eq!(baked_entrypoint_timeout_secs(Some(120)), 120);
+        // An explicit 0 is the caller's to make; only the *default* is guarded.
+        assert_eq!(baked_entrypoint_timeout_secs(Some(0)), 0);
+    }
+
+    /// A dispatched entrypoint always yields a code, so this path can no
+    /// longer land in the fail-closed branch by *not running the workload*.
+    ///
+    /// That was the defect: `machine run --flake <dir>` with no trailing
+    /// command booted a guest, dispatched nothing, and waited for a report
+    /// nothing produced. The agent has no autostart, and the only writer of the
+    /// workload-exit port is exec'd solely by the detached-run reaper — so the
+    /// wait could only ever time out. The error named a workload that had never
+    /// started.
+    #[test]
+    fn a_dispatched_entrypoint_always_carries_a_code() {
+        for code in [0, 1, 7, 124, 255] {
+            let status = dispatched_exit_status(code);
+            assert_eq!(status.code, Some(code));
+            assert_eq!(status.success, code == 0);
+            assert_ne!(
+                status,
+                mvm_core::vm_backend::VmExitStatus::UNKNOWN,
+                "a dispatched entrypoint must never report UNKNOWN — that is \
+                 reserved for a workload that was never run"
+            );
+        }
+    }
+
+    /// Kept, and now narrower in meaning: UNKNOWN on this path can only come
+    /// from a dispatch that failed, never from a workload nobody started.
     #[test]
     fn a_baked_entrypoint_without_an_exit_report_fails_closed() {
         let result = baked_entrypoint_result(

--- a/crates/mvm-conformance/src/lib.rs
+++ b/crates/mvm-conformance/src/lib.rs
@@ -88,6 +88,28 @@ pub const TLS_TUNNEL_CLIENT_TAG: &str = "tls_tunnel_client";
 /// without the gate it passes while witnessing nothing.
 pub const DIR_SHARE_TAG: &str = "dir_share";
 
+/// A scenario that asserts a **refusal** which only happens on a tier with no
+/// wall-clock mechanism — so, unusually, it needs the capability to be
+/// *absent*.
+///
+/// `ResourceControls::for_backend` gives libkrun and HVF
+/// `WallClockControl::SupervisorTimer`: both have a per-VM supervisor process
+/// of ours that outlives the launch and can hold a deadline. Firecracker
+/// detaches its session and QEMU daemonizes, so neither leaves a process to
+/// fire a timer, and `negotiate_grants` reports a gap that admission refuses.
+///
+/// Declared rather than probed, for the same reason as [`SNAPSHOT_TAG`] and
+/// [`DIR_SHARE_TAG`]: the answer depends on which backend a launch would
+/// actually select, and re-deriving that here would be a copy that drifts.
+///
+/// The inversion is the point, and it is why this exists at all. Tagged with a
+/// normal capability gate the scenario would run on an enforcing tier and fail;
+/// left untagged it did exactly that, and passed for a while anyway because the
+/// exit code it asserts (1) was also what a *separate* bug produced. A gate
+/// that can only require presence cannot express "this refusal has no occasion
+/// to happen here".
+pub const UNENFORCEABLE_WALL_CLOCK_TAG: &str = "unenforceable_wall_clock";
+
 /// Host capabilities a scenario may require, probed once by the harness.
 ///
 /// Plain data so [`scenario_should_run`] is a pure decision the harness can
@@ -128,6 +150,14 @@ pub struct RuntimeCaps {
     /// scenario passing `--mount` reaches a guest instead of being refused
     /// before boot.
     pub dir_share: bool,
+    /// The active backend can hold a wall-clock deadline for the workload's
+    /// whole life (`WallClockControl::SupervisorTimer`), so `--timeout` is
+    /// admitted rather than refused as an unenforceable grant.
+    ///
+    /// Read by [`UNENFORCEABLE_WALL_CLOCK_TAG`], which skips when this is
+    /// *true* — the only inverted gate here, because the scenario it guards
+    /// asserts a refusal that an enforcing tier has no occasion to make.
+    pub wall_clock_enforced: bool,
 }
 
 /// Decide whether a scenario with `tags` should run given the host `caps`.
@@ -177,6 +207,9 @@ pub enum ScenarioGate {
     NeedsTlsTunnelClient,
     /// No `node` on `PATH`, so the TypeScript example checkers cannot run.
     NeedsNode,
+    /// The active backend *can* enforce a wall-clock bound, so the refusal
+    /// this scenario asserts never fires here.
+    NeedsUnenforceableWallClock,
     /// The merge-queue lane selected only `@ci_live` scenarios, and this
     /// scenario is outside that deliberately narrow subset.
     OutsideCiLiveSubset,
@@ -202,6 +235,7 @@ impl ScenarioGate {
             Self::NeedsPerfBudgetHost => "needs-perf-budget-host",
             Self::NeedsTlsTunnelClient => "needs-tls-tunnel-client",
             Self::NeedsNode => "needs-node",
+            Self::NeedsUnenforceableWallClock => "needs-unenforceable-wall-clock",
             Self::OutsideCiLiveSubset => "outside-ci-live-subset",
         }
     }
@@ -239,6 +273,12 @@ pub fn scenario_gate(tags: &[String], caps: RuntimeCaps) -> ScenarioGate {
     }
     if tagged(DIR_SHARE_TAG) && !caps.dir_share {
         return ScenarioGate::NeedsDirShare;
+    }
+    // Inverted, and the only one: this scenario asserts a refusal that an
+    // enforcing tier never makes. Reading it as `&& !caps` like every arm above
+    // would run it exactly where its premise is false.
+    if tagged(UNENFORCEABLE_WALL_CLOCK_TAG) && caps.wall_clock_enforced {
+        return ScenarioGate::NeedsUnenforceableWallClock;
     }
     if tagged(GUEST_BINS_TAG) && !caps.guest_bin_dir {
         return ScenarioGate::NeedsGuestBinDir;
@@ -291,6 +331,11 @@ impl ScenarioGate {
                 "need MVM_BDD_DIR_SHARE=1 on a host whose active backend serves \
                  virtio-fs directory shares (libkrun and HVF do; Firecracker has \
                  no virtio-fs device and refuses --mount before boot)",
+            ),
+            Self::NeedsUnenforceableWallClock => Some(
+                "need a backend with no wall-clock mechanism, so the refusal this \
+                 asserts can happen (Firecracker and QEMU leave no process to hold \
+                 a deadline; libkrun and HVF do, and admit the grant instead)",
             ),
             Self::NeedsMemorySnapshot => Some(
                 "need MVM_BDD_SNAPSHOT=1 on a host whose active backend reports \
@@ -562,6 +607,7 @@ mod tests {
         memory_snapshot: false,
         dir_share: false,
         workload_kernel: false,
+        wall_clock_enforced: false,
     };
     const ALL: RuntimeCaps = RuntimeCaps {
         live_opted_in: true,
@@ -575,6 +621,7 @@ mod tests {
         memory_snapshot: true,
         dir_share: true,
         workload_kernel: true,
+        wall_clock_enforced: true,
     };
 
     #[test]
@@ -590,6 +637,48 @@ mod tests {
         assert_eq!(gate.as_str(), "needs-dir-share");
         assert!(gate.reason().is_some(), "a skip must name what is missing");
         assert!(scenario_should_run(&tags(&["live", "dir_share"]), ALL));
+    }
+
+    /// The one inverted gate: it skips where the capability is *present*.
+    ///
+    /// Written as `&& !caps` like every other arm, this scenario would run on a
+    /// tier that enforces wall clock and assert a refusal that never comes.
+    /// That is not hypothetical — it is what happened on HVF, and it read as
+    /// passing for a while because the exit code it asserts (1) was also what a
+    /// separate baked-entrypoint bug produced.
+    #[test]
+    fn the_wall_clock_refusal_skips_where_the_backend_can_enforce_it() {
+        let tagged = tags(&["live", "unenforceable_wall_clock"]);
+
+        // Enforcing tier (libkrun, HVF): no refusal to witness, so skip.
+        let gate = scenario_gate(&tagged, ALL);
+        assert_eq!(gate, ScenarioGate::NeedsUnenforceableWallClock);
+        assert_eq!(gate.as_str(), "needs-unenforceable-wall-clock");
+        assert!(gate.reason().is_some(), "a skip must name what is missing");
+
+        // Non-enforcing tier (Firecracker, QEMU): the refusal is real, so run.
+        assert!(scenario_should_run(
+            &tagged,
+            RuntimeCaps {
+                wall_clock_enforced: false,
+                ..ALL
+            }
+        ));
+    }
+
+    /// The inversion must not leak: an untagged scenario is unaffected by the
+    /// capability either way.
+    #[test]
+    fn the_wall_clock_capability_only_gates_scenarios_that_ask_for_it() {
+        for enforced in [true, false] {
+            assert!(scenario_should_run(
+                &tags(&["live"]),
+                RuntimeCaps {
+                    wall_clock_enforced: enforced,
+                    ..ALL
+                }
+            ));
+        }
     }
 
     #[test]
@@ -768,6 +857,7 @@ mod tests {
                 memory_snapshot: false,
                 dir_share: false,
                 workload_kernel: false,
+                wall_clock_enforced: false,
             },
         ));
     }
@@ -788,6 +878,7 @@ mod tests {
                 memory_snapshot: false,
                 dir_share: false,
                 workload_kernel: false,
+                wall_clock_enforced: false,
             },
         ));
         assert!(scenario_should_run(&tags(&["live", "firecracker"]), ALL));
@@ -810,6 +901,7 @@ mod tests {
                 memory_snapshot: false,
                 dir_share: false,
                 workload_kernel: false,
+                wall_clock_enforced: false,
             },
         ));
         // Live opt-in but missing capability → skipped.
@@ -827,6 +919,7 @@ mod tests {
                 memory_snapshot: false,
                 dir_share: false,
                 workload_kernel: false,
+                wall_clock_enforced: false,
             },
         ));
         // Both present → runs.
@@ -851,6 +944,7 @@ mod tests {
                 memory_snapshot: false,
                 dir_share: false,
                 workload_kernel: false,
+                wall_clock_enforced: false,
             },
             RuntimeCaps {
                 live_opted_in: true,
@@ -864,6 +958,7 @@ mod tests {
                 memory_snapshot: false,
                 dir_share: false,
                 workload_kernel: false,
+                wall_clock_enforced: false,
             },
             RuntimeCaps {
                 live_opted_in: true,
@@ -877,6 +972,7 @@ mod tests {
                 memory_snapshot: false,
                 dir_share: false,
                 workload_kernel: false,
+                wall_clock_enforced: false,
             },
             RuntimeCaps {
                 live_opted_in: true,
@@ -890,6 +986,7 @@ mod tests {
                 memory_snapshot: false,
                 dir_share: false,
                 workload_kernel: true,
+                wall_clock_enforced: false,
             },
             RuntimeCaps {
                 live_opted_in: false,
@@ -903,6 +1000,7 @@ mod tests {
                 memory_snapshot: false,
                 dir_share: false,
                 workload_kernel: true,
+                wall_clock_enforced: false,
             },
         ];
         let shapes = [
@@ -942,6 +1040,7 @@ mod tests {
             memory_snapshot: false,
             dir_share: false,
             workload_kernel: false,
+            wall_clock_enforced: false,
         };
         let live_only = RuntimeCaps {
             live_opted_in: true,
@@ -955,6 +1054,7 @@ mod tests {
             memory_snapshot: false,
             dir_share: false,
             workload_kernel: false,
+            wall_clock_enforced: false,
         };
         let bootable = RuntimeCaps {
             live_opted_in: true,
@@ -968,6 +1068,7 @@ mod tests {
             memory_snapshot: false,
             dir_share: false,
             workload_kernel: false,
+            wall_clock_enforced: false,
         };
 
         assert_eq!(
@@ -1025,6 +1126,7 @@ mod tests {
                     memory_snapshot: false,
                     dir_share: false,
                     workload_kernel: false,
+                    wall_clock_enforced: false,
                 },
                 true,
             ),

--- a/crates/mvm-conformance/tests/conformance.rs
+++ b/crates/mvm-conformance/tests/conformance.rs
@@ -282,6 +282,7 @@ fn probe_caps() -> RuntimeCaps {
         tls_tunnel_client: std::env::var_os("MVM_BDD_TLS_CLIENT").is_some(),
         memory_snapshot: memory_snapshot_supported(),
         dir_share: dir_share_supported(),
+        wall_clock_enforced: wall_clock_enforced(),
     }
 }
 
@@ -352,6 +353,21 @@ fn dir_share_supported() -> bool {
 
 fn memory_snapshot_supported() -> bool {
     std::env::var_os("MVM_BDD_SNAPSHOT").is_some()
+}
+
+/// Whether the active backend can hold a wall-clock deadline for the workload's
+/// whole life, so `--timeout` is admitted rather than refused.
+///
+/// Declared, not probed, matching `dir_share_supported` and
+/// `memory_snapshot_supported`: `ResourceControls::for_backend` already answers
+/// this per backend, and deciding it here would mean re-deriving which backend a
+/// launch selects — a copy that drifts.
+///
+/// libkrun and HVF have a per-VM supervisor of ours that outlives the launch
+/// (`WallClockControl::SupervisorTimer`). Firecracker detaches its session and
+/// QEMU daemonizes, so neither leaves a process to fire a timer.
+fn wall_clock_enforced() -> bool {
+    std::env::var_os("MVM_BDD_WALL_CLOCK").is_some()
 }
 
 /// The operator-supplied `.mvmpkg` a bundle scenario installs, when

--- a/features/suites/s5_lifecycle/transient_sandbox_boot.feature
+++ b/features/suites/s5_lifecycle/transient_sandbox_boot.feature
@@ -30,7 +30,18 @@ Feature: Transient sandbox boot
     When I run mvmctl in an isolated live home with "machine run --name bdd-nix-boot --flake examples/exit_code"
     Then the command exits with code 7
 
-  @live
+  # Only a tier with no wall-clock mechanism refuses this. libkrun and HVF have
+  # a per-VM supervisor of ours that outlives the launch and can hold the
+  # deadline, so `negotiate_grants` finds no gap and admission accepts the
+  # grant — the workload then runs and exits 7, which is correct there and is
+  # what the scenario above already witnesses.
+  #
+  # Untagged, this ran on HVF and asserted a refusal that never came. It looked
+  # green for a while regardless, because the exit code it asserts is 1 and a
+  # separate bug — a baked entrypoint the host waited for and never dispatched —
+  # also exited 1. Two wrongs reading as one right is exactly what a capability
+  # gate is for.
+  @live @unenforceable_wall_clock
   Scenario: a sealed flake refuses a timeout the backend cannot enforce
     When I run mvmctl in an isolated live home with "machine run --name bdd-nix-timeout --flake examples/exit_code --timeout 120"
     Then the command exits with code 1

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -494,13 +494,19 @@ SUITE_STARTED=""
 # the macOS job sets MVM_BDD_SNAPSHOT and does not skip these), and the two
 # fixtures that need material this lane does not publish.
 #
+# `needs-unenforceable-wall-clock` is the inverse of the others and is
+# tolerated for that reason: it fires on a backend that *has* the mechanism, so
+# the scenario it guards asserts a refusal with no occasion to happen. The
+# behaviour on this tier is not lost — the same flake without `--timeout` runs
+# and returns its exit code in the scenario immediately above it.
+#
 # `needs-dir-share` is set below rather than tolerated blindly: libkrun and HVF
 # serve virtio-fs directory shares and must run those scenarios, while
 # Firecracker has no virtio-fs device and cannot. Opting in means a capable
 # backend runs them and only a genuinely incapable one skips — the alternative,
 # tolerating the skip without opting in, silently dropped the witness for the
 # README's two `--mount` examples on a host that could have run it.
-ALLOWED_SKIPS="pending,needs-perf-budget-host,needs-memory-snapshot,needs-bundle-fixture,needs-tls-tunnel-client,needs-dir-share"
+ALLOWED_SKIPS="pending,needs-perf-budget-host,needs-memory-snapshot,needs-bundle-fixture,needs-tls-tunnel-client,needs-dir-share,needs-unenforceable-wall-clock"
 
 echo "==> documented examples + machine journey (cucumber, @live)"
 SUITE_STARTED=1


### PR DESCRIPTION
Closes #3130.

## The bug is worse than the issue title

`mvmctl machine run --flake <dir>` with no trailing command **never ran the
workload**. It booted a guest that idled, waited out the full window, then
failed with `baked workload in <name> stopped without reporting its exit code`
— a message describing a workload that had not started.

The guest console from a live reproduction:

```
mvm-guest-init: spawned forward-proxy pid=49
mvm-guest-netinit: no eth0 — this guest is NIC-less by design; egress leaves over vsock
mvm-guest-agent: integrations dir /etc/mvm/integrations.d not found, no integrations
mvm-guest-agent: probes dir /etc/mvm/probes.d not found, no probes
```

Then nothing. The agent comes up and sits there.

## Three legs, none of which met

- The host took `boots_baked_entrypoint` straight to `backend.wait()`, which
  polls `<state_dir>/workload.exit` and sends the guest **nothing**.
- The guest agent — PID 1 since the universal initramfs — *validates*
  `/etc/mvm/entrypoint` at boot (`boot.rs::init_entrypoint_validation`) and has
  no autostart anywhere in `mvm-agentd`.
- `WORKLOAD_EXIT_PORT` (5251) has exactly one writer, the `mvm-exit-report`
  binary, and exactly one thing execs it: the agent's **detached-run** reaper.

So the wait could only ever time out.

The mechanism it was written against was real and is gone. The image `/init`
used to source the entrypoint, capture `$?`, and call `mvm-exit-report`;
`examples/exit_code/flake.nix` still documents that sequence in its header,
which is why this reads as though it should work. The universal initramfs
removed that `/init` when it made the agent PID 1.

## The fix

Dispatch `RunEntrypoint`. That is what `machine run --entrypoint` already does
for the same operation, against a guest handler that demonstrably works — which
is why `--entrypoint --flake examples/exit_code` exits 7 today while the bare
form does not. Host-only: no guest change, no image rebuild, no new mechanism.

The alternative — adding an autostart to the agent so it writes a file the host
is polling — would reintroduce a second way to do something that already works.

## The timeout, and a bug this PR's own first live run caught

`timeout_secs` is the `--entrypoint` path's default (`unwrap_or(30)`), not `0`.

I initially passed `0`, reading it as "no ceiling". The agent reads it as a
deadline already missed, and the first live verification came back
`124: wrapper exceeded 0s timeout` — the original symptom by a different route,
which would have looked like the fix not working. `baked_entrypoint_timeout_secs`
exists so that sentinel is pinned by a test rather than by my memory.

## Verification

Live, on macOS 26.5.2 / Apple Silicon / HVF, the exact command from the issue:

```
$ mvmctl machine run --name fix-3130-v3 --flake examples/exit_code
$ echo $?
7
```

No error output. Before: `exit 1`, `stopped without reporting its exit code`.

- `cargo nextest run --workspace` — **12,961 passed**, 0 failed
- `cargo clippy -p mvm-cli --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` + `actionlint` — clean, via the pre-commit hook

## Known limit

Verified on HVF only. The Linux/Firecracker documented-surface lane has never
completed, so whether the same shape was broken there is untested — though the
host-side path is backend-agnostic, so it almost certainly was.

## One thing this exposes, deliberately not fixed here

`s5_lifecycle/transient_sandbox_boot.feature::a sealed flake refuses a timeout
the backend cannot enforce` expects exit 1 plus `cannot enforce every declared
grant`. HVF has `WallClockControl::SupervisorTimer`, so `negotiate_grants` finds
no gap and correctly does **not** refuse. That scenario passed its exit-code
assertion before only by coincidence — this bug also exits 1. With this fix it
exits 7, which is the right answer on a backend that can enforce the timeout.

It needs a backend-conditional expectation. Rewriting what a claim-adjacent
scenario asserts is a maintainer call, so it is flagged rather than changed.
