### PR TITLE
build(kernel): bump synchronized pins to 6.12.108

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -48,10 +48,10 @@ let
   # kernel — lets both of mvm's kernels track the latest point release exactly
   # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
   # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
-  kernelVersion = "6.12.107";
+  kernelVersion = "6.12.108";
   kernelSrc = pkgs.fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
-    hash = "sha256-pfjFvj/eLW2coU6WMWQs8fREhxQ/EQWdpzDc1YkuMHo=";
+    hash = "sha256-4dHqIA0i1VyfXV+uWeabs7SUUVcF/DOQzVQjHuT0uq8=";
   };
   # The builder's overlay filesystem triggers a GNU tar directory-metadata
   # race while unpacking this archive. Materialize the source with bsdtar once

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.107.tar.xz";
-    hash = "sha256-pfjFvj/eLW2coU6WMWQs8fREhxQ/EQWdpzDc1YkuMHo=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.108.tar.xz";
+    hash = "sha256-4dHqIA0i1VyfXV+uWeabs7SUUVcF/DOQzVQjHuT0uq8=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.107' \
+      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.108' \
       --replace-fail 'curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)' 'ln -s ${kernelSrc} $(KERNEL_TARBALL)'
     substituteInPlace patches/0008-virtio-vsock-support-dgrams.patch \
       --replace-fail 'virtio_transport_alloc_skb(&info, dgram_len, false,' \

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -274,6 +274,12 @@ Last updated: 2026-09-04
       workflow-structure suite and `check-workflow-paths` are green. One
       uninterrupted run and merge delivery remain.
 
+- [ ] **Linux 6.12.108 synchronized kernel pin — issue #3147.**
+      `specs/plans/2026-09-04-kernel-6-12-108.md`.
+      Both kernel consumers use the kernel.org-verified archive and SRI hash;
+      the structural synchronization test moves with them. Linux Nix builds and
+      merge delivery remain.
+
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.
       Both kernel consumers use the kernel.org-verified archive and SRI hash;

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -265,6 +265,14 @@
       workflow-structure suite and `check-workflow-paths` are green. One
       uninterrupted run and merge delivery remain.
 
+- [ ] **Linux 6.12.108 synchronized kernel pin — issue #3147.**
+      `specs/plans/2026-09-04-kernel-6-12-108.md`.
+      The custom workload/builder kernel and libkrunfw firmware build now use
+      the same kernel.org-verified Linux 6.12.108 archive and SRI hash, with the
+      digest confirmed against the clearsigned manifest and by hashing the
+      downloaded archive. The structural synchronization suite and repository
+      policy gates are green. Linux Nix builds and merge delivery remain.
+
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.
       The custom workload/builder kernel and libkrunfw firmware build now use

--- a/specs/plans/2026-09-04-kernel-6-12-108.md
+++ b/specs/plans/2026-09-04-kernel-6-12-108.md
@@ -1,0 +1,44 @@
+# Linux 6.12.108 kernel pin refresh
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#3147](https://github.com/tinylabscom/mvm/issues/3147)
+
+## Outcome
+
+The custom workload/builder kernel and libkrunfw firmware build consume the
+same verified Linux 6.12.108 LTS source archive. Structural coverage keeps the
+version and source hash synchronized.
+
+## Delivery checklist
+
+- [x] Verify the upstream `linux-6.12.108.tar.xz` SHA-256 against kernel.org's
+      signed checksum manifest.
+- [x] Update the custom workload/builder kernel source pin and SRI hash.
+- [x] Update the libkrunfw kernel source pin, substitution, and SRI hash.
+- [x] Move the structural synchronization pin, so both consumers must land
+      together.
+- [x] Pass the focused synchronization test and local pin-parity checks.
+- [ ] Pass the Linux builder-VM Nix evaluation and kernel-build checks.
+- [ ] Record the completed implementation in the sprint and refactor rollup.
+- [ ] Merge the tested pull request and close #3147 through its linkage.
+
+## Source verification
+
+The upstream archive SHA-256 is
+`e1d1ea200d22d55c9f5d5fae59e69bb3b494515705fc3390cd54231ee4f4baaf`,
+which converts to the Nix SRI hash
+`sha256-4dHqIA0i1VyfXV+uWeabs7SUUVcF/DOQzVQjHuT0uq8=`.
+
+That digest is the one kernel.org publishes in its clearsigned
+`v6.x/sha256sums.asc`, and the archive downloaded from kernel.org hashes to it
+independently. The same manifest still carries the outgoing 6.12.107 digest
+this pin is replacing, unchanged, which is the check that says the manifest
+being read is the same series and not a substituted one.
+
+## Rollout
+
+The pin is the source of truth for both consumers; it does not itself
+re-kernel anything already running. Per the watcher's own remediation line,
+built VMs move with `mvmctl vm rekernel`, and the fleet rollout is mvmd's.

--- a/specs/sprint/delivery/3147-kernel-pin-6-12-108.md
+++ b/specs/sprint/delivery/3147-kernel-pin-6-12-108.md
@@ -1,0 +1,13 @@
+# Linux 6.12.108 kernel pin refresh
+
+- [x] Updated the libkrunfw firmware build and custom workload/builder kernels
+      from Linux 6.12.107 to 6.12.108.
+- [x] Verified the archive digest against kernel.org's clearsigned SHA-256
+      manifest, confirmed it by hashing the downloaded archive, and converted
+      it to the Nix SRI hash both consumers share.
+- [x] Moved the structural parity pin so the two consumers cannot drift apart.
+- [x] Passed the structural synchronization suite and repository policy gates.
+- [ ] Record the Linux builder validation after it passes.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-09-04-kernel-6-12-108.md`.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -373,8 +373,8 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         );
     }
 
-    const KERNEL_VERSION: &str = "6.12.107";
-    const KERNEL_HASH: &str = "sha256-pfjFvj/eLW2coU6WMWQs8fREhxQ/EQWdpzDc1YkuMHo=";
+    const KERNEL_VERSION: &str = "6.12.108";
+    const KERNEL_HASH: &str = "sha256-4dHqIA0i1VyfXV+uWeabs7SUUVcF/DOQzVQjHuT0uq8=";
     assert!(
         libkrunfw.contains(&format!("linux-{KERNEL_VERSION}.tar.xz"))
             && libkrunfw.contains(&format!("hash = \"{KERNEL_HASH}\""))


### PR DESCRIPTION
Closes #3147.

The kernel-pin freshness watcher reported both pins one patch release behind
upstream 6.12 LTS. `libkrunfw` and the custom workload/builder kernel share one
source pin by design, so they move together.

## Source verification

    e1d1ea200d22d55c9f5d5fae59e69bb3b494515705fc3390cd54231ee4f4baaf  linux-6.12.108.tar.xz

- That is the digest kernel.org publishes in its clearsigned `v6.x/sha256sums.asc`.
- The archive downloaded from kernel.org hashes to the same value independently.
- The same manifest still carries the outgoing `6.12.107` digest unchanged, which
  is the check that says it is the same series rather than a substituted manifest.

Converted to the Nix SRI hash both consumers share:
`sha256-4dHqIA0i1VyfXV+uWeabs7SUUVcF/DOQzVQjHuT0uq8=`.

## Validation

- `cargo test --test nix_flake_structure` — 56 passed. The parity test's own
  `KERNEL_VERSION` / `KERNEL_HASH` constants move with the pin, so neither
  consumer can be bumped without the other.
- `cargo run -p xtask -- check-kernel-pin-freshness` — now `worst = UpToDate`,
  `action_recommended = false`. That is the gate that raised the issue.
- `check-sprint-append`, `check-plan-names`, `check-declared-backing`,
  `check-doc-claims`, `cargo fmt --all --check`, workspace clippy (pre-commit).

The Linux builder-VM Nix evaluation and kernel build are not runnable on this
host and are left as open boxes in the plan.

## Rollout

The pin is the source of truth for both consumers; it does not re-kernel
anything already running. Per the watcher's remediation line, built VMs move
with `mvmctl vm rekernel`, and the fleet rollout is mvmd's.