### PR TITLE
docs(specs): close the aux-helper contract merge boxes

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -13,7 +13,7 @@ Last updated: 2026-09-02
       mirrors dev-env.sh: inside-tree values honored, outside-tree values
       reclaimed loudly, MVM_DEV_ENV_KEEP_INHERITED=1 keeps them anyway. Gate
       tests and CI shellcheck green; merged via #3135.
-- [ ] **Aux host-helper contract verification.**
+- [x] **Aux host-helper contract verification.**
       `specs/plans/2026-09-02-aux-helper-contract.md`.
       Host helpers answer a `--contract-version` probe and `mvmctl` verifies
       the answer before spawning: a stale helper in a source checkout is
@@ -23,7 +23,7 @@ Last updated: 2026-09-02
       an "unknown field" spawn failure. A `HvfSupervisorConfig` shape pin
       forces the contract version to bump with the schema. Focused
       regressions, affected crate suites, zero-warning Clippy, and Linux/BDD
-      gated compilation are green; merge delivery remains.
+      gated compilation are green; merged via #3132.
 
 - [ ] **Signed caller commitment — issue #3070.**
       `specs/plans/2026-09-01-signed-caller-commitment.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -27,7 +27,7 @@
       ledger with a BDD suite (`s33_content_addressed_assets`, 4 scenarios).
       Workspace check, host tests, gated Linux cross-check, clippy, fmt, and
       the claim/CLI lint gates are green. Merge delivery remains.
-- [ ] **Aux host-helper contract verification.**
+- [x] **Aux host-helper contract verification.**
       `specs/plans/2026-09-02-aux-helper-contract.md`.
       Host helpers now carry a compiled-in contract version and answer a
       `--contract-version` probe; `mvmctl` probes before spawn and never
@@ -39,7 +39,7 @@
       contract version to move with the schema. Focused resolver, probe, and
       spawn-path regressions, the mvm-vmm / mvm-backends / mvm-hostd /
       mvm-runtime suites, zero-warning Clippy, and Linux/BDD gated
-      compilation are green; merge delivery remains.
+      compilation are green; merged via #3132.
 
 - [ ] **Mounted PTY image environment.**
       `specs/plans/2026-09-01-mounted-pty-image-environment.md`.

--- a/specs/plans/2026-09-02-aux-helper-contract.md
+++ b/specs/plans/2026-09-02-aux-helper-contract.md
@@ -35,4 +35,4 @@ silent fallback is gone.
 - [x] Profile-mismatch warning machinery removed (subsumed by verification).
 - [x] Tests green on host; workspace clippy and gated-target checks green in
       the builder VM.
-- [x] `specs/SPRINT.md` updated; PR opened from the worktree branch.
+- [x] `specs/SPRINT.md` updated; merged via #3132 (squash `2eff78c623`).


### PR DESCRIPTION
## What

#3132 (aux host-helper contract verification) landed as squash `2eff78c623`. This closes the merge-delivery tracking that PR could not close for itself:

- `specs/SPRINT.md` — in-progress mirror entry checked, "merge delivery remains" → "merged via #3132"
- `specs/REFACTOR-STATUS.md` — entry checked, same reword
- `specs/plans/2026-09-02-aux-helper-contract.md` — final delivery bullet now records the merge

Docs-only; no code, no behavior change.