### PR TITLE
fix(claims): close the survivors the dead mvm-cli shard was hiding

### DIFF
--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -2522,6 +2522,140 @@ allow_hosts = ["localhost:8443"]
         path
     }
 
+    /// Admission pins a directory share's content digest, and only where one
+    /// is missing and the grant really is a directory.
+    ///
+    /// The pin is what makes claim 19's post-admission drift refusal possible:
+    /// enforcement re-hashes at attach time and compares. If admission records
+    /// no digest, there is nothing to compare against and the refusal cannot
+    /// fire — it reports present and never bites, which is worse than no
+    /// refusal because it is believed.
+    ///
+    /// Two mutants survived here and this covers both. Flipping `==` to `!=`
+    /// hashes disks and skips directory shares, so exactly the grants the claim
+    /// is about lose their pin. Relaxing `&&` to `||` re-hashes a share that
+    /// already carries a digest, overwriting a caller-supplied identity with
+    /// whatever the tree happens to be at admission — which turns a pin into a
+    /// snapshot and admits the drift it exists to refuse.
+    ///
+    /// The existing witness, `admitted_share_digest_refuses_directory_changed_after_admission`,
+    /// tests the enforcement side in mvm-hostd. It cannot see this: it is
+    /// handed a plan that already carries a digest.
+    #[test]
+    fn admission_pins_a_directory_shares_digest_and_leaves_other_grants_alone() {
+        let _env = mvm_core::util::test_env::TestEnv::new();
+        let shared = tempfile::tempdir().unwrap();
+        std::fs::write(shared.path().join("payload.txt"), b"admitted bytes").unwrap();
+        let canonical = std::fs::canonicalize(shared.path()).unwrap();
+        let expected = mvm_fs::hash::hash_source(&canonical).expect("the tree hashes");
+
+        let disk_dir = tempfile::tempdir().unwrap();
+        let disk = disk_dir.path().join("data.img");
+        std::fs::write(&disk, b"disk bytes").unwrap();
+
+        const ALREADY_PINNED: &str =
+            "1111111111111111111111111111111111111111111111111111111111111111";
+
+        let share = |tag: &str, host: &std::path::Path, guest: &str, kind, digest: Option<&str>| {
+            mvm_core::plan::HostShareGrant {
+                tag: tag.to_string(),
+                host_path: host.display().to_string(),
+                guest_path: guest.to_string(),
+                kind,
+                read_only: false,
+                encrypted: false,
+                content_sha256: digest.map(str::to_string),
+            }
+        };
+
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path());
+        let ledger = InMemoryNonceLedger::new();
+        let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            network_mode: mvm_contract::plan::NetworkMode::default(),
+            tenant: "local",
+            vm_name: "vm-shares",
+            backend_name: "firecracker",
+            rootfs_path: &rootfs,
+            kernel_path: None,
+            precomputed_image_sha256: None,
+            boot_artifact_identity: None,
+            cpus: 1,
+            mem_mib: 512,
+            seccomp_tier: mvm_core::plan::PlanSeccompTier::Standard,
+            secret_release: mvm_core::plan::SecretReleasePolicy::None,
+            secrets: Vec::new(),
+            caller_commitment: None,
+            no_supervisor: false,
+            ledger: &ledger,
+            keys_dir: Some(keys_dir.path()),
+            audit_dir: Some(audit_dir.path()),
+            policy_dir: None,
+            bundle_pin: None,
+            deps_volume: None,
+            shares: vec![
+                share(
+                    "uvol0",
+                    shared.path(),
+                    "/work",
+                    mvm_core::plan::ShareKind::DirShare,
+                    None,
+                ),
+                share(
+                    "uvol1",
+                    shared.path(),
+                    "/pinned",
+                    mvm_core::plan::ShareKind::DirShare,
+                    Some(ALREADY_PINNED),
+                ),
+                share(
+                    "uvol2",
+                    &disk,
+                    "/data",
+                    mvm_core::plan::ShareKind::Disk,
+                    None,
+                ),
+            ],
+            redaction: mvm_core::policy::RedactionPolicy::default(),
+            network_policy: mvm_core::network_policy::NetworkPolicy::deny_all(),
+            agent_verb_override: vec![],
+            restrict_agent_verbs: false,
+            services: Vec::new(),
+            grants: None,
+            backend_kind: Some(mvm_contract::protocol::vm_backend::BackendKind::Firecracker),
+            entrypoint: ResolvedEntrypoint::unresolved("this test does not resolve one"),
+            assets: Vec::new(),
+        })
+        .expect("admission")
+        .expect("Some when admission ran");
+
+        let shares = &ctx.admitted.plan().shares;
+        let by_tag = |tag: &str| {
+            shares
+                .iter()
+                .find(|s| s.tag == tag)
+                .unwrap_or_else(|| panic!("the signed plan carries {tag}"))
+        };
+
+        assert_eq!(
+            by_tag("uvol0").content_sha256.as_deref(),
+            Some(expected.as_str()),
+            "an unpinned directory share must be hashed at admission, or drift              enforcement has nothing to compare against"
+        );
+        assert_eq!(
+            by_tag("uvol1").content_sha256.as_deref(),
+            Some(ALREADY_PINNED),
+            "a share that already carries a digest must keep it — re-hashing              would replace a pin with a snapshot of the tree at admission"
+        );
+        assert_eq!(
+            by_tag("uvol2").content_sha256,
+            None,
+            "a disk is not a directory tree and must not be hashed as one"
+        );
+    }
+
     #[test]
     fn a_manifest_grant_reaches_the_signed_plan() {
         let _env = mvm_core::util::test_env::TestEnv::new();

--- a/crates/mvm-contract/src/policy/network_policy.rs
+++ b/crates/mvm-contract/src/policy/network_policy.rs
@@ -769,6 +769,57 @@ mod tests {
         );
     }
 
+    /// `admits_outbound` is the disjunction, and each side alone is enough.
+    ///
+    /// This is the question every site deciding whether to *build* the outbound
+    /// machinery has to ask — the per-VM endpoint, the identity drive, the
+    /// guest's own dialer. `allows_egress` answers only the host allow-list, and
+    /// asking the narrow question at those sites booted guests whose documented
+    /// `--peer` route had nothing to dial through.
+    ///
+    /// The peer-only row is the one that carries the difference: it is deny-all
+    /// for ordinary egress and must still admit outbound. Without it, narrowing
+    /// the `||` back to `&&` — or dropping the `!` — reads as a no-op, and both
+    /// survived. So did replacing the whole function with a constant, which is
+    /// claim 10's default-deny posture either refusing every peer route or
+    /// building the outbound path for a policy that admits nothing.
+    #[test]
+    fn admits_outbound_is_egress_or_a_peer_route() {
+        let peer = crate::peer::PeerBinding {
+            name: crate::peer::PeerName::parse("db.mvm.peer").expect("valid peer name"),
+            port: 5432,
+            host_addr: "127.0.0.1".into(),
+            host_port: 34567,
+        };
+
+        // Neither side: the deny-all default admits nothing outbound.
+        assert!(!NetworkPolicy::deny_all().admits_outbound());
+        assert!(!NetworkPolicy::allow_list(vec![]).admits_outbound());
+
+        // Egress alone.
+        assert!(NetworkPolicy::unrestricted().admits_outbound());
+        assert!(NetworkPolicy::allow_list(vec![HostPort::new("a.com", 443)]).admits_outbound());
+
+        // A peer route alone, over a policy that is deny-all for ordinary
+        // egress. This is the case the function was added for.
+        let peer_only = NetworkPolicy::deny_all().with_peers(vec![peer.clone()]);
+        assert!(
+            !peer_only.allows_egress(),
+            "a peer-only policy must stay deny-all for ordinary egress"
+        );
+        assert!(
+            peer_only.admits_outbound(),
+            "a peer route must still build the outbound path"
+        );
+
+        // Both sides.
+        assert!(
+            NetworkPolicy::allow_list(vec![HostPort::new("a.com", 443)])
+                .with_peers(vec![peer])
+                .admits_outbound()
+        );
+    }
+
     #[test]
     fn allows_egress_covers_every_shape() {
         assert!(!NetworkPolicy::deny_all().allows_egress());

--- a/specs/plans/2026-09-04-claim-witnesses-that-bite.md
+++ b/specs/plans/2026-09-04-claim-witnesses-that-bite.md
@@ -102,6 +102,12 @@ pairs, and the full 1007-test suite passes with the mutation applied.
 - [x] Record the one equivalent mutant with a proof rather than a re-pin.
 - [x] Verify every new witness by applying the reported mutation and confirming
       it fails.
+- [x] Close the survivors the dead shard was hiding. Stopping the crash let the
+      mvm-cli shard reach `commands/vm/up/admission.rs`, which sorts after
+      `commands/tests.rs` and had never run; the mvm-contract shard surfaced
+      `NetworkPolicy::admits_outbound`, added by #3170 after the run this plan
+      was written from. Six more mutants, all killed, all verified by applying
+      the mutation.
 - [ ] Confirm on the first uninterrupted nightly that all three shards are green.
 - [ ] Close #3148 and #3149 through their linkage.
 

--- a/specs/sprint/delivery/3148-mutation-witness-gaps.md
+++ b/specs/sprint/delivery/3148-mutation-witness-gaps.md
@@ -21,3 +21,22 @@
 - [ ] Merge the linked pull request through the queue.
 
 Owning plan: `specs/plans/2026-09-04-claim-witnesses-that-bite.md`.
+
+## Follow-up: the survivors the dead shard was hiding
+
+The first fix stopped the mvm-cli shard dying, which let it reach files it had
+never run. Two more shards' worth of survivors came out from behind it.
+
+- [x] Closed the four claim-10 survivors in `NetworkPolicy::admits_outbound`.
+      #3170 added the function — the "egress rules *or* a peer route" question
+      every site deciding whether to build the outbound path must ask — and it
+      shipped without a witness. Replacing it with `true` or `false`, narrowing
+      the `||`, and dropping the `!` all survived.
+- [x] Closed the two claim-19 survivors in `admit_plan_for_boot_with_ingress`,
+      where admission pins a directory share's content digest. `==` to `!=`
+      hashes disks and skips directory shares; `&&` to `||` overwrites a
+      caller-supplied pin with a snapshot of the tree. The existing witness
+      tests the enforcement side in mvm-hostd and is handed a plan that already
+      carries a digest, so it cannot see either.
+- [x] Verified all six by applying the reported mutation and confirming failure.
+- [ ] Confirm the shards green on the next nightly.


### PR DESCRIPTION
Refs #3148, #3149. Follows #3180.

#3180 stopped the mvm-cli shard dying on a `#![cfg(test)]` module file. The
first Security run after it merged ([33951076938](https://github.com/tinylabscom/mvm/actions/runs/33951076938))
surfaced six more survivors. That is the ratchet working: the crash had been
hiding them, and stopping it let the shard reach files it had never run.

## Two in `admit_plan_for_boot_with_ingress` — hidden by the crash

`commands/vm/up/admission.rs` sorts after `commands/tests.rs`, so the abort had
always come first. Both mutants sit on the line where admission pins a
directory share's content digest:

```rust
if grant.kind == mvm_core::plan::ShareKind::DirShare && grant.content_sha256.is_none() {
```

That pin is what makes claim 19's post-admission drift refusal possible —
enforcement re-hashes at attach time and compares. With no digest recorded
there is nothing to compare against, so the refusal reports present and can
never fire, which is worse than no refusal because it is believed.

- `==` → `!=` hashes disks and skips directory shares: exactly the grants the
  claim is about lose their pin.
- `&&` → `||` re-hashes a share that already carries a digest, replacing a
  caller-supplied pin with a snapshot of whatever the tree happened to be at
  admission — turning a pin into an observation and admitting the drift it
  exists to refuse.

The claim's existing witness, `admitted_share_digest_refuses_directory_changed_after_admission`,
tests the *enforcement* side in mvm-hostd and is handed a plan that already
carries a digest. It cannot see either of these.

## Four in `NetworkPolicy::admits_outbound` — newer than the original run

These are not hidden survivors; they are new. #3170 added the function after
the run #3180 was written from:

```rust
pub fn admits_outbound(&self) -> bool {
    self.allows_egress() || !self.peers().is_empty()
}
```

It is the question every site deciding whether to *build* the outbound
machinery must ask — the per-VM endpoint, the identity drive, the guest's own
dialer — and it shipped without a witness. Replacing it with `true` or `false`,
narrowing the `||` to `&&`, and dropping the `!` all survived.

The peer-only row is what carries the difference: a policy that is deny-all for
ordinary egress and must still admit outbound. Without it the `||` reads as a
no-op. `allows_egress_covers_every_shape` covers the narrow question already;
this is its counterpart for the wide one.

## Every mutant verified against the mutation

| mutation applied | test that failed |
|---|---|
| `admits_outbound` → `true` | `admits_outbound_is_egress_or_a_peer_route` |
| `admits_outbound` → `false` | `admits_outbound_is_egress_or_a_peer_route` |
| `\|\|` → `&&` | `admits_outbound_is_egress_or_a_peer_route` |
| delete `!` | `admits_outbound_is_egress_or_a_peer_route` |
| share `==` → `!=` | `admission_pins_a_directory_shares_digest_and_leaves_other_grants_alone` |
| share `&&` → `\|\|` | `admission_pins_a_directory_shares_digest_and_leaves_other_grants_alone` |

## Validation

- `cargo nextest run --workspace` — **13132 passed**, 0 failed, 22 skipped.
- `cargo test --workspace --doc` — all green.
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0.
- `cargo fmt --all -- --check` — clean.
- `check-mutation-witnesses` (surface pinned and clean, 46 files, 164 accepted
  misses — unchanged, no re-pin needed), `check-claim-catalog` (20 claims, 105
  witnesses), `check-witness-citations`, `check-sprint-append`.

No baseline entry was added and nothing was re-pinned: all six are killable and
are killed.

#3148 and #3149 should stay open until a nightly reports all shards green.