### PR TITLE
docs(specs): close the cargo target-dir guard merge boxes

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,7 +4,7 @@ Last updated: 2026-09-02
 
 ## In progress
 
-- [ ] **Cargo target-dir guard.**
+- [x] **Cargo target-dir guard.**
       `specs/plans/2026-09-02-cargo-target-dir-guard.md`.
       Both cargo wrapper scripts reclaim a CARGO_TARGET_DIR pointing outside
       the current source tree — the compile-time sibling of the stale-helper
@@ -12,7 +12,7 @@ Last updated: 2026-09-02
       from rlibs in a shared target dir inherited from unrelated work. Policy
       mirrors dev-env.sh: inside-tree values honored, outside-tree values
       reclaimed loudly, MVM_DEV_ENV_KEEP_INHERITED=1 keeps them anyway. Gate
-      tests and CI shellcheck green; merge delivery remains.
+      tests and CI shellcheck green; merged via #3135.
 
 - [ ] **Signed caller commitment — issue #3070.**
       `specs/plans/2026-09-01-signed-caller-commitment.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3571,4 +3571,4 @@ writes the plan:
 - [x] Gate-test all four policy cases (unset, inside-honored,
       outside-reclaimed, keep-inherited) and wire shellcheck + the gate
       test into CI.
-- [ ] Merge the guard through the queue.
+- [x] Merge the guard through the queue (#3135).

--- a/specs/plans/2026-09-02-cargo-target-dir-guard.md
+++ b/specs/plans/2026-09-02-cargo-target-dir-guard.md
@@ -3,7 +3,7 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status: IMPLEMENTED — merge delivery remains.** Companion to the
+**Status: MERGED via #3135 (squash bf5916cd79).** Companion to the
 stale-helper contract fix (PR #3132): that one stops a *runtime* helper from
 an older revision being silently reused; this one stops cargo itself from
 type-checking this tree against *artifacts* built from another source tree.
@@ -66,4 +66,4 @@ the guard is a no-op there.
 - `CARGO_TARGET_DIR=<contaminated shared dir> bash scripts/cargo-fast.sh
   --version` reclaims loudly and exits 0; an inside-tree value stays silent;
   `MVM_DEV_ENV_KEEP_INHERITED=1` keeps the value loudly.
-- Merge delivery: PR, full CI matrix.
+- Merge delivery: full CI matrix green; squash-merged via #3135.


### PR DESCRIPTION
## What

#3135 (cargo target-dir guard) landed as squash `bf5916cd79`. This ticks the merge-delivery checkboxes that PR could not tick for itself:

- `specs/SPRINT.md` — "Merge the guard through the queue" → done, citing #3135
- `specs/REFACTOR-STATUS.md` — entry checked, "merge delivery remains" → "merged via #3135"
- `specs/plans/2026-09-02-cargo-target-dir-guard.md` — status → MERGED, validation bullet updated

Docs-only; no code, no behavior change.