### PR TITLE
Flush writable OCI disks before teardown

### DIFF
--- a/crates/mvm-agentd/src/bin/mvm-exit-report.rs
+++ b/crates/mvm-agentd/src/bin/mvm-exit-report.rs
@@ -30,7 +30,7 @@ fn main() -> ExitCode {
     // Ordered before `report` so the bytes are on their way to the disk while
     // the exit round-trip is in flight, and unconditional: the guest cannot
     // know which of its mounts the host cares about.
-    flush_filesystems();
+    mvm_agentd::filesystem_sync::flush_filesystems();
     match report(code) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
@@ -39,21 +39,6 @@ fn main() -> ExitCode {
         }
     }
 }
-
-/// `sync(2)` — schedule every dirty page for writeback.
-///
-/// Best-effort and infallible by design: `sync` cannot fail in a way this
-/// helper could act on, and a guest must never block or abort its exit path
-/// over a flush.
-#[cfg(target_os = "linux")]
-fn flush_filesystems() {
-    // SAFETY: `sync` takes no arguments, returns nothing, and has no failure
-    // mode to check.
-    unsafe { libc::sync() };
-}
-
-#[cfg(not(target_os = "linux"))]
-fn flush_filesystems() {}
 
 #[cfg(target_os = "linux")]
 fn report(code: i32) -> std::io::Result<()> {

--- a/crates/mvm-agentd/src/bin/mvm-guest-agent/handlers.rs
+++ b/crates/mvm-agentd/src/bin/mvm-guest-agent/handlers.rs
@@ -33,23 +33,27 @@ use crate::socket::write_response;
 
 /// Sync filesystems and drop page cache.
 fn do_sleep_prep() -> (bool, String) {
-    // Sync all filesystems.
-    let sync_ok = std::process::Command::new("sync")
-        .status()
-        .is_ok_and(|s| s.success());
+    do_sleep_prep_with(mvm_agentd::filesystem_sync::flush_filesystems, || {
+        std::fs::write("/proc/sys/vm/drop_caches", "3").is_ok()
+    })
+}
 
-    // Drop page cache (requires root, best-effort).
-    let drop_ok = std::fs::write("/proc/sys/vm/drop_caches", "3").is_ok();
+fn do_sleep_prep_with(
+    flush_filesystems: impl FnOnce(),
+    drop_page_cache: impl FnOnce() -> bool,
+) -> (bool, String) {
+    // The direct syscall is part of the runtime agent, so even a scratch OCI
+    // image with no `sync` executable can acknowledge durable teardown.
+    flush_filesystems();
+    let drop_ok = drop_page_cache();
 
-    if sync_ok && drop_ok {
+    if drop_ok {
         (true, "filesystems synced, page cache dropped".to_string())
-    } else if sync_ok {
+    } else {
         (
             true,
             "filesystems synced, page cache drop failed (non-root?)".to_string(),
         )
-    } else {
-        (false, "sync failed".to_string())
     }
 }
 
@@ -933,5 +937,36 @@ pub(crate) fn handle_update_idle_timeout(secs: u64) -> GuestResponse {
             previous_secs: 0,
             applied_secs: 0,
         },
+    }
+}
+
+#[cfg(test)]
+mod sleep_prep_tests {
+    use std::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn sleep_prep_flushes_before_dropping_cache_and_acknowledging() {
+        let flushed = Cell::new(false);
+        let (success, detail) = do_sleep_prep_with(
+            || flushed.set(true),
+            || {
+                assert!(flushed.get(), "cache drop must follow the filesystem flush");
+                true
+            },
+        );
+
+        assert!(success);
+        assert_eq!(detail, "filesystems synced, page cache dropped");
+    }
+
+    #[test]
+    fn cache_drop_failure_does_not_downgrade_a_completed_flush() {
+        let (success, detail) = do_sleep_prep_with(|| {}, || false);
+
+        assert!(success);
+        assert!(detail.contains("filesystems synced"), "{detail}");
+        assert!(detail.contains("cache drop failed"), "{detail}");
     }
 }

--- a/crates/mvm-agentd/src/filesystem_sync.rs
+++ b/crates/mvm-agentd/src/filesystem_sync.rs
@@ -1,0 +1,16 @@
+//! Guest-wide filesystem flush used by every forced-shutdown path.
+
+/// Schedule every dirty filesystem page for writeback before the host tears
+/// down the VM.
+///
+/// Linux `sync(2)` has no error return. The non-Linux stub keeps host-side
+/// workspace builds portable; this code runs for real only inside Linux guests.
+#[cfg(target_os = "linux")]
+pub fn flush_filesystems() {
+    // SAFETY: `sync` takes no arguments, returns nothing, and has no failure
+    // mode to inspect.
+    unsafe { libc::sync() };
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn flush_filesystems() {}

--- a/crates/mvm-agentd/src/lib.rs
+++ b/crates/mvm-agentd/src/lib.rs
@@ -38,6 +38,8 @@ pub mod entrypoint;
 pub mod entrypoint_stream;
 /// Boot-validated optional extension executables.
 pub mod extension;
+/// Guest-wide filesystem flush shared by forced-shutdown paths.
+pub mod filesystem_sync;
 /// Guest-side FlowMux client for the converged single networking path.
 #[cfg(feature = "flowmux-async")]
 pub mod flowmux;

--- a/crates/mvm-agentd/src/vsock/api.rs
+++ b/crates/mvm-agentd/src/vsock/api.rs
@@ -21,8 +21,16 @@ pub fn query_worker_status(instance_dir: &str) -> Result<GuestResponse> {
 /// Ok(false) if guest NAKed or timed out.
 pub fn request_sleep_prep(instance_dir: &str, drain_timeout_secs: u64) -> Result<bool> {
     let mut stream = connect(instance_dir, drain_timeout_secs)?;
-    let resp = send_request(&mut stream, &GuestRequest::SleepPrep { drain_timeout_secs })?;
+    request_sleep_prep_on(&mut stream, drain_timeout_secs)
+}
 
+/// Request sleep preparation on an already-connected backend-agnostic stream.
+pub fn request_sleep_prep_on(stream: &mut UnixStream, drain_timeout_secs: u64) -> Result<bool> {
+    let resp = send_request(stream, &GuestRequest::SleepPrep { drain_timeout_secs })?;
+    interpret_sleep_prep(resp)
+}
+
+fn interpret_sleep_prep(resp: GuestResponse) -> Result<bool> {
     match resp {
         GuestResponse::SleepPrepAck { success, .. } => Ok(success),
         GuestResponse::Error { message } => {
@@ -660,6 +668,31 @@ mod tests {
             })
             .is_err()
         );
+    }
+
+    #[test]
+    fn sleep_prep_response_requires_a_successful_ack() {
+        assert!(
+            interpret_sleep_prep(GuestResponse::SleepPrepAck {
+                success: true,
+                detail: Some("filesystems synced".into()),
+            })
+            .unwrap()
+        );
+        assert!(
+            !interpret_sleep_prep(GuestResponse::SleepPrepAck {
+                success: false,
+                detail: Some("sync failed".into()),
+            })
+            .unwrap()
+        );
+        assert!(
+            interpret_sleep_prep(GuestResponse::Error {
+                message: "agent refused".into(),
+            })
+            .is_err()
+        );
+        assert!(interpret_sleep_prep(GuestResponse::Pong).is_err());
     }
 
     #[test]

--- a/crates/mvm-agentd/src/vsock/mod.rs
+++ b/crates/mvm-agentd/src/vsock/mod.rs
@@ -37,9 +37,9 @@ pub use api::{
     post_restore_with_grant_at, query_fs_diff, query_fs_diff_at, query_fs_diff_on,
     query_integration_status, query_integration_status_at, query_primed_at, query_probe_status,
     query_probe_status_at, query_resource_usage, query_resource_usage_at, query_worker_status,
-    query_worker_status_at, request_sleep_prep, send_fs_request, send_fs_request_on,
-    send_proc_request, send_proc_request_on, send_proc_wait, send_proc_wait_on, signal_wake,
-    workload_is_primed_at,
+    query_worker_status_at, request_sleep_prep, request_sleep_prep_on, send_fs_request,
+    send_fs_request_on, send_proc_request, send_proc_request_on, send_proc_wait, send_proc_wait_on,
+    signal_wake, workload_is_primed_at,
 };
 pub use connection::{
     HOST_CID, connect_host_vsock, connect_to, connect_to_port, connect_to_port_once, send_request,

--- a/crates/mvm-cli/src/commands/shared/mod.rs
+++ b/crates/mvm-cli/src/commands/shared/mod.rs
@@ -22,11 +22,11 @@ pub(super) use format::{human_age_secs, human_bytes};
 pub(in crate::commands) use grants::{GrantInputs, enforced_network_policy, resolve_run_grants};
 pub(super) use hints::with_hints;
 pub(crate) use parse::AssetSpec;
+pub(crate) use parse::materialize_disk_volume;
 pub(crate) use parse::{DirShareSpec, parse_dir_share_spec};
 pub(super) use parse::{
-    VolumeSpec, clap_flake_ref, clap_port_spec, clap_vm_name, clap_volume_spec,
-    materialize_disk_volume, parse_asset_spec, parse_port_spec, parse_volume_spec,
-    validate_volume_spec, vm_volume_from_spec_validated,
+    VolumeSpec, clap_flake_ref, clap_port_spec, clap_vm_name, clap_volume_spec, parse_asset_spec,
+    parse_port_spec, parse_volume_spec, validate_volume_spec, vm_volume_from_spec_validated,
 };
 pub(super) use resolve::{
     ManifestArgRef, egress_enforcement_label, parse_peer_binding, resolve_effective_hypervisor,

--- a/crates/mvm-cli/src/commands/vm/exec.rs
+++ b/crates/mvm-cli/src/commands/vm/exec.rs
@@ -963,16 +963,18 @@ fn validate_run_profile(args: &RunArgs) -> Result<()> {
         // directory-specific rule to disks without revisiting it, and the
         // message it carried ("transient live shares are read-only") described
         // only the case it was written for.
-        let (read_only, shape) = match super::shared::parse_volume_spec(spec)? {
-            super::shared::VolumeSpec::DirShare { read_only, .. } => (read_only, "directory"),
-            super::shared::VolumeSpec::Disk { read_only, .. } => (read_only, "disk"),
-        };
-        if !read_only {
+        let parsed = super::shared::parse_volume_spec(spec)?;
+        if matches!(
+            parsed,
+            super::shared::VolumeSpec::DirShare {
+                read_only: false,
+                ..
+            }
+        ) {
             anyhow::bail!(
-                "--mount '{spec}' requests rw, but a transient run attaches every {shape} \
-                 read-only. Nothing a transient guest writes reaches the host. For a writable \
-                 volume, register one with `mvmctl machine volume mount` and boot the machine \
-                 with `mvmctl machine start`."
+                "--mount '{spec}' requests rw, but a transient directory snapshot is read-only. \
+                 Writes to the snapshot would not reach the host directory. Use a sized disk \
+                 (`HOST:/GUEST:SIZE:rw`) or register a persistent machine volume."
             );
         }
     }
@@ -1237,18 +1239,6 @@ fn build_exec_request(
     };
     let memory_mib = parse_human_size(&args.memory).context("Invalid --memory")?;
     let mounts = parse_transient_mounts(&args.mounts)?;
-    // Hold every disk image's sidecar lock for as long as this run owns the
-    // VM. `ensure_persistent_volume_image` has always taken the lock, and
-    // `materialize_disk_volume` has always dropped it on the way out — which
-    // was harmless while every transient mount was read-only, and is not once
-    // a disk can be attached `rw`: two runs naming one image would both format
-    // and write it. `_disk_locks` must outlive the boot, so it is bound rather
-    // than discarded.
-    let _disk_locks: Vec<_> = mounts
-        .disk_volumes
-        .iter()
-        .map(super::shared::materialize_disk_volume)
-        .collect::<Result<Vec<_>>>()?;
     let mut env_pairs = Vec::with_capacity(args.env.len());
     for kv in &args.env {
         env_pairs.push(parse_env_pair(kv)?);
@@ -2111,14 +2101,11 @@ mod tests {
         }
     }
 
-    /// Both shapes are refused `rw`, and the message names the one it got.
-    ///
-    /// Enabling `rw` for the *disk* shape is a live question, not a hypothetical
-    /// — it was measured working end to end and then reverted, because an OCI
-    /// guest has no flush on teardown and the write is lost unless the workload
-    /// syncs. See `specs/plans/2026-09-02-workload-output-affordance.md`.
+    /// A directory remains read-only because its transient snapshot is thrown
+    /// away. A sized disk names a persistent caller-owned image and can be
+    /// writable once teardown flushes the guest before stopping the VMM.
     #[test]
-    fn a_transient_rw_refusal_names_the_shape_it_refused() {
+    fn transient_rw_policy_distinguishes_directory_snapshots_from_sized_disks() {
         let dir_err = {
             let mut args = run_args(RunProfile::Standard);
             args.mounts.push("/h/src:/work:rw".to_string());
@@ -2126,28 +2113,24 @@ mod tests {
         };
         assert!(dir_err.to_string().contains("directory"), "{dir_err}");
 
-        let disk_err = {
-            let mut args = run_args(RunProfile::Standard);
-            args.mounts.push("/h/data.img:/work:2G:rw".to_string());
-            validate_run_profile(&args).expect_err("rw must be refused")
-        };
-        let msg = disk_err.to_string();
-        assert!(msg.contains("disk"), "{msg}");
+        let mut disk_args = run_args(RunProfile::Standard);
+        disk_args.mounts.push("/h/data.img:/work:2G:rw".to_string());
         assert!(
-            !msg.contains("live share"),
-            "a sized disk is not a live share: {msg}"
+            validate_run_profile(&disk_args).is_ok(),
+            "a persistent sized disk should accept rw"
         );
     }
 
-    /// The refusal is a dead end unless it says where writable volumes live.
+    /// The directory refusal is a dead end unless it names the writable disk
+    /// shape that preserves guest writes at the caller's path.
     #[test]
-    fn the_rw_refusal_points_at_the_path_that_can_write() {
+    fn the_directory_rw_refusal_points_at_sized_disks() {
         let mut args = run_args(RunProfile::Standard);
         args.mounts.push("/h/src:/work:rw".to_string());
         let msg = validate_run_profile(&args)
             .expect_err("rw must be refused")
             .to_string();
-        assert!(msg.contains("machine start"), "{msg}");
+        assert!(msg.contains("HOST:/GUEST:SIZE:rw"), "{msg}");
     }
 
     /// `Default` is hand-written, so it can drift from the `default_value`

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -47,7 +47,10 @@ pub use session::{
     AdmitInputs, SessionAdmit, SessionAuditSubstrate, SessionVm, boot_session_vm,
     dispatch_in_session, tear_down_session_vm, wait_for_agent,
 };
-use transient::{BootAttempt, boot_transient_vm, install_ctrlc_teardown, teardown_transient_vm};
+use transient::{
+    BootAttempt, boot_transient_vm, combine_run_and_flush, flush_writable_disks_before_teardown,
+    install_ctrlc_teardown, teardown_transient_vm,
+};
 
 pub const EXEC_TIMEOUT_EXIT_CODE: i32 = 124;
 
@@ -647,6 +650,15 @@ fn run_inner(
     let mut sub_marks = crate::commands::vm::phase_timing::LaunchSubMarks::new(timing);
     let t_start = timing.then(std::time::Instant::now);
 
+    // Keep every writable disk image's sidecar lock alive until after the VM
+    // has flushed and stopped. Materializing during request construction used
+    // to drop these guards before `run_inner` was even called.
+    let _disk_locks = req
+        .disk_volumes
+        .iter()
+        .map(crate::commands::shared::materialize_disk_volume)
+        .collect::<Result<Vec<_>>>()?;
+
     // Everything from backend selection through admission and the runtime
     // overlay attach. It yields a bootable config without booting, which is
     // also what `pool warm` needs — so it lives in one function both call
@@ -743,6 +755,10 @@ fn run_inner(
         Ok((either, vsock_ready)) => (Ok(either), vsock_ready),
         Err(e) => (Err(e), None),
     };
+    result = combine_run_and_flush(
+        result,
+        flush_writable_disks_before_teardown(&vm_name, &req.disk_volumes),
+    );
     let warm_memory_result = warm_memory_start.map(|start| {
         start.and_then(|start| finish_warm_memory_measurement(&backend, &vm_name, start))
     });

--- a/crates/mvm-cli/src/exec/transient.rs
+++ b/crates/mvm-cli/src/exec/transient.rs
@@ -161,6 +161,65 @@ pub(super) fn install_ctrlc_teardown(
     interrupted
 }
 
+pub(super) fn has_writable_disk(volumes: &[VmVolume]) -> bool {
+    volumes
+        .iter()
+        .any(|volume| volume.kind == mvm_core::vm_backend::VmVolumeKind::Disk && !volume.read_only)
+}
+
+/// Ask the authenticated guest agent to flush every filesystem before the VMM
+/// is force-stopped. The existing sleep-preparation verb is a control-plane
+/// lifecycle operation and adds no new guest capability or transport surface.
+pub(super) fn flush_writable_disks_before_teardown(
+    vm_name: &str,
+    volumes: &[VmVolume],
+) -> Result<()> {
+    if !has_writable_disk(volumes) {
+        return Ok(());
+    }
+
+    let transport = vsock_transport::for_vm(vm_name)
+        .with_context(|| format!("resolving guest transport for '{vm_name}' filesystem flush"))?;
+    let mut stream = transport
+        .connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
+        .with_context(|| format!("connecting to guest '{vm_name}' for filesystem flush"))?;
+    let timeout = std::time::Duration::from_secs(mvm_agentd::vsock::DEFAULT_TIMEOUT_SECS);
+    stream
+        .set_read_timeout(Some(timeout))
+        .context("bounding the guest filesystem-flush response")?;
+    stream
+        .set_write_timeout(Some(timeout))
+        .context("bounding the guest filesystem-flush request")?;
+
+    let verb = "sleep-prep";
+    mvm_core::audit_emit!(
+        NetworkPolicyAllow,
+        vm: vm_name,
+        "scope=rpc,direction=in,kind=vsock,verb={verb}",
+        verb = verb,
+    );
+    let acknowledged = mvm_agentd::vsock::request_sleep_prep_on(
+        &mut stream,
+        mvm_agentd::vsock::DEFAULT_TIMEOUT_SECS,
+    )
+    .with_context(|| format!("requesting guest '{vm_name}' filesystem flush"))?;
+    if !acknowledged {
+        anyhow::bail!("guest '{vm_name}' did not acknowledge its filesystem flush");
+    }
+    Ok(())
+}
+
+pub(super) fn combine_run_and_flush<T>(run: Result<T>, flush: Result<()>) -> Result<T> {
+    match (run, flush) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Ok(_), Err(flush_error)) => Err(flush_error),
+        (Err(run_error), Ok(())) => Err(run_error),
+        (Err(run_error), Err(flush_error)) => Err(run_error.context(format!(
+            "guest filesystem flush also failed before teardown: {flush_error:#}"
+        ))),
+    }
+}
+
 /// Tear down the transient VM after the guest command finishes (or fails to
 /// dispatch): stop the backend VM, top up the warm pool toward its target,
 /// and remove the host VM state directory (`~/.mvm/vms/<name>`), which includes
@@ -283,6 +342,50 @@ pub(super) fn restore_via_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn volume(kind: mvm_core::vm_backend::VmVolumeKind, read_only: bool) -> VmVolume {
+        VmVolume {
+            kind,
+            read_only,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn only_a_writable_disk_requires_a_pre_teardown_flush() {
+        let writable_disk = volume(mvm_core::vm_backend::VmVolumeKind::Disk, false);
+        let read_only_disk = volume(mvm_core::vm_backend::VmVolumeKind::Disk, true);
+        let directory = volume(mvm_core::vm_backend::VmVolumeKind::DirShare, false);
+
+        assert!(has_writable_disk(&[writable_disk]));
+        assert!(!has_writable_disk(&[read_only_disk]));
+        assert!(!has_writable_disk(&[directory]));
+        assert!(!has_writable_disk(&[]));
+    }
+
+    #[test]
+    fn a_flush_failure_replaces_success_and_preserves_a_run_failure() {
+        let flush_failed = anyhow::anyhow!("flush unavailable");
+        let error = combine_run_and_flush::<i32>(Ok(0), Err(flush_failed))
+            .expect_err("a successful workload cannot hide a failed flush");
+        assert!(error.to_string().contains("flush unavailable"), "{error:#}");
+
+        let run_failed = anyhow::anyhow!("workload failed");
+        let flush_failed = anyhow::anyhow!("flush unavailable");
+        let error = combine_run_and_flush::<i32>(Err(run_failed), Err(flush_failed))
+            .expect_err("both failures must remain an error");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("workload failed"), "{rendered}");
+        assert!(rendered.contains("flush unavailable"), "{rendered}");
+    }
+
+    #[test]
+    fn a_successful_flush_preserves_the_workload_outcome() {
+        assert_eq!(combine_run_and_flush(Ok(7), Ok(())).unwrap(), 7);
+        let error = combine_run_and_flush::<i32>(Err(anyhow::anyhow!("workload failed")), Ok(()))
+            .expect_err("a flush must not hide the workload failure");
+        assert!(error.to_string().contains("workload failed"), "{error:#}");
+    }
 
     #[test]
     fn warm_claim_cleanup_removes_requested_and_effective_state_dirs() {

--- a/features/suites/s0_cli/machine_run_contract.feature
+++ b/features/suites/s0_cli/machine_run_contract.feature
@@ -89,6 +89,14 @@ Feature: machine run request contract
     And the output contains "cpus=4"
     And the output contains "memory=1G (1024 MiB)"
 
+  # A sized disk persists at the caller's path. Unlike a directory snapshot,
+  # writes are not thrown away, and foreground teardown flushes the guest before
+  # the VMM releases the image.
+  Scenario: machine run accepts a writable sized disk
+    When I run mvmctl with "machine run --image alpine --dry-run --mount /tmp/mvm-bdd-output.img:/data:64M:rw -- /bin/true" and an isolated mvm home
+    Then the command exits with code 0
+    And the output contains "no VM will be booted"
+
   # Inference decides which image boots. It must not decide anything else: a
   # detected run carries the same profile and the same deny-all egress as one
   # that named its image, or the convenience would be a policy bypass.

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,8 +1,20 @@
 # Refactor status
 
-Last updated: 2026-09-02
+Last updated: 2026-09-03
 
 ## In progress
+
+- [ ] **Workload output affordance — durable writable inline disks.**
+      `specs/plans/2026-09-02-workload-output-affordance.md`.
+      Foreground transient runs now flush writable disks through the existing
+      authenticated guest-agent `SleepPrep` request before forced teardown.
+      The OCI-safe handler uses `sync(2)` directly, shares that implementation
+      with the detached exit reporter, treats a failed flush as a run failure,
+      and holds caller-owned image locks through teardown. Sized writable disk
+      mounts are admitted while directory snapshots remain read-only. A
+      no-explicit-sync write survived a second fresh Alpine VM on macOS HVF;
+      gated compilation, the full workspace nextest suite, doc tests, all-targets Clippy,
+      policy checks, and BDD are green. Broader surface design and merge remain.
 
 - [x] **Cargo target-dir guard.**
       `specs/plans/2026-09-02-cargo-target-dir-guard.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,18 @@
 
 ## In progress
 
+- [ ] **Workload output affordance — durable writable inline disks.**
+      `specs/plans/2026-09-02-workload-output-affordance.md`.
+      Foreground transient runs with writable sized disks now issue the
+      existing authenticated `SleepPrep` request before VM stop; arbitrary OCI
+      guests flush through a direct `sync(2)` helper shared with the detached
+      exit reporter. Flush refusal fails an otherwise successful run, disk
+      image locks remain held through teardown, and directory snapshots remain
+      read-only. A no-explicit-sync write survived into a second fresh Alpine
+      VM on macOS HVF. Gated compilation, the full workspace nextest suite, doc
+      tests, all-targets zero-warning Clippy, policy checks, and BDD are green;
+      the plan's broader output-surface design and merge delivery remain.
+
 - [ ] **Content-addressed asset identity.**
       `specs/plans/2026-09-02-content-addressed-asset-identity.md`.
       Every dataset, model, prompt, agent, policy, and compute environment a

--- a/specs/plans/2026-09-02-workload-output-affordance.md
+++ b/specs/plans/2026-09-02-workload-output-affordance.md
@@ -3,7 +3,7 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status: NOT STARTED — design only.**
+**Status: IN PROGRESS — OCI teardown flush complete; surface design remains.**
 
 ## The gap, measured
 
@@ -74,7 +74,7 @@ So the blocker on `rw` is not policy, and not the lock. It is that a workload's
 writes are not durable unless it happens to sync, and losing data quietly is
 worse than refusing to write.
 
-- [ ] **Flush the OCI guest before teardown.** That is the whole prerequisite
+- [x] **Flush the OCI guest before teardown.** That is the whole prerequisite
       for making `HOST:/GUEST:SIZE:rw` safe, and it makes this plan's remaining
       scope much smaller: with a durable writable disk, a workload hands results
       back through an ordinary ext4 image the host reads with `ext4-view`, and
@@ -84,11 +84,25 @@ worse than refusing to write.
       **detached** path (its reaper is the only caller) and is correct there.
       The non-detached OCI run does not go through it — that is the gap.
 
-**Groundwork already landed** so the flag is one flush away rather than a
-rewrite: `materialize_disk_volume` now returns the `VolumeImageLock` instead of
-discarding it, and the transient run holds it for the VM's lifetime. The
-exclusion always existed and was released before boot, which was harmless only
-because every transient mount was read-only.
+      The foreground path now reuses the authenticated `SleepPrep` request
+      before stopping a transient VM whenever it carries a writable disk. The
+      guest handler calls `sync(2)` directly, so an arbitrary OCI image does
+      not need to contain a `sync` executable; the detached exit reporter uses
+      the same helper. A failed request makes an otherwise successful run fail
+      rather than silently claiming durability. This adds no verb, transport,
+      grant, or guest-to-host data path.
+
+      Live macOS HVF evidence used two fresh Alpine OCI VMs and one caller-owned
+      64 MiB image. The first wrote `mvm-oci-flush-survived-20260903` without an
+      explicit `sync`; the second mounted the image read-only and returned the
+      exact marker. `check-gated`, the full workspace nextest suite, workspace doc
+      tests, all-targets zero-warning Clippy, `check-all`, and BDD are green.
+
+**Lock groundwork had already landed** so the flag was one flush away rather
+than a rewrite: `materialize_disk_volume` returns the `VolumeImageLock` instead
+of discarding it. The foreground call site was still acquiring that guard in
+request construction and dropping it before boot; this work moves acquisition
+into the run lifecycle and holds the guard through the flush and teardown.
 
 ## Shape to build
 


### PR DESCRIPTION
## Summary

- flush writable transient disks through the existing authenticated SleepPrep path before forced foreground teardown
- share the direct sync(2) helper with the detached exit reporter and hold image locks through flush and stop
- admit sized writable inline disks while keeping transient directory snapshots read-only

## Security

- reuses the existing authenticated guest-agent verb and transport
- adds no new guest capability, network path, grant, or host-filesystem exposure
- treats flush failure as a run failure instead of silently claiming durability

## Validation

- live macOS HVF: an Alpine write without explicit sync survived and was read by a second fresh VM
- just check-gated
- cargo nextest run --workspace (13,048 passed)
- cargo test --workspace --doc
- cargo clippy --workspace --all-targets -- -D warnings
- cargo run -p xtask -- check-all (68 gates)
- just bdd (248 scenarios: 247 passed, 1 intentional skip; 73 tagged scenarios not run)