### PR TITLE
docs(plan): close the DirShare question by measurement

### DIFF
--- a/specs/plans/2026-09-02-retire-dirshare.md
+++ b/specs/plans/2026-09-02-retire-dirshare.md
@@ -72,10 +72,41 @@ constructs it for `VolumeSourceKind::ManagedDirectory` /
 
 So the first question is not about `VmVolumeKind` at all:
 
-- [ ] **Decide what a managed *directory* volume is.** Either it materializes
-      like `--mount` does (and `LocalVolumeKind::Directory` collapses into
-      `BlockImage`), or it stays a genuinely different thing and needs its own
-      discriminator.
+- [x] **Decide what a managed *directory* volume is.** Answered by measurement,
+      and the answer makes the retirement smaller than this plan assumed: **an
+      unmaterialized `DirShare` is unreachable on every path.** There is no
+      live configuration in which one serves a guest, so
+      `LocalVolumeKind::Directory` needs neither materialization nor a new
+      discriminator — it needs deleting.
+
+      The two paths reach that end differently, which is why one measurement
+      did not answer for both:
+
+      | path | behaviour |
+      | --- | --- |
+      | transient `machine run --name` | registration silently ignored; boot succeeds; mount absent |
+      | persistent `machine start` | **refused before boot**, naming the volume and two ways forward |
+
+      The persistent refusal comes from the workload runner, not the guest:
+      *"the WorkloadRunner has no virtio-fs device yet, so a live
+      host-directory share can't be expressed. Use a disk-image volume instead
+      (host:/guest:SIZE)"*. It never reaches guest init, so the predicted
+      virtiofs `ENODEV` never happens — worth recording, because the code path
+      (`resolve_mount_entry` ends `LocalVolumeKind::Directory => {}`, no
+      conversion) correctly predicted *that it fails* and wrongly predicted
+      *where*.
+
+      Measured on macOS 26 / HVF via `machine start`, which needs no LUKS
+      fixture because the FileVault probe admits the registration. `#3146` pins
+      the same refusal on Firecracker, so it holds on both backends.
+
+- [ ] **The transient path is now the inconsistent one.** `machine start`
+      refuses with a diagnostic; `machine run --name` accepts the
+      registration, lists it in `volume ls`, boots, and provides nothing — a
+      warning was added, but a warning after the fact is weaker than the
+      refusal the other path already gives. The information is available at
+      `machine volume mount` time, which is the one place both paths share, so
+      that is where a consistent refusal belongs.
 
 ### What live testing established
 


### PR DESCRIPTION
docs(plan): close the DirShare question by measurement

The load-bearing box asked what a managed directory volume is - whether it
materializes like --mount does, or stays a different thing needing its own
discriminator. Measured, it is neither: an unmaterialized DirShare is
unreachable on every path, so LocalVolumeKind::Directory needs deleting rather
than a design.

The two paths reach that end differently, which is why one measurement could
not answer for both. Transient machine run --name silently ignores the
registration and boots without the mount. Persistent machine start refuses
before boot, from the workload runner, naming the volume and two ways forward:
"the WorkloadRunner has no virtio-fs device yet, so a live host-directory share
can't be expressed. Use a disk-image volume instead (host:/guest:SIZE)".

Measured on macOS 26 / HVF via machine start, which needs no LUKS fixture
because the FileVault probe admits the registration - the Linux route would
have needed one. #3146 pins the same refusal on Firecracker, so it holds on
both backends.

Recorded because the prediction was half wrong in an instructive way: reading
resolve_mount_entry (which ends LocalVolumeKind::Directory => {}, no
conversion) correctly said the boot fails, and wrongly said it would fail as a
virtiofs ENODEV inside guest init. It never reaches the guest.

The inconsistency has moved rather than gone: machine start refuses with a
diagnostic while machine run --name accepts the registration, lists it in
volume ls, boots, and provides nothing but a warning. The information is
available at machine volume mount time, which is the one place both paths
share, so that is where a consistent refusal belongs. Left as the successor
item.
