### PR TITLE
fix(vmm): retry a rebuilt helper probe timeout

### DIFF
--- a/crates/mvm-vmm/src/host/aux_bin.rs
+++ b/crates/mvm-vmm/src/host/aux_bin.rs
@@ -235,7 +235,16 @@ fn recover_stale_helper(
     ));
     plan.run(env)?;
     let rebuilt = resolve_from(spec, lookup)?;
-    match probe_contract(&rebuilt, env.probe_timeout) {
+    let mut rebuilt_probe = probe_contract(&rebuilt, env.probe_timeout);
+    if matches!(rebuilt_probe, ProbeOutcome::TimedOut) {
+        // A freshly linked macOS executable can miss its first bounded launch
+        // deadline while the host validates it, then answer immediately on the
+        // next exec. Cargo already completed successfully, so give only this
+        // post-build timeout one retry; malformed and wrong-version answers
+        // still fail closed without retrying.
+        rebuilt_probe = probe_contract(&rebuilt, env.probe_timeout);
+    }
+    match rebuilt_probe {
         ProbeOutcome::Answered(version)
             if version == helper_contract::HOST_HELPER_CONTRACT_VERSION =>
         {
@@ -568,6 +577,31 @@ mod tests {
         "#!/bin/sh\nexit 0\n".to_string()
     }
 
+    /// A stand-in for `cargo` whose freshly rebuilt helper stalls only on its
+    /// first probe, then answers normally on the next invocation.
+    fn cargo_with_transient_first_probe(bin: &str, marker: &Path) -> String {
+        format!(
+            "#!/bin/sh\n\
+             profile=debug\n\
+             for arg in \"$@\"; do\n\
+             \x20   if [ \"$arg\" = \"--release\" ]; then profile=release; fi\n\
+             done\n\
+             mkdir -p \"target/$profile\"\n\
+             cat > \"target/$profile/{bin}\" <<'PROBE_EOF'\n\
+             #!/bin/sh\n\
+             if [ ! -f '{marker}' ]; then\n\
+             \x20   touch '{marker}'\n\
+             \x20   sleep 1\n\
+             \x20   exit 0\n\
+             fi\n\
+             printf '%s\\n' '{bin} contract-version={current}'\n\
+             PROBE_EOF\n\
+             chmod +x \"target/$profile/{bin}\"\n",
+            marker = marker.display(),
+            current = helper_contract::HOST_HELPER_CONTRACT_VERSION,
+        )
+    }
+
     /// A stand-in for `cargo` that leaves a marker file when run, so tests
     /// can assert no rebuild was attempted.
     fn marker_cargo(marker: &Path) -> String {
@@ -698,6 +732,33 @@ mod tests {
             .to_string();
         assert!(err.contains("did not produce a helper"), "{err}");
         assert!(err.contains("cargo build -p mvm-hostd --bins"), "{err}");
+    }
+
+    #[test]
+    fn verified_resolve_retries_a_transient_timeout_after_rebuild() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = scratch_checkout(tmp.path());
+        let stale = root.join("target/debug/mvm-hvf-supervisor");
+        write_exe(&stale, &answering_helper("mvm-hvf-supervisor", 0));
+
+        let marker = tmp.path().join("first-probe-started");
+        let cargo = tmp.path().join("cargo");
+        write_exe(
+            &cargo,
+            &cargo_with_transient_first_probe("mvm-hvf-supervisor", &marker),
+        );
+
+        let mut env = test_env(Some(root.clone()));
+        env.cargo = cargo;
+        env.probe_timeout = Duration::from_millis(250);
+        let lookup = Lookup {
+            override_path: None,
+            dirs: vec![root.join("target/release"), root.join("target/debug")],
+        };
+
+        let got = resolve_verified_in(&hvf_spec(), &lookup, &env).unwrap();
+        assert_eq!(got, root.join("target/debug/mvm-hvf-supervisor"));
+        assert!(marker.is_file());
     }
 
     #[test]

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -33,7 +33,10 @@ Last updated: 2026-09-03
       hard error naming both contract versions and the rebuild command,
       replacing the recurring silent cross-profile fallback that surfaced as
       an "unknown field" spawn failure. A `HvfSupervisorConfig` shape pin
-      forces the contract version to bump with the schema. Focused
+      forces the contract version to bump with the schema. A freshly rebuilt
+      helper gets one retry only when its first bounded probe times out,
+      covering the observed macOS first-launch transient without accepting a
+      malformed or wrong-version helper. Focused
       regressions, affected crate suites, zero-warning Clippy, and Linux/BDD
       gated compilation are green; merged via #3132.
 

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -49,7 +49,9 @@
       anything else is a hard error naming both versions and the exact
       rebuild command. A shape pin on `HvfSupervisorConfig` forces the
       contract version to move with the schema. Focused resolver, probe, and
-      spawn-path regressions, the mvm-vmm / mvm-backends / mvm-hostd /
+      spawn-path regressions, including a follow-up for a freshly rebuilt
+      macOS helper whose first probe transiently times out, the mvm-vmm /
+      mvm-backends / mvm-hostd /
       mvm-runtime suites, zero-warning Clippy, and Linux/BDD gated
       compilation are green; merged via #3132.
 

--- a/specs/plans/2026-09-02-aux-helper-contract.md
+++ b/specs/plans/2026-09-02-aux-helper-contract.md
@@ -36,3 +36,9 @@ silent fallback is gone.
 - [x] Tests green on host; workspace clippy and gated-target checks green in
       the builder VM.
 - [x] `specs/SPRINT.md` updated; merged via #3132 (squash `2eff78c623`).
+- [x] Follow-up: retry one transient timeout from the freshly rebuilt helper.
+      A real macOS launch showed Cargo completing the rebuild and writing a
+      current helper, while its immediate first contract probe missed the
+      ten-second deadline; the same binary answered in milliseconds afterward.
+      The retry remains restricted to this post-build timeout and a focused
+      regression covers timeout-then-answer recovery.


### PR DESCRIPTION
## Problem

A stale mvm-hvf-supervisor was correctly detected and rebuilt, but the freshly linked macOS binary's immediate contract probe timed out once. The rebuilt helper answered in milliseconds afterward, so machine run discarded a valid rebuild after several minutes of work.

The existing regression used an instant fake helper and covered only a successful first post-build probe. The live launch gate also prebuilds fresh helpers, so it never exercises stale-helper recovery; hosted CI has no Apple Silicon HVF runner, tracked by #3011.

## Fix

Retry exactly once when, and only when, the freshly rebuilt helper's first bounded contract probe times out. Wrong contract versions, malformed answers, failed builds, path overrides, and helpers outside the checkout continue to fail closed without retrying.

Add a regression for stale helper to successful rebuild to transient first-probe timeout to valid second answer, and update the active plan, sprint, and refactor rollup.

## Validation

- cargo test -p mvm-vmm host::aux_bin::tests: 24 passed
- new regression demonstrated red before the fix and green after it
- cargo check --workspace: passed
- cargo clippy --workspace --all-targets -- -D warnings: passed
- pre-commit workspace Clippy and mvm-vmm all-targets Clippy: passed
- cargo test --workspace progressed through the changed crate and thousands of passing tests, then hit unrelated timing flake mvm-observability::repeated_calls_accumulate_into_one_row; isolated rerun passed
