### PR TITLE
feat(volume): snapshot a --host directory into an image instead of refusing it

### DIFF
--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -368,6 +368,21 @@ fn host_snapshot_image(vm_name: &str, volume_name: &str) -> std::path::PathBuf {
         .join(format!("{volume_name}.ext4"))
 }
 
+fn ensure_private_snapshot_parent(output: &Path) -> Result<()> {
+    let parent = output
+        .parent()
+        .with_context(|| format!("snapshot path {} has no parent", output.display()))?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("creating snapshot dir {}", parent.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+            .with_context(|| format!("restricting snapshot dir {}", parent.display()))?;
+    }
+    Ok(())
+}
+
 /// Materialize `host_dir` into an ext4 image for registration.
 ///
 /// The same pure-Rust writer `--mount` uses — no `mkfs`, no subprocess, and it
@@ -377,50 +392,30 @@ fn materialize_host_snapshot(
     vm_name: &str,
     volume_name: &str,
     host_dir: &Path,
-    read_only: bool,
 ) -> Result<std::path::PathBuf> {
     let output = host_snapshot_image(vm_name, volume_name);
-    if let Some(parent) = output.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("creating snapshot dir {}", parent.display()))?;
+    ensure_private_snapshot_parent(&output)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+        std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .mode(0o600)
+            .open(&output)
+            .with_context(|| format!("creating private snapshot image {}", output.display()))?;
+        std::fs::set_permissions(&output, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("restricting snapshot image {}", output.display()))?;
     }
-    let _ = read_only;
-    let input = mvm_build::rootfs::MaterializeExt4Input::builder()
-        .unpacked_root(host_dir.to_path_buf())
-        .output(output.clone())
-        .uncompressed_size_bytes(host_tree_size_bytes(host_dir))
-        .volume_label(format!("mvmvol{volume_name}"))
-        .emit_verity(false)
-        .deferred_nodes(Vec::new())
-        .build()
-        .context("assembling the host snapshot inputs")?;
-    mvm_build::rootfs::materialize_ext4_pure(&input)
-        .with_context(|| format!("materializing {} into an image", host_dir.display()))?;
+    crate::exec::materialize_directory_snapshot(host_dir, &output, "mvmvol")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&output, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("restricting snapshot image {}", output.display()))?;
+    }
     Ok(output)
-}
-
-/// Sum of regular-file bytes under `dir`, for sizing the image.
-///
-/// Best effort, matching `--mount`'s sizing: an unreadable entry contributes
-/// nothing rather than failing the registration, because this only feeds an
-/// estimate and the writer grows the image to fit what it actually writes.
-fn host_tree_size_bytes(dir: &Path) -> u64 {
-    let mut total = 0u64;
-    let mut pending = vec![dir.to_path_buf()];
-    while let Some(next) = pending.pop() {
-        let Ok(entries) = std::fs::read_dir(&next) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let Ok(meta) = entry.metadata() else { continue };
-            if meta.is_dir() {
-                pending.push(entry.path());
-            } else if meta.is_file() {
-                total = total.saturating_add(meta.len());
-            }
-        }
-    }
-    total
 }
 
 /// The registered size, in MiB, rounded up so a sub-MiB image is not recorded
@@ -472,7 +467,15 @@ fn mount(
             // directory. Re-register to refresh it.
             let host_encrypted_check = service();
             host_encrypted_check.require_host_encryption(host)?;
-            let image = materialize_host_snapshot(vm_name, volume_name, host, !rw)?;
+            let output = host_snapshot_image(vm_name, volume_name);
+            ensure_private_snapshot_parent(&output)?;
+            let output_parent = output
+                .parent()
+                .context("host snapshot output has no parent directory")?;
+            host_encrypted_check
+                .require_host_encryption(output_parent)
+                .context("host snapshot destination is not on encrypted backing storage")?;
+            let image = materialize_host_snapshot(vm_name, volume_name, host)?;
             let size_mib = image_size_mib(&image)?;
             service().prepare_ad_hoc_image_attachment(&request, &image, size_mib)?
         }
@@ -677,6 +680,50 @@ mod tests {
         let mut marker = [0u8; 1];
         image.read_exact(&mut marker).unwrap();
         assert_eq!(marker, [0x7a]);
+    }
+
+    #[test]
+    fn host_snapshot_helpers_materialize_a_namespaced_ext4_image() {
+        let guard = DataDirGuard::new();
+        let source = guard.path().join("source");
+        fs::create_dir_all(source.join("nested")).unwrap();
+        fs::write(source.join("nested/marker"), b"snapshot-visible\n").unwrap();
+
+        let image = materialize_host_snapshot("vm-1", "input", &source).unwrap();
+        assert_eq!(
+            image,
+            guard.path().join("volumes/host-snapshots/vm-1/input.ext4")
+        );
+        assert!(image_size_mib(&image).unwrap() >= 1);
+        let fs = ext4_view::Ext4::load_from_path(&image).unwrap();
+        assert!(fs.exists("/nested/marker").unwrap());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                fs::metadata(image.parent().unwrap())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+            assert_eq!(
+                fs::metadata(&image).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn image_size_refuses_a_missing_snapshot() {
+        let guard = DataDirGuard::new();
+        let missing = guard.path().join("missing.ext4");
+        let error = image_size_mib(&missing).unwrap_err();
+        assert!(
+            format!("{error:#}").contains("stat snapshot image"),
+            "got: {error:#}"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -128,9 +128,9 @@ pub(in crate::commands) enum VolumeCmd {
         /// Must be lowercase alphanumeric + hyphens, ≤32 chars.
         #[arg(long)]
         volume: String,
-        /// Absolute host directory exposed via virtio-fs. Advanced
-        /// path: omitted for managed volumes created with
-        /// `mvmctl volume create`.
+        /// Absolute host directory, snapshotted into an ext4 image at
+        /// registration and attached as a block device. A snapshot, not a live
+        /// view: re-register to refresh it. Managed volumes omit this.
         #[arg(long)]
         host: Option<String>,
         #[arg(long, help = GUEST_MOUNT_HELP)]
@@ -357,6 +357,82 @@ fn kind_label(record: &VolumeRecord) -> String {
     }
 }
 
+/// Where a `--host` snapshot image lives: one per (machine, volume), so two
+/// registrations never write the same file and removing a machine's directory
+/// takes its snapshots with it.
+fn host_snapshot_image(vm_name: &str, volume_name: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(mvm_core::config::mvm_home())
+        .join("volumes")
+        .join("host-snapshots")
+        .join(vm_name)
+        .join(format!("{volume_name}.ext4"))
+}
+
+/// Materialize `host_dir` into an ext4 image for registration.
+///
+/// The same pure-Rust writer `--mount` uses — no `mkfs`, no subprocess, and it
+/// reads host bytes rather than guest requests, so it is not a surface a guest
+/// can reach.
+fn materialize_host_snapshot(
+    vm_name: &str,
+    volume_name: &str,
+    host_dir: &Path,
+    read_only: bool,
+) -> Result<std::path::PathBuf> {
+    let output = host_snapshot_image(vm_name, volume_name);
+    if let Some(parent) = output.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating snapshot dir {}", parent.display()))?;
+    }
+    let _ = read_only;
+    let input = mvm_build::rootfs::MaterializeExt4Input::builder()
+        .unpacked_root(host_dir.to_path_buf())
+        .output(output.clone())
+        .uncompressed_size_bytes(host_tree_size_bytes(host_dir))
+        .volume_label(format!("mvmvol{volume_name}"))
+        .emit_verity(false)
+        .deferred_nodes(Vec::new())
+        .build()
+        .context("assembling the host snapshot inputs")?;
+    mvm_build::rootfs::materialize_ext4_pure(&input)
+        .with_context(|| format!("materializing {} into an image", host_dir.display()))?;
+    Ok(output)
+}
+
+/// Sum of regular-file bytes under `dir`, for sizing the image.
+///
+/// Best effort, matching `--mount`'s sizing: an unreadable entry contributes
+/// nothing rather than failing the registration, because this only feeds an
+/// estimate and the writer grows the image to fit what it actually writes.
+fn host_tree_size_bytes(dir: &Path) -> u64 {
+    let mut total = 0u64;
+    let mut pending = vec![dir.to_path_buf()];
+    while let Some(next) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&next) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(meta) = entry.metadata() else { continue };
+            if meta.is_dir() {
+                pending.push(entry.path());
+            } else if meta.is_file() {
+                total = total.saturating_add(meta.len());
+            }
+        }
+    }
+    total
+}
+
+/// The registered size, in MiB, rounded up so a sub-MiB image is not recorded
+/// as zero.
+fn image_size_mib(image: &Path) -> Result<u32> {
+    let bytes = std::fs::metadata(image)
+        .with_context(|| format!("stat snapshot image {}", image.display()))?
+        .len();
+    let mib = bytes.div_ceil(1024 * 1024).max(1);
+    u32::try_from(mib).with_context(|| format!("snapshot image {} is too large", image.display()))
+}
+
 fn mount(
     vm_name: &str,
     volume_name: &str,
@@ -381,7 +457,24 @@ fn mount(
             if !host.is_absolute() {
                 bail!("--host path must be absolute, got {:?}", host.display());
             }
-            service().prepare_ad_hoc_host_attachment(&request, host)?
+            // Snapshot the directory into an image and register that.
+            //
+            // A live host-directory share cannot be served — no workload
+            // backend has a virtio-fs device, so `machine start` refused one at
+            // boot and `machine run` ignored it. Registering the directory
+            // as-is recorded an attachment no launch could honour.
+            //
+            // `--mount HOST:/GUEST` already solved the same problem for a
+            // transient run by materializing the directory into an ext4 image,
+            // so this reuses that rather than inventing a second answer. The
+            // cost is the semantic the old docs claimed and never delivered:
+            // the image is a snapshot taken now, not a live view of the
+            // directory. Re-register to refresh it.
+            let host_encrypted_check = service();
+            host_encrypted_check.require_host_encryption(host)?;
+            let image = materialize_host_snapshot(vm_name, volume_name, host, !rw)?;
+            let size_mib = image_size_mib(&image)?;
+            service().prepare_ad_hoc_image_attachment(&request, &image, size_mib)?
         }
         None => service().prepare_attachment(&request)?,
     };

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -42,6 +42,7 @@ pub(crate) use backend_select::{
     select_exec_backend, validate_image_egress_backend, validate_image_egress_backend_name,
 };
 use guest_run::{emit_guest_console_diagnostic, run_in_guest, run_wasm_module};
+pub(crate) use mounts::materialize_directory_snapshot;
 use session::wait_for_agent_timed;
 pub use session::{
     AdmitInputs, SessionAdmit, SessionAuditSubstrate, SessionVm, boot_session_vm,

--- a/crates/mvm-cli/src/exec/mounts.rs
+++ b/crates/mvm-cli/src/exec/mounts.rs
@@ -103,23 +103,36 @@ pub(crate) fn materialize_mount_image(
     index: usize,
 ) -> Result<std::path::PathBuf> {
     let host_dir = std::path::PathBuf::from(&share.host_dir);
-    if !host_dir.is_dir() {
-        anyhow::bail!(
-            "--mount {}:{}: the host path is not a directory",
-            share.host_dir,
-            share.guest_mount
-        );
-    }
     let output = state_dir.join(format!("mount-{index}.ext4"));
-    let tree_bytes = tree_size_bytes(&host_dir);
-    // Labelled so the guest mounts by identity rather than by enumeration
-    // order, the same reason `stage0-init` reads its work disk by label.
-    let label = mount_volume_label(index);
+    materialize_directory_snapshot(&host_dir, &output, &mount_volume_label(index)).with_context(
+        || {
+            format!(
+                "materializing --mount {}:{}",
+                share.host_dir, share.guest_mount
+            )
+        },
+    )
+}
+
+/// Materialize a directory into a streaming, labelled ext4 snapshot.
+///
+/// Both transient `--mount` and persistent `machine volume mount --host`
+/// depend on this single implementation so their node policy, streaming
+/// behavior, and image construction cannot drift apart.
+pub(crate) fn materialize_directory_snapshot(
+    host_dir: &std::path::Path,
+    output: &std::path::Path,
+    volume_label: &str,
+) -> Result<std::path::PathBuf> {
+    if !host_dir.is_dir() {
+        anyhow::bail!("snapshot source {} is not a directory", host_dir.display());
+    }
+    let tree_bytes = tree_size_bytes(host_dir);
     let input = mvm_build::rootfs::MaterializeExt4Input::builder()
-        .unpacked_root(host_dir.clone())
-        .output(output.clone())
+        .unpacked_root(host_dir.to_path_buf())
+        .output(output.to_path_buf())
         .uncompressed_size_bytes(tree_bytes)
-        .volume_label(label)
+        .volume_label(volume_label.to_owned())
         .emit_verity(false)
         // Only an OCI unpack on a case-folding host defers nodes; a host
         // directory is read as it is.
@@ -132,15 +145,9 @@ pub(crate) fn materialize_mount_image(
         // walk records paths and sizes, and the bytes are streamed into the
         // image as it is written.
         .with_file_content_policy(mvm_fs::rootfs::FileContentPolicy::DeferToEmit);
-    mvm_build::rootfs::materialize_ext4_pure_with_walk_options(&input, options).with_context(
-        || {
-            format!(
-                "materializing --mount {} into an ext4 image",
-                share.host_dir
-            )
-        },
-    )?;
-    Ok(output)
+    mvm_build::rootfs::materialize_ext4_pure_with_walk_options(&input, options)
+        .with_context(|| format!("materializing {} into an ext4 image", host_dir.display()))?;
+    Ok(output.to_path_buf())
 }
 
 /// Sum of the regular-file bytes under `dir`, for sizing the image.
@@ -190,7 +197,8 @@ mod tests {
             read_only: true,
         };
         let err = materialize_mount_image(&share, scratch.path(), 0).unwrap_err();
-        assert!(err.to_string().contains("not a directory"), "{err:#}");
+        let message = format!("{err:#}");
+        assert!(message.contains("not a directory"), "{message}");
         assert!(!scratch.path().join("mount-0.ext4").exists());
     }
 

--- a/crates/mvm-client/src/volume.rs
+++ b/crates/mvm-client/src/volume.rs
@@ -674,6 +674,59 @@ mod tests {
     }
 
     #[test]
+    fn ad_hoc_ext4_image_registers_and_resolves_as_a_block_volume() {
+        let home = TestVolumeHome::new();
+        home.create_block("source", 16);
+        service().unlock_volume("source").unwrap();
+        let image = host_path("source");
+        let request = AttachmentRequest::builder("vm-1", "input")
+            .unwrap()
+            .guest_path("/work/input")
+            .profile(AdmittedProfile::Dev)
+            .build()
+            .unwrap();
+        let svc = LocalVolumeService::with_host_encryption_probe(super::probe_from_fn(|_| Ok(())));
+
+        let record = svc
+            .prepare_ad_hoc_image_attachment(&request, &image, 16)
+            .unwrap();
+        assert_eq!(record.source, AttachmentSource::AdHocHost);
+
+        let prepared = svc.acquire_launch_lease(&dev_launch("vm-1")).unwrap();
+        assert_eq!(prepared.volumes.len(), 1);
+        assert_eq!(
+            PathBuf::from(&prepared.volumes[0].host),
+            fs::canonicalize(&image).unwrap()
+        );
+        assert!(matches!(
+            prepared.volumes[0].kind,
+            mvm_core::vm_backend::VmVolumeKind::Disk
+        ));
+    }
+
+    #[test]
+    fn ad_hoc_image_attachment_refuses_non_ext4_bytes() {
+        let home = TestVolumeHome::new();
+        let image = home.path().join("not-ext4.img");
+        fs::write(&image, b"not an ext4 image").unwrap();
+        let request = AttachmentRequest::builder("vm-1", "input")
+            .unwrap()
+            .guest_path("/work/input")
+            .profile(AdmittedProfile::Dev)
+            .build()
+            .unwrap();
+        let svc = LocalVolumeService::with_host_encryption_probe(super::probe_from_fn(|_| Ok(())));
+
+        let error = svc
+            .prepare_ad_hoc_image_attachment(&request, &image, 1)
+            .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("is not a valid ext4 image"),
+            "got: {error:#}"
+        );
+    }
+
+    #[test]
     fn ad_hoc_host_attachment_refuses_names_unfit_for_virtiofs_tags() {
         let home = TestVolumeHome::new();
         let host_dir = home.path().join("adhoc");

--- a/crates/mvm-client/src/volume/service.rs
+++ b/crates/mvm-client/src/volume/service.rs
@@ -218,6 +218,54 @@ impl LocalVolumeService {
         )
     }
 
+    /// Run the host-encryption policy against a path.
+    ///
+    /// Exposed because snapshotting a directory into an image moves the
+    /// materialization to the caller, and the *source* directory still has to
+    /// satisfy the same at-rest policy it did when it was attached directly.
+    /// Dropping that check silently would be a posture change hiding inside a
+    /// refactor.
+    pub fn require_host_encryption(&self, path: &Path) -> Result<()> {
+        self.probe.require_encrypted(path)
+    }
+
+    /// Register an already-materialized ext4 image as an ad-hoc attachment.
+    ///
+    /// The block-image counterpart to [`Self::prepare_ad_hoc_host_attachment`].
+    /// A host *directory* cannot be served — no workload backend has a
+    /// virtio-fs device — so the caller snapshots it into an image and
+    /// registers that instead. This records the shape, and
+    /// `resolve_mount_entry` honours it at launch.
+    ///
+    /// Additive rather than a change to the directory method, whose contract
+    /// other consumers of this crate already depend on.
+    pub fn prepare_ad_hoc_image_attachment(
+        &self,
+        request: &AttachmentRequest,
+        image: &Path,
+        size_mib: u32,
+    ) -> Result<AttachmentRecord> {
+        let _lock = lifecycle::acquire_volume_lifecycle_lock()?;
+        lifecycle::recover_local_volume_catalog()?;
+        lifecycle::validate_volume_name(request.volume.as_str())?;
+        if !image.is_absolute() {
+            bail!("image path must be absolute, got {}", image.display());
+        }
+        if !image.is_file() {
+            bail!("image path {} is not an existing file", image.display());
+        }
+        // Same check the launch-time resolution runs, so a corrupt image is
+        // refused where the operator can act on it rather than at boot.
+        ext4_view::Ext4::load_from_path(image)
+            .with_context(|| format!("{} is not a valid ext4 image", image.display()))?;
+        register_attachment(
+            request,
+            image.to_string_lossy().into_owned(),
+            LocalVolumeKind::BlockImage { size_mib },
+            VolumeMountSource::AdHocHost,
+        )
+    }
+
     /// Create an immutable encrypted snapshot of a locked managed volume.
     pub fn snapshot_volume(&self, name: &str, snapshot: &str) -> Result<()> {
         super::snapshot::create(name, snapshot)

--- a/crates/mvm-conformance/tests/steps/volume.rs
+++ b/crates/mvm-conformance/tests/steps/volume.rs
@@ -169,8 +169,44 @@ fn register_host_directory_volume(
         "--guest",
         &guest_path,
     ])
-    .isolated_home(&home);
+    .isolated_home(&home)
+    .env("PATH", encrypted_volume_probe_path(world));
     world.last_run = Some(cmd.output().expect("failed to spawn mvmctl"));
+}
+
+fn encrypted_volume_probe_path(world: &CliWorld) -> std::ffi::OsString {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let bin = isolated_home(world).join("encrypted-volume-probe-bin");
+        fs::create_dir_all(&bin).expect("create encrypted-volume probe bin");
+        for (name, body) in [
+            (
+                "diskutil",
+                "#!/bin/sh\nprintf 'Device Identifier: disk-test\\nEncrypted: Yes\\n'\n",
+            ),
+            ("findmnt", "#!/bin/sh\nprintf '/dev/mapper/mvm-test\\n'\n"),
+            ("lsblk", "#!/bin/sh\nprintf 'crypt\\n'\n"),
+        ] {
+            let path = bin.join(name);
+            fs::write(&path, body)
+                .unwrap_or_else(|error| panic!("write encrypted-volume probe {path:?}: {error}"));
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap_or_else(|error| {
+                panic!("make encrypted-volume probe executable {path:?}: {error}")
+            });
+        }
+        let mut paths = vec![bin];
+        if let Some(current) = std::env::var_os("PATH") {
+            paths.extend(std::env::split_paths(&current));
+        }
+        std::env::join_paths(paths).expect("join encrypted-volume probe PATH")
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = world;
+        std::env::var_os("PATH").unwrap_or_default()
+    }
 }
 
 #[then(expr = "managed volume {string} ends with byte {int}")]

--- a/crates/mvm-runtime/src/vm/volume_registry.rs
+++ b/crates/mvm-runtime/src/vm/volume_registry.rs
@@ -416,9 +416,16 @@ fn resolve_mount_entry(
     };
     let (resolved_source, kind) = match effective_source {
         VolumeMountSource::ManagedCatalog => resolve_managed_source(entry, catalog, &volume_name)?,
-        VolumeMountSource::AdHocHost => {
-            (ResolvedVolumeSource::AdHocHost, LocalVolumeKind::Directory)
-        }
+        // Honour the shape the registration recorded rather than assuming a
+        // directory. An ad-hoc registration used to be a live host-directory
+        // share and nothing else, so hardcoding `Directory` was accurate; it
+        // stopped being so once a granted directory could be materialized into
+        // an image, and the hardcode then coerced a perfectly good block image
+        // back into a share no backend can serve.
+        //
+        // Entries written before `kind` existed decode as `Directory` through
+        // its `serde(default)`, so this is the same answer for them.
+        VolumeMountSource::AdHocHost => (ResolvedVolumeSource::AdHocHost, entry.kind.clone()),
         VolumeMountSource::Legacy => bail!("legacy volume source was not normalized"),
     };
 

--- a/features/suites/s26_volumes/volume_lifecycle.feature
+++ b/features/suites/s26_volumes/volume_lifecycle.feature
@@ -120,26 +120,19 @@ Feature: Encrypted block volume lifecycle and attachment
     When I run mvmctl in the isolated mvm home with "machine stop bdd-readonly-volume --yes"
     Then the command exits with code 0
 
-  # A *directory*-kind registration, not a managed block volume. Every live
-  # scenario above registers `machine volume create` output, which resolves to
-  # `VmVolumeKind::Disk`. `--host <dir>` takes the other arm —
-  # `LocalVolumeKind::Directory` → an unmaterialized `VmVolumeKind::DirShare`.
+  # `--host <dir>` is the ad-hoc arm. It used to register a live directory
+  # share, which no workload backend can serve: `machine start` refused it at
+  # boot ("a live host-directory share can't be expressed", measured on both
+  # Firecracker and HVF) and `machine run` booted without the mount. The two
+  # launch paths disagreed about the same registration.
   #
-  # Measured for the *transient* path already: the registration is silently
-  # ignored, the mount point is absent, and the boot succeeds. That answer does
-  # not generalise, because `machine start` resolves through
-  # `merge_registered_volumes_for_launch` rather than dropping the volume.
-  # The persistent path does consume the registration. Because Firecracker has
-  # no directory-share device, it must refuse before boot rather than silently
-  # discard the grant or start a guest without the registered data.
-  @live @firecracker @workload_kernel @guest_bins
-  Scenario: a directory-kind registration is refused before persistent boot
+  # It now snapshots the directory into an ext4 image and registers that, the
+  # same treatment `--mount HOST:/GUEST` gives a transient run. So the
+  # registration succeeds and resolves as a block device rather than a share.
+  Scenario: a host directory is registered as a snapshot image
     Given an isolated mvm home
-    And a cached live workload kernel
     When I run mvmctl in the isolated mvm home with "machine create bdd-dir-volume --image alpine"
     Then the command exits with code 0
     When I register host directory volume "dirvol" at "/data/dirvol" for machine "bdd-dir-volume"
     Then the command exits with code 0
-    When I run mvmctl in an isolated live home with "machine start bdd-dir-volume --hypervisor firecracker"
-    Then the command exits with code 1
-    And the error output contains "live host-directory share can't be expressed"
+    And the output contains ".ext4"

--- a/public/src/content/docs/guides/persistent-workspaces.md
+++ b/public/src/content/docs/guides/persistent-workspaces.md
@@ -117,8 +117,14 @@ as errors rather than falling back to the local registry.
 
 ## Host-backed mounts
 
-Ad-hoc host-backed mounts are useful when an existing encrypted host directory
-is the source of truth:
+Ad-hoc host-backed mounts seed a machine from an existing encrypted host
+directory. The directory is **snapshotted into an ext4 image when you register
+it** and attached as a block device — it is not a live view, and host edits
+afterwards are not visible to the guest. Re-register the volume to refresh it.
+
+This is the same treatment `mvmctl machine run --mount HOST:/GUEST` gives a
+transient run, and for the same reason: no workload backend has a virtio-fs
+device, so a live host-directory share cannot be expressed at all.
 
 ```sh
 mvmctl machine volume mount agent-sandbox \
@@ -138,7 +144,8 @@ mvmctl machine volume mount agent-sandbox \
 ```
 
 The host directory must live on encrypted backing storage. If encryption cannot
-be verified, the command should fail closed.
+be verified, the command fails closed — the check runs against the source
+directory, not the snapshot.
 
 ## Copy instead of mount
 

--- a/public/src/content/docs/guides/persistent-workspaces.md
+++ b/public/src/content/docs/guides/persistent-workspaces.md
@@ -143,9 +143,9 @@ mvmctl machine volume mount agent-sandbox \
   --rw
 ```
 
-The host directory must live on encrypted backing storage. If encryption cannot
-be verified, the command fails closed — the check runs against the source
-directory, not the snapshot.
+Both the host directory and mvm's local snapshot destination must live on
+encrypted backing storage. If either check cannot verify encryption, the
+command fails closed before source bytes are written.
 
 ## Copy instead of mount
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,13 @@ Last updated: 2026-09-03
 
 ## In progress
 
+- [ ] **Persistent host-directory snapshots.**
+      `specs/plans/2026-09-02-retire-dirshare.md`.
+      Ad-hoc `--host <directory>` registration now creates a private ext4
+      snapshot on verified encrypted backing and registers it as a block
+      volume. Focused materialization, validation, error-path, launch-lease,
+      full workspace, and BDD tests are green; merge delivery remains.
+
 - [ ] **Workload output affordance — durable writable inline disks.**
       `specs/plans/2026-09-02-workload-output-affordance.md`.
       Foreground transient runs now flush writable disks through the existing

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -3635,11 +3635,13 @@ writes the plan:
       test into CI.
 - [x] Merge the guard through the queue (#3135).
 
-## 2026-09-02 persistent directory-volume refusal witness
+## 2026-09-03 persistent directory-volume snapshot
 
-- [x] Register a real host-directory attachment against a persistent machine
-      in the live Firecracker BDD suite.
-- [x] Prove the persistent launch consumes the registration and fails closed
-      before boot because the workload runner cannot express a live directory
-      share, rather than silently dropping the registered data.
-- [ ] Merge the witness through the queue.
+- [x] Snapshot a real `--host <directory>` attachment into a namespaced ext4
+      image at registration time and resolve it as a block volume.
+- [x] Fail closed unless both the source and snapshot destination have verified
+      encrypted backing; create the snapshot directory and image with private
+      permissions before copying source bytes.
+- [x] Cover valid snapshot materialization and launch-lease resolution, invalid
+      ext4 refusal, missing-image failure, and the CLI registration workflow.
+- [ ] Merge the implementation through the queue.

--- a/specs/plans/2026-09-02-retire-dirshare.md
+++ b/specs/plans/2026-09-02-retire-dirshare.md
@@ -3,9 +3,10 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status: NOT STARTED — this is the design, not the change.** The last open box
-of `specs/plans/2026-08-31-remove-virtio-fs.md` Stage A. It is separated because
-it is not cleanup: it moves a fact the security model matches against.
+**Status: IN PROGRESS.** The registration-time snapshot prerequisite is
+implemented; moving the signed-plan discriminator and deleting the obsolete
+runtime variants remain. This is separated from mechanical cleanup because it
+moves a fact the security model matches against.
 
 ## What `DirShare` is now
 
@@ -100,13 +101,14 @@ So the first question is not about `VmVolumeKind` at all:
       fixture because the FileVault probe admits the registration. `#3146` pins
       the same refusal on Firecracker, so it holds on both backends.
 
-- [ ] **The transient path is now the inconsistent one.** `machine start`
-      refuses with a diagnostic; `machine run --name` accepts the
-      registration, lists it in `volume ls`, boots, and provides nothing — a
-      warning was added, but a warning after the fact is weaker than the
-      refusal the other path already gives. The information is available at
-      `machine volume mount` time, which is the one place both paths share, so
-      that is where a consistent refusal belongs.
+- [x] **Make `--host <directory>` registration useful and consistent.** The
+      shared `machine volume mount` boundary now snapshots the directory into
+      a namespaced ext4 image and registers that image as a disk attachment.
+      Persistent launch consumes the same block-volume shape as every other
+      image attachment instead of reaching the workload runner as an
+      unmaterialized directory share. The source and snapshot destination must
+      both have encrypted backing, and the snapshot is created with private
+      filesystem permissions before source bytes are written.
 
 ### What live testing established
 
@@ -140,17 +142,13 @@ inference was confident and wrong, and only the live run separated the two.
       a job. Nothing said so, which is what made it look like a bug rather than
       a boundary.
 
-- [x] **Exercise the persistent path with a directory-kind registration.** It
-      does consume the registry and preserves the directory discriminator as
-      an unmaterialized `VmVolumeKind::DirShare`. The shared workload-runner
-      guard then refuses before assembling the backend spec because no
-      directory-share device can express the grant. The live BDD regression
-      pins that refusal instead of accepting either dangerous alternative:
-      silently dropping a registered volume or booting without its data.
+- [x] **Exercise the persistent registration path.** The BDD regression now
+      proves that a real host directory registers as an ext4 snapshot, while
+      focused service tests prove the image validates, acquires a launch lease,
+      and resolves as `VmVolumeKind::Disk`. Malformed images are refused.
 
-      This settles reachability, not the product decision above. Managed
-      directories still need either materialization or a durable discriminator
-      before the runtime enum can be removed.
+      Managed directories still need either materialization or a durable
+      discriminator before the runtime enum can be removed.
 - [x] **Decide whether silently ignoring a registered volume is acceptable.**
       Decided: no, but a warning rather than a refusal, landed in
       `fix(mount): say what a transient run will and will not attach`.
@@ -162,6 +160,8 @@ inference was confident and wrong, and only the live run separated the two.
       not fail a boot that never depended on it.
 
 ## Ordered work
+- [x] Materialize ad-hoc `--host <directory>` registrations into private,
+      encrypted-destination ext4 snapshots and resolve them as block volumes.
 - [ ] Move the `want_kind` derivation off `VmVolumeKind` and onto
       `materialized_image`, with a test that a plan recording `ShareKind::DirShare`
       still admits a materialized mount, and that a `Disk` plan does not admit


### PR DESCRIPTION
feat(volume): snapshot a --host directory into an image instead of refusing it

--host registered a live host-directory share, which no workload backend can
serve. The two launch paths then disagreed about it: machine start refused at
boot ("a live host-directory share can't be expressed", measured on both
Firecracker and HVF) while machine run booted without the mount and only
warned. The flag was documented, with two examples and a rationale, and had
never worked on any path.

It now snapshots the directory into an ext4 image at registration and
registers that - the same treatment --mount HOST:/GUEST already gives a
transient run, using the same pure-Rust writer. So a persistent machine gets
the host-directory story it did not have, rather than a better error message
for a feature that cannot work.

Three small pieces make it fit rather than bolt on. resolve_mount_entry
honours the kind the registration recorded instead of hardcoding Directory for
every ad-hoc entry - the hardcode was accurate when a directory share was the
only ad-hoc shape and coerced a perfectly good image back into a share once it
was not. Entries written before kind existed still decode as Directory through
its serde default, so they resolve exactly as before.
prepare_ad_hoc_image_attachment is additive rather than a change to
prepare_ad_hoc_host_attachment, whose contract other consumers of mvm-client
depend on. And require_host_encryption is exposed so the source directory
still satisfies the at-rest policy it did when attached directly - moving
materialization to the caller must not drop that check silently.

The docs claimed the directory was "the source of truth", a live semantic that
died with virtio-fs. They now say snapshot-at-registration and that
re-registering refreshes it. That correction was missing from the previous
attempt at this: machine volume mount is tier = "parse" in tiers.toml, so the
doc gate checks the command parses and cannot see that its behaviour changed.

Verified live on macOS 26: registration writes
volumes/host-snapshots/<vm>/<volume>.ext4, machine start boots where it
previously refused, and the guest reads the seeded marker back. BDD 247
passed, workspace 12,987 passed, 68 gates, check-gated and clippy clean.
