### PR TITLE
docs(security): close public CVE delivery

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,10 +4,12 @@ Last updated: 2026-09-06
 
 ## In progress
 
-- [ ] **Public CVE evidence corpus.**
+- [x] **Public CVE evidence corpus.**
       `specs/plans/2026-09-06-public-cve-corpus.md`.
-      Promote the generated assurance bundle through the existing public MVM
-      site while preserving its checksum and non-certifying claim boundary.
+      The generated assurance bundle is live at
+      <https://runmvm.com/security/cve-corpus/> with its checksums and
+      non-certifying claim boundary intact; merged via #3192 and deployed by
+      run #34061894511.
 
 - [ ] **Execute the documented README surface.**
       `specs/plans/2026-09-03-readme-execution-coverage.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,11 +10,12 @@
 
 ## In progress
 
-- [ ] **Publish the reviewed CVE evidence corpus.**
+- [x] **Publish the reviewed CVE evidence corpus.**
       `specs/plans/2026-09-06-public-cve-corpus.md`.
-      The existing public Cloudflare Pages site will carry the generated static
-      bundle unchanged, with a discoverable guide, checksum verification, and
-      the current non-certifying tier stated explicitly.
+      The generated bundle is live at
+      <https://runmvm.com/security/cve-corpus/> with checksum verification, a
+      discoverable guide, and the non-certifying tier stated explicitly;
+      merged via #3192 and deployed by run #34061894511.
 
 - [ ] **Execute the documented README surface.**
       `specs/plans/2026-09-03-readme-execution-coverage.md`.

--- a/specs/plans/2026-09-06-public-cve-corpus.md
+++ b/specs/plans/2026-09-06-public-cve-corpus.md
@@ -3,7 +3,7 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status: IN PROGRESS**
+**Status: COMPLETE**
 
 ## Goal
 
@@ -20,8 +20,11 @@ repository or overstating the evidence tier.
 - [x] Add a discoverable security guide that states the non-certifying posture
       and links to the evidence.
 - [x] Build the production site and run the focused integrity regression.
-- [ ] Deploy through the existing Cloudflare Pages workflow and verify the live
+- [x] Deploy through the existing Cloudflare Pages workflow and verify the live
       artifact.
+
+Delivered by PR #3192 and deployment run #34061894511. The canonical live
+corpus is at <https://runmvm.com/security/cve-corpus/>.
 
 ## Publication boundary
 

--- a/specs/sprint/delivery/3192-public-cve-corpus.md
+++ b/specs/sprint/delivery/3192-public-cve-corpus.md
@@ -1,0 +1,7 @@
+# Public CVE evidence corpus
+
+PR #3192 published the reviewed `mvm-assurance` static evidence bundle through
+the MVM site without exposing the private source repository. Checksums are
+verified in CI, the guide and entry pages state the non-certifying boundary,
+and Cloudflare deployment run #34061894511 served the canonical corpus at
+<https://runmvm.com/security/cve-corpus/>.


### PR DESCRIPTION
## Summary
- mark the public CVE corpus plan complete
- record PR #3192 and Cloudflare deployment run #34061894511
- add the landed delivery entry with the canonical production URL

## Verification
- cargo fmt --all --check
- cargo run -p xtask -- check-sprint-append
- git diff --check
- live 200 responses and non-certifying wording at runmvm.com