### PR TITLE
docs(adr): deduplicate ADR-037 by renumbering the superseded datapath to 052

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1902,11 +1902,11 @@ resume` takes a `current_head` and refuses when it differs from the
   - [x] Validate load/attach on a live Linux host (PR #2221)
 
 - [~] Plan 287 — Userspace socket datapath
-  (`specs/plans/287-userspace-socket-datapath.md`, ADR-037)
+  (`specs/plans/287-userspace-socket-datapath.md`, ADR-052)
   Tracked end to end under epic #2111, which also carries plan 285's
   deferred set. Every workstream below has its own issue; the epic
   records the ordering and the two gates that are not preference.
-  **Frozen by plan 316 Phase 0.** ADR-037 is superseded for production
+  **Frozen by plan 316 Phase 0.** ADR-052 is superseded for production
   workload networking: this datapath forwarded raw IP packets for
   `l3-vsock`, which no longer boots. No feature work lands on its runtime
   path; deletion is plan 316 Phase 7 (#2376).
@@ -1938,10 +1938,10 @@ resume` takes a `current_head` and refuses when it differs from the
         closes it out in the docs: the guide's platform matrix now splits
         by forwarding backend rather than by platform, ADR-036's
         present-tense `MacosUserspaceGateway` prose is corrected, and
-        ADR-037's memory ceiling is re-derived from `limits.rs` — its
+        ADR-052's memory ceiling is re-derived from `limits.rs` — its
         `1024 × 32 KiB = 32 MiB` was wrong three ways over, against a real
         46,500,608 bytes (44.35 MiB). **Three defects were shipped and
-        recorded rather than hidden**, in ADR-037 §"Known defects in what
+        recorded rather than hidden**, in ADR-052 §"Known defects in what
         shipped" and in plan 287's own deferred set; **two are now
         closed**. Every host socket the datapath opens is registered on the
         set behind `readiness_fd`, so a resolved connect and an arriving
@@ -2049,7 +2049,7 @@ resume` takes a `current_head` and refuses when it differs from the
         offered and what the host leased, and `Config::decode` refuses a
         frame where the bit and the assignment disagree. A leased pair sets
         `required_capabilities.ipv6_flows`, so a backend without it refuses
-        at open with a shortfall naming it — closing ADR-037's fourth known
+        at open with a shortfall naming it — closing ADR-052's fourth known
         defect. A plan that does not ask is unchanged in every byte.
         **Both backends now carry the family.** The packet backend's v6
         half is the host-side mirror of the guest's: an `AF_INET6`

--- a/specs/adrs/001-microvm-security-posture.md
+++ b/specs/adrs/001-microvm-security-posture.md
@@ -462,7 +462,7 @@ does not construct a FlowMux client. Synthetic negative fixtures prove a
 second path or socket owner fails CI, while a projection test proves all flow
 classes share the same admitted object graph.
 
-**The retired `l3-vsock` path.** ADR-036 and ADR-037 historically supplied an
+**The retired `l3-vsock` path.** ADR-036 and ADR-052 historically supplied an
 opt-in raw-packet compatibility mode. ADR-042 superseded them, and the public
 mode, guest TUN and agent, packet protocol, policy branch, host forwarders,
 VMM hooks, dependencies, packaging, and temporary migration ratchets are now

--- a/specs/adrs/036-l3-tun-over-vsock.md
+++ b/specs/adrs/036-l3-tun-over-vsock.md
@@ -336,7 +336,7 @@ application TCP, UDP, and host-terminated DNS. It does not cover raw
 sockets, arbitrary IP protocols, arbitrary ICMP, or multicast, and it does
 not claim to.
 
-**Status: superseded in part by [ADR-037](037-userspace-socket-datapath.md),
+**Status: superseded in part by [ADR-052](052-userspace-socket-datapath.md),
 which designs the translator and widens it from a macOS-only backend to a
 platform-neutral unprivileged one.** What shipped with *this* ADR was a
 placeholder, `MacosUserspaceGateway` — a capability declaration plus a
@@ -357,7 +357,7 @@ declaration claims are not yet true of the datapath behind it: declared
 ingress is advertised with no listening socket serving it, and the
 readiness descriptor it exposes has nothing registered on it, so
 host-originated traffic moves on the drive loop's 50 ms tick rather than on
-the event that made it ready. Both are recorded in ADR-037 §"Known defects
+the event that made it ready. Both are recorded in ADR-052 §"Known defects
 in what shipped".
 
 The later full-packet backend would need privileged operations mvm has no
@@ -894,7 +894,7 @@ only against measurements like these, not against intuition.
   kernel.
 - macOS gains no L3 support in this change, and says so explicitly
   rather than degrading. (Since closed: the userspace socket datapath of
-  ADR-037 now serves macOS, within the limits §macOS states.)
+  ADR-052 now serves macOS, within the limits §macOS states.)
 
 ## Future work
 

--- a/specs/adrs/037-mvmd-only-production-launch.md
+++ b/specs/adrs/037-mvmd-only-production-launch.md
@@ -2,6 +2,11 @@
 
 **Status: Accepted**
 **Date: 2026-08-04**
+**Note on the number.** Until 2026-09-04 two ADRs held 037: this one and the
+userspace socket datapath, now [ADR-052](052-userspace-socket-datapath.md).
+This one kept the number because it is `Accepted` and cited as current
+authority. A citation of "ADR-037" that predates that date and discusses
+networking means ADR-052; one that discusses launch authority means this ADR.
 
 ## Context
 

--- a/specs/adrs/038-ipv6-support.md
+++ b/specs/adrs/038-ipv6-support.md
@@ -30,7 +30,7 @@ network spec is leased a unique-local `/126` at the same index as its
 gateway requires `ipv6_flows` of whichever forwarding backend was selected.
 A plan that does not ask for IPv6 is unchanged in every byte. See §"Host
 allocation: a unique-local /126 per machine, on request".
-**Complements ADR-036 (L3 TUN-over-vsock) and ADR-037 (the userspace
+**Complements ADR-036 (L3 TUN-over-vsock) and ADR-052 (the userspace
 socket datapath). Supersedes nothing; it removes IPv6 from ADR-036's
 deferred set and gives it a design.**
 

--- a/specs/adrs/039-macos-network-helper.md
+++ b/specs/adrs/039-macos-network-helper.md
@@ -3,7 +3,7 @@
 **Status: Rejected — 2026-08-03. mvm adds no root-capable component.**
 **Date: proposed 2026-08-02, rejected 2026-08-03. Tracked as issue #2122.**
 **Complements ADR-036 (L3 TUN-over-vsock) §"macOS (Apple Silicon)", which
-enumerated the four privileged operations, and ADR-037 (the userspace
+enumerated the four privileged operations, and ADR-052 (the userspace
 socket datapath), which deliberately avoids needing any of them.**
 
 ## Why this ADR needs a signature, not just a review

--- a/specs/adrs/040-node-to-node-transport.md
+++ b/specs/adrs/040-node-to-node-transport.md
@@ -6,7 +6,7 @@ reasons named below. Nothing here should be built until its prerequisites
 land. Tracked as issue #2119.**
 **Date: 2026-08-04**
 **Complements ADR-036 (L3 TUN-over-vsock) §"Cross-node traffic", which
-described the interface and recorded it as not implemented, and ADR-037
+described the interface and recorded it as not implemented, and ADR-052
 (the userspace socket datapath), which owns the local forwarding backend
 unchanged.**
 

--- a/specs/adrs/042-single-flow-vsock-networking.md
+++ b/specs/adrs/042-single-flow-vsock-networking.md
@@ -2,8 +2,8 @@
 
 **Status: Accepted**
 **Date: 2026-08-11**
-**Supersedes: ADR-036 (L3 TUN-over-vsock) and ADR-037
-(`037-userspace-socket-datapath.md`) for the production workload networking
+**Supersedes: ADR-036 (L3 TUN-over-vsock) and ADR-052
+(`052-userspace-socket-datapath.md`) for the production workload networking
 path. Their measurements, threat analysis, and historical rationale stand;
 their implementations stop being a supported production transport.
 Complements ADR-003 (hypervisor egress policy), ADR-014 (signed/audited
@@ -20,7 +20,7 @@ the guest, is the party that opens sockets.
 
 ADR-036 then added `l3-vsock`, an opt-in compatibility mode that gives the
 guest a real IP stack on a `mvm0` TUN and tunnels raw IPv4/IPv6 packets to a
-host forwarder. ADR-037 added a second, unprivileged forwarding backend for
+host forwarder. ADR-052 added a second, unprivileged forwarding backend for
 it. Both shipped. The tree therefore carries **two** production workload
 networking paths with different policy code, different resource accounting,
 different audit shapes, and different security properties — and

--- a/specs/adrs/052-userspace-socket-datapath.md
+++ b/specs/adrs/052-userspace-socket-datapath.md
@@ -1,8 +1,18 @@
-# ADR-037 — The userspace socket datapath
+# ADR-052 — The userspace socket datapath
 
 **Status: Superseded for production workload networking by ADR-042
 (2026-08-11).**
 **Date: 2026-08-02**
+**Renumbered 037 → 052 on 2026-09-04.** Two ADRs held 037: this one and
+ADR-037 (`mvmd` is the only production launch authority), so a citation of
+"ADR-037" named two different decisions and a reader could not tell which.
+This one moved because it is superseded and its inbound citations are
+backward-looking, while the launch-authority ADR is Accepted and cited as
+current authority. Every in-tree citation that meant this document was
+retargeted in the same change. A reference to "ADR-037" predating that date
+and discussing networking means this ADR. The number 052 was held by a
+different ADR before the v1 restructure deleted it; nothing in the tree cited
+that one.
 **Superseded by: ADR-042 (one flow-aware vsock networking path). This ADR's
 datapath forwarded raw IP packets for `l3-vsock`, which is leaving the
 production workload path along with the mode itself. Its unprivileged-

--- a/specs/plans/2026-09-03-adr-001-ledger-drift-repair.md
+++ b/specs/plans/2026-09-03-adr-001-ledger-drift-repair.md
@@ -65,11 +65,12 @@ in-process rootfs materialization as a decision.
 entirely (`xtask/src/check_adr_coverage.rs:119–123`) so that ADRs referring to
 themselves do not inflate the reference count.
 
-### 4. Duplicate ADR number `037`
+### 4. Duplicate ADR number `037` — resolved 2026-09-04
 
-`037-mvmd-only-production-launch.md` and `037-userspace-socket-datapath.md`.
-Same failure mode `check-plan-names` exists to stop for plans; ADRs have no
-equivalent gate.
+`037-mvmd-only-production-launch.md` and what was then
+`037-userspace-socket-datapath.md`. Same failure mode `check-plan-names` exists
+to stop for plans; ADRs have no equivalent gate. The datapath ADR is now
+ADR-052 — see WS-E.
 
 ### 5. `specs/claims/` ghosts, including two in a public file
 
@@ -136,7 +137,10 @@ Needs a decision before it can be executed — see Open questions.
 
 ### WS-E — Rename one duplicate ADR-037
 
-- [ ] Pick the one to renumber and update its inbound references
+- [x] Renumbered the **superseded** side: `037-userspace-socket-datapath.md` is now `052-userspace-socket-datapath.md`. ADR-037 stays with `mvmd-only-production-launch`, which is `Accepted` and cited as current authority; renumbering a superseded document churns only backward-looking references.
+- [x] Retargeted all 23 inbound citations that meant the datapath, classified line by line rather than by blanket replace. 15 that meant the launch-authority ADR were left alone. Two ambiguous ones — ADR-046's `Complements:` list and this plan's own `ADR-037/040/041 cross-repo ownership` line — were resolved to the launch-authority ADR: ADR-040 and ADR-041 are cross-node trust boundaries, and ADR-042 already covers the networking path, so listing the datapath there would be redundant.
+- [x] `052` was verified free: sweeping every ADR number from 052 to 120, the only ones cited anywhere in the tree were 106, 107 (the dangling pair WS-B still owns) and 110 (which exists). A different ADR held 052 before the v1 restructure deleted it, which both files now record. Note the number cannot be named here in citation form without the coverage gate reading it as a reference — that gate caught exactly that mistake in an earlier draft of this line.
+- [x] Updated `check_declared_backing.rs`'s `PENDING` entry, which named the old path and would have failed the gate on a rename alone.
 
 ## Why nothing caught this, and the minimum to stop it recurring
 
@@ -170,4 +174,4 @@ Three structural blind spots:
 
 1. **What happens to the two deleted decisions?** They scope claim 3: dm-verity witnesses the claim on block+ext4 backends, and virtiofs-root is a dev tier with a weaker contract that does not witness it. That scoping is load-bearing for a `Shipped` claim and currently rests on two citations that resolve to nothing. Restoring the content as a new ADR in the 0xx range is the safer option; inlining it into ADR-001 is cheaper but grows a file that is already 1,080 lines. Needs a call.
 2. **Is the 052–111 citation sweep bounded?** Item 3 was found by grepping two specific numbers. The full inbound-reference set for the deleted range has not been enumerated; WS-B's third box may be larger than it looks.
-3. **Which ADR-037 keeps the number?** Both are live documents.
+3. ~~**Which ADR-037 keeps the number?**~~ Resolved in WS-E: the live `Accepted` launch-authority ADR keeps 037; the superseded datapath ADR became 052. They were not both live — that was the wrong premise.

--- a/specs/plans/285-l3-tun-over-vsock.md
+++ b/specs/plans/285-l3-tun-over-vsock.md
@@ -266,7 +266,7 @@ Read ADR-036 first; this plan is the sequencing and the checkbox ledger.
       guest, which that backend does not build. The packet backend serves
       both.
 - [x] **macOS userspace socket gateway.** Delivered by
-      `specs/plans/287-userspace-socket-datapath.md` (ADR-037), and widened
+      `specs/plans/287-userspace-socket-datapath.md` (ADR-052), and widened
       on the way: `UserspaceSocketDatapath` is platform-neutral, so it also
       serves a Linux host that holds no `CAP_NET_ADMIN`. The
       `MacosUserspaceGateway` placeholder — declaration plus refusal — is
@@ -274,7 +274,7 @@ Read ADR-036 first; this plan is the sequencing and the checkbox ledger.
       at admission on it, and two gaps are open rather than closed:
       declared ingress is advertised with nothing listening behind it, and
       the readiness descriptor has nothing registered on it, so every
-      host-driven step waits for a 50 ms tick. Both are recorded in ADR-037
+      host-driven step waits for a 50 ms tick. Both are recorded in ADR-052
       §"Known defects in what shipped".
 - [ ] **macOS `utun` + PF datapath.** The later full-packet backend.
       Requires a privileged host helper mvm does not have. ADR-036 §macOS

--- a/specs/plans/287-userspace-socket-datapath.md
+++ b/specs/plans/287-userspace-socket-datapath.md
@@ -12,7 +12,7 @@ FlowMux; the userspace L3 datapath and smoltcp dependency no longer ship.
 
 **Tech Stack:** Rust, smoltcp (new dependency), mio (existing workspace dependency, new `mvm-hostd` edge), `std::os::unix` sockets.
 
-**ADR:** [037](../adrs/037-userspace-socket-datapath.md). Read it first — this plan is the sequencing.
+**ADR:** [037](../adrs/052-userspace-socket-datapath.md). Read it first — this plan is the sequencing.
 
 ## Global Constraints
 
@@ -1666,12 +1666,12 @@ existing prose were false rather than merely stale:
   but has nothing behind it, so every host-driven step waits for the drive
   loop's tick), `declared_ingress: true` advertised with no listening
   socket serving it, and `poll_inbound`'s unbudgeted drain. They are in
-  the guide as user-visible costs and in ADR-037 §"Known defects in what
+  the guide as user-visible costs and in ADR-052 §"Known defects in what
   shipped" as engineering record.
 - ADR-036 described `MacosUserspaceGateway` in the present tense. Every
   reference is corrected; the type is deleted.
 
-**ADR-037's memory ceiling was wrong and is re-derived.** It claimed
+**ADR-052's memory ceiling was wrong and is re-derived.** It claimed
 `1024 × 32 KiB = 32 MiB`, wrong in three independent ways: the cap is 256,
 a flow costs 176,768 bytes rather than its 32,768 bytes of ring buffers
 (each flow owns its own smoltcp device and its two packet queues), and UDP
@@ -1869,7 +1869,7 @@ cannot meet — not a flow count, a measured shortfall.
 Not scope reductions — things that are wrong, recorded so the close-out is
 not read as "finished". Three were listed at close-out; two of those closed,
 two more were found while closing them, and those two are now closed as well.
-One remains. ADR-037 §"Known defects in what shipped" carries the original
+One remains. ADR-052 §"Known defects in what shipped" carries the original
 three with the mechanism.
 
 - [x] **Register host sockets on the datapath's poll set.** Done. Every
@@ -1950,7 +1950,7 @@ three with the mechanism.
       **Still open: TCP.** A declared stream mapping is admitted and binds
       nothing on this backend; serving one needs a listener whose accepted
       connections are originated toward the guest. It is skipped at open
-      rather than refused, opens no socket, and is recorded in ADR-037
+      rather than refused, opens no socket, and is recorded in ADR-052
       §"Known defects in what shipped" as the remaining over-claim.
 - [x] **Give `Gateway::poll_inbound` a per-pass budget.** Done, mirroring
       the guest-facing drain rather than inventing a second mechanism:

--- a/specs/plans/316-single-flow-vsock-networking.md
+++ b/specs/plans/316-single-flow-vsock-networking.md
@@ -179,7 +179,7 @@ the admitted launch state, never from guest bytes.
 - [x] Add an accepted ADR that records the L4-with-selective-L7 decision, the
       impossibility of arbitrary guest TLS plus host replacement without TLS
       interception, and the rejection of a host MITM CA as the universal path.
-- [x] Mark ADR-036 and ADR-037 superseded for production workload networking;
+- [x] Mark ADR-036 and ADR-052 superseded for production workload networking;
       retain their measurements and historical rationale without describing
       either implementation as live.
 - [x] Reconcile `specs/refactor/03-networking.md`, ADR-001's backend matrix and
@@ -199,7 +199,7 @@ the admitted launch state, never from guest bytes.
       ensures the migration never operates three live production paths.
 
 **Landed as.** ADR-042 (`specs/adrs/042-single-flow-vsock-networking.md`);
-superseded-for-production markers on ADR-036 and ADR-037; a rewritten
+superseded-for-production markers on ADR-036 and ADR-052; a rewritten
 `specs/refactor/03-networking.md`; a qualified tier matrix and claim-10 section
 in ADR-001; `xtask check-l3-expansion-freeze`
 (`xtask/src/check_l3_expansion_freeze.rs`, wired into the CI Lint job) with a

--- a/specs/sprint/delivery/2368-single-flow-vsock-networking.md
+++ b/specs/sprint/delivery/2368-single-flow-vsock-networking.md
@@ -10,7 +10,7 @@ only for a typed flow whose signed plan requires it. A plan requiring
 transformation refuses an opaque shape rather than downgrading.
 
 Phase 0 is complete: ADR-042 ratifies the invariant, supersedes ADR-036 and
-ADR-037 for production workload networking, corrects the networking refactor
+ADR-052 for production workload networking, corrects the networking refactor
 record, and freezes expansion of the retired L3 path. The temporary
 `check-l3-expansion-freeze` ratchet fails on new production references outside
 its shrinking allowlist. Synthesis, supervisor admission, and CLI preflight all

--- a/specs/sprint/delivery/deduplicate-adr-037.md
+++ b/specs/sprint/delivery/deduplicate-adr-037.md
@@ -1,0 +1,44 @@
+# ADR-037 held two decisions; the superseded one is now ADR-052
+
+Two files carried the number: `037-mvmd-only-production-launch.md` (`Accepted`)
+and `037-userspace-socket-datapath.md` (`Superseded` by ADR-042). Forty
+citations of "ADR-037" resolved to whichever a reader happened to open.
+
+**Which one moved, and why.** The datapath ADR. It is superseded, so its inbound
+citations are backward-looking and cheap to redirect; the launch-authority ADR is
+`Accepted` and cited by ADR-006, ADR-045 and ADR-049 as current authority, where
+a renumber would churn live references. Note the datapath ADR was the *older* of
+the two (2026-08-02 vs 08-04) and so had the number first — that lost to the
+live-versus-superseded criterion, which is about reader cost, not seniority.
+
+**Why 052.** Sweeping every ADR number from 052 to 120, the only ones cited
+anywhere were 106 and 107 (the dangling pair the ledger-drift plan still owns)
+and 110 (which exists). A different ADR held 052 before the v1 restructure
+deleted it; both files now record that, so a stale external reference is not
+silently misread.
+
+**The citations were classified by hand, not blanket-replaced.** 23 meant the
+datapath and were retargeted line by line; 15 meant the launch authority and were
+left alone. Two were genuinely ambiguous — ADR-046's `Complements:` list and the
+secure-message-fabric plan's `ADR-037/040/041 cross-repo ownership` line. Both
+resolved to the launch authority: ADR-040 and ADR-041 are cross-node trust
+boundaries, and ADR-042 already covers the networking path, so naming the
+datapath in either place would be redundant. Both ADRs now carry a note saying
+which reading a pre-2026-09-04 citation takes.
+
+**A rename alone would have failed the build.** `check_declared_backing.rs`
+listed the old path in `PENDING`, and that list may only shrink — a `PENDING`
+entry naming a file that no longer exists is a hard error. Updated with the move.
+
+**`check-adr-coverage` caught a self-inflicted defect, twice.** A draft of the
+plan's WS-E note wrote the swept range in citation form, so the upper bound
+parsed as a reference to an ADR that does not exist and the gate went red. The
+first draft of *this* note then made the same mistake while describing it. Both
+reworded. Prose about ADR numbers has to avoid the citation form or it becomes a
+citation — the gate cannot tell the difference, and should not try. It is doing
+here exactly what WS-B of the ledger-drift plan records it cannot do inside
+`specs/adrs/`.
+
+Verified: `check-all` 67 gates clean, `cargo nextest run -p xtask` 705 passed,
+`just bdd` 252 scenarios 251 passed 1 skipped, and no duplicate ADR number
+remains.

--- a/xtask/src/check_declared_backing.rs
+++ b/xtask/src/check_declared_backing.rs
@@ -142,7 +142,7 @@ const PENDING: &[&str] = &[
     "specs/adrs/035-workload-stream-plane.md",
     "specs/adrs/036-l3-tun-over-vsock.md",
     "specs/adrs/037-mvmd-only-production-launch.md",
-    "specs/adrs/037-userspace-socket-datapath.md",
+    "specs/adrs/052-userspace-socket-datapath.md",
     "specs/adrs/038-ipv6-support.md",
     "specs/adrs/039-macos-network-helper.md",
     "specs/adrs/040-node-to-node-transport.md",


### PR DESCRIPTION
Executes WS-E of `specs/plans/2026-09-03-adr-001-ledger-drift-repair.md`.

## The problem

Two files held the number, and 40 citations of "ADR-037" resolved to whichever one a reader happened to open:

| File | Status | Date |
|---|---|---|
| `037-mvmd-only-production-launch.md` | **Accepted** | 2026-08-04 |
| `037-userspace-socket-datapath.md` | **Superseded** by ADR-042 | 2026-08-02 |

## Which one moved

The **datapath** ADR, now `052-userspace-socket-datapath.md`.

It is superseded, so its inbound citations are backward-looking and cheap to redirect. The launch-authority ADR is `Accepted` and cited by ADR-006, ADR-045 and ADR-049 as current authority, where a renumber would churn live references.

Worth stating plainly: the datapath ADR was the **older** of the two and had the number first. That lost to live-versus-superseded, which is a judgement about reader cost, not seniority. My earlier plan asserted "both are live documents" — that was simply wrong, and reading the two status lines settled it in one step.

## Why 052

Sweeping every ADR number from 052 to 120, the only ones cited anywhere in the tree were **106** and **107** (the dangling pair WS-B still owns) and **110** (which exists). So 052 is genuinely free and keeps the run contiguous.

A different ADR held 052 before the v1 restructure deleted it. Both files now record that, so a stale external reference to the old one is not silently misread.

## Citations classified by hand, not blanket-replaced

Of the 40:

- **23 meant the datapath** → retargeted line by line, each line verified to contain `ADR-037` before substitution.
- **15 meant the launch authority** → left alone.
- **2 were this plan's own WS-E text** → updated to record the resolution.

Two were genuinely ambiguous and are worth naming: ADR-046's `Complements:` list, and the secure-message-fabric plan's `ADR-037/040/041 cross-repo ownership references` line. Both resolve to the **launch authority** — ADR-040 and ADR-041 are cross-node trust boundaries, and ADR-042 already covers the networking path, so naming the superseded datapath in either place would be redundant.

Both ADRs now carry a note saying which reading a pre-2026-09-04 citation takes, so the ambiguity is resolvable from either side rather than only from this PR.

## Two things that would have broken

**A rename alone fails the build.** `check_declared_backing.rs` listed the old path in `PENDING`, and that list may only shrink — an entry naming a file that no longer exists is a hard error. Updated with the move.

**`check-adr-coverage` caught a self-inflicted defect, twice.** A draft of the plan's WS-E note wrote the swept range in citation form, so the upper bound parsed as a reference to a nonexistent ADR. The first draft of the delivery note then repeated the mistake *while describing it*. Both reworded. Prose about ADR numbers has to avoid the citation form or it becomes a citation — and note the gate is doing here exactly what WS-B records it cannot do inside `specs/adrs/`, which is where the real dangling citations still sit.

## Verification

- `cargo run -p xtask -- check-all` — 67 gates clean
- `cargo nextest run -p xtask` — 705 passed
- `just bdd` — 252 scenarios, 251 passed, 1 skipped, 0 failed
- No duplicate ADR number remains
