### PR TITLE
fix(contract): pin the sdk_uses_sidecar default, and declare it dormant

### DIFF
--- a/crates/mvm-contract/src/plan/execution_plan.rs
+++ b/crates/mvm-contract/src/plan/execution_plan.rs
@@ -432,6 +432,54 @@ mod tests {
 
     use super::*;
 
+    /// A plan written before `sdk_uses_sidecar` existed must deserialize as
+    /// *requiring* the sidecar, not forbidding one.
+    ///
+    /// The field is a two-sided assertion: admission reads `true` as "the
+    /// sidecar must be attached" and `false` as "it must not be"
+    /// (`enforce_sdk_sidecar_attachment`). So the default is not a tie-break
+    /// between equivalent options — one of them refuses to admit every plan
+    /// that predates the field, and it is the one a bare `#[serde(default)]`
+    /// would pick, because `bool::default()` is `false`.
+    ///
+    /// Four PRs proposed exactly that substitution. This test is what makes
+    /// the fifth fail in CI instead of in production.
+    #[test]
+    fn an_absent_sdk_uses_sidecar_defaults_to_requiring_the_sidecar() {
+        let plan = minimal_plan();
+        let mut value = serde_json::to_value(&plan).expect("plan serializes");
+        value
+            .as_object_mut()
+            .expect("plan is a JSON object")
+            .remove("sdk_uses_sidecar");
+
+        let back: ExecutionPlan =
+            serde_json::from_value(value).expect("a plan without the field still deserializes");
+        assert!(
+            back.sdk_uses_sidecar,
+            "an absent sdk_uses_sidecar must default to true; false makes admission \
+             refuse the sidecar for every plan written before the field existed"
+        );
+    }
+
+    /// The serialized default and the synthesized value are one decision.
+    ///
+    /// `synthesize_plan` hardcodes `true`, so a default of `false` would mean a
+    /// round-trip through JSON changed a plan's meaning depending only on
+    /// whether the field happened to be written. Pinning them together is
+    /// cheaper than discovering the divergence through an admission refusal.
+    #[test]
+    fn the_sdk_sidecar_default_matches_what_synthesis_produces() {
+        assert!(
+            default_sdk_uses_sidecar(),
+            "the serde default must equal the value plan synthesis writes"
+        );
+        assert!(
+            minimal_plan().sdk_uses_sidecar,
+            "the canonical minimal plan must carry the same answer"
+        );
+    }
+
     #[test]
     fn default_network_limits_preserve_existing_signed_bytes() {
         let plan = minimal_plan();

--- a/xtask/dormant-controls.toml
+++ b/xtask/dormant-controls.toml
@@ -34,6 +34,28 @@ indistinguishable from an unbounded one. Losing its caller in the CLI start \
 path puts it straight back there."""
 
 [[control]]
+symbol = "default_sdk_uses_sidecar"
+file = "crates/mvm-contract/src/plan/execution_plan.rs"
+dormant = true
+why = """
+`ExecutionPlan::sdk_uses_sidecar` is a two-sided assertion — `true` makes \
+admission *require* the SDK sidecar, `false` makes it *forbid* one — but no \
+production path can produce `false`. Both construction sites hardcode `true` \
+(`plan/synthesis.rs`, `commands/vm/policy_resolver.rs`), there is no CLI flag, \
+and no workload IR field feeds it, so the forbidding half is reachable only by \
+hand-building a plan in a test.
+
+That is what makes this entry worth having. The default is the only observable \
+thing about the field, so it attracted four separate PRs proposing to change \
+it, one of which would have flipped it to `false` and refused the sidecar for \
+every signed plan predating the field. A dormant control whose only visible \
+knob is its default invites exactly that.
+
+Wiring it — a launch-time way to declare a workload speaks the broker protocol \
+directly — is issue #3068's work. This entry fails the moment that lands and \
+`false` becomes producible, which is the signal to delete it."""
+
+[[control]]
 symbol = "enforced_grants_after_start"
 file = "crates/mvm-client/src/boot.rs"
 dormant = false


### PR DESCRIPTION
Fix CI failures for sdk_uses_sidecar by pinning the default and adding tests.

Generated with Qwen Code