### PR TITLE
docs: document release workflows and add release-image command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -770,14 +770,14 @@ release-image VERSION:
     set -euo pipefail
     V="{{ VERSION }}"
     TAG="boot-image/v$V"
-    # Check if tag already exists
-    if git rev-parse "$TAG" >/dev/null 2>&1; then
-        echo "Tag $TAG already exists."
+    git fetch origin main --tags
+    if git rev-parse --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+        echo "ERROR: tag $TAG already exists." >&2
         exit 1
     fi
-    git tag "$TAG"
+    git tag "$TAG" origin/main
     git push origin "$TAG"
-    echo "Created and pushed tag $TAG — the boot-image release pipeline will build + publish."
+    echo "==> Pushed tag $TAG from origin/main — the boot-image release pipeline will build + publish."
 
 # ── Documentation ────────────────────────────────────────────────────────
 

--- a/Justfile
+++ b/Justfile
@@ -760,6 +760,25 @@ tag:
     git tag v{{ version }}
     @echo "Tagged v{{ version }}"
 
+# Release the boot image train (`boot-image/v*`)
+# This creates and pushes a tag for the boot image release, which triggers
+# the release-boot-image.yml workflow to build and publish all microVM assets.
+# Usage: just release-image <version>
+#   version: The version tag (e.g., 1.2.3) - creates boot-image/v1.2.3
+release-image VERSION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    V="{{ VERSION }}"
+    TAG="boot-image/v$V"
+    # Check if tag already exists
+    if git rev-parse "$TAG" >/dev/null 2>&1; then
+        echo "Tag $TAG already exists."
+        exit 1
+    fi
+    git tag "$TAG"
+    git push origin "$TAG"
+    echo "Created and pushed tag $TAG — the boot-image release pipeline will build + publish."
+
 # ── Documentation ────────────────────────────────────────────────────────
 
 # Install docs site dependencies

--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ claims), each backed by a named test or workflow gate. In summary:
     in the signed plan.
 16. **Every workload asset and pinned host share is content-identified in the
     signed plan, and share drift after admission fails closed** — `--asset
-    KIND:HOST_PATH` hashes the asset into the signed plan, and a directory
+KIND:HOST_PATH` hashes the asset into the signed plan, and a directory
     share whose contents change after admission is refused at attach time.
 17. **Every published release artifact is authenticated under the release
     workflow's identity** — archives and checksum manifests carry keyless
@@ -931,6 +931,118 @@ live-KVM smokes) needs real `/dev/kvm`; cloud-init scaffolding for a throwaway
 KVM box lives in [`nix/ops/hetzner/`](nix/ops/hetzner/), and the
 [contributor guide](public/src/content/docs/contributing/development.md) has the
 details.
+
+### Release workflows
+
+This project maintains **two separate release trains** that version and publish
+independently:
+
+| Release train   | Tag pattern          | What it releases                                 | Workflow file                              | Key command                    |
+| --------------- | -------------------- | ------------------------------------------------ | ------------------------------------------ | ------------------------------ |
+| **CLI release** | `v*` (e.g. `v1.2.3`) | `mvmctl` binary, initramfs, crates.io packages   | `.github/workflows/release.yml`            | `just release <version>`       |
+| **Boot image**  | `boot-image/v*`      | Rootfs, builder VM, runtime overlay, SDK sidecar | `.github/workflows/release-boot-image.yml` | `just release-image <version>` |
+
+**Why two trains?** The CLI and boot image have independent lifecycles:
+
+- A kernel or rootfs security fix can ship via `boot-image/v1.2.4` without a
+  CLI version bump.
+- A CLI bug fix doesn't need to rebuild unchanged images.
+
+#### CLI release (`v*`)
+
+The **CLI release train** packages the `mvmctl` binary, the initramfs, and
+publishes Rust crates to crates.io. It runs on `v*` tags and produces:
+
+- `mvmctl-{target}.tar.gz` (macOS Apple Silicon, Linux x86_64/aarch64)
+- `initramfs-{arch}.tar.gz` (universal initramfs)
+- `checksums-sha256.txt` (combined checksums)
+- SBOM (`sbom.cdx`)
+
+**Release steps:**
+
+```bash
+# Option 1: Automatic version bump (based on conventional commits)
+just release-auto
+
+# Option 2: Explicit version
+just release 1.2.3
+
+# The above commands:
+# 1. Run formatting, clippy, and all tests
+# 2. Bump version in Cargo.toml and internal path-deps
+# 3. Update Nix flake versions (runtime-overlay, mvmctl.nix, mvm-sdk-cdylib.nix)
+# 4. Generate changelog with git-cliff
+# 5. Commit and open a PR on branch release/v<version>
+
+# After the PR merges to main, tag and publish:
+just release-tag 1.2.3
+# This pushes the v1.2.3 tag, triggering the release.yml workflow
+```
+
+The workflow runs on tag push and:
+
+1. Builds `mvmctl` for all targets (cross-compiling Linux binaries)
+2. Builds per-VM host binaries (supervisors, agent, signer, broker)
+3. Builds the universal initramfs for both arches
+4. Runs BDD and e2e-docs tests (all documented examples must pass)
+5. Packages binaries, generates checksums, signs with cosign (keyless OIDC)
+6. Creates a GitHub release with all artifacts
+
+**Critical gate:** A CLI release **must** include boot-image assets. If no
+`boot-image/v*` release exists (or it's incomplete), the publish fails with an
+error. This prevents fresh installs from 404ing on first boot.
+
+#### Boot image release (`boot-image/v*`)
+
+The **boot image release train** produces all artifacts needed to boot a
+microVM:
+
+- `builder-vm-*` (builder VM vmlinux, rootfs, SBOM, pack manifest)
+- `runtime-overlay-{arch}.tar.gz` (read-only overlay for agent/seccomp/SDK)
+- `sdk-sidecar-{arch}-{libc}.tar.gz` (SDK server runtime, per libc)
+- `default-microvm-*` (default prod image: vmlinux, verity-sealed rootfs)
+
+**Release steps:**
+
+```bash
+# Build and publish a boot image release
+just release-image 1.2.3
+# This creates and pushes the boot-image/v1.2.3 tag
+
+# Or use the Just alias (add to your shell):
+alias release-image='git tag boot-image/v && git push origin boot-image/v'
+```
+
+The workflow runs on `boot-image/v*` tags and:
+
+1. Builds the builder VM image (cross-compiles host-vm binaries)
+2. Builds the runtime overlay image
+3. Builds SDK sidecar images (4 variants: x86_64/aarch64 × glibc/musl)
+4. Builds the default microVM (prod variant, sealed + verity)
+5. Generates checksums and SBOMs
+6. Signs all artifacts with cosign (keyless OIDC)
+7. Creates a GitHub release under `boot-image/v*`
+
+**Key differences from CLI release:**
+
+- Uses protected environment `boot-image-signing` (restricted to `boot-image/v*` refs)
+- No `--features embed-host-bins` (no CLI binary to embed)
+- Builds Nix images (`nix/images/builder-vm`, `nix/images/runtime-overlay`, etc.)
+- Produces raw kernel/initramfs/rootfs blobs, not packaged binaries
+
+#### Verifying a release
+
+```bash
+# Verify the latest release's signatures
+mvmctl update check          # Check for CLI updates
+mvmctl trust audit verify    # Verify all downloaded artifacts
+
+# Check which boot image a binary would download
+mvmctl doctor                # Reports boot image resolution
+```
+
+For more details, see the [release workflow files](.github/workflows/release.yml) and [
+boot image workflow file](.github/workflows/release-boot-image.yml).
 
 ### Repository layout
 

--- a/README.md
+++ b/README.md
@@ -768,7 +768,7 @@ claims), each backed by a named test or workflow gate. In summary:
     in the signed plan.
 16. **Every workload asset and pinned host share is content-identified in the
     signed plan, and share drift after admission fails closed** — `--asset
-KIND:HOST_PATH` hashes the asset into the signed plan, and a directory
+    KIND:HOST_PATH` hashes the asset into the signed plan, and a directory
     share whose contents change after admission is refused at attach time.
 17. **Every published release artifact is authenticated under the release
     workflow's identity** — archives and checksum manifests carry keyless
@@ -958,26 +958,12 @@ publishes Rust crates to crates.io. It runs on `v*` tags and produces:
 - `checksums-sha256.txt` (combined checksums)
 - SBOM (`sbom.cdx`)
 
-**Release steps:**
-
-```bash
-# Option 1: Automatic version bump (based on conventional commits)
-just release-auto
-
-# Option 2: Explicit version
-just release 1.2.3
-
-# The above commands:
-# 1. Run formatting, clippy, and all tests
-# 2. Bump version in Cargo.toml and internal path-deps
-# 3. Update Nix flake versions (runtime-overlay, mvmctl.nix, mvm-sdk-cdylib.nix)
-# 4. Generate changelog with git-cliff
-# 5. Commit and open a PR on branch release/v<version>
-
-# After the PR merges to main, tag and publish:
-just release-tag 1.2.3
-# This pushes the v1.2.3 tag, triggering the release.yml workflow
-```
+To prepare the next version from conventional commits, run `just release-auto`.
+To choose the version explicitly, run `just release 1.2.3`. Both commands run
+the local release gates, update the workspace and Nix package versions, prepend
+the generated changelog, and open a `release/v<version>` pull request. After
+that pull request merges, run `just release-tag 1.2.3`; it tags the merged
+`origin/main` commit and triggers the CLI workflow.
 
 The workflow runs on tag push and:
 
@@ -1002,16 +988,10 @@ microVM:
 - `sdk-sidecar-{arch}-{libc}.tar.gz` (SDK server runtime, per libc)
 - `default-microvm-*` (default prod image: vmlinux, verity-sealed rootfs)
 
-**Release steps:**
-
-```bash
-# Build and publish a boot image release
-just release-image 1.2.3
-# This creates and pushes the boot-image/v1.2.3 tag
-
-# Or use the Just alias (add to your shell):
-alias release-image='git tag boot-image/v && git push origin boot-image/v'
-```
+To publish a boot image release, run `just release-image 1.2.3`. The command
+refreshes `origin/main`, refuses to reuse an existing tag, and tags the merged
+main commit as `boot-image/v1.2.3`. Pushing that tag triggers the boot-image
+workflow.
 
 The workflow runs on `boot-image/v*` tags and:
 
@@ -1032,17 +1012,13 @@ The workflow runs on `boot-image/v*` tags and:
 
 #### Verifying a release
 
-```bash
-# Verify the latest release's signatures
-mvmctl update check          # Check for CLI updates
-mvmctl trust audit verify    # Verify all downloaded artifacts
+Run `mvmctl image boot check` to compare the locally recorded boot-image tag
+with the latest published image release. Run `mvmctl trust audit verify` to
+verify the local audit chain, and `mvmctl doctor` to inspect the host and boot
+image acquisition posture.
 
-# Check which boot image a binary would download
-mvmctl doctor                # Reports boot image resolution
-```
-
-For more details, see the [release workflow files](.github/workflows/release.yml) and [
-boot image workflow file](.github/workflows/release-boot-image.yml).
+For more details, see the [CLI release workflow](.github/workflows/release.yml)
+and [boot image release workflow](.github/workflows/release-boot-image.yml).
 
 ### Repository layout
 

--- a/crates/mvm-conformance/tests/steps/doc_examples.rs
+++ b/crates/mvm-conformance/tests/steps/doc_examples.rs
@@ -1426,7 +1426,7 @@ fn docs_coverage_ratchet(_world: &mut CliWorld) {
 /// deliberate act that should carry its reason in the commit, because the
 /// alternative is what happened before this existed: the count drifted up
 /// while everyone believed coverage was improving.
-const PARSE_TIER_PIN: usize = 62;
+const PARSE_TIER_PIN: usize = 63;
 
 #[then(expr = "no more command paths sit at the parse tier than the pinned count")]
 fn parse_tier_does_not_grow(_world: &mut CliWorld) {

--- a/features/suites/s29_doc_examples/tiers.toml
+++ b/features/suites/s29_doc_examples/tiers.toml
@@ -119,6 +119,11 @@ tier = "parse"
 reason = "needs an OCI image already pulled into the cache"
 
 [[command]]
+path = "image boot check"
+tier = "parse"
+reason = "queries the GitHub releases API, so its result depends on live network and release state; the comparison logic is covered with local unit tests"
+
+[[command]]
 path = "init"
 tier = "exec"
 

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -39,6 +39,10 @@ fn boot_image_workflow() -> String {
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
 }
 
+fn justfile() -> String {
+    fs::read_to_string("Justfile").expect("Justfile must be readable")
+}
+
 fn ci_workflow() -> String {
     let path = Path::new(".github/workflows/ci.yml");
     fs::read_to_string(path)
@@ -627,6 +631,51 @@ fn the_two_release_trains_cannot_fire_each_other() {
     assert!(
         !cli_tag.starts_with(&prefix("boot-image/v*")),
         "{cli_tag} must not match the boot image train's pattern"
+    );
+}
+
+/// Publishing an image tag from a topic branch would disclose code that has
+/// not passed the repository's merge gates. Keep the image release helper on
+/// the same merged-main boundary as the CLI release helper.
+#[test]
+fn boot_image_release_recipe_tags_the_fetched_main_commit() {
+    let justfile = justfile();
+    let recipe = justfile
+        .split("release-image VERSION:")
+        .nth(1)
+        .expect("Justfile must define release-image")
+        .split("\n# ── Documentation")
+        .next()
+        .expect("release-image recipe must end before documentation recipes");
+
+    assert!(
+        recipe.contains("git fetch origin main"),
+        "release-image must refresh origin/main before choosing the release commit"
+    );
+    assert!(
+        recipe.contains("git tag \"$TAG\" origin/main"),
+        "release-image must tag merged origin/main, never the caller's current HEAD"
+    );
+    assert!(
+        !recipe.contains("git tag \"$TAG\"\n"),
+        "release-image must not implicitly tag the caller's current HEAD"
+    );
+}
+
+#[test]
+fn boot_image_release_recipe_refuses_an_existing_tag() {
+    let justfile = justfile();
+    let recipe = justfile
+        .split("release-image VERSION:")
+        .nth(1)
+        .expect("Justfile must define release-image")
+        .split("\n# ── Documentation")
+        .next()
+        .expect("release-image recipe must end before documentation recipes");
+
+    assert!(
+        recipe.contains("git rev-parse --verify \"refs/tags/$TAG\""),
+        "release-image must refuse a tag that already exists after fetching tags"
     );
 }
 


### PR DESCRIPTION
## Summary

- document the independent CLI and boot-image release trains
- add `just release-image <version>`
- tag fetched `origin/main` and refuse existing boot-image tags
- keep README commands aligned with the real CLI and documentation coverage gates

## Testing

- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo nextest run --workspace` (13,148 passed)
- `cargo test --test release_assets` (35 passed)
- `just bdd` (251 passed, 1 expected skip)
- `just --list`
