### PR TITLE
fix(claims): make the red mutation shards green on their merits

### DIFF
--- a/crates/mvm-cli/src/commands/env/artifact_verify.rs
+++ b/crates/mvm-cli/src/commands/env/artifact_verify.rs
@@ -438,6 +438,153 @@ mod tests {
         );
     }
 
+    /// Read every `dev_image_verify_*` counter at once.
+    ///
+    /// The assertion that matters is not "the counter went up" but "that
+    /// counter went up and no other did" — a misrouted outcome is invisible
+    /// to the first and obvious to the second.
+    fn verify_counters() -> [u64; 7] {
+        let m = mvm_core::observability::metrics::global();
+        let r = std::sync::atomic::Ordering::Relaxed;
+        [
+            m.dev_image_verify_sig_invalid.load(r),
+            m.dev_image_verify_digest_mismatch.load(r),
+            m.dev_image_verify_version_skew.load(r),
+            m.dev_image_verify_revoked.load(r),
+            m.dev_image_verify_expired.load(r),
+            m.dev_image_verify_network.load(r),
+            m.dev_image_verify_ok.load(r),
+        ]
+    }
+
+    /// Each outcome bumps its own counter and nobody else's.
+    ///
+    /// These counters are the alerting channel: mvmd's reconciliation loop
+    /// watches `sig_invalid`, `digest_mismatch` and `revoked` for
+    /// attack-shaped spikes. An outcome routed to the wrong counter, or to no
+    /// counter at all, does not make verification fail — it makes a rejection
+    /// stop being visible, which is the failure this rung exists to prevent.
+    ///
+    /// Deleting any one arm of the match sends that outcome to the defensive
+    /// `_` branch, which warns and bumps nothing. Every arm survived that
+    /// deletion because nothing asserted the routing.
+    #[test]
+    fn each_verify_outcome_bumps_its_own_counter_and_no_other() {
+        let _env = TestEnv::new();
+        for (index, outcome) in [
+            "sig_invalid",
+            "digest_mismatch",
+            "version_skew",
+            "revoked",
+            "expired",
+            "network",
+        ]
+        .iter()
+        .enumerate()
+        {
+            let before = verify_counters();
+            bump_verify_outcome(outcome);
+            let after = verify_counters();
+            for (slot, (b, a)) in before.iter().zip(after.iter()).enumerate() {
+                let expected = if slot == index { b + 1 } else { *b };
+                assert_eq!(
+                    *a, expected,
+                    "outcome '{outcome}' moved counter slot {slot} from {b} to {a}"
+                );
+            }
+        }
+    }
+
+    /// An unknown outcome bumps nothing rather than landing on a neighbour.
+    ///
+    /// The `_` arm is the reason a deleted match arm is silent, so it is also
+    /// the thing that has to be checked directly: the guarantee is that an
+    /// unroutable outcome is dropped, not that it is quietly counted as
+    /// something else.
+    #[test]
+    fn an_unknown_verify_outcome_bumps_nothing() {
+        let _env = TestEnv::new();
+        let before = verify_counters();
+        bump_verify_outcome("not_an_outcome");
+        assert_eq!(verify_counters(), before);
+    }
+
+    /// Only security-relevant outcomes reach the audit log.
+    ///
+    /// The split is deliberate and the two channels are not interchangeable:
+    /// the counter alerts, the audit line is the forensics record. `network`
+    /// is operational — a flaky download is not evidence of anything — so it
+    /// is counted and not recorded, while every other outcome is both.
+    ///
+    /// Inverting the guard survived, which would file every failed download as
+    /// a security event and file no actual rejection at all.
+    #[test]
+    fn only_security_outcomes_are_written_to_the_audit_log() {
+        let mut env = TestEnv::new();
+        let home = tempfile::tempdir().unwrap();
+        env.isolate_mvm_home(home.path());
+        let log = std::path::PathBuf::from(mvm_core::policy::audit::default_audit_log());
+
+        bump_verify_outcome("network");
+        let after_network = std::fs::read_to_string(&log).unwrap_or_default();
+        assert!(
+            !after_network.contains("ImageVerifyFailed"),
+            "an operational network failure is not a security event: {after_network}"
+        );
+
+        bump_verify_outcome("revoked");
+        let after_revoked = std::fs::read_to_string(&log)
+            .expect("a security-relevant rejection must be recorded for forensics");
+        assert!(
+            after_revoked.contains("outcome=revoked"),
+            "the audit line must name the outcome: {after_revoked}"
+        );
+    }
+
+    /// A manifest line is a digest only if it is 64 characters *and* hex.
+    ///
+    /// This map is the pin every downloaded artifact is then held to, so a
+    /// line admitted into it is a digest mvm will trust. Relaxing the
+    /// conjunction to a disjunction survived: it would admit a 64-character
+    /// run of anything, and any length of hex, as a pinned SHA-256. A
+    /// truncated digest that still "matches" a truncated computation is the
+    /// shape that turns a hash pin into a formality.
+    ///
+    /// The valid line is present so the test cannot pass by rejecting
+    /// everything.
+    #[test]
+    fn a_manifest_digest_needs_both_the_length_and_the_alphabet() {
+        let mut env = TestEnv::new();
+        env.set("MVM_SKIP_COSIGN_VERIFY", "1");
+        let good = "a".repeat(64);
+        let body = format!(
+            "{good}  well-formed\n\
+             {}  right-length-wrong-alphabet\n\
+             {}  right-alphabet-wrong-length\n",
+            "z".repeat(64),
+            "b".repeat(63),
+        );
+        let (_dir, base_url) = stage_manifest(&body);
+
+        let map = fetch_expected_hashes(&manifest(&base_url), &["well-formed"])
+            .expect("the well-formed line must be admitted");
+        assert_eq!(map.get("well-formed"), Some(&good));
+
+        for rejected in ["right-length-wrong-alphabet", "right-alphabet-wrong-length"] {
+            assert!(
+                !map.contains_key(rejected),
+                "'{rejected}' is not a SHA-256 digest and must not become a pin"
+            );
+            let err = fetch_expected_hashes(&manifest(&base_url), &[rejected])
+                .expect_err("asking for a malformed entry must refuse")
+                .to_string();
+            assert!(
+                err.contains("did not include"),
+                "the refusal must say the entry is absent: {err}"
+            );
+        }
+    }
+
     /// The manifest is the trust anchor for every digest under it, so an
     /// unsigned one must be refused with nothing read out of it. The staged
     /// manifest is also missing the wanted entry: if the signature rung ever

--- a/crates/mvm-contract/src/plan/types.rs
+++ b/crates/mvm-contract/src/plan/types.rs
@@ -2156,3 +2156,146 @@ mod asset_identity_tests {
         }
     }
 }
+
+/// Small total functions on the plan's own vocabulary: the hex decoder, the
+/// nonce view, the two mode predicates, and the seccomp-tier parser.
+///
+/// Each is a handful of lines with no branching worth the name, which is
+/// exactly why none of them was covered — they read as too obvious to test.
+/// They are not: every one of them is consumed by something that decides
+/// policy, and each was replaceable by a constant, or by the wrong constant,
+/// without a single witness noticing.
+#[cfg(test)]
+mod plan_vocabulary_tests {
+    use super::*;
+    use core::str::FromStr as _;
+
+    /// The hex decoder produces the bytes the digest actually names.
+    ///
+    /// `caller_commitment_nibble` subtracts the ASCII base; adding it instead
+    /// survived. A commitment that decodes to the wrong bytes still parses,
+    /// still round-trips through `Display`, and still compares equal to
+    /// itself — so nothing short of pinning a known value against its known
+    /// bytes can tell the difference. The digit and letter halves are checked
+    /// separately because they are separate arms with separate bases.
+    #[test]
+    fn caller_commitment_hex_decodes_to_the_bytes_it_names() {
+        let digits = "0123456789".to_string() + &"ab".repeat(27);
+        let parsed = CallerCommitment::from_hex(&digits).expect("valid lowercase hex");
+        assert_eq!(
+            parsed.as_bytes()[..5],
+            [0x01, 0x23, 0x45, 0x67, 0x89],
+            "the digit arm must subtract b'0'"
+        );
+
+        let letters = "abcdef".to_string() + &"00".repeat(29);
+        let parsed = CallerCommitment::from_hex(&letters).expect("valid lowercase hex");
+        assert_eq!(
+            parsed.as_bytes()[..3],
+            [0xab, 0xcd, 0xef],
+            "the letter arm must subtract b'a' and add ten"
+        );
+
+        // High and low nibbles are not interchangeable: a decoder that
+        // swapped them would satisfy every assertion above that used a
+        // repeated pair.
+        let asymmetric = "10".to_string() + &"00".repeat(31);
+        assert_eq!(
+            CallerCommitment::from_hex(&asymmetric)
+                .expect("valid lowercase hex")
+                .as_bytes()[0],
+            0x10,
+        );
+    }
+
+    /// `as_hex` is a view of the parsed value, not a fresh string.
+    ///
+    /// Replacing it with `""` or a literal survived. The nonce is the plan's
+    /// replay key: the admission store remembers what it has seen by this
+    /// exact string, so a constant here collapses every plan onto one nonce
+    /// and either rejects the second boot or accepts an unlimited replay,
+    /// depending on which side of the store you stand.
+    #[test]
+    fn nonce_as_hex_returns_the_value_it_was_parsed_from() {
+        let value = "0123456789abcdef0123456789abcdef";
+        let nonce = Nonce::from_hex(value).expect("32 lowercase hex characters");
+        assert_eq!(nonce.as_hex(), value);
+
+        let other = Nonce::from_hex("fedcba9876543210fedcba9876543210").expect("valid nonce");
+        assert_ne!(
+            nonce.as_hex(),
+            other.as_hex(),
+            "two distinct nonces must not share a rendering"
+        );
+    }
+
+    /// `persists` distinguishes the two retention modes.
+    ///
+    /// It answers "is a durable transcript written", which is what decides
+    /// whether a reader attaching after the workload ends finds a recording.
+    /// Both constant replacements survived, and either one makes the mode
+    /// selection have no effect at all.
+    #[test]
+    fn only_the_persist_retention_mode_keeps_a_transcript() {
+        assert!(StreamRetention::Persist.persists());
+        assert!(!StreamRetention::Ephemeral.persists());
+        assert!(
+            StreamRetention::default().persists(),
+            "the default must keep a transcript, since it is what an \
+             unspecified plan gets"
+        );
+    }
+
+    /// `is_prod` distinguishes the two policy variants.
+    ///
+    /// It gates the production-strict requirements — no dev RCE primitives,
+    /// no plain-HTTP egress, verity-required rootfs. Replacing it with `true`
+    /// applies those to dev; replacing it with `false` lifts them from prod,
+    /// which is the direction that matters. Neither was detected.
+    #[test]
+    fn only_the_prod_variant_carries_production_strict_policy() {
+        assert!(Variant::Prod.is_prod());
+        assert!(!Variant::Dev.is_prod());
+    }
+
+    /// Every seccomp tier parses from its own spelling, and only its own.
+    ///
+    /// Each of the five match arms could be deleted without a witness
+    /// noticing. A deleted arm does not silently downgrade — the tier fails
+    /// to parse, so a plan naming it is refused — but a plan that legitimately
+    /// asks for `essential` being rejected as unspellable is a failure the
+    /// error message would not explain, and the arm set is the wire contract
+    /// either way.
+    ///
+    /// Round-tripped through `Display` so the parser and the renderer cannot
+    /// drift apart, and paired with a rejection so the test cannot pass by
+    /// accepting everything.
+    #[test]
+    fn every_seccomp_tier_parses_from_its_own_spelling() {
+        for (spelling, tier) in [
+            ("essential", PlanSeccompTier::Essential),
+            ("minimal", PlanSeccompTier::Minimal),
+            ("standard", PlanSeccompTier::Standard),
+            ("network", PlanSeccompTier::Network),
+            ("unrestricted", PlanSeccompTier::Unrestricted),
+        ] {
+            assert_eq!(
+                PlanSeccompTier::from_str(spelling),
+                Ok(tier),
+                "'{spelling}' must parse to its own tier"
+            );
+            assert_eq!(
+                alloc::format!("{tier}"),
+                spelling,
+                "the rendering must be the spelling the parser accepts"
+            );
+        }
+
+        assert!(
+            PlanSeccompTier::from_str("Standard").is_err(),
+            "the spellings are exact; a near miss must be refused rather \
+             than resolved to a neighbouring tier"
+        );
+        assert!(PlanSeccompTier::from_str("").is_err());
+    }
+}

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -274,11 +274,25 @@ Last updated: 2026-09-04
       workflow-structure suite and `check-workflow-paths` are green. One
       uninterrupted run and merge delivery remain.
 
-- [ ] **Linux 6.12.108 synchronized kernel pin — issue #3147.**
+- [x] **Linux 6.12.108 synchronized kernel pin — issue #3147.**
       `specs/plans/2026-09-04-kernel-6-12-108.md`.
       Both kernel consumers use the kernel.org-verified archive and SRI hash;
-      the structural synchronization test moves with them. Linux Nix builds and
-      merge delivery remain.
+      the structural synchronization test moves with them. Both architecture
+      kernel builds and the full merge-group matrix passed, PR #3177 landed,
+      and the issue closed.
+
+- [ ] **Claim witnesses that bite — issues #3148, #3149.**
+      `specs/plans/2026-09-04-claim-witnesses-that-bite.md`.
+      `security.yml`'s three mutation shards were red. The mvm-cli shard was
+      not reporting survivors at all — it died reading an `outcomes.json`
+      cargo-mutants never wrote for a `#![cfg(test)]` module file that
+      resolution had put on the surface. Resolution now keeps such files off
+      it. Eight claim-20 survivors in `artifact_verify.rs` and twelve of the
+      twenty in `plan/types.rs` are closed by witnesses verified against the
+      reported mutation; the twentieth is proven equivalent and recorded with
+      its proof. Nothing was resolved with `--write-baseline --run`. The
+      focused suites, the surface pin and `check-mutation-witnesses` are green.
+      The nightly confirmation and merge delivery remain.
 
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -265,13 +265,27 @@
       workflow-structure suite and `check-workflow-paths` are green. One
       uninterrupted run and merge delivery remain.
 
-- [ ] **Linux 6.12.108 synchronized kernel pin — issue #3147.**
+- [x] **Linux 6.12.108 synchronized kernel pin — issue #3147.**
       `specs/plans/2026-09-04-kernel-6-12-108.md`.
       The custom workload/builder kernel and libkrunfw firmware build now use
       the same kernel.org-verified Linux 6.12.108 archive and SRI hash, with the
       digest confirmed against the clearsigned manifest and by hashing the
       downloaded archive. The structural synchronization suite and repository
-      policy gates are green. Linux Nix builds and merge delivery remain.
+      policy gates are green. Both architecture kernel builds and the full
+      merge-group matrix passed, PR #3177 landed, and the issue closed.
+
+- [ ] **Claim witnesses that bite — issues #3148, #3149.**
+      `specs/plans/2026-09-04-claim-witnesses-that-bite.md`.
+      `security.yml`'s three mutation shards were red. The mvm-cli shard was
+      not reporting survivors at all — it died reading an `outcomes.json`
+      cargo-mutants never wrote for a `#![cfg(test)]` module file that
+      resolution had put on the surface. Resolution now keeps such files off
+      it. Eight claim-20 survivors in `artifact_verify.rs` and twelve of the
+      twenty in `plan/types.rs` are closed by witnesses verified against the
+      reported mutation; the twentieth is proven equivalent and recorded with
+      its proof. Nothing was resolved with `--write-baseline --run`. The
+      focused suites, the surface pin and `check-mutation-witnesses` are green.
+      The nightly confirmation and merge delivery remain.
 
 - [ ] **Linux 6.12.107 synchronized kernel pin — issue #2971.**
       `specs/plans/2026-08-28-kernel-6-12-107.md`.

--- a/specs/plans/2026-09-04-claim-witnesses-that-bite.md
+++ b/specs/plans/2026-09-04-claim-witnesses-that-bite.md
@@ -1,0 +1,116 @@
+# Claim witnesses that bite
+
+Backing: shipped-source
+Validation: check-mutation-witnesses
+
+**Issues:** [#3148](https://github.com/tinylabscom/mvm/issues/3148),
+[#3149](https://github.com/tinylabscom/mvm/issues/3149)
+
+## Outcome
+
+`security.yml`'s three red mutation shards go green on their own merits: every
+surviving mutant is either killed by a witness verified against the reported
+mutation, or recorded as equivalent with a proof. Nothing is re-pinned away.
+
+## Why the lane went red
+
+Claims 19 and 20 landed in #3133 and #3162. Adding a claim adds its witnesses'
+files to the mutation surface, and the surface pin is the cheap check that runs
+on a PR — so both PRs correctly re-pinned it. What neither could do is record
+the *misses*, because that needs the six-hour run the nightly owns. The next
+nightly therefore met four new surface files with no accepted-miss entries and
+failed, which is the ratchet working as designed and reporting a real gap.
+
+`check-claim-witness-freshness` (#3149) is downstream of that: it reports that
+claims 1, 3, 4, 5, 6, 7, 10, 11 and 15 have a green ledger entry and a red
+witness lane. It is a symptom, and it clears when #3148 does.
+
+## The three shards
+
+### mvm-cli — a dead shard, not a witness gap
+
+The shard did not report survivors. It died:
+
+    Error: reading .../crates_mvm-cli_src_commands_tests.rs/mutants.out/outcomes.json
+    Caused by: No such file or directory (os error 2)
+
+`crates/mvm-cli/src/commands/tests.rs` is 165 KB behind `#![cfg(test)]`.
+cargo-mutants does not mutate test code, so it generated no mutants and wrote
+no outcomes file at all — and the gate died reading that path, taking the whole
+package's run with it. The four files in the same shard that *did* have mutants
+reported nothing, and the error named a temp-directory path that reads as a
+missing file rather than as a run that never started.
+
+The file is on the surface because resolution maps a `fn:` witness to the file
+declaring it, assuming that file is the enforcement code the witness guards.
+That assumption is stated in the module docs and holds because this repo keeps
+`#[cfg(test)] mod tests` inline. It does not hold when the tests are a separate
+module file: `commands/mod.rs` declares `mod tests;`, so claim 19's
+`test_audit_asset_id_parses` resolved onto the tests themselves.
+
+Resolution now recognises the inner attribute and keeps such a file off the
+surface, the same way it already keeps `crates/*/tests/` off it. Claim 19 keeps
+its coverage — it still resolves to four other files — so the surface loses one
+entry and no claim loses a witness. The uncovered-claim reason is reworded to
+cover both shapes of test-only code.
+
+### mvm-cli — eight survivors in the claim-20 verifier
+
+`bump_verify_outcome`'s six match arms could each be deleted, and its
+`outcome != "network"` guard inverted, without a witness noticing. These are
+not cosmetic: the counters are the alerting channel mvmd's reconciliation loop
+watches for attack-shaped spikes, and the guard is what decides that a
+security-relevant rejection reaches the forensics log while an operational
+download failure does not. A deleted arm does not fail verification; it makes a
+rejection stop being visible.
+
+`fetch_expected_hashes`'s digest predicate could have its `&&` relaxed to `||`.
+That map is the pin every downloaded artifact is then held to, so the
+disjunction admits a 64-character run of anything, and any length of hex, as a
+pinned SHA-256.
+
+Four tests close all eight, each verified by applying the reported mutation and
+confirming the failure.
+
+### mvm-contract — twenty survivors in `plan/types.rs`
+
+Seven are closed by `specs/plans/2026-09-04-evidence-that-earns-trust.md`'s work
+(the ingress cap boundary, the `as_str` wire spellings, `is_default`).
+
+Twelve are closed here: the hex decoder's ASCII bases, `Nonce::as_hex` as a view
+rather than a constant, `StreamRetention::persists`, `Variant::is_prod`, and the
+five `PlanSeccompTier` spellings. Each is a handful of lines with no branching
+worth the name, which is why none was covered — they read as too obvious to
+test. Each is consumed by something that decides policy, and each was
+replaceable by a constant, or the wrong constant, unnoticed.
+
+One is equivalent and is recorded as an accepted miss with its proof: replacing
+`|` with `^` in `CallerCommitment::from_hex`. `caller_commitment_nibble` returns
+0..=15, so `high << 4` occupies bits 4-7 and `low` occupies bits 0-3; the bit
+sets are disjoint, which makes the two operators the same function over every
+input the expression can receive. Checked exhaustively over all 256 nibble
+pairs, and the full 1007-test suite passes with the mutation applied.
+
+## Delivery checklist
+
+- [x] Keep `#![cfg(test)]` module files off the mutation surface, so a witness
+      resolving into test code cannot kill a shard.
+- [x] Re-pin the surface for that resolution change alone, and confirm no claim
+      lost coverage.
+- [x] Close the eight claim-20 survivors in `artifact_verify.rs`.
+- [x] Close the twelve killable survivors in `plan/types.rs`.
+- [x] Record the one equivalent mutant with a proof rather than a re-pin.
+- [x] Verify every new witness by applying the reported mutation and confirming
+      it fails.
+- [ ] Confirm on the first uninterrupted nightly that all three shards are green.
+- [ ] Close #3148 and #3149 through their linkage.
+
+## What was deliberately not done
+
+`--write-baseline --run` would have made the lane green in one command by
+re-recording every survivor as accepted. That converts a real gap into a green
+light, and it is what the ledger exists to prevent. The surface pin was re-taken
+exactly once, for a resolution change whose diff is one file.
+
+The mvm-hostd shard's four survivors were closed separately in #3170 and are
+already on `main`.

--- a/specs/sprint/delivery/3148-mutation-witness-gaps.md
+++ b/specs/sprint/delivery/3148-mutation-witness-gaps.md
@@ -1,0 +1,23 @@
+# Claim witnesses that bite
+
+- [x] Kept `#![cfg(test)]` module files off the mutation surface. Resolution
+      assumes a witness's file is the enforcement code it guards, which fails
+      for a separate tests module — and the cost was a dead shard, not a weak
+      measurement: cargo-mutants writes no `outcomes.json` for a file with no
+      mutants, and the gate died reading it, reporting nothing about the four
+      files in the same shard that did have mutants.
+- [x] Re-pinned the surface for that change alone; claim 19 keeps its coverage
+      through four other files and no claim became uncovered.
+- [x] Closed the eight claim-20 survivors in `artifact_verify.rs` — outcome
+      counter routing, the security-versus-operational audit guard, and the
+      manifest digest predicate.
+- [x] Closed twelve of the twenty survivors in `plan/types.rs`; seven more are
+      closed by the evidence-that-earns-trust work, and the twentieth is proven
+      equivalent and recorded as an accepted miss with its proof.
+- [x] Verified every new witness by applying the reported mutation and
+      confirming the test fails.
+- [x] Resolved nothing with `--write-baseline --run`.
+- [ ] Confirm the three shards green on the first uninterrupted nightly.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-09-04-claim-witnesses-that-bite.md`.

--- a/xtask/mutation-witness-baseline.json
+++ b/xtask/mutation-witness-baseline.json
@@ -107,13 +107,6 @@
       ]
     },
     {
-      "path": "crates/mvm-cli/src/commands/tests.rs",
-      "package": "mvm-cli",
-      "claims": [
-        19
-      ]
-    },
-    {
       "path": "crates/mvm-cli/src/commands/vm/console.rs",
       "package": "mvm-cli",
       "claims": [
@@ -364,7 +357,7 @@
     },
     {
       "number": 16,
-      "why": "every fn: witness lives in crates/*/tests/, which cargo-mutants does not mutate"
+      "why": "every fn: witness lives in test-only code (crates/*/tests/, or a #![cfg(test)] module file), which cargo-mutants does not mutate"
     }
   ],
   "accepted_misses": [
@@ -952,6 +945,11 @@
       "file": "crates/mvm-cli/src/commands/shared/resolve.rs",
       "mutant": "replace || with && in resolve_manifest_arg",
       "reason": "the discriminating input is a bare relative name that exists as a file or directory in the process's current directory. A test cannot create one without writing into the repo working tree or mutating process-global CWD shared by parallel tests under the documented cargo test fallback."
+    },
+    {
+      "file": "crates/mvm-contract/src/plan/types.rs",
+      "mutant": "replace | with ^ in CallerCommitment::from_hex",
+      "reason": "equivalent mutant — no test can kill it. `caller_commitment_nibble` returns a value in 0..=15, so `high << 4` occupies bits 4-7 and `low` occupies bits 0-3. The bit sets are disjoint, which makes `|` and `^` the same function over every input the expression can receive; checked exhaustively over all 256 nibble pairs, and the whole 1007-test mvm-contract suite passes with the mutation applied. Accepted rather than scoped out, because the surrounding decoder is claim surface and is witnessed by caller_commitment_hex_decodes_to_the_bytes_it_names."
     },
     {
       "file": "crates/mvm-contract/src/policy/network_policy.rs",

--- a/xtask/src/check_mutation_witnesses.rs
+++ b/xtask/src/check_mutation_witnesses.rs
@@ -148,8 +148,8 @@ pub struct UncoveredClaim {
 
 /// Why a claim's `fn:` witnesses yield nothing mutable.
 const WHY_NO_FN_WITNESS: &str = "no fn: witness — witnessed by CI lanes only, nothing to mutate";
-const WHY_ONLY_INTEGRATION_TESTS: &str =
-    "every fn: witness lives in crates/*/tests/, which cargo-mutants does not mutate";
+const WHY_ONLY_INTEGRATION_TESTS: &str = "every fn: witness lives in test-only code (crates/*/tests/, or a #![cfg(test)] \
+     module file), which cargo-mutants does not mutate";
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Baseline {
@@ -346,6 +346,10 @@ pub fn resolve_surface(workspace: &Path) -> Result<Surface> {
     // integration test can be reported as uncovered rather than
     // silently vanishing.
     let mut hits: BTreeMap<String, BTreeSet<u32>> = BTreeMap::new();
+    // Files that resolved but hold nothing cargo-mutants would mutate, kept
+    // apart from the ones that do so the uncovered-claim accounting can tell
+    // "no witness resolved here" from "a witness resolved into test code".
+    let mut unmutatable: BTreeSet<String> = BTreeSet::new();
     let crates = workspace.join("crates");
     claims_ledger::for_each_file(&crates, Some("rs"), &mut |path, content| {
         for (name, claims) in &wanted {
@@ -353,6 +357,9 @@ pub fn resolve_surface(workspace: &Path) -> Result<Surface> {
                 let Some(rel) = workspace_relative(workspace, path) else {
                     continue;
                 };
+                if is_test_only_module(content) {
+                    unmutatable.insert(rel.clone());
+                }
                 hits.entry(rel).or_default().extend(claims.iter().copied());
             }
         }
@@ -360,7 +367,7 @@ pub fn resolve_surface(workspace: &Path) -> Result<Surface> {
 
     let mut files: Vec<SurfaceFile> = hits
         .iter()
-        .filter(|(path, _)| !is_integration_test(path))
+        .filter(|(path, _)| !is_integration_test(path) && !unmutatable.contains(*path))
         .filter_map(|(path, claims)| {
             Some(SurfaceFile {
                 path: path.clone(),
@@ -414,6 +421,33 @@ pub fn package_for(rel_path: &str) -> Option<String> {
 /// True for `crates/<pkg>/tests/...`, which cargo-mutants never mutates.
 pub fn is_integration_test(rel_path: &str) -> bool {
     rel_path.split('/').nth(2) == Some("tests")
+}
+
+/// True for a module file that is compiled only under `cfg(test)`.
+///
+/// Resolution maps a `fn:` witness to the file declaring it and assumes that
+/// file is the enforcement code the witness guards — which holds because this
+/// repo keeps `#[cfg(test)] mod tests` inline, beside the implementation. It
+/// does not hold when the tests are a *separate* module file: there the
+/// resolved file is the tests themselves, and the code they guard is
+/// elsewhere.
+///
+/// The cost of not noticing is not a weak measurement, it is a dead shard.
+/// cargo-mutants does not mutate test code, so such a file yields zero mutants
+/// and cargo-mutants writes no `outcomes.json` at all — the gate then died
+/// reading a missing path under a temp directory, taking the whole package's
+/// run with it and reporting nothing about the files that did have mutants.
+/// `crates/mvm-cli/src/commands/tests.rs` is the case in point: 165 KB behind
+/// `#![cfg(test)]`, reached because `commands/mod.rs` declares `mod tests;`.
+///
+/// Matched on the inner attribute rather than the filename, because it is the
+/// attribute and not the name that decides whether anything compiles outside
+/// test.
+fn is_test_only_module(content: &str) -> bool {
+    content
+        .lines()
+        .map(str::trim)
+        .any(|line| line == "#![cfg(test)]")
 }
 
 fn workspace_relative(workspace: &Path, path: &Path) -> Option<String> {
@@ -2037,6 +2071,82 @@ jobs:
         assert_eq!(surface.uncovered.len(), 1);
         assert_eq!(surface.uncovered[0].number, 2);
         assert_eq!(surface.uncovered[0].why, WHY_ONLY_INTEGRATION_TESTS);
+    }
+
+    /// A `#![cfg(test)]` module file stays off the surface, and a claim that
+    /// has other witnesses keeps its coverage.
+    ///
+    /// Resolution assumes the file declaring a witness is the enforcement code
+    /// the witness guards. A separate tests module breaks that assumption, and
+    /// the failure is not a weak measurement but a dead shard: cargo-mutants
+    /// mutates no test code, so it writes no `outcomes.json`, and the gate used
+    /// to die reading that missing path — losing every other file in the same
+    /// package's run along with it.
+    #[test]
+    fn a_test_only_module_file_is_not_mutation_surface() {
+        let tmp = ledger_tree(
+            "\
+| 1 | one | fn:enforces_it, fn:also_checked_in_the_tests_module | auth | Shipped |
+",
+        );
+        let demo = tmp.path().join("crates").join("demo").join("src");
+        std::fs::create_dir_all(&demo).unwrap();
+        std::fs::write(demo.join("lib.rs"), "fn enforces_it() {}\n").unwrap();
+        std::fs::write(
+            demo.join("tests.rs"),
+            "#![cfg(test)]\nfn also_checked_in_the_tests_module() {}\n",
+        )
+        .unwrap();
+
+        let surface = resolve_surface(tmp.path()).unwrap();
+        let paths: Vec<&str> = surface.files.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["crates/demo/src/lib.rs"],
+            "the tests module has nothing cargo-mutants would mutate"
+        );
+        assert!(
+            surface.uncovered.is_empty(),
+            "claim 1 still resolves to enforcement code, so it is not uncovered"
+        );
+    }
+
+    /// A claim witnessed *only* from a tests module has no surface at all, and
+    /// says which kind of test-only code it landed in.
+    #[test]
+    fn a_claim_witnessed_only_from_a_tests_module_is_reported_as_uncovered() {
+        let tmp = ledger_tree(
+            "\
+| 1 | one | fn:enforces_it | auth | Shipped |
+| 2 | two | fn:only_in_the_tests_module | auth | Shipped |
+",
+        );
+        let demo = tmp.path().join("crates").join("demo").join("src");
+        std::fs::create_dir_all(&demo).unwrap();
+        std::fs::write(demo.join("lib.rs"), "fn enforces_it() {}\n").unwrap();
+        std::fs::write(
+            demo.join("tests.rs"),
+            "#![cfg(test)]\nfn only_in_the_tests_module() {}\n",
+        )
+        .unwrap();
+
+        let surface = resolve_surface(tmp.path()).unwrap();
+        assert_eq!(surface.uncovered.len(), 1);
+        assert_eq!(surface.uncovered[0].number, 2);
+        assert_eq!(surface.uncovered[0].why, WHY_ONLY_INTEGRATION_TESTS);
+    }
+
+    /// Only the inner attribute counts. A file with ordinary `#[cfg(test)] mod
+    /// tests` beside its implementation is exactly the shape resolution is
+    /// built around, and dropping it would silently delete real surface.
+    #[test]
+    fn an_inline_test_module_does_not_make_the_file_test_only() {
+        assert!(is_test_only_module("#![cfg(test)]\nfn a() {}\n"));
+        assert!(is_test_only_module("//! docs\n\n  #![cfg(test)]\n"));
+        assert!(!is_test_only_module(
+            "fn enforce() {}\n\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn t() {}\n}\n"
+        ));
+        assert!(!is_test_only_module("fn enforce() {}\n"));
     }
 
     fn uncovered(number: u32) -> UncoveredClaim {


### PR DESCRIPTION
Refs #3148, #3149.

`security.yml`'s three claim-witness shards were red, so
`check-claim-witness-freshness` was correctly reporting that claims 1, 3, 4, 5,
6, 7, 10, 11 and 15 had a green ledger entry and no live evidence. #3149 is the
symptom; it clears when #3148 does.

Nothing here is resolved with `--write-baseline --run`. That would have made the
lane green in one command by re-recording every survivor as accepted, which
converts a real gap into a green light.

## Why the lane went red

Claims 19 and 20 landed in #3133 and #3162. Adding a claim adds its witnesses'
files to the mutation surface, and the surface pin is the cheap check that runs
on a PR — so both PRs correctly re-pinned it. What neither could do is record
the *misses*, which needs the six-hour run the nightly owns. The next nightly
met four new surface files with no accepted-miss entries and failed. The ratchet
worked, and it was reporting a real gap.

## mvm-cli — a dead shard, not a witness gap

The shard reported no survivors. It died:

```
Error: reading .../crates_mvm-cli_src_commands_tests.rs/mutants.out/outcomes.json
Caused by: No such file or directory (os error 2)
```

`crates/mvm-cli/src/commands/tests.rs` is 165 KB behind `#![cfg(test)]`.
cargo-mutants does not mutate test code, so it generated no mutants and wrote no
outcomes file at all — and the gate died reading that path, taking the whole
package's run with it. The four files in the same shard that *did* have mutants
reported nothing, and the error named a temp-directory path that reads as a
missing file rather than as a run that never started.

The file is on the surface because resolution maps a `fn:` witness to its
declaring file, assuming that file is the enforcement code the witness guards.
That assumption is stated in the module docs and holds because this repo keeps
`#[cfg(test)] mod tests` inline. It does not hold when the tests are a separate
module file: `commands/mod.rs` declares `mod tests;`, so claim 19's
`test_audit_asset_id_parses` resolved onto the tests themselves.

Resolution now recognises the inner attribute, exactly as it already recognises
`crates/*/tests/`. Claim 19 keeps its coverage through four other files, so the
surface loses one entry and no claim becomes uncovered — the whole baseline diff
is that one deletion, one reworded reason, and one accepted miss.

## mvm-cli — eight real survivors in the claim-20 verifier

- `bump_verify_outcome`'s six match arms could each be deleted unnoticed. These
  counters are the alerting channel mvmd's reconciliation loop watches for
  attack-shaped spikes; a deleted arm does not fail verification, it makes a
  rejection stop being visible.
- Inverting `outcome != "network"` would file every flaky download as a security
  event and file no actual rejection at all.
- Relaxing `fetch_expected_hashes`'s digest predicate from `&&` to `||` admits a
  64-character run of anything, and any length of hex, as a pinned SHA-256 —
  and that map is the pin every downloaded artifact is then held to.

Four tests close all eight.

## mvm-contract — twenty survivors in `plan/types.rs`

- **Seven** are closed by #3175 (the ingress cap boundary, the `as_str` wire
  spellings, `is_default`). This PR does not touch them, and does not touch that
  file region.
- **Twelve** are closed here: the hex decoder's ASCII bases, `Nonce::as_hex` as
  a view rather than a constant, `StreamRetention::persists`, `Variant::is_prod`,
  and the five `PlanSeccompTier` spellings. Each reads as too obvious to test;
  each is consumed by something that decides policy, and each was replaceable by
  a constant, or the wrong constant, unnoticed.
- **One is equivalent** and is recorded as an accepted miss with its proof:
  `caller_commitment_nibble` returns 0..=15, so `high << 4` occupies bits 4-7
  and `low` occupies bits 0-3. The bit sets are disjoint, so `|` and `^` are the
  same function over every input the expression can receive. Verified over all
  256 nibble pairs, and the full 1007-test suite passes with the mutation
  applied. No test can ever kill it.

The mvm-hostd shard's four survivors were closed in #3170 and are already on
`main`.

## Every new witness was verified against the reported mutation

Not "a test now exists" — the mutation was applied to the source and the test
confirmed to fail, then reverted. All twelve killable mutants:

| mutation applied | test that failed |
|---|---|
| delete arm `"revoked"` / `"network"` | `each_verify_outcome_bumps_its_own_counter_and_no_other` |
| `outcome != "network"` → `==` | `only_security_outcomes_are_written_to_the_audit_log` |
| `&&` → `\|\|` in the digest predicate | `a_manifest_digest_needs_both_the_length_and_the_alphabet` |
| `byte - b'0'` → `+` (digit arm) | `caller_commitment_hex_decodes_to_the_bytes_it_names` |
| `byte - b'a'` → `+` (letter arm) | `caller_commitment_hex_decodes_to_the_bytes_it_names` |
| `Nonce::as_hex` → `""` | `nonce_as_hex_returns_the_value_it_was_parsed_from` |
| `persists` → `false` / `true` | `only_the_persist_retention_mode_keeps_a_transcript` |
| `is_prod` → `false` / `true` | `only_the_prod_variant_carries_production_strict_policy` |
| delete arm `"essential"` / `"unrestricted"` | `every_seccomp_tier_parses_from_its_own_spelling` |

The resolution change is likewise verified by a test that fails on the defect it
guards, plus two that pin the boundary: an inline `#[cfg(test)] mod tests` must
*not* be treated as test-only, or the fix would silently delete real surface.

## Validation

- `cargo nextest run --workspace` — **13116 passed**, 0 failed, 22 skipped.
- `cargo test --workspace --doc` — green.
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0.
- `cargo fmt --all -- --check` — clean.
- `check-mutation-witnesses` — surface pinned and clean, 46 files, 164 accepted
  misses.
- `check-claim-catalog` (20 claims, 105 witnesses), `check-witness-citations`,
  `check-asserted-absence`, `check-nextest-groups`, `check-honesty`,
  `check-no-overclaim`, `check-sprint-append`, `check-plan-names`,
  `check-declared-backing`.

## Ordering

Independent of #3175 — different files, and different regions of
`plan/types.rs`. Both are needed for the mvm-contract shard to go green: seven
of its twenty survivors are #3175's. Either can land first.

#3148 and #3149 should stay open until a nightly confirms all three shards
green. #3178 is what lets that nightly finish.