### PR TITLE
release: v0.18.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to mvm are documented in this file.
 
-## [0.18.0] — 2026-09-02
+## [0.18.0-rc.1] — 2026-09-06
 
 ### Added
 - **mvm-cli**: Fetch + apply the signed pack revocation list (Plan 213 §I)
@@ -221,8 +221,13 @@ All notable changes to mvm are documented in this file.
 - **builder**: Move the persistent HVF builder onto the disk transport
 - **xtask**: Pin the SDK cdylib closure free of host HTTP/TLS/async
 - **vmm**: Attribute a helper resolved from the other build profile
-- **fs**: Stream host file contents into the image instead of buffering them
 - **memory**: WS5-WS6 agent memory plane store and handler (+47 more)
+- **contract**: Content-addressed asset identity in the signed plan
+- **contract**: Make SDK sidecar delivery explicit
+- **evidence**: Boot beacon, deployments inventory, verity-sealed provenance mark + in-toto sidecar
+- **volume**: Snapshot a --host directory into an image instead of refusing it
+- **claims**: Claim release-artifact authenticity as MVM-SEC-20
+- **release**: Attest build provenance for the release tarballs
 
 ### Changed
 - Ignore transfer directory
@@ -250,6 +255,9 @@ All notable changes to mvm are documented in this file.
 - **hvf**: Delete the now-dead virtio-fs share wiring
 - **vmm**: Delete the virtio-fs device and its FUSE server
 - Remove worktrees from git history
+- Stop tracking .agent-memory/
+- **agent-memory**: Follow the untracking through the docs and the gate
+- **kernel**: Bump synchronized pins to 6.12.108
 
 ### Documentation
 - Plan HVF density memory reductions
@@ -385,13 +393,21 @@ All notable changes to mvm are documented in this file.
 - **qemu**: Record why this backend declares no vCPU ceiling
 - Stop crediting mvm-sdk with a cdylib it does not build
 - **plan**: The Stage C re-scope was overtaken by #3061
-- Plan for cutting the 0.18 release
-- Record the release-gate decisions in the 0.18 plan
-- **notes**: Record the mvm-hostd --lib tracing flake
-- Correct the virtio-fs claims the code no longer supports
 - **plan**: Design out retiring VmVolumeKind::DirShare
 - Add implementation prompt for issue plans
 - Point the helper rebuild at the recipe, and finish the crate list
+- Document every workspace crate
+- **plan**: Close the two DirShare boxes that are already answered
+- **specs**: Close the cargo target-dir guard merge boxes
+- Cover every Cargo crate README
+- **plan**: Close the DirShare question by measurement
+- **specs**: Close the aux-helper contract merge boxes
+- **plans**: Plan the ADR-001 ledger drift repair
+- **security**: Correct SECURITY.md, the ADR-001 claim numbering, and two CLAUDE.md facts
+- Keep the main checkout on synchronized main
+- **plans**: Claim release-artifact authenticity, then decide on provenance
+- **adr**: Deduplicate ADR-037 by renumbering the superseded datapath to 052
+- **security**: Publish CVE evidence corpus
 
 ### Fixed
 - **hvf/oci**: Guest BROKER_PORT bridge + OCI rootfs self-heal
@@ -741,14 +757,32 @@ All notable changes to mvm are documented in this file.
 - **build**: The typed persistent route read back an empty export
 - **ci**: Let Extended CI's red mean a regression again
 - **ci**: Fix the two Extended CI failures that were not the product
-- **release**: Require e2e-docs to have succeeded, not merely finished
-- **xtask**: Register check-release-evidence with the gate lane
 - **core**: Enforce the 0700 mvm-home posture at the creation seam
 - **build**: Refuse a disk-transport session instead of hanging on its lock
 - **vsock**: Stop the exec stream inheriting a connect timeout
 - **doctor**: Ask diskutil about the volume, not the directory
 - **guest**: Name the missing device-mapper instead of the missing file
 - **mount**: Say what a transient run will and will not attach
+- **mount**: Hold a disk volume's lock for the VM's lifetime, and flush on exit
+- **scripts**: Reclaim CARGO_TARGET_DIR inherited from another source tree
+- **template**: Boot a workload guest on the workload kernel, on x86_64 too
+- **just**: Strip supervisor binaries on macOS again
+- **cli**: Run the image's baked entrypoint instead of waiting for it
+- **e2e**: Provision the guest-runtime directory the @guest_bins lane needs
+- **vmm**: Verify the host-helper contract before spawn
+- **release**: Make the documented-surface gate actually gate a release
+- **contract**: Pin the sdk_uses_sidecar default, and declare it dormant
+- **runtime**: Flush writable OCI disks before teardown
+- **vmm**: Retry a rebuilt helper probe timeout
+- Execute every README example, and fix the three defects that found
+- **ci**: Stop the nightly lanes from cancelling themselves
+- **stage0**: Carry the build config on the input disk, and two live-lane preconditions
+- **claims**: Make the red mutation shards green on their merits
+- **claims**: Close the survivors the dead mvm-cli shard was hiding
+- **e2e**: The three real failures the Linux lane was hiding
+- **ci**: Write an entrypoint marker the guest agent can accept
+- A contended builder ate the whole e2e suite, and an rc would have published as latest
+- **update**: Order releases instead of comparing them as strings
 
 ### Other
 - OCI materialize hygiene: multi-block ext4 dirs + builder orphan-sweep
@@ -969,7 +1003,8 @@ All notable changes to mvm are documented in this file.
 - Add qemu-wasm-smoke-pack build/download scripts
 - Realign landing page with the MVM one-pager
 - Bind caller commitments into signed execution plans
-- Merge remote-tracking branch 'origin/main' into worktree-release-0-18-plan
+- Move libkrun Stage 0 to block transport
+- Refresh host directory snapshots at machine start
 
 ### Performance
 - **verb-grant**: Base64 the cmdline envelope instead of hex
@@ -1006,6 +1041,7 @@ All notable changes to mvm are documented in this file.
 - **build**: Take mvm-cli's build script off the inner loop
 - **audit**: Fold a cached prefix instead of re-reading the log
 - **timing**: Name the parts of the admit window
+- Cache command_names to fix hanging CLI help tests
 
 ### Refactored
 - Typed PackBuilder authority, --sbom-uri, protected signing env, runtime-pack producer
@@ -1068,6 +1104,7 @@ All notable changes to mvm are documented in this file.
 - **contract**: Move GuestLibc below the crates that need it
 - **hvf**: Delete the dev-tier virtio-fs root
 - **qemu**: Refuse virtio-fs shares and delete the virtiofsd module
+- **volume**: Retire runtime directory shares
 
 ### Testing
 - Test(guest)+build: verify detached-workload handler in CI; keep embedded agent fresh
@@ -1136,8 +1173,10 @@ All notable changes to mvm are documented in this file.
 - **bdd**: Witness broker on default backends
 - **bdd**: Ratchet the parse tier so it cannot grow unnoticed
 - **e2e**: Rebuild the per-VM supervisors before the launch gate boots
-- **release**: Gate a release on evidence the documented surface ran
-- **e2e**: Point the --mount witnesses at the directory the README mounts
+- **volume**: Pin persistent directory-share refusal
+- **bdd**: Parallelize alternative CLI help coverage
+- Make hosted live witnesses deterministic
+- **claims**: Close the last claim-witness survivors so the security lane can go green
 
 ## [0.17.0] — 2026-07-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,7 +2723,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libkrun-sys"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "libc",
  "mvm-agentd",
@@ -2910,7 +2910,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-agentd"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-backends"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-build"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2998,7 +2998,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-capture"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-cli"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3064,7 +3064,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-client"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-conformance"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-contract"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3150,7 +3150,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-fs"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "am-fs-ext4",
  "async-trait",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-host-services"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "mvm-agentd",
  "mvm-core",
@@ -3235,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-hostd"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3290,7 +3290,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-http"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3310,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-mcp"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "chrono",
  "mvm-client",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-net"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "mvm-contract",
  "mvm-core",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-observability"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "mvm-core",
  "serde_json",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-runtime"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3415,7 +3415,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-vmm"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "mvmctl"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ resolver = "3"
 # functionally different software. Bumping the minor signals "0.x
 # breaking changes" without prematurely committing to a 1.0 stability
 # promise.
-version = "0.18.0"
+version = "0.18.0-rc.1"
 edition = "2024"
 rust-version = "1.85"
 license = "Apache-2.0"
@@ -356,31 +356,31 @@ tree-sitter-typescript = "0.23.2"
 # here because member crates can't override that on a workspace-inherited
 # dependency unless the workspace entry already carries it. The root binary
 # opts back into user-facing defaults through its own `[features]` block.
-mvm-contract = { path = "crates/mvm-contract", version = "0.18.0", default-features = false, features = ["protocol"] }
-mvm-core = { path = "crates/mvm-core", version = "0.18.0" }
-mvm-client = { path = "crates/mvm-client", version = "0.18.0" }
-mvm-mcp = { path = "crates/mvm-mcp", version = "0.18.0" }
-mvm-agentd = { path = "crates/mvm-agentd", version = "0.18.0" }
-mvm-host-services = { path = "crates/mvm-host-services", version = "0.18.0" }
-mvm-build = { path = "crates/mvm-build", version = "0.18.0", default-features = false }
-mvm-runtime = { path = "crates/mvm-runtime", version = "0.18.0", default-features = false }
-mvm-vmm = { path = "crates/mvm-vmm", version = "0.18.0" }
-mvm-backends = { path = "crates/mvm-backends", version = "0.18.0" }
-mvm-fs = { path = "crates/mvm-fs", version = "0.18.0" }
-mvm-http = { path = "crates/mvm-http", version = "0.18.0" }
-mvm-observability = { path = "crates/mvm-observability", version = "0.18.0" }
-mvm-net = { path = "crates/mvm-net", version = "0.18.0" }
-mvm-cli = { path = "crates/mvm-cli", version = "0.18.0", default-features = false }
-mvm-hostd = { path = "crates/mvm-hostd", version = "0.18.0", default-features = false }
+mvm-contract = { path = "crates/mvm-contract", version = "0.18.0-rc.1", default-features = false, features = ["protocol"] }
+mvm-core = { path = "crates/mvm-core", version = "0.18.0-rc.1" }
+mvm-client = { path = "crates/mvm-client", version = "0.18.0-rc.1" }
+mvm-mcp = { path = "crates/mvm-mcp", version = "0.18.0-rc.1" }
+mvm-agentd = { path = "crates/mvm-agentd", version = "0.18.0-rc.1" }
+mvm-host-services = { path = "crates/mvm-host-services", version = "0.18.0-rc.1" }
+mvm-build = { path = "crates/mvm-build", version = "0.18.0-rc.1", default-features = false }
+mvm-runtime = { path = "crates/mvm-runtime", version = "0.18.0-rc.1", default-features = false }
+mvm-vmm = { path = "crates/mvm-vmm", version = "0.18.0-rc.1" }
+mvm-backends = { path = "crates/mvm-backends", version = "0.18.0-rc.1" }
+mvm-fs = { path = "crates/mvm-fs", version = "0.18.0-rc.1" }
+mvm-http = { path = "crates/mvm-http", version = "0.18.0-rc.1" }
+mvm-observability = { path = "crates/mvm-observability", version = "0.18.0-rc.1" }
+mvm-net = { path = "crates/mvm-net", version = "0.18.0-rc.1" }
+mvm-cli = { path = "crates/mvm-cli", version = "0.18.0-rc.1", default-features = false }
+mvm-hostd = { path = "crates/mvm-hostd", version = "0.18.0-rc.1", default-features = false }
 
 # plan 60 Phase 5 — build-time SDK port from ../mvmforge.
-mvm-sdk = { path = "crates/mvm-sdk", version = "0.18.0" }
-mvm-capture = { path = "crates/mvm-capture", version = "0.18.0" }
+mvm-sdk = { path = "crates/mvm-sdk", version = "0.18.0-rc.1" }
+mvm-capture = { path = "crates/mvm-capture", version = "0.18.0-rc.1" }
 # Plan 57 W1 — libkrun FFI bindings split out of mvm-providers so the
 # bindgen + libclang build cost is isolated from the rest of the
 # workspace. Default feature set is empty; consumers wanting real FFI
 # enable `libkrun-sys` on a host with libkrun installed.
-libkrun-sys = { path = "crates/deps/libkrun-sys", version = "0.18.0" }
+libkrun-sys = { path = "crates/deps/libkrun-sys", version = "0.18.0-rc.1" }
 
 # Dev dependencies
 assert_cmd = "2"

--- a/crates/deps/libkrun-sys/fuzz/Cargo.lock
+++ b/crates/deps/libkrun-sys/fuzz/Cargo.lock
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "libkrun-sys"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "libc",
  "mvm-core",
@@ -602,7 +602,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mvm-contract"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/crates/mvm-agentd/fuzz/Cargo.lock
+++ b/crates/mvm-agentd/fuzz/Cargo.lock
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-agentd"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-build"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-contract"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-fs"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "async-trait",
  "ed25519-dalek",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-host-services"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "mvm-agentd",
  "mvm-core",
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-http"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "bytes",
@@ -1207,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-net"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "mvm-contract",
  "mvm-core",
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "blake3",
@@ -1242,7 +1242,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-vmm"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/mvm-contract/fuzz/Cargo.lock
+++ b/crates/mvm-contract/fuzz/Cargo.lock
@@ -210,7 +210,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mvm-contract"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "chrono",

--- a/crates/mvm-core/fuzz/Cargo.lock
+++ b/crates/mvm-core/fuzz/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mvm-contract"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/crates/mvm-fs/fuzz-ext4/Cargo.lock
+++ b/crates/mvm-fs/fuzz-ext4/Cargo.lock
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-contract"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "chrono",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-fs"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "async-trait",
  "ed25519-dalek",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-http"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "bytes",

--- a/crates/mvm-fs/fuzz-oci/Cargo.lock
+++ b/crates/mvm-fs/fuzz-oci/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-contract"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "chrono",
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-fs"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "async-trait",
  "ed25519-dalek",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-http"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "bytes",

--- a/crates/mvm-http/fuzz/Cargo.lock
+++ b/crates/mvm-http/fuzz/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-http"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "bytes",

--- a/crates/mvm-runtime/fuzz-backend/Cargo.lock
+++ b/crates/mvm-runtime/fuzz-backend/Cargo.lock
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "libkrun-sys"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "libc",
  "mvm-core",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-agentd"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-backends"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-build"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-contract"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-fs"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "async-trait",
  "ed25519-dalek",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-host-services"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "mvm-agentd",
  "mvm-core",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-http"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "bytes",
@@ -1251,7 +1251,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-net"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "mvm-contract",
  "mvm-core",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-runtime"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "blake3",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-vmm"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/crates/mvm-sdk/fuzz/Cargo.lock
+++ b/crates/mvm-sdk/fuzz/Cargo.lock
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-agentd"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-contract"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-core"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-host-services"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "mvm-agentd",
  "mvm-core",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "mvm-sdk"
-version = "0.18.0"
+version = "0.18.0-rc.1"
 dependencies = [
  "base64",
  "blake3",

--- a/nix/images/runtime-overlay/flake.nix
+++ b/nix/images/runtime-overlay/flake.nix
@@ -118,7 +118,7 @@
       # the two in lock-step or `mvmctl up` admission fails.
       # `xtask check-runtime-overlay-version` (a CI gate)
       # asserts this match so the pin can't silently go stale.
-      overlayVersion = "0.18.0";
+      overlayVersion = "0.18.0-rc.1";
 
       # mvm-agentd binaries — agent + seccomp shim + verity-init.
       # the universal initramfs agent is PID 1; it lives in the

--- a/nix/packages/mvm-sdk-cdylib.nix
+++ b/nix/packages/mvm-sdk-cdylib.nix
@@ -68,7 +68,7 @@ in
 
 pkgs.rustPlatform.buildRustPackage ({
   pname = "mvm-sdk-cdylib" + lib.optionalString isMusl "-musl";
-  version = "0.18.0";
+  version = "0.18.0-rc.1";
 
   src = mvmSrc;
 

--- a/nix/packages/mvmctl.nix
+++ b/nix/packages/mvmctl.nix
@@ -51,7 +51,7 @@ let
 in
 rustPlatform.buildRustPackage {
   pname = "mvmctl";
-  version = "0.18.0";
+  version = "0.18.0-rc.1";
 
   src = mvmSrc;
 


### PR DESCRIPTION
Version bump + git-cliff changelog for v0.18.0-rc.1. Merge via the queue, then `just release-tag 0.18.0-rc.1`.