### PR TITLE
refactor(volume): retire runtime directory-share kinds

### DIFF
--- a/crates/mvm-backends/src/driver/libkrun_process.rs
+++ b/crates/mvm-backends/src/driver/libkrun_process.rs
@@ -340,7 +340,7 @@ pub fn attach_workload_rootfs(mut krun: KrunContext, config: &VmStartConfig) -> 
 /// coordination key the guest mount manifest uses at the requested guest path.
 pub fn attach_user_volumes(mut krun: KrunContext, config: &VmStartConfig) -> Result<KrunContext> {
     for (idx, vol) in config.volumes.iter().enumerate() {
-        krun = attach_user_volume(krun, idx, vol)?;
+        krun = attach_user_volume(krun, idx, vol);
     }
     Ok(krun)
 }
@@ -349,19 +349,12 @@ fn attach_user_volume(
     krun: KrunContext,
     index: usize,
     volume: &mvm_core::vm_backend::VmVolume,
-) -> Result<KrunContext> {
-    if !volume.attaches_as_block() {
-        bail!(
-            "libkrun requires directory volume '{}' -> '{}' to have a materialized block image",
-            volume.host,
-            volume.guest
-        );
-    }
-    Ok(krun.add_disk(
+) -> KrunContext {
+    krun.add_disk(
         format!("uvol{index}"),
         volume.block_source().to_string(),
         volume.read_only,
-    ))
+    )
 }
 
 /// Assemble the per-workload [`KrunContext`]: the workload-independent base
@@ -679,7 +672,7 @@ pub(crate) fn cleanup_vsock_sockets(state_dir: &Path) {
 mod tests {
     use super::attach_user_volume;
     use libkrun_sys::KrunContext;
-    use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+    use mvm_core::vm_backend::VmVolume;
 
     fn context() -> KrunContext {
         KrunContext::new("volume-test", "/kernel", "/rootfs")
@@ -691,13 +684,11 @@ mod tests {
             host: "/granted/source".into(),
             guest: "/data".into(),
             read_only: true,
-            kind: VmVolumeKind::DirShare,
             materialized_image: Some("/state/source.ext4".into()),
             ..VmVolume::default()
         };
 
-        let krun = attach_user_volume(context(), 2, &volume)
-            .expect("a materialized directory grant is attachable");
+        let krun = attach_user_volume(context(), 2, &volume);
         assert_eq!(krun.extra_disks.len(), 1);
         assert_eq!(krun.extra_disks[0].id, "uvol2");
         assert_eq!(krun.extra_disks[0].path, "/state/source.ext4");
@@ -706,30 +697,14 @@ mod tests {
     }
 
     #[test]
-    fn unmaterialized_directory_volume_is_refused() {
-        let volume = VmVolume {
-            host: "/granted/source".into(),
-            guest: "/data".into(),
-            kind: VmVolumeKind::DirShare,
-            ..VmVolume::default()
-        };
-
-        let error = attach_user_volume(context(), 0, &volume)
-            .expect_err("an unmaterialized directory grant must fail closed");
-        assert!(error.to_string().contains("materialized block image"));
-    }
-
-    #[test]
     fn disk_volume_attaches_its_declared_host_image() {
         let volume = VmVolume {
             host: "/images/data.ext4".into(),
             guest: "/data".into(),
-            kind: VmVolumeKind::Disk,
             ..VmVolume::default()
         };
 
-        let krun = attach_user_volume(context(), 1, &volume)
-            .expect("an ordinary disk volume is attachable");
+        let krun = attach_user_volume(context(), 1, &volume);
         assert_eq!(krun.extra_disks[0].id, "uvol1");
         assert_eq!(krun.extra_disks[0].path, "/images/data.ext4");
     }

--- a/crates/mvm-backends/src/driver/qemu_process.rs
+++ b/crates/mvm-backends/src/driver/qemu_process.rs
@@ -185,31 +185,13 @@ pub fn qemu_drive_args(config: &VmStartConfig) -> Vec<String> {
 }
 
 pub fn append_qemu_user_disks(drives: &mut Vec<String>, config: &VmStartConfig) {
-    drives.extend(
-        config
-            .volumes
-            .iter()
-            .filter(|volume| matches!(volume.kind, mvm_core::vm_backend::VmVolumeKind::Disk))
-            .map(|volume| {
-                let read_only = if volume.read_only { ",readonly=on" } else { "" };
-                format!("file={},if=virtio,format=raw{read_only}", volume.host)
-            }),
-    );
-}
-
-pub fn ensure_qemu_volumes_supported(config: &VmStartConfig) -> Result<()> {
-    if let Some(volume) = config
-        .volumes
-        .iter()
-        .find(|volume| matches!(volume.kind, mvm_core::vm_backend::VmVolumeKind::DirShare))
-    {
-        bail!(
-            "qemu directory-share volume '{}' -> '{}' is unsupported; use a disk-image volume",
-            volume.host,
-            volume.guest
-        );
-    }
-    Ok(())
+    drives.extend(config.volumes.iter().map(|volume| {
+        let read_only = if volume.read_only { ",readonly=on" } else { "" };
+        format!(
+            "file={},if=virtio,format=raw{read_only}",
+            volume.block_source()
+        )
+    }));
 }
 
 // ─── KVM / qemu probing ─────────────────────────────────────────────

--- a/crates/mvm-cli/src/commands/machine/mod.rs
+++ b/crates/mvm-cli/src/commands/machine/mod.rs
@@ -1523,6 +1523,19 @@ fn build_machine_volume_cfg(
     let mut volume_cfg = Vec::with_capacity(volume_specs.len());
     for volume in volume_specs {
         let spec = super::shared::parse_volume_spec(volume)?;
+        if let super::shared::VolumeSpec::DirShare {
+            host_dir,
+            guest_mount,
+            ..
+        } = &spec
+        {
+            bail!(
+                "persistent machine volume '{host_dir}' -> '{guest_mount}' cannot be attached: \
+                 a live host-directory share can't be expressed. Snapshot and register it with \
+                 `mvmctl machine volume mount <machine> --volume <name> --host {host_dir} \
+                 --guest {guest_mount}` before starting the machine."
+            );
+        }
         let vmv = super::shared::vm_volume_from_spec_validated(&spec)
             .with_context(|| format!("volume {volume:?}"))?;
         super::shared::materialize_disk_volume(&vmv)

--- a/crates/mvm-cli/src/commands/machine/tests.rs
+++ b/crates/mvm-cli/src/commands/machine/tests.rs
@@ -1075,6 +1075,23 @@ fn run_rw_volume_requires_dev_profile() {
 }
 
 #[test]
+fn persistent_directory_volume_refuses_with_the_snapshot_registration_path() {
+    let dir = tempfile::tempdir().expect("tmpdir");
+    let volume = format!("{}:/work:ro", dir.path().display());
+    let err = build_machine_volume_cfg(&[volume])
+        .expect_err("a persistent machine cannot carry a live directory share");
+    let message = err.to_string();
+    assert!(
+        message.contains("live host-directory share can't be expressed"),
+        "message: {message}"
+    );
+    assert!(
+        message.contains("machine volume mount"),
+        "message: {message}"
+    );
+}
+
+#[test]
 fn persistent_spec_reconnects_without_image_and_errors_when_absent() {
     // No `--image`: reconnect to the existing spec verbatim.
     let reconnect = parse_run(&["run", "--name", "web"]).expect("parse");

--- a/crates/mvm-cli/src/commands/pool.rs
+++ b/crates/mvm-cli/src/commands/pool.rs
@@ -973,9 +973,9 @@ fn compat_for_launch(backend: &dyn VmBackend, cfg: &VmStartConfig) -> Result<Sta
 /// child's own policy. A shared parent therefore holds nothing per-launch that
 /// could reach the next claim.
 ///
-/// `VmVolumeKind::DirShare` is included in the volume check. The current
-/// factory-parent path has no late attachment operation for a host path, so a
-/// live read-only share remains cold-path-only until the backend supplies one.
+/// Materialized directory grants are included in the volume check. The current
+/// factory-parent path has no late attachment operation for their image, so
+/// they remain cold-path-only.
 fn warm_eligible_launch(cfg: &VmStartConfig) -> bool {
     cfg.volumes.is_empty()
 }
@@ -1397,18 +1397,18 @@ mod tests {
     }
 
     #[test]
-    fn try_warm_claim_cold_with_directory_share_volume() {
+    fn try_warm_claim_cold_with_materialized_directory_volume() {
         use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
         let b = AnyBackend::from_hypervisor("libkrun");
         let mut c = eligible_cfg();
         c.volumes = vec![VmVolume {
-            materialized_image: None,
+            materialized_image: Some("/state/mount.ext4".to_string()),
             volume_label: None,
             host: "/h".into(),
             guest: "/g".into(),
             size: String::new(),
             read_only: false,
-            kind: VmVolumeKind::DirShare,
+            kind: VmVolumeKind::Disk,
             encrypted: false,
         }];
         assert_eq!(try_warm_claim(&b, &c, false).unwrap(), None);

--- a/crates/mvm-cli/src/commands/shared/parse.rs
+++ b/crates/mvm-cli/src/commands/shared/parse.rs
@@ -285,7 +285,7 @@ pub fn volume_spec_to_vm_volume(spec: &VolumeSpec) -> VmVolume {
             guest: guest_mount.clone(),
             size: String::new(),
             read_only: *read_only,
-            kind: VmVolumeKind::DirShare,
+            kind: VmVolumeKind::Disk,
             encrypted: false,
         },
         VolumeSpec::Disk {
@@ -308,9 +308,8 @@ pub fn volume_spec_to_vm_volume(spec: &VolumeSpec) -> VmVolume {
 }
 
 /// Sparse-create the backing image for one disk-image volume so the
-/// hypervisor can attach it (a directory share needs nothing). The image
-/// is created at its declared size if absent; an existing image is left
-/// intact so its data survives. No-op for a directory share.
+/// hypervisor can attach it. The image is created at its declared size if
+/// absent; an existing image is left intact so its data survives.
 ///
 /// The sidecar-lock guard from `ensure_persistent_volume_image` is
 /// released immediately: the hypervisor (HVF) takes its own exclusive lock
@@ -326,9 +325,6 @@ pub fn volume_spec_to_vm_volume(spec: &VolumeSpec) -> VmVolume {
 pub fn materialize_disk_volume(
     v: &VmVolume,
 ) -> Result<Option<mvm_build::volume_image::VolumeImageLock>> {
-    if !matches!(v.kind, VmVolumeKind::Disk) {
-        return Ok(None);
-    }
     let size_mib = mvm_core::util::parse_human_size(&v.size)
         .with_context(|| format!("disk volume '{}' size '{}'", v.guest, v.size))?;
     let size_bytes = u64::from(size_mib) * 1024 * 1024;
@@ -468,7 +464,7 @@ pub fn vm_volume_from_spec_validated(spec: &VolumeSpec) -> Result<VmVolume> {
     validate_volume_spec(spec)?;
 
     let mut vmv = volume_spec_to_vm_volume(spec);
-    let expect_dir = matches!(vmv.kind, VmVolumeKind::DirShare);
+    let expect_dir = matches!(spec, VolumeSpec::DirShare { .. });
     vmv.host = validate_host_path(&vmv.host, expect_dir)?;
     Ok(vmv)
 }
@@ -856,25 +852,6 @@ mod volume_spec_tests {
         assert!(
             len > requested - (1024 * 1024) && len <= requested,
             "a 10M request must produce very nearly 10 MiB, got {len} bytes"
-        );
-
-        // A directory share is not a disk and must not have an image
-        // written for it — the early return is its own mutant.
-        let share_host = tmp.path().join("share");
-        let share = VmVolume {
-            materialized_image: None,
-            volume_label: None,
-            host: share_host.to_string_lossy().into_owned(),
-            guest: "/share".to_string(),
-            size: "10M".to_string(),
-            read_only: false,
-            kind: VmVolumeKind::DirShare,
-            encrypted: false,
-        };
-        materialize_disk_volume(&share).expect("a dir share is a no-op");
-        assert!(
-            !share_host.exists(),
-            "a directory share must not materialise a disk image"
         );
     }
 }

--- a/crates/mvm-cli/src/commands/shared/start.rs
+++ b/crates/mvm-cli/src/commands/shared/start.rs
@@ -324,7 +324,7 @@ impl VmStartParams<'_> {
                 .volumes
                 .iter()
                 .map(|v| mvm_core::vm_backend::VmVolume {
-                    materialized_image: None,
+                    materialized_image: v.materialized_image.clone(),
                     volume_label: None,
                     host: v.host.clone(),
                     guest: v.guest.clone(),

--- a/crates/mvm-cli/src/commands/tests.rs
+++ b/crates/mvm-cli/src/commands/tests.rs
@@ -635,7 +635,6 @@ fn volume_create_parses_default_root() {
                 volume::VolumeCmd::Create {
                     volume,
                     root,
-                    host_backed,
                     size,
                     remote,
                     bucket,
@@ -644,46 +643,6 @@ fn volume_create_parses_default_root() {
         })) => {
             assert_eq!(volume, "work");
             assert_eq!(root, None);
-            assert!(!host_backed);
-            assert_eq!(size, "1G");
-            assert!(!remote);
-            assert!(bucket.is_none());
-            assert!(storage_class.is_none());
-        }
-        _ => panic!("Expected volume create command"),
-    }
-}
-
-#[test]
-fn volume_create_host_backed_parses() {
-    let cli = Cli::try_parse_from([
-        "mvmctl",
-        "machine",
-        "volume",
-        "create",
-        "work",
-        "--host-backed",
-    ])
-    .unwrap();
-    let Commands::Machine(mg) = cli.command else {
-        panic!("expected machine group")
-    };
-    match mg.action {
-        machine::MachineAction::Vm(group::VmCmd::Volume(volume::Args {
-            command:
-                volume::VolumeCmd::Create {
-                    volume,
-                    root,
-                    host_backed,
-                    size,
-                    remote,
-                    bucket,
-                    storage_class,
-                },
-        })) => {
-            assert_eq!(volume, "work");
-            assert_eq!(root, None);
-            assert!(host_backed);
             assert_eq!(size, "1G");
             assert!(!remote);
             assert!(bucket.is_none());
@@ -1600,23 +1559,6 @@ fn a_materialized_disk_volume_hands_back_a_lock_the_caller_can_hold() {
         .expect("a disk volume yields a lock");
     assert_eq!(held.path(), image.as_path());
     assert!(image.is_file(), "the backing image is created");
-}
-
-/// A directory volume has no image and so no lock — `None`, not a failure.
-#[test]
-fn a_dir_share_volume_yields_no_lock() {
-    let volume = mvm_core::vm_backend::VmVolume {
-        host: "/h/src".to_string(),
-        guest: "/work".to_string(),
-        read_only: true,
-        kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
-        ..Default::default()
-    };
-    assert!(
-        crate::commands::shared::materialize_disk_volume(&volume)
-            .expect("no-op for a dir share")
-            .is_none()
-    );
 }
 
 #[test]

--- a/crates/mvm-cli/src/commands/vm/up/policy.rs
+++ b/crates/mvm-cli/src/commands/vm/up/policy.rs
@@ -79,9 +79,10 @@ pub(super) fn shares_from_volume_cfg(
             tag: format!("uvol{idx}"),
             host_path: v.host.clone(),
             guest_path: v.guest.clone(),
-            kind: match v.kind {
-                mvm_core::vm_backend::VmVolumeKind::Disk => mvm_core::plan::ShareKind::Disk,
-                mvm_core::vm_backend::VmVolumeKind::DirShare => mvm_core::plan::ShareKind::DirShare,
+            kind: if v.materialized_image.is_some() {
+                mvm_core::plan::ShareKind::DirShare
+            } else {
+                mvm_core::plan::ShareKind::Disk
             },
             read_only: v.read_only,
             encrypted: v.encrypted,

--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -61,10 +61,6 @@ pub(in crate::commands) enum VolumeCmd {
         /// will be created. Defaults to ~/.mvm/volumes/local.
         #[arg(long)]
         root: Option<String>,
-        /// Use the previous host-backed encryption gate instead of
-        /// an mvm-managed encrypted archive.
-        #[arg(long)]
-        host_backed: bool,
         /// Capacity of a new portable ext4 block volume.
         #[arg(long, default_value = "1G")]
         size: String,
@@ -172,19 +168,18 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
         VolumeCmd::Create {
             volume,
             root,
-            host_backed,
             size,
             remote,
             bucket,
             storage_class,
         } => {
             if remote {
-                if root.is_some() || host_backed {
-                    bail!("--root and --host-backed are local-only volume options");
+                if root.is_some() {
+                    bail!("--root is a local-only volume option");
                 }
                 return remote::create(&volume, &size, bucket.as_deref(), storage_class.as_deref());
             }
-            create(&volume, root.as_deref(), host_backed, &size)
+            create(&volume, root.as_deref(), &size)
         }
         VolumeCmd::Unlock { volume } => unlock(&volume),
         VolumeCmd::Lock { volume } => lock(&volume),
@@ -264,26 +259,15 @@ pub(in crate::commands) fn run(_cli: &Cli, args: Args, _cfg: &MvmConfig) -> Resu
     }
 }
 
-/// The local volume service, wired to the doctor's host-encryption
-/// diagnostics so host-backed directory volumes keep their encrypted-backing
-/// verification.
+/// The local volume service, wired to the doctor's host-encryption diagnostics
+/// so a directory snapshotted by `--host` is checked before it is read.
 fn service() -> LocalVolumeService {
     LocalVolumeService::with_host_encryption_probe(probe_from_fn(|path| {
         crate::doctor::require_local_volume_host_path_encrypted(path)
     }))
 }
 
-fn create(volume_name: &str, root: Option<&str>, host_backed: bool, size: &str) -> Result<()> {
-    if host_backed {
-        let record = service()
-            .create_host_backed_volume(volume_name, root.map(Path::new))
-            .with_context(|| format!("creating host-backed volume {volume_name:?}"))?;
-        println!(
-            "created encrypted local volume {volume_name:?} at {}",
-            record.host_artifact.as_deref().unwrap_or("<unknown>")
-        );
-        return Ok(());
-    }
+fn create(volume_name: &str, root: Option<&str>, size: &str) -> Result<()> {
     let size_mib = mvm_core::util::parse_human_size(size)
         .with_context(|| format!("invalid volume size {size:?}"))?;
     let mut builder = CreateBlockVolumeRequest::builder(volume_name)
@@ -633,7 +617,7 @@ mod tests {
     fn mvm_managed_volume_create_unlock_lock_roundtrip() {
         let guard = DataDirGuard::new();
         let root = guard.path().join("vol-root");
-        create("work", Some(root.to_str().unwrap()), false, "16M").unwrap();
+        create("work", Some(root.to_str().unwrap()), "16M").unwrap();
 
         let catalog = LocalVolumeCatalog::load().unwrap();
         let entry = catalog.get("work").unwrap();
@@ -730,7 +714,7 @@ mod tests {
     fn registered_managed_mount_is_consumed_by_launch_resolution() {
         let guard = DataDirGuard::new();
         let root = guard.path().join("vol-root");
-        create("work", Some(root.to_str().unwrap()), false, "16M").unwrap();
+        create("work", Some(root.to_str().unwrap()), "16M").unwrap();
         unlock("work").unwrap();
         mount("vm-1", "work", None, "/data/work", true).unwrap();
 
@@ -749,7 +733,7 @@ mod tests {
     fn block_attachment_lease_is_exclusive_and_released_on_stop() {
         let guard = DataDirGuard::new();
         let root = guard.path().join("vol-root");
-        create("work", Some(root.to_str().unwrap()), false, "16M").unwrap();
+        create("work", Some(root.to_str().unwrap()), "16M").unwrap();
         unlock("work").unwrap();
         mount("vm-1", "work", None, "/data/work", true).unwrap();
         mount("vm-2", "work", None, "/data/work", true).unwrap();
@@ -783,7 +767,7 @@ mod tests {
     fn launch_resolution_refuses_volume_locked_after_registration() {
         let guard = DataDirGuard::new();
         let root = guard.path().join("vol-root");
-        create("work", Some(root.to_str().unwrap()), false, "16M").unwrap();
+        create("work", Some(root.to_str().unwrap()), "16M").unwrap();
         unlock("work").unwrap();
         mount("vm-1", "work", None, "/data/work", false).unwrap();
         lock("work").unwrap();
@@ -796,7 +780,7 @@ mod tests {
     fn launch_resolution_refuses_explicit_guest_path_collision() {
         let guard = DataDirGuard::new();
         let root = guard.path().join("vol-root");
-        create("work", Some(root.to_str().unwrap()), false, "16M").unwrap();
+        create("work", Some(root.to_str().unwrap()), "16M").unwrap();
         unlock("work").unwrap();
         mount("vm-1", "work", None, "/data/work", false).unwrap();
         let explicit = mvm_runtime::image::RuntimeVolume {
@@ -804,6 +788,7 @@ mod tests {
             guest: "/data/work".to_string(),
             size: "1G".to_string(),
             read_only: true,
+            materialized_image: None,
             kind: mvm_core::vm_backend::VmVolumeKind::Disk,
             encrypted: false,
         };
@@ -819,7 +804,7 @@ mod tests {
     fn mvm_managed_mount_refuses_locked_volume() {
         let guard = DataDirGuard::new();
         let root = guard.path().join("vol-root");
-        create("work", Some(root.to_str().unwrap()), false, "16M").unwrap();
+        create("work", Some(root.to_str().unwrap()), "16M").unwrap();
         let err = mount("vm-1", "work", None, "/data/work", false).unwrap_err();
         assert!(format!("{err:#}").contains("is locked"), "got: {err:#}");
     }
@@ -828,7 +813,7 @@ mod tests {
     fn mvm_managed_unlock_rejects_tampered_ciphertext() {
         let guard = DataDirGuard::new();
         let root = guard.path().join("vol-root");
-        create("work", Some(root.to_str().unwrap()), false, "16M").unwrap();
+        create("work", Some(root.to_str().unwrap()), "16M").unwrap();
         let catalog = LocalVolumeCatalog::load().unwrap();
         let entry = catalog.get("work").unwrap();
         let ciphertext = match &entry.encryption {

--- a/crates/mvm-cli/src/exec/mounts.rs
+++ b/crates/mvm-cli/src/exec/mounts.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+use mvm_core::vm_backend::VmVolume;
 
 use crate::commands::DirShareSpec;
 
@@ -43,7 +43,6 @@ pub(crate) fn materialize_mount_volumes(
                 host: share.host_dir.clone(),
                 guest: share.guest_mount.clone(),
                 read_only: share.read_only,
-                kind: VmVolumeKind::DirShare,
                 materialized_image: Some(image.display().to_string()),
                 // Same authority the image was written with, so the guest
                 // mounts the label that is actually on the bytes.

--- a/crates/mvm-cli/src/exec/transient.rs
+++ b/crates/mvm-cli/src/exec/transient.rs
@@ -164,7 +164,7 @@ pub(super) fn install_ctrlc_teardown(
 pub(super) fn has_writable_disk(volumes: &[VmVolume]) -> bool {
     volumes
         .iter()
-        .any(|volume| volume.kind == mvm_core::vm_backend::VmVolumeKind::Disk && !volume.read_only)
+        .any(|volume| volume.materialized_image.is_none() && !volume.read_only)
 }
 
 /// Ask the authenticated guest agent to flush every filesystem before the VMM
@@ -343,9 +343,9 @@ pub(super) fn restore_via_snapshot(
 mod tests {
     use super::*;
 
-    fn volume(kind: mvm_core::vm_backend::VmVolumeKind, read_only: bool) -> VmVolume {
+    fn volume(materialized_image: Option<&str>, read_only: bool) -> VmVolume {
         VmVolume {
-            kind,
+            materialized_image: materialized_image.map(str::to_string),
             read_only,
             ..Default::default()
         }
@@ -353,9 +353,9 @@ mod tests {
 
     #[test]
     fn only_a_writable_disk_requires_a_pre_teardown_flush() {
-        let writable_disk = volume(mvm_core::vm_backend::VmVolumeKind::Disk, false);
-        let read_only_disk = volume(mvm_core::vm_backend::VmVolumeKind::Disk, true);
-        let directory = volume(mvm_core::vm_backend::VmVolumeKind::DirShare, false);
+        let writable_disk = volume(None, false);
+        let read_only_disk = volume(None, true);
+        let directory = volume(Some("/state/mount.ext4"), false);
 
         assert!(has_writable_disk(&[writable_disk]));
         assert!(!has_writable_disk(&[read_only_disk]));

--- a/crates/mvm-client/src/volume.rs
+++ b/crates/mvm-client/src/volume.rs
@@ -45,7 +45,7 @@ pub use dto::{
 pub use lease::LaunchLease;
 pub use service::{
     DenyAllHostEncryptionProbe, HostEncryptionProbe, LaunchPreparation, LocalVolumeService,
-    VolumeService, default_block_volume_root, default_host_backed_volume_root, probe_from_fn,
+    VolumeService, default_block_volume_root, probe_from_fn,
 };
 
 #[cfg(test)]
@@ -108,6 +108,19 @@ mod tests {
                 .unwrap()
                 .host_path,
         )
+    }
+
+    fn create_ext4_image(path: &Path, size_mib: u32) {
+        let mut image = fs::OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .expect("create ext4 image");
+        let size_bytes = u64::from(size_mib) * 1024 * 1024;
+        image.set_len(size_bytes).expect("size ext4 image");
+        mvm_fs::ext4::mkfs::format_empty_ext4(&mut image, size_bytes).expect("format ext4 image");
+        image.sync_all().expect("sync ext4 image");
     }
 
     #[test]
@@ -298,6 +311,7 @@ mod tests {
             guest: "/data/work".to_string(),
             size: "1G".to_string(),
             read_only: true,
+            materialized_image: None,
             kind: mvm_core::vm_backend::VmVolumeKind::Disk,
             encrypted: false,
         };
@@ -311,6 +325,29 @@ mod tests {
             format!("{err:#}").contains("duplicate guest mount path"),
             "got: {err:#}"
         );
+    }
+
+    #[test]
+    fn materialized_directory_grant_does_not_take_a_direct_disk_lease() {
+        let _home = TestVolumeHome::new();
+        let materialized = mvm_runtime::image::RuntimeVolume {
+            host: "/granted/directory".to_string(),
+            guest: "/work".to_string(),
+            size: "1G".to_string(),
+            read_only: true,
+            materialized_image: Some("/state/mount.ext4".to_string()),
+            kind: mvm_core::vm_backend::VmVolumeKind::Disk,
+            encrypted: false,
+        };
+        let request = LaunchLeaseRequest::builder("vm-1")
+            .unwrap()
+            .explicit_volumes(vec![materialized])
+            .profile(AdmittedProfile::Dev)
+            .build();
+
+        let prepared = service().acquire_launch_lease(&request).unwrap();
+        assert_eq!(prepared.volumes.len(), 1);
+        assert!(AttachmentLeaseCatalog::load().unwrap().leases.is_empty());
     }
 
     #[test]
@@ -620,12 +657,11 @@ mod tests {
     }
 
     #[test]
-    fn host_backed_creation_fails_closed_without_a_probe() {
+    fn host_directory_encryption_check_fails_closed_without_a_probe() {
         let home = TestVolumeHome::new();
         let root = home.path().join("plain");
-        let err = service()
-            .create_host_backed_volume("plainvol", Some(&root))
-            .unwrap_err();
+        fs::create_dir(&root).unwrap();
+        let err = service().require_host_encryption(&root).unwrap_err();
         assert!(
             format!("{err:#}").contains("no host encryption probe"),
             "got: {err:#}"
@@ -633,24 +669,20 @@ mod tests {
     }
 
     #[test]
-    fn host_backed_creation_works_through_an_injected_probe() {
+    fn host_directory_encryption_check_uses_the_injected_probe() {
         let home = TestVolumeHome::new();
         let root = home.path().join("encrypted-backing");
+        fs::create_dir(&root).unwrap();
         let probe = super::probe_from_fn(|_path: &Path| Ok(()));
         let svc = LocalVolumeService::with_host_encryption_probe(probe);
-        let record = svc
-            .create_host_backed_volume("hostvol", Some(&root))
-            .unwrap();
-        assert_eq!(record.source, VolumeSourceKind::ManagedDirectory);
-        assert_eq!(record.encryption, EncryptionState::HostBacked);
-        assert!(record.host_artifact.is_some());
+        svc.require_host_encryption(&root).unwrap();
     }
 
     #[test]
-    fn ad_hoc_host_attachment_requires_probe_and_registers() {
+    fn ad_hoc_image_attachment_registers_a_block_image() {
         let home = TestVolumeHome::new();
-        let host_dir = home.path().join("adhoc");
-        fs::create_dir(&host_dir).unwrap();
+        let image = home.path().join("adhoc.ext4");
+        create_ext4_image(&image, 16);
         let request = AttachmentRequest::builder("vm-1", "input")
             .unwrap()
             .guest_path("/work/input")
@@ -658,19 +690,11 @@ mod tests {
             .build()
             .unwrap();
 
-        let err = service()
-            .prepare_ad_hoc_host_attachment(&request, &host_dir)
-            .unwrap_err();
-        assert!(
-            format!("{err:#}").contains("no host encryption probe"),
-            "got: {err:#}"
-        );
-
-        let svc = LocalVolumeService::with_host_encryption_probe(super::probe_from_fn(|_| Ok(())));
-        let record = svc
-            .prepare_ad_hoc_host_attachment(&request, &host_dir)
+        let record = service()
+            .prepare_ad_hoc_image_attachment(&request, &image, 16)
             .unwrap();
         assert_eq!(record.source, AttachmentSource::AdHocHost);
+        assert_eq!(record.host_path, image.display().to_string());
     }
 
     #[test]
@@ -727,15 +751,14 @@ mod tests {
     }
 
     #[test]
-    fn ad_hoc_host_attachment_refuses_names_unfit_for_virtiofs_tags() {
+    fn ad_hoc_image_attachment_refuses_invalid_volume_names() {
         let home = TestVolumeHome::new();
-        let host_dir = home.path().join("adhoc");
-        fs::create_dir(&host_dir).unwrap();
-        let svc = LocalVolumeService::with_host_encryption_probe(super::probe_from_fn(|_| Ok(())));
+        let image = home.path().join("adhoc.ext4");
+        create_ext4_image(&image, 16);
+        let svc = service();
 
-        // Accepted by the general name type but too loose for the virtio-fs
-        // tag the guest kernel sees: underscores and >32-char names must be
-        // refused with the same rule managed creation enforces.
+        // Accepted by the general name type but too loose for the conservative
+        // local-volume identity rule.
         for name in ["input_data", &"a".repeat(33)] {
             let request = AttachmentRequest::builder("vm-1", name)
                 .unwrap()
@@ -744,7 +767,7 @@ mod tests {
                 .build()
                 .unwrap();
             let err = svc
-                .prepare_ad_hoc_host_attachment(&request, &host_dir)
+                .prepare_ad_hoc_image_attachment(&request, &image, 16)
                 .unwrap_err();
             assert!(
                 format!("{err:#}").contains("volume name"),
@@ -754,20 +777,18 @@ mod tests {
     }
 
     #[test]
-    fn launch_reprobes_host_backed_attachments() {
+    fn launch_reprobes_ad_hoc_image_attachments() {
         let home = TestVolumeHome::new();
-        let host_dir = home.path().join("adhoc");
-        fs::create_dir(&host_dir).unwrap();
+        let image = home.path().join("adhoc.ext4");
+        create_ext4_image(&image, 16);
         let request = AttachmentRequest::builder("vm-1", "input")
             .unwrap()
             .guest_path("/work/input")
             .profile(AdmittedProfile::Dev)
             .build()
             .unwrap();
-        let permissive =
-            LocalVolumeService::with_host_encryption_probe(super::probe_from_fn(|_| Ok(())));
-        permissive
-            .prepare_ad_hoc_host_attachment(&request, &host_dir)
+        service()
+            .prepare_ad_hoc_image_attachment(&request, &image, 16)
             .unwrap();
 
         // The launch-time recheck runs with the deny-all probe: the host

--- a/crates/mvm-client/src/volume/lifecycle.rs
+++ b/crates/mvm-client/src/volume/lifecycle.rs
@@ -11,7 +11,7 @@
 //! new lifecycle operation proceeds.
 
 use std::fs::{self, File};
-use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -26,15 +26,6 @@ use rand::Rng;
 use secrecy::ExposeSecret;
 
 use super::lease::ensure_volume_not_attached;
-use super::service::HostEncryptionProbe;
-
-/// Root for host-backed managed volume directories.
-pub(crate) fn default_managed_volume_root() -> PathBuf {
-    PathBuf::from(mvm_core::config::mvm_home())
-        .join("volumes")
-        .join("local")
-}
-
 /// Root for mvm-managed encrypted volume state (`encrypted/` + `unlocked/`).
 pub(crate) fn default_mvm_volume_root() -> PathBuf {
     PathBuf::from(mvm_core::config::mvm_home())
@@ -77,14 +68,11 @@ pub(crate) fn ensure_private_dir(path: &Path) -> Result<()> {
         .with_context(|| format!("creating {} privately", path.display()))
 }
 
-/// Volume-name shape check for creation: the name doubles as the virtio-fs
-/// tag the guest kernel sees, so it stays short and conservative.
+/// Volume-name shape check for creation. Names stay short and conservative
+/// because they are persisted as registry and lease identifiers.
 pub(crate) fn validate_volume_name(name: &str) -> Result<()> {
     if name.is_empty() || name.len() > 32 {
-        bail!(
-            "volume name length {} outside [1, 32] (used as virtio-fs tag)",
-            name.len()
-        );
+        bail!("volume name length {} outside [1, 32]", name.len());
     }
     if !name
         .chars()
@@ -101,12 +89,6 @@ pub(crate) fn validate_volume_name(name: &str) -> Result<()> {
 fn validate_materialized_volume(entry: &LocalVolumeEntry) -> Result<()> {
     let host_path = Path::new(&entry.host_path);
     match &entry.kind {
-        LocalVolumeKind::Directory if host_path.is_dir() => Ok(()),
-        LocalVolumeKind::Directory => bail!(
-            "materialized directory volume {:?} is missing: {}",
-            entry.volume_name,
-            host_path.display()
-        ),
         LocalVolumeKind::BlockImage { .. } if !host_path.is_file() => bail!(
             "materialized block volume {:?} is missing: {}",
             entry.volume_name,
@@ -129,12 +111,8 @@ fn remove_materialized_volume(entry: &LocalVolumeEntry) -> Result<()> {
     if !host_path.exists() {
         return Ok(());
     }
-    match &entry.kind {
-        LocalVolumeKind::Directory => fs::remove_dir_all(host_path)
-            .with_context(|| format!("removing directory volume {}", host_path.display())),
-        LocalVolumeKind::BlockImage { .. } => fs::remove_file(host_path)
-            .with_context(|| format!("removing block volume {}", host_path.display())),
-    }
+    fs::remove_file(host_path)
+        .with_context(|| format!("removing block volume {}", host_path.display()))
 }
 
 pub(crate) fn set_local_volume_state(
@@ -259,57 +237,6 @@ pub(crate) fn recover_local_volume_catalog() -> Result<LocalVolumeCatalog> {
         catalog.save()?;
     }
     Ok(catalog)
-}
-
-/// Create a host-backed managed directory volume. The probe must confirm the
-/// backing path lives on encrypted host storage.
-pub(crate) fn create_host_backed(
-    volume_name: &str,
-    root: Option<&Path>,
-    probe: &dyn HostEncryptionProbe,
-) -> Result<LocalVolumeEntry> {
-    let root = match root {
-        Some(root) => root.to_path_buf(),
-        None => default_managed_volume_root(),
-    };
-    if !root.is_absolute() {
-        bail!(
-            "managed volume root must be absolute, got {}",
-            root.display()
-        );
-    }
-    ensure_private_dir(&root)
-        .with_context(|| format!("creating managed volume root {}", root.display()))?;
-    probe.require_encrypted(&root)?;
-
-    let host_path = root.join(volume_name);
-    if host_path.exists() && !host_path.is_dir() {
-        bail!(
-            "managed volume path {} exists but is not a directory",
-            host_path.display()
-        );
-    }
-    ensure_private_dir(&host_path)
-        .with_context(|| format!("creating managed volume {}", host_path.display()))?;
-    probe.require_encrypted(&host_path)?;
-
-    let mut catalog = LocalVolumeCatalog::load()?;
-    let entry = LocalVolumeEntry {
-        volume_name: volume_name.to_string(),
-        host_path: host_path.to_string_lossy().into_owned(),
-        encrypted: true,
-        kind: LocalVolumeKind::Directory,
-        encryption: LocalVolumeEncryption::HostBacked,
-        created_at: mvm_core::util::time::utc_now(),
-    };
-    catalog.add(entry.clone())?;
-    catalog.save()?;
-    mvm_core::audit_emit!(
-        VolumeCreate,
-        "volume={volume_name} host={} encrypted=true",
-        host_path.display()
-    );
-    Ok(entry)
 }
 
 /// Create an mvm-managed encrypted block volume: an empty ext4 image sealed
@@ -545,51 +472,6 @@ pub(crate) fn unwrap_volume_key(entry: &LocalVolumeEntry) -> Result<secrecy::Sec
     Ok(secrecy::SecretBox::new(Box::new(dek)))
 }
 
-fn write_plain_archive(src_dir: &Path, archive_path: &Path) -> Result<()> {
-    let archive = fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o600)
-        .open(archive_path)
-        .with_context(|| format!("creating archive {}", archive_path.display()))?;
-    let mut builder = tar::Builder::new(archive);
-    builder
-        .append_dir_all(".", src_dir)
-        .with_context(|| format!("archiving {}", src_dir.display()))?;
-    builder.finish().context("finishing volume archive")?;
-    Ok(())
-}
-
-pub(crate) fn write_encrypted_volume_archive(
-    src_dir: &Path,
-    ciphertext_path: &Path,
-    dek: &[u8],
-) -> Result<()> {
-    if let Some(parent) = ciphertext_path.parent() {
-        ensure_private_dir(parent)?;
-    }
-    let tmp = ciphertext_path.with_extension(format!("{}.plain.tmp", std::process::id()));
-    let result = (|| -> Result<()> {
-        write_plain_archive(src_dir, &tmp)?;
-        mvm_core::crypto::snapshot_encryption::encrypt_file_in_place(&tmp, dek)
-            .context("encrypting volume archive")?;
-        fs::rename(&tmp, ciphertext_path).with_context(|| {
-            format!(
-                "renaming encrypted archive {} -> {}",
-                tmp.display(),
-                ciphertext_path.display()
-            )
-        })?;
-        fs::set_permissions(ciphertext_path, fs::Permissions::from_mode(0o600))
-            .with_context(|| format!("chmod 0600 {}", ciphertext_path.display()))?;
-        Ok(())
-    })();
-    if result.is_err() {
-        let _ = fs::remove_file(&tmp);
-    }
-    result
-}
-
 pub(crate) fn write_encrypted_volume_file(
     src_file: &Path,
     ciphertext_path: &Path,
@@ -624,54 +506,6 @@ pub(crate) fn write_encrypted_volume_file(
     })();
     if result.is_err() {
         let _ = fs::remove_file(&tmp);
-    }
-    result
-}
-
-fn decrypt_volume_archive_to_dir(
-    ciphertext_path: &Path,
-    dest_dir: &Path,
-    dek: &[u8],
-) -> Result<()> {
-    if dest_dir.exists() {
-        bail!(
-            "plaintext volume directory {} already exists",
-            dest_dir.display()
-        );
-    }
-    let staging = unlock_staging_path(dest_dir);
-    let tmp = dest_dir.with_extension("unlocking-archive");
-    let result = (|| -> Result<()> {
-        fs::create_dir(&staging)
-            .with_context(|| format!("creating unlock staging dir {}", staging.display()))?;
-        fs::set_permissions(&staging, fs::Permissions::from_mode(0o700))
-            .with_context(|| format!("chmod 0700 {}", staging.display()))?;
-        fs::copy(ciphertext_path, &tmp).with_context(|| {
-            format!(
-                "copy encrypted archive {} -> {}",
-                ciphertext_path.display(),
-                tmp.display()
-            )
-        })?;
-        mvm_core::crypto::snapshot_encryption::decrypt_file_in_place(&tmp, dek)
-            .context("decrypting volume archive")?;
-        let file = File::open(&tmp).with_context(|| format!("opening {}", tmp.display()))?;
-        let mut archive = tar::Archive::new(file);
-        archive
-            .unpack(&staging)
-            .with_context(|| format!("unpacking volume into {}", staging.display()))?;
-        fs::rename(&staging, dest_dir).with_context(|| {
-            format!(
-                "publishing unlocked directory {} -> {}",
-                staging.display(),
-                dest_dir.display()
-            )
-        })?;
-        Ok(())
-    })();
-    let _ = fs::remove_file(&tmp);
-    if result.is_err() {
-        let _ = fs::remove_dir_all(&staging);
     }
     result
 }
@@ -746,18 +580,11 @@ pub(crate) fn unlock_volume_locked(
     };
     set_local_volume_state(catalog, volume_name, LocalVolumeState::Unlocking)?;
     catalog.save()?;
-    match &entry.kind {
-        LocalVolumeKind::Directory => decrypt_volume_archive_to_dir(
-            &ciphertext_path,
-            Path::new(&entry.host_path),
-            dek.expose_secret(),
-        )?,
-        LocalVolumeKind::BlockImage { .. } => decrypt_volume_file(
-            &ciphertext_path,
-            Path::new(&entry.host_path),
-            dek.expose_secret(),
-        )?,
-    }
+    decrypt_volume_file(
+        &ciphertext_path,
+        Path::new(&entry.host_path),
+        dek.expose_secret(),
+    )?;
     set_local_volume_state(catalog, volume_name, LocalVolumeState::Unlocked)?;
     catalog.save()?;
     mvm_core::audit_emit!(VolumeOpen, "volume={volume_name} state=unlocked");
@@ -790,10 +617,6 @@ pub(crate) fn lock_volume_locked(
     };
     let host_path = PathBuf::from(&entry.host_path);
     match &entry.kind {
-        LocalVolumeKind::Directory if !host_path.is_dir() => bail!(
-            "plaintext volume directory {} is missing; cannot lock",
-            host_path.display()
-        ),
         LocalVolumeKind::BlockImage { .. } if !host_path.is_file() => bail!(
             "plaintext block volume {} is missing; cannot lock",
             host_path.display()
@@ -806,19 +629,11 @@ pub(crate) fn lock_volume_locked(
                 )
             })?;
         }
-        LocalVolumeKind::Directory => {}
     }
     set_local_volume_state(catalog, volume_name, LocalVolumeState::Locking)?;
     catalog.save()?;
     let tmp_ciphertext = lock_staging_path(&ciphertext_path);
-    match &entry.kind {
-        LocalVolumeKind::Directory => {
-            write_encrypted_volume_archive(&host_path, &tmp_ciphertext, dek.expose_secret())?
-        }
-        LocalVolumeKind::BlockImage { .. } => {
-            write_encrypted_volume_file(&host_path, &tmp_ciphertext, dek.expose_secret())?
-        }
-    }
+    write_encrypted_volume_file(&host_path, &tmp_ciphertext, dek.expose_secret())?;
     let new_hash = ciphertext_content_hash(&tmp_ciphertext)?;
     let catalog_entry = catalog
         .get_mut(volume_name)

--- a/crates/mvm-client/src/volume/service.rs
+++ b/crates/mvm-client/src/volume/service.rs
@@ -23,10 +23,10 @@ use super::lifecycle;
 /// Verifies that a host path lives on encrypted backing storage.
 ///
 /// mvm-managed volumes carry their own encryption lifecycle, so they never
-/// consult the probe; host-backed and ad-hoc directory volumes are plaintext
-/// while mounted and must sit on encrypted host storage. The check is
-/// host-diagnostic work (platform tooling like `diskutil` / `lsblk`), so the
-/// presentation surface that owns the diagnostics injects it.
+/// consult the probe. An ad-hoc source directory is plaintext while being
+/// snapshotted and must sit on encrypted host storage. The check is diagnostic
+/// work (platform tooling like `diskutil` / `lsblk`), so the presentation
+/// surface that owns those diagnostics injects it.
 pub trait HostEncryptionProbe: Send + Sync {
     /// Return `Ok(())` only when `path` is confirmed to live on encrypted
     /// backing storage; unknown must fail closed.
@@ -164,58 +164,11 @@ impl LocalVolumeService {
         }
     }
 
-    /// Service with a caller-supplied host-encryption probe, enabling
-    /// host-backed directory volumes.
+    /// Service with a caller-supplied host-encryption probe, enabling ad-hoc
+    /// directory snapshotting.
     #[must_use]
     pub fn with_host_encryption_probe(probe: Box<dyn HostEncryptionProbe>) -> Self {
         Self { probe }
-    }
-
-    /// Create a host-backed managed directory volume (relies on encrypted
-    /// host storage, verified through the probe). Not part of the
-    /// [`VolumeService`] contract: host-directory volumes are a
-    /// CLI-compatibility surface, not a service-consumer feature.
-    pub fn create_host_backed_volume(
-        &self,
-        name: &str,
-        root: Option<&Path>,
-    ) -> Result<VolumeRecord> {
-        lifecycle::validate_volume_name(name)
-            .with_context(|| format!("invalid volume name: {name:?}"))?;
-        let _lock = lifecycle::acquire_volume_lifecycle_lock()?;
-        lifecycle::recover_local_volume_catalog()?;
-        let entry = lifecycle::create_host_backed(name, root, self.probe.as_ref())?;
-        volume_record(&entry, &AttachmentLeaseCatalog::load()?)
-    }
-
-    /// Register an operator-supplied host directory as an attachment. The
-    /// probe must confirm the directory lives on encrypted storage. Not part
-    /// of the [`VolumeService`] contract (arbitrary host-directory mounts are
-    /// out of the service's scope).
-    pub fn prepare_ad_hoc_host_attachment(
-        &self,
-        request: &AttachmentRequest,
-        host_dir: &Path,
-    ) -> Result<AttachmentRecord> {
-        let _lock = lifecycle::acquire_volume_lifecycle_lock()?;
-        lifecycle::recover_local_volume_catalog()?;
-        lifecycle::validate_volume_name(request.volume.as_str())?;
-        if !host_dir.is_absolute() {
-            bail!("host path must be absolute, got {}", host_dir.display());
-        }
-        if !host_dir.is_dir() {
-            bail!(
-                "host path {} is not an existing directory",
-                host_dir.display()
-            );
-        }
-        self.probe.require_encrypted(host_dir)?;
-        register_attachment(
-            request,
-            host_dir.to_string_lossy().into_owned(),
-            LocalVolumeKind::Directory,
-            VolumeMountSource::AdHocHost,
-        )
     }
 
     /// Run the host-encryption policy against a path.
@@ -231,14 +184,8 @@ impl LocalVolumeService {
 
     /// Register an already-materialized ext4 image as an ad-hoc attachment.
     ///
-    /// The block-image counterpart to [`Self::prepare_ad_hoc_host_attachment`].
-    /// A host *directory* cannot be served — no workload backend has a
-    /// virtio-fs device — so the caller snapshots it into an image and
-    /// registers that instead. This records the shape, and
-    /// `resolve_mount_entry` honours it at launch.
-    ///
-    /// Additive rather than a change to the directory method, whose contract
-    /// other consumers of this crate already depend on.
+    /// A host *directory* cannot be served, so the caller snapshots it into an
+    /// image and registers that block-image shape for launch.
     pub fn prepare_ad_hoc_image_attachment(
         &self,
         request: &AttachmentRequest,
@@ -373,12 +320,6 @@ impl VolumeService for LocalVolumeService {
             bail!("host path must be absolute, got {:?}", entry.host_path);
         }
         match &entry.kind {
-            LocalVolumeKind::Directory if !host_path.is_dir() => {
-                bail!(
-                    "host path {:?} is not an existing directory",
-                    entry.host_path
-                )
-            }
             LocalVolumeKind::BlockImage { .. } if !host_path.is_file() => {
                 bail!(
                     "managed block volume {:?} is not an existing file",
@@ -390,7 +331,6 @@ impl VolumeService for LocalVolumeService {
                     format!("managed block volume {:?} is not ext4", entry.host_path)
                 })?;
             }
-            LocalVolumeKind::Directory => {}
         }
         register_attachment(
             request,
@@ -563,12 +503,11 @@ fn enforce_profile_access(
     Ok(())
 }
 
-/// Lease intents for the caller-supplied explicit volume list (block volumes
-/// only — directory shares are not exclusive).
+/// Lease intents for the caller-supplied explicit block-volume list.
 fn explicit_lease_intents(owner: &str, explicit: &[RuntimeVolume]) -> Result<Vec<LeaseIntent>> {
     explicit
         .iter()
-        .filter(|volume| matches!(volume.kind, mvm_core::vm_backend::VmVolumeKind::Disk))
+        .filter(|volume| volume.materialized_image.is_none())
         .map(|volume| {
             Ok(LeaseIntent {
                 key: lease::lease_key(Path::new(&volume.host))?,
@@ -633,16 +572,6 @@ fn volume_record(
     leases: &AttachmentLeaseCatalog,
 ) -> Result<VolumeRecord> {
     let (source, encryption, host_artifact) = match (&entry.kind, &entry.encryption) {
-        (LocalVolumeKind::Directory, LocalVolumeEncryption::HostBacked) => (
-            VolumeSourceKind::ManagedDirectory,
-            EncryptionState::HostBacked,
-            Some(entry.host_path.clone()),
-        ),
-        (LocalVolumeKind::Directory, LocalVolumeEncryption::MvmManaged(enc)) => (
-            VolumeSourceKind::ManagedDirectory,
-            managed_encryption_state(enc.state),
-            (enc.state == LocalVolumeState::Unlocked).then(|| entry.host_path.clone()),
-        ),
         (LocalVolumeKind::BlockImage { size_mib }, LocalVolumeEncryption::HostBacked) => (
             VolumeSourceKind::ManagedBlock {
                 capacity_mib: *size_mib,
@@ -689,10 +618,4 @@ fn managed_encryption_state(state: LocalVolumeState) -> EncryptionState {
 #[must_use]
 pub fn default_block_volume_root() -> PathBuf {
     lifecycle::default_mvm_volume_root()
-}
-
-/// Default host-backed volume root helper.
-#[must_use]
-pub fn default_host_backed_volume_root() -> PathBuf {
-    lifecycle::default_managed_volume_root()
 }

--- a/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
+++ b/crates/mvm-conformance/tests/steps/sdk_sidecar.rs
@@ -256,9 +256,9 @@ fn read_only_directory_mount(world: &mut CliWorld, guest_path: String) {
         guest: guest_path,
         size: String::new(),
         read_only: true,
-        kind: VmVolumeKind::DirShare,
+        kind: VmVolumeKind::Disk,
         encrypted: false,
-        materialized_image: None,
+        materialized_image: Some("/state/wheels.ext4".to_string()),
         volume_label: None,
     });
 }
@@ -502,12 +502,8 @@ fn launch_refused_integrity(world: &mut CliWorld) {
     );
 }
 
-/// Build the launch config this scenario's resolution implies and assemble a
-/// real sealed workload cmdline from it, so the guest-visible half of the
-/// contract is asserted, not assumed.
-fn assembled_cmdline(world: &mut CliWorld) -> String {
-    let state = tempfile::tempdir().expect("create the cmdline state dir");
-    let config = VmStartConfig {
+fn start_config(world: &mut CliWorld) -> VmStartConfig {
+    VmStartConfig {
         name: "bdd-sdk-sidecar".to_string(),
         rootfs_path: "/image/rootfs.ext4".to_string(),
         verity_path: Some("/image/rootfs.verity".to_string()),
@@ -518,7 +514,15 @@ fn assembled_cmdline(world: &mut CliWorld) -> String {
         runtime_overlay_roothash: Some("b".repeat(64)),
         volumes: attached_volumes(world),
         ..Default::default()
-    };
+    }
+}
+
+/// Build the launch config this scenario's resolution implies and assemble a
+/// real sealed workload cmdline from it, so the guest-visible half of the
+/// contract is asserted, not assumed.
+fn assembled_cmdline(world: &mut CliWorld) -> String {
+    let state = tempfile::tempdir().expect("create the cmdline state dir");
+    let config = start_config(world);
     let driver = HvfDriver::new();
     mvm_runtime::workload_runner::assemble_workload_cmdline_for_test(
         &driver as &dyn VmmDriver,
@@ -538,14 +542,12 @@ fn cmdline_names_no_sidecar(world: &mut CliWorld) {
 
 #[then(expr = "the assembled workload cmdline names the SDK sidecar device the backend attached")]
 fn cmdline_names_sidecar(world: &mut CliWorld) {
-    let volumes = attached_volumes(world);
-    assert!(!volumes.is_empty(), "no sidecar volume was resolved");
+    let config = start_config(world);
+    let expected = mvm_vmm::host::spec_map::sdk_sidecar_block_device(&config)
+        .expect("the resolved sidecar must occupy a block-device slot");
     let cmdline = assembled_cmdline(world);
-    // A sealed boot carries rootfs + verity + overlay pair, so the sidecar is
-    // the fifth block device. Asserting the exact device — rather than just the
-    // token's presence — is what proves the guest is told where to look.
     assert!(
-        cmdline.contains("mvm.sdk_dev=/dev/vde"),
+        cmdline.contains(&format!("mvm.sdk_dev={expected}")),
         "the cmdline must name the device the backend attached: {cmdline}"
     );
 }
@@ -561,7 +563,7 @@ fn user_volume_manifest_excludes_sidecar(world: &mut CliWorld, guest_path: Strin
         .expect("the ordinary directory mount must emit a user-volume manifest");
 
     assert!(
-        manifest.contains(&format!("uvol0:{user_path}:ro:fs")),
+        manifest.contains(&format!("uvol0:{user_path}:ro:blk")),
         "the ordinary mount must remain in user-volume activation: {cmdline}"
     );
     assert!(

--- a/crates/mvm-conformance/tests/steps/volume.rs
+++ b/crates/mvm-conformance/tests/steps/volume.rs
@@ -133,9 +133,8 @@ fn write_managed_volume_marker(world: &mut CliWorld, value: i64, volume_name: St
     image.sync_all().expect("sync volume marker");
 }
 
-/// Register a **host directory** volume — the `--host <dir>` arm, which is
-/// `LocalVolumeKind::Directory` rather than the `machine volume create` block
-/// image every other live scenario here uses.
+/// Register a **host directory** volume through the `--host <dir>` arm, which
+/// snapshots it into the same block-image shape every live scenario here uses.
 ///
 /// The directory is created under the isolated home and seeded with a marker,
 /// so a guest that can read it proves the registration reached the VM and a

--- a/crates/mvm-contract/src/protocol/vm_backend.rs
+++ b/crates/mvm-contract/src/protocol/vm_backend.rs
@@ -48,18 +48,15 @@ pub struct VmPortMapping {
 
 /// Which hypervisor device a [`VmVolume`] / `RuntimeVolume` maps to.
 ///
-/// Default is `Disk`: the legacy `RuntimeVolume` carrier (and any
-/// runtime-config file written before this field existed) means a disk
-/// image. A live directory share is the new case and is always set
-/// explicitly, so defaulting to `Disk` keeps old configs correct.
+/// The only supported transport is a block image. Directory grants retain
+/// their audited origin in [`VmVolume::materialized_image`] while reaching the
+/// guest through this same transport.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum VmVolumeKind {
     /// Persistent ext4 disk image attached as a virtio-blk device.
     #[default]
     Disk,
-    /// Live host-directory share over virtio-fs (two-way unless read-only).
-    DirShare,
 }
 
 /// A volume to mount in the guest, backend-agnostic.
@@ -69,20 +66,17 @@ pub struct VmVolume {
     pub host: String,
     /// Mount point inside the guest.
     pub guest: String,
-    /// Size hint (e.g. "1G"). Used as the sparse cap for a `Disk`; a
-    /// `DirShare` ignores it.
+    /// Size hint (e.g. "1G"). Used as the sparse cap for a disk image.
     pub size: String,
     /// Mark the underlying device read-only at the hypervisor level.
     pub read_only: bool,
-    /// Directory share (virtio-fs) vs disk image (virtio-blk). Backends
-    /// attach the right device per kind rather than inferring from `size`.
+    /// Runtime transport kind. Only virtio-blk disk images are supported.
     pub kind: VmVolumeKind,
-    /// `:enc` — route a `Disk` volume through in-guest encryption.
-    /// Fails closed at launch until that lands; never silently
-    /// plaintext. Always false for a `DirShare`.
+    /// `:enc` — route a disk volume through in-guest encryption.
+    /// Fails closed at launch until that lands; never silently plaintext.
     pub encrypted: bool,
-    /// For a `DirShare`, the ext4 image the granted directory was
-    /// materialized into, which is what the backend actually attaches.
+    /// The ext4 image a granted directory was materialized into, which is what
+    /// the backend actually attaches.
     ///
     /// `host` stays the directory that was *granted*, because that is the fact
     /// an admission record has to carry: a chain entry naming an image under
@@ -90,7 +84,7 @@ pub struct VmVolume {
     /// given. The grant and its transport are different things, and only the
     /// first belongs in the audit.
     ///
-    /// `None` on a `Disk`, whose `host` is already the image.
+    /// `None` when `host` is already the image.
     pub materialized_image: Option<String>,
     /// ext4 volume label written into the attached image, when the host set
     /// one, so the guest can mount by identity rather than by enumeration
@@ -104,21 +98,6 @@ pub struct VmVolume {
 }
 
 impl VmVolume {
-    /// Whether this volume reaches the guest as a virtio-blk device.
-    ///
-    /// Every volume does, now that a granted directory is delivered as an
-    /// image — but the two arrive at it differently, and three separate places
-    /// (the block list, the slot arithmetic, and the guest device mapping) have
-    /// to agree on which volumes are in that list and in what order. They agree
-    /// by calling this rather than by each matching on `kind`.
-    #[must_use]
-    pub fn attaches_as_block(&self) -> bool {
-        match self.kind {
-            VmVolumeKind::Disk => true,
-            VmVolumeKind::DirShare => self.materialized_image.is_some(),
-        }
-    }
-
     /// The host file to attach: the materialized image when there is one, the
     /// `host` path otherwise.
     #[must_use]
@@ -131,9 +110,9 @@ impl VmVolume {
 /// (`mvm-host-vm-init`) parses to mount each at its requested path.
 ///
 /// Format (one entry per volume, `;`-separated):
-/// `mvm.uvols=<tag>:<hex(guest_path)>:<ro|rw>:<fs|blk>`
-/// where `tag` is `uvol{idx}` — the virtio-fs tag / virtio-blk id the
-/// backend assigned for the volume at the same index. The guest path is
+/// `mvm.uvols=<tag>:<hex(guest_path)>:<ro|rw>:blk`
+/// where `tag` is `uvol{idx}` — the virtio-blk id the backend assigned for the
+/// volume at the same index. The guest path is
 /// hex-encoded so an arbitrary path can't collide with the cmdline's
 /// space / `:` / `;` delimiters. Returns `None` for an empty volume set
 /// so no parameter is appended.
@@ -146,13 +125,9 @@ pub fn encode_user_volumes_cmdline(volumes: &[VmVolume]) -> Option<String> {
     }
     let mut entries = Vec::with_capacity(volumes.len());
     for (idx, v) in volumes.iter().enumerate() {
-        let kind = match v.kind {
-            VmVolumeKind::DirShare => "fs",
-            VmVolumeKind::Disk => "blk",
-        };
         let mode = if v.read_only { "ro" } else { "rw" };
         let hexpath: String = v.guest.bytes().map(|b| format!("{b:02x}")).collect();
-        entries.push(format!("uvol{idx}:{hexpath}:{mode}:{kind}"));
+        entries.push(format!("uvol{idx}:{hexpath}:{mode}:blk"));
     }
     Some(format!("mvm.uvols={}", entries.join(";")))
 }
@@ -2008,7 +1983,7 @@ mod tests {
                 host: "/h/src".into(),
                 guest: "/work2".into(),
                 read_only: true,
-                kind: VmVolumeKind::DirShare,
+                materialized_image: Some("/state/mount-0.ext4".into()),
                 ..Default::default()
             },
             VmVolume {
@@ -2021,8 +1996,9 @@ mod tests {
         // "/work2" = 2f776f726b32, "/data" = 2f64617461
         assert_eq!(
             encode_user_volumes_cmdline(&vols).unwrap(),
-            "mvm.uvols=uvol0:2f776f726b32:ro:fs;uvol1:2f64617461:rw:blk"
+            "mvm.uvols=uvol0:2f776f726b32:ro:blk;uvol1:2f64617461:rw:blk"
         );
+        assert_eq!(vols[0].block_source(), "/state/mount-0.ext4");
         // No spaces — must be a single cmdline token.
         assert!(!encode_user_volumes_cmdline(&vols).unwrap().contains(' '));
     }

--- a/crates/mvm-hostd/src/plan_admission.rs
+++ b/crates/mvm-hostd/src/plan_admission.rs
@@ -1291,11 +1291,11 @@ pub fn enforce_admitted_shares(
     volumes: &[mvm_core::vm_backend::VmVolume],
     plan: &ExecutionPlan,
 ) -> Result<()> {
-    use mvm_core::vm_backend::VmVolumeKind;
     for v in volumes {
-        let want_kind = match v.kind {
-            VmVolumeKind::DirShare => mvm_core::plan::ShareKind::DirShare,
-            VmVolumeKind::Disk => mvm_core::plan::ShareKind::Disk,
+        let want_kind = if v.materialized_image.is_some() {
+            mvm_core::plan::ShareKind::DirShare
+        } else {
+            mvm_core::plan::ShareKind::Disk
         };
         let admitted = plan.shares.iter().find(|g| {
             g.host_path == v.host
@@ -1400,7 +1400,6 @@ pub fn enforce_sdk_sidecar_attachment(
     image_libc: GuestLibc,
 ) -> Result<()> {
     use mvm_core::plan::{SDK_SIDECAR_GUEST_PATH, sdk_host_services_in, sdk_sidecar_required};
-    use mvm_core::vm_backend::VmVolumeKind;
 
     // When sdk_uses_sidecar is false, the workload speaks the broker protocol
     // directly and may not carry the SDK sidecar.
@@ -1465,7 +1464,7 @@ pub fn enforce_sdk_sidecar_attachment(
             sidecar.host,
         );
     }
-    if !matches!(sidecar.kind, VmVolumeKind::Disk) {
+    if sidecar.materialized_image.is_some() {
         anyhow::bail!(
             "refusing to attach '{}' at {SDK_SIDECAR_GUEST_PATH}: the SDK sidecar is a read-only \
              disk image, not a host-directory share",
@@ -2987,7 +2986,6 @@ mod tests {
             host: "/h/src".into(),
             guest: "/data".into(),
             read_only: true,
-            kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
             materialized_image: Some("/state/mount-0.ext4".into()),
             volume_label: None,
             ..Default::default()
@@ -3004,6 +3002,22 @@ mod tests {
         assert!(
             enforce_admitted_shares(std::slice::from_ref(&ungranted), &plan).is_err(),
             "only the granted host path may reach a guest"
+        );
+
+        let mut disk_input = fixture_input("vm-materialized-share-as-disk");
+        disk_input.shares = vec![mvm_core::plan::HostShareGrant {
+            tag: "uvol0".into(),
+            host_path: "/h/src".into(),
+            guest_path: "/data".into(),
+            kind: mvm_core::plan::ShareKind::Disk,
+            read_only: true,
+            encrypted: false,
+            content_sha256: None,
+        }];
+        let disk_plan = synthesize_plan(&disk_input).expect("synthesize disk plan");
+        assert!(
+            enforce_admitted_shares(std::slice::from_ref(&materialized), &disk_plan).is_err(),
+            "a materialized directory must not satisfy a disk grant"
         );
     }
 
@@ -3032,7 +3046,7 @@ mod tests {
             host: host.into(),
             guest: "/data".into(),
             read_only: true,
-            kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
+            materialized_image: Some("/state/mount-0.ext4".into()),
             ..Default::default()
         };
 
@@ -3064,7 +3078,7 @@ mod tests {
 
     #[test]
     fn enforce_admitted_shares_refuses_unadmitted_or_mismatched() {
-        use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
+        use mvm_core::vm_backend::VmVolume;
         let grant = mvm_core::plan::HostShareGrant {
             tag: "uvol0".into(),
             host_path: "/h/src".into(),
@@ -3082,7 +3096,7 @@ mod tests {
             host: "/h/src".into(),
             guest: "/data".into(),
             read_only: true,
-            kind: VmVolumeKind::DirShare,
+            materialized_image: Some("/state/mount-0.ext4".into()),
             ..Default::default()
         };
         // The exact admitted volume passes.
@@ -3093,7 +3107,7 @@ mod tests {
             host: "/etc".into(),
             guest: "/data".into(),
             read_only: true,
-            kind: VmVolumeKind::DirShare,
+            materialized_image: Some("/state/mount-1.ext4".into()),
             ..Default::default()
         };
         assert!(enforce_admitted_shares(&[unadmitted], &plan).is_err());
@@ -3213,7 +3227,6 @@ mod tests {
     /// attachment at the sidecar mount point is a different, unadmitted shape.
     #[test]
     fn a_writable_or_dir_share_sidecar_fails_closed() {
-        use mvm_core::vm_backend::VmVolumeKind;
         let plan = plan_binding(&["host.audit.v1"]);
 
         let writable = mvm_core::vm_backend::VmVolume {
@@ -3225,7 +3238,7 @@ mod tests {
         assert!(err.to_string().contains("read-only"), "{err}");
 
         let share = mvm_core::vm_backend::VmVolume {
-            kind: VmVolumeKind::DirShare,
+            materialized_image: Some("/state/mount.ext4".to_string()),
             ..sdk_sidecar_volume()
         };
         let err = enforce_sdk_sidecar_attachment(&[share], &plan, LOADABLE_LIBC)
@@ -5475,7 +5488,8 @@ mod tests {
                 host: "/etc".into(),
                 guest: "/data".into(),
                 read_only: true,
-                kind: VmVolumeKind::DirShare,
+                kind: VmVolumeKind::Disk,
+                materialized_image: Some("/state/mount.ext4".to_string()),
                 ..Default::default()
             }],
             ..Default::default()

--- a/crates/mvm-hostd/src/run.rs
+++ b/crates/mvm-hostd/src/run.rs
@@ -124,9 +124,10 @@ pub fn shares_from_vm_volumes(volumes: &[VmVolume]) -> Vec<mvm_core::plan::HostS
             tag: format!("uvol{idx}"),
             host_path: v.host.clone(),
             guest_path: v.guest.clone(),
-            kind: match v.kind {
-                mvm_core::vm_backend::VmVolumeKind::Disk => mvm_core::plan::ShareKind::Disk,
-                mvm_core::vm_backend::VmVolumeKind::DirShare => mvm_core::plan::ShareKind::DirShare,
+            kind: if v.materialized_image.is_some() {
+                mvm_core::plan::ShareKind::DirShare
+            } else {
+                mvm_core::plan::ShareKind::Disk
             },
             read_only: v.read_only,
             encrypted: v.encrypted,
@@ -450,13 +451,13 @@ mod tests {
                 encrypted: false,
             },
             VmVolume {
-                materialized_image: None,
+                materialized_image: Some("/state/src.ext4".to_string()),
                 volume_label: None,
                 host: "/h/src".into(),
                 guest: "/data/src".into(),
                 size: String::new(),
                 read_only: false,
-                kind: VmVolumeKind::DirShare,
+                kind: VmVolumeKind::Disk,
                 encrypted: false,
             },
         ];

--- a/crates/mvm-runtime/src/backend.rs
+++ b/crates/mvm-runtime/src/backend.rs
@@ -114,14 +114,12 @@ pub struct FirecrackerConfig {
 impl FirecrackerConfig {
     /// Convert a backend-agnostic config into the legacy artifact shape.
     pub fn from_start_config(config: &VmStartConfig) -> Result<Self> {
-        validate_firecracker_start_config(config)?;
         let slot = microvm::allocate_slot(&config.name)?;
         Self::from_start_config_with_slot(config, slot)
     }
 
     /// Convert a config using a slot that has already been reserved.
     pub fn from_start_config_with_slot(config: &VmStartConfig, slot: VmSlot) -> Result<Self> {
-        validate_firecracker_start_config(config)?;
         let run_config = FlakeRunConfig {
             name: config.name.clone(),
             slot,
@@ -147,6 +145,7 @@ impl FirecrackerConfig {
                     guest: v.guest.clone(),
                     size: v.size.clone(),
                     read_only: v.read_only,
+                    materialized_image: v.materialized_image.clone(),
                     kind: v.kind,
                     encrypted: v.encrypted,
                 })
@@ -180,22 +179,6 @@ impl FirecrackerConfig {
         };
         Ok(Self { run_config })
     }
-}
-
-fn validate_firecracker_start_config(config: &VmStartConfig) -> Result<()> {
-    if let Some(v) = config
-        .volumes
-        .iter()
-        .find(|v| matches!(v.kind, mvm_core::vm_backend::VmVolumeKind::DirShare))
-    {
-        anyhow::bail!(
-            "Firecracker has no virtio-fs, so directory share '{}' -> '{}' isn't supported; \
-             use a disk-image volume instead (host:/guest:SIZE).",
-            v.host,
-            v.guest
-        );
-    }
-    Ok(())
 }
 
 /// Isolation tier of a `VmBackend`.
@@ -1075,33 +1058,33 @@ mod tests {
     }
 
     #[test]
-    fn firecracker_config_rejects_dirshare_before_claim() {
+    fn firecracker_config_carries_a_materialized_directory_as_a_block_volume() {
         let config = VmStartConfig {
             name: "standby-a".into(),
             rootfs_path: "/images/rootfs.ext4".into(),
             kernel_path: Some("/kernels/vmlinux".into()),
             volumes: vec![mvm_core::vm_backend::VmVolume {
-                materialized_image: None,
+                materialized_image: Some("/state/mount.ext4".to_string()),
                 volume_label: None,
                 host: "/host".into(),
                 guest: "/guest".into(),
                 size: String::new(),
                 read_only: true,
-                kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
+                kind: mvm_core::vm_backend::VmVolumeKind::Disk,
                 encrypted: false,
             }],
             ..Default::default()
         };
 
-        let err = match FirecrackerConfig::from_start_config_with_slot(
-            &config,
-            VmSlot::new("standby-a", 7),
-        ) {
-            Ok(_) => panic!("dir shares are unsupported"),
-            Err(err) => err,
-        };
-
-        assert!(err.to_string().contains("Firecracker has no virtio-fs"));
+        let firecracker =
+            FirecrackerConfig::from_start_config_with_slot(&config, VmSlot::new("standby-a", 7))
+                .expect("materialized directory uses the block transport");
+        assert_eq!(
+            firecracker.run_config.volumes[0]
+                .materialized_image
+                .as_deref(),
+            Some("/state/mount.ext4")
+        );
     }
 
     #[test]

--- a/crates/mvm-runtime/src/image.rs
+++ b/crates/mvm-runtime/src/image.rs
@@ -139,9 +139,12 @@ pub struct RuntimeVolume {
     /// otherwise, which is also what a config omitting the field means.
     #[serde(default)]
     pub read_only: bool,
-    /// Disk image (virtio-blk) vs live directory share (virtio-fs).
-    /// Defaults to `Disk` so a runtime-config file written before this
-    /// field existed keeps its persistent-volume meaning.
+    /// Materialized block image for a directory grant. `host` retains the
+    /// granted directory for signed-plan admission; this is the file attached
+    /// by the backend. Older configs omit it and remain direct disk volumes.
+    #[serde(default)]
+    pub materialized_image: Option<String>,
+    /// Runtime transport kind. Defaults to `Disk` for older configs.
     #[serde(default)]
     pub kind: mvm_core::vm_backend::VmVolumeKind,
     /// `:enc` — route a disk volume through in-guest encryption.
@@ -157,6 +160,7 @@ impl From<&mvm_core::vm_backend::VmVolume> for RuntimeVolume {
             guest: v.guest.clone(),
             size: v.size.clone(),
             read_only: v.read_only,
+            materialized_image: v.materialized_image.clone(),
             kind: v.kind,
             encrypted: v.encrypted,
         }
@@ -727,6 +731,43 @@ ls -lh "$IMAGES_DIR/{name}.$(uname -m).elf"
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn runtime_volume_defaults_to_an_unmaterialized_disk() {
+        let config: RuntimeConfig = toml::from_str(
+            r#"
+[[volumes]]
+host = "/vol/data.ext4"
+guest = "/data"
+size = "1G"
+"#,
+        )
+        .unwrap();
+
+        let volume = config.volumes.first().unwrap();
+        assert_eq!(volume.kind, mvm_core::vm_backend::VmVolumeKind::Disk);
+        assert_eq!(volume.materialized_image, None);
+    }
+
+    #[test]
+    fn runtime_volume_records_a_materialized_directory_image() {
+        let config: RuntimeConfig = toml::from_str(
+            r#"
+[[volumes]]
+host = "/host/data"
+guest = "/data"
+size = "1G"
+materialized_image = "/state/data.ext4"
+"#,
+        )
+        .unwrap();
+
+        let volume = config.volumes.first().unwrap();
+        assert_eq!(
+            volume.materialized_image.as_deref(),
+            Some("/state/data.ext4")
+        );
+    }
 
     #[test]
     fn test_parse_minimal_config() {

--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -324,30 +324,16 @@ fn build_volume_configs(config: &VmStartConfig) -> Result<Vec<VolumeConfig>> {
         .filter(|(volume, _)| !mvm_vmm::host::spec_map::is_sdk_sidecar_volume(volume))
         .enumerate()
         .map(|(idx, (volume, device))| {
-            // A granted directory that was materialized into an image reaches
-            // the guest as a block device like any other. The guest is told
-            // what it actually has, not what the operator asked for.
-            let (kind, device) = if volume.attaches_as_block() {
-                (VolumeConfigKind::Block, device)
-            } else {
-                (VolumeConfigKind::VirtioFs, None)
-            };
-            if volume.attaches_as_block() && device.is_none() {
+            if device.is_none() {
                 bail!("missing VMM block device for user volume uvol{idx}");
             }
             Ok(VolumeConfig {
                 tag: format!("uvol{idx}"),
                 mountpoint: volume.guest.clone(),
                 read_only: volume.read_only,
-                kind,
+                kind: VolumeConfigKind::Block,
                 device,
-                // Only a block volume can be found by label; a virtio-fs share
-                // is addressed by tag and has no filesystem the guest reads a
-                // label from.
-                label: volume
-                    .attaches_as_block()
-                    .then(|| volume.volume_label.clone())
-                    .flatten(),
+                label: volume.volume_label.clone(),
             })
         })
         .collect()
@@ -592,14 +578,19 @@ mod tests {
     }
 
     #[test]
-    fn build_env_maps_directory_and_block_volumes() {
+    fn build_env_maps_materialized_directory_and_direct_disk_as_blocks() {
         let (_env, _dir) = test_env();
         let config = VmStartConfig {
             name: "test-vm".into(),
             roothash: Some(VALID_HASH.into()),
             runtime_overlay_roothash: Some(VALID_HASH.into()),
             volumes: vec![
-                VmVolumeKind::DirShare.into_volume("/host/share", "/guest/share", false),
+                mvm_core::protocol::vm_backend::VmVolume {
+                    host: "/host/share".into(),
+                    guest: "/guest/share".into(),
+                    materialized_image: Some("/state/share.ext4".into()),
+                    ..Default::default()
+                },
                 VmVolumeKind::Disk.into_volume("/host/disk", "/guest/disk", true),
             ],
             ..base_config()
@@ -612,9 +603,9 @@ mod tests {
         assert!(!env.volumes[0].read_only);
         assert!(matches!(
             env.volumes[0].kind,
-            mvm_agentd::vsock::VolumeConfigKind::VirtioFs
+            mvm_agentd::vsock::VolumeConfigKind::Block
         ));
-        assert_eq!(env.volumes[0].device, None);
+        assert_eq!(env.volumes[0].device.as_deref(), Some("/dev/vdb"));
         assert_eq!(env.volumes[1].tag, "uvol1");
         assert_eq!(env.volumes[1].mountpoint, "/guest/disk");
         assert!(env.volumes[1].read_only);
@@ -622,7 +613,7 @@ mod tests {
             env.volumes[1].kind,
             mvm_agentd::vsock::VolumeConfigKind::Block
         ));
-        assert_eq!(env.volumes[1].device.as_deref(), Some("/dev/vdb"));
+        assert_eq!(env.volumes[1].device.as_deref(), Some("/dev/vdc"));
     }
 
     #[test]

--- a/crates/mvm-runtime/src/vm/volume_registry.rs
+++ b/crates/mvm-runtime/src/vm/volume_registry.rs
@@ -1,15 +1,10 @@
 //! Per-VM volume mount registry.
 //!
-//! Tracks which virtio-fs volumes are currently attached to a VM
-//! so `mvmctl volume ls` / `rm` operate on a stable list rather
-//! than guessing at host-side state. Persisted at
+//! Tracks which local block volumes are registered with a VM so `mvmctl volume
+//! ls` / `rm` operate on a stable list rather than guessing at host-side state.
+//! Persisted at
 //! `~/.mvm/instances/<vm>/volume_mounts.json` (mode 0600, atomic
 //! writes).
-//!
-//! The host-side `virtiofsd` process and Firecracker
-//! virtio-device-attach plumbing live elsewhere — this registry
-//! is the catalog the orchestrator hands to those tools and
-//! reads back from on subsequent calls.
 //!
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -20,11 +15,9 @@ use mvm_core::domain::volume::{GuestPath, VolumeName, WrappedKey};
 use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
 use serde::{Deserialize, Serialize};
 
-/// Maximum number of volume mounts per VM. Defends against
-/// `mvmctl volume mount` being looped without bound and the
-/// agent's virtio-fs tag namespace exhausting (the kernel limits
-/// per-VM devices already, but we cap earlier so callers see a
-/// clear error rather than virtio-fs's opaque ENOMEM).
+/// Maximum number of volume mounts per VM. Defends against `mvmctl volume
+/// mount` being looped without bound and caps the per-VM block-device surface
+/// before a backend-specific device limit is reached.
 pub const MAX_VOLUME_MOUNTS_PER_VM: usize = 16;
 
 /// Per-host managed local volume catalog path:
@@ -42,11 +35,7 @@ pub struct LocalVolumeEntry {
     pub volume_name: String,
     pub host_path: String,
     pub encrypted: bool,
-    /// Local artifact shape presented to the VM after unlock. Absent in a
-    /// catalog written before the field existed, and defaulted rather than
-    /// version-bumped — a new optional field is `#[serde(default)]`, not a
-    /// schema migration.
-    #[serde(default)]
+    /// Local block-image shape presented to the VM after unlock.
     pub kind: LocalVolumeKind,
     #[serde(default)]
     pub encryption: LocalVolumeEncryption,
@@ -54,12 +43,9 @@ pub struct LocalVolumeEntry {
 }
 
 /// Materialized shape of a managed local volume.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "kebab-case", deny_unknown_fields)]
 pub enum LocalVolumeKind {
-    /// Legacy host directory exposed only by backends with directory sharing.
-    #[default]
-    Directory,
     /// Portable ext4 image attached as a virtio block device.
     BlockImage { size_mib: u32 },
 }
@@ -191,20 +177,14 @@ fn validate_local_volume_entry(entry: &LocalVolumeEntry) -> Result<()> {
     Ok(())
 }
 
-/// One attached virtio-fs volume mount.
-///
-/// `volume_name` is the logical identity (also used as the
-/// virtio-fs tag the kernel sees, so the agent's `MountVolume`
-/// validation applies). `host_path` is the absolute host-side
-/// directory exposed via virtio-fs.
+/// One attached local block-volume mount.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct VolumeMountEntry {
-    /// Logical volume identifier — used as the virtio-fs tag and
-    /// as the future foreign key into the per-host volume
-    /// catalog.
+    /// Logical volume identifier and future foreign key into the per-host
+    /// volume catalog.
     pub volume_name: String,
-    /// Absolute host-side directory exposed via virtio-fs.
+    /// Absolute host-side block-image path.
     pub host_path: String,
     /// Mount point inside the guest. Validated via
     /// `mvm_core::crypto::policy::MountPathPolicy` before reaching
@@ -212,9 +192,7 @@ pub struct VolumeMountEntry {
     pub guest_path: String,
     /// `true` when the volume is exposed read-only.
     pub read_only: bool,
-    /// Artifact shape captured when the registration is created. Legacy
-    /// persisted mounts decode as directories.
-    #[serde(default)]
+    /// Block-image shape captured when the registration is created.
     pub kind: LocalVolumeKind,
     /// RFC 3339 timestamp of attach.
     pub attached_at: String,
@@ -265,12 +243,9 @@ pub struct ResolvedVolumeAttachment {
 impl ResolvedVolumeAttachment {
     /// Convert into the single backend-agnostic VM attachment carrier.
     pub fn as_vm_volume(&self) -> VmVolume {
-        let (size, kind) = match &self.kind {
-            LocalVolumeKind::Directory => (String::new(), VmVolumeKind::DirShare),
-            LocalVolumeKind::BlockImage { size_mib } => {
-                (format!("{size_mib}M"), VmVolumeKind::Disk)
-            }
-        };
+        let LocalVolumeKind::BlockImage { size_mib } = self.kind;
+        let size = format!("{size_mib}M");
+        let kind = VmVolumeKind::Disk;
         VmVolume {
             materialized_image: None,
             volume_label: None,
@@ -416,15 +391,9 @@ fn resolve_mount_entry(
     };
     let (resolved_source, kind) = match effective_source {
         VolumeMountSource::ManagedCatalog => resolve_managed_source(entry, catalog, &volume_name)?,
-        // Honour the shape the registration recorded rather than assuming a
-        // directory. An ad-hoc registration used to be a live host-directory
-        // share and nothing else, so hardcoding `Directory` was accurate; it
-        // stopped being so once a granted directory could be materialized into
-        // an image, and the hardcode then coerced a perfectly good block image
-        // back into a share no backend can serve.
-        //
-        // Entries written before `kind` existed decode as `Directory` through
-        // its `serde(default)`, so this is the same answer for them.
+        // Honour the shape the registration recorded. Ad-hoc directory grants
+        // are snapshotted before registration, so the persisted path is a
+        // block image just like a directly supplied image.
         VolumeMountSource::AdHocHost => (ResolvedVolumeSource::AdHocHost, entry.kind.clone()),
         VolumeMountSource::Legacy => bail!("legacy volume source was not normalized"),
     };
@@ -445,11 +414,6 @@ fn resolve_mount_entry(
         )
     })?;
     match &kind {
-        LocalVolumeKind::Directory if !host_path.is_dir() => bail!(
-            "registered directory volume {:?} is not a directory: {}",
-            volume_name,
-            host_path.display()
-        ),
         LocalVolumeKind::BlockImage { .. } if !host_path.is_file() => bail!(
             "registered block volume {:?} is not a file: {}",
             volume_name,
@@ -464,7 +428,6 @@ fn resolve_mount_entry(
                 )
             })?;
         }
-        LocalVolumeKind::Directory => {}
     }
 
     Ok(ResolvedVolumeAttachment {
@@ -562,7 +525,7 @@ mod tests {
             host_path: format!("/host/{vol}"),
             guest_path: guest.to_string(),
             read_only: false,
-            kind: LocalVolumeKind::Directory,
+            kind: LocalVolumeKind::BlockImage { size_mib: 16 },
             attached_at: "2026-05-05T00:00:00Z".to_string(),
             source: VolumeMountSource::ManagedCatalog,
         }
@@ -573,7 +536,7 @@ mod tests {
             volume_name: name.to_string(),
             host_path: format!("/encrypted/{name}"),
             encrypted: true,
-            kind: LocalVolumeKind::Directory,
+            kind: LocalVolumeKind::BlockImage { size_mib: 16 },
             encryption: LocalVolumeEncryption::HostBacked,
             created_at: "2026-05-05T00:00:00Z".to_string(),
         }
@@ -584,7 +547,7 @@ mod tests {
             volume_name: name.to_string(),
             host_path: format!("/plain/{name}"),
             encrypted: true,
-            kind: LocalVolumeKind::Directory,
+            kind: LocalVolumeKind::BlockImage { size_mib: 16 },
             encryption: LocalVolumeEncryption::MvmManaged(MvmManagedVolumeEncryption {
                 state,
                 ciphertext_path: format!("/cipher/{name}.mvve"),
@@ -597,6 +560,19 @@ mod tests {
             }),
             created_at: "2026-05-05T00:00:00Z".to_string(),
         }
+    }
+
+    fn create_ext4_image(path: &Path, size_mib: u32) {
+        let mut image = std::fs::OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+        let size_bytes = u64::from(size_mib) * 1024 * 1024;
+        image.set_len(size_bytes).unwrap();
+        mvm_fs::ext4::mkfs::format_empty_ext4(&mut image, size_bytes).unwrap();
+        image.sync_all().unwrap();
     }
 
     #[test]
@@ -728,7 +704,7 @@ mod tests {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(
             &path,
-            r#"{"volumes":{"work":{"volume_name":"work","host_path":"/encrypted/work","encrypted":true,"created_at":"2026-05-05T00:00:00Z"}}}"#,
+            r#"{"volumes":{"work":{"volume_name":"work","host_path":"/encrypted/work.ext4","encrypted":true,"kind":{"type":"block-image","size_mib":16},"created_at":"2026-05-05T00:00:00Z"}}}"#,
         )
         .unwrap();
         let loaded = LocalVolumeCatalog::load().unwrap();
@@ -736,7 +712,10 @@ mod tests {
             loaded.get("work").unwrap().encryption,
             LocalVolumeEncryption::HostBacked
         ));
-        assert_eq!(loaded.get("work").unwrap().kind, LocalVolumeKind::Directory);
+        assert_eq!(
+            loaded.get("work").unwrap().kind,
+            LocalVolumeKind::BlockImage { size_mib: 16 }
+        );
     }
 
     #[test]
@@ -759,69 +738,35 @@ mod tests {
     #[test]
     fn legacy_mount_entry_defaults_to_legacy_source() {
         let entry: VolumeMountEntry = serde_json::from_str(
-            r#"{"volume_name":"work","host_path":"/host/work","guest_path":"/data/work","read_only":true,"attached_at":"2026-05-05T00:00:00Z"}"#,
+            r#"{"volume_name":"work","host_path":"/host/work.ext4","guest_path":"/data/work","read_only":true,"kind":{"type":"block-image","size_mib":16},"attached_at":"2026-05-05T00:00:00Z"}"#,
         )
         .unwrap();
         assert_eq!(entry.source, VolumeMountSource::Legacy);
     }
 
     #[test]
-    fn managed_unlocked_mount_resolves_to_typed_vm_volume() {
-        let tmp = tempfile::tempdir().unwrap();
-        let host = tmp.path().join("plain");
-        std::fs::create_dir(&host).unwrap();
-        let mut catalog = LocalVolumeCatalog::default();
-        let mut local = make_mvm_managed_entry("work", LocalVolumeState::Unlocked);
-        local.host_path = host.display().to_string();
-        catalog.add(local).unwrap();
-        let registry = VolumeMountRegistry {
-            mounts: BTreeMap::from([(
-                "/data/work".to_string(),
-                VolumeMountEntry {
-                    volume_name: "work".to_string(),
-                    host_path: host.display().to_string(),
-                    guest_path: "/data/work".to_string(),
-                    read_only: true,
-                    kind: LocalVolumeKind::Directory,
-                    attached_at: "2026-05-05T00:00:00Z".to_string(),
-                    source: VolumeMountSource::ManagedCatalog,
-                },
-            )]),
-        };
+    fn persisted_mount_without_a_kind_is_rejected() {
+        let err = serde_json::from_str::<VolumeMountEntry>(
+            r#"{"volume_name":"work","host_path":"/host/work.ext4","guest_path":"/data/work","read_only":true,"attached_at":"2026-05-05T00:00:00Z"}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("missing field `kind`"), "{err}");
+    }
 
-        let resolved = registry.resolve_for_launch(&catalog).unwrap();
-        assert_eq!(resolved.len(), 1);
-        assert_eq!(resolved[0].volume_name.as_str(), "work");
-        assert_eq!(resolved[0].guest_path.as_str(), "/data/work");
-        assert_eq!(resolved[0].host_path, host.canonicalize().unwrap());
-        assert_eq!(resolved[0].source, ResolvedVolumeSource::MvmManaged);
-        let vm_volume = resolved[0].as_vm_volume();
-        assert_eq!(
-            vm_volume.host,
-            host.canonicalize().unwrap().display().to_string()
-        );
-        assert_eq!(vm_volume.guest, "/data/work");
-        assert!(vm_volume.read_only);
-        assert!(matches!(
-            vm_volume.kind,
-            mvm_core::vm_backend::VmVolumeKind::DirShare
-        ));
-        assert!(!vm_volume.encrypted);
+    #[test]
+    fn persisted_directory_mount_kind_is_rejected() {
+        let err = serde_json::from_str::<VolumeMountEntry>(
+            r#"{"volume_name":"work","host_path":"/host/work","guest_path":"/data/work","read_only":true,"kind":{"type":"directory"},"attached_at":"2026-05-05T00:00:00Z"}"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("unknown variant"), "{err}");
     }
 
     #[test]
     fn managed_block_mount_resolves_to_portable_disk_volume() {
         let tmp = tempfile::tempdir().unwrap();
         let host = tmp.path().join("work.ext4");
-        let mut image = std::fs::OpenOptions::new()
-            .create_new(true)
-            .read(true)
-            .write(true)
-            .open(&host)
-            .unwrap();
-        image.set_len(16 * 1024 * 1024).unwrap();
-        mvm_fs::ext4::mkfs::format_empty_ext4(&mut image, 16 * 1024 * 1024).unwrap();
-        image.sync_all().unwrap();
+        create_ext4_image(&host, 16);
 
         let mut catalog = LocalVolumeCatalog::default();
         let mut local = make_mvm_managed_entry("work", LocalVolumeState::Unlocked);
@@ -889,8 +834,8 @@ mod tests {
     #[test]
     fn ad_hoc_mount_resolves_without_catalog_but_remains_distinguishable() {
         let tmp = tempfile::tempdir().unwrap();
-        let host = tmp.path().join("adhoc");
-        std::fs::create_dir(&host).unwrap();
+        let host = tmp.path().join("adhoc.ext4");
+        create_ext4_image(&host, 16);
         let mut entry = make_entry("/work/input", "input");
         entry.host_path = host.display().to_string();
         entry.source = VolumeMountSource::AdHocHost;

--- a/crates/mvm-runtime/src/wasm_activation.rs
+++ b/crates/mvm-runtime/src/wasm_activation.rs
@@ -8,9 +8,9 @@
 //! - **Preopens instead of mounts.** The runtime overlay's guest binaries
 //!   are preopened read-only at `/mvm/runtime` (the same guest path the
 //!   dm-verity overlay occupies on microVM backends), and each declared
-//!   `DirShare` volume is preopened at its guest mountpoint with its
-//!   read-only flag honored. WASI has no block devices: a `Disk` volume
-//!   fails closed before any of this, in
+//!   materialized directory grant is preopened at its guest mountpoint with
+//!   its read-only flag honored. WASI has no block devices: a direct disk
+//!   volume fails closed before any of this, in
 //!   [`crate::wasm_backend::WasmBackendError`].
 //! - **An activation file instead of a vsock verb.** The run's environment
 //!   summary — overlay guest path, volume mountpoints, the network
@@ -39,7 +39,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
-use mvm_core::vm_backend::{VmStartConfig, VmVolumeKind};
+use mvm_core::vm_backend::VmStartConfig;
 use serde::{Deserialize, Serialize};
 
 use crate::wasm_backend::WasmBackendError;
@@ -103,7 +103,7 @@ pub struct WasmPreopenPlan {
 
 /// Translate a launch config into the preopen/env plan: the activation run
 /// dir first (read-only, always present), then the runtime overlay
-/// (read-only, when resolved), then every declared `DirShare` volume in
+/// (read-only, when resolved), then every materialized directory grant in
 /// config order with its read-only flag honored. Pure — no I/O, no
 /// wasmtime — so the exact tuples are assertable in a test.
 pub fn build_wasm_preopen_plan(
@@ -126,7 +126,7 @@ pub fn build_wasm_preopen_plan(
     for volume in config
         .volumes
         .iter()
-        .filter(|v| matches!(v.kind, VmVolumeKind::DirShare))
+        .filter(|v| v.materialized_image.is_some())
     {
         preopens.push(WasmPreopen {
             host_dir: PathBuf::from(&volume.host),
@@ -253,7 +253,7 @@ pub fn prepare_wasm_activation(
         volumes: config
             .volumes
             .iter()
-            .filter(|v| matches!(v.kind, VmVolumeKind::DirShare))
+            .filter(|v| v.materialized_image.is_some())
             .map(|v| WasmVolume {
                 guest_path: v.guest.clone(),
                 read_only: v.read_only,
@@ -285,13 +285,13 @@ mod tests {
 
     fn dir_share(host: &str, guest: &str, read_only: bool) -> VmVolume {
         VmVolume {
-            materialized_image: None,
+            materialized_image: Some("/state/materialized.ext4".to_string()),
             volume_label: None,
             host: host.into(),
             guest: guest.into(),
             size: String::new(),
             read_only,
-            kind: VmVolumeKind::DirShare,
+            kind: mvm_core::vm_backend::VmVolumeKind::Disk,
             encrypted: false,
         }
     }
@@ -304,7 +304,7 @@ mod tests {
             guest: guest.into(),
             size: String::new(),
             read_only: false,
-            kind: VmVolumeKind::Disk,
+            kind: mvm_core::vm_backend::VmVolumeKind::Disk,
             encrypted: false,
         }
     }

--- a/crates/mvm-runtime/src/wasm_backend.rs
+++ b/crates/mvm-runtime/src/wasm_backend.rs
@@ -116,7 +116,7 @@ pub enum WasmBackendError {
 
     #[error(
         "wasm backend cannot attach block volume '{host}' — a WASI instance has no block \
-         devices; use a directory-share volume instead"
+         devices; use `machine run --mount` with a host directory instead"
     )]
     DiskVolumeNotSupported { host: String },
 
@@ -308,14 +308,15 @@ fn reject_unsupported_start_config(
     if let Some(volume) = config
         .volumes
         .iter()
-        .find(|v| matches!(v.kind, mvm_core::vm_backend::VmVolumeKind::Disk))
+        .find(|v| v.materialized_image.is_none())
     {
         return Err(WasmBackendError::DiskVolumeNotSupported {
             host: volume.host.clone(),
         });
     }
-    // Every directory share becomes a WASI preopen verbatim, so its guest
-    // mountpoint must pass the mount-path policy before any of it starts.
+    // Every materialized directory grant becomes a WASI preopen of its
+    // original host path, so its guest mountpoint must pass the mount-path
+    // policy before any of it starts.
     for volume in &config.volumes {
         crate::wasm_activation::validate_wasm_volume_guest_path(&volume.guest)?;
     }
@@ -1743,7 +1744,7 @@ mod tests {
     }
 
     #[test]
-    fn disk_volume_fails_closed_dir_share_passes() {
+    fn disk_volume_fails_closed_materialized_directory_grant_passes() {
         let mut config = cfg("x", "/tmp/mod.wasm");
         config.volumes = vec![mvm_core::vm_backend::VmVolume {
             materialized_image: None,
@@ -1762,7 +1763,7 @@ mod tests {
             })
         );
 
-        config.volumes[0].kind = mvm_core::vm_backend::VmVolumeKind::DirShare;
+        config.volumes[0].materialized_image = Some("/state/mount.ext4".to_string());
         assert!(reject_unsupported_start_config(&config).is_ok());
     }
 
@@ -1771,13 +1772,13 @@ mod tests {
         for bad in ["mnt/relative", "/run/mvm", "/mvm/runtime"] {
             let mut config = cfg("x", "/tmp/mod.wasm");
             config.volumes = vec![mvm_core::vm_backend::VmVolume {
-                materialized_image: None,
+                materialized_image: Some("/state/mount.ext4".to_string()),
                 volume_label: None,
                 host: "/host/share".into(),
                 guest: bad.into(),
                 size: String::new(),
                 read_only: true,
-                kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
+                kind: mvm_core::vm_backend::VmVolumeKind::Disk,
                 encrypted: false,
             }];
             assert!(

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -51,9 +51,7 @@ use mvm_vmm::host::egress_shared::{decode_plan_secrets_from_state, plan_stream_r
 use mvm_vmm::host::network_endpoint_spawn::{
     EndpointTransport, SubstitutionSpawnParams, reap_network_endpoint, spawn_network_endpoint,
 };
-use mvm_vmm::host::spec_map::{
-    WorkloadSpecInputs, ensure_no_dir_share_volumes, workload_spec, workload_vsock_ports,
-};
+use mvm_vmm::host::spec_map::{WorkloadSpecInputs, workload_spec, workload_vsock_ports};
 use mvm_vmm::post_restore::PostRestoreOutcome;
 
 mod admission;
@@ -348,17 +346,6 @@ impl<D: VmmDriver, S: NetworkEndpointSpawner, B: BrokerRegistrar> WorkloadRunner
     /// secret-free deny-all workload has no egress capability and therefore
     /// carries no endpoint process or guest egress channel.
     pub fn start_workload(&self, inputs: &WorkloadLaunchInputs<'_>) -> Result<Box<dyn RunningVm>> {
-        // Fail closed before any side effect (endpoint spawn) runs: a
-        // `DirShare` volume has no `VmmSpec` representation on this driver
-        // seam, so refuse it here rather than silently dropping it later in
-        // `workload_blocks`.
-        // No driver serves a live directory share any more: a `--mount` is
-        // materialized into an image before it reaches here. A volume still
-        // asking to be shared is one nothing materialized, and it must refuse
-        // rather than be dropped — a workload booting without its mount is
-        // worse than one that will not boot.
-        ensure_no_dir_share_volumes(inputs.config)?;
-
         // A caller times this call from outside and cannot see past it, yet the
         // VMM boot and every post-boot registration happen in here. Off unless
         // a measurement asked for it.
@@ -2543,19 +2530,6 @@ mod tests {
         }
     }
 
-    fn dir_share_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
-        mvm_core::vm_backend::VmVolume {
-            materialized_image: None,
-            volume_label: None,
-            host: host.into(),
-            guest: guest.into(),
-            size: String::new(),
-            read_only: false,
-            kind: mvm_core::vm_backend::VmVolumeKind::DirShare,
-            encrypted: false,
-        }
-    }
-
     /// A `--volume` disk (claim 11's sealed app-dep disk, or any other
     /// `Disk`-kind volume) must reach a runner-booted guest both as an
     /// attached `BlockDev` and as an `mvm.uvols=` cmdline entry naming it —
@@ -2696,53 +2670,6 @@ mod tests {
         assert_eq!(
             meta.rootfs_path.as_deref(),
             Some(admitted.rootfs_path.as_str())
-        );
-    }
-
-    /// A `DirShare` volume has no `VmmSpec` representation on this driver
-    /// seam. `start_workload` must refuse it before spawning the gating
-    /// endpoint or the broker — never boot a VM missing a share the caller
-    /// asked for.
-    #[test]
-    fn start_workload_refuses_a_dir_share_volume_before_any_side_effect() {
-        let policy = NetworkPolicy::deny_all();
-        let redaction = RedactionPolicy::default();
-        let runner = WorkloadRunner::new(
-            MockDriver::default(),
-            RecordingSpawner::new("/run/ep.sock"),
-            RecordingBrokerRegistrar::new(),
-        );
-
-        let cfg = VmStartConfig {
-            volumes: vec![dir_share_volume("/host/dir", "/mnt/share")],
-            ..config("w-dirshare-refused")
-        };
-        let result = runner.start_workload(&WorkloadLaunchInputs {
-            config: &cfg,
-            tenant: "tenant-x",
-            secrets: &[],
-            redaction: &redaction,
-            network_policy: &policy,
-            cmdline: String::new(),
-        });
-        let message = match result {
-            Ok(_) => panic!("a DirShare volume must be refused"),
-            Err(e) => e.to_string(),
-        };
-        assert!(message.contains("/host/dir"), "message: {message}");
-        assert!(message.contains("/mnt/share"), "message: {message}");
-
-        assert!(
-            runner.driver.booted_specs().is_empty(),
-            "refused start must never reach the driver"
-        );
-        assert!(
-            runner.spawner.seen.lock().unwrap().is_none(),
-            "refused start must never spawn the gating endpoint"
-        );
-        assert!(
-            runner.broker.seen.lock().unwrap().is_none(),
-            "refused start must never register the broker"
         );
     }
 

--- a/crates/mvm-vmm/src/host/spec_map.rs
+++ b/crates/mvm-vmm/src/host/spec_map.rs
@@ -4,10 +4,9 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Result, bail};
 use mvm_agentd::vsock::dev_console_data_ports;
 use mvm_core::config::vm_hvf_vsock_port_socket_at;
-use mvm_core::vm_backend::{VmStartConfig, VmVolumeKind};
+use mvm_core::vm_backend::VmStartConfig;
 use mvm_net::channel::GuestService;
 
 use crate::driver::spec::{
@@ -23,9 +22,7 @@ use crate::driver::spec::{
 /// or other `--volume` disk image) lands at the next free slot, in `volumes`
 /// order — the same order `encode_user_volumes_cmdline` walks to number its
 /// `uvol{idx}` tokens, so the Nth appended volume block matches the Nth
-/// `mvm.uvols=` entry. A `DirShare` volume has no block-device representation
-/// and is skipped here; callers must refuse it before reaching this function
-/// (see `ensure_no_dir_share_volumes`) rather than relying on this silent skip.
+/// `mvm.uvols=` entry. Every volume has a block-device representation.
 ///
 /// The rootfs/verity/overlay devices are read-only: a workload rootfs is
 /// sealed, and the verity sidecars are integrity data the guest only reads.
@@ -66,7 +63,7 @@ pub fn workload_blocks(config: &VmStartConfig) -> Vec<BlockDev> {
         blocks.push(ro(overlay_verity, blocks.len() as u8));
     }
 
-    for volume in config.volumes.iter().filter(|v| v.attaches_as_block()) {
+    for volume in &config.volumes {
         let slot = blocks.len() as u8;
         blocks.push(BlockDev {
             source: volume.block_source().to_string().into(),
@@ -84,31 +81,20 @@ pub fn workload_blocks(config: &VmStartConfig) -> Vec<BlockDev> {
 
 /// Resolve the guest block device for each configured volume.
 ///
-/// The returned entries preserve `config.volumes` order. Directory shares have
-/// no block device and therefore produce `None`; disk volumes resolve to the
-/// exact `/dev/vd*` node present in [`workload_blocks`]. Keeping this mapping
-/// here makes callers use the same slot calculation as the VMM and the guest
-/// activation path.
+/// The returned entries preserve `config.volumes` order. Every user volume is
+/// a block image and resolves to the exact `/dev/vd*` node present in
+/// [`workload_blocks`]. Keeping this mapping here makes callers use the same
+/// slot calculation as the VMM and the guest activation path.
 pub fn workload_volume_devices(config: &VmStartConfig) -> Vec<Option<String>> {
     let blocks = workload_blocks(config);
-    let disk_count = config
-        .volumes
-        .iter()
-        .filter(|volume| volume.attaches_as_block())
-        .count();
+    let disk_count = config.volumes.len();
     let first_user_block = blocks.len().saturating_sub(disk_count);
     let mut block_devices = blocks[first_user_block..].iter().map(BlockDev::device_node);
 
     config
         .volumes
         .iter()
-        .map(|volume| {
-            if volume.attaches_as_block() {
-                block_devices.next()
-            } else {
-                None
-            }
-        })
+        .map(|_| block_devices.next())
         .collect()
 }
 
@@ -117,8 +103,7 @@ pub fn workload_volume_devices(config: &VmStartConfig) -> Vec<Option<String>> {
 /// The sidecar is physically a disk, but it is not a user volume: the guest
 /// mounts it through the dedicated `mvm.sdk_dev` contract at `/mvm/sdk`.
 pub fn is_sdk_sidecar_volume(volume: &mvm_core::vm_backend::VmVolume) -> bool {
-    volume.guest == mvm_core::plan::SDK_SIDECAR_GUEST_PATH
-        && matches!(volume.kind, VmVolumeKind::Disk)
+    volume.guest == mvm_core::plan::SDK_SIDECAR_GUEST_PATH && volume.materialized_image.is_none()
 }
 
 /// The guest device node the SDK sidecar lands on for this launch config, or
@@ -135,31 +120,6 @@ pub fn sdk_sidecar_block_device(config: &VmStartConfig) -> Option<String> {
         .get(sidecar_index)
         .cloned()
         .flatten()
-}
-
-/// Refuse a `DirShare` volume before a `VmmSpec` is assembled: the runner's
-/// `VmmSpec` has no virtio-fs device, so a directory share can't be expressed
-/// on this path (unlike a `Disk` volume, which becomes a `BlockDev`). Fails
-/// closed with the offending volume named, rather than letting
-/// `workload_blocks` silently drop it. `VmmSpec.shares` (virtio-fs) is a
-/// deferred follow-up; the dev-tier `virtiofs_root` flat share is a separate,
-/// unrelated field and out of scope here.
-pub fn ensure_no_dir_share_volumes(config: &VmStartConfig) -> Result<()> {
-    if let Some(v) = config
-        .volumes
-        .iter()
-        .find(|v| matches!(v.kind, VmVolumeKind::DirShare) && !v.attaches_as_block())
-    {
-        bail!(
-            "directory-share volume '{}' -> '{}' cannot be attached: the WorkloadRunner has no \
-             virtio-fs device yet, so a live host-directory share can't be expressed. Use a \
-             disk-image volume instead (host:/guest:SIZE), or run this workload on a backend \
-             with virtio-fs support.",
-            v.host,
-            v.guest
-        );
-    }
-    Ok(())
 }
 
 /// The host-side unix sockets a workload's standing vsock channels bind to.
@@ -377,7 +337,7 @@ pub fn workload_spec(inputs: &WorkloadSpecInputs) -> VmmSpec {
 mod tests {
     use super::*;
     use mvm_agentd::vsock::{EGRESS_PORT, GUEST_AGENT_PORT, WORKLOAD_EXIT_PORT};
-    use mvm_core::vm_backend::VmVolume;
+    use mvm_core::vm_backend::{VmVolume, VmVolumeKind};
     use std::path::PathBuf;
 
     fn base() -> VmStartConfig {
@@ -388,13 +348,13 @@ mod tests {
         }
     }
 
-    fn granted_dir(host: &str, guest: &str, image: Option<&str>) -> VmVolume {
+    fn granted_dir(host: &str, guest: &str, image: &str) -> VmVolume {
         VmVolume {
             host: host.into(),
             guest: guest.into(),
             read_only: true,
-            kind: VmVolumeKind::DirShare,
-            materialized_image: image.map(str::to_string),
+            kind: VmVolumeKind::Disk,
+            materialized_image: Some(image.to_string()),
             volume_label: None,
             ..Default::default()
         }
@@ -413,17 +373,9 @@ mod tests {
     fn a_materialized_grant_is_attached_as_a_block_device_and_not_as_a_share() {
         // The point of the whole change: no virtio-fs device is asked for.
         let cfg = VmStartConfig {
-            volumes: vec![granted_dir(
-                "/home/me/src",
-                "/work",
-                Some("/state/mount-0.ext4"),
-            )],
+            volumes: vec![granted_dir("/home/me/src", "/work", "/state/mount-0.ext4")],
             ..base()
         };
-        assert!(
-            ensure_no_dir_share_volumes(&cfg).is_ok(),
-            "a materialized grant is not a directory share"
-        );
         let blocks = workload_blocks(&cfg);
         assert!(
             blocks
@@ -446,7 +398,7 @@ mod tests {
         // someone else's data, which no error surfaces.
         let cfg = VmStartConfig {
             volumes: vec![
-                granted_dir("/src", "/work", Some("/state/mount-0.ext4")),
+                granted_dir("/src", "/work", "/state/mount-0.ext4"),
                 disk("/state/data.ext4", "/data"),
             ],
             ..base()
@@ -471,23 +423,6 @@ mod tests {
         };
         assert_eq!(devices[0], node_of("/state/mount-0.ext4"));
         assert_eq!(devices[1], node_of("/state/data.ext4"));
-    }
-
-    #[test]
-    fn an_unmaterialized_grant_is_still_refused_rather_than_silently_dropped() {
-        // Nothing produces one now, but the refusal is what makes that true
-        // rather than assumed: a share with no image has no way to reach the
-        // guest, and dropping it would boot a workload without its mount.
-        let cfg = VmStartConfig {
-            volumes: vec![granted_dir("/src", "/work", None)],
-            ..base()
-        };
-        assert!(ensure_no_dir_share_volumes(&cfg).is_err());
-        assert!(
-            workload_blocks(&cfg)
-                .iter()
-                .all(|b| b.source.as_path() != Path::new("/src"))
-        );
     }
 
     #[test]
@@ -542,38 +477,46 @@ mod tests {
         blocks.iter().map(BlockDev::device_node).collect()
     }
 
-    /// Neither kind of directory volume produces a share any more — including
-    /// the read-write one, which used to be refused by a separate check rather
-    /// than being unrepresentable.
+    /// Neither access mode turns a materialized directory grant back into a
+    /// live share.
     #[test]
-    fn no_directory_volume_produces_a_share_whatever_its_mode() {
+    fn materialized_directory_grants_are_blocks_whatever_their_mode() {
         let cfg = VmStartConfig {
             volumes: vec![
                 VmVolume {
-                    materialized_image: None,
+                    materialized_image: Some("/state/rw.ext4".to_string()),
                     volume_label: None,
                     host: "/host/rw".into(),
                     guest: "/guest/rw".into(),
                     size: String::new(),
                     read_only: false,
-                    kind: VmVolumeKind::DirShare,
+                    kind: VmVolumeKind::Disk,
                     encrypted: false,
                 },
                 VmVolume {
-                    materialized_image: None,
+                    materialized_image: Some("/state/ro.ext4".to_string()),
                     volume_label: None,
                     host: "/host/ro".into(),
                     guest: "/guest/ro".into(),
                     size: String::new(),
                     read_only: true,
-                    kind: VmVolumeKind::DirShare,
+                    kind: VmVolumeKind::Disk,
                     encrypted: false,
                 },
             ],
             ..base()
         };
-        // An unmaterialized grant refuses rather than being silently dropped.
-        assert!(ensure_no_dir_share_volumes(&cfg).is_err());
+        let blocks = workload_blocks(&cfg);
+        assert!(
+            blocks
+                .iter()
+                .any(|block| block.source == Path::new("/state/rw.ext4"))
+        );
+        assert!(
+            blocks
+                .iter()
+                .any(|block| block.source == Path::new("/state/ro.ext4"))
+        );
     }
 
     #[test]
@@ -650,19 +593,6 @@ mod tests {
         }
     }
 
-    fn dir_share_volume(host: &str, guest: &str) -> mvm_core::vm_backend::VmVolume {
-        mvm_core::vm_backend::VmVolume {
-            materialized_image: None,
-            volume_label: None,
-            host: host.into(),
-            guest: guest.into(),
-            size: String::new(),
-            read_only: false,
-            kind: VmVolumeKind::DirShare,
-            encrypted: false,
-        }
-    }
-
     #[test]
     fn a_disk_volume_lands_at_slot_4_after_the_full_base_stack() {
         let cfg = VmStartConfig {
@@ -693,14 +623,18 @@ mod tests {
             runtime_overlay_roothash: Some("ab".repeat(32)),
             volumes: vec![
                 disk_volume("/vol/first.img", "/first", true),
-                dir_share_volume("/host/share", "/share"),
+                granted_dir("/host/share", "/share", "/state/share.ext4"),
                 disk_volume("/vol/second.img", "/second", false),
             ],
             ..base()
         };
         assert_eq!(
             workload_volume_devices(&cfg),
-            vec![Some("/dev/vde".into()), None, Some("/dev/vdf".into())]
+            vec![
+                Some("/dev/vde".into()),
+                Some("/dev/vdf".into()),
+                Some("/dev/vdg".into())
+            ]
         );
     }
 
@@ -778,15 +712,15 @@ mod tests {
         assert_eq!(sdk_sidecar_block_device(&cfg).as_deref(), Some("/dev/vdb"));
     }
 
-    /// A directory share at the sidecar mount point is not a sidecar
-    /// attachment; the admission gate already refuses it, and this resolver
-    /// must not paper over it by naming a block device that was never attached.
+    /// A materialized directory grant at the sidecar mount point is not the
+    /// reserved SDK sidecar attachment.
     #[test]
-    fn a_dir_share_at_the_sidecar_path_resolves_no_device() {
+    fn a_materialized_directory_at_the_sidecar_path_is_not_the_sidecar() {
         let cfg = VmStartConfig {
-            volumes: vec![dir_share_volume(
+            volumes: vec![granted_dir(
                 "/cache/sdk",
                 mvm_core::plan::SDK_SIDECAR_GUEST_PATH,
+                "/state/sdk-shaped-mount.ext4",
             )],
             ..base()
         };
@@ -830,19 +764,6 @@ mod tests {
         assert_eq!(blocks[1].source, PathBuf::from("/vol/data.img"));
     }
 
-    #[test]
-    fn a_dir_share_volume_is_skipped_by_workload_blocks() {
-        // workload_blocks itself has no Result to refuse through; the fail-closed
-        // guard lives in `ensure_no_dir_share_volumes`, which callers must run
-        // first. This only proves the low-level mapper never fabricates a bogus
-        // block device for a share it can't express.
-        let cfg = VmStartConfig {
-            volumes: vec![dir_share_volume("/host/dir", "/data")],
-            ..base()
-        };
-        assert_eq!(nodes(&workload_blocks(&cfg)), vec!["/dev/vda"]);
-    }
-
     /// The inverse of what this used to assert, and the property that matters
     /// now: a user volume never becomes a virtio-fs share. A granted directory
     /// is materialized into an image and attached as virtio-blk, so the only
@@ -852,7 +773,7 @@ mod tests {
         let cfg = VmStartConfig {
             volumes: vec![
                 disk_volume("/vol/data.img", "/data", true),
-                dir_share_volume("/host/dir", "/mnt/share"),
+                granted_dir("/host/dir", "/mnt/share", "/state/share.ext4"),
             ],
             ..base()
         };
@@ -862,31 +783,6 @@ mod tests {
             "no volume may produce a virtio-fs share: {:?}",
             spec.shares
         );
-    }
-
-    #[test]
-    fn ensure_no_dir_share_volumes_accepts_disk_only_configs() {
-        let cfg = VmStartConfig {
-            volumes: vec![disk_volume("/vol/data.img", "/data", true)],
-            ..base()
-        };
-        assert!(ensure_no_dir_share_volumes(&cfg).is_ok());
-    }
-
-    #[test]
-    fn ensure_no_dir_share_volumes_refuses_and_names_the_volume() {
-        let cfg = VmStartConfig {
-            volumes: vec![
-                disk_volume("/vol/data.img", "/data", true),
-                dir_share_volume("/host/dir", "/mnt/share"),
-            ],
-            ..base()
-        };
-        let err = ensure_no_dir_share_volumes(&cfg)
-            .expect_err("a DirShare volume must be refused, not silently dropped");
-        let message = err.to_string();
-        assert!(message.contains("/host/dir"), "message: {message}");
-        assert!(message.contains("/mnt/share"), "message: {message}");
     }
 
     #[test]

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -100,7 +100,7 @@ Feature: every README-documented CLI launch mode boots a real guest
   # budget and every one of them fails on the tree's size rather than on
   # anything `--mount` did. A witness for a documented example should run the
   # documented example.
-  @live @dir_share
+  @live
   Scenario: --mount shares a host directory the workload can read
     When I launch "machine run --image alpine --mount ./examples/python/hello-app:/work -- ls /work/README.md"
     Then the launch succeeds
@@ -121,12 +121,10 @@ Feature: every README-documented CLI launch mode boots a real guest
   # a real install inside the guest, and the installed package imported back.
   #
   # The README form also mounts `$PWD` read-only and runs `/work/app.py` from
-  # it. That half is dropped here deliberately — `--mount` needs a virtio-fs
-  # directory share, which Firecracker has no device for, so keeping it would
-  # gate this behind `@dir_share` and lose the scenario on the Linux lane. The
-  # share itself is covered by its own scenario; what is unique here is that a
-  # workload can reach a package index only because two hosts were admitted,
-  # and can then run what it installed.
+  # it. That half is dropped here deliberately because the snapshot transport
+  # is covered by its own scenario; what is unique here is that a workload can
+  # reach a package index only because two hosts were admitted, and can then
+  # run what it installed.
   @live
   Scenario: the documented pip install reaches an admitted package index
     # No nested double quotes: the step tokenizer does not carry them through to

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -161,7 +161,11 @@ Last updated: 2026-09-03
 
 - [x] **Remove virtio-fs — `specs/plans/2026-08-31-remove-virtio-fs.md`.**
       Stage A: `--mount` is materialized into an ext4 image and attached as
-      virtio-blk, and the directory-share capability seam is gone. Stage B: the
+      virtio-blk, the directory-share capability seam is gone, and the runtime
+      `VmVolumeKind::DirShare` / local `Directory` variants are retired while
+      signed plans retain `ShareKind::DirShare` for claim 1. Workspace, gated,
+      and BDD checks plus a live Firecracker `machine run --mount` witness are
+      green. Stage B: the
       dev-tier virtio-fs root is deleted end to end — the tier gate, the
       capability, the launch-config field, the driver bootargs arm, and the HVF
       device model's root channel including the `MVM_HVF_VIRTIOFS_ROOT` env hook

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -33,6 +33,17 @@
       tests, all-targets zero-warning Clippy, policy checks, and BDD are green;
       the plan's broader output-surface design and merge delivery remain.
 
+- [ ] **Retire runtime directory-share volume variants.**
+      `specs/plans/2026-09-02-retire-dirshare.md`.
+      Runtime volumes are disk-only, while signed plans retain
+      `ShareKind::DirShare` as the audited directory-grant fact and admission
+      derives it from `materialized_image`. Managed `--host` attachments are
+      registered as block images; obsolete persisted directory-kind records
+      fail closed. Workspace tests, check, formatting, zero-warning Clippy,
+      Linux/BDD gated compilation, the 248-scenario BDD suite, and a live
+      Firecracker `machine run --mount` boot witness are green; merge delivery
+      remains.
+
 - [ ] **Content-addressed asset identity.**
       `specs/plans/2026-09-02-content-addressed-asset-identity.md`.
       Every dataset, model, prompt, agent, policy, and compute environment a
@@ -2257,13 +2268,13 @@ Then unify + retire the old paths:
 
 - [ ] **Sub-second launch**, verified: a timed `mvmctl up` → PTY shell → `mvmctl down` e2e on Mac (HVF) and Linux (libkrun + FC), asserting sub-second boot + clean teardown.
 - [~] **Warm start / warm pool** (pre-warmed standby VMs), **snapshot / fork / restore** (bake once, fork many via CoW, fast restore), **streaming exec**, **`expose_tcp`** (host↔guest port forward), **live host-directory mount** — the fast-local-runtime capabilities, exposed through `mvm-client` + the SDK.
-      The transient `machine run --mount HOST:/GUEST:ro` path now uses a live
-      read-only virtio-fs share on HVF instead of materializing an ext4 image;
+      The transient `machine run --mount HOST:/GUEST:ro` path materializes a
+      read-only ext4 snapshot and attaches it as virtio-blk on every backend;
       warm-start remains separately gated on a backend standby-pool capability.
       Phase timing now labels every launch `launch_mode=cold|warm` and reports
       `pool_wait_ms`, `claim_ms`, `warm_window_ms`, and `warm_slo=ok|over|na`;
-      directory-share claims remain fail-closed until a
-      backend can late-bind the host path after warm-child materialization.
+      materialized mount claims remain cold-path-only until a backend can
+      late-bind the image after warm-child materialization.
       Plan 298 now breaks the implementation into eight owned issues: #2192
       defines the resident claim service and now has the typed warm/cold
       contract, service-owned lease registry, lease-origin reporting, and

--- a/specs/plans/2026-08-31-remove-virtio-fs.md
+++ b/specs/plans/2026-08-31-remove-virtio-fs.md
@@ -123,23 +123,23 @@ the legacy arm, not building the portable one.
       advertised `directory_shares` capability, the `directory_shares` field on
       `VmCapabilities`, the two-arm `ensure_dir_share_support`, and
       `workload_shares`' volume arm. 85 lines out, 10 in.
-- [x] `VmVolumeKind::DirShare` and `LocalVolumeKind::Directory` stay for now:
-      `DirShare` is what records a *directory* grant in the plan, which claim 1
-      matches against, so removing it means moving that fact somewhere else
-      first. `VirtioFsShare` also stays as the low-level supervisor/config type
-      consumed by explicit refusal tests; no workload or builder produces one.
+- [x] `VmVolumeKind::DirShare` and `LocalVolumeKind::Directory` are retired.
+      Claim 1 still records a directory grant as `ShareKind::DirShare` in the
+      signed plan; admission derives that fact from `materialized_image` while
+      the runtime transport stays disk-only. `VirtioFsShare` remains only for
+      builder-VM transport.
 
       **Designed out into its own plan:**
       `specs/plans/2026-09-02-retire-dirshare.md`. The fact lives in
       `enforce_admitted_shares`, which derives the `ShareKind` it demands from
       the runtime enum; the resolution is to derive it from
       `materialized_image` instead and keep `ShareKind::DirShare` in the signed
-      plan. The blocker is that `LocalVolumeKind::Directory` can still produce
-      an *unmaterialized* `DirShare`, so what a managed directory volume is has
-      to be settled first.
+      plan. `machine volume mount --host` now snapshots and registers a block
+      image, while old persisted directory-kind entries fail closed.
 
-**Custom volumes are unaffected.** A managed volume is already a
-`BlockImage`/`Disk` today. Nothing about `mvmctl volume` changes.
+**Managed block volumes are unaffected.** The obsolete host-backed directory
+creation arm is removed with `LocalVolumeKind::Directory`; `--host` snapshots
+the source directory into a registered block image.
 
 **Deliberately not in this stage:** content-addressing and caching of the
 materialized image. The `mount_fingerprint` / `mount_cache_lookup` /

--- a/specs/plans/2026-09-02-retire-dirshare.md
+++ b/specs/plans/2026-09-02-retire-dirshare.md
@@ -3,10 +3,9 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status: IN PROGRESS.** The registration-time snapshot prerequisite is
-implemented; moving the signed-plan discriminator and deleting the obsolete
-runtime variants remain. This is separated from mechanical cleanup because it
-moves a fact the security model matches against.
+**Status: COMPLETE.** The registration-time snapshot prerequisite and runtime
+variant retirement are implemented. This was separated from mechanical cleanup
+because it moves a fact the security model matches against.
 
 ## What `DirShare` is now
 
@@ -62,14 +61,14 @@ materialized into"; its doc already explains that `host` stays the directory
 that was granted "because that is the fact an admission record has to carry".
 The information is present. Only the derivation reads the wrong field.
 
-## What blocks it today
+## Resolved prerequisite
 
-**Unmaterialized `DirShare` is still producible.** `LocalVolume::as_vm_volume`
-maps `LocalVolumeKind::Directory` to `VmVolumeKind::DirShare` with
-`materialized_image: None`, and that kind is reachable: `register_attachment`
-constructs it for `VolumeSourceKind::ManagedDirectory` /
-`AdHocHostDirectory`. Under the derivation above those volumes would resolve to
-`ShareKind::Disk` and stop matching their own plans.
+The apparent blocker was an unmaterialized `DirShare` from the local-volume
+registry. Live measurement established that it never reached a guest, and
+#3151 removed the last producer: `machine volume mount --host` snapshots the
+directory into an ext4 image and registers `LocalVolumeKind::BlockImage`.
+Persistent machine-spec directory entries remain an explicit refusal before a
+runtime volume is built.
 
 So the first question is not about `VmVolumeKind` at all:
 
@@ -162,15 +161,31 @@ inference was confident and wrong, and only the live run separated the two.
 ## Ordered work
 - [x] Materialize ad-hoc `--host <directory>` registrations into private,
       encrypted-destination ext4 snapshots and resolve them as block volumes.
-- [ ] Move the `want_kind` derivation off `VmVolumeKind` and onto
+- [x] Move the `want_kind` derivation off `VmVolumeKind` and onto
       `materialized_image`, with a test that a plan recording `ShareKind::DirShare`
       still admits a materialized mount, and that a `Disk` plan does not admit
       one.
-- [ ] Only then delete `VmVolumeKind::DirShare` and `LocalVolumeKind::Directory`.
-- [ ] Live-validate `mvmctl machine run --mount` end to end. The claim-1 check
+- [x] Only then delete `VmVolumeKind::DirShare` and `LocalVolumeKind::Directory`.
+- [x] Live-validate `mvmctl machine run --mount` end to end. The claim-1 check
       is the boot path; a unit test that constructs both sides agrees with
       itself by construction, which is the failure mode this repo has hit
       repeatedly.
+
+## Verification
+
+- `cargo fmt --all -- --check`
+- `cargo check --workspace`
+- `cargo test --workspace`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `just check-gated` (x86_64 Linux all-target and BDD compilation)
+- `just bdd` (65 features, 249 scenarios: 248 passed and one capability skip)
+- Live Firecracker `mvmctl machine run --mount` against immutable Alpine
+  `sha256:e7a1a92a5bfeee40966aea60f0796b0e7917cc35591542701834f03a68fa3d18`.
+  The signed plan admitted the directory grant, the assembled cmdline carried
+  `mvm.uvols=uvol0:2f776f726b:ro:blk`, the guest read the materialized mount at
+  `/work`, and printed `dirshare-retirement-live-ok`. The project builder VM
+  cannot expose nested KVM, so the owner-approved Lima KVM test provider was
+  used strictly for this live Firecracker witness and stopped afterwards.
 
 ## Fixed while scoping: the encryption probe could never succeed
 
@@ -191,7 +206,7 @@ Fixed in this change: resolve the path to its containing volume's device with
 modes separately. Registration now succeeds, which is what made the live test
 above possible at all.
 
-## Found while scoping, not part of this work
+## Found while scoping and removed here
 
 `validate_firecracker_start_config` (`mvm-runtime/src/backend.rs:185`) refuses
 **any** volume whose kind is `DirShare`, with:
@@ -203,9 +218,9 @@ That message describes the world before Stage A. A materialized `--mount` *is* a
 disk-image volume and Firecracker can serve it, but the check matches on `kind`
 alone and would refuse it.
 
-It is **not a live bug**: its only callers are `FirecrackerConfig::from_start_config`
-and `…_with_slot`, and `FirecrackerConfig` has no consumer outside its own
-module beyond a `pub use` in `lib.rs`. The wrapper's own doc calls it legacy.
-Recorded because it is a landmine for whoever revives it, and because it is
-evidence for this plan: a `DirShare` that is really a block device already
-misleads one reader in the tree.
+It was **not a live bug**: its only callers were
+`FirecrackerConfig::from_start_config` and `…_with_slot`, and
+`FirecrackerConfig` has no consumer outside its own module beyond a `pub use`
+in `lib.rs`. Retiring the runtime variant also removes this obsolete validator,
+so the legacy wrapper now carries materialized directory images as block
+volumes if it is inspected.

--- a/specs/sprint/delivery/mount-by-volume-label.md
+++ b/specs/sprint/delivery/mount-by-volume-label.md
@@ -64,13 +64,12 @@ so it takes effect for an image once that image is rebuilt. An image carrying an
 older agent ignores the unknown field via `#[serde(default)]` and mounts by node
 exactly as before — it does not fail.
 
-## Not done: retiring `DirShare`
+## Follow-up: retiring `DirShare`
 
-The sibling box (`VmVolumeKind::DirShare` / `LocalVolumeKind::Directory`) stays
-open. `DirShare` is what records a *directory* grant in the plan, which claim 1
-matches against, so removing it means relocating a claim-bearing fact through
-the admission path. That is a security-model change, not cleanup, and does not
-belong bundled with a mount-resolution fix.
+The sibling work subsequently retired `VmVolumeKind::DirShare` and
+`LocalVolumeKind::Directory`. Claim 1 still records a directory grant as
+`ShareKind::DirShare`; admission now derives that plan fact from
+`materialized_image`, not from the runtime transport enum.
 
 ## Verification
 

--- a/specs/sprint/delivery/mount-is-a-block-image.md
+++ b/specs/sprint/delivery/mount-is-a-block-image.md
@@ -36,10 +36,10 @@ Almost all of it already existed, and most of what was left was deletion.
 
 ## The audit decision
 
-`plan_admission` maps `VmVolumeKind::DirShare` → `ShareKind::DirShare`, and the
-chain records the host path under claim 1. Had `--mount` simply become a `Disk`,
-the chain would record an ext4 image under `~/.mvm` and lose the fact that a
-host *directory* was granted.
+`plan_admission` now maps `materialized_image: Some(_)` →
+`ShareKind::DirShare`, and the chain records the host path under claim 1. Had
+`--mount` simply become an undifferentiated disk, the chain would record an
+ext4 image under `~/.mvm` and lose the fact that a host *directory* was granted.
 
 So `VmVolume.host` stays the granted directory and a new
 `VmVolume.materialized_image` carries what is actually attached. The grant and
@@ -49,10 +49,10 @@ record.
 ## One predicate, three callers
 
 The block list, the slot arithmetic and the guest device mapping all have to
-agree on which volumes are attached and in what order. They previously each
-matched on `kind`. They now all call `VmVolume::attaches_as_block`, because
-drift between them means a guest mounts a real device holding someone else's
-data and nothing errors.
+agree on which volumes are attached and in what order. All runtime volumes are
+now block images; the shared mapping derives each guest node from that one
+ordered list. Drift between them would mean a guest mounts a real device
+holding someone else's data and nothing errors.
 
 `a_materialized_grant_resolves_to_the_block_node_the_vmm_created` is the test
 for exactly that.
@@ -123,9 +123,9 @@ shared content-addressed store — which is the heavy feature this work avoided.
 
 ## Not done
 
-- **`VmVolumeKind::DirShare` stays.** It is what records a *directory* grant in
-  the signed plan, which `enforce_admitted_shares` matches against for claim 1.
-  Removing it means moving that fact somewhere else first.
+- **Subsequently completed:** `VmVolumeKind::DirShare` was retired after claim
+  1's derivation moved to `materialized_image`. `ShareKind::DirShare` remains in
+  the signed plan and still records the directory grant.
 - **`virtiofsd --sandbox none` is untouched.** It is on the QEMU path, which does
   not run on the macOS dev host, and landing a blind change to a sandbox flag is
   how it got there.


### PR DESCRIPTION
## Summary

- derive admitted share kind from the materialized-image marker while retaining DirShare in signed execution plans
- remove the unreachable runtime DirShare and local Directory variants
- fail closed on legacy directory records and keep materialized directory grants distinct from direct disks for leases, flushing, WASM, and audit semantics
- update BDD coverage and plan, sprint, and refactor status documents

## Security invariant

Signed plans still record ShareKind::DirShare for directory grants. Claim 1 admission matches that audited fact through materialized_image; this does not collapse directory grants into disk grants.

## Verification

- cargo fmt --all -- --check
- cargo check --workspace
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- just check-gated
- just bdd: 65 features, 249 scenarios; 248 passed, 1 capability-skipped
- check-sprint-append
- live Firecracker machine run --mount: signed directory grant admitted, attached as virtio-blk, guest read /work and printed dirshare-retirement-live-ok