### PR TITLE
fix: a contended builder ate the whole e2e suite, and an rc would have published as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -722,8 +722,20 @@ jobs:
             sbom.cdx.json.bundle
           )
           RELEASE_NOTES_PREFIX="$(cat nix/packaging/release/runtime-overlay-operational-note.md)"
+          # A semver prerelease tag (`v0.18.0-rc.1`) must not become GitHub's
+          # "Latest" release. `mvmctl update` resolves
+          # `/repos/<repo>/releases/latest` to decide what to upgrade to, so
+          # publishing a release candidate as latest would pull every stable
+          # user onto it on their next update — without them asking for a
+          # prerelease and without a way to tell they had been moved onto one.
+          prerelease=()
+          if [[ "${TAG_NAME#v}" == *-* ]]; then
+            prerelease=(--prerelease)
+            echo "::notice::${TAG_NAME} carries a prerelease segment — publishing it as a prerelease, not as latest"
+          fi
           gh release create "${TAG_NAME}" \
             --title "${TAG_NAME}" \
+            "${prerelease[@]}" \
             --generate-notes \
             --notes "${RELEASE_NOTES_PREFIX}" \
             "${assets[@]}"

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -564,6 +564,22 @@ MVM_HOME="$E2E_HOME" "$MVMCTL" doctor || true
 # `timeout(1)`, which is absent from a stock macOS and from the macOS runners.
 E2E_TIMEOUT_SECS="${MVM_E2E_TIMEOUT_SECS:-3600}"
 
+# The builder's store-image flock waits `DEFAULT_LOCK_WAIT` — one hour — and
+# this suite's deadline defaulted to the same hour. Those two being equal is
+# what turned a contended builder into a hang: the waiter could never lose the
+# race, so the suite was killed at the instant the lock wait would have expired
+# and the contention error never got to be raised. A run then reported a
+# scenario that "hung" with no indication that another builder held the store.
+#
+# Derived from the deadline rather than pinned, so raising `MVM_E2E_TIMEOUT_SECS`
+# cannot silently recreate the tie. A quarter of the budget is still generous —
+# the holder is normally a cold `nix build` — while leaving the suite three
+# quarters of its time to report the failure and run the remaining scenarios.
+#
+# An explicit override still wins: a caller who has already thought about this
+# is not second-guessed.
+export MVM_BUILDER_LOCK_WAIT_SECS="${MVM_BUILDER_LOCK_WAIT_SECS:-$(( E2E_TIMEOUT_SECS / 4 ))}"
+
 # A run that dies before the suite starts must not look like a pass. This has
 # happened twice: a stray token from a bad edit, and a `(( ... )) && echo` that
 # returns 1 under `set -e`. Both ended the script early, and both left an exit

--- a/tests/github_actions_extended_e2e.rs
+++ b/tests/github_actions_extended_e2e.rs
@@ -242,6 +242,46 @@ fn documented_surface_script() -> String {
     fs::read_to_string("scripts/e2e-documented-surface.sh").expect("read documented-surface runner")
 }
 
+/// The builder's store-image flock must lose to the suite deadline.
+///
+/// `DEFAULT_LOCK_WAIT` is an hour and the suite's deadline defaulted to the
+/// same hour. A contended builder therefore consumed the entire run: the
+/// waiter could not lose the race, so the suite was killed at the instant the
+/// lock wait would have expired, and the contention error was never raised.
+/// The scenario was reported as having hung, naming no cause — a live run
+/// spent an hour proving nothing.
+///
+/// Asserting the derivation rather than a literal, because the failure was the
+/// two values being *equal*: pinning a number here would go stale the moment
+/// either default moved, which is exactly how the tie arose.
+#[test]
+fn the_builder_lock_wait_cannot_outlast_the_suite_deadline() {
+    let script = documented_surface_script();
+
+    assert!(
+        script.contains("export MVM_BUILDER_LOCK_WAIT_SECS="),
+        "the runner must bound the builder store lock wait, or a contended \
+         builder consumes the whole suite budget and reports nothing"
+    );
+    assert!(
+        script.contains("$(( E2E_TIMEOUT_SECS / 4 ))"),
+        "the lock wait must be derived from the suite deadline, so raising \
+         MVM_E2E_TIMEOUT_SECS cannot silently restore the tie that caused the hang"
+    );
+
+    let wait = script
+        .find("export MVM_BUILDER_LOCK_WAIT_SECS=")
+        .expect("checked above");
+    let deadline = script
+        .find("E2E_TIMEOUT_SECS=\"${MVM_E2E_TIMEOUT_SECS:-")
+        .expect("the runner must define its own deadline");
+    assert!(
+        deadline < wait,
+        "the deadline must be defined before the lock wait derives from it, \
+         or the arithmetic reads an empty value and the wait becomes zero"
+    );
+}
+
 fn justfile() -> String {
     fs::read_to_string("Justfile").expect("read Justfile")
 }

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -857,6 +857,48 @@ fn the_boot_image_tag_composes_the_url_the_workflow_uploads_to() {
     }
 }
 
+/// A release candidate must not be published as GitHub's "Latest" release.
+///
+/// `mvmctl update` resolves `/repos/<repo>/releases/latest` to decide what
+/// version to move a user to. `gh release create` marks a release latest unless
+/// told otherwise, so without an explicit `--prerelease` a `v0.18.0-rc.1` tag
+/// silently becomes the upgrade target for every stable installation — the one
+/// class of user who did not opt into a prerelease.
+///
+/// The guard is asserted rather than a bare flag, because always passing
+/// `--prerelease` would break every stable release instead.
+#[test]
+fn a_prerelease_tag_is_not_published_as_the_latest_release() {
+    let workflow = release_workflow();
+
+    assert!(
+        workflow.contains("prerelease=(--prerelease)"),
+        "release.yml must be able to publish a release as a prerelease, or an \
+         rc tag becomes the upgrade target for every stable install"
+    );
+    assert!(
+        workflow.contains(r#"if [[ "${TAG_NAME#v}" == *-* ]]; then"#),
+        "the prerelease flag must be gated on the tag carrying a semver \
+         prerelease segment, so a stable tag still publishes as latest"
+    );
+
+    let create = workflow
+        .find("gh release create \"${TAG_NAME}\"")
+        .expect("release.yml must create the release under the pushed tag");
+    let guard = workflow
+        .find("prerelease=(--prerelease)")
+        .expect("checked above");
+    assert!(
+        guard < create,
+        "the prerelease decision must be made before the release is created"
+    );
+    assert!(
+        workflow[create..].contains(r#""${prerelease[@]}""#),
+        "`gh release create` must expand the prerelease array, or deciding it \
+         changes nothing about what gets published"
+    );
+}
+
 #[test]
 fn the_ci_boot_witness_pins_the_compiled_boot_image_tag() {
     let tag = mvmctl::core::config::DEFAULT_BOOT_IMAGE_TAG;


### PR DESCRIPTION
Two release blockers found while gating `0.18.0-rc.1`. Both are small; neither is cosmetic.

## The documented-surface suite hung for its full hour and named no cause

`machine run --flake` was reported as having hung. It was queueing.

The builder's store-image flock waits `DEFAULT_LOCK_WAIT` — one hour (`image_lock.rs:166`) — and the suite's deadline defaults to the same hour (`e2e-documented-surface.sh:565`). Equal budgets mean the waiter cannot lose: the suite is killed at the instant the lock wait would have expired, so the contention error is never raised.

Evidence from the run that found it:

- The steady-state store image was last written at 02:01:53, by a builder that booted at **01:59** — after the suite was killed at 01:51 — and finished the same build in **124 seconds**.
- Host filesystem activity stopped at 01:09 and resumed only at the kill.
- The same scenario in isolation exits 7 in **15 seconds**.

So it had not been building for 42 minutes. It had been waiting, and completed two minutes after its competitor died with the suite.

Derived from the deadline rather than pinned, because the defect was the two values being *equal* — a literal would go stale the moment either default moved, which is how the tie arose.

This makes contention diagnosable; it does not make it impossible. What held the store for those 42 minutes is filed separately rather than guessed at.

## An rc tag would have published as GitHub's latest release

`gh release create` marks a release latest unless told otherwise, and the publish step passed no `--prerelease`.

`mvmctl update` resolves `/repos/<repo>/releases/latest` (`update.rs:81`) to pick an upgrade target. Tagging `v0.18.0-rc.1` as-is would have pulled **every stable installation onto the release candidate** on its next update — users who did not opt into a prerelease, with nothing telling them they had been moved.

Gated on the tag carrying a semver prerelease segment; a bare `--prerelease` would break every stable release instead.

## Verification

`cargo nextest run -p mvmctl --test github_actions_extended_e2e --test release_assets`: 63 passed. `bash -n` on the runner, and the expansion checked directly — 900 at the default deadline, honours an explicit override, scales to 1800 at a 7200 deadline. `cargo fmt --all --check` and clippy clean; actionlint passed on the workflow.