### PR TITLE
feat(evidence): boot beacon, deployments inventory, verity-sealed provenance mark + in-toto sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,6 +2983,7 @@ dependencies = [
  "nix 0.29.0",
  "rand 0.10.2",
  "serde",
+ "serde_jcs",
  "serde_json",
  "sha2 0.11.0",
  "tar",

--- a/crates/mvm-agentd/fuzz/Cargo.lock
+++ b/crates/mvm-agentd/fuzz/Cargo.lock
@@ -1072,6 +1072,7 @@ name = "mvm-build"
 version = "0.18.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "ed25519-dalek",
  "flate2",
@@ -1087,6 +1088,7 @@ dependencies = [
  "mvm-vmm",
  "nix",
  "serde",
+ "serde_jcs",
  "serde_json",
  "sha2",
  "tar",

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent.rs
@@ -727,6 +727,19 @@ fn main() {
     let guest_signing_key = Arc::new(SigningKey::from_bytes(&guest_seed));
     boot_state.mark_vsock_bound();
 
+    // Boot beacon: report agent liveness to the host once, on a
+    // background thread with bounded retries. Fail-open by contract —
+    // a missing host broker (dev images without an audit signer, a
+    // boot-time race the retries don't cover) must never delay or
+    // fail the workload's boot.
+    let beacon_boot_unix_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0);
+    std::thread::spawn(move || {
+        mvm_agentd::host_beacon::report_boot_beacon(beacon_boot_unix_ms);
+    });
+
     // On legacy per-rootfs boots the agent is not PID 1 and the workload
     // root is already in place, so validate the entrypoint and start the warm
     // pool now. On the universal initramfs path validation is deferred until

--- a/crates/mvm-agentd/src/host_beacon.rs
+++ b/crates/mvm-agentd/src/host_beacon.rs
@@ -1,0 +1,325 @@
+//! In-guest `host.beacon.v1` typed method — the boot beacon.
+//!
+//! The platform's own guest agent calls `report` exactly once at boot,
+//! over the broker transport ([`crate::broker_client`]), to record on
+//! the host's chain-signed audit log that the admitted workload's agent
+//! came alive. The payload types ([`BeaconReport`] / [`BeaconAck`]) are
+//! the shared wire contract in [`mvm_core::protocol::host_beacon`].
+//!
+//! The beacon is advisory and fail-open by design: a missing host
+//! broker (dev images without an audit signer, boot-time races) must
+//! never delay or fail the agent's boot. Callers log and move on.
+//!
+//! This client is **not a security boundary** — it runs inside the
+//! untrusted guest and carries no key. The host stamps the
+//! authoritative identity into the chain entry from the connection
+//! context; the guest cannot influence the binding.
+
+use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use mvm_core::protocol::broker::{CorrelationId, ServiceCall, ServiceErrorCode, ServiceId};
+use mvm_core::protocol::host_beacon::{BeaconAck, BeaconReport, HOST_BEACON_SERVICE};
+
+use crate::broker_client::{self, BrokerError};
+
+/// Failure of a `host.beacon.v1` call. The beacon is best-effort, so
+/// callers typically log and continue; the typed variants exist so a
+/// caller that *does* care can distinguish refusal kinds.
+#[derive(Debug, thiserror::Error)]
+pub enum BeaconError {
+    /// The host rejected the report shape.
+    #[error("beacon report rejected: {0}")]
+    BadRequest(String),
+    /// The host audit path is unavailable (signer down).
+    #[error("beacon service unavailable: {0}")]
+    Unavailable(String),
+    /// `host.beacon.v1` is not registered for this workload (no audit
+    /// signer configured).
+    #[error("beacon service not bound")]
+    NotBound,
+    /// Any other typed broker error code.
+    #[error("beacon failed [{code:?}]: {message}")]
+    Service {
+        /// The host's typed error code.
+        code: ServiceErrorCode,
+        /// Host-authored detail.
+        message: String,
+    },
+    /// Connect, framing, or (de)serialization failure on the vsock path.
+    #[error("beacon transport error: {0}")]
+    Transport(anyhow::Error),
+}
+
+impl From<BrokerError> for BeaconError {
+    fn from(err: BrokerError) -> Self {
+        match err {
+            BrokerError::Transport(e) => BeaconError::Transport(e),
+            BrokerError::Service { code, message } => match code {
+                ServiceErrorCode::BadRequest => BeaconError::BadRequest(message),
+                ServiceErrorCode::Unavailable => BeaconError::Unavailable(message),
+                ServiceErrorCode::NotBound => BeaconError::NotBound,
+                other => BeaconError::Service {
+                    code: other,
+                    message,
+                },
+            },
+        }
+    }
+}
+
+/// Report the boot beacon with bounded retries, then give up quietly.
+///
+/// Called once from the guest agent's boot path. The host broker
+/// subprocess can still be starting when the agent comes up, so a
+/// small number of spaced retries covers the race; every failure mode
+/// is fail-open because a missing beacon must never delay or fail the
+/// workload boot.
+pub fn report_boot_beacon(boot_unix_ms: u64) {
+    let beacon = BeaconReport {
+        agent_version: env!("CARGO_PKG_VERSION").to_string(),
+        boot_unix_ms,
+    };
+    const ATTEMPTS: u32 = 3;
+    const BACKOFF: std::time::Duration = std::time::Duration::from_secs(2);
+    // The outcome is already logged inside the retry loop; the boot
+    // path deliberately ignores it.
+    let _ = report_with_retries(&beacon, ATTEMPTS, BACKOFF, |r| report(r, 5));
+}
+
+/// Retry wrapper over a `dial` closure, exposed for testing. Returns
+/// the final outcome after `attempts` tries spaced by `backoff`.
+fn report_with_retries(
+    report: &BeaconReport,
+    attempts: u32,
+    backoff: std::time::Duration,
+    mut dial: impl FnMut(&BeaconReport) -> Result<BeaconAck, BeaconError>,
+) -> Result<BeaconAck, BeaconError> {
+    let mut last = None;
+    for attempt in 1..=attempts {
+        match dial(report) {
+            Ok(ack) => return Ok(ack),
+            Err(err) => {
+                tracing::debug!(
+                    attempt,
+                    attempts,
+                    error = %err,
+                    "boot beacon report failed; the host broker may not be up yet"
+                );
+                last = Some(err);
+                if attempt < attempts {
+                    std::thread::sleep(backoff);
+                }
+            }
+        }
+    }
+    let err = last.expect("at least one attempt always runs");
+    tracing::warn!(error = %err, "boot beacon report gave up; continuing without it");
+    Err(err)
+}
+
+/// Report agent liveness over an already-open broker stream.
+pub fn report_on(stream: &mut UnixStream, report: &BeaconReport) -> Result<BeaconAck, BeaconError> {
+    let call = build_call(report)?;
+    let payload = broker_client::call(stream, &call)?;
+    decode(payload)
+}
+
+/// Dial the broker port and report agent liveness.
+pub fn report(report: &BeaconReport, timeout_secs: u64) -> Result<BeaconAck, BeaconError> {
+    let call = build_call(report)?;
+    let payload = broker_client::broker_call(&call, timeout_secs)?;
+    decode(payload)
+}
+
+/// Build the `host.beacon.v1` `ServiceCall`. The `correlation_id` is a
+/// placeholder the host reassigns at frame ingress.
+fn build_call(report: &BeaconReport) -> Result<ServiceCall, BeaconError> {
+    let payload =
+        serde_json::to_value(report).map_err(|e| BeaconError::Transport(anyhow::Error::from(e)))?;
+    Ok(ServiceCall {
+        service: host_beacon_service(),
+        verb: "report".to_string(),
+        correlation_id: next_correlation_id(),
+        payload,
+        capability: None,
+    })
+}
+
+/// Decode a broker `Ok` payload into the typed response `T`.
+fn decode<T: serde::de::DeserializeOwned>(payload: serde_json::Value) -> Result<T, BeaconError> {
+    serde_json::from_value(payload).map_err(|e| BeaconError::Transport(anyhow::Error::from(e)))
+}
+
+/// The `host.beacon.v1` service id.
+fn host_beacon_service() -> ServiceId {
+    ServiceId::parse(HOST_BEACON_SERVICE).expect("host.beacon.v1 is a valid ServiceId")
+}
+
+/// Mint a per-call placeholder correlation id; the supervisor reassigns
+/// the authoritative id at ingress.
+fn next_correlation_id() -> CorrelationId {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    CorrelationId::new(format!("wl-beacon-{n}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    use mvm_core::protocol::broker::ServiceResponse;
+
+    use super::*;
+    use crate::vsock::{read_frame, write_frame};
+
+    fn sample_report() -> BeaconReport {
+        BeaconReport {
+            agent_version: "0.17.0".into(),
+            boot_unix_ms: 1_787_181_844_000,
+        }
+    }
+
+    /// Spawn a mock broker on the server half of a socket pair: read the
+    /// one `ServiceCall`, hand it to `respond` (which also captures it),
+    /// write the returned `ServiceResponse`.
+    fn serve_once(
+        server: UnixStream,
+        captured: Arc<Mutex<Option<ServiceCall>>>,
+        respond: impl FnOnce(&ServiceCall) -> ServiceResponse + Send + 'static,
+    ) -> thread::JoinHandle<()> {
+        thread::spawn(move || {
+            let mut server = server;
+            let call: ServiceCall = read_frame(&mut server).unwrap();
+            *captured.lock().unwrap() = Some(call.clone());
+            write_frame(&mut server, &respond(&call)).unwrap();
+        })
+    }
+
+    #[test]
+    fn report_sends_host_beacon_v1_envelope_and_returns_chain_head() {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        let captured = Arc::new(Mutex::new(None));
+        let handle = serve_once(server, captured.clone(), |call| ServiceResponse::Ok {
+            correlation_id: call.correlation_id.clone(),
+            payload: serde_json::json!({"chain_head": "head-001"}),
+        });
+
+        let ack = report_on(&mut client, &sample_report()).expect("report must succeed");
+        assert_eq!(ack.chain_head, "head-001");
+        handle.join().unwrap();
+
+        let call = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("server must capture call");
+        assert_eq!(call.service.as_str(), "host.beacon.v1");
+        assert_eq!(call.verb, "report");
+        assert!(
+            call.payload.get("workload_id").is_none(),
+            "guest payload must not carry identity fields"
+        );
+        let report: BeaconReport = serde_json::from_value(call.payload).unwrap();
+        assert_eq!(report, sample_report());
+    }
+
+    #[test]
+    fn report_surfaces_not_bound_as_typed_error() {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        let captured = Arc::new(Mutex::new(None));
+        let handle = serve_once(server, captured, |call| ServiceResponse::Err {
+            correlation_id: call.correlation_id.clone(),
+            code: ServiceErrorCode::NotBound,
+            message: "service `host.beacon.v1` not registered".into(),
+        });
+
+        let err = report_on(&mut client, &sample_report()).expect_err("must surface NotBound");
+        assert!(matches!(err, BeaconError::NotBound), "got {err:?}");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn report_surfaces_unavailable_as_typed_error() {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        let captured = Arc::new(Mutex::new(None));
+        let handle = serve_once(server, captured, |call| ServiceResponse::Err {
+            correlation_id: call.correlation_id.clone(),
+            code: ServiceErrorCode::Unavailable,
+            message: "audit-signer transport failed".into(),
+        });
+
+        let err = report_on(&mut client, &sample_report()).expect_err("must surface unavailable");
+        assert!(matches!(err, BeaconError::Unavailable(_)), "got {err:?}");
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn report_surfaces_bad_request_as_typed_error() {
+        let (mut client, server) = UnixStream::pair().unwrap();
+        let captured = Arc::new(Mutex::new(None));
+        let handle = serve_once(server, captured, |call| ServiceResponse::Err {
+            correlation_id: call.correlation_id.clone(),
+            code: ServiceErrorCode::BadRequest,
+            message: "payload parse failed".into(),
+        });
+
+        let err = report_on(&mut client, &sample_report()).expect_err("must surface BadRequest");
+        match err {
+            BeaconError::BadRequest(msg) => assert!(msg.contains("parse")),
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn minted_correlation_ids_are_distinct() {
+        assert_ne!(next_correlation_id(), next_correlation_id());
+    }
+
+    #[test]
+    fn retries_return_ack_on_first_success() {
+        let report = sample_report();
+        let mut calls = 0;
+        let outcome = report_with_retries(&report, 3, std::time::Duration::ZERO, |r| {
+            calls += 1;
+            assert_eq!(r, &sample_report());
+            Ok(BeaconAck {
+                chain_head: "head-1".into(),
+            })
+        });
+        assert_eq!(outcome.expect("succeeds").chain_head, "head-1");
+        assert_eq!(calls, 1, "no retry after success");
+    }
+
+    #[test]
+    fn retries_exhaust_attempts_and_return_last_error() {
+        let report = sample_report();
+        let mut calls = 0;
+        let outcome = report_with_retries(&report, 3, std::time::Duration::ZERO, |_| {
+            calls += 1;
+            Err(BeaconError::NotBound)
+        });
+        assert!(matches!(outcome, Err(BeaconError::NotBound)), "{outcome:?}");
+        assert_eq!(calls, 3, "every attempt must run");
+    }
+
+    #[test]
+    fn retries_succeed_after_transient_failure() {
+        let report = sample_report();
+        let mut calls = 0;
+        let outcome = report_with_retries(&report, 3, std::time::Duration::ZERO, |_| {
+            calls += 1;
+            if calls == 1 {
+                Err(BeaconError::Unavailable("signer starting".into()))
+            } else {
+                Ok(BeaconAck {
+                    chain_head: "head-2".into(),
+                })
+            }
+        });
+        assert_eq!(outcome.expect("recovers").chain_head, "head-2");
+        assert_eq!(calls, 2);
+    }
+}

--- a/crates/mvm-agentd/src/lib.rs
+++ b/crates/mvm-agentd/src/lib.rs
@@ -76,6 +76,7 @@ pub mod guest_vsock_session;
 /// In-guest `host.audit.v1` typed methods: `emit` / `emit_batch` over the
 /// broker transport, letting a workload append to the chain-signed audit log.
 pub mod host_audit;
+pub mod host_beacon;
 /// In-guest `host.cost.v1` typed methods: `workload` / `tenant` spend queries
 /// over the broker transport.
 pub mod host_cost;

--- a/crates/mvm-build/Cargo.toml
+++ b/crates/mvm-build/Cargo.toml
@@ -94,6 +94,11 @@ hex.workspace = true
 libkrun-sys = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
+# JCS canonicalization for the in-rootfs provenance mark and the
+# in-toto DSSE sidecar — the same canonical form the audit chain uses.
+serde_jcs = "0.1"
+# DSSE envelope payloads and signatures are base64 on the wire.
+base64.workspace = true
 sha2.workspace = true
 # `.mvm` packed artifacts carry an Ed25519
 # manifest signature. We verify (and produce, when the caller

--- a/crates/mvm-build/src/intoto.rs
+++ b/crates/mvm-build/src/intoto.rs
@@ -1,0 +1,478 @@
+//! in-toto provenance statement (SLSA v1.0 predicate) as a DSSE envelope.
+//!
+//! At seal time, beside the verity-sealed `rootfs.ext4` we emit
+//! `<stem>.intoto.json`: an in-toto Statement whose subject is the sealed
+//! image file (SHA-256) and whose predicate is the SLSA v1.0 provenance
+//! of the seal operation, wrapped in a DSSE envelope signed by the same
+//! builder key that wrote the in-rootfs provenance mark.
+//!
+//! This is an interchange format, not an internal model: compliance
+//! tooling that speaks in-toto/SLSA can consume the sidecar directly,
+//! while our own verification goes through [`verify_sidecar`].
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use base64::Engine as _;
+use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+
+use crate::provenance_mark::{SealEvidence, builder_id, jcs_bytes, key_fingerprint};
+
+/// DSSE payload type for in-toto statements.
+pub const DSSE_IN_TOTO_PAYLOAD_TYPE: &str = "application/vnd.in-toto+json";
+
+/// in-toto Statement `_type` (v1).
+pub const IN_TOTO_STATEMENT_TYPE: &str = "https://in-toto.io/Statement/v1";
+
+/// SLSA provenance predicate type (v1).
+pub const SLSA_PROVENANCE_PREDICATE: &str = "https://slsa.dev/provenance/v1";
+
+/// Our buildType URI for the OCI run-image seal.
+pub const MVM_BUILD_TYPE: &str = "https://mvm.dev/buildType/run-image/v1";
+
+/// Sidecar suffix for the DSSE-sealed provenance statement.
+pub const INTOTO_SIDECAR_SUFFIX: &str = ".intoto.json";
+
+/// in-toto Statement with an SLSA v1.0 provenance predicate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProvenanceStatement {
+    #[serde(rename = "_type")]
+    pub statement_type: String,
+    pub subject: Vec<StatementSubject>,
+    #[serde(rename = "predicateType")]
+    pub predicate_type: String,
+    pub predicate: SlsaProvenance,
+}
+
+/// One named subject with content digests.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StatementSubject {
+    pub name: String,
+    pub digest: std::collections::BTreeMap<String, String>,
+}
+
+/// SLSA v1.0 provenance predicate.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SlsaProvenance {
+    pub build_definition: BuildDefinition,
+    pub run_details: RunDetails,
+}
+
+/// SLSA buildDefinition.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildDefinition {
+    #[serde(rename = "buildType")]
+    pub build_type: String,
+    #[serde(rename = "externalParameters")]
+    pub external_parameters: serde_json::Value,
+    #[serde(rename = "internalParameters")]
+    pub internal_parameters: serde_json::Value,
+    #[serde(rename = "resolvedDependencies")]
+    pub resolved_dependencies: Vec<serde_json::Value>,
+}
+
+/// SLSA runDetails.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunDetails {
+    pub builder: BuilderId,
+    pub metadata: RunMetadata,
+    pub byproducts: Vec<serde_json::Value>,
+}
+
+/// SLSA builder identity — the same `mvm:builder:ed25519:sha256:<hex>`
+/// fingerprint the in-rootfs mark carries.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuilderId {
+    pub id: String,
+}
+
+/// SLSA run metadata.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunMetadata {
+    #[serde(rename = "startedOn")]
+    pub started_on: String,
+    #[serde(rename = "finishedOn")]
+    pub finished_on: String,
+}
+
+/// Build a provenance statement for one sealed image file.
+///
+/// `subject_sha256` is the hex SHA-256 of the exact sealed artifact
+/// bytes (the caller hashes the file after sealing, so the statement
+/// can never name bytes that were not sealed).
+pub fn build_statement(
+    evidence: &SealEvidence<'_>,
+    subject_name: &str,
+    subject_sha256: &str,
+    started_on: &str,
+    finished_on: &str,
+) -> ProvenanceStatement {
+    let verifying = evidence.signer().verifying_key();
+    let mut digest = std::collections::BTreeMap::new();
+    digest.insert("sha256".to_string(), subject_sha256.to_string());
+    let mut external = serde_json::json!({});
+    if let Some(image_ref) = evidence.image_ref() {
+        external["imageRef"] = serde_json::Value::String(image_ref.to_string());
+    }
+    if let Some(image_digest) = evidence.image_digest() {
+        external["imageDigest"] = serde_json::Value::String(image_digest.to_string());
+    }
+    ProvenanceStatement {
+        statement_type: IN_TOTO_STATEMENT_TYPE.to_string(),
+        subject: vec![StatementSubject {
+            name: subject_name.to_string(),
+            digest,
+        }],
+        predicate_type: SLSA_PROVENANCE_PREDICATE.to_string(),
+        predicate: SlsaProvenance {
+            build_definition: BuildDefinition {
+                build_type: MVM_BUILD_TYPE.to_string(),
+                external_parameters: external,
+                internal_parameters: serde_json::json!({}),
+                resolved_dependencies: Vec::new(),
+            },
+            run_details: RunDetails {
+                builder: BuilderId {
+                    id: builder_id(&verifying),
+                },
+                metadata: RunMetadata {
+                    started_on: started_on.to_string(),
+                    finished_on: finished_on.to_string(),
+                },
+                byproducts: Vec::new(),
+            },
+        },
+    }
+}
+
+/// A DSSE envelope (`payloadType` + base64 payload + signatures).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DsseEnvelope {
+    #[serde(rename = "payloadType")]
+    pub payload_type: String,
+    pub payload: String,
+    pub signatures: Vec<DsseSignature>,
+}
+
+/// One DSSE signature. `keyid` is the builder key fingerprint.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DsseSignature {
+    pub keyid: String,
+    pub sig: String,
+}
+
+/// DSSE Pre-Authentication-Encoding, RFC 8032-style framing:
+/// `DSSEv1 <len(payloadType)> <payloadType> <len(payload)> <payload>`
+/// with SP = 0x20 and decimal ASCII lengths.
+pub fn pae_encode(payload_type: &str, payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"DSSEv1 ");
+    out.extend_from_slice(payload_type.len().to_string().as_bytes());
+    out.push(b' ');
+    out.extend_from_slice(payload_type.as_bytes());
+    out.push(b' ');
+    out.extend_from_slice(payload.len().to_string().as_bytes());
+    out.push(b' ');
+    out.extend_from_slice(payload);
+    out
+}
+
+const B64: base64::engine::GeneralPurpose = base64::engine::general_purpose::STANDARD;
+
+/// Sign a statement into a DSSE envelope with the builder key.
+pub fn sign_envelope(statement: &ProvenanceStatement, signer: &SigningKey) -> Result<DsseEnvelope> {
+    let payload = serde_json::to_vec(statement).context("serialize in-toto statement")?;
+    let pae = pae_encode(DSSE_IN_TOTO_PAYLOAD_TYPE, &payload);
+    let signature = signer.sign(&pae);
+    Ok(DsseEnvelope {
+        payload_type: DSSE_IN_TOTO_PAYLOAD_TYPE.to_string(),
+        payload: B64.encode(&payload),
+        signatures: vec![DsseSignature {
+            keyid: key_fingerprint(&signer.verifying_key()),
+            sig: B64.encode(signature.to_bytes()),
+        }],
+    })
+}
+
+/// The verified contents of a DSSE envelope over an in-toto statement.
+#[derive(Debug, Clone)]
+pub struct VerifiedStatement {
+    /// The parsed statement.
+    pub statement: ProvenanceStatement,
+    /// Builder key fingerprint that produced the (accepted) signature.
+    pub signer_fingerprint: String,
+}
+
+/// Verify a DSSE envelope against an explicit trust-anchor key and
+/// parse the in-toto statement payload.
+pub fn verify_sidecar(envelope: &DsseEnvelope, anchor: &VerifyingKey) -> Result<VerifiedStatement> {
+    if envelope.payload_type != DSSE_IN_TOTO_PAYLOAD_TYPE {
+        anyhow::bail!(
+            "unsupported DSSE payloadType {:?}; want {DSSE_IN_TOTO_PAYLOAD_TYPE}",
+            envelope.payload_type
+        );
+    }
+    let payload = B64
+        .decode(&envelope.payload)
+        .context("decode DSSE payload base64")?;
+    if envelope.signatures.len() != 1 {
+        anyhow::bail!(
+            "expected exactly one DSSE signature, got {}",
+            envelope.signatures.len()
+        );
+    }
+    let signature_bytes: [u8; 64] = B64
+        .decode(&envelope.signatures[0].sig)
+        .context("decode DSSE signature base64")?
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("DSSE signature is not 64 bytes"))?;
+    let pae = pae_encode(&envelope.payload_type, &payload);
+    let signature = ed25519_dalek::Signature::from_bytes(&signature_bytes);
+    anchor
+        .verify(&pae, &signature)
+        .context("DSSE signature invalid against trust anchor")?;
+    let fingerprint = key_fingerprint(anchor);
+    if envelope.signatures[0].keyid != fingerprint {
+        anyhow::bail!(
+            "DSSE keyid {} does not match verifying key fingerprint {}",
+            envelope.signatures[0].keyid,
+            fingerprint
+        );
+    }
+    let statement: ProvenanceStatement =
+        serde_json::from_slice(&payload).context("parse in-toto statement payload")?;
+    Ok(VerifiedStatement {
+        statement,
+        signer_fingerprint: fingerprint,
+    })
+}
+
+/// Sidecar path for a sealed image: `<stem>.intoto.json`.
+pub fn sidecar_path(image: &Path) -> std::path::PathBuf {
+    let stem = image.with_extension("");
+    std::path::PathBuf::from(format!("{}{INTOTO_SIDECAR_SUFFIX}", stem.display()))
+}
+
+/// Emit and write the `<stem>.intoto.json` sidecar beside a sealed
+/// image. `subject_sha256` is the hex digest of the sealed file's exact
+/// bytes; `started_on`/`finished_on` bracket the seal operation.
+pub fn write_sidecar(
+    image: &Path,
+    subject_sha256: &str,
+    evidence: &SealEvidence<'_>,
+    started_on: &str,
+    finished_on: &str,
+) -> Result<std::path::PathBuf> {
+    let subject_name = image
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "rootfs.ext4".to_string());
+    let statement = build_statement(
+        evidence,
+        &subject_name,
+        subject_sha256,
+        started_on,
+        finished_on,
+    );
+    let envelope = sign_envelope(&statement, evidence.signer())?;
+    let bytes = jcs_bytes(&envelope)?;
+    let path = sidecar_path(image);
+    std::fs::write(&path, bytes).with_context(|| format!("write {}", path.display()))?;
+    tracing::info!(sidecar = %path.display(), "in-toto provenance sidecar written");
+    Ok(path)
+}
+
+/// Read + verify a `<stem>.intoto.json` sidecar against a trust anchor.
+pub fn read_sidecar(image: &Path, anchor: &VerifyingKey) -> Result<Option<VerifiedStatement>> {
+    let path = sidecar_path(image);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let envelope: DsseEnvelope = serde_json::from_slice(
+        &std::fs::read(&path).with_context(|| format!("read {}", path.display()))?,
+    )
+    .with_context(|| format!("parse {}", path.display()))?;
+    verify_sidecar(&envelope, anchor).map(Some)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key() -> SigningKey {
+        SigningKey::from_bytes(&[99; 32])
+    }
+
+    fn evidence(key: &SigningKey) -> SealEvidence<'_> {
+        SealEvidence::builder(key)
+            .with_image_ref("docker.io/library/nginx:1.27")
+            .with_image_digest("sha256:deadbeef")
+            .with_created("2026-09-02T00:00:01Z")
+            .build()
+    }
+
+    #[test]
+    fn pae_encoding_matches_the_dsse_spec_shape() {
+        // DSSE PAE: "DSSEv1 <pt-len> <pt> <payload-len> <payload>"; the
+        // in-toto JSON payload type is 28 bytes.
+        let pae = pae_encode("application/vnd.in-toto+json", b"abc");
+        assert_eq!(
+            pae,
+            b"DSSEv1 28 application/vnd.in-toto+json 3 abc".to_vec()
+        );
+    }
+
+    #[test]
+    fn statement_carries_slsa_v1_provenance() {
+        let key = key();
+        let statement = build_statement(
+            &evidence(&key),
+            "rootfs.ext4",
+            "f0e12d3",
+            "2026-09-02T00:00:00Z",
+            "2026-09-02T00:00:02Z",
+        );
+        assert_eq!(statement.statement_type, IN_TOTO_STATEMENT_TYPE);
+        assert_eq!(statement.predicate_type, SLSA_PROVENANCE_PREDICATE);
+        assert_eq!(statement.subject.len(), 1);
+        assert_eq!(statement.subject[0].digest["sha256"], "f0e12d3");
+        assert_eq!(
+            statement.predicate.build_definition.build_type,
+            MVM_BUILD_TYPE
+        );
+        assert_eq!(
+            statement.predicate.build_definition.external_parameters["imageRef"],
+            "docker.io/library/nginx:1.27"
+        );
+        assert_eq!(
+            statement.predicate.run_details.builder.id,
+            builder_id(&key.verifying_key())
+        );
+    }
+
+    #[test]
+    fn envelope_roundtrips_through_sign_and_verify() {
+        let key = key();
+        let statement = build_statement(
+            &evidence(&key),
+            "rootfs.ext4",
+            "f0e12d3",
+            "2026-09-02T00:00:00Z",
+            "2026-09-02T00:00:02Z",
+        );
+        let envelope = sign_envelope(&statement, &key).unwrap();
+        assert_eq!(envelope.payload_type, DSSE_IN_TOTO_PAYLOAD_TYPE);
+        let verified = verify_sidecar(&envelope, &key.verifying_key()).unwrap();
+        assert_eq!(verified.statement, statement);
+        assert_eq!(
+            verified.signer_fingerprint,
+            key_fingerprint(&key.verifying_key())
+        );
+    }
+
+    #[test]
+    fn envelope_signed_by_another_key_fails_against_anchor() {
+        let key = key();
+        let statement = build_statement(
+            &evidence(&key),
+            "rootfs.ext4",
+            "f0e12d3",
+            "2026-09-02T00:00:00Z",
+            "2026-09-02T00:00:02Z",
+        );
+        let envelope = sign_envelope(&statement, &key).unwrap();
+        let other = SigningKey::from_bytes(&[1; 32]);
+        assert!(verify_sidecar(&envelope, &other.verifying_key()).is_err());
+    }
+
+    #[test]
+    fn tampered_payload_fails_verification() {
+        let key = key();
+        let statement = build_statement(
+            &evidence(&key),
+            "rootfs.ext4",
+            "f0e12d3",
+            "2026-09-02T00:00:00Z",
+            "2026-09-02T00:00:02Z",
+        );
+        let mut envelope = sign_envelope(&statement, &key).unwrap();
+        // Swap the payload for a same-shape statement with a different digest.
+        let mut other = statement.clone();
+        other.subject[0]
+            .digest
+            .insert("sha256".into(), "tampered".into());
+        envelope.payload = B64.encode(serde_json::to_vec(&other).unwrap());
+        assert!(verify_sidecar(&envelope, &key.verifying_key()).is_err());
+    }
+
+    #[test]
+    fn keyid_claim_must_match_the_verifying_key() {
+        let key = key();
+        let statement = build_statement(
+            &evidence(&key),
+            "rootfs.ext4",
+            "f0e12d3",
+            "2026-09-02T00:00:00Z",
+            "2026-09-02T00:00:02Z",
+        );
+        let mut envelope = sign_envelope(&statement, &key).unwrap();
+        envelope.signatures[0].keyid = "00".repeat(32);
+        assert!(verify_sidecar(&envelope, &key.verifying_key()).is_err());
+    }
+
+    #[test]
+    fn wrong_payload_type_is_refused() {
+        let key = key();
+        let statement = build_statement(
+            &evidence(&key),
+            "rootfs.ext4",
+            "f0e12d3",
+            "2026-09-02T00:00:00Z",
+            "2026-09-02T00:00:02Z",
+        );
+        let mut envelope = sign_envelope(&statement, &key).unwrap();
+        envelope.payload_type = "text/plain".to_string();
+        assert!(verify_sidecar(&envelope, &key.verifying_key()).is_err());
+    }
+
+    #[test]
+    fn sidecar_roundtrips_beside_the_image() {
+        let dir = tempfile::tempdir().unwrap();
+        let image = dir.path().join("rootfs.ext4");
+        std::fs::write(&image, b"ext4-bytes").unwrap();
+        let key = key();
+        let evidence = evidence(&key);
+        let path = write_sidecar(
+            &image,
+            "f0e12d3",
+            &evidence,
+            "2026-09-02T00:00:00Z",
+            "2026-09-02T00:00:02Z",
+        )
+        .unwrap();
+        assert_eq!(path, dir.path().join("rootfs.intoto.json"));
+        let verified = read_sidecar(&image, &key.verifying_key())
+            .unwrap()
+            .expect("sidecar present");
+        assert_eq!(verified.statement.subject[0].digest["sha256"], "f0e12d3");
+        assert!(
+            read_sidecar(&dir.path().join("absent.ext4"), &key.verifying_key())
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/crates/mvm-build/src/lib.rs
+++ b/crates/mvm-build/src/lib.rs
@@ -58,6 +58,7 @@ pub mod guest_libc;
 /// macOS backend, raw HVF backend). Shared by `mvm_runtime::backends::hvf` (writer) + the bin.
 /// Universal initramfs build + cache resolution.
 pub mod initramfs;
+pub mod intoto;
 /// Hash-verify a fetched kernel image against its [`mvm_core::kernel_artifact::KernelArtifactId`].
 pub mod kernel_fetch;
 /// Portable signed `.mvm` artifacts. A tar.gz wrapper around kernel +
@@ -73,6 +74,7 @@ pub mod persistent_builder_transport;
 /// Build-provenance recorder: content-addresses produced artifacts into the
 /// signed plan's `BuildProvenance`.
 pub mod provenance;
+pub mod provenance_mark;
 /// OCI-unpacked tree to ext4 rootfs image. The host only allocates the
 /// sparse file; formatting and copying happen inside the builder VM.
 pub mod rootfs;

--- a/crates/mvm-build/src/provenance_mark.rs
+++ b/crates/mvm-build/src/provenance_mark.rs
@@ -1,0 +1,441 @@
+//! Verity-sealed in-artifact provenance mark.
+//!
+//! At seal time (before the dm-verity hash is computed) the builder writes
+//! two files into the rootfs being sealed:
+//!
+//! - `/mvm/provenance.json` — a canonical-JSON document naming the image
+//!   identity, the signing builder, and the tool that sealed it.
+//! - `/mvm/provenance.sig` — a detached Ed25519 signature over the
+//!   JCS-canonical mark bytes, hex-encoded.
+//!
+//! Because the mark lands inside the image *before* verity formatting, the
+//! kernel's dm-verity check covers it: a tampered mark changes the rootfs
+//! bytes, breaks the roothash, and the guest refuses to boot. The signature
+//! additionally binds the mark to a builder key at read time, so a mark can
+//! be verified offline against an embedded public key and then matched to a
+//! local trust anchor (`~/.mvm/keys/host-signer.pub`).
+//!
+//! Identity convention: `builder_id` is `mvm:builder:ed25519:sha256:<hex>`
+//! where `<hex>` is the SHA-256 of the raw 32-byte Ed25519 verifying key —
+//! the same fingerprint [`verify_mark`] recomputes from the embedded key, so
+//! a mark that lies about its builder fails verification.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::Digest as _;
+
+/// Wire schema of `/mvm/provenance.json`.
+pub const PROVENANCE_MARK_SCHEMA: &str = "mvm.provenance-mark/v1";
+
+/// In-rootfs path of the mark (relative to the unpacked tree root).
+pub const MARK_PATH: &str = "mvm/provenance.json";
+
+/// In-rootfs path of the detached mark signature.
+pub const MARK_SIG_PATH: &str = "mvm/provenance.sig";
+
+/// Ed25519 signature byte length.
+const SIGNATURE_BYTES: usize = 64;
+
+/// Inputs needed to write a provenance mark into a rootfs tree.
+///
+/// Built with [`SealEvidence::builder`]; the seal timestamp defaults to
+/// "now" so ordinary callers only supply a signer and optionally the image
+/// identity being sealed.
+#[derive(Debug, Clone)]
+pub struct SealEvidence<'a> {
+    signer: &'a SigningKey,
+    image_ref: Option<&'a str>,
+    image_digest: Option<&'a str>,
+    created: String,
+}
+
+impl<'a> SealEvidence<'a> {
+    /// Builder entry point. `signer` is the builder identity key — the
+    /// host signer conventionally (`mvmctl artifact pack` signs with the
+    /// same key, so one trust anchor covers both artifact forms).
+    pub fn builder(signer: &'a SigningKey) -> SealEvidenceBuilder<'a> {
+        SealEvidenceBuilder {
+            signer,
+            image_ref: None,
+            image_digest: None,
+            created: None,
+        }
+    }
+
+    /// The signing key — the statement/sidecar emitters reuse it.
+    pub fn signer(&self) -> &'a SigningKey {
+        self.signer
+    }
+
+    /// Canonical registry reference, when supplied.
+    pub fn image_ref(&self) -> Option<&'a str> {
+        self.image_ref
+    }
+
+    /// Resolved manifest digest, when supplied.
+    pub fn image_digest(&self) -> Option<&'a str> {
+        self.image_digest
+    }
+
+    fn mark(&self) -> ProvenanceMark {
+        let verifying = self.signer.verifying_key();
+        ProvenanceMark {
+            schema: PROVENANCE_MARK_SCHEMA.to_string(),
+            image_ref: self.image_ref.map(str::to_string),
+            image_digest: self.image_digest.map(str::to_string),
+            builder_id: builder_id(&verifying),
+            signer_public_key: hex::encode(verifying.to_bytes()),
+            tool: "mvmctl".to_string(),
+            tool_version: env!("CARGO_PKG_VERSION").to_string(),
+            created: self.created.clone(),
+        }
+    }
+}
+
+/// Builder for [`SealEvidence`].
+#[derive(Debug, Clone)]
+pub struct SealEvidenceBuilder<'a> {
+    signer: &'a SigningKey,
+    image_ref: Option<&'a str>,
+    image_digest: Option<&'a str>,
+    created: Option<String>,
+}
+
+impl<'a> SealEvidenceBuilder<'a> {
+    /// Canonical registry reference of the image being sealed
+    /// (e.g. `docker.io/library/nginx:1.27`).
+    pub fn with_image_ref(mut self, image_ref: &'a str) -> Self {
+        self.image_ref = Some(image_ref);
+        self
+    }
+
+    /// Resolved manifest digest of the image being sealed
+    /// (e.g. `sha256:…`), when the caller resolved one.
+    pub fn with_image_digest(mut self, image_digest: &'a str) -> Self {
+        self.image_digest = Some(image_digest);
+        self
+    }
+
+    /// Seal timestamp, RFC 3339. Defaults to the current wall clock.
+    pub fn with_created(mut self, created: impl Into<String>) -> Self {
+        self.created = Some(created.into());
+        self
+    }
+
+    pub fn build(self) -> SealEvidence<'a> {
+        SealEvidence {
+            signer: self.signer,
+            image_ref: self.image_ref,
+            image_digest: self.image_digest,
+            created: self.created.unwrap_or_else(now_rfc3339),
+        }
+    }
+}
+
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+/// The `/mvm/provenance.json` document.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProvenanceMark {
+    /// Wire schema; readers refuse anything else.
+    pub schema: String,
+    /// Canonical registry reference of the sealed image, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_ref: Option<String>,
+    /// Resolved manifest digest (`sha256:…`), when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_digest: Option<String>,
+    /// Builder identity fingerprint — `mvm:builder:ed25519:sha256:<hex>`.
+    pub builder_id: String,
+    /// Raw 32-byte Ed25519 verifying key, hex-encoded. Embedded so the
+    /// mark is self-verifying; trust is decided by matching the
+    /// recomputed fingerprint against a local anchor.
+    pub signer_public_key: String,
+    /// Tool that wrote the mark.
+    pub tool: String,
+    /// Version of the writing tool.
+    pub tool_version: String,
+    /// Seal timestamp, RFC 3339.
+    pub created: String,
+}
+
+/// The parsed, signature-verified mark plus the recomputed builder
+/// fingerprint — everything a reader needs to decide trust.
+#[derive(Debug, Clone)]
+pub struct VerifiedMark {
+    /// The mark document.
+    pub mark: ProvenanceMark,
+    /// `mvm:builder:ed25519:sha256:<hex>` recomputed from the embedded
+    /// key. Matches `mark.builder_id` by construction of verification.
+    pub builder_fingerprint: String,
+}
+
+/// Compute the builder-id fingerprint for a verifying key.
+pub fn builder_id(key: &VerifyingKey) -> String {
+    format!("mvm:builder:ed25519:sha256:{}", key_fingerprint(key))
+}
+
+/// SHA-256 of the raw 32-byte Ed25519 verifying key, hex-encoded.
+pub fn key_fingerprint(key: &VerifyingKey) -> String {
+    let digest: [u8; 32] = sha2::Sha256::digest(key.to_bytes()).into();
+    hex::encode(digest)
+}
+
+/// JCS-canonical bytes of a serializable value.
+pub(crate) fn jcs_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    serde_jcs::to_vec(value).context("JCS-canonical encode")
+}
+
+/// Write the mark and its detached signature into `tree_root` (the
+/// unpacked rootfs tree, before ext4 materialization/verity hashing).
+pub fn write_mark(tree_root: &Path, evidence: &SealEvidence<'_>) -> Result<()> {
+    let mark = evidence.mark();
+    let mark_bytes = jcs_bytes(&mark)?;
+    let signature = evidence.signer.sign(&mark_bytes);
+    let mark_dir = tree_root.join("mvm");
+    std::fs::create_dir_all(&mark_dir).with_context(|| format!("create {}", mark_dir.display()))?;
+    std::fs::write(mark_dir.join("provenance.json"), &mark_bytes)
+        .context("write /mvm/provenance.json")?;
+    std::fs::write(
+        mark_dir.join("provenance.sig"),
+        format!("{}\n", hex::encode(signature.to_bytes())),
+    )
+    .context("write /mvm/provenance.sig")?;
+    tracing::info!(
+        builder_id = %mark.builder_id,
+        image_ref = ?mark.image_ref,
+        "provenance mark written into sealed rootfs"
+    );
+    Ok(())
+}
+
+/// Verify a mark document + detached hex signature.
+///
+/// Re-canonicalizes the parsed document with JCS (so whitespace or key
+/// order changes between write and read cannot desync the signed bytes),
+/// verifies the Ed25519 signature against the embedded public key, and
+/// checks the embedded key matches the claimed `builder_id`. Trust
+/// against a local anchor is the caller's decision.
+pub fn verify_mark(mark_json: &[u8], signature_hex: &str) -> Result<VerifiedMark> {
+    let mark: ProvenanceMark =
+        serde_json::from_slice(mark_json).context("parse provenance mark")?;
+    if mark.schema != PROVENANCE_MARK_SCHEMA {
+        anyhow::bail!(
+            "unsupported provenance mark schema {:?}; want {PROVENANCE_MARK_SCHEMA}",
+            mark.schema
+        );
+    }
+    let key_bytes: [u8; 32] = hex::decode(&mark.signer_public_key)
+        .context("decode embedded signer_public_key hex")?
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("signer_public_key is not 32 bytes"))?;
+    let verifying = VerifyingKey::from_bytes(&key_bytes).context("parse embedded public key")?;
+    let signature_bytes: [u8; SIGNATURE_BYTES] = hex::decode(signature_hex.trim())
+        .context("decode provenance signature hex")?
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("provenance signature is not {SIGNATURE_BYTES} bytes"))?;
+    let signature = ed25519_dalek::Signature::from_bytes(&signature_bytes);
+    let canonical = jcs_bytes(&mark)?;
+    verifying
+        .verify(&canonical, &signature)
+        .context("provenance mark signature invalid")?;
+    let fingerprint = key_fingerprint(&verifying);
+    if mark.builder_id != builder_id(&verifying) {
+        anyhow::bail!(
+            "mark builder_id {} does not match embedded key fingerprint {}",
+            mark.builder_id,
+            fingerprint
+        );
+    }
+    Ok(VerifiedMark {
+        mark,
+        builder_fingerprint: fingerprint,
+    })
+}
+
+/// Read the provenance mark out of a sealed ext4 image using host
+/// `debugfs` (offline, no mount). Returns `Ok(None)` when the image has
+/// no mark. `debugfs` is a Linux/e2fsprogs tool; on other hosts this
+/// returns an error naming the limitation — roothash verification via
+/// [`mvm_fs::ext4::verity::root_hash`] remains available everywhere.
+pub fn read_mark_from_ext4(image: &Path) -> Result<Option<VerifiedMark>> {
+    let debugfs = locate_debugfs().context(
+        "debugfs (e2fsprogs) not found; reading an in-rootfs mark needs a Linux host or the builder VM",
+    )?;
+    let Some(mark_json) = debugfs_cat(&debugfs, image, "/mvm/provenance.json")? else {
+        return Ok(None);
+    };
+    let Some(signature_hex) = debugfs_cat(&debugfs, image, "/mvm/provenance.sig")? else {
+        anyhow::bail!("image has /mvm/provenance.json but no /mvm/provenance.sig");
+    };
+    verify_mark(mark_json.as_bytes(), &signature_hex).map(Some)
+}
+
+fn locate_debugfs() -> Option<std::path::PathBuf> {
+    for candidate in [
+        "/usr/sbin/debugfs",
+        "/sbin/debugfs",
+        "/usr/bin/debugfs",
+        "/bin/debugfs",
+    ] {
+        let path = Path::new(candidate);
+        if path.is_file() {
+            return Some(path.to_path_buf());
+        }
+    }
+    which::which("debugfs").ok()
+}
+
+/// `debugfs -R "cat <guest_path>" <image>`; `Ok(None)` when the guest
+/// path is absent from the image.
+fn debugfs_cat(debugfs: &Path, image: &Path, guest_path: &str) -> Result<Option<String>> {
+    let output = std::process::Command::new(debugfs)
+        .args(["-R", &format!("cat {guest_path}")])
+        .arg(image)
+        .output()
+        .with_context(|| format!("spawn debugfs for {guest_path}"))?;
+    if output.status.success() {
+        return Ok(Some(String::from_utf8_lossy(&output.stdout).into_owned()));
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("not found") {
+        return Ok(None);
+    }
+    anyhow::bail!("debugfs cat {guest_path} failed: {stderr}");
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> SigningKey {
+        SigningKey::from_bytes(&[42; 32])
+    }
+
+    fn evidence(key: &SigningKey) -> SealEvidence<'_> {
+        SealEvidence::builder(key)
+            .with_image_ref("docker.io/library/nginx:1.27")
+            .with_image_digest("sha256:abc123")
+            .with_created("2026-09-02T00:00:00Z")
+            .build()
+    }
+
+    #[test]
+    fn mark_roundtrips_through_write_and_verify() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = test_key();
+        write_mark(dir.path(), &evidence(&key)).unwrap();
+
+        let mark_json = std::fs::read(dir.path().join("mvm/provenance.json")).unwrap();
+        let sig = std::fs::read_to_string(dir.path().join("mvm/provenance.sig")).unwrap();
+        let verified = verify_mark(&mark_json, &sig).expect("mark verifies");
+
+        assert_eq!(verified.mark.schema, PROVENANCE_MARK_SCHEMA);
+        assert_eq!(
+            verified.mark.image_ref.as_deref(),
+            Some("docker.io/library/nginx:1.27")
+        );
+        assert_eq!(verified.mark.image_digest.as_deref(), Some("sha256:abc123"));
+        assert_eq!(verified.mark.builder_id, builder_id(&key.verifying_key()));
+        assert_eq!(
+            verified.builder_fingerprint,
+            key_fingerprint(&key.verifying_key())
+        );
+    }
+
+    #[test]
+    fn whitespace_and_key_order_changes_do_not_break_verification() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = test_key();
+        write_mark(dir.path(), &evidence(&key)).unwrap();
+        let mark: ProvenanceMark =
+            serde_json::from_slice(&std::fs::read(dir.path().join("mvm/provenance.json")).unwrap())
+                .unwrap();
+        // Re-serialize in a different shape: pretty, different key order.
+        let mut value = serde_json::to_value(&mark).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        let created = obj.remove("created").unwrap();
+        obj.insert("created".to_string(), created);
+        let pretty = serde_json::to_string_pretty(&value).unwrap();
+        let sig = std::fs::read_to_string(dir.path().join("mvm/provenance.sig")).unwrap();
+        verify_mark(pretty.as_bytes(), &sig)
+            .expect("JCS re-canonicalization covers reserialization");
+    }
+
+    #[test]
+    fn tampered_mark_fails_verification() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = test_key();
+        write_mark(dir.path(), &evidence(&key)).unwrap();
+        let sig = std::fs::read_to_string(dir.path().join("mvm/provenance.sig")).unwrap();
+        let tampered = br#"{"schema":"mvm.provenance-mark/v1","tool":"mvmctl","tool_version":"0.18.0","created":"2026-09-02T00:00:00Z","builder_id":"x","signer_public_key":"y","image_ref":"evil"}"#;
+        assert!(verify_mark(tampered, &sig).is_err());
+    }
+
+    #[test]
+    fn mark_signed_by_another_key_fails_verification() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = test_key();
+        write_mark(dir.path(), &evidence(&key)).unwrap();
+        let mark_json = std::fs::read(dir.path().join("mvm/provenance.json")).unwrap();
+        let other = SigningKey::from_bytes(&[7; 32]);
+        let mark: ProvenanceMark = serde_json::from_slice(&mark_json).unwrap();
+        let forged = serde_json::to_vec(&ProvenanceMark {
+            signer_public_key: hex::encode(other.verifying_key().to_bytes()),
+            builder_id: builder_id(&other.verifying_key()),
+            ..mark
+        })
+        .unwrap();
+        let sig = std::fs::read_to_string(dir.path().join("mvm/provenance.sig")).unwrap();
+        assert!(verify_mark(&forged, &sig).is_err());
+    }
+
+    #[test]
+    fn unknown_schema_is_refused() {
+        let err = verify_mark(
+            br#"{"schema":"mvm.provenance-mark/v2","tool":"t","tool_version":"1","created":"c","builder_id":"b","signer_public_key":"00"}"#,
+            "00",
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported provenance mark schema")
+        );
+    }
+
+    #[test]
+    fn missing_optional_identity_fields_roundtrip() {
+        let key = test_key();
+        let mark = SealEvidence::builder(&key)
+            .with_created("2026-09-02T00:00:00Z")
+            .build()
+            .mark();
+        let json = serde_json::to_value(&mark).unwrap();
+        assert!(json.get("image_ref").is_none());
+        assert!(json.get("image_digest").is_none());
+        let back: ProvenanceMark = serde_json::from_value(json).unwrap();
+        assert_eq!(back, mark);
+    }
+
+    #[test]
+    fn mark_rejects_unknown_fields() {
+        let key = test_key();
+        let mark = evidence(&key).mark();
+        let mut value = serde_json::to_value(&mark).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("extra".to_string(), serde_json::json!(1));
+        assert!(serde_json::from_value::<ProvenanceMark>(value).is_err());
+    }
+}

--- a/crates/mvm-build/src/run_image.rs
+++ b/crates/mvm-build/src/run_image.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 
 use crate::oci_runtime_inject::{ImageRuntimeConfig, MvmRuntimeBinaries};
+use crate::provenance_mark::SealEvidence;
 use crate::rootfs::MaterializeExt4Input;
 use mvm_fs::oci_to_rootfs::{
     MaterializedRootfs, OciUnpackError, VeritySealedRootfs, VeritysetupOptions, seal_with_verity,
@@ -25,6 +26,7 @@ pub struct InjectAndMaterializeRequest<'a> {
     entrypoint: Option<&'a ImageRuntimeConfig>,
     sealed: bool,
     deferred_nodes: Vec<mvm_fs::ext4::Node>,
+    evidence: Option<SealEvidence<'a>>,
 }
 
 impl<'a> InjectAndMaterializeRequest<'a> {
@@ -42,6 +44,7 @@ impl<'a> InjectAndMaterializeRequest<'a> {
             entrypoint: None,
             sealed: false,
             deferred_nodes: Vec::new(),
+            evidence: None,
         }
     }
 }
@@ -54,6 +57,7 @@ pub struct InjectAndMaterializeRequestBuilder<'a> {
     entrypoint: Option<&'a ImageRuntimeConfig>,
     sealed: bool,
     deferred_nodes: Vec<mvm_fs::ext4::Node>,
+    evidence: Option<SealEvidence<'a>>,
 }
 
 impl<'a> InjectAndMaterializeRequestBuilder<'a> {
@@ -74,6 +78,16 @@ impl<'a> InjectAndMaterializeRequestBuilder<'a> {
         self
     }
 
+    /// Seal-evidence inputs: when set on a `sealed` request, a signed
+    /// provenance mark is written into the rootfs before the dm-verity
+    /// hash is computed (so the mark is tamper-evident under verified
+    /// boot) and an in-toto/DSSE provenance sidecar is written beside
+    /// the sealed image. Ignored for unsealed requests.
+    pub fn evidence(mut self, evidence: Option<SealEvidence<'a>>) -> Self {
+        self.evidence = evidence;
+        self
+    }
+
     pub fn build(self) -> InjectAndMaterializeRequest<'a> {
         InjectAndMaterializeRequest {
             cache_root: self.cache_root,
@@ -83,6 +97,7 @@ impl<'a> InjectAndMaterializeRequestBuilder<'a> {
             entrypoint: self.entrypoint,
             sealed: self.sealed,
             deferred_nodes: self.deferred_nodes,
+            evidence: self.evidence,
         }
     }
 }
@@ -109,11 +124,19 @@ pub fn inject_and_materialize(request: InjectAndMaterializeRequest<'_>) -> Resul
         entrypoint,
         sealed,
         deferred_nodes,
+        evidence,
     } = request;
     let bins = resolve_guest_binaries(cache_root)?;
     crate::oci_runtime_inject::inject_mvm_runtime(unpacked_root, &bins, entrypoint, sealed)
         .context("inject mvm runtime into OCI rootfs")?;
     ensure_volume_mount_roots(unpacked_root)?;
+
+    // The provenance mark must land inside the tree BEFORE any hashing:
+    // both the materializer's sizing pass below and the verity seal hash
+    // the exact bytes they see, so a mark written later would change the
+    // roothash and break the signature's coverage.
+    let seal_started = chrono::Utc::now().to_rfc3339();
+    maybe_write_provenance_mark(unpacked_root, sealed, evidence.as_ref())?;
 
     // Measure AFTER injection so the ext4 sizing covers everything injected.
     let tree_size = unpacked_tree_size(unpacked_root)
@@ -128,6 +151,18 @@ pub fn inject_and_materialize(request: InjectAndMaterializeRequest<'_>) -> Resul
     // verity-boot.
     if sealed {
         seal_rootfs_for_run(output)?;
+        if let Some(evidence) = &evidence {
+            let subject_sha256 = mvm_core::crypto::image_verify::sha256_file(output)
+                .context("hash sealed rootfs for provenance sidecar")?;
+            crate::intoto::write_sidecar(
+                output,
+                &subject_sha256,
+                evidence,
+                &seal_started,
+                &chrono::Utc::now().to_rfc3339(),
+            )
+            .context("write in-toto provenance sidecar")?;
+        }
     }
 
     // The sidecar lives next to rootfs.ext4 so the backend's admit_runtime_overlay_contract
@@ -139,6 +174,34 @@ pub fn inject_and_materialize(request: InjectAndMaterializeRequest<'_>) -> Resul
         .write_to_dir(rootfs_dir)
         .with_context(|| format!("write OCI sidecar in {}", rootfs_dir.display()))?;
     Ok(())
+}
+
+/// Write the signed provenance mark into the tree being sealed, when the
+/// caller asked for a sealed image and supplied seal evidence.
+///
+/// A sealed image with no evidence is a caller mistake worth a loud warning,
+/// not a hard failure: the verity seal itself still stands, and the run-path
+/// self-heal may seal again with evidence present. An unsealed image never
+/// carries the mark — without the verity boot chain there is nothing for the
+/// signature to be tamper-evident under.
+fn maybe_write_provenance_mark(
+    unpacked_root: &Path,
+    sealed: bool,
+    evidence: Option<&SealEvidence<'_>>,
+) -> Result<()> {
+    if !sealed {
+        return Ok(());
+    }
+    match evidence {
+        Some(evidence) => crate::provenance_mark::write_mark(unpacked_root, evidence)
+            .context("write provenance mark into rootfs"),
+        None => {
+            tracing::warn!(
+                "sealed rootfs carries no provenance mark: caller supplied no seal evidence"
+            );
+            Ok(())
+        }
+    }
 }
 
 /// Build the sidecar describing a materialized OCI run rootfs.
@@ -567,6 +630,70 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(read.libc, crate::guest_libc::GuestLibc::Unknown);
+    }
+
+    fn test_evidence<'a>(
+        signer: &'a ed25519_dalek::SigningKey,
+        image_ref: &'a str,
+        image_digest: &'a str,
+    ) -> SealEvidence<'a> {
+        SealEvidence::builder(signer)
+            .with_image_ref(image_ref)
+            .with_image_digest(image_digest)
+            .build()
+    }
+
+    #[test]
+    fn sealed_request_with_evidence_writes_a_verifiable_mark() {
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let tree = tempfile::tempdir().unwrap();
+
+        maybe_write_provenance_mark(
+            tree.path(),
+            true,
+            Some(&test_evidence(&signer, "app:1", "sha256:abc")),
+        )
+        .expect("mark write succeeds");
+
+        let mark_path = tree.path().join("mvm/provenance.json");
+        let sig_path = tree.path().join("mvm/provenance.sig");
+        assert!(mark_path.is_file(), "mark must land in the tree");
+        assert!(
+            sig_path.is_file(),
+            "detached signature must land beside the mark"
+        );
+        let verified = crate::provenance_mark::verify_mark(
+            &std::fs::read(&mark_path).unwrap(),
+            std::fs::read_to_string(&sig_path).unwrap().trim(),
+        )
+        .expect("mark verifies against the signer");
+        assert_eq!(verified.mark.image_ref.as_deref(), Some("app:1"));
+    }
+
+    #[test]
+    fn sealed_request_without_evidence_warns_but_leaves_no_mark() {
+        let tree = tempfile::tempdir().unwrap();
+
+        maybe_write_provenance_mark(tree.path(), true, None)
+            .expect("missing evidence is not a hard failure");
+
+        assert!(!tree.path().join("mvm/provenance.json").exists());
+        assert!(!tree.path().join("mvm/provenance.sig").exists());
+    }
+
+    #[test]
+    fn unsealed_request_never_carries_the_mark() {
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[9u8; 32]);
+        let tree = tempfile::tempdir().unwrap();
+
+        maybe_write_provenance_mark(
+            tree.path(),
+            false,
+            Some(&test_evidence(&signer, "app:1", "sha256:abc")),
+        )
+        .expect("unsealed request is a no-op");
+
+        assert!(!tree.path().join("mvm/provenance.json").exists());
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/GROUPING.md
+++ b/crates/mvm-cli/src/commands/GROUPING.md
@@ -27,6 +27,11 @@ deferred to Task 7 — see plan.)
 
 ## Groups (clap group = directory)
 
+**`deployments/`** (additive, 2026-09-02) — `deployments ls` reads the
+local-first deploy store (`<mvm_home>/deployments/<ir-hash>/deploy.json`).
+Sits beside `deploy` (the write path) the way `deps` sits beside build.
+
+
 **`build/`** (D1) — `build image`(was the bare `build`) · `build compile`
 · `build validate` · `build kernel`(from flat `kernel.rs`).
 

--- a/crates/mvm-cli/src/commands/cmd_audit.rs
+++ b/crates/mvm-cli/src/commands/cmd_audit.rs
@@ -284,6 +284,7 @@ impl Commands {
             // `build <sub>` delegates to the per-op verb (image/compile/validate/kernel).
             Commands::Build(a) => a.action.verb_name(),
             Commands::Deploy(_) => "deploy",
+            Commands::Deployments(_) => "deployments",
             Commands::ShellInit(_) => "shell-init",
             // `ops <sub>` delegates to the per-op verb (metrics/config/MCP).
             Commands::Ops(a) => a.action.verb_name(),

--- a/crates/mvm-cli/src/commands/deployments/list.rs
+++ b/crates/mvm-cli/src/commands/deployments/list.rs
@@ -1,0 +1,77 @@
+//! `mvmctl deployments ls`.
+
+use anyhow::Result;
+use serde::Serialize;
+
+use mvm_core::config::deployments_dir;
+use mvm_sdk::deploy::list_deployments;
+
+use crate::ui;
+
+/// One row of `deployments ls` — the fields a user needs to recognize
+/// a deployment and trace it to exact bytes, flattened for JSON.
+#[derive(Debug, Serialize)]
+struct DeploymentRow {
+    workload_id: String,
+    ir_hash: String,
+    image_blake3: String,
+    image_sha256: String,
+    boot_sha256: String,
+    kernel_sha256: Option<String>,
+    sbom_sha256: Option<String>,
+}
+
+pub(in crate::commands) fn run(workload: Option<String>, json: bool) -> Result<()> {
+    let (entries, skips) = list_deployments(&deployments_dir())?;
+    let rows: Vec<DeploymentRow> = entries
+        .iter()
+        .filter(|entry| {
+            workload
+                .as_deref()
+                .is_none_or(|wanted| entry.record.workload_id == wanted)
+        })
+        .map(|entry| DeploymentRow {
+            workload_id: entry.record.workload_id.clone(),
+            ir_hash: entry.ir_hash.clone(),
+            image_blake3: entry.record.image.blake3.clone(),
+            image_sha256: entry.record.image.sha256.clone(),
+            boot_sha256: entry.record.boot_artifact.sha256.clone(),
+            kernel_sha256: entry
+                .record
+                .environment
+                .as_ref()
+                .map(|pin| pin.kernel_sha256.clone()),
+            sbom_sha256: entry
+                .record
+                .dependency_volume
+                .as_ref()
+                .map(|volume| volume.sbom_sha256.clone()),
+        })
+        .collect();
+
+    for skip in &skips {
+        ui::warn(&format!("skipping {}: {}", skip.dir, skip.reason));
+    }
+
+    if json {
+        crate::json_out::emit_json(&rows)?;
+        return Ok(());
+    }
+
+    if rows.is_empty() {
+        ui::info("No deployments recorded. `mvmctl deploy` records one per deployment.");
+        return Ok(());
+    }
+
+    for row in &rows {
+        println!(
+            "{:<24}  {:<12}  blake3:{}  boot:{}",
+            row.workload_id,
+            row.ir_hash.get(..12).unwrap_or(&row.ir_hash),
+            row.image_blake3.get(..12).unwrap_or(&row.image_blake3),
+            row.boot_sha256.get(..12).unwrap_or(&row.boot_sha256),
+        );
+    }
+    ui::info("Exact digests: re-run with --json.");
+    Ok(())
+}

--- a/crates/mvm-cli/src/commands/deployments/mod.rs
+++ b/crates/mvm-cli/src/commands/deployments/mod.rs
@@ -1,0 +1,42 @@
+//! `mvmctl deployments` — inventory of the local deployment store.
+//!
+//! Every `mvmctl deploy` writes a `DeployRecord` under
+//! `<mvm_home>/deployments/<ir-hash>/` before anything ships anywhere;
+//! this group is the read side of that local-first record. It answers
+//! "what have I deployed from this machine, and what exact bytes were
+//! sealed?" — the same record shape the control-plane query answers
+//! fleet-wide.
+
+use anyhow::Result;
+use clap::{Args as ClapArgs, Subcommand};
+
+use mvm_core::user_config::MvmConfig;
+
+use super::Cli;
+
+mod list;
+
+#[derive(ClapArgs, Debug, Clone)]
+pub(in crate::commands) struct Args {
+    #[command(subcommand)]
+    pub action: DeploymentsAction,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub(in crate::commands) enum DeploymentsAction {
+    /// List recorded local deployments
+    Ls {
+        /// Only list deployments of this workload id
+        #[arg(long)]
+        workload: Option<String>,
+        /// Emit machine-readable JSON to stdout
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Result<()> {
+    match args.action {
+        DeploymentsAction::Ls { workload, json } => list::run(workload, json),
+    }
+}

--- a/crates/mvm-cli/src/commands/dispatch.rs
+++ b/crates/mvm-cli/src/commands/dispatch.rs
@@ -32,6 +32,7 @@ impl TopLevelCommand for Commands {
             Commands::Prepare(a) => vm::prepare::run(a),
             Commands::Build(a) => build::group::run(cli, a, cfg),
             Commands::Deploy(a) => deploy::run(cli, a, cfg),
+            Commands::Deployments(a) => deployments::run(cli, a, cfg),
             Commands::Kernel(a) => build::kernel::run(cli, a, cfg),
             Commands::Generate(a) => generate::run(cli, a, cfg),
             Commands::Template(a) => template::run(cli, a, cfg),

--- a/crates/mvm-cli/src/commands/image/materialize.rs
+++ b/crates/mvm-cli/src/commands/image/materialize.rs
@@ -153,18 +153,23 @@ pub(super) fn ensure_rootfs_verity_sidecars(
     );
 }
 
+/// One rootfs materialize invocation, grouped so the materializer callback
+/// stays a single-argument signature no matter how many inputs a seal needs.
+pub(super) struct MaterializeCall<'a> {
+    pub(super) cache_root: &'a Path,
+    pub(super) unpacked_root: &'a Path,
+    pub(super) rootfs_abs: &'a Path,
+    pub(super) image_label: &'a str,
+    pub(super) entrypoint: Option<&'a ImageRuntimeConfig>,
+    pub(super) sealed: bool,
+    pub(super) deferred_nodes: Vec<mvm_fs::ext4::Node>,
+    pub(super) evidence: Option<mvm_build::provenance_mark::SealEvidence<'a>>,
+}
+
 /// Callback signature used to inject the mvm guest runtime and seal a rootfs.
 /// A type alias rather than a bare fn pointer everywhere it's threaded, and
 /// swappable in tests for a fake that skips the real Nix/ext4 machinery.
-pub(super) type RuntimeMaterializer = fn(
-    &Path,
-    &Path,
-    &Path,
-    &str,
-    Option<&ImageRuntimeConfig>,
-    bool,
-    Vec<mvm_fs::ext4::Node>,
-) -> Result<()>;
+pub(super) type RuntimeMaterializer = for<'a> fn(MaterializeCall<'a>) -> Result<()>;
 
 pub(super) fn rematerialize_cached_image(
     cache_root: &Path,
@@ -190,15 +195,30 @@ pub(super) fn rematerialize_cached_image(
     };
     let rootfs_abs = safe_cache_path(cache_root, &rootfs_path)?;
     if !rootfs_abs.is_file() {
-        materialize(
+        let signer;
+        let evidence = if prod {
+            signer = crate::commands::vm::host_signer::load_or_init()
+                .context("load host signing key for the provenance mark")?;
+            Some(
+                mvm_build::provenance_mark::SealEvidence::builder(&signer.signing)
+                    .with_image_ref(&image.reference)
+                    .with_image_digest(&image.resolved_digest)
+                    .build(),
+            )
+        } else {
+            None
+        };
+        materialize(MaterializeCall {
             cache_root,
-            &unpacked_root,
-            &rootfs_abs,
-            &image.reference,
-            oci_entrypoint_from_cache_path(cache_root, image.config_path.as_deref())?.as_ref(),
-            prod,
-            super::cache::read_deferred_nodes(cache_root, &image.resolved_digest)?,
-        )
+            unpacked_root: &unpacked_root,
+            rootfs_abs: &rootfs_abs,
+            image_label: &image.reference,
+            entrypoint: oci_entrypoint_from_cache_path(cache_root, image.config_path.as_deref())?
+                .as_ref(),
+            sealed: prod,
+            deferred_nodes: super::cache::read_deferred_nodes(cache_root, &image.resolved_digest)?,
+            evidence,
+        })
         .with_context(|| {
             format!(
                 "re-materializing cached OCI image {} from {}",
@@ -235,15 +255,17 @@ pub(super) fn materialize_run_rootfs(input: &MaterializeExt4Input) -> Result<()>
 /// injected `/init` + baked agent + `/mvm/runtime` mount point make the
 /// rootfs genuinely overlay-aware, so the `for_oci_run` sidecar admits
 /// honestly through `admit_runtime_overlay_contract` without weakening the gate.
-pub(super) fn inject_runtime_and_materialize(
-    cache_root: &Path,
-    unpacked_root: &Path,
-    rootfs_abs: &Path,
-    image_label: &str,
-    entrypoint: Option<&ImageRuntimeConfig>,
-    sealed: bool,
-    deferred_nodes: Vec<mvm_fs::ext4::Node>,
-) -> Result<()> {
+pub(super) fn inject_runtime_and_materialize(call: MaterializeCall<'_>) -> Result<()> {
+    let MaterializeCall {
+        cache_root,
+        unpacked_root,
+        rootfs_abs,
+        image_label,
+        entrypoint,
+        sealed,
+        deferred_nodes,
+        evidence,
+    } = call;
     mvm_build::run_image::inject_and_materialize(
         mvm_build::run_image::InjectAndMaterializeRequest::builder(
             cache_root,
@@ -254,6 +276,7 @@ pub(super) fn inject_runtime_and_materialize(
         .entrypoint(entrypoint)
         .sealed(sealed)
         .deferred_nodes(deferred_nodes)
+        .evidence(evidence)
         .build(),
     )
 }
@@ -308,15 +331,16 @@ pub(super) fn materialize_overlay_lean_rootfs(
             staging_root.display()
         )
     })?;
-    let result = inject_runtime_and_materialize(
+    let result = inject_runtime_and_materialize(MaterializeCall {
         cache_root,
-        &staging_root,
+        unpacked_root: &staging_root,
         rootfs_abs,
         image_label,
-        None,
-        false,
+        entrypoint: None,
+        sealed: false,
         deferred_nodes,
-    );
+        evidence: None,
+    });
     let cleanup = fs::remove_dir_all(&staging_root);
     if let Err(err) = cleanup
         && staging_root.exists()
@@ -641,6 +665,137 @@ mod tests {
         // A current tag with no materialized rootfs is still not bootable.
         image.rootfs_path = None;
         assert!(!cached_rootfs_is_current(&image, &current));
+    }
+
+    /// A fn-pointer materializer cannot capture, so the evidence the
+    /// rematerializer handed it is recorded on disk for the caller to
+    /// assert on — same pattern as the deferred-nodes recording in the
+    /// pull-path tests.
+    fn evidence_recording_materialize(call: MaterializeCall<'_>) -> Result<()> {
+        assert!(call.unpacked_root.is_dir(), "unpacked root must exist");
+        let parent = call.rootfs_abs.parent().expect("rootfs has parent");
+        fs::create_dir_all(parent)?;
+        let seen = serde_json::json!({
+            "sealed": call.sealed,
+            "label": call.image_label,
+            "evidence": call.evidence.map(|e| serde_json::json!({
+                "image_ref": e.image_ref(),
+                "image_digest": e.image_digest(),
+            })),
+        });
+        fs::write(
+            parent.join("evidence-seen.json"),
+            serde_json::to_vec(&seen)?,
+        )?;
+        fs::write(
+            call.rootfs_abs,
+            format!("materialized:{}", call.image_label),
+        )?;
+        Ok(())
+    }
+
+    fn seed_index_and_unpacked(cache_root: &Path, image: &CachedOciImage) {
+        let index = super::super::oci_types::OciCacheIndex {
+            schema_version: 1,
+            images: vec![image.clone()],
+        };
+        fs::create_dir_all(cache_root).expect("create cache root");
+        fs::write(
+            cache_root.join(super::super::oci_types::INDEX_FILE),
+            serde_json::to_vec_pretty(&index).expect("serialize index"),
+        )
+        .expect("write index");
+        let unpacked = cache_root
+            .join("unpacked")
+            .join(super::super::cache::sha256_hex(&image.resolved_digest).expect("digest hex"));
+        fs::create_dir_all(&unpacked).expect("create unpacked tree");
+    }
+
+    #[test]
+    fn prod_rematerialize_hands_seal_evidence_to_the_materializer() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let keys_home = tempfile::tempdir().expect("keys tempdir");
+        // The evidence builder loads (and may create) the host signing key;
+        // point the whole mvm world at a scratch home so the test never
+        // touches the developer's real keyring.
+        let mut env = mvm_core::util::test_env::TestEnv::new();
+        env.isolate_mvm_home(keys_home.path());
+        let digest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let mut image = sample_image("docker.io/library/alpine:3.20", digest, "blobs/a");
+        // No OCI config blob: the entrypoint lookup must not touch the network
+        // of config files a pull would have written.
+        image.config_path = None;
+        seed_index_and_unpacked(tmp.path(), &image);
+        let runtime_tag = oci_runtime_tag(tmp.path());
+
+        let repaired = rematerialize_cached_image(
+            tmp.path(),
+            image,
+            &runtime_tag,
+            evidence_recording_materialize,
+            true,
+        )
+        .expect("prod rematerialize succeeds")
+        .expect("unpacked tree present");
+
+        let rootfs_abs =
+            safe_cache_path(tmp.path(), repaired.rootfs_path.as_deref().expect("rootfs"))
+                .expect("resolve recorded rootfs");
+        let seen: serde_json::Value = serde_json::from_slice(
+            &fs::read(
+                rootfs_abs
+                    .parent()
+                    .expect("rootfs has parent")
+                    .join("evidence-seen.json"),
+            )
+            .expect("materializer recorded the evidence it was handed"),
+        )
+        .expect("parse recorded evidence");
+        assert_eq!(seen["sealed"], true, "prod request seals the rootfs");
+        assert_eq!(
+            seen["evidence"]["image_ref"], "docker.io/library/alpine:3.20",
+            "mark names the canonical image reference"
+        );
+        assert_eq!(seen["evidence"]["image_digest"], digest);
+    }
+
+    #[test]
+    fn dev_rematerialize_passes_no_seal_evidence() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let digest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+        let mut image = sample_image("docker.io/library/alpine:3.20", digest, "blobs/a");
+        image.config_path = None;
+        seed_index_and_unpacked(tmp.path(), &image);
+        let runtime_tag = oci_runtime_tag(tmp.path());
+
+        let repaired = rematerialize_cached_image(
+            tmp.path(),
+            image,
+            &runtime_tag,
+            evidence_recording_materialize,
+            false,
+        )
+        .expect("dev rematerialize succeeds")
+        .expect("unpacked tree present");
+
+        let rootfs_abs =
+            safe_cache_path(tmp.path(), repaired.rootfs_path.as_deref().expect("rootfs"))
+                .expect("resolve recorded rootfs");
+        let seen: serde_json::Value = serde_json::from_slice(
+            &fs::read(
+                rootfs_abs
+                    .parent()
+                    .expect("rootfs has parent")
+                    .join("evidence-seen.json"),
+            )
+            .expect("materializer recorded the evidence it was handed"),
+        )
+        .expect("parse recorded evidence");
+        assert_eq!(seen["sealed"], false);
+        assert!(
+            seen["evidence"].is_null(),
+            "unsealed requests must not carry provenance evidence"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -149,16 +149,36 @@ pub(super) fn resolve_or_pull_run_image_with(
         match unpacked_dir_if_present(cache_root, &image.resolved_digest) {
             Some(unpacked_root) => {
                 sweep_before_builder_vm();
-                materialize(
+                let signer;
+                let evidence = if prod {
+                    signer = crate::commands::vm::host_signer::load_or_init()
+                        .context("load host signing key for the provenance mark")?;
+                    Some(
+                        mvm_build::provenance_mark::SealEvidence::builder(&signer.signing)
+                            .with_image_ref(&image.reference)
+                            .with_image_digest(&image.resolved_digest)
+                            .build(),
+                    )
+                } else {
+                    None
+                };
+                materialize(super::materialize::MaterializeCall {
                     cache_root,
-                    &unpacked_root,
-                    &rootfs_path,
-                    &image.reference,
-                    oci_entrypoint_from_cache_path(cache_root, image.config_path.as_deref())?
-                        .as_ref(),
-                    prod,
-                    super::cache::read_deferred_nodes(cache_root, &image.resolved_digest)?,
-                )
+                    unpacked_root: &unpacked_root,
+                    rootfs_abs: &rootfs_path,
+                    image_label: &image.reference,
+                    entrypoint: oci_entrypoint_from_cache_path(
+                        cache_root,
+                        image.config_path.as_deref(),
+                    )?
+                    .as_ref(),
+                    sealed: prod,
+                    deferred_nodes: super::cache::read_deferred_nodes(
+                        cache_root,
+                        &image.resolved_digest,
+                    )?,
+                    evidence,
+                })
                 .with_context(|| {
                     format!(
                         "re-materializing cached OCI rootfs artifacts for {} from {}",
@@ -345,15 +365,16 @@ fn pull_image_ref(
     let rootfs_path = format!("rootfs/{manifest_hex}-{runtime_tag}/rootfs.ext4");
     let rootfs_abs = cache_root.join(&rootfs_path);
     super::cache::write_deferred_nodes(cache_root, &manifest.digest, &deferred_nodes)?;
-    inject_runtime_and_materialize(
+    inject_runtime_and_materialize(super::materialize::MaterializeCall {
         cache_root,
-        &unpacked_root,
-        &rootfs_abs,
-        &image_ref.canonical(),
-        None,
-        false,
+        unpacked_root: &unpacked_root,
+        rootfs_abs: &rootfs_abs,
+        image_label: &image_ref.canonical(),
+        entrypoint: None,
+        sealed: false,
         deferred_nodes,
-    )?;
+        evidence: None,
+    })?;
 
     let provenance = super::oci_types::OciProvenance {
         schema_version: 1,
@@ -542,7 +563,6 @@ fn is_gzip_layer(media_type: &str) -> bool {
 mod tests {
     use super::super::oci_types::OciCacheIndex;
     use super::*;
-    use mvm_build::oci_runtime_inject::ImageRuntimeConfig;
 
     fn sample_image(reference: &str, digest: &str, layer_path: &str) -> CachedOciImage {
         CachedOciImage {
@@ -618,25 +638,22 @@ mod tests {
     }
 
     fn fake_runtime_materialize(
-        _cache_root: &Path,
-        unpacked_root: &Path,
-        rootfs_abs: &Path,
-        image_label: &str,
-        _entrypoint: Option<&ImageRuntimeConfig>,
-        _sealed: bool,
-        deferred_nodes: Vec<mvm_fs::ext4::Node>,
+        call: super::super::materialize::MaterializeCall<'_>,
     ) -> Result<()> {
-        assert!(unpacked_root.is_dir(), "unpacked root must exist");
-        let parent = rootfs_abs.parent().expect("rootfs has parent");
+        assert!(call.unpacked_root.is_dir(), "unpacked root must exist");
+        let parent = call.rootfs_abs.parent().expect("rootfs has parent");
         fs::create_dir_all(parent)?;
-        fs::write(rootfs_abs, format!("materialized:{image_label}"))?;
+        fs::write(
+            call.rootfs_abs,
+            format!("materialized:{}", call.image_label),
+        )?;
         fs::write(parent.join("rootfs.verity"), b"fake-verity")?;
         fs::write(parent.join("rootfs.roothash"), b"abc\n")?;
         // A fn pointer can't capture, so the deferred set the materializer
         // was handed is recorded on disk for the caller to assert on.
         fs::write(
             parent.join("deferred-seen.json"),
-            serde_json::to_vec(&deferred_nodes)?,
+            serde_json::to_vec(&call.deferred_nodes)?,
         )?;
         Ok(())
     }

--- a/crates/mvm-cli/src/commands/mod.rs
+++ b/crates/mvm-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ mod cmd_audit;
 mod completions;
 mod dashboard;
 mod deploy;
+mod deployments;
 mod deps;
 mod dispatch;
 pub(crate) mod env;
@@ -134,6 +135,9 @@ pub(in crate::commands) enum Commands {
     /// Build, seal, and record a workload; optionally ship it to mvmd
     #[command(display_order = 4)]
     Deploy(deploy::Args),
+    /// Inventory of recorded local deployments
+    #[command(display_order = 4)]
+    Deployments(deployments::Args),
     /// Build the custom microVM kernels (builder / workload)
     #[command(display_order = 3)]
     Kernel(build::kernel::Args),

--- a/crates/mvm-contract/src/protocol/host_beacon.rs
+++ b/crates/mvm-contract/src/protocol/host_beacon.rs
@@ -1,0 +1,124 @@
+//! `host.beacon.v1` payload types — guest-agent boot beacon.
+//!
+//! One verb:
+//!
+//! - `report` — the in-guest agent reports its own liveness once at
+//!   boot. Payload is [`BeaconReport`]; response is [`BeaconAck`]
+//!   carrying the new `chain_head`.
+//!
+//! Unlike `host.audit.v1` (workload-emitted, workload-asserted entries),
+//! the beacon originates from the platform's own guest agent, and the
+//! host records it as a system `lifecycle` entry: the handler stamps the
+//! supervisor-authoritative `workload_id` / `tenant_id` / `session_id` /
+//! `correlation_id` from the call context, so the chain entry proves the
+//! admitted workload's agent came alive, not merely that the VM process
+//! started. The guest-supplied fields (`agent_version`, `boot_unix_ms`)
+//! ride through as data under the host-authored `lifecycle.beacon_reported`
+//! event name; a compromised guest can lie about them, but cannot forge
+//! the binding to the admitted identity.
+//!
+//! Identity fields are deliberately absent from the payloads — the
+//! broker handler fills them from `ServiceCallCtx`, same discipline as
+//! `host.audit.v1`.
+
+use alloc::string::String;
+
+use serde::{Deserialize, Serialize};
+
+/// The broker service the guest agent's boot beacon targets.
+pub const HOST_BEACON_SERVICE: &str = "host.beacon.v1";
+
+/// The audit chain event the host handler records for a beacon report.
+pub const BEACON_REPORTED_EVENT: &str = "lifecycle.beacon_reported";
+
+/// Payload for `host.beacon.v1::report`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct BeaconReport {
+    /// Version of the reporting guest agent (`CARGO_PKG_VERSION` of
+    /// `mvm-agentd`). Guest-asserted data, recorded verbatim.
+    pub agent_version: String,
+    /// Guest wall-clock milliseconds since UNIX epoch at agent boot.
+    /// The audit-signer records its own monotonic receipt time in
+    /// addition, so a guest clock skew is detectable, not destructive.
+    pub boot_unix_ms: u64,
+}
+
+/// Response for `host.beacon.v1::report`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct BeaconAck {
+    /// Hash of the JCS-canonical chain entry bytes, signed by the
+    /// audit-signer's chain key. This is the new chain head after the
+    /// append — the guest learns its beacon is durably recorded.
+    pub chain_head: String,
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn report_roundtrips_through_json() {
+        let report = BeaconReport {
+            agent_version: "0.17.0".into(),
+            boot_unix_ms: 1_787_181_844_000,
+        };
+        let json = serde_json::to_value(&report).expect("serialize");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "agent_version": "0.17.0",
+                "boot_unix_ms": 1_787_181_844_000_u64,
+            })
+        );
+        let back: BeaconReport = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(back, report);
+    }
+
+    #[test]
+    fn report_rejects_unknown_fields() {
+        let err = serde_json::from_value::<BeaconReport>(serde_json::json!({
+            "agent_version": "0.17.0",
+            "boot_unix_ms": 0,
+            "workload_id": "wl-spoof",
+        }))
+        .expect_err("identity fields must not be guest-expressible");
+        assert!(err.to_string().contains("unknown field"), "{err}");
+    }
+
+    #[test]
+    fn report_rejects_missing_fields() {
+        assert!(
+            serde_json::from_value::<BeaconReport>(serde_json::json!({
+                "agent_version": "0.17.0",
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn ack_roundtrips_through_json() {
+        let ack = BeaconAck {
+            chain_head: "head-001".into(),
+        };
+        let json = serde_json::to_value(&ack).expect("serialize");
+        assert_eq!(json, serde_json::json!({"chain_head": "head-001"}));
+        let back: BeaconAck = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(back, ack);
+    }
+
+    #[test]
+    fn event_name_lives_under_the_lifecycle_category() {
+        let (category, _) = BEACON_REPORTED_EVENT
+            .split_once('.')
+            .expect("event name is category-prefixed");
+        assert_eq!(category, "lifecycle");
+    }
+}

--- a/crates/mvm-contract/src/protocol/mod.rs
+++ b/crates/mvm-contract/src/protocol/mod.rs
@@ -14,6 +14,7 @@ pub mod extension_controller;
 pub mod extension_pack;
 pub mod handler;
 pub mod host_audit;
+pub mod host_beacon;
 pub mod host_cost;
 pub mod host_kv;
 pub mod host_signer;

--- a/crates/mvm-core/src/protocol/mod.rs
+++ b/crates/mvm-core/src/protocol/mod.rs
@@ -15,8 +15,8 @@ pub mod volume_bridge;
 // host_cost,host_kv,host_signer,host_time,routing,signing}::X`
 // path keeps resolving unchanged.
 pub use mvm_contract::protocol::{
-    audit_signer, broker, dns, host_audit, host_cost, host_kv, host_signer, host_time, routing,
-    signing,
+    audit_signer, broker, dns, host_audit, host_beacon, host_cost, host_kv, host_signer, host_time,
+    routing, signing,
 };
 
 // Flatten protocol.rs contents up to `mvm_core::protocol::*`.

--- a/crates/mvm-hostd/src/bin/mvm-broker.rs
+++ b/crates/mvm-hostd/src/bin/mvm-broker.rs
@@ -39,6 +39,7 @@ use tracing::{error, info, warn};
 use mvm_hostd::broker::audit_client::AuditClient;
 use mvm_hostd::broker::config::{SubprocessConfig, parse as parse_config};
 use mvm_hostd::broker::handlers::host_audit_v1::HostAuditV1Handler;
+use mvm_hostd::broker::handlers::host_beacon_v1::HostBeaconV1Handler;
 use mvm_hostd::broker::handlers::register_bound_handlers;
 use mvm_hostd::broker::registry::Registry;
 use mvm_hostd::broker::server::serve_on_listener;
@@ -125,6 +126,7 @@ fn main() -> Result<()> {
 /// `Err(NotBound)` for the missing service.
 fn register_handlers(registry: &mut Registry, cfg: &SubprocessConfig) {
     let _bound = register_bound_handlers(registry, &cfg.services_bindings);
+    register_beacon(registry, cfg);
     let host_audit = mvm_core::protocol::broker::ServiceId::parse("host.audit.v1")
         .expect("host.audit.v1 is a valid ServiceId");
     if !cfg.services_bindings.contains(&host_audit) {
@@ -152,4 +154,23 @@ fn register_handlers(registry: &mut Registry, cfg: &SubprocessConfig) {
             );
         }
     }
+}
+
+/// Register `host.beacon.v1` when the audit-signer UDS is available.
+///
+/// Deliberately not gated on `services_bindings`: the beacon is emitted by
+/// the platform's own guest agent, not by workload code, and it is the
+/// default-on liveness signal for deployment evidence. Workloads without an
+/// audit signer (dev fixtures, doctor probes) get no registration and the
+/// guest's report returns `NotBound`, which the agent logs and ignores.
+fn register_beacon(registry: &mut Registry, cfg: &SubprocessConfig) {
+    let Some(path) = &cfg.audit_signer_uds_path else {
+        return;
+    };
+    let handler = Arc::new(HostBeaconV1Handler::new(AuditClient::new(path.clone())));
+    registry.register(handler);
+    info!(
+        audit_signer_uds_path = %path.display(),
+        "host.beacon.v1 handler registered"
+    );
 }

--- a/crates/mvm-hostd/src/broker/handlers/host_beacon_v1.rs
+++ b/crates/mvm-hostd/src/broker/handlers/host_beacon_v1.rs
@@ -1,0 +1,452 @@
+//! `host.beacon.v1` — guest-agent boot beacon.
+//!
+//! The platform's own guest agent calls `report` once at boot; this
+//! handler forwards one chain-signed entry to `mvm-audit-signer` in the
+//! system `lifecycle` category under the `lifecycle.beacon_reported`
+//! event name. The entry is host-authoritative in its identity binding
+//! (`workload_id` / `tenant_id` / `session_id` / `correlation_id` all
+//! come from the supervisor's `ServiceCallCtx`) and guest-asserted only
+//! in its data fields (`agent_version`, `boot_unix_ms`).
+//!
+//! This is the deployment-evidence counterpart to `plan.launched`: that
+//! entry proves the supervisor started a backend for the plan; this one
+//! proves the admitted workload's agent actually came alive inside it —
+//! the "is my code actually running in production?" signal, recorded on
+//! the same tamper-evident chain.
+//!
+//! Limits:
+//!
+//! - Rate limit: 1 token/sec/workload (`BEACON_TOKENS_PER_SEC`) with a
+//!   one-second burst — a boot beacon needs exactly one token; a
+//!   compromised guest looping `report` can bloat the chain by at most
+//!   one entry per second.
+//! - Payload cap: 4 KiB (`BEACON_REPORT_BYTES`) on the serialized
+//!   report, enforced before parse effects.
+//!
+//! Refusal semantics:
+//!
+//! - Unknown verb → `ServiceErrorCode::NotImplemented`.
+//! - Oversize payload → `ServiceErrorCode::BadRequest`.
+//! - Rate limit exceeded → `ServiceErrorCode::RateLimitExceeded`.
+//! - Audit-signer transport error → `ServiceErrorCode::Unavailable`.
+
+use std::pin::Pin;
+use std::time::Duration;
+
+use mvm_core::policy::security::AgentProfile;
+use mvm_core::protocol::audit_signer::AppendEntryRequest;
+use mvm_core::protocol::broker::{AuditDurability, Idempotency, ServiceErrorCode, ServiceId};
+use mvm_core::protocol::handler::{
+    ServiceCallCtx, ServiceDispatchResult, ServiceError, ServiceHandler,
+};
+use mvm_core::protocol::host_beacon::{BEACON_REPORTED_EVENT, BeaconAck, BeaconReport};
+use mvm_core::rate_limit::TokenBucket;
+use tokio::sync::Mutex;
+
+use crate::broker::audit_client::{AuditClient, AuditClientError};
+
+/// The audit category the beacon entry is recorded under. Chosen from
+/// the audit-signer's existing allow-list: the beacon marks a workload
+/// lifecycle fact (agent came alive), not a new evidence class.
+const BEACON_CATEGORY: &str = "lifecycle";
+
+/// Serialized-payload cap for one `report` call.
+const BEACON_REPORT_BYTES: usize = 4096;
+
+/// Per-workload report rate: one beacon per second bounds chain bloat
+/// under a hostile guest while leaving boot-time retries (agent may
+/// fire before the host broker is fully up) cheap.
+const BEACON_TOKENS_PER_SEC: u32 = 1;
+
+/// The handler. Holds the `AuditClient` it forwards to and a
+/// per-workload token bucket.
+pub struct HostBeaconV1Handler {
+    audit_client: AuditClient,
+    rate_limiter: Mutex<TokenBucket>,
+    call_timeout: Duration,
+}
+
+impl HostBeaconV1Handler {
+    /// New handler with the default rate ([`BEACON_TOKENS_PER_SEC`]) and
+    /// a 5-second call timeout (fsync on the audit-signer side is
+    /// typically <50ms but pathological disks can stall longer).
+    pub fn new(audit_client: AuditClient) -> Self {
+        Self {
+            audit_client,
+            rate_limiter: Mutex::new(TokenBucket::new(BEACON_TOKENS_PER_SEC)),
+            call_timeout: Duration::from_secs(5),
+        }
+    }
+
+    /// Test/override hook for the bucket rate. Production uses
+    /// [`BEACON_TOKENS_PER_SEC`] via [`Self::new`].
+    pub fn with_rate(audit_client: AuditClient, tokens_per_sec: u32) -> Self {
+        Self {
+            audit_client,
+            rate_limiter: Mutex::new(TokenBucket::new(tokens_per_sec)),
+            call_timeout: Duration::from_secs(5),
+        }
+    }
+
+    async fn handle_report(
+        &self,
+        ctx: &ServiceCallCtx,
+        payload: serde_json::Value,
+    ) -> ServiceDispatchResult {
+        let size = serde_json::to_vec(&payload)
+            .map(|v| v.len())
+            .unwrap_or(usize::MAX);
+        if size > BEACON_REPORT_BYTES {
+            return Err(ServiceError::new(
+                ServiceErrorCode::BadRequest,
+                format!("report {size} bytes exceeds cap {BEACON_REPORT_BYTES}"),
+            ));
+        }
+        let report: BeaconReport = serde_json::from_value(payload).map_err(|e| {
+            ServiceError::new(
+                ServiceErrorCode::BadRequest,
+                format!("report payload parse failed: {e}"),
+            )
+        })?;
+        if !self.rate_limiter.lock().await.try_take() {
+            return Err(ServiceError::new(
+                ServiceErrorCode::RateLimitExceeded,
+                "beacon report rate limit exceeded",
+            ));
+        }
+        let chain_head = self.dispatch_one(build_append_entry(ctx, &report)).await?;
+        let ack = BeaconAck { chain_head };
+        serde_json::to_value(ack).map_err(|e| {
+            ServiceError::new(
+                ServiceErrorCode::InternalError,
+                format!("report response encode failed: {e}"),
+            )
+        })
+    }
+
+    async fn dispatch_one(&self, append: AppendEntryRequest) -> Result<String, ServiceError> {
+        let resp = self
+            .audit_client
+            .append(&append)
+            .await
+            .map_err(|e| match e {
+                AuditClientError::Connect { .. } | AuditClientError::Io { .. } => {
+                    ServiceError::new(
+                        ServiceErrorCode::Unavailable,
+                        "audit-signer transport failed",
+                    )
+                }
+                AuditClientError::ResponseTooLarge { .. }
+                | AuditClientError::Decode { .. }
+                | AuditClientError::Encode { .. }
+                | AuditClientError::Protocol { .. } => ServiceError::new(
+                    ServiceErrorCode::InternalError,
+                    "audit-signer protocol violation",
+                ),
+            })?;
+        match resp {
+            mvm_core::protocol::audit_signer::AppendEntryResponse::Ok { chain_head, .. } => {
+                Ok(chain_head)
+            }
+            mvm_core::protocol::audit_signer::AppendEntryResponse::Pong { .. } => {
+                Err(ServiceError::new(
+                    ServiceErrorCode::InternalError,
+                    "audit-signer responded Pong to AppendEntry",
+                ))
+            }
+            mvm_core::protocol::audit_signer::AppendEntryResponse::Err { code, .. } => {
+                Err(ServiceError::new(
+                    ServiceErrorCode::InternalError,
+                    format!("audit-signer rejected entry: {code:?}"),
+                ))
+            }
+        }
+    }
+}
+
+impl ServiceHandler for HostBeaconV1Handler {
+    fn id(&self) -> ServiceId {
+        ServiceId::parse(mvm_core::protocol::host_beacon::HOST_BEACON_SERVICE)
+            .expect("host.beacon.v1 is a valid ServiceId")
+    }
+
+    fn profiles(&self) -> &[AgentProfile] {
+        // Every profile runs the platform agent; the beacon carries no
+        // authority, only liveness evidence.
+        &[
+            AgentProfile::SealedProd,
+            AgentProfile::Dev,
+            AgentProfile::Builder,
+        ]
+    }
+
+    fn audit_durability(&self) -> AuditDurability {
+        // PerCall — the beacon entry fsyncs through the audit-signer
+        // before the broker returns, so the ack's `chain_head` is
+        // durable. The handler does not emit a separate per-call entry:
+        // the beacon entry IS the audit emission.
+        AuditDurability::PerCall
+    }
+
+    fn idempotency(&self) -> Idempotency {
+        // Each boot mints a fresh entry; retries after a host-broker
+        // race legitimately produce a second entry, and the rate limit
+        // bounds the total.
+        Idempotency::MintFresh
+    }
+
+    fn call_timeout(&self) -> Duration {
+        self.call_timeout
+    }
+
+    fn dispatch<'a>(
+        &'a self,
+        ctx: &'a ServiceCallCtx,
+        verb: &'a str,
+        payload: serde_json::Value,
+    ) -> Pin<Box<dyn std::future::Future<Output = ServiceDispatchResult> + Send + 'a>> {
+        Box::pin(async move {
+            match verb {
+                "report" => self.handle_report(ctx, payload).await,
+                other => Err(ServiceError::new(
+                    ServiceErrorCode::NotImplemented,
+                    format!("host.beacon.v1: unknown verb `{other}`"),
+                )),
+            }
+        })
+    }
+}
+
+/// Stamp the supervisor-authoritative identifiers and the host-authored
+/// event into an `AppendEntryRequest::AppendEntry`. The guest-supplied
+/// `agent_version` / `boot_unix_ms` ride through as data fields only.
+fn build_append_entry(ctx: &ServiceCallCtx, report: &BeaconReport) -> AppendEntryRequest {
+    AppendEntryRequest::AppendEntry {
+        request_id: format!("{}-beacon", ctx.correlation_id.as_str()),
+        category: BEACON_CATEGORY.into(),
+        ts: chrono::Utc::now().to_rfc3339(),
+        workload_id: ctx.workload_id.clone(),
+        tenant_id: ctx.tenant_id.clone(),
+        session_id: ctx.session_id.clone(),
+        correlation_id: ctx.correlation_id.as_str().to_string(),
+        fields: serde_json::json!({
+            "event": BEACON_REPORTED_EVENT,
+            "agent_version": report.agent_version,
+            "boot_unix_ms": report.boot_unix_ms,
+        }),
+    }
+}
+
+// Force-cite the cap constant so a future maintainer can grep for it
+// without chasing serde.
+const _: usize = BEACON_REPORT_BYTES;
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use mvm_core::protocol::audit_signer::{AppendEntryResponse, AuditSignerErrorCode};
+    use mvm_core::protocol::broker::CorrelationId;
+    use mvm_core::security::SIG_ALG_ED25519;
+    use tempfile::tempdir;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixListener;
+    use tokio::sync::Mutex as TokioMutex;
+
+    use super::*;
+
+    fn ctx() -> ServiceCallCtx {
+        ServiceCallCtx {
+            workload_id: "wl-001".into(),
+            tenant_id: "t-001".into(),
+            correlation_id: CorrelationId::new("01HCORR0000000000000000"),
+            session_id: "sess-001".into(),
+            profile: AgentProfile::Dev,
+            composition_depth: 0,
+            composition_width: 0,
+        }
+    }
+
+    fn sample_report() -> BeaconReport {
+        BeaconReport {
+            agent_version: "0.17.0".into(),
+            boot_unix_ms: 1_787_181_844_000,
+        }
+    }
+
+    /// Spin a minimal mock audit-signer that records the requests it
+    /// receives and replies with a canned `Ok` head.
+    async fn spawn_mock_signer(
+        path: std::path::PathBuf,
+        captured: Arc<TokioMutex<Vec<AppendEntryRequest>>>,
+    ) -> tokio::task::JoinHandle<()> {
+        let listener = UnixListener::bind(&path).unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut len_buf = [0u8; 4];
+                if stream.read_exact(&mut len_buf).await.is_err() {
+                    return;
+                }
+                let len = u32::from_be_bytes(len_buf) as usize;
+                let mut body = vec![0u8; len];
+                stream.read_exact(&mut body).await.unwrap();
+                let req: AppendEntryRequest = serde_json::from_slice(&body).unwrap();
+                let request_id = req.request_id().to_string();
+                captured.lock().await.push(req);
+                let resp = AppendEntryResponse::Ok {
+                    request_id,
+                    chain_head: "head-mock".into(),
+                    entry_hash: "head-mock".into(),
+                    sig_alg: SIG_ALG_ED25519,
+                };
+                let resp_bytes = serde_json::to_vec(&resp).unwrap();
+                let resp_len: u32 = resp_bytes.len().try_into().unwrap();
+                stream.write_all(&resp_len.to_be_bytes()).await.unwrap();
+                stream.write_all(&resp_bytes).await.unwrap();
+                let _ = stream.shutdown().await;
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn report_appends_lifecycle_beacon_entry_with_authoritative_identity() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("signer.sock");
+        let captured = Arc::new(TokioMutex::new(Vec::new()));
+        let mock = spawn_mock_signer(sock.clone(), captured.clone()).await;
+        tokio::task::yield_now().await;
+
+        let handler = HostBeaconV1Handler::new(AuditClient::new(&sock));
+        let ack = handler
+            .handle_report(&ctx(), serde_json::to_value(sample_report()).unwrap())
+            .await
+            .expect("report must succeed");
+        assert_eq!(ack["chain_head"], "head-mock");
+
+        let entries = captured.lock().await;
+        assert_eq!(entries.len(), 1);
+        let AppendEntryRequest::AppendEntry {
+            category,
+            workload_id,
+            tenant_id,
+            session_id,
+            fields,
+            ..
+        } = &entries[0]
+        else {
+            panic!("expected AppendEntry");
+        };
+        assert_eq!(category, "lifecycle");
+        assert_eq!(workload_id, "wl-001");
+        assert_eq!(tenant_id, "t-001");
+        assert_eq!(session_id, "sess-001");
+        assert_eq!(fields["event"], BEACON_REPORTED_EVENT);
+        assert_eq!(fields["agent_version"], "0.17.0");
+        assert_eq!(fields["boot_unix_ms"], 1_787_181_844_000_u64);
+        mock.abort();
+    }
+
+    #[tokio::test]
+    async fn report_refuses_guest_supplied_identity() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("signer.sock");
+        let captured = Arc::new(TokioMutex::new(Vec::new()));
+        let mock = spawn_mock_signer(sock.clone(), captured.clone()).await;
+        tokio::task::yield_now().await;
+
+        let handler = HostBeaconV1Handler::new(AuditClient::new(&sock));
+        // `deny_unknown_fields` makes the identity unexpressible: the
+        // parse itself must fail before any rate token is consumed.
+        let err = handler
+            .handle_report(
+                &ctx(),
+                serde_json::json!({
+                    "agent_version": "0.17.0",
+                    "boot_unix_ms": 0,
+                    "workload_id": "wl-spoof",
+                }),
+            )
+            .await
+            .expect_err("guest-supplied identity must be refused");
+        assert_eq!(err.code, ServiceErrorCode::BadRequest);
+
+        assert!(
+            captured.lock().await.is_empty(),
+            "no chain entry may be written for a refused report"
+        );
+        mock.abort();
+    }
+
+    #[tokio::test]
+    async fn report_enforces_rate_limit() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("signer.sock");
+        let captured = Arc::new(TokioMutex::new(Vec::new()));
+        let mock = spawn_mock_signer(sock.clone(), captured.clone()).await;
+        tokio::task::yield_now().await;
+
+        // Bucket capacity equals the rate: the first report takes the
+        // one burst token, the immediate second report is refused.
+        let handler = HostBeaconV1Handler::with_rate(AuditClient::new(&sock), 1);
+        handler
+            .handle_report(&ctx(), serde_json::to_value(sample_report()).unwrap())
+            .await
+            .expect("first report succeeds");
+        let err = handler
+            .handle_report(&ctx(), serde_json::to_value(sample_report()).unwrap())
+            .await
+            .expect_err("second immediate report exceeds burst");
+        assert_eq!(err.code, ServiceErrorCode::RateLimitExceeded);
+        assert_eq!(captured.lock().await.len(), 1);
+        mock.abort();
+    }
+
+    #[tokio::test]
+    async fn report_maps_signer_rejection_to_internal_error() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("signer.sock");
+        let listener = UnixListener::bind(&sock).unwrap();
+        let signer = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut len_buf = [0u8; 4];
+            stream.read_exact(&mut len_buf).await.unwrap();
+            let len = u32::from_be_bytes(len_buf) as usize;
+            let mut body = vec![0u8; len];
+            stream.read_exact(&mut body).await.unwrap();
+            let resp = AppendEntryResponse::Err {
+                request_id: "req-1".into(),
+                code: AuditSignerErrorCode::InvalidRequest,
+                message: "category not in allow-list".into(),
+            };
+            let resp_bytes = serde_json::to_vec(&resp).unwrap();
+            let resp_len: u32 = resp_bytes.len().try_into().unwrap();
+            stream.write_all(&resp_len.to_be_bytes()).await.unwrap();
+            stream.write_all(&resp_bytes).await.unwrap();
+        });
+
+        let handler = HostBeaconV1Handler::new(AuditClient::new(&sock));
+        let err = handler
+            .handle_report(&ctx(), serde_json::to_value(sample_report()).unwrap())
+            .await
+            .expect_err("signer rejection must surface");
+        assert_eq!(err.code, ServiceErrorCode::InternalError);
+        signer.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unknown_verb_is_not_implemented() {
+        let dir = tempdir().unwrap();
+        let sock = dir.path().join("signer.sock");
+        let handler = HostBeaconV1Handler::new(AuditClient::new(&sock));
+        let outcome = handler
+            .dispatch(&ctx(), "bogus", serde_json::json!({}))
+            .await;
+        let err = outcome.expect_err("unknown verb must be refused");
+        assert_eq!(err.code, ServiceErrorCode::NotImplemented);
+    }
+}

--- a/crates/mvm-hostd/src/broker/handlers/mod.rs
+++ b/crates/mvm-hostd/src/broker/handlers/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod host_assurance_v1;
 pub mod host_audit_v1;
+pub mod host_beacon_v1;
 pub mod host_kv_v1;
 pub mod host_time_v1;
 

--- a/crates/mvm-runtime/fuzz-backend/Cargo.lock
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.lock
@@ -1113,6 +1113,7 @@ name = "mvm-build"
 version = "0.18.0"
 dependencies = [
  "anyhow",
+ "base64",
  "chrono",
  "ed25519-dalek",
  "flate2",
@@ -1130,6 +1131,7 @@ dependencies = [
  "mvm-vmm",
  "nix",
  "serde",
+ "serde_jcs",
  "serde_json",
  "sha2",
  "tar",

--- a/crates/mvm-sdk/src/deploy.rs
+++ b/crates/mvm-sdk/src/deploy.rs
@@ -445,6 +445,74 @@ pub fn write_deploy_record(record: &DeployRecord, path: &Path) -> Result<(), Dep
     Ok(())
 }
 
+/// A readable deployment plus its content-addressed store key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeploymentEntry {
+    /// Directory name under the deployments store — the IR hash key.
+    pub ir_hash: String,
+    /// The recorded deployment.
+    pub record: DeployRecord,
+}
+
+/// A deployment directory that could not be read, with the reason.
+/// Listing is a read-only inventory: one unreadable record must not
+/// hide the rest, but silently dropping it would hide schema drift, so
+/// the caller surfaces these.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeploymentSkip {
+    /// Directory name under the deployments store.
+    pub dir: String,
+    /// Human-readable refusal reason.
+    pub reason: String,
+}
+
+/// Enumerate the local deployment store (`<mvm_home>/deployments/`).
+///
+/// Every subdirectory is one deployment keyed by its IR hash; the
+/// record lives in `deploy.json` inside it. A missing store is an
+/// empty inventory, not an error. Directories whose record is absent,
+/// malformed, or a schema version this reader doesn't know are
+/// returned as skips alongside the readable entries.
+pub fn list_deployments(
+    dir: &Path,
+) -> Result<(Vec<DeploymentEntry>, Vec<DeploymentSkip>), DeployError> {
+    let mut entries = Vec::new();
+    let mut skips = Vec::new();
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(read_dir) => read_dir,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok((entries, skips));
+        }
+        Err(e) => return Err(DeployError::Io(e)),
+    };
+    for item in read_dir {
+        let item = item.map_err(DeployError::Io)?;
+        let dir_name = item.file_name().to_string_lossy().into_owned();
+        let record_path = item.path().join("deploy.json");
+        if !record_path.is_file() {
+            skips.push(DeploymentSkip {
+                dir: dir_name,
+                reason: "no deploy.json in directory".to_string(),
+            });
+            continue;
+        }
+        match read_deploy_record(&record_path) {
+            Ok(record) => entries.push(DeploymentEntry {
+                ir_hash: dir_name,
+                record,
+            }),
+            Err(e) => skips.push(DeploymentSkip {
+                dir: dir_name,
+                reason: e.to_string(),
+            }),
+        }
+    }
+    // Deterministic output order: key by the IR hash / directory name.
+    entries.sort_by(|a, b| a.ir_hash.cmp(&b.ir_hash));
+    skips.sort_by(|a, b| a.dir.cmp(&b.dir));
+    Ok((entries, skips))
+}
+
 /// Read a deploy record and reject stale or future schemas before any of its
 /// fields can influence admission.
 pub fn read_deploy_record(path: &Path) -> Result<DeployRecord, DeployError> {
@@ -1101,5 +1169,106 @@ mod tests {
         assert!(body.contains("{\"workload_id\":\"demo\"}"));
         assert!(body.contains("name=\"bundle\"; filename=\"image.tar.gz\""));
         assert!(body.ends_with("\r\n"));
+    }
+
+    fn sample_record(workload_id: &str, ir_hash: &str) -> DeployRecord {
+        DeployRecord {
+            schema_version: DEPLOY_RECORD_SCHEMA_VERSION,
+            workload_id: workload_id.to_string(),
+            ir_hash: ir_hash.to_string(),
+            image: ArtifactDigests {
+                blake3: "b3".repeat(32),
+                sha256: "ab".repeat(32),
+                size_bytes: 1024,
+            },
+            boot_artifact: BootArtifactIdentity {
+                kind: "rootfs.ext4".to_string(),
+                blake3: "c4".repeat(32),
+                sha256: "cd".repeat(32),
+                size_bytes: 512,
+            },
+            environment: None,
+            dependency_volume: None,
+        }
+    }
+
+    #[test]
+    fn list_deployments_returns_empty_for_missing_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let (entries, skips) =
+            list_deployments(&dir.path().join("nope")).expect("missing store is empty");
+        assert!(entries.is_empty());
+        assert!(skips.is_empty());
+    }
+
+    #[test]
+    fn list_deployments_reads_records_sorted_and_skips_unreadable() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("deployments");
+
+        write_deploy_record(
+            &sample_record("wl-b", "bbbb"),
+            &store.join("bbbb/deploy.json"),
+        )
+        .unwrap();
+        write_deploy_record(
+            &sample_record("wl-a", "aaaa"),
+            &store.join("aaaa/deploy.json"),
+        )
+        .unwrap();
+        // A directory with no record.
+        std::fs::create_dir_all(store.join("cccc")).unwrap();
+        // A record with a future schema version.
+        std::fs::create_dir_all(store.join("dddd")).unwrap();
+        std::fs::write(
+            store.join("dddd/deploy.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "schema_version": DEPLOY_RECORD_SCHEMA_VERSION + 1,
+                "workload_id": "wl-future",
+                "ir_hash": "dddd",
+                "image": {"blake3": "e".repeat(64), "sha256": "e".repeat(64), "size_bytes": 1},
+                "boot_artifact": {
+                    "kind": "rootfs.ext4",
+                    "blake3": "f".repeat(64),
+                    "sha256": "f".repeat(64),
+                    "size_bytes": 1
+                },
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let (entries, skips) = list_deployments(&store).expect("lists");
+        assert_eq!(
+            entries
+                .iter()
+                .map(|e| e.ir_hash.as_str())
+                .collect::<Vec<_>>(),
+            ["aaaa", "bbbb"],
+            "entries sort by IR hash"
+        );
+        assert_eq!(entries[0].record.workload_id, "wl-a");
+        assert_eq!(skips.len(), 2);
+        assert_eq!(skips[0].dir, "cccc");
+        assert!(skips[0].reason.contains("no deploy.json"));
+        assert_eq!(skips[1].dir, "dddd");
+        assert!(
+            skips[1].reason.contains("schema version"),
+            "future schema must be surfaced, got: {}",
+            skips[1].reason
+        );
+    }
+
+    #[test]
+    fn list_deployments_surfaces_malformed_records_as_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = dir.path().join("deployments");
+        std::fs::create_dir_all(store.join("bad")).unwrap();
+        std::fs::write(store.join("bad/deploy.json"), b"{not json").unwrap();
+
+        let (entries, skips) = list_deployments(&store).expect("lists");
+        assert!(entries.is_empty());
+        assert_eq!(skips.len(), 1);
+        assert_eq!(skips[0].dir, "bad");
     }
 }

--- a/features/suites/s29_doc_examples/tiers.toml
+++ b/features/suites/s29_doc_examples/tiers.toml
@@ -69,6 +69,10 @@ path = "catalog list"
 tier = "exec"
 
 [[command]]
+path = "deployments ls"
+tier = "exec"
+
+[[command]]
 path = "deps audit"
 tier = "parse"
 reason = "same sealed-volume fixture as deps inspect"

--- a/public/src/content/docs/reference/cli-commands.md
+++ b/public/src/content/docs/reference/cli-commands.md
@@ -1106,6 +1106,7 @@ running microVM.
 | `mvmctl template info <name>`          | Show details for one bundled or remote template                                                                                                                           |
 | `mvmctl deploy <ir.json>`              | Build, seal, and record a workload into a local deployment directory (`image.tar.gz`, `rootfs.ext4`, `deploy.json`); optionally ship it to mvmd                           |
 | `mvmctl deploy --from-ir <path>`       | Read the Workload IR from a file instead of a positional path or stdin                                                                                                    |
+| `mvmctl deployments ls`                | Inventory of recorded local deployments (`--workload <ir-hash>` to filter, `--json` for machine output); unreadable records surface as named skips                        |
 | `mvmctl prepare`                       | Report whether a verified runtime pack is ready for instant launch                                                                                                        |
 | `mvmctl plugin list`                   | List the coding agents mvm can emit an integration for                                                                                                                    |
 | `mvmctl plugin install <agent>`        | Write that agent's integration files into the project (`--dir`, `--dry-run`, `--force`). Emits config only — mvm runs no agent-facing server                              |

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -14,6 +14,14 @@ Last updated: 2026-09-02
       reclaimed loudly, MVM_DEV_ENV_KEEP_INHERITED=1 keeps them anyway. Gate
       tests and CI shellcheck green; merged via #3135.
 
+- [ ] **Supply-chain evidence carryover (WS1.1 beacon + WS1.4 deployments
+      inventory).**
+      `specs/plans/2026-09-02-supply-chain-evidence-carryover.md` on
+      `feat/supply-chain-evidence`. Boot-liveness beacon recorded as a
+      chain-signed `lifecycle.beacon_reported` entry; local deploy store
+      gains its first read path (`mvmctl deployments ls`). Cross-repo
+      items (mvmd registry/queries, studio pages) remain open in the plan.
+
 - [ ] **Signed caller commitment — issue #3070.**
       `specs/plans/2026-09-01-signed-caller-commitment.md`.
       Replaces reliance on overwriteable free-form audit labels with one typed,

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -14,13 +14,16 @@ Last updated: 2026-09-02
       reclaimed loudly, MVM_DEV_ENV_KEEP_INHERITED=1 keeps them anyway. Gate
       tests and CI shellcheck green; merged via #3135.
 
-- [ ] **Supply-chain evidence carryover (WS1.1 beacon + WS1.4 deployments
-      inventory).**
+- [ ] **Supply-chain evidence carryover (WS1.1 + WS1.4 + WS2.1 + WS3.1).**
       `specs/plans/2026-09-02-supply-chain-evidence-carryover.md` on
       `feat/supply-chain-evidence`. Boot-liveness beacon recorded as a
       chain-signed `lifecycle.beacon_reported` entry; local deploy store
-      gains its first read path (`mvmctl deployments ls`). Cross-repo
-      items (mvmd registry/queries, studio pages) remain open in the plan.
+      gains its first read path (`mvmctl deployments ls`); sealed OCI
+      rematerializes now write a JCS+Ed25519 provenance mark into the
+      rootfs before verity hashing (`/mvm/provenance.json` + detached
+      signature) and an in-toto/SLSA v1 DSSE sidecar (`rootfs.intoto.json`)
+      beside the sealed image. Cross-repo items (mvmd registry/queries,
+      studio pages, scout verification) remain open in the plan.
 
 - [ ] **Signed caller commitment — issue #3070.**
       `specs/plans/2026-09-01-signed-caller-commitment.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -20,7 +20,7 @@
       are green; merge delivery remains.
 
 - [ ] **Supply-chain evidence carryover — Phase 1 slice (boot beacon +
-      deployments inventory).**
+      deployments inventory, provenance mark, in-toto sidecar).**
       `specs/plans/2026-09-02-supply-chain-evidence-carryover.md`.
       WS1.1: `host.beacon.v1` broker service — the guest agent reports
       boot liveness and the host appends a chain-signed
@@ -28,7 +28,14 @@
       identity (fail-open, rate-limited, default-on where an audit signer
       exists). WS1.4: `mvmctl deployments ls [--workload] [--json]` reads
       the local-first deploy store, surfacing unreadable records as named
-      skips. Workspace tests, zero-warning Clippy, and Linux/BDD gated
+      skips. WS2.1: every sealed OCI rematerialize writes a
+      JCS-canonical Ed25519 provenance mark (`/mvm/provenance.json` +
+      detached signature) into the rootfs before the dm-verity hash is
+      computed, signed by the host key, so a tampered mark breaks the
+      verified boot chain. WS3.1: the seal also emits an in-toto
+      Statement (SLSA v1.0 provenance predicate) as a DSSE envelope
+      (`rootfs.intoto.json`) whose subject binds the sealed image's exact
+      bytes. Workspace tests, zero-warning Clippy, and Linux/BDD gated
       checks are green; merge delivery remains.
 
 - [x] **Signed caller commitment — issue #3070, PR #3076.**

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -19,6 +19,18 @@
       Workspace, Clippy, gated-target, formatting, and non-live BDD validation
       are green; merge delivery remains.
 
+- [ ] **Supply-chain evidence carryover — Phase 1 slice (boot beacon +
+      deployments inventory).**
+      `specs/plans/2026-09-02-supply-chain-evidence-carryover.md`.
+      WS1.1: `host.beacon.v1` broker service — the guest agent reports
+      boot liveness and the host appends a chain-signed
+      `lifecycle.beacon_reported` entry with supervisor-authoritative
+      identity (fail-open, rate-limited, default-on where an audit signer
+      exists). WS1.4: `mvmctl deployments ls [--workload] [--json]` reads
+      the local-first deploy store, surfacing unreadable records as named
+      skips. Workspace tests, zero-warning Clippy, and Linux/BDD gated
+      checks are green; merge delivery remains.
+
 - [x] **Signed caller commitment — issue #3070, PR #3076.**
       `specs/plans/2026-09-01-signed-caller-commitment.md`.
       One typed opaque 32-byte commitment now reaches the signed execution

--- a/specs/plans/2026-09-02-supply-chain-evidence-carryover.md
+++ b/specs/plans/2026-09-02-supply-chain-evidence-carryover.md
@@ -1,0 +1,311 @@
+# Supply-Chain Evidence Carryover Plan
+
+Date: 2026-09-02
+Status: PROPOSED
+Repos: `mvm` (this repo), `mvmd`, `mvm-studio`, `mvm-assurance`
+
+## Context
+
+A competitor's product in the artifact-provenance space is deployed at a
+prospective customer. Their pitch rests on three verbs — tag every artifact
+with signed provenance at build time, track artifacts into production with
+runtime beacons, and trust the result because the evidence is verifiable, not
+inferred. Their marketing poses a fixed set of questions a user can ask
+("which of our code is in production?", "where did this artifact come from?",
+"who built it?", "what dependencies are actually in this build?", "are we
+exposed to CVE X?").
+
+Our platform already has the cryptographic substrate to answer every one of
+those questions — but the answers are scattered across CLI verbs, sidecars,
+and unwired library seams, and several of the questions have no query surface
+at all. This plan closes those gaps. It is written without naming the
+competitor anywhere in code, commits, PRs, or docs.
+
+## What we confirmed exists (evidence base)
+
+### `mvm` (first-hand)
+
+- Build provenance content-addressed into the signed plan:
+  `crates/mvm-build/src/provenance.rs` (`record_provenance`), plan id re-derived
+  before signing at `crates/mvm-core/src/plan/signing.rs:50-73`.
+- Local-first deploy records with exact-byte digests:
+  `crates/mvm-sdk/src/deploy.rs:36-109` (`DeployRecord` v2), stored under
+  `~/.mvm/deployments/<ir-hash>`.
+- Chain-signed, genesis-sealed, per-tenant append-only audit log with Merkle
+  roots, inclusion proofs, PROV-O export, and `.mvmev` evidence archives:
+  `crates/mvm-hostd/src/supervisor/audit_file.rs`, `crates/mvm-hostd/src/audit/`.
+- Witness sink for off-host root publication:
+  `crates/mvm-hostd/src/audit/witness.rs` (HTTP/file, fail-open, documented
+  limits in the module header).
+- dm-verity verified boot (tampered rootfs refuses to boot, MVM-SEC-03).
+- Host-signed attestation export/verify with nonce and boot measurement;
+  hardware providers are stubs (`AttestationMode` in
+  `crates/mvm-contract/src/plan/types.rs:1014-1032`,
+  `crates/mvm-core/src/crypto/attestation/provider.rs`).
+- CycloneDX SBOM + CVE scan sidecars on hash-locked dependency volumes:
+  `crates/mvm-sdk/src/compile/deps_audit.rs`.
+- Signed, content-addressed `.mvmpkg` packs and publisher trust store:
+  `crates/mvm-cli/src/commands/bundle/`, `trust/`.
+- `mvmctl explain <run-id>` answers "what happened in this run" from the
+  verified chain.
+
+### `mvmd` (first-hand; note this is the V1 from-scratch rewrite)
+
+- 9 crates: `mvmd`, `mvmd-core`, `mvmd-types`, `mvmd-api`, `mvmd-mvm`,
+  `mvmd-rama`, `mvmd-iroh`, `mvmd-veilid`, `mvmd-conformance`.
+- REST surface (`crates/mvmd-api/src/lib.rs:136-152`): `/v1/fleet`,
+  `/v1/nodes`, `/v1/instances`, `/v1/nodes/{id}/reconcile`,
+  `/v1/billing/account`, `/v1/mailboxes/{id}/{messages,lease,ack}`.
+  **No** deployment/provenance/audit/SBOM/attestation query endpoints.
+- Digest-bound placement chain: `crates/mvmd-types/src/placement.rs` binds
+  `workload_digest`, `execution_plan_digest`, `receipt_digest`, and the signed
+  plan envelope into permits/leases. This is the natural anchor for
+  deployment truth.
+- Hash-chained usage receipts (BLAKE3, chain-digest validation,
+  replay protection): `crates/mvmd-core/src/billing.rs:30,141-152`.
+- Node heartbeats with 30 s freshness gating placement
+  (`crates/mvmd-core/src/scheduler.rs:4,60-61`).
+- SQLite store (WAL). **No** fleet audit journal, no provenance/SBOM store,
+  no standards-format attestation anywhere.
+
+### `mvm-studio` (first-hand)
+
+- Tauri 2 desktop app; single Machines page rendering only
+  `{id, name, status}` (`ui/src/lib/tauri.ts:29-34`).
+- The verified audit-reading seam `LocalAuditReader` already ships in
+  `mvm-client` (`crates/mvm-client/src/audit/mod.rs`, first-hand from the mvm
+  repo) and is entirely unwired in studio.
+- Gateway sidecar runs with an ephemeral memory store + temp data dir per
+  launch (`src-tauri/src/sidecar.rs`) — nothing durable survives restarts.
+
+### `mvm-assurance` (first-hand)
+
+- `mvm-scout`: deterministic scanning; reports in Markdown, JSON, SARIF,
+  NDJSON (`crates/mvm-assurance-report/src/lib.rs`).
+- `scoutd` extension pack ships an SPDX SBOM and an embedded signature block
+  (`extensions/scoutd/extension-pack.json:92-93`).
+- No publisher trust root (all packs signed with ephemeral keys), no
+  in-toto/DSSE/SLSA interchange, and no certifying result without hardware
+  attestation.
+
+## What the competitor gets right (carryover principles)
+
+1. **The identity travels with the artifact.** Correlation dies when an
+   artifact leaves your database. We must make provenance portable and
+   self-verifying inside the artifact itself.
+2. **"Which of our code is in production?" is the killer query.** Simple,
+   asked constantly, answered nowhere in our surface today.
+3. **Adoption must be five lines of YAML and fail-open.** The build must
+   never break because of us. Frictionlessness wins deals.
+4. **SBOM is a byproduct of the build, not a step.** Record what actually
+   ended up in the artifact; diff it against what was declared.
+5. **Beats beat registries.** Workloads that self-report at startup give
+   real-time deployment truth with zero polling infrastructure.
+6. **Third-party verifiability.** Evidence published to an external
+   transparency service is auditable without trusting us.
+7. **Desktop capture of AI coding sessions is the new front of the chain.**
+   Signed record of what the agent did, at the machine, before the commit.
+
+## Workstreams
+
+### WS1 — Deployment truth: beacon, registry, and the "prod or not" query
+
+The competitor's core demo is answering "what version of what code is running
+in which environment, right now?" We have all the raw truth (deploy records,
+digest-bound placement, heartbeats) and no query that joins it.
+
+- [x] WS1.1 (mvm): guest startup beacon. Shipped as broker service
+      `host.beacon.v1`: on boot `mvm-agentd` reports `{agent_version,
+      boot_unix_ms}` over the existing vsock broker channel; the host
+      handler stamps the supervisor-authoritative identity from
+      `ServiceCallCtx` and appends a chain-signed
+      `lifecycle.beacon_reported` entry through the audit-signer
+      (`crates/mvm-hostd/src/broker/handlers/host_beacon_v1.rs`). Identity
+      is host-bound by construction — the guest payload cannot express
+      `workload_id`/`tenant_id` (`deny_unknown_fields`), unlike a
+      guest-asserted `workload_audit` entry. Default-on: registered
+      whenever the audit-signer UDS is present; a 1 token/s rate limit
+      bounds chain bloat under a hostile guest; guest-side fail-open with
+      bounded retries (3 tries, 2 s apart). Plan-policy suppression seam
+      (a `SubprocessConfig` flag sourced from plan policy) is the
+      designed follow-up — deferred to the mvmd environment-model work.
+      Tests: socket-pair client envelope tests, mock-signer handler tests
+      (authoritative stamping, guest-spoof refusal, rate limit, signer
+      error mapping), retry-helper tests.
+- [ ] WS1.2 (mvmd): persist launch records. Placement already binds
+      `workload_digest`/`execution_plan_digest` (`mvmd-types/src/placement.rs`);
+      add a durable `launches` table keyed by `(fleet, environment, workload_id)`
+      recording plan digest, environment, permit id, and beacon arrival.
+- [ ] WS1.3 (mvmd): query endpoints `GET /v1/deployments` and
+      `GET /v1/deployments/{workload_id}` returning environment × version
+      truth, plus `environment` as a first-class attribute on start requests.
+      BDD scenarios in `mvmd-conformance`.
+- [x] WS1.4 (mvm): `mvmctl deployments ls [--workload Y] [--json]` over the
+      local `<mvm_home>/deployments/` store for the no-control-plane path
+      (`mvmctl deployments ls`, `mvm_sdk::deploy::list_deployments`).
+      Unreadable records surface as named skips rather than failing or
+      hiding the listing. `--env` filtering waits for the environment
+      model (WS1.3) — deploy records today pin only the kernel digest,
+      not an environment name. Row shape is designed to match the future
+      mvmd response so studio renders one type.
+- [ ] WS1.5 (mvm-studio): Deployments page consuming 1.4 / the mvmd endpoint.
+- Tests (all repos): positive, wrong-fleet/role negative, stale-beacon path.
+
+### WS2 — Verity-sealed in-artifact provenance mark
+
+Their core mechanism is an embedded signed mark. Our stronger version: write
+the signed provenance record into the sealed rootfs **before** the dm-verity
+hash is computed, so the mark is not only embedded in the artifact but
+refuses to boot if tampered — tamper-evidence enforced by the kernel, not
+just a signature check.
+
+- [ ] WS2.1 (mvm-build): emit `ProvenanceMark` (canonical JSON, Ed25519-signed:
+      plan id, input digests, builder identity, timestamp, SBOM reference)
+      into the rootfs at `/mvm/provenance.json` + detached signature during
+      seal, before verity sidecar generation. Gate behind a plan/build flag,
+      default on for new builds.
+- [ ] WS2.2 (mvm): `mvmctl artifact inspect <image|rootfs>` reads and verifies
+      the mark offline (verity-aware: report whether the artifact's roothash
+      matches a recomputation). Docker/OCI images additionally get the mark
+      as OCI manifest annotations so registries carry it.
+- [ ] WS2.3 (mvm-assurance): `mvm-scout artifact` scan mode verifies a foreign
+      artifact's mark if present and reports it as a finding — so our
+      scanning story also recognizes third-party marked artifacts.
+- Tests: roundtrip seal→inspect→verify; tampered mark → boot refusal and
+  inspect failure; mark survives registry push/pull (OCI annotations).
+
+### WS3 — Standards interchange: DSSE-signed in-toto provenance statements
+
+Our provenance is bespoke canonical JSON. Compliance teams ask for SLSA-style
+statements. Emit them without changing our internal model — serialization
+decision only.
+
+- [ ] WS3.1 (mvm-build): emit an in-toto Statement (SLSA v1.0 provenance
+      predicate) as a DSSE envelope at seal time, signed with the builder
+      Ed25519 key; optional keyless Sigstore signature using the existing
+      `sigstore-verify` dependency family. Ship alongside the artifact and
+      record its digest in the audit chain.
+- [ ] WS3.2 (mvm-assurance): DSSE-wrap scout reports and the `scoutd` pack
+      provenance block; verify on admission in `verify_pack_at`
+      (`mvm-core/src/packs.rs`). SPDX already exists for scoutd — keep.
+- [ ] WS3.3 (mvmd): accept and store the statement digest at
+      `/v1/deploy-artifacts`-equivalent upload; expose it in the deployment
+      query response (WS1.3).
+- Tests: statement roundtrip, wrong-key rejection, digest binding to the
+  audit chain.
+
+### WS4 — External transparency publication
+
+Our Merkle roots are self-signed and local. Extend the existing witness sink
+to publish to a public transparency log so auditors don't have to trust us.
+
+- [ ] WS4.1 (mvm): extend `mvm-hostd/src/audit/witness.rs` `HttpWitnessSink`
+      with a Rekor/SCITT-compatible publisher (the SCITT capsule design in
+      `specs/2026-08-25-scitt-integration-and-hash-chained-action-state.md`
+      is the starting point). Publish `SignedAuditRoot`; keep the current
+      sink as fallback. Fail-open with an `audit.witness_failed` event.
+- [ ] WS4.2 (mvm): `mvmctl trust audit verify --against <log>` re-checks
+      inclusion of witnessed roots online.
+- [ ] WS4.3 (mvm): verify the pack `transparency_log` reference
+      (`TransparencyLogReference`, `mvm-core/src/packs.rs:337-356`) against
+      the real log instead of accepting it as metadata.
+- Tests: published root inclusion proof verifies; withheld root detects
+  fork; offline fallback path.
+
+### WS5 — Hardware attestation providers
+
+The single biggest gap — every real attestation-dependent result today is
+`INCONCLUSIVE`. The challenge/join machinery is complete and fail-closed;
+only the providers are stubs.
+
+- [ ] WS5.1 (mvm): implement the TPM2 provider end-to-end on Linux
+      (`crypto/attestation/tpm2.rs`, `tss-esapi` already behind the
+      `attestation-tpm2` feature): AK quote against enrolled EK/manufacturer
+      roots, returning `RuntimeAttestationVerification`.
+- [ ] WS5.2 (mvm): implement a SEV-SNP verifier (VCEK/ASK/ARK collateral
+      validation) behind its existing feature gate; same shape as 5.1.
+- [ ] WS5.3 (mvm + mvm-assurance): collateral enrollment tooling + docs;
+      re-run the live canary so `assurance.attestation_verified` is real and
+      the campaign verdict can certify.
+- Tests: quote verify positive/negative (tampered quote, wrong collateral,
+  expired), fail-closed when device absent.
+
+### WS6 — SBOM as build byproduct + exposure queries
+
+- [ ] WS6.1 (mvm-build): capture the actual dependency set observed during
+      build (what the installer fetched — `fetch.log` already records every
+      URL) and diff against the declared manifest; emit CycloneDX **and**
+      SPDX for built images, not just dep volumes.
+- [ ] WS6.2 (mvm): `mvmctl deps audit --exposed <CVE>` joins the local CVE
+      sidecars with deployment truth from WS1.4 to answer "are we exposed,
+      and where?".
+- [ ] WS6.3 (mvm-studio): exposure view (WS1.5 + WS6.2 join).
+- Tests: mutation between manifest and build is detected and reported.
+
+### WS7 — Studio query surface
+
+- [ ] WS7.1 (mvm-studio): wire `LocalAuditReader` (`mvm-client`) into an
+      Audit Trail page — verified, cursor-paginated, per-machine trail. No
+      backend changes required; the seam exists.
+- [ ] WS7.2 (mvm-studio): render the provenance fields already present on
+      `MachineState` (`revision`, `flake_ref`, `profile`) in a machine
+      detail panel.
+- [ ] WS7.3 (mvm-studio): durable gateway mode — persistent data dir and
+      token reuse instead of per-launch ephemeral state, so audit and
+      deployment history survive restarts.
+- Tests: UI typecheck/build CI already present; add component tests for the
+  new pages.
+
+### WS8 — CI integration and fail-open adoption
+
+- [ ] WS8.1 (mvm): publish a GitHub Action + GitLab CI template
+      (five YAML lines) that wraps a build with `mvmctl build`, emits the
+      WS3.1 statement, and uploads it. Fail-open: on any mvm failure, rerun
+      the original build command untouched.
+- [ ] WS8.2 (mvm): a verify-mode action that fails the pipeline when an
+      artifact's mark/statement doesn't verify (strict mode, opt-in).
+- Tests: hermetic pipeline fixture; failure injection proves fail-open.
+
+### WS9 — Desktop AI-session capture (research → phase 3)
+
+The competitor's newest capability is signed capture of AI coding sessions on
+the developer machine (prompts, tool calls, edits, commits). We have the
+runtime-side analog (`mvm-assurance` campaigns evaluate agent behavior inside
+admitted microVMs) but nothing at the desktop front of the chain.
+
+- [ ] WS9.1 (mvm-assurance): research spike — can `mvm-scout` host a
+      hook-based observer for coding agents that emits digest-signed session
+      records which later join the build provenance (same join mechanism as
+      the Scout scan → campaign join)? Privacy posture: digest-first, like
+      the existing prompt handling.
+- No production commitment until the spike lands.
+
+## Phasing
+
+- **Phase 1 (demo parity):** WS1, WS2, WS3, WS7.1–7.2. These answer every
+  homepage question in our vocabulary with our differentiators (verity-sealed
+  marks, chain-signed audit) intact. All are serialization/UI/API work — no
+  hardware, no new infra.
+- **Phase 2 (trust depth):** WS4, WS6, WS8, WS7.3.
+- **Phase 3 (hard claims):** WS5, WS9.
+
+## Non-goals
+
+- We do not build a general-purpose mark inserter for arbitrary third-party
+  binaries (their `insert` UX). We seal what we build and verify what we
+  admit; `mvm-scout` *recognizes* foreign marks (WS2.3) but we stay a
+  runtime-evidence platform, not an artifact-mutating tool.
+- No floating-point or scoring changes in mvmd placement (AGENTS.md rule).
+- No server/daemon grows inside `mvm` itself (ADR boundary); fleet queries
+  live in mvmd, local queries in `mvmctl`, presentation in studio.
+
+## Open questions
+
+1. Environment model in mvmd V1: is `environment` (dev/staging/prod) a
+   fleet attribute, a workload label, or a launch-time field on the start
+   request? Decision needed before WS1.3.
+2. Rekor vs self-hosted transparency service for enterprise/self-host
+   customers — WS4 publisher should be pluggable like the existing
+   `WitnessSink` trait. Confirm with the customer deployment model.
+3. Do we offer strict admission (refuse unmarked images) in v1, or
+   report-only? Leaning report-only first, strict as plan policy.

--- a/specs/plans/2026-09-02-supply-chain-evidence-carryover.md
+++ b/specs/plans/2026-09-02-supply-chain-evidence-carryover.md
@@ -1,5 +1,8 @@
 # Supply-Chain Evidence Carryover Plan
 
+Backing: shipped-source
+Validation: check-declared-backing
+
 Date: 2026-09-02
 Status: PROPOSED
 Repos: `mvm` (this repo), `mvmd`, `mvm-studio`, `mvm-assurance`

--- a/specs/plans/2026-09-02-supply-chain-evidence-carryover.md
+++ b/specs/plans/2026-09-02-supply-chain-evidence-carryover.md
@@ -159,11 +159,15 @@ hash is computed, so the mark is not only embedded in the artifact but
 refuses to boot if tampered — tamper-evidence enforced by the kernel, not
 just a signature check.
 
-- [ ] WS2.1 (mvm-build): emit `ProvenanceMark` (canonical JSON, Ed25519-signed:
-      plan id, input digests, builder identity, timestamp, SBOM reference)
-      into the rootfs at `/mvm/provenance.json` + detached signature during
-      seal, before verity sidecar generation. Gate behind a plan/build flag,
-      default on for new builds.
+- [x] WS2.1 (mvm-build): emit `ProvenanceMark` (canonical JSON, Ed25519-signed:
+      input ref + resolved digest, builder identity, timestamp; SBOM reference
+      reserved as `None` until WS6) into the rootfs at `/mvm/provenance.json` +
+      detached signature during seal, before verity hashing. Emitted for every
+      sealed OCI rematerialize; the host signer is `~/.mvm/keys/host-signer.ed25519`
+      (same key as `artifact pack`). Deviation from the original text: no
+      separate build flag — the mark is tied to the existing `sealed` request
+      flag, so sealed images always carry it (a sealed request with no
+      evidence logs a warning instead). `crates/mvm-build/src/provenance_mark.rs`.
 - [ ] WS2.2 (mvm): `mvmctl artifact inspect <image|rootfs>` reads and verifies
       the mark offline (verity-aware: report whether the artifact's roothash
       matches a recomputation). Docker/OCI images additionally get the mark
@@ -180,11 +184,12 @@ Our provenance is bespoke canonical JSON. Compliance teams ask for SLSA-style
 statements. Emit them without changing our internal model — serialization
 decision only.
 
-- [ ] WS3.1 (mvm-build): emit an in-toto Statement (SLSA v1.0 provenance
+- [x] WS3.1 (mvm-build): emit an in-toto Statement (SLSA v1.0 provenance
       predicate) as a DSSE envelope at seal time, signed with the builder
-      Ed25519 key; optional keyless Sigstore signature using the existing
-      `sigstore-verify` dependency family. Ship alongside the artifact and
-      record its digest in the audit chain.
+      Ed25519 key, written as `rootfs.intoto.json` beside the sealed image
+      (subject = sha256 of the sealed rootfs's exact bytes). Deviation from
+      the original text: keyless Sigstore and audit-chain digest recording
+      not in this slice (WS4 covers publication). `crates/mvm-build/src/intoto.rs`.
 - [ ] WS3.2 (mvm-assurance): DSSE-wrap scout reports and the `scoutd` pack
       provenance block; verify on admission in `verify_pack_at`
       (`mvm-core/src/packs.rs`). SPDX already exists for scoutd — keep.

--- a/tests/audit_total_coverage.rs
+++ b/tests/audit_total_coverage.rs
@@ -205,6 +205,9 @@ const PACK_SUB: &[(&str, AuditPosture)] = &[
     ("update", AuditPosture::Emits("PackCacheChange")),
 ];
 
+/// `deployments` is a read-only inventory of the local deploy store.
+const DEPLOYMENTS_SUB: &[(&str, AuditPosture)] = &[("ls", AuditPosture::ReadOnly)];
+
 // Plan 200 — beginner machine UX. `machine run` translates into the same
 // transient-runner path as top-level `run`, so it shares `run`'s
 // `InteractiveOrControl` posture (it streams guest output; the admitted
@@ -544,6 +547,7 @@ const AUDIT_POSTURE: &[(&str, AuditPosture)] = &[
     // Deploy mutates the local sealed-artifact store and is wrapped by the
     // top-level cmd.* audit envelope even when no remote is configured.
     ("deploy", AuditPosture::Emits("cmd.deploy")),
+    ("deployments", AuditPosture::DelegatesToSub(DEPLOYMENTS_SUB)),
     // Runtime-pack readiness report — reads the local pack cache only, no
     // mutation and no audit-chain emission.
     ("prepare", AuditPosture::ReadOnly),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -46,6 +46,63 @@ fn machine_create_readme_form_persists_the_named_spec() {
     assert_eq!(spec["memory"], "512M");
 }
 
+/// `deployments ls` inventories the local-first deploy store
+/// (`<mvm_home>/deployments/<ir-hash>/deploy.json`) without contacting a
+/// control plane, and `--workload` filters to one workload.
+#[test]
+fn deployments_ls_inventories_local_deploy_store() {
+    let mvm_home = tempfile::tempdir().unwrap();
+    let record_dir = mvm_home.path().join("deployments").join("aaaa");
+    std::fs::create_dir_all(&record_dir).unwrap();
+    let hex64 = "ab".repeat(32);
+    std::fs::write(
+        record_dir.join("deploy.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "schema_version": 2,
+            "workload_id": "wl-a",
+            "ir_hash": "aaaa",
+            "image": {"blake3": hex64, "sha256": hex64, "size_bytes": 3},
+            "boot_artifact": {
+                "kind": "rootfs.ext4",
+                "blake3": hex64,
+                "sha256": hex64,
+                "size_bytes": 1
+            },
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_mvmctl"))
+        .env("MVM_HOME", mvm_home.path())
+        .env("HOME", mvm_home.path())
+        .env("MVM_NO_AUTO_DEV", "1")
+        .args(["deployments", "ls", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "deployments ls must succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let rows: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("ls --json emits rows");
+    assert_eq!(rows.as_array().expect("rows").len(), 1);
+    assert_eq!(rows[0]["workload_id"], "wl-a");
+    assert_eq!(rows[0]["ir_hash"], "aaaa");
+
+    let filtered = Command::new(env!("CARGO_BIN_EXE_mvmctl"))
+        .env("MVM_HOME", mvm_home.path())
+        .env("HOME", mvm_home.path())
+        .env("MVM_NO_AUTO_DEV", "1")
+        .args(["deployments", "ls", "--workload", "wl-missing", "--json"])
+        .output()
+        .unwrap();
+    assert!(filtered.status.success());
+    let rows: serde_json::Value = serde_json::from_slice(&filtered.stdout).unwrap();
+    assert_eq!(rows.as_array().expect("rows").len(), 0);
+}
+
 /// Regression guard on how `machine run` takes stdin.
 ///
 /// This previously asserted `--stdin` must never appear, because piped stdin


### PR DESCRIPTION
Phase 1 slice of `specs/plans/2026-09-02-supply-chain-evidence-carryover.md` — closes the supply-chain evidence gaps against the competitive baseline in that plan: WS1.1 boot beacon, WS1.4 deployments inventory, WS2.1 verity-sealed provenance mark, WS3.1 in-toto/DSSE provenance sidecar.

## `host.beacon.v1` — boot liveness on the chain

The guest agent reports its own boot once over the existing vsock broker; the host handler stamps the supervisor-authoritative identity (`workload_id` / `tenant_id` / `session_id` / `correlation_id`) from `ServiceCallCtx` and appends a chain-signed `lifecycle.beacon_reported` entry through the audit-signer.

- **Host-derived identity by construction** — the guest payload cannot express identity fields (`deny_unknown_fields`), so unlike a `workload_audit` entry the binding is not guest-asserted; a compromised guest can lie about its version string but cannot forge which workload the entry proves alive.
- **Default-on** wherever an audit signer exists (not gated on `services_bindings`, since the emitter is the platform agent, not workload code); plan-policy suppression seam (`SubprocessConfig` flag) is the designed follow-up, deferred to the environment-model work.
- **Fail-open**: guest-side bounded retries (3 × 2 s) cover host-broker boot races; every failure mode logs and continues — a missing beacon never delays a workload boot.
- **Bounded**: 1 token/s per-workload rate limit caps chain bloat under a hostile guest; 4 KiB payload cap.

Complements `plan.launched`: that entry proves the supervisor started a backend; this one proves the admitted workload's agent actually came alive inside it — the raw signal behind "is this deployment actually running?".

## `mvmctl deployments ls [--workload] [--json]`

The first read path for the local-first deploy store (`<mvm_home>/deployments/<ir-hash>/deploy.json`). Unreadable records (missing, malformed, future schema) surface as named skips instead of failing the listing or silently disappearing. `--env` filtering waits for the environment model in WS1.3 — records today pin only the kernel digest. Row shape is designed to match the future control-plane response so studio renders one type.

## Verity-sealed provenance mark (WS2.1)

Every **sealed** OCI rematerialize now writes a provenance mark into the rootfs at `/mvm/provenance.json` + detached Ed25519 signature **before** the dm-verity hash is computed — so a tampered mark breaks the verified boot chain (kernel-enforced), not just a signature check. The mark is canonical JSON (JCS) covering input reference, resolved digest, builder identity, timestamps, and tool version; the SBOM reference is reserved as `None` until SBOM emission lands (WS6). Signed with the host signer (`~/.mvm/keys/host-signer.ed25519`, the same key as `artifact pack`). Gated on the existing `sealed` request flag — sealed images always carry the mark; a sealed request with no evidence logs a warning instead of failing the seal.

## in-toto / SLSA v1 provenance sidecar (WS3.1)

The seal also emits an in-toto Statement (SLSA v1.0 provenance predicate) wrapped in a DSSE envelope (PAE signing, builder Ed25519 key) as `rootfs.intoto.json` beside the sealed image. The statement subject binds the sha256 of the sealed rootfs's exact bytes, so the sidecar is a standards-shaped interchange view of the same facts as the in-artifact mark. Keyless Sigstore and audit-chain digest recording are deferred (WS4 covers publication).

## Validation

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `just check-gated` (Linux cross-compile of all targets + BDD-feature conformance check) clean
- `xtask check-all` clean (plan names, spec-ref lint, sprint append, CLI-help-vs-docs, honesty, …)
- 32 new tests: WS1.1 payload roundtrips + spoof refusal, client envelope/socket-pair, handler stamping/rate-limit/signer-error mapping, retry semantics; WS1.4 store enumeration/skips, CLI end-to-end with hermetic `MVM_HOME`; WS2.1 mark roundtrip/tamper-rejection/JCS determinism, seal-gate behavior (sealed+evidence → verifiable mark, sealed+none → warn, unsealed → no mark), CLI evidence threading (prod vs dev rematerialize); WS3.1 PAE encoding, statement shape, DSSE wrong-key rejection, sidecar read/verify
