### PR TITLE
fix(ci): stop the nightly lanes from cancelling themselves

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -14,13 +14,21 @@ on:
     - cron: "51 4 * * *"
   workflow_dispatch:
 
-# Cancel a previous run when a new commit lands on the same branch.
-# Without this, the PR check panel accumulates stale failed runs from
-# superseded SHAs (we hit this on PRs #17 and #18). `main` runs are
-# never cancelled because the group is keyed on workflow + ref.
+# This workflow has no `pull_request` trigger, so there is no check panel to
+# keep free of superseded SHAs — the only thing cancellation could reach here
+# is a lane that has been running for hours. Keying on `ref` alone made that
+# worse rather than harmless: a scheduled run and an operator dispatch both
+# carry `refs/heads/main`, so they shared a group and killed each other. Four
+# consecutive Extended CI runs were cancelled that way, each reporting
+# `cancelled`, which reads as a red lane. The lane was not red; the
+# documented-surface e2e job had never been allowed to finish.
+#
+# Same shape as ci.yml: dispatches are keyed on their own run id so an operator
+# request never lands on top of the nightly, and the nightly is keyed on the
+# ref so only one runs at a time. Nothing in flight is cancelled.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -22,9 +22,12 @@ on:
     - cron: "20 4 * * *"
   workflow_dispatch:
 
+# Scheduled and dispatched only, so cancellation has no PR check panel to
+# tidy and can only reach a run that is already under way. Both triggers carry
+# `refs/heads/main`, so keying on the ref alone let a dispatch kill the nightly.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,13 +25,18 @@ on:
     - cron: "17 4 * * *"
   workflow_dispatch:
 
-# Cancel a previous run when a new commit lands on the same branch.
-# Same rationale as ci.yml — keep the PR check panel free of stale
-# failed runs from superseded SHAs. `main` pushes and the nightly
-# cron are never cancelled (different ref → different group).
+# There is no `pull_request` trigger here, so there is no check panel to keep
+# free of superseded SHAs. The claim that the nightly cron was never cancelled
+# because of a different ref was wrong: a scheduled run and an operator
+# dispatch both carry `refs/heads/main` and so shared a group. The mutation
+# shards run for over two hours, and cancelling one leaves nine numbered claims
+# with a green ledger entry and no evidence behind it.
+#
+# Tag pushes already sit in their own group by ref. Dispatches now get their
+# own by run id, and the nightly keeps the ref, so no run cancels another.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -262,6 +262,18 @@ Last updated: 2026-09-04
       signed-audit regression now verifies authenticated labels exactly; live
       CI witnesses and merge delivery remain.
 
+- [ ] **Nightly lanes stop cancelling themselves — issue #3007.**
+      `specs/plans/2026-09-04-nightly-lanes-stop-cancelling-themselves.md`.
+      `Extended CI`, `Security` and `Miri` have no `pull_request` trigger, so
+      `cancel-in-progress` could only reach a run already in flight, and keying
+      the group on `github.ref` grouped the nightly cron *with* operator
+      dispatches instead of apart from them. Four consecutive Extended CI runs
+      cancelled each other, each reporting `cancelled`, which read as a red
+      lane. ci.yml's group expression is reused, and a derived structural test
+      fails any non-PR workflow that sets `cancel-in-progress: true`. The
+      workflow-structure suite and `check-workflow-paths` are green. One
+      uninterrupted run and merge delivery remain.
+
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.
       Both kernel consumers use the kernel.org-verified archive and SRI hash;

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -253,6 +253,18 @@
       Clippy, formatting, and repository policy gates are green; live
       default-backend witnesses and merge delivery remain.
 
+- [ ] **Nightly lanes stop cancelling themselves — issue #3007.**
+      `specs/plans/2026-09-04-nightly-lanes-stop-cancelling-themselves.md`.
+      `Extended CI`, `Security` and `Miri` have no `pull_request` trigger, so
+      `cancel-in-progress` could only reach a run already in flight, and keying
+      the group on `github.ref` grouped the nightly cron *with* operator
+      dispatches instead of apart from them. Four consecutive Extended CI runs
+      cancelled each other, each reporting `cancelled`, which read as a red
+      lane. ci.yml's group expression is reused, and a derived structural test
+      fails any non-PR workflow that sets `cancel-in-progress: true`. The
+      workflow-structure suite and `check-workflow-paths` are green. One
+      uninterrupted run and merge delivery remain.
+
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.
       The custom workload/builder kernel and libkrunfw firmware build now use

--- a/specs/plans/2026-09-04-nightly-lanes-stop-cancelling-themselves.md
+++ b/specs/plans/2026-09-04-nightly-lanes-stop-cancelling-themselves.md
@@ -1,0 +1,93 @@
+# Nightly lanes stop cancelling themselves
+
+Backing: shipped-source
+Validation: check-workflow-paths
+
+**Issue:** [#3007](https://github.com/tinylabscom/mvm/issues/3007)
+
+## Outcome
+
+`Extended CI`, `Security` and `Miri` no longer cancel a run that is already
+under way. Each is scheduled-and-dispatched only, so cancellation could never
+reach the thing it was written for and could only reach the thing it must not.
+
+## What was actually wrong
+
+All three carried:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+with a comment explaining that this keeps a pull request's check panel free of
+runs from superseded SHAs, and that `main` runs are safe because the group is
+keyed on the ref.
+
+Both halves are wrong for these files.
+
+None of the three has a `pull_request` trigger, so there is no check panel to
+keep tidy — the only run cancellation can reach is one already in flight.
+
+And the ref does not separate the triggers that *do* exist. A scheduled run and
+an operator dispatch both carry `refs/heads/main`, so far from putting them in
+different groups, keying on the ref put them in the *same* one. Every dispatch
+killed the nightly, and every dispatch killed the dispatch before it.
+
+That is what #3007 is. Four consecutive `Extended CI` runs were cancelled by
+their successors while the documented-surface e2e lane — which needs over an
+hour — was still running. Each reported `cancelled`, which in a run list is
+indistinguishable from a failure, so the lane read as red. It was not red. It
+had never been allowed to finish, and so had never produced the
+Linux/Firecracker verdict the release wanted from it.
+
+On `Security` the same defect has a sharper cost: the mutation shards run for
+over two hours, and a cancelled run leaves nine numbered claims with a green
+ledger entry and nothing behind it, which is the condition
+`check-claim-witness-freshness` exists to report.
+
+## The fix
+
+`ci.yml` already solved this, so the shape is reused rather than invented:
+
+```yaml
+group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
+cancel-in-progress: false
+```
+
+A dispatch is keyed on its own run id, so an operator request never lands on
+top of the nightly and never waits behind one. The nightly keeps the ref, so
+only one runs at a time. Tag pushes on `Security` already sat in their own
+group. Nothing in flight is cancelled.
+
+## Keeping it
+
+`a_workflow_without_pull_requests_never_cancels_a_run_in_flight` walks
+`.github/workflows/` and fails any file that has no `pull_request:` trigger yet
+sets `cancel-in-progress: true`. Derived from the trigger list rather than a
+filename allow-list, so a new nightly workflow inherits the rule instead of
+having to be remembered. Verified by reverting `miri.yml` and confirming the
+test names that file and that reason.
+
+Workflows that *do* have a `pull_request` trigger are untouched: cancellation
+is correct for them, and `network-perf.yml` and `kernel-cve-watch.yml` keep it.
+
+## Delivery checklist
+
+- [x] Scope the concurrency group on `ci-full.yml` so a scheduled or dispatched
+      run is not cancelled by the next one.
+- [x] Apply the same repair to `security.yml` and `miri.yml`, which carry the
+      identical defect.
+- [x] Add a derived structural test so a new nightly workflow cannot
+      reintroduce it.
+- [ ] Confirm with one uninterrupted `Extended CI` run that the documented
+      surface lane completes and reports a scenario summary.
+- [ ] Merge the tested pull request and close #3007 through its linkage.
+
+## What this does not fix
+
+The two documented-surface e2e failures named in #3007 are separately in
+flight. This change is the precondition for reading their verdict at all: while
+runs cancelled each other, a red lane and an unfinished lane were the same
+symbol.

--- a/specs/sprint/delivery/3007-nightly-lane-concurrency.md
+++ b/specs/sprint/delivery/3007-nightly-lane-concurrency.md
@@ -1,0 +1,17 @@
+# Nightly lanes stop cancelling themselves
+
+- [x] Repaired the concurrency group on `ci-full.yml`, `security.yml` and
+      `miri.yml`. None has a `pull_request` trigger, so `cancel-in-progress`
+      could only reach a run already under way; and keying the group on
+      `github.ref` grouped the nightly cron together with operator dispatches
+      rather than separating them, so each killed the other.
+- [x] Reused ci.yml's proven group expression rather than inventing one:
+      dispatches key on their own run id, the nightly keeps the ref.
+- [x] Added `a_workflow_without_pull_requests_never_cancels_a_run_in_flight`,
+      derived from each workflow's trigger list, and verified it fails on the
+      exact defect it guards.
+- [x] Passed the workflow-structure suite (31 tests) and `check-workflow-paths`.
+- [ ] Record the first uninterrupted Extended CI run.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-09-04-nightly-lanes-stop-cancelling-themselves.md`.

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -1073,6 +1073,52 @@ mod tests {
         );
     }
 
+    /// A workflow with no `pull_request` trigger may not cancel itself.
+    ///
+    /// `cancel-in-progress` exists to keep a PR's check panel free of runs
+    /// from superseded SHAs. A workflow that pull requests never trigger has
+    /// no such panel, so the only run cancellation can reach is one already
+    /// under way — and on the schedule-plus-dispatch workflows those run for
+    /// hours. Worse, `github.ref` does not separate them: a nightly cron and
+    /// an operator dispatch both carry `refs/heads/main`, so keying the group
+    /// on the ref alone put them in the *same* group rather than different
+    /// ones. Four consecutive `Extended CI` runs cancelled each other that
+    /// way, and each reported `cancelled`, which reads as a red lane rather
+    /// than as a lane that was never allowed to finish.
+    ///
+    /// Derived from the trigger list rather than a filename allow-list, so a
+    /// new nightly workflow inherits the rule instead of having to be
+    /// remembered.
+    #[test]
+    fn a_workflow_without_pull_requests_never_cancels_a_run_in_flight() {
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join(".github/workflows");
+        let mut checked = 0usize;
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.extension().is_none_or(|e| e != "yml") {
+                continue;
+            }
+            let src = std::fs::read_to_string(&path).unwrap();
+            if src.contains("\n  pull_request:") {
+                continue;
+            }
+            checked += 1;
+            assert!(
+                !src.contains("cancel-in-progress: true"),
+                "{}: no pull_request trigger, so cancel-in-progress can only \
+                 kill a run already in flight",
+                path.display()
+            );
+        }
+        assert!(
+            checked >= 3,
+            "expected several non-PR workflows; found {checked} — has the \
+             trigger spelling this scans for changed?"
+        );
+    }
+
     /// No workflow in the tree may float, exception aside.
     #[test]
     fn no_workflow_floats_a_third_party_action() {


### PR DESCRIPTION
Refs #3007.

## What #3007 actually is

The issue reads "Extended CI lane is red", naming two failing documented-surface
e2e jobs. The lane was not red. It had never been allowed to finish.

`ci-full.yml`, `security.yml` and `miri.yml` each carried:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

with a comment saying this keeps a pull request's check panel free of runs from
superseded SHAs, and that `main` runs are safe because the group is keyed on the
ref. Both halves are wrong for these three files.

**None of them has a `pull_request` trigger.** There is no check panel to keep
tidy, so the only run cancellation can reach is one already in flight.

**The ref does not separate the triggers that do exist.** A scheduled run and an
operator dispatch both carry `refs/heads/main` — so keying on the ref put them
in the *same* group rather than different ones. Every dispatch killed the
nightly, and every dispatch killed the dispatch before it.

Four consecutive Extended CI runs were cancelled by their successors while the
documented-surface lane, which needs over an hour, was still running. Each
reported `cancelled`, which in a run list is indistinguishable from a failure.

On `Security` the same defect costs more: the mutation shards run for over two
hours, and a cancelled run leaves nine numbered claims with a green ledger entry
and nothing behind it — the condition `check-claim-witness-freshness` reports
(#3149).

## The fix

`ci.yml` already solved this, so its expression is reused rather than a new one
invented:

```yaml
group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
cancel-in-progress: false
```

A dispatch is keyed on its own run id, so an operator request never lands on top
of the nightly and never waits behind one. The nightly keeps the ref, so only
one runs at a time. Tag pushes on `Security` already sat in their own group.
Nothing in flight is cancelled.

Workflows that *do* have a `pull_request` trigger are untouched — cancellation
is correct for them, and `network-perf.yml` and `kernel-cve-watch.yml` keep it.

## Keeping it

`a_workflow_without_pull_requests_never_cancels_a_run_in_flight` walks
`.github/workflows/` and fails any file with no `pull_request:` trigger that
sets `cancel-in-progress: true`. Derived from each workflow's trigger list
rather than a filename allow-list, so a new nightly workflow inherits the rule
instead of having to be remembered.

Verified it bites: reverting `miri.yml` to `cancel-in-progress: true` fails the
test naming that file and that reason.

## Validation

- `cargo test -p xtask check_workflow_paths` — 31 passed.
- `cargo run -p xtask -- check-workflow-paths` — clean, 26 workflow files.
- `tests/ci_scope_aggregate.rs`, `github_actions_bdd_gate`, `github_actions_fuzz_gate` — green.
- `actionlint` (pre-commit) — clean.
- `check-sprint-append`, `check-plan-names`, `check-declared-backing`, fmt, workspace clippy.

## What this does not fix

The two documented-surface e2e failures named in #3007 are separately in flight
(#3174, #3175). This change is the precondition for reading their verdict at
all: while runs cancelled each other, a red lane and an unfinished lane were the
same symbol. #3007 should stay open until one uninterrupted Extended CI run
reports a scenario summary.

It also ticks the "scope the concurrency group" box in
`specs/plans/2026-09-04-evidence-that-earns-trust.md`, which arrives with #3175.