### PR TITLE
chore(agent-memory): follow the untracking through the docs and the gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -774,17 +774,23 @@ Every new module, type, or function needs test coverage:
 Never write scratch, temporary, or intermediate files anywhere inside the repo working tree — not the root, not a subdirectory, not a hidden dotfile, not a gitignored path. This covers **every** kind of agent-created scratch (analysis lists, command output, intermediate JSON/TSV, logs, ad-hoc scripts, `git merge-file` inputs), not just screenshots/binaries. Write them under `/tmp/` instead. See AGENTS.md §"Screenshots & Temporary Files" for the full rule.
 
 `.agent-memory/notes/` is the one exception, and it is not an exception to the
-rule so much as a different thing: those are committed findings, reviewed in a
-PR like any other file. Scratch is what you produce while working; a note is
-what you learned.
+rule so much as a different thing: scratch is what you produce while working, a
+note is what you learned. It is gitignored, so writing one does not put anything
+in the repository.
 
-## Committed findings (`.agent-memory/`)
+## Local findings (`.agent-memory/`)
+
+**These notes are local to your checkout.** `.agent-memory/` is gitignored and
+untracked; it was committed until 2026-09-03 and was deliberately made
+local-only again. Nothing here is reviewed, shared, or carried to another clone,
+and a note you write is a note only you will read.
 
 One finding per file under `.agent-memory/notes/<slug>.md`, with `title`,
 `date` and `tags` frontmatter. `just recall <terms>` searches them, `just
 notes` lists them, `just remember <slug>` scaffolds one. `xtask
 check-agent-notes` holds the shape and refuses a `[[link]]` to a note that does
-not exist.
+not exist — run it yourself; it is not in `check-all`, because in CI the
+directory does not exist and the gate has nothing to check.
 
 **Recall before you investigate.** A measurement already in there is one you do
 not have to pay for twice.
@@ -794,11 +800,12 @@ you learn something is *false*. The falsifications are the notes that earn
 their keep: `teardown-scales-with-guest-ram` records the obvious fix, the A/B
 that refuted it, and why it could not have worked, which is the difference
 between a day spent and a paragraph read. Say what not to retry, and say why.
-Commit the note with the change it explains.
 
-Machine-specific context — host names, fleet layout, ssh targets, local paths —
-does not go here. It belongs in your own agent memory; in the repository it
-just confuses contributors.
+Because the notes are local, anything another contributor needs to know has to
+go somewhere tracked — a `specs/` doc, an ADR, a comment, or the PR body. A note
+is where you keep a measurement for your own next session, not how you tell
+anyone else. Machine-specific context — host names, fleet layout, ssh targets,
+local paths — is exactly what it is for.
 
 These notes are observations, not authority. `specs/adrs/` owns decisions and
 the claims ledger owns what is enforced; where a note disagrees with one of

--- a/Justfile
+++ b/Justfile
@@ -523,12 +523,19 @@ deferrals:
 
 # ── Agent memory (.agent-memory/notes) ───────────────────────────────────
 
-# Recall committed findings. Lexical, because at a few hundred terse,
+# Recall local findings. Lexical, because at a few hundred terse,
 # keyword-dense notes a substring match beats anything with a model in it.
 # Terms are OR-ed: `just recall teardown ram` finds notes mentioning either.
+#
+# `.agent-memory/` is gitignored, so a fresh clone has none of this and the
+# recipes say so rather than erroring.
 recall +TERMS:
     #!/usr/bin/env bash
     set -euo pipefail
+    if [ ! -d .agent-memory/notes ]; then
+        echo "no .agent-memory/notes yet — notes are local and gitignored; \`just remember <slug>\` starts one"
+        exit 0
+    fi
     pattern=$(printf '%s' "{{ TERMS }}" | tr ' ' '|')
     rg -il --sort path -e "$pattern" .agent-memory/notes | while read -r path; do
         printf '%s\n    %s\n' \
@@ -540,14 +547,20 @@ recall +TERMS:
 notes:
     #!/usr/bin/env bash
     set -euo pipefail
-    for path in .agent-memory/notes/*.md; do
+    shopt -s nullglob
+    set -- .agent-memory/notes/*.md
+    if [ "$#" -eq 0 ]; then
+        echo "no .agent-memory/notes yet — notes are local and gitignored; \`just remember <slug>\` starts one"
+        exit 0
+    fi
+    for path in "$@"; do
         printf '%s  %s — %s\n' \
             "$(sed -n 's/^date: //p' "$path")" \
             "$(basename "$path" .md)" \
             "$(sed -n 's/^title: //p' "$path")"
     done | sort -r
 
-# Scaffold a note. Fill in the body, then commit it with the change it explains.
+# Scaffold a note. Fill in the body; it stays in your checkout, gitignored.
 remember SLUG:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -556,7 +569,8 @@ remember SLUG:
     printf -- '---\ntitle: \ndate: %s\ntags: []\n---\n\n' "$(date +%F)" > "$path"
     echo "created $path"
 
-# Committed findings parse, are dated, and link to notes that exist.
+# Local findings parse, are dated, and link to notes that exist. Not in
+# `check-all`: CI has no .agent-memory/ to check.
 agent-notes:
     cargo run -p xtask -- check-agent-notes
 

--- a/specs/sprint/delivery/agent-memory-is-local-only.md
+++ b/specs/sprint/delivery/agent-memory-is-local-only.md
@@ -1,0 +1,34 @@
+# `.agent-memory/` is local-only, and the docs and gate now say so
+
+Untracking `.agent-memory/` (#3166) made the notes local to a checkout. Three
+things still described them as committed, and one gate went quietly dead.
+
+**The dead gate.** `check-agent-notes` was gate 109 of the PR-gating
+`check-all`. With the directory gitignored, CI has no `.agent-memory/notes` at
+all, so the gate printed "nothing to check" and exited 0 on every pull request —
+green because there was nothing to look at, which is the vacuity failure the
+verification matrix exists to catch. Moved into `NOT_IN_LINT_LANE` with the
+reason stated. It still dispatches standalone for the one place it is
+meaningful: a contributor who has just written a note. `check-all` is 67 gates.
+
+**The prose.** `CLAUDE.md` still called the section "Committed findings", said
+the notes are "reviewed in a PR like any other file", and told you to "commit
+the note with the change it explains". All three were false the moment #3166
+landed. The section now says the notes are local, when they stopped being
+committed, and that anything another contributor needs has to go somewhere
+tracked instead. The "machine-specific context does not go here" rule inverted
+with it — a local note is exactly where host names and local paths belong now.
+
+**The recipes.** A fresh clone is now the default state, and both readers broke
+in it: `just notes` emitted two `sed: No such file or directory` lines and a
+stray `* — `, and `just recall` failed outright with exit 2. Both now detect the
+missing directory and print one line pointing at `just remember`. Their comments
+no longer claim the findings are committed.
+
+Left alone deliberately: `release_evidence.rs` still lists `.agent-memory/`
+among the paths that are not material to release evidence. It is now moot rather
+than wrong, and it stays correct if the directory is ever tracked again.
+
+Verified: `cargo run -p xtask -- check-all` 67 gates clean, `cargo nextest run
+-p xtask` 705 passed including the three `check_all` exclusion invariants, and
+both recipes exercised against a checkout with no `.agent-memory/`.

--- a/xtask/src/check_all.rs
+++ b/xtask/src/check_all.rs
@@ -106,7 +106,6 @@ pub const GATES: &[Gate] = &[
         crate::check_witness_citations::run,
     ),
     ("check-asserted-absence", crate::check_asserted_absence::run),
-    ("check-agent-notes", crate::check_agent_notes::run),
     ("check-dormant-controls", crate::check_dormant_controls::run),
     ("check-conformance", conformance_read_only),
     ("check-deferrals", crate::check_deferrals::run),
@@ -280,6 +279,12 @@ mod tests {
     /// which is exactly what had happened to three of the entries above.
     const NOT_IN_LINT_LANE: &[(&str, &str)] = &[
         ("check-all", "this driver"),
+        (
+            "check-agent-notes",
+            "validates `.agent-memory/notes/`, which is gitignored and local to \
+             a checkout; in CI the directory does not exist and the gate has \
+             nothing to check. Run it yourself when you write a note",
+        ),
         (
             "check-binary-size",
             "needs a release binary; runs in release.yml",


### PR DESCRIPTION
Untracking `.agent-memory/` (#3166) made the notes local to a checkout. Three places still described them as committed, and one gate went quietly dead.

## A gate that now passes because there is nothing to check

`check-agent-notes` was gate 109 of the PR-gating `check-all`. With the directory gitignored, CI has no `.agent-memory/notes` at all, so on every pull request the gate printed:

```
check-agent-notes: no .agent-memory/notes directory; nothing to check
```

and exited 0. Green because there was nothing to look at — the vacuity failure `specs/VERIFICATION.md` exists to catch, sitting inside the lane that is supposed to catch it.

Moved into `NOT_IN_LINT_LANE` with the reason recorded. It still dispatches standalone for the one case where it means something: a contributor who has just written a note. `check-all` is now **67 gates**.

The three `check_all` invariants (`every_dispatched_gate_is_in_the_lane_or_excluded_with_a_reason`, `every_exclusion_names_a_real_gate`, `the_table_and_the_exclusions_are_disjoint_and_unique`) all pass, so the exclusion is registered rather than hidden.

## Prose that went false the moment #3166 landed

`CLAUDE.md` called the section "Committed findings", said the notes are "reviewed in a PR like any other file", and instructed you to "commit the note with the change it explains". None of that has been true since the untracking.

The section now says the notes are local, says when they stopped being committed, and says that anything another contributor needs has to go somewhere tracked instead. One rule **inverted** and is now stated the other way round: "machine-specific context — host names, fleet layout, ssh targets, local paths — does not go here" was correct when the directory was shared. A local note is now exactly where that belongs.

## Recipes that broke in what is now the default state

A fresh clone has no `.agent-memory/`, and both readers failed in it:

```
$ just notes
sed: .agent-memory/notes/*.md: No such file or directory
sed: .agent-memory/notes/*.md: No such file or directory
  * —

$ just recall teardown
rg: IO error for operation on .agent-memory/notes: No such file or directory
error: Recipe `recall` failed with exit code 2
```

Both now detect the missing directory and print one line pointing at `just remember`. Their comments no longer claim the findings are committed.

## Left alone deliberately

`xtask/src/release_evidence.rs` still lists `.agent-memory/` among the paths that are not material to release evidence. That is now moot rather than wrong, and it stays correct if the directory is ever tracked again — so it is not worth the churn.

The `68 gates clean` lines in `specs/sprint/delivery/*.md` are archival records of what was true when that work landed, not live claims. Untouched.

## Verification

- `cargo run -p xtask -- check-all` — 67 gates clean
- `cargo nextest run -p xtask` — 705 passed, including the three exclusion invariants
- `cargo run -p xtask -- check-agent-notes` — still dispatches standalone
- `just notes` and `just recall` exercised against a checkout with no `.agent-memory/`
- `cargo fmt --all` + `clippy -D warnings` via the pre-commit hook
