### PR TITLE
fix(e2e): the three real failures the Linux lane was hiding

### DIFF
--- a/crates/mvm-cli/src/commands/image/pull_core.rs
+++ b/crates/mvm-cli/src/commands/image/pull_core.rs
@@ -365,12 +365,19 @@ fn pull_image_ref(
     let rootfs_path = format!("rootfs/{manifest_hex}-{runtime_tag}/rootfs.ext4");
     let rootfs_abs = cache_root.join(&rootfs_path);
     super::cache::write_deferred_nodes(cache_root, &manifest.digest, &deferred_nodes)?;
+    // The config blob written above is the image's own declaration of `Env`,
+    // `WorkingDir` and `Entrypoint`/`Cmd`. Materializing without it discards
+    // all three: the guest then falls back to `workload_env::DEFAULT_PATH`, so
+    // an image's own tools are off `PATH` even though the binaries are in the
+    // rootfs. The cache-hit path beside this one has always passed it; this
+    // one computed `config_path` forty lines earlier and dropped it.
+    let entrypoint = oci_entrypoint_from_cache_path(cache_root, config_path.as_deref())?;
     inject_runtime_and_materialize(super::materialize::MaterializeCall {
         cache_root,
         unpacked_root: &unpacked_root,
         rootfs_abs: &rootfs_abs,
         image_label: &image_ref.canonical(),
-        entrypoint: None,
+        entrypoint: entrypoint.as_ref(),
         sealed: false,
         deferred_nodes,
         evidence: None,

--- a/crates/mvm-cli/src/commands/vm/volume.rs
+++ b/crates/mvm-cli/src/commands/vm/volume.rs
@@ -531,8 +531,46 @@ fn refresh_registered_host_snapshots_with_service(
     volume_service: &LocalVolumeService,
     vm_name: &str,
 ) -> Result<()> {
-    let cache = crate::mount_cache::MountImageCache::new()?;
-    for attachment in volume_service.list_attachments(vm_name)? {
+    refresh_registered_host_snapshots_using(
+        volume_service,
+        vm_name,
+        crate::mount_cache::MountImageCache::new,
+    )
+}
+
+/// The cache constructor is a parameter so a test can observe *whether* it
+/// runs.
+///
+/// It has to be: `MountImageCache::new` is `#[cfg(test)]`-stubbed to skip the
+/// encrypted-backing verification, so under test the eager construction this
+/// function used to do was indistinguishable from the lazy one. The check that
+/// failed in production did not exist in the build that tested it, which is
+/// how a launch-blocking refusal reached a live lane unnoticed.
+fn refresh_registered_host_snapshots_using(
+    volume_service: &LocalVolumeService,
+    vm_name: &str,
+    open_cache: impl FnOnce() -> Result<crate::mount_cache::MountImageCache>,
+) -> Result<()> {
+    // Nothing to refresh means nothing to build. Constructing the cache
+    // verifies that its directory sits on encrypted backing storage, and that
+    // check is about where a *mounted host directory's* bytes come to rest.
+    // Running it before looking at the attachments charged it to every launch:
+    // a named machine with no registered volumes and no `--mount` at all was
+    // refused on any host without a dm-crypt/LUKS mapping, for a cache it was
+    // never going to write to.
+    //
+    // The enforcement is unchanged where it applies. One attachment carrying a
+    // host snapshot is enough to construct the cache, and `require_host_encryption`
+    // below still guards each snapshot's source directory separately.
+    let attachments = volume_service.list_attachments(vm_name)?;
+    if !attachments
+        .iter()
+        .any(|attachment| attachment.host_snapshot.is_some())
+    {
+        return Ok(());
+    }
+    let cache = open_cache()?;
+    for attachment in attachments {
         let Some(snapshot) = attachment.host_snapshot else {
             continue;
         };
@@ -800,6 +838,65 @@ mod tests {
 
     fn accepting_host_encryption_service() -> LocalVolumeService {
         LocalVolumeService::with_host_encryption_probe(probe_from_fn(|_| Ok(())))
+    }
+
+    /// A launch with nothing mounted never opens the mount-image cache.
+    ///
+    /// Opening it verifies that its directory sits on encrypted backing
+    /// storage. Doing that on entry charged the check to every launch: a named
+    /// machine with no registered volumes and no `--mount` was refused on any
+    /// host without a dm-crypt/LUKS mapping, for a cache it would never write
+    /// to. That is what stopped `mvmctl machine run -d` on an ordinary disk,
+    /// and it took down the SDK live lane, which mounts nothing at all.
+    ///
+    /// The constructor is injected because `MountImageCache::new` is
+    /// `#[cfg(test)]`-stubbed to skip the very verification that failed, so
+    /// calling the real one here would prove nothing either way.
+    #[test]
+    fn a_launch_with_no_host_snapshots_never_opens_the_mount_cache() {
+        let _guard = DataDirGuard::new();
+        let volume_service = accepting_host_encryption_service();
+
+        refresh_registered_host_snapshots_using(&volume_service, "vm-no-mounts", || {
+            panic!("the mount-image cache must not be opened for a launch with no host snapshots")
+        })
+        .expect("a launch that mounts nothing must not be refused");
+    }
+
+    /// The converse, so the laziness cannot be "never opens it".
+    ///
+    /// One attachment carrying a host snapshot is enough: the cache is opened,
+    /// and the encrypted-backing verification it performs still applies
+    /// wherever a host directory's bytes actually come to rest.
+    #[test]
+    fn a_launch_with_a_host_snapshot_opens_the_mount_cache() {
+        let guard = DataDirGuard::new();
+        let volume_service = accepting_host_encryption_service();
+        let source = guard.path().join("mounted");
+        fs::create_dir(&source).unwrap();
+        fs::write(source.join("marker"), b"bytes").unwrap();
+        mount_with_service(
+            &volume_service,
+            "vm-mounted",
+            "mounted",
+            Some(source.to_str().unwrap()),
+            "/data/mounted",
+            false,
+        )
+        .unwrap();
+
+        let opened = std::cell::Cell::new(false);
+        refresh_registered_host_snapshots_using(&volume_service, "vm-mounted", || {
+            opened.set(true);
+            crate::mount_cache::MountImageCache::new()
+        })
+        .expect("refresh succeeds");
+
+        assert!(
+            opened.get(),
+            "a registered host snapshot must still open the cache, or the \
+             encrypted-backing verification stops applying where it matters"
+        );
     }
 
     #[test]

--- a/crates/mvm-conformance/fixtures/e2e/sandbox_script.py
+++ b/crates/mvm-conformance/fixtures/e2e/sandbox_script.py
@@ -16,6 +16,15 @@ this one has to actually execute on both the plan and the live path:
   A digest is content-addressed, so this does not rot with the upstream
   `alpine:latest` tag.
 
+  The pin is the multi-arch *index* digest, not a platform manifest's. Both are
+  immutable and both satisfy claim 14, and the difference is invisible until
+  the host's architecture stops matching whoever wrote the pin: this fixture
+  used to name alpine's `arm64/v8` manifest, so the guest was handed aarch64
+  binaries on an x86_64 host and `uname` failed to exec with `ENOEXEC`. It
+  passed on Apple Silicon and could not pass on the Linux/Firecracker lane,
+  which is the only lane that boots a guest. Pin an index; let the registry
+  client pick the platform.
+
 `files.write` is back. It was removed when the whole guest-RPC `fs`/`proc` verb
 family answered "Unexpected response to ... verb" against a running HVF guest
 (#2887); that turned out to be a grant refusal misreported as a protocol
@@ -27,9 +36,12 @@ without declaring a share.
 
 import mvm
 
+# alpine:3.22's multi-arch index. Carries linux/amd64 and linux/arm64 (among
+# others), so this resolves to the host's own architecture everywhere the suite
+# runs.
 ALPINE = (
     "docker.io/library/alpine"
-    "@sha256:e7a1a92a5bfeee40966aea60f0796b0e7917cc35591542701834f03a68fa3d18"
+    "@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce"
 )
 
 with mvm.Sandbox.create(image=ALPINE) as sb:

--- a/crates/mvm-sdk/sdks/python/mvm/_sandbox.py
+++ b/crates/mvm-sdk/sdks/python/mvm/_sandbox.py
@@ -64,6 +64,7 @@ import json
 import os
 import re
 import secrets
+import shlex
 import subprocess
 import sys
 import threading
@@ -216,6 +217,21 @@ class SandboxLiveError(RuntimeError):
         self.argv = list(argv) if argv else []
         self.exit_code = exit_code
         self.stderr = stderr or ""
+
+    def __str__(self) -> str:
+        # The captured stderr is the only place the refusing verb says *why*.
+        # Storing it on the exception and rendering only the summary line was
+        # the same as not capturing it: a failing `mvmctl` shell surfaced as
+        # "failed with exit code 1" and nothing else, and the diagnosis had to
+        # be re-run by hand outside the SDK. The docstring above promised this
+        # and the type did not deliver it.
+        parts = [super().__str__()]
+        if self.argv:
+            parts.append("command: " + shlex.join(self.argv))
+        detail = self.stderr.strip()
+        if detail:
+            parts.append("stderr:\n" + detail)
+        return "\n".join(parts)
 
 
 class SandboxDevOnly(SandboxLiveError):

--- a/crates/mvm-sdk/sdks/python/tests/test_sandbox_live.py
+++ b/crates/mvm-sdk/sdks/python/tests/test_sandbox_live.py
@@ -1135,3 +1135,42 @@ def test_connect_refuses_second_session(tmp_path: Path) -> None:
 def test_connect_rejects_empty_id() -> None:
     with pytest.raises(ValueError, match="non-empty machine id"):
         mvm.Sandbox.connect("")
+
+
+# ── error rendering ──────────────────────────────────────────────────
+
+
+def test_live_error_renders_the_stderr_that_says_why() -> None:
+    """The captured stderr is the only place the refusing verb explains itself.
+
+    Storing it on the exception and rendering only the summary line is the
+    same as not capturing it: the failure surfaces as "failed with exit code
+    1" and the diagnosis has to be re-run by hand outside the SDK. A live
+    documented-surface failure was undiagnosable from its CI log for exactly
+    this reason.
+    """
+    error = mvm.SandboxLiveError(
+        "`mvmctl machine proc start` failed with exit code 1",
+        argv=["mvmctl", "machine", "proc", "start", "--", "uname", "-s"],
+        exit_code=1,
+        stderr="Error: the guest refused the request\n",
+    )
+
+    rendered = str(error)
+    assert "failed with exit code 1" in rendered
+    assert "the guest refused the request" in rendered, (
+        "the reason the verb refused must be in the rendered message, not "
+        "only reachable through the .stderr attribute"
+    )
+    assert "mvmctl machine proc start -- uname -s" in rendered
+
+    # The structured attributes stay available and unchanged.
+    assert error.exit_code == 1
+    assert error.stderr == "Error: the guest refused the request\n"
+    assert error.argv[0] == "mvmctl"
+
+
+def test_live_error_without_detail_renders_only_its_message() -> None:
+    """No argv and no stderr must not grow blank sections."""
+    assert str(mvm.SandboxLiveError("plain refusal")) == "plain refusal"
+    assert str(mvm.SandboxLiveError("plain refusal", stderr="   \n")) == "plain refusal"

--- a/crates/mvm-sdk/sdks/typescript/src/_sandbox.ts
+++ b/crates/mvm-sdk/sdks/typescript/src/_sandbox.ts
@@ -105,9 +105,25 @@ export class SandboxLiveError extends Error {
     message: string,
     opts: { argv?: string[]; exitCode?: number | null; stderr?: string } = {},
   ) {
-    super(message);
+    // The captured stderr is the only place the refusing verb says *why*.
+    // Storing it on the error and rendering only the summary line was the
+    // same as not capturing it: a failing `mvmctl` shell surfaced as "failed
+    // with exit code 1" and nothing else, and the diagnosis had to be re-run
+    // by hand outside the SDK. Folded into the message so every reporter --
+    // `console.error`, an uncaught rejection, a test runner -- shows it,
+    // rather than only the ones that know to read `.stderr`.
+    const argv = opts.argv ?? [];
+    const stderr = (opts.stderr ?? "").trim();
+    const parts = [message];
+    if (argv.length > 0) {
+      parts.push(`command: ${argv.join(" ")}`);
+    }
+    if (stderr.length > 0) {
+      parts.push(`stderr:\n${stderr}`);
+    }
+    super(parts.join("\n"));
     this.name = "SandboxLiveError";
-    this.argv = opts.argv ?? [];
+    this.argv = argv;
     this.exitCode = opts.exitCode ?? null;
     this.stderr = opts.stderr ?? "";
   }

--- a/crates/mvm-sdk/sdks/typescript/tests/sandbox_live.test.ts
+++ b/crates/mvm-sdk/sdks/typescript/tests/sandbox_live.test.ts
@@ -1074,3 +1074,38 @@ describe("BrowserSandbox", () => {
     expect(() => new mvm.BrowserSandbox("safari")).toThrow(/unknown browser/);
   });
 });
+
+describe("SandboxLiveError rendering", () => {
+  // The captured stderr is the only place the refusing verb explains itself.
+  // Storing it on the error and rendering only the summary line is the same as
+  // not capturing it: a live documented-surface failure was undiagnosable from
+  // its CI log for exactly this reason.
+  it("renders the stderr that says why", () => {
+    const error = new mvm.SandboxLiveError(
+      "`mvmctl machine proc start` failed with exit code 1",
+      {
+        argv: ["mvmctl", "machine", "proc", "start", "--", "uname", "-s"],
+        exitCode: 1,
+        stderr: "Error: the guest refused the request\n",
+      },
+    );
+
+    expect(error.message).toContain("failed with exit code 1");
+    expect(error.message).toContain("the guest refused the request");
+    expect(error.message).toContain("mvmctl machine proc start -- uname -s");
+
+    // The structured attributes stay available and unchanged.
+    expect(error.exitCode).toBe(1);
+    expect(error.stderr).toBe("Error: the guest refused the request\n");
+    expect(error.argv[0]).toBe("mvmctl");
+  });
+
+  it("renders only its message when there is no detail", () => {
+    expect(new mvm.SandboxLiveError("plain refusal").message).toBe(
+      "plain refusal",
+    );
+    expect(
+      new mvm.SandboxLiveError("plain refusal", { stderr: "   \n" }).message,
+    ).toBe("plain refusal");
+  });
+});

--- a/features/suites/s31_launch_e2e/cli_launch_modes.feature
+++ b/features/suites/s31_launch_e2e/cli_launch_modes.feature
@@ -66,6 +66,21 @@ Feature: every README-documented CLI launch mode boots a real guest
     And the guest printed "NAME=ari"
     And the guest control plane came up
 
+  # The mounted-PTY scenario above was written for a routing bug and kept
+  # failing for a different one underneath it: the OCI pull path materialized
+  # every rootfs with `entrypoint: None`, so the image's declared `Env`,
+  # `WorkingDir` and `Entrypoint` were discarded and the guest fell back to
+  # `workload_env::DEFAULT_PATH`. Nothing about that needs a mount or a
+  # terminal, and stating it on the plain path is what says so: if this passes
+  # and the mounted-PTY one fails, the routing really is the problem; while
+  # both failed, the mount and the PTY were a red herring.
+  @live
+  Scenario: an image's declared environment reaches a plain run
+    When I launch "machine run --image rust -- /bin/bash -c 'command -v cargo'"
+    Then the launch succeeds
+    And the guest printed "/usr/local/cargo/bin/cargo"
+    And the guest control plane came up
+
   # The same defect stated as the mount it actually is, on the non-interactive
   # path so it runs on a host with no terminal to give — a CI runner, or this
   # suite under `just bdd`. devtmpfs supplies /dev/ptmx and the image supplies

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -146,6 +146,20 @@ Last updated: 2026-09-04
       reads preserve retryable I/O sources. Focused regressions are green;
       broad validation and merge delivery remain.
 
+- [ ] **Linux e2e lane's real failures — issue #3007.**
+      `specs/plans/2026-09-05-linux-e2e-regressions.md`.
+      With the lane finally allowed to finish, three scenario failures were
+      real. The OCI fresh-pull path passed `entrypoint: None`, so every image
+      lost its declared `Env`/`WorkingDir`/`Entrypoint` and fell back to
+      `DEFAULT_PATH`. The mount-image cache was constructed on entry, and
+      constructing it runs the encrypted-backing check, so `machine run -d` was
+      refused on any host without dm-crypt even with no volumes at all. The SDK
+      fixture pinned an `arm64/v8` manifest digest, which ENOEXEC'd on x86_64.
+      All three fixed and verified on real KVM hardware; the SDK error types now
+      render the stderr that made the CI log undiagnosable. #3039 is the third
+      lane failure and stays separately tracked. One Extended CI run and merge
+      delivery remain.
+
 - [ ] **Warm claim authenticated readiness — issue #3039.**
       `specs/plans/2026-08-31-warm-claim-authenticated-readiness.md`.
       A restored child advances only after an authenticated Ping proves its

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -185,6 +185,20 @@
       witness, focused regressions, workspace suite, workspace check, and zero-
       warning Clippy are green on macOS.
 
+- [ ] **Linux e2e lane's real failures — issue #3007.**
+      `specs/plans/2026-09-05-linux-e2e-regressions.md`.
+      With the lane finally allowed to finish, three scenario failures were
+      real. The OCI fresh-pull path passed `entrypoint: None`, so every image
+      lost its declared `Env`/`WorkingDir`/`Entrypoint` and fell back to
+      `DEFAULT_PATH`. The mount-image cache was constructed on entry, and
+      constructing it runs the encrypted-backing check, so `machine run -d` was
+      refused on any host without dm-crypt even with no volumes at all. The SDK
+      fixture pinned an `arm64/v8` manifest digest, which ENOEXEC'd on x86_64.
+      All three fixed and verified on real KVM hardware; the SDK error types now
+      render the stderr that made the CI log undiagnosable. #3039 is the third
+      lane failure and stays separately tracked. One Extended CI run and merge
+      delivery remain.
+
 - [ ] **Warm claim authenticated readiness — issue #3039.**
       `specs/plans/2026-08-31-warm-claim-authenticated-readiness.md`.
       Post-restore readiness now requires the existing authenticated guest-agent

--- a/specs/plans/2026-09-05-linux-e2e-regressions.md
+++ b/specs/plans/2026-09-05-linux-e2e-regressions.md
@@ -1,0 +1,123 @@
+# The Linux e2e lane's three real failures
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#3007](https://github.com/tinylabscom/mvm/issues/3007)
+
+## Outcome
+
+Two of the three scenario failures the documented-surface Linux lane reported
+are fixed at their root cause, both verified on real KVM hardware. The third is
+#3039 and is already gated.
+
+## Why these were invisible
+
+`Extended CI` had never been allowed to finish (fixed separately in #3178), so
+nobody had read this lane's verdict in days. Underneath that, two of the three
+failures could only ever have been seen there: the macOS/HVF documented-surface
+job is **skipped** on hosted runners, so Linux/Firecracker is the only lane in
+the repository that boots a guest at all.
+
+Both bugs are host-architecture- or host-storage-dependent, which is exactly the
+class a developer machine cannot see.
+
+## 1. Every OCI image lost its own environment
+
+`pull_core.rs`'s fresh-pull path built its `MaterializeCall` with
+`entrypoint: None`, forty lines after computing `config_path` and never using
+it. The sibling cache-hit path had always passed it.
+
+The image's config blob is its declaration of `Env`, `WorkingDir` and
+`Entrypoint`/`Cmd`. Dropping it means `/etc/mvm/image-runtime.json` is never
+written into the rootfs, and the guest falls back to
+`workload_env::DEFAULT_PATH` — so an image's own tools are off `PATH` even
+though the binaries are right there in the rootfs.
+
+Measured on the KVM box, `machine run --image rust -- /bin/bash -c 'command -v
+cargo; echo PATH=$PATH'`:
+
+    before  PATH=/run/mvm/bin:/usr/local/sbin:/usr/local/bin:...   (no cargo)
+    after   PATH=/run/mvm/bin:/usr/local/cargo/bin:/usr/local/sbin:...
+            /usr/local/cargo/bin/cargo
+
+and `/etc/mvm/` in the materialized rootfs goes from `name variant` to
+`entrypoint image-runtime.json name variant`.
+
+The scenario that caught this was written for a *different* bug — a mounted PTY
+run being routed through `/bin/sh -lc`. That fix (#3104) is intact; it was
+failing underneath for this reason, which is why the mount and the terminal
+looked implicated and were not. A plain-path scenario now states the defect as
+it actually is.
+
+## 2. A machine with no volumes was refused on an unencrypted disk
+
+`refresh_registered_host_snapshots_*` constructed `MountImageCache` on entry,
+and constructing it verifies that its directory sits on encrypted backing
+storage. That check is about where a *mounted host directory's* bytes come to
+rest, but charging it to every launch meant a named machine with no registered
+volumes and no `--mount` at all was refused on any host without a dm-crypt/LUKS
+mapping:
+
+    mount image cache is not on encrypted backing storage
+    /root/.mvm/cache/mount-images is backed by /dev/md2, which does NOT
+    appear to sit on a dm-crypt/LUKS mapping
+
+This is a production defect, not only a lane failure: it blocks `machine run -d`
+for any user on an ordinary disk. The cache is now opened only once an
+attachment carrying a host snapshot is found; `require_host_encryption` still
+guards each snapshot's source separately, so enforcement is unchanged where it
+applies.
+
+It survived because `MountImageCache::new` is `#[cfg(test)]`-stubbed to skip the
+very verification that fails, so under test eager and lazy construction were
+indistinguishable. The constructor is now injected at that seam and the test
+asserts *whether* it runs.
+
+## 3. The SDK fixture pinned an architecture
+
+`sandbox_script.py` pinned `alpine@sha256:e7a1a92a…`, which the registry reports
+as a single-platform `linux/arm64/v8` manifest — not a multi-arch index. On
+x86_64 the guest is handed aarch64 binaries and `uname` fails to exec:
+
+    Guest proc error (SpawnFailed): Exec format error (os error 8)
+
+It passes on Apple Silicon and cannot pass on the only lane that boots a guest.
+Repinned to alpine:3.22's index digest, which carries amd64 and arm64 among
+others. Still immutable and content-addressed, so claim 14's plan-mode refusal
+of mutable references is unaffected — verified: plan mode still reports
+`ADMITTED`.
+
+A digest pin looks architecture-neutral and is not. Every other `@sha256:` image
+pin under `features/`, `fixtures/` and `scripts/` was audited; this was the only
+real one.
+
+## 4. The failure that hid all of this
+
+`SandboxLiveError` captured `mvmctl`'s stderr and rendered only its summary
+line, so the CI log said `failed with exit code 1` and nothing else — for a
+class whose whole diagnosis is in that stderr. Its own docstring promised
+"exactly which verb refused and why". Fixed in both the Python and TypeScript
+SDKs; the first run with it produced the encrypted-storage error above
+immediately.
+
+## Delivery checklist
+
+- [x] Pass the image's declared runtime config through the fresh-pull path.
+- [x] Open the mount-image cache only when a host snapshot needs it.
+- [x] Repin the SDK fixture to a multi-arch index digest.
+- [x] Render captured stderr in both SDKs' live errors.
+- [x] Verify every fix on real KVM hardware, not only in unit tests.
+- [x] State the image-environment defect as a plain-path scenario.
+- [ ] Confirm on the first Extended CI run after this lands.
+- [ ] Close #3007 once the lane reports clean.
+
+## What is deliberately not fixed here
+
+`pool warm` (#3039) is the third failure and is separately tracked; it is now
+gated into the "did NOT run" tally rather than failing.
+
+The wiring in fix 1 is witnessed by the live scenario, not by a hermetic test.
+The pull path does network I/O before it reaches the materializer, so there is
+no seam that proves the config reaches it without booting. That is honest about
+what the guard is: the live lane.

--- a/specs/sprint/delivery/3007-linux-e2e-regressions.md
+++ b/specs/sprint/delivery/3007-linux-e2e-regressions.md
@@ -1,0 +1,20 @@
+# The Linux e2e lane's three real failures
+
+- [x] Fixed the fresh-pull path dropping every OCI image's declared `Env`,
+      `WorkingDir` and `Entrypoint`; `/etc/mvm/image-runtime.json` was never
+      written, so images fell back to `DEFAULT_PATH` and their own tools were
+      off `PATH`. Verified on KVM hardware with `--image rust`.
+- [x] Made the mount-image cache open lazily. Constructing it runs the
+      encrypted-backing check, so every `machine run -d` was refused on a host
+      without dm-crypt even with no volumes and no `--mount` — a production
+      defect, not just a lane failure.
+- [x] Repinned the SDK conformance fixture from an `arm64/v8` manifest digest
+      to alpine:3.22's multi-arch index digest; the old pin could only ever
+      pass on Apple Silicon and ENOEXEC'd on x86_64.
+- [x] Rendered captured stderr in the Python and TypeScript `SandboxLiveError`,
+      which is what made the original CI failure diagnosable at all.
+- [x] Verified all three fixes end-to-end on the Hetzner KVM box.
+- [ ] Confirm on the first Extended CI run after this lands.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-09-05-linux-e2e-regressions.md`.


### PR DESCRIPTION
Refs #3007. Follows #3178, which is what let this lane finish and produce a
verdict at all.

Three scenario failures, three distinct root causes, all verified on real KVM
hardware (Hetzner x86_64, `/dev/kvm`) rather than only in unit tests. None could
have been seen elsewhere: the macOS/HVF documented-surface job is **skipped** on
hosted runners, so Linux/Firecracker is the only lane in the repository that
boots a guest.

## 1. Every OCI image lost its own environment

`pull_core.rs`'s fresh-pull path built its `MaterializeCall` with
`entrypoint: None` — forty lines after computing `config_path`, and never using
it. The sibling cache-hit path had always passed it.

That blob is the image's declaration of `Env`, `WorkingDir` and
`Entrypoint`/`Cmd`. Dropping it means `/etc/mvm/image-runtime.json` is never
written, so the guest falls back to `workload_env::DEFAULT_PATH`.

Measured on hardware, `machine run --image rust -- /bin/bash -c 'command -v cargo; echo PATH=$PATH'`:

```
before  PATH=/run/mvm/bin:/usr/local/sbin:/usr/local/bin:...     (cargo: nothing)
after   PATH=/run/mvm/bin:/usr/local/cargo/bin:/usr/local/sbin:...
        /usr/local/cargo/bin/cargo
```

and `/etc/mvm/` in the materialized rootfs goes from `name variant` to
`entrypoint image-runtime.json name variant`.

The scenario that caught this was written for a *different* bug (#3104 — a
mounted PTY run routed through `/bin/sh -lc`). That fix is intact; it was
failing underneath for this reason, which is exactly why the mount and the
terminal looked implicated and were not. A plain-path scenario now states the
defect as it actually is, so the two can never again be confused.

## 2. A machine with no volumes was refused on an unencrypted disk

`refresh_registered_host_snapshots_*` constructed `MountImageCache` on entry,
and constructing it verifies encrypted backing storage:

```
mount image cache is not on encrypted backing storage
/root/.mvm/cache/mount-images is backed by /dev/md2, which does NOT
appear to sit on a dm-crypt/LUKS mapping
```

That check is about where a *mounted host directory's* bytes come to rest.
Charging it to every launch refused `machine run -d` on any host without
dm-crypt, with no registered volumes and no `--mount` at all, for a cache it
would never write to. **This is a production defect, not just a lane failure.**

The cache now opens only once an attachment carrying a host snapshot is found.
`require_host_encryption` still guards each snapshot's source separately, so
enforcement is unchanged where it applies.

It survived because `MountImageCache::new` is `#[cfg(test)]`-stubbed to skip
the very verification that fails — eager and lazy construction were
indistinguishable under test. The constructor is now injected at that seam and
the test asserts *whether* it runs. Verified the test bites: reverting to eager
construction fails it by name.

## 3. The SDK fixture pinned an architecture

`sandbox_script.py` pinned `alpine@sha256:e7a1a92a…`, which the registry reports
as a single-platform manifest:

```
mediaType: application/vnd.oci.image.manifest.v1+json
config.architecture: arm64 | os: linux | variant: v8
```

So on x86_64 the guest gets aarch64 binaries and `uname` fails with
`Exec format error (os error 8)`. It passes on Apple Silicon and cannot pass on
the only lane that boots a guest.

Repinned to alpine:3.22's **index** digest
(`application/vnd.oci.image.index.v1+json`, amd64 + arm64 + 5 more). Still
immutable and content-addressed, so claim 14's plan-mode refusal of mutable
references is unaffected — verified plan mode still reports `ADMITTED`.

A digest pin looks architecture-neutral and is not. Every other `@sha256:` image
pin under `features/`, `fixtures/` and `scripts/` was audited; this was the only
real one.

## 4. What hid all of it

`SandboxLiveError` captured `mvmctl`'s stderr and rendered only its summary
line, so the CI log said `failed with exit code 1` and nothing else — for a
class whose entire diagnosis is in that stderr, against a docstring promising it
carries "exactly which verb refused and why". Fixed in both SDKs. The first run
with it produced the encrypted-storage refusal immediately, which is how cause 2
was found.

## Validation

- **On real KVM hardware:** `--image rust` PATH before/after; the new scenario's
  exact command; the SDK live script end-to-end (`exit=0`); plan mode still
  `ADMITTED`; rootfs contents inspected with `debugfs`.
- `cargo nextest run --workspace` — **13132 passed**, 0 failed, 22 skipped.
- `just bdd` — 966 steps, 965 passed, 1 skipped, 0 failed.
- Python SDK — 231 passed. TypeScript SDK — 153 passed.
- `cargo clippy --workspace --all-targets -- -D warnings` exit 0; `cargo fmt
  --all --check`; `just check-gated`.
- `check-sprint-append`, `check-plan-names`, `check-declared-backing`,
  `check-conformance`.

## Scope

`pool warm` (#3039) is the third lane failure and stays separately tracked; it
is now gated into the "did NOT run" tally rather than failing.

The wiring in fix 1 is witnessed by the live scenario, not by a hermetic test —
the pull path does network I/O before it reaches the materializer, so there is
no seam that proves the config arrives without booting. Stating that plainly
rather than adding a test that would not have caught it.

#3007 should stay open until an Extended CI run reports the lane clean.