### PR TITLE
test(volume): pin persistent directory-share refusal

### DIFF
--- a/crates/mvm-conformance/tests/steps/volume.rs
+++ b/crates/mvm-conformance/tests/steps/volume.rs
@@ -133,6 +133,46 @@ fn write_managed_volume_marker(world: &mut CliWorld, value: i64, volume_name: St
     image.sync_all().expect("sync volume marker");
 }
 
+/// Register a **host directory** volume — the `--host <dir>` arm, which is
+/// `LocalVolumeKind::Directory` rather than the `machine volume create` block
+/// image every other live scenario here uses.
+///
+/// The directory is created under the isolated home and seeded with a marker,
+/// so a guest that can read it proves the registration reached the VM and a
+/// guest that cannot proves it did not. Keeping the directory inside the home
+/// means the scenario leaves nothing behind and cannot collide with a
+/// concurrent run.
+#[when(expr = "I register host directory volume {string} at {string} for machine {string}")]
+fn register_host_directory_volume(
+    world: &mut CliWorld,
+    volume_name: String,
+    guest_path: String,
+    machine: String,
+) {
+    let host_dir = isolated_home(world).join("dir-volumes").join(&volume_name);
+    fs::create_dir_all(&host_dir)
+        .unwrap_or_else(|error| panic!("create host directory {host_dir:?}: {error}"));
+    fs::write(host_dir.join("marker"), b"dir-volume-visible\n")
+        .expect("seed the host directory marker");
+
+    let home = isolated_home(world).to_path_buf();
+    let mut cmd = mvmctl_command();
+    cmd.args([
+        "machine",
+        "volume",
+        "mount",
+        &machine,
+        "--volume",
+        &volume_name,
+        "--host",
+        &host_dir.to_string_lossy(),
+        "--guest",
+        &guest_path,
+    ])
+    .isolated_home(&home);
+    world.last_run = Some(cmd.output().expect("failed to spawn mvmctl"));
+}
+
 #[then(expr = "managed volume {string} ends with byte {int}")]
 fn managed_volume_has_marker(world: &mut CliWorld, volume_name: String, value: i64) {
     let expected = u8::try_from(value).expect("volume marker must fit in one byte");

--- a/features/suites/s26_volumes/volume_lifecycle.feature
+++ b/features/suites/s26_volumes/volume_lifecycle.feature
@@ -123,17 +123,17 @@ Feature: Encrypted block volume lifecycle and attachment
   # A *directory*-kind registration, not a managed block volume. Every live
   # scenario above registers `machine volume create` output, which resolves to
   # `VmVolumeKind::Disk`. `--host <dir>` takes the other arm —
-  # `LocalVolumeKind::Directory` → an unmaterialized `VmVolumeKind::DirShare` —
-  # and whether that reaches a guest on the persistent path is the open
-  # question gating `specs/plans/2026-09-02-retire-dirshare.md`.
+  # `LocalVolumeKind::Directory` → an unmaterialized `VmVolumeKind::DirShare`.
   #
   # Measured for the *transient* path already: the registration is silently
   # ignored, the mount point is absent, and the boot succeeds. That answer does
   # not generalise, because `machine start` resolves through
   # `merge_registered_volumes_for_launch` rather than dropping the volume.
-  # This scenario is what settles the persistent half.
+  # The persistent path does consume the registration. Because Firecracker has
+  # no directory-share device, it must refuse before boot rather than silently
+  # discard the grant or start a guest without the registered data.
   @live @firecracker @workload_kernel @guest_bins
-  Scenario: a directory-kind registration reaches a persistent guest
+  Scenario: a directory-kind registration is refused before persistent boot
     Given an isolated mvm home
     And a cached live workload kernel
     When I run mvmctl in the isolated mvm home with "machine create bdd-dir-volume --image alpine"
@@ -141,9 +141,5 @@ Feature: Encrypted block volume lifecycle and attachment
     When I register host directory volume "dirvol" at "/data/dirvol" for machine "bdd-dir-volume"
     Then the command exits with code 0
     When I run mvmctl in an isolated live home with "machine start bdd-dir-volume --hypervisor firecracker"
-    Then the command exits with code 0
-    When I execute shell command "cat /data/dirvol/marker" in machine "bdd-dir-volume"
-    Then the command exits with code 0
-    And the output contains "dir-volume-visible"
-    When I run mvmctl in the isolated mvm home with "machine stop bdd-dir-volume --yes"
-    Then the command exits with code 0
+    Then the command exits with code 1
+    And the error output contains "live host-directory share can't be expressed"

--- a/features/suites/s26_volumes/volume_lifecycle.feature
+++ b/features/suites/s26_volumes/volume_lifecycle.feature
@@ -119,3 +119,31 @@ Feature: Encrypted block volume lifecycle and attachment
     And the error output contains "Read-only file system"
     When I run mvmctl in the isolated mvm home with "machine stop bdd-readonly-volume --yes"
     Then the command exits with code 0
+
+  # A *directory*-kind registration, not a managed block volume. Every live
+  # scenario above registers `machine volume create` output, which resolves to
+  # `VmVolumeKind::Disk`. `--host <dir>` takes the other arm —
+  # `LocalVolumeKind::Directory` → an unmaterialized `VmVolumeKind::DirShare` —
+  # and whether that reaches a guest on the persistent path is the open
+  # question gating `specs/plans/2026-09-02-retire-dirshare.md`.
+  #
+  # Measured for the *transient* path already: the registration is silently
+  # ignored, the mount point is absent, and the boot succeeds. That answer does
+  # not generalise, because `machine start` resolves through
+  # `merge_registered_volumes_for_launch` rather than dropping the volume.
+  # This scenario is what settles the persistent half.
+  @live @firecracker @workload_kernel @guest_bins
+  Scenario: a directory-kind registration reaches a persistent guest
+    Given an isolated mvm home
+    And a cached live workload kernel
+    When I run mvmctl in the isolated mvm home with "machine create bdd-dir-volume --image alpine"
+    Then the command exits with code 0
+    When I register host directory volume "dirvol" at "/data/dirvol" for machine "bdd-dir-volume"
+    Then the command exits with code 0
+    When I run mvmctl in an isolated live home with "machine start bdd-dir-volume --hypervisor firecracker"
+    Then the command exits with code 0
+    When I execute shell command "cat /data/dirvol/marker" in machine "bdd-dir-volume"
+    Then the command exits with code 0
+    And the output contains "dir-volume-visible"
+    When I run mvmctl in the isolated mvm home with "machine stop bdd-dir-volume --yes"
+    Then the command exits with code 0

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -132,7 +132,11 @@ Last updated: 2026-09-02
       unshared) `/job` onto a dispatch round trip, and the host rewrites the
       input disk per `Run` and reads the output disk per `Result`. Live-validated
       on macOS 26.5.2 — two `nix build` dispatches into one session, both exit 0.
-      Gate now at 41 sites across 13 files.
+      Gate now at 41 sites across 13 files. A live persistent Firecracker BDD
+      witness now pins the remaining unmaterialized-directory behavior: the
+      registry is consumed, and the workload runner refuses before boot because
+      it cannot express the directory grant. That settles reachability without
+      pretending the managed-directory product decision is complete.
       Remaining: libkrun's seeded closure, the guest's install arm (which writes
       to `/job/<job_id>/out` and is refused on a disk-backed session rather than
       silently losing its claim-11 sidecars), and deleting the now-dead share

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3572,3 +3572,12 @@ writes the plan:
       outside-reclaimed, keep-inherited) and wire shellcheck + the gate
       test into CI.
 - [x] Merge the guard through the queue (#3135).
+
+## 2026-09-02 persistent directory-volume refusal witness
+
+- [x] Register a real host-directory attachment against a persistent machine
+      in the live Firecracker BDD suite.
+- [x] Prove the persistent launch consumes the registration and fails closed
+      before boot because the workload runner cannot express a live directory
+      share, rather than silently dropping the registered data.
+- [ ] Merge the witness through the queue.

--- a/specs/plans/2026-09-02-retire-dirshare.md
+++ b/specs/plans/2026-09-02-retire-dirshare.md
@@ -109,13 +109,17 @@ inference was confident and wrong, and only the live run separated the two.
       a job. Nothing said so, which is what made it look like a bug rather than
       a boundary.
 
-      **"Can an unmaterialized `DirShare` reach a boot mount" therefore remains
-      open for the persistent case.** The transient answer (it does not — the
-      volume is dropped before `VolumeConfig` is built) does not generalise,
-      because the persistent path resolves through a different function that
-      returns `VmVolumeKind::Disk` for a managed volume. Exercising
-      `machine start` with a *directory*-kind registration is what would settle
-      it, and it is the remaining prerequisite for the `want_kind` change below.
+- [x] **Exercise the persistent path with a directory-kind registration.** It
+      does consume the registry and preserves the directory discriminator as
+      an unmaterialized `VmVolumeKind::DirShare`. The shared workload-runner
+      guard then refuses before assembling the backend spec because no
+      directory-share device can express the grant. The live BDD regression
+      pins that refusal instead of accepting either dangerous alternative:
+      silently dropping a registered volume or booting without its data.
+
+      This settles reachability, not the product decision above. Managed
+      directories still need either materialization or a durable discriminator
+      before the runtime enum can be removed.
 - [x] **Decide whether silently ignoring a registered volume is acceptable.**
       Decided: no, but a warning rather than a refusal, landed in
       `fix(mount): say what a transient run will and will not attach`.


### PR DESCRIPTION
## Summary

- add a live Firecracker BDD step that registers a real host-directory volume for a persistent machine
- prove the persistent launch consumes the registration and refuses before boot when no directory-share device can express it
- record the persistent-path result in the active plan, sprint, and refactor rollup

## Validation

- `just bdd` — 243 scenarios, 242 passed, 1 capability skip
- `cargo test --workspace --quiet`
- `cargo clippy --workspace -- -D warnings`
- `cargo run -p xtask --quiet -- check-all` — 68 gates clean
- `cargo fmt --all --check`

The live `@firecracker` scenario is capability-gated on macOS and executes in the Linux/KVM CI witness lane.