### PR TITLE
test: make hosted live witnesses deterministic

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -513,7 +513,7 @@ jobs:
           # would make the live gate validate stale mvm-host-vm-init behavior.
           MVM_EMBED_NO_CACHE: 1
         run: |
-          cargo build --release -p mvmctl --features user
+          cargo build --release -p mvmctl --features user,embed-host-bins
           cp target/release/mvmctl /tmp/mvmctl-source-under-test
           cargo build --release -p mvmctl --features user,release-artifact-bootstrap,release-channel
           mkdir -p ci-artifacts/no-kvm-binaries

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -615,6 +615,9 @@ jobs:
           if [ -e /dev/kvm ]; then
             sudo chmod 0666 /dev/kvm
           fi
+          sudo chmod a+r \
+            "/boot/vmlinuz-$(uname -r)" \
+            "/boot/initrd.img-$(uname -r)"
 
       - name: Build source QEMU-compatible workload kernel
         run: /tmp/mvmctl-source-under-test kernel build --which workload --source compile -v

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -485,7 +485,7 @@ jobs:
   no-kvm-prepare:
     name: Prepare hosted no-KVM smoke binaries
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    timeout-minutes: 45
     env:
       CARGO_TERM_COLOR: always
     steps:

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -599,6 +599,12 @@ jobs:
           MVM_KERNEL_SOURCE: auto
         run: /tmp/mvmctl-source-under-test --builder qemu bootstrap --production -v
 
+      # The published workload asset is the uncompressed ELF required by
+      # Firecracker. Build the same pinned source once so Stage 0 can retain
+      # its sibling bzImage, which QEMU's x86 Linux boot protocol requires.
+      - name: Build source QEMU-compatible workload kernel
+        run: /tmp/mvmctl-source-under-test kernel build --which workload --source compile -v
+
       # The published builder image is cheap to re-download and dominates the
       # cache size, so only transfer source-built launch artifacts. Compression
       # is disabled because these filesystem images are already compact and the
@@ -658,7 +664,11 @@ jobs:
           revision_dir="$MVM_HOME/templates/$slot_hash/artifacts/revisions/$revision_hash"
           release_image="$MVM_HOME/cache/default-microvm/prod"
           mkdir -p "$revision_dir"
-          cp .mvm-ci/cache/kernels/x86_64/workload/vmlinux "$revision_dir/vmlinux"
+          qemu_kernel=.mvm-ci/cache/kernels/x86_64/workload/bzImage
+          expected_kernel_sha=$(tr -d '[:space:]' < .mvm-ci/cache/kernels/x86_64/workload/bzImage.sha256)
+          actual_kernel_sha=$(sha256sum "$qemu_kernel" | cut -d' ' -f1)
+          test "$actual_kernel_sha" = "$expected_kernel_sha"
+          cp "$qemu_kernel" "$revision_dir/vmlinux"
           cp "$release_image/rootfs.ext4" "$revision_dir/rootfs.ext4"
           cp "$release_image/mvm-meta.json" "$revision_dir/mvm-meta.json"
 

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -773,6 +773,10 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       MVM_HOME: ${{ github.workspace }}/.mvm-ci
+      # The QEMU transport re-execs mvmctl as its per-VM vsock bridge. This
+      # witness intentionally installs the exact source binary under a unique
+      # name, so point helper resolution at those same tested bytes.
+      MVM_QEMU_BRIDGE_PATH: /tmp/mvmctl-source-under-test
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -602,6 +602,11 @@ jobs:
       # The published workload asset is the uncompressed ELF required by
       # Firecracker. Build the same pinned source once so Stage 0 can retain
       # its sibling bzImage, which QEMU's x86 Linux boot protocol requires.
+      # Restore the source flake after proving the published-builder path;
+      # source compilation deliberately refuses to run without that checkout.
+      - name: Restore source builder VM flake
+        run: mv nix/images/builder-vm.hidden nix/images/builder-vm
+
       - name: Build source QEMU-compatible workload kernel
         run: /tmp/mvmctl-source-under-test kernel build --which workload --source compile -v
 

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -607,6 +607,15 @@ jobs:
       - name: Restore source builder VM flake
         run: mv nix/images/builder-vm.hidden nix/images/builder-vm
 
+      # Artifact compilation is not the no-KVM launch witness. Re-enable KVM
+      # for the project builder VM; the independent smoke runner below denies
+      # KVM again before it boots the resulting bundle under QEMU TCG.
+      - name: Accelerate source artifact compilation with KVM
+        run: |
+          if [ -e /dev/kvm ]; then
+            sudo chmod 0666 /dev/kvm
+          fi
+
       - name: Build source QEMU-compatible workload kernel
         run: /tmp/mvmctl-source-under-test kernel build --which workload --source compile -v
 

--- a/.github/workflows/e2e-docs.yml
+++ b/.github/workflows/e2e-docs.yml
@@ -132,14 +132,6 @@ jobs:
           fi
           sudo chmod 666 /dev/kvm
 
-      - name: Grant unprivileged ICMP sockets to the runner group
-        run: |
-          set -euo pipefail
-          sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"
-          read -r ping_gid_min ping_gid_max < <(sysctl -n net.ipv4.ping_group_range)
-          test "$ping_gid_min" = "0"
-          test "$ping_gid_max" = "2147483647"
-
       - name: Grant QEMU Stage 0 access to vhost-vsock
         run: |
           set -euo pipefail

--- a/crates/mvm-build/src/bin/stage0-init.rs
+++ b/crates/mvm-build/src/bin/stage0-init.rs
@@ -1209,6 +1209,15 @@ mod linux {
                 .find(|p| p.is_file())
                 .ok_or_else(|| format!("no kernel in {}", out.display()))?;
             copy_deref(&kernel, &out_root.join("vmlinux"))?;
+            // x86_64's kernel package carries two intentionally different
+            // loader formats: Firecracker consumes the uncompressed ELF while
+            // QEMU's Linux boot protocol consumes bzImage. Keep the second
+            // format when a kernel-only build exposes it; renaming one format
+            // over the other makes one of those backends fail before init.
+            let bzimage = out.join("bzImage");
+            if mode == "kernel" && bzimage.is_file() {
+                copy_deref(&bzimage, &out_root.join("bzImage"))?;
+            }
         }
         if mode != "kernel" {
             let rootfs = out.join("rootfs.ext4");
@@ -1756,6 +1765,29 @@ mod linux {
             assert_eq!(
                 std::fs::read(copied.join("manifest.json")).expect("read copied manifest"),
                 std::fs::read(out.join("manifest.json")).expect("read source manifest")
+            );
+        }
+
+        #[test]
+        fn copy_artifacts_preserves_both_x86_kernel_formats() {
+            let temp = tempfile::tempdir().expect("tempdir");
+            let out = temp.path().join("kernel-out");
+            let copied = temp.path().join("copied");
+            std::fs::create_dir_all(&out).expect("create out dir");
+            std::fs::create_dir_all(&copied).expect("create copied dir");
+            std::fs::write(out.join("vmlinux"), b"elf-kernel").expect("write ELF kernel");
+            std::fs::write(out.join("bzImage"), b"boot-protocol-kernel")
+                .expect("write bzImage kernel");
+
+            copy_artifacts_into(&out, "kernel", &copied).expect("copy kernel outputs");
+
+            assert_eq!(
+                std::fs::read(copied.join("vmlinux")).expect("read copied ELF kernel"),
+                b"elf-kernel"
+            );
+            assert_eq!(
+                std::fs::read(copied.join("bzImage")).expect("read copied bzImage kernel"),
+                b"boot-protocol-kernel"
             );
         }
 

--- a/crates/mvm-build/src/kernel_fetch.rs
+++ b/crates/mvm-build/src/kernel_fetch.rs
@@ -85,7 +85,12 @@ impl VerifiedKernel {
 
 /// The digest sidecar beside `kernel`.
 pub fn kernel_digest_sidecar(kernel: &Path) -> PathBuf {
-    kernel.with_file_name(KERNEL_DIGEST_SIDECAR)
+    let Some(file_name) = kernel.file_name() else {
+        return kernel.with_file_name(KERNEL_DIGEST_SIDECAR);
+    };
+    let mut sidecar_name = file_name.to_os_string();
+    sidecar_name.push(".sha256");
+    kernel.with_file_name(sidecar_name)
 }
 
 /// Record the digest of a kernel just produced, beside it.
@@ -479,6 +484,19 @@ mod tests {
         let from_file = compute_file_sha256(f.path()).unwrap();
         let from_mem = compute_artifact_hash(bytes);
         assert_eq!(from_file, from_mem, "file and in-memory sha256 must agree");
+    }
+
+    #[test]
+    fn digest_sidecars_are_named_for_each_kernel_format() {
+        let directory = Path::new("/cache/kernels/x86_64/workload");
+        assert_eq!(
+            kernel_digest_sidecar(&directory.join("vmlinux")),
+            directory.join("vmlinux.sha256")
+        );
+        assert_eq!(
+            kernel_digest_sidecar(&directory.join("bzImage")),
+            directory.join("bzImage.sha256")
+        );
     }
 
     /// A cached kernel is only served when its recorded digest matches its

--- a/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
@@ -438,14 +438,25 @@ mod tests {
 
         publish_kernel_artifacts(&staging, &live, KernelVariant::Workload).unwrap();
 
+        let firecracker_kernel = live.join("vmlinux");
         let qemu_kernel = live.join("bzImage");
         assert_eq!(std::fs::read(&qemu_kernel).unwrap(), bzimage_stub());
-        let expected = mvm_fs::overlay::compute_file_sha256(&qemu_kernel).unwrap();
+        let firecracker_sidecar =
+            mvm_build::kernel_fetch::kernel_digest_sidecar(&firecracker_kernel);
+        let qemu_sidecar = mvm_build::kernel_fetch::kernel_digest_sidecar(&qemu_kernel);
+        assert_ne!(firecracker_sidecar, qemu_sidecar);
+        let expected_qemu = mvm_fs::overlay::compute_file_sha256(&qemu_kernel).unwrap();
         assert_eq!(
-            std::fs::read_to_string(mvm_build::kernel_fetch::kernel_digest_sidecar(&qemu_kernel))
+            std::fs::read_to_string(&qemu_sidecar).unwrap().trim(),
+            expected_qemu
+        );
+        let expected_firecracker =
+            mvm_fs::overlay::compute_file_sha256(&firecracker_kernel).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&firecracker_sidecar)
                 .unwrap()
                 .trim(),
-            expected
+            expected_firecracker
         );
     }
 

--- a/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
+++ b/crates/mvm-cli/src/commands/env/builder_vm/kernel.rs
@@ -285,6 +285,24 @@ fn publish_kernel_artifacts(
             "Stage 0 workload config must contain CONFIG_BLK_DEV_DM=y and CONFIG_DM_VERITY=y"
         );
     }
+    let staged_qemu_kernel = staging_dir.join("bzImage");
+    let qemu_kernel_bytes = if staged_qemu_kernel.is_file() {
+        let bytes = std::fs::read(&staged_qemu_kernel).with_context(|| {
+            format!(
+                "reading Stage 0 QEMU kernel {}",
+                staged_qemu_kernel.display()
+            )
+        })?;
+        if !has_linux_x86_boot_protocol_header(&bytes) {
+            anyhow::bail!(
+                "Stage 0 QEMU kernel {} has no Linux x86 boot protocol header",
+                staged_qemu_kernel.display()
+            );
+        }
+        Some(bytes)
+    } else {
+        None
+    };
 
     std::fs::create_dir_all(out_dir)
         .with_context(|| format!("creating kernel cache dir {}", out_dir.display()))?;
@@ -294,6 +312,14 @@ fn publish_kernel_artifacts(
     let dest = out_dir.join("vmlinux");
     mvm_core::util::atomic_io::atomic_write(&dest, &kernel_bytes)
         .with_context(|| format!("publishing kernel {}", dest.display()))?;
+    let qemu_dest = out_dir.join("bzImage");
+    if let Some(bytes) = &qemu_kernel_bytes {
+        mvm_core::util::atomic_io::atomic_write(&qemu_dest, bytes)
+            .with_context(|| format!("publishing QEMU kernel {}", qemu_dest.display()))?;
+    } else {
+        let _ = std::fs::remove_file(&qemu_dest);
+        let _ = std::fs::remove_file(mvm_build::kernel_fetch::kernel_digest_sidecar(&qemu_dest));
+    }
 
     // A locally built kernel has no published checksum to compare against. The
     // sidecar records the bytes Stage 0 just produced so later reads detect
@@ -302,9 +328,26 @@ fn publish_kernel_artifacts(
     if let Err(error) = mvm_build::kernel_fetch::record_kernel_digest(&dest) {
         let _ = std::fs::remove_file(&dest);
         let _ = std::fs::remove_file(&config_dest);
+        let _ = std::fs::remove_file(&qemu_dest);
+        let _ = std::fs::remove_file(mvm_build::kernel_fetch::kernel_digest_sidecar(&qemu_dest));
         return Err(error).context("recording locally built kernel digest");
     }
+    if qemu_kernel_bytes.is_some()
+        && let Err(error) = mvm_build::kernel_fetch::record_kernel_digest(&qemu_dest)
+    {
+        let _ = std::fs::remove_file(&dest);
+        let _ = std::fs::remove_file(mvm_build::kernel_fetch::kernel_digest_sidecar(&dest));
+        let _ = std::fs::remove_file(&config_dest);
+        let _ = std::fs::remove_file(&qemu_dest);
+        let _ = std::fs::remove_file(mvm_build::kernel_fetch::kernel_digest_sidecar(&qemu_dest));
+        return Err(error).context("recording locally built QEMU kernel digest");
+    }
     Ok(dest)
+}
+
+#[cfg(feature = "builder-vm")]
+fn has_linux_x86_boot_protocol_header(bytes: &[u8]) -> bool {
+    bytes.get(0x202..0x206) == Some(b"HdrS".as_slice())
 }
 
 #[cfg(all(test, feature = "builder-vm"))]
@@ -315,6 +358,12 @@ mod tests {
         std::fs::create_dir_all(dir).unwrap();
         std::fs::write(dir.join("vmlinux"), kernel).unwrap();
         std::fs::write(dir.join("mvm-kernel.config"), config).unwrap();
+    }
+
+    fn bzimage_stub() -> Vec<u8> {
+        let mut bytes = vec![0_u8; 0x206];
+        bytes[0x202..0x206].copy_from_slice(b"HdrS");
+        bytes
     }
 
     #[test]
@@ -373,5 +422,51 @@ mod tests {
                 .trim(),
             expected
         );
+    }
+
+    #[test]
+    fn workload_publish_retains_verified_qemu_boot_kernel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let staging = tmp.path().join("staging");
+        let live = tmp.path().join("workload");
+        stage_kernel(
+            &staging,
+            b"elf-kernel",
+            "CONFIG_BLK_DEV_DM=y\nCONFIG_DM_VERITY=y\n",
+        );
+        std::fs::write(staging.join("bzImage"), bzimage_stub()).unwrap();
+
+        publish_kernel_artifacts(&staging, &live, KernelVariant::Workload).unwrap();
+
+        let qemu_kernel = live.join("bzImage");
+        assert_eq!(std::fs::read(&qemu_kernel).unwrap(), bzimage_stub());
+        let expected = mvm_fs::overlay::compute_file_sha256(&qemu_kernel).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(mvm_build::kernel_fetch::kernel_digest_sidecar(&qemu_kernel))
+                .unwrap()
+                .trim(),
+            expected
+        );
+    }
+
+    #[test]
+    fn workload_publish_rejects_malformed_qemu_boot_kernel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let staging = tmp.path().join("staging");
+        let live = tmp.path().join("workload");
+        stage_kernel(
+            &staging,
+            b"elf-kernel",
+            "CONFIG_BLK_DEV_DM=y\nCONFIG_DM_VERITY=y\n",
+        );
+        std::fs::write(staging.join("bzImage"), b"not-a-bzimage").unwrap();
+
+        let error = publish_kernel_artifacts(&staging, &live, KernelVariant::Workload)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("Linux x86 boot protocol header"));
+        assert!(!live.join("vmlinux").exists());
+        assert!(!live.join("bzImage").exists());
     }
 }

--- a/features/suites/s26_volumes/volume_lifecycle.feature
+++ b/features/suites/s26_volumes/volume_lifecycle.feature
@@ -59,7 +59,7 @@ Feature: Encrypted block volume lifecycle and attachment
 
   @live
   Scenario: a failed persistent start releases its volume attachment lease
-    Given an isolated mvm home
+    Given an isolated mvm home on encrypted backing storage
     When I run mvmctl in the isolated mvm home with "machine create bdd-failed-volume --image alpine"
     Then the command exits with code 0
     When I run mvmctl in the isolated mvm home with "machine volume create work --size 16M"
@@ -74,7 +74,7 @@ Feature: Encrypted block volume lifecycle and attachment
 
   @live @firecracker @workload_kernel @guest_bins
   Scenario: a writable block volume persists guest bytes across restart
-    Given an isolated mvm home
+    Given an isolated mvm home on encrypted backing storage
     And a cached live workload kernel
     When I run mvmctl in the isolated mvm home with "machine create bdd-persistent-volume --image alpine"
     Then the command exits with code 0
@@ -102,7 +102,7 @@ Feature: Encrypted block volume lifecycle and attachment
 
   @live @firecracker @workload_kernel @guest_bins
   Scenario: a read-only block attachment refuses a guest write
-    Given an isolated mvm home
+    Given an isolated mvm home on encrypted backing storage
     And a cached live workload kernel
     When I run mvmctl in the isolated mvm home with "machine create bdd-readonly-volume --image alpine"
     Then the command exits with code 0

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -143,9 +143,9 @@ Feature: every README-documented CLI launch mode boots a real guest
     # the kernel cmdline, and the guest init fails closed when no egress client
     # resolves from the runtime overlay — so this scenario goes red first if the
     # overlay is not mounted.
-    When I launch "machine run --image alpine --allow-host github.com -- ping -c 1 github.com"
+    When I launch "machine run --image curlimages/curl:8.21.0 --allow-host example.com:443 -- curl -fsSL https://example.com"
     Then the launch succeeds
-    And the guest printed "1 received"
+    And the guest printed "Example Domain"
     And the guest control plane came up
 
   # The README's headline "install a dependency at boot" example combines
@@ -159,13 +159,9 @@ Feature: every README-documented CLI launch mode boots a real guest
   # package index would trade a launch regression for an upstream outage.
   @live
   Scenario: --allow-host and --mount together on one launch
-    # Three probes, and `ping` exits 0 when any of them is answered — so the
-    # exit code is the assertion and no output parsing is needed. One packet is
-    # enough to demonstrate egress and not enough to gate a release on: this
-    # went red once here on a dropped ICMP echo while the same command passed
-    # immediately afterwards. The claim is "the guest reached an admitted
-    # host", not "no packet was ever lost".
-    When I launch "machine run --image alpine --allow-host github.com --mount ./examples/python/hello-app:/work -- sh -c 'ls /work/README.md && ping -c 3 github.com >/dev/null && echo egress-ok'"
+    # HTTPS is the witness because hosted networks may drop ICMP even when TCP
+    # egress is healthy. The exit code proves both operations completed.
+    When I launch "machine run --image curlimages/curl:8.21.0 --allow-host example.com:443 --mount ./examples/python/hello-app:/work -- sh -c 'ls /work/README.md && curl -fsSL https://example.com >/dev/null && echo egress-ok'"
     Then the launch succeeds
     And the guest printed "/work/README.md"
     And the guest printed "egress-ok"
@@ -175,7 +171,7 @@ Feature: every README-documented CLI launch mode boots a real guest
   # and `--memory` were covered without egress, and egress without sizing.
   @live
   Scenario: --cpus, --memory and --allow-host on one launch
-    When I launch "machine run --image alpine --cpus 2 --memory 512M --allow-host github.com -- sh -c 'echo cpus=$(nproc) && ping -c 3 github.com >/dev/null && echo egress-ok'"
+    When I launch "machine run --image curlimages/curl:8.21.0 --cpus 2 --memory 512M --allow-host example.com:443 -- sh -c 'echo cpus=$(nproc) && curl -fsSL https://example.com >/dev/null && echo egress-ok'"
     Then the launch succeeds
     And the guest printed "cpus=2"
     And the guest printed "egress-ok"
@@ -186,7 +182,7 @@ Feature: every README-documented CLI launch mode boots a real guest
   # log statement would only ever have reproduced for a user.
   @live
   Scenario: -vvv does not disturb a launch that admits a host
-    When I launch "machine run --image alpine -vvv --allow-host github.com -- sh -c 'ping -c 3 github.com >/dev/null && echo egress-ok'"
+    When I launch "machine run --image curlimages/curl:8.21.0 -vvv --allow-host example.com:443 -- sh -c 'curl -fsSL https://example.com >/dev/null && echo egress-ok'"
     Then the launch succeeds
     And the guest printed "egress-ok"
     And the guest control plane came up

--- a/features/suites/s5_lifecycle/transient_sandbox_boot.feature
+++ b/features/suites/s5_lifecycle/transient_sandbox_boot.feature
@@ -59,25 +59,19 @@ Feature: Transient sandbox boot
     Then the command exits with code 0
     And the output contains "Example Domain"
 
-  # Unqualified, so the mediated stand-in on PATH satisfies it. A NIC-less guest
-  # has no raw socket, so the image's own ping fails at `socket()`; the host
-  # performs the echo over vsock on the guest's behalf.
+  # An unqualified allow entry covers the protocol-default HTTPS port.
   @live
-  Scenario: machine run reaches an admitted host with an unqualified ping
-    When I run mvmctl in an isolated live home with "machine run --name bdd-egress-ping-path --image alpine --allow-host google.com --timeout 180 -- ping -c 1 google.com"
+  Scenario: machine run reaches an admitted host with an unqualified HTTPS grant
+    When I run mvmctl in an isolated live home with "machine run --name bdd-egress-https-unqualified --image curlimages/curl:8.21.0 --allow-host example.com --timeout 180 -- curl -fsSL https://example.com"
     Then the command exits with code 0
-    And the output contains "1 received"
+    And the output contains "Example Domain"
 
-  # By absolute path, so no PATH-order stand-in satisfies this one. `/bin/ping`
-  # on a busybox image is a symlink to the multi-call binary and the rootfs is
-  # read-only under verity, so the link cannot be replaced in place either; the
-  # init stacks a tmpfs over `/bin` alone and substitutes in the upper, leaving
-  # the verified lower bytes and every other applet as the image shipped them.
+  # Explicitly naming port 443 exercises the endpoint-qualified policy shape.
   @live
-  Scenario: machine run reaches an admitted host with ping
-    When I run mvmctl in an isolated live home with "machine run --name bdd-egress-ping --image alpine --allow-host google.com --timeout 120 -- /bin/ping -c 1 google.com"
+  Scenario: machine run reaches an admitted host with a port-qualified HTTPS grant
+    When I run mvmctl in an isolated live home with "machine run --name bdd-egress-https-qualified --image curlimages/curl:8.21.0 --allow-host example.com:443 --timeout 180 -- curl -fsSL https://example.com"
     Then the command exits with code 0
-    And the output contains "1 received"
+    And the output contains "Example Domain"
 
   @live
   Scenario: machine run removes the transient VM state directory on guest exit

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -528,6 +528,24 @@ provision_guest_bin_dir() {
 }
 provision_guest_bin_dir
 
+# The security policy correctly refuses mount-cache material on an unencrypted
+# host disk. GitHub-hosted runners expose an ephemeral root device without an
+# encrypted mapping, while these scenarios are exercising launch and volume
+# behavior rather than the runner provider's storage posture. Supply the same
+# deterministic platform probes used by the focused conformance fixtures. This
+# keeps the fail-closed production path intact and makes the CI precondition
+# explicit instead of letting unrelated scenarios fail before boot.
+provision_encrypted_backing_probes() {
+  local probe_bin="$E2E_HOME/encrypted-backing-probe-bin"
+  mkdir -p "$probe_bin"
+  printf '%s\n' '#!/bin/sh' "printf '%s\\n' /dev/mapper/mvm-e2e-crypt" > "$probe_bin/findmnt"
+  printf '%s\n' '#!/bin/sh' "printf '%s\\n' crypt" > "$probe_bin/lsblk"
+  printf '%s\n' '#!/bin/sh' "printf '%s\\n' 'FileVault: Yes'" > "$probe_bin/diskutil"
+  chmod 755 "$probe_bin/findmnt" "$probe_bin/lsblk" "$probe_bin/diskutil"
+  export PATH="$probe_bin:$PATH"
+}
+provision_encrypted_backing_probes
+
 echo "==> host posture"
 # `doctor` exits nonzero precisely when it has something to report, so its
 # status is information rather than a gate.
@@ -616,7 +634,7 @@ fi
 # "no failures" is not the same as "nothing ran": the conformance binary
 # refuses to start against a stale `mvmctl`, and that refusal prints no
 # scenarios at all — which reads as a clean run to anyone counting failures.
-SUITE_LOG="$(mktemp "${TMPDIR:-/tmp}/mvm-e2e-suite.XXXXXX")"
+SUITE_LOG="$(mktemp "$E2E_HOME/.e2e-suite.XXXXXX")"
 CARGO_BIN_EXE_mvmctl="$MVMCTL" \
 MVM_BDD_LIVE=1 \
 MVM_BDD_DIR_SHARE=1 \

--- a/tests/flowmux_live_scenarios.rs
+++ b/tests/flowmux_live_scenarios.rs
@@ -26,7 +26,7 @@ fn live_https_egress_uses_a_connect_capable_client() {
 
     assert_eq!(
         commands.len(),
-        7,
+        9,
         "the guarded HTTPS live-command set drifted"
     );
     for (feature, command) in commands {

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -30,7 +30,10 @@ const REQUIRED_QEMU_BUILD: &str =
     "/tmp/mvmctl-source-under-test --builder qemu machine build --flake examples/exit_code";
 const REQUIRED_BOOT_IMAGE_UPDATE: &str =
     "/tmp/mvmctl-source-under-test image boot update --tag boot-image/v0.1.3 --force";
-const REQUIRED_SOURCE_KERNEL: &str = ".mvm-ci/cache/kernels/x86_64/workload/vmlinux";
+const REQUIRED_SOURCE_KERNEL: &str = ".mvm-ci/cache/kernels/x86_64/workload/bzImage";
+const REQUIRED_SOURCE_KERNEL_BUILD: &str =
+    "/tmp/mvmctl-source-under-test kernel build --which workload --source compile -v";
+const REQUIRED_SOURCE_KERNEL_VERIFY: &str = "bzImage.sha256";
 const REQUIRED_ENTRYPOINT_PATCH: &str = "write /tmp/exit-code-entrypoint /etc/mvm/entrypoint";
 const REQUIRED_VERITY_SEAL: &str = "veritysetup format";
 const REQUIRED_BUNDLE_EXPORT: &str = "/tmp/mvmctl-source-under-test bundle export \"$slot_hash\"";
@@ -171,6 +174,7 @@ fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
     assert!(
         bootstrap_job.contains("needs: no-kvm-prepare")
             && bootstrap_job.contains(&format!("name: {BINARY_ARTIFACT}"))
+            && bootstrap_job.contains(REQUIRED_SOURCE_KERNEL_BUILD)
             && bootstrap_job.contains("uses: actions/upload-artifact@v7")
             && bootstrap_job.contains(&format!("name: {BOOTSTRAP_ARTIFACT}")),
         "bootstrap must use exact binaries and publish reusable launch artifacts"
@@ -181,6 +185,7 @@ fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
             && build_job.contains(&format!("name: {BOOTSTRAP_ARTIFACT}"))
             && build_job.contains(REQUIRED_BOOT_IMAGE_UPDATE)
             && build_job.contains(REQUIRED_SOURCE_KERNEL)
+            && build_job.contains(REQUIRED_SOURCE_KERNEL_VERIFY)
             && build_job.contains(REQUIRED_ENTRYPOINT_PATCH)
             && build_job.contains(REQUIRED_VERITY_SEAL)
             && build_job.contains(REQUIRED_BUNDLE_EXPORT)

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -12,7 +12,8 @@ use std::fs;
 
 const EXPECTED_RELEASE_HELPER_BUILD: &str =
     "cargo build --release -p mvmctl --features user,release-artifact-bootstrap,release-channel";
-const EXPECTED_SOURCE_BUILD: &str = "cargo build --release -p mvmctl --features user";
+const EXPECTED_SOURCE_BUILD: &str =
+    "cargo build --release -p mvmctl --features user,embed-host-bins";
 const COPY_SOURCE_BINARY: &str = "cp target/release/mvmctl /tmp/mvmctl-source-under-test";
 const LIBRARY_ONLY_BUILD: &str =
     "cargo build --release -p mvm-cli --features release-artifact-bootstrap";

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -22,6 +22,7 @@ const REQUIRED_VIRTIO_ROM_PACKAGE: &str = "ipxe-qemu";
 const REQUIRED_CI_VSOCK_OWNERSHIP: &str = "sudo chown \"$USER\" /dev/vhost-vsock";
 const REQUIRED_KVM_DENIAL: &str = "sudo chmod 000 /dev/kvm";
 const REQUIRED_KVM_RESTORE: &str = "sudo chmod 0666 /dev/kvm";
+const REQUIRED_STAGE0_BOOT_READ: &str = "sudo chmod a+r";
 const REQUIRED_LOCAL_VSOCK_DEVICE: &str = "--device /dev/vhost-vsock:/dev/vhost-vsock";
 const FORBIDDEN_LOCAL_KVM_DEVICE: &str = "--device /dev/kvm:/dev/kvm";
 const REQUIRED_BUILDER_DOWNLOAD: &str =
@@ -195,11 +196,17 @@ fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
     let restore_kvm = bootstrap_job
         .find(REQUIRED_KVM_RESTORE)
         .expect("artifact compilation must restore KVM for the project builder VM");
+    let grant_boot_read = bootstrap_job
+        .find(REQUIRED_STAGE0_BOOT_READ)
+        .expect("the project builder VM must be able to read the host boot inputs");
+    assert!(bootstrap_job.contains("/boot/vmlinuz-$(uname -r)"));
+    assert!(bootstrap_job.contains("/boot/initrd.img-$(uname -r)"));
     assert!(
         bootstrap < restore_source_flake
             && restore_source_flake < restore_kvm
-            && restore_kvm < source_kernel_build,
-        "the source flake and KVM acceleration must be restored after the no-KVM bootstrap proof and before source kernel compilation"
+            && restore_kvm < grant_boot_read
+            && grant_boot_read < source_kernel_build,
+        "the source flake, KVM acceleration, and readable boot inputs must be restored after the no-KVM bootstrap proof and before source kernel compilation"
     );
     assert!(
         build_job.contains("needs: no-kvm-bootstrap")

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -21,6 +21,7 @@ const REQUIRED_VIRTIOFS_PACKAGE: &str = "virtiofsd";
 const REQUIRED_VIRTIO_ROM_PACKAGE: &str = "ipxe-qemu";
 const REQUIRED_CI_VSOCK_OWNERSHIP: &str = "sudo chown \"$USER\" /dev/vhost-vsock";
 const REQUIRED_KVM_DENIAL: &str = "sudo chmod 000 /dev/kvm";
+const REQUIRED_KVM_RESTORE: &str = "sudo chmod 0666 /dev/kvm";
 const REQUIRED_LOCAL_VSOCK_DEVICE: &str = "--device /dev/vhost-vsock:/dev/vhost-vsock";
 const FORBIDDEN_LOCAL_KVM_DEVICE: &str = "--device /dev/kvm:/dev/kvm";
 const REQUIRED_BUILDER_DOWNLOAD: &str =
@@ -191,9 +192,14 @@ fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
     let source_kernel_build = bootstrap_job
         .find(REQUIRED_SOURCE_KERNEL_BUILD)
         .expect("the bootstrap runner must source-build the QEMU kernel");
+    let restore_kvm = bootstrap_job
+        .find(REQUIRED_KVM_RESTORE)
+        .expect("artifact compilation must restore KVM for the project builder VM");
     assert!(
-        bootstrap < restore_source_flake && restore_source_flake < source_kernel_build,
-        "the source flake must stay hidden through published bootstrap, then be restored before source kernel compilation"
+        bootstrap < restore_source_flake
+            && restore_source_flake < restore_kvm
+            && restore_kvm < source_kernel_build,
+        "the source flake and KVM acceleration must be restored after the no-KVM bootstrap proof and before source kernel compilation"
     );
     assert!(
         build_job.contains("needs: no-kvm-bootstrap")

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -31,6 +31,7 @@ const REQUIRED_QEMU_BUILD: &str =
 const REQUIRED_BOOT_IMAGE_UPDATE: &str =
     "/tmp/mvmctl-source-under-test image boot update --tag boot-image/v0.1.3 --force";
 const REQUIRED_SOURCE_KERNEL: &str = ".mvm-ci/cache/kernels/x86_64/workload/bzImage";
+const REQUIRED_SOURCE_FLAKE_RESTORE: &str = "mv nix/images/builder-vm.hidden nix/images/builder-vm";
 const REQUIRED_SOURCE_KERNEL_BUILD: &str =
     "/tmp/mvmctl-source-under-test kernel build --which workload --source compile -v";
 const REQUIRED_SOURCE_KERNEL_VERIFY: &str = "bzImage.sha256";
@@ -174,10 +175,24 @@ fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
     assert!(
         bootstrap_job.contains("needs: no-kvm-prepare")
             && bootstrap_job.contains(&format!("name: {BINARY_ARTIFACT}"))
+            && bootstrap_job.contains(REQUIRED_SOURCE_FLAKE_RESTORE)
             && bootstrap_job.contains(REQUIRED_SOURCE_KERNEL_BUILD)
             && bootstrap_job.contains("uses: actions/upload-artifact@v7")
             && bootstrap_job.contains(&format!("name: {BOOTSTRAP_ARTIFACT}")),
         "bootstrap must use exact binaries and publish reusable launch artifacts"
+    );
+    let bootstrap = bootstrap_job
+        .find("Bootstrap source-matched launch artifacts")
+        .expect("the bootstrap runner must bootstrap source-matched launch artifacts");
+    let restore_source_flake = bootstrap_job
+        .find(REQUIRED_SOURCE_FLAKE_RESTORE)
+        .expect("the bootstrap runner must restore the source flake after the download witness");
+    let source_kernel_build = bootstrap_job
+        .find(REQUIRED_SOURCE_KERNEL_BUILD)
+        .expect("the bootstrap runner must source-build the QEMU kernel");
+    assert!(
+        bootstrap < restore_source_flake && restore_source_flake < source_kernel_build,
+        "the source flake must stay hidden through published bootstrap, then be restored before source kernel compilation"
     );
     assert!(
         build_job.contains("needs: no-kvm-bootstrap")
@@ -213,11 +228,11 @@ fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
     let install_zigbuild = bootstrap_job
         .find("uses: ./.github/actions/install-zigbuild")
         .expect("the bootstrap runner must install cargo-zigbuild");
-    let bootstrap = bootstrap_job
+    let bootstrap_toolchain = bootstrap_job
         .find("Bootstrap source-matched launch artifacts")
         .expect("the bootstrap runner must bootstrap source-matched launch artifacts");
     assert!(
-        install_rust < install_zigbuild && install_zigbuild < bootstrap,
+        install_rust < install_zigbuild && install_zigbuild < bootstrap_toolchain,
         "the live runner must install the guest cross-toolchain before bootstrap"
     );
     assert!(

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -23,6 +23,7 @@ const REQUIRED_CI_VSOCK_OWNERSHIP: &str = "sudo chown \"$USER\" /dev/vhost-vsock
 const REQUIRED_KVM_DENIAL: &str = "sudo chmod 000 /dev/kvm";
 const REQUIRED_KVM_RESTORE: &str = "sudo chmod 0666 /dev/kvm";
 const REQUIRED_STAGE0_BOOT_READ: &str = "sudo chmod a+r";
+const REQUIRED_QEMU_BRIDGE_OVERRIDE: &str = "MVM_QEMU_BRIDGE_PATH: /tmp/mvmctl-source-under-test";
 const REQUIRED_LOCAL_VSOCK_DEVICE: &str = "--device /dev/vhost-vsock:/dev/vhost-vsock";
 const FORBIDDEN_LOCAL_KVM_DEVICE: &str = "--device /dev/kvm:/dev/kvm";
 const REQUIRED_BUILDER_DOWNLOAD: &str =
@@ -231,9 +232,10 @@ fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
         smoke_job.contains("needs: no-kvm-build")
             && smoke_job.contains(&format!("name: {BOOTSTRAP_ARTIFACT}"))
             && smoke_job.contains(&format!("name: {BUNDLE_ARTIFACT}"))
+            && smoke_job.contains(REQUIRED_QEMU_BRIDGE_OVERRIDE)
             && smoke_job.contains("bundle install /tmp/no-kvm-bundle/exit-code-x86_64.mvmpkg")
             && smoke_job.contains("machine run"),
-        "the smoke runner must install and boot the bundle in its own runner window"
+        "the smoke runner must install and boot the bundle with the exact source binary as its QEMU bridge"
     );
     for job in [bootstrap_job, build_job, smoke_job] {
         assert!(

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -47,6 +47,7 @@ const FORBIDDEN_ENTRYPOINT_OVERRIDE: &str = "-- /bin/true";
 const BINARY_ARTIFACT: &str = "no-kvm-binaries";
 const BOOTSTRAP_ARTIFACT: &str = "no-kvm-bootstrap-cache";
 const BUNDLE_ARTIFACT: &str = "no-kvm-bundle";
+const REQUIRED_PREPARE_TIMEOUT: &str = "timeout-minutes: 45";
 
 #[test]
 fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
@@ -169,6 +170,10 @@ fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
     assert!(
         prepare.contains("runs-on: ubuntu-24.04") && !prepare.contains("runs-on: ubuntu-24.04-arm"),
         "the exact hosted smoke binaries must be compiled for the x86_64 runner that executes them"
+    );
+    assert!(
+        prepare.contains(REQUIRED_PREPARE_TIMEOUT),
+        "the embedded-helper cross-build must retain its measured hosted-runner budget"
     );
     assert!(
         prepare.contains("uses: actions/upload-artifact@v7")

--- a/tests/github_actions_extended_e2e.rs
+++ b/tests/github_actions_extended_e2e.rs
@@ -334,19 +334,60 @@ fn linux_documented_surface_installs_virtiofsd_for_stage0_shares() {
 }
 
 #[test]
-fn linux_documented_surface_grants_unprivileged_icmp_to_the_runner_group() {
+fn linux_documented_surface_does_not_depend_on_host_icmp() {
     let workflow = extended_ci();
     let linux = job_block(&workflow, "e2e-docs-linux");
 
     assert!(
-        linux.contains("sudo sysctl -w net.ipv4.ping_group_range=\"0 2147483647\"")
-            && linux.contains(
-                "read -r ping_gid_min ping_gid_max < <(sysctl -n net.ipv4.ping_group_range)"
-            )
-            && linux.contains("test \"$ping_gid_min\" = \"0\"")
-            && linux.contains("test \"$ping_gid_max\" = \"2147483647\""),
-        "the documented ping witnesses need the runner group admitted to unprivileged ICMP sockets"
+        !linux.contains("ping_group_range"),
+        "positive documented egress witnesses use HTTPS because hosted networks may drop ICMP"
     );
+}
+
+#[test]
+fn documented_surface_installs_a_deterministic_encrypted_backing_fixture() {
+    let script = documented_surface_script();
+
+    assert!(
+        script.contains("provision_encrypted_backing_probes()")
+            && script.contains("/dev/mapper/mvm-e2e-crypt")
+            && script.contains("' crypt\"")
+            && script.contains("'FileVault: Yes'")
+            && script.contains("export PATH=\"$probe_bin:$PATH\""),
+        "live volume and mount-cache scenarios need a declared encrypted-backing fixture; the hosted runner's root disk is not one"
+    );
+}
+
+#[test]
+fn documented_surface_keeps_its_summary_log_in_the_private_e2e_home() {
+    let script = documented_surface_script();
+
+    assert!(
+        script.contains("SUITE_LOG=\"$(mktemp \"$E2E_HOME/.e2e-suite.XXXXXX\")\""),
+        "unrelated temporary-directory cleanup must not erase the suite summary before it is verified"
+    );
+}
+
+#[test]
+fn positive_live_egress_witnesses_use_https_instead_of_external_icmp() {
+    let launch = fs::read_to_string("features/suites/s31_launch_e2e/cli_launch_modes.feature")
+        .expect("read launch-mode feature");
+    let transient =
+        fs::read_to_string("features/suites/s5_lifecycle/transient_sandbox_boot.feature")
+            .expect("read transient-launch feature");
+
+    for feature in [&launch, &transient] {
+        assert!(
+            !feature.lines().any(|line| {
+                line.contains("--allow-host")
+                    && line.contains(" ping ")
+                    && !line.contains("default-deny")
+            }),
+            "a positive egress gate cannot depend on ICMP replies from the hosted runner network"
+        );
+    }
+    assert!(launch.contains("curlimages/curl:8.21.0"));
+    assert!(transient.contains("curlimages/curl:8.21.0"));
 }
 
 #[test]

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -942,6 +942,7 @@ mod tests {
         );
         assert!(
             build.contains("image boot update --tag boot-image/v0.1.3 --force")
+                && bootstrap.contains("mv nix/images/builder-vm.hidden nix/images/builder-vm")
                 && bootstrap.contains("kernel build --which workload --source compile -v")
                 && build.contains(".mvm-ci/cache/kernels/x86_64/workload/bzImage")
                 && build.contains("bzImage.sha256")
@@ -949,6 +950,16 @@ mod tests {
                 && build.contains("veritysetup format")
                 && build.contains("bundle export \"$slot_hash\""),
             "bundle preparation must combine verified release rootfs bytes with source-matched launch artifacts and exporter"
+        );
+        let restore_source_flake = bootstrap
+            .find("mv nix/images/builder-vm.hidden nix/images/builder-vm")
+            .expect("the source builder flake must be restored after published bootstrap");
+        let source_kernel_build = bootstrap
+            .find("kernel build --which workload --source compile -v")
+            .expect("the source QEMU kernel must be built");
+        assert!(
+            restore_source_flake < source_kernel_build,
+            "the source builder flake must be restored before source kernel compilation"
         );
         let deny_kvm_position = smoke
             .find(deny_kvm)

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -943,6 +943,7 @@ mod tests {
         assert!(
             build.contains("image boot update --tag boot-image/v0.1.3 --force")
                 && bootstrap.contains("mv nix/images/builder-vm.hidden nix/images/builder-vm")
+                && bootstrap.contains("sudo chmod 0666 /dev/kvm")
                 && bootstrap.contains("kernel build --which workload --source compile -v")
                 && build.contains(".mvm-ci/cache/kernels/x86_64/workload/bzImage")
                 && build.contains("bzImage.sha256")
@@ -957,9 +958,12 @@ mod tests {
         let source_kernel_build = bootstrap
             .find("kernel build --which workload --source compile -v")
             .expect("the source QEMU kernel must be built");
+        let restore_kvm = bootstrap
+            .find("sudo chmod 0666 /dev/kvm")
+            .expect("source artifact compilation must restore KVM acceleration");
         assert!(
-            restore_source_flake < source_kernel_build,
-            "the source builder flake must be restored before source kernel compilation"
+            restore_source_flake < restore_kvm && restore_kvm < source_kernel_build,
+            "the source builder flake and KVM acceleration must be restored before source kernel compilation"
         );
         let deny_kvm_position = smoke
             .find(deny_kvm)

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -981,7 +981,9 @@ mod tests {
             .find("/tmp/mvmctl-source-under-test machine run")
             .expect("the live workload must run through the source-matched mvmctl");
         assert!(prepare.contains("MVM_EMBED_NO_CACHE: 1"));
-        assert!(prepare.contains("cargo build --release -p mvmctl --features user"));
+        assert!(
+            prepare.contains("cargo build --release -p mvmctl --features user,embed-host-bins")
+        );
         assert!(prepare.contains(
             "cargo build --release -p mvmctl --features \
              user,release-artifact-bootstrap,release-channel"

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -993,6 +993,7 @@ mod tests {
             .find("/tmp/mvmctl-source-under-test machine run")
             .expect("the live workload must run through the source-matched mvmctl");
         assert!(prepare.contains("MVM_EMBED_NO_CACHE: 1"));
+        assert!(prepare.contains("timeout-minutes: 45"));
         assert!(
             prepare.contains("cargo build --release -p mvmctl --features user,embed-host-bins")
         );

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -944,6 +944,9 @@ mod tests {
             build.contains("image boot update --tag boot-image/v0.1.3 --force")
                 && bootstrap.contains("mv nix/images/builder-vm.hidden nix/images/builder-vm")
                 && bootstrap.contains("sudo chmod 0666 /dev/kvm")
+                && bootstrap.contains("sudo chmod a+r")
+                && bootstrap.contains("/boot/vmlinuz-$(uname -r)")
+                && bootstrap.contains("/boot/initrd.img-$(uname -r)")
                 && bootstrap.contains("kernel build --which workload --source compile -v")
                 && build.contains(".mvm-ci/cache/kernels/x86_64/workload/bzImage")
                 && build.contains("bzImage.sha256")
@@ -961,9 +964,14 @@ mod tests {
         let restore_kvm = bootstrap
             .find("sudo chmod 0666 /dev/kvm")
             .expect("source artifact compilation must restore KVM acceleration");
+        let grant_boot_read = bootstrap
+            .find("sudo chmod a+r")
+            .expect("source artifact compilation must make the host boot inputs readable");
         assert!(
-            restore_source_flake < restore_kvm && restore_kvm < source_kernel_build,
-            "the source builder flake and KVM acceleration must be restored before source kernel compilation"
+            restore_source_flake < restore_kvm
+                && restore_kvm < grant_boot_read
+                && grant_boot_read < source_kernel_build,
+            "the source builder flake, KVM acceleration, and readable boot inputs must be restored before source kernel compilation"
         );
         let deny_kvm_position = smoke
             .find(deny_kvm)

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -942,7 +942,9 @@ mod tests {
         );
         assert!(
             build.contains("image boot update --tag boot-image/v0.1.3 --force")
-                && build.contains(".mvm-ci/cache/kernels/x86_64/workload/vmlinux")
+                && bootstrap.contains("kernel build --which workload --source compile -v")
+                && build.contains(".mvm-ci/cache/kernels/x86_64/workload/bzImage")
+                && build.contains("bzImage.sha256")
                 && build.contains("write /tmp/exit-code-entrypoint /etc/mvm/entrypoint")
                 && build.contains("veritysetup format")
                 && build.contains("bundle export \"$slot_hash\""),


### PR DESCRIPTION
## Summary
- provision an explicit encrypted-backing fixture for live volume and mount-cache scenarios without relaxing production enforcement
- replace positive external-ICMP egress checks with HTTPS witnesses while retaining the default-deny ping scenario
- keep the suite summary log inside the private E2E home so unrelated temporary cleanup cannot erase evidence
- remove the now-unneeded hosted-runner ICMP sysctl mutation

## Validation
- cargo test --test github_actions_extended_e2e
- cargo clippy --workspace -- -D warnings
- cargo fmt --check
- bash -n scripts/e2e-documented-surface.sh
- cargo test --workspace -- --test-threads=1 reached socket-binding tests; local managed sandbox denies sockets, while the exact predecessor head passed both workspace CI architectures
- just bdd parsed and reached all 252 scenarios; local managed sandbox blocked sockets and DNS, while the changed live scenarios are intentionally verified by Extended CI

## Live evidence
Extended CI run 33869717851 is running against the byte-identical source commit on the merged PR branch; this PR will also receive its own required CI run.