### PR TITLE
test(claims): close the last claim-witness survivors so the security lane can go green

### DIFF
--- a/crates/mvm-cli/src/commands/vm/up/admission.rs
+++ b/crates/mvm-cli/src/commands/vm/up/admission.rs
@@ -2039,6 +2039,79 @@ mod admit_plan_tests {
         .expect("the input grant token is a valid service id")
     }
 
+    /// Admission content-hashes directory shares, and only those.
+    ///
+    /// Two mutants survived on the guard: `==` swapped for `!=`, and `&&` for
+    /// `||`. Both change *which* grants get a content identity written into the
+    /// signed plan. A `Disk` share hashed here carries a digest that
+    /// enforcement re-checks against a tree the grant never described; a
+    /// `DirShare` skipped here reaches enforcement with nothing to re-check,
+    /// which is the pinning that refuses a directory edited after admission.
+    ///
+    /// The discriminating fixture is a non-`DirShare` grant with no digest:
+    /// under either mutant it acquires one, and under the real guard it does
+    /// not.
+    #[test]
+    fn admission_hashes_directory_shares_and_leaves_disk_shares_alone() {
+        let keys_dir = tempfile::tempdir().unwrap();
+        let audit_dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = tempfile::tempdir().unwrap();
+        let share_dir = tempfile::tempdir().unwrap();
+        std::fs::write(share_dir.path().join("payload"), b"shared bytes").unwrap();
+        let disk_image = rootfs_dir.path().join("vol.img");
+        std::fs::write(&disk_image, b"disk bytes").unwrap();
+        let rootfs = write_rootfs(rootfs_dir.path(), b"share-digest-payload");
+        let ledger = InMemoryNonceLedger::new();
+
+        let ctx = admit_plan_for_boot(AdmitPlanForBootParams {
+            keys_dir: Some(keys_dir.path()),
+            audit_dir: Some(audit_dir.path()),
+            shares: vec![
+                mvm_core::plan::HostShareGrant {
+                    tag: "dirvol".into(),
+                    host_path: share_dir.path().to_string_lossy().into_owned(),
+                    guest_path: "/data".into(),
+                    kind: mvm_core::plan::ShareKind::DirShare,
+                    read_only: true,
+                    encrypted: false,
+                    content_sha256: None,
+                },
+                mvm_core::plan::HostShareGrant {
+                    tag: "diskvol".into(),
+                    host_path: disk_image.to_string_lossy().into_owned(),
+                    guest_path: "/disk".into(),
+                    kind: mvm_core::plan::ShareKind::Disk,
+                    read_only: true,
+                    encrypted: false,
+                    content_sha256: None,
+                },
+            ],
+            ..pinning_params(&rootfs, &ledger)
+        })
+        .expect("admission with a directory and a disk share")
+        .expect("Some when admission ran");
+
+        let shares = &ctx.admitted.plan().shares;
+        let dir = shares
+            .iter()
+            .find(|g| g.tag == "dirvol")
+            .expect("the directory share survives admission");
+        let disk = shares
+            .iter()
+            .find(|g| g.tag == "diskvol")
+            .expect("the disk share survives admission");
+
+        assert!(
+            dir.content_sha256.is_some(),
+            "a directory share must carry the content identity enforcement re-checks"
+        );
+        assert!(
+            disk.content_sha256.is_none(),
+            "a disk share must not be hashed here; a digest it never described is \
+             one enforcement would re-check against the wrong thing"
+        );
+    }
+
     #[test]
     fn a_non_shell_entrypoint_with_the_grant_is_admitted_under_prod() {
         let keys_dir = tempfile::tempdir().unwrap();

--- a/crates/mvm-contract/src/policy/network_policy.rs
+++ b/crates/mvm-contract/src/policy/network_policy.rs
@@ -729,6 +729,55 @@ pub fn unmap_v4_mapped(ip: IpAddr) -> IpAddr {
 
 #[cfg(test)]
 mod tests {
+    /// `admits_outbound` answers for each way a policy can reach off-box, and
+    /// only those ways.
+    ///
+    /// Four mutants survived here: the function replaced by `true`, by `false`,
+    /// its `||` swapped for `&&`, and its `!` deleted. Nothing observed it
+    /// directly — the `--peer` fix that introduced it tested its *effects*
+    /// through `effective_vsock_egress` and never the predicate itself, which
+    /// is the difference between "the behaviour happens to be right" and "the
+    /// function is pinned".
+    ///
+    /// It decides whether a workload gets an outbound path built at all. Stuck
+    /// `true`, every deny-all workload gets an endpoint and a guest dialer it
+    /// should not have. Stuck `false`, no workload can reach anything.
+    #[test]
+    fn admits_outbound_covers_each_route_off_box_and_nothing_else() {
+        let peer = crate::peer::PeerBinding {
+            name: crate::peer::PeerName::parse("db.mvm.peer").expect("valid peer name"),
+            port: 5432,
+            host_addr: "127.0.0.1".parse().expect("loopback literal"),
+            host_port: 34567,
+        };
+
+        // Neither route: the default posture reaches nothing. Kills `-> true`.
+        assert!(
+            !NetworkPolicy::deny_all().admits_outbound(),
+            "deny-all with no peers reaches nothing"
+        );
+
+        // Egress only. Kills `-> false`.
+        assert!(
+            NetworkPolicy::allow_list(vec![HostPort::new("api.example.com", 443)])
+                .admits_outbound(),
+            "an admitted host is a route off-box"
+        );
+
+        // Peer only — deny-all for ordinary egress. Kills `-> false`, `||`->`&&`
+        // (the left side is false here, so `&&` would answer false), and the
+        // deleted `!` (which would read "peers is empty" and answer false).
+        let peer_only = NetworkPolicy::deny_all().with_peers(vec![peer]);
+        assert!(
+            !peer_only.allows_egress(),
+            "fixture must exercise the peer route, not an allow-list"
+        );
+        assert!(
+            peer_only.admits_outbound(),
+            "a peer binding is a route off-box even under deny-all egress"
+        );
+    }
+
     use alloc::vec;
 
     use super::*;

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -601,7 +601,28 @@ SUITE_STARTED=""
 # backend runs them and only a genuinely incapable one skips — the alternative,
 # tolerating the skip without opting in, silently dropped the witness for the
 # README's two `--mount` examples on a host that could have run it.
-ALLOWED_SKIPS="pending,needs-perf-budget-host,needs-memory-snapshot,needs-bundle-fixture,needs-tls-tunnel-client,needs-dir-share,needs-unenforceable-wall-clock"
+#
+# `needs-warm-claim` joins the tolerated set for the same reason as
+# `needs-unenforceable-wall-clock`: it is a property of the host, not a
+# capability this lane is supposed to provide. A forked child that never answers
+# the post-restore identity handshake cannot be made to answer by configuring
+# the lane differently, and the launch still runs — it cold-boots instead of
+# claiming a standby. The skip stays counted and its reason names the tracking
+# issue, so the coverage that was not taken is visible rather than absent.
+ALLOWED_SKIPS="pending,needs-perf-budget-host,needs-memory-snapshot,needs-bundle-fixture,needs-tls-tunnel-client,needs-dir-share,needs-unenforceable-wall-clock,needs-warm-claim"
+
+# `needs-firecracker` is deliberately intolerable above, and stays that way on
+# the lane that runs Firecracker. On macOS there is no `/dev/kvm` and no
+# Firecracker to put on PATH, so the skip is a property of the tier rather than
+# a lane that failed to boot what it claims to — the distinction the rest of
+# this allow-list is built on.
+#
+# Tolerating it per-platform rather than globally keeps the Linux lane strict:
+# a Firecracker skip there still means the backend under test did not run, and
+# still fails.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  ALLOWED_SKIPS="$ALLOWED_SKIPS,needs-firecracker"
+fi
 
 echo "==> documented examples + machine journey (cucumber, @live)"
 SUITE_STARTED=1


### PR DESCRIPTION
Closes the last six unaccepted survivors on the claim-witness lane, so
`security.yml` can go green and claims 1, 3, 4, 5, 6, 7, 10, 11 and 15 stop
carrying a green ledger entry with a red witness behind it.

Refs #3148, #3149.

## What was still red after #3170 and #3180

The dispatched run on `57e27e5809` reported `4 problem(s)` for `mvm-contract`
and 2 for `mvm-cli`. Raw cargo-mutants output also lists three more as `MISSED`
— the `|`/`^` in `CallerCommitment::from_hex`, `AiPolicy::disabled`, and the
`ClientOperationCapabilities::builder` alias — but those are already recorded as
accepted equivalents by #3180 and do not fail the gate. They are equivalent for
a checkable reason: `caller_commitment_nibble` returns `0..=15`, so `high << 4`
occupies bits 4-7 and `low` bits 0-3, and over disjoint ranges `|` and `^` agree
on every input; the other two substitute an expression for itself.

So six real ones.

## `NetworkPolicy::admits_outbound` — four

Replaced by `true`, by `false`, `||` swapped for `&&`, and `!` deleted. Nothing
observed the function directly. It was added earlier in this release cycle for
the peer fix and tested only through its effects on `effective_vsock_egress`,
which is the difference between the behaviour happening to be right and the
function being pinned.

It decides whether a workload gets an outbound path built at all. Stuck `true`,
every deny-all workload gets a per-VM endpoint and an in-guest dialer it should
not have. Stuck `false`, nothing reaches anything.

Three assertions kill all four: deny-all with no peers, an allow-list, and a
peer-only policy — the last being the case where `||` and `&&` disagree and
where the deleted `!` inverts.

## The admission share-hashing guard — two

`==` swapped for `!=`, and `&&` for `||`. Both change *which* grants get a
content identity written into the signed plan. A `Disk` share hashed there
carries a digest enforcement re-checks against a tree the grant never described;
a `DirShare` skipped there arrives at enforcement with nothing to re-check,
which is the pinning that refuses a directory edited after admission.

The discriminating fixture is a non-`DirShare` grant with no digest: under
either mutant it acquires one, and under the real guard it does not.

## Verification

Each test was checked by applying the exact reported mutation and confirming it
fails. Nothing here is resolved with `--write-baseline`: the baseline had not
drifted, and re-recording a survivor as accepted converts a real gap into a
green light.

Also carries the e2e allow-list fix from the same run: `needs-warm-claim` (the
gate's own slug, missing when the gate landed) and `needs-firecracker` on macOS
only, where there is no `/dev/kvm` to have. The Linux lane keeps failing on a
Firecracker skip, because there it means the backend under test did not run.
