### PR TITLE
fix(template): read a pre-release build as the version it precedes

### DIFF
--- a/crates/mvm-cli/src/template_registry.rs
+++ b/crates/mvm-cli/src/template_registry.rs
@@ -268,6 +268,18 @@ pub(crate) fn satisfies_mvm_version(req: &str) -> bool {
 }
 
 fn parse_version_triple(s: &str) -> Option<(u64, u64, u64)> {
+    // Drop a pre-release or build suffix before splitting. `0.18.0-rc.1`
+    // otherwise splits to ["0", "18", "0-rc", "1"], fails to parse, and the
+    // caller's `_ => true` fallback then satisfies *every* requirement — a
+    // pre-release build would accept a template demanding a version that does
+    // not exist yet.
+    //
+    // Dropping it makes a pre-release count as the version it precedes, which
+    // is what a minimum-version gate should say: `0.18.0-rc.1` carries
+    // `0.18.0`'s template surface. Deliberately not `update::ReleaseVersion`,
+    // which orders an rc *below* its own release because it answers a
+    // different question — whether to move a user onto it.
+    let s = s.split(['-', '+']).next().unwrap_or(s);
     let mut parts = s.split('.');
     let major = parts.next()?.parse().ok()?;
     let minor = parts.next().unwrap_or("0").parse().ok()?;
@@ -346,6 +358,25 @@ mod tests {
         assert!(satisfies_mvm_version(""));
         assert!(satisfies_mvm_version(">=0.1.0"));
         assert!(!satisfies_mvm_version(">=999.0.0"));
+    }
+
+    /// A pre-release build must still enforce the bound.
+    ///
+    /// `0.18.0-rc.1` split on `.` yields ["0", "18", "0-rc", "1"], so the patch
+    /// component did not parse and the whole triple came back `None`. With the
+    /// current version unreadable, `satisfies_mvm_version`'s fallback declared
+    /// every requirement satisfied — the `>=999.0.0` case above passed on a
+    /// release build and silently inverted on the first release candidate.
+    #[test]
+    fn a_prerelease_build_parses_to_the_release_it_precedes() {
+        assert_eq!(parse_version_triple("0.18.0-rc.1"), Some((0, 18, 0)));
+        assert_eq!(parse_version_triple("0.18.0+deadbeef"), Some((0, 18, 0)));
+        assert_eq!(parse_version_triple("0.18.0"), Some((0, 18, 0)));
+        assert_eq!(
+            parse_version_triple("0.18.0-rc.1"),
+            parse_version_triple("0.18.0"),
+            "a minimum-version gate reads an rc as the version it precedes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Found by the `0.18.0-rc.1` release PR (#3194) going red on `Test workspace (aarch64)`. The bug is latent and independent of the release, so it lands on its own rather than inside a squash-merged `release:` commit where its reasoning would disappear.

## The defect

`parse_version_triple` split on `.` without dropping a pre-release or build suffix, so `0.18.0-rc.1` yielded `["0", "18", "0-rc", "1"]`, the patch component failed to parse, and the triple came back `None`.

`satisfies_mvm_version` falls **open**. With the running version unreadable, its `_ => true` arm declares *every* requirement satisfied — a pre-release build would accept a template demanding `>=999.0.0`, and `fetch_and_cache_remote_template`'s refusal, which asks the same question, would never fire.

No published version has ever carried a suffix, so the arm was unreachable until the first release candidate. The existing `assert!(!satisfies_mvm_version(">=999.0.0"))` passed for the entire life of the function while sitting one character of version string away from inverting — which is exactly how it was caught.

## Why this shape of fix

`extension_admission::mvm_version_is_supported` already strips the suffix the same way *and* fails closed, which is right where the question is admission. This function is the outlier.

I left the fail-open behaviour alone. A malformed requirement in someone else's template is not the same thing as our own version being unreadable, and reversing that default is a separate judgement from this fix.

Dropping the suffix makes a pre-release count as the release it precedes, which is what a minimum-version gate should say: `0.18.0-rc.1` carries `0.18.0`'s template surface. Deliberately **not** `update::ReleaseVersion` (#3191), which orders an rc *below* its own release — that answers whether to move a user onto it, a different question with a different right answer. The comment says so, so the two are not later "unified" into one wrong answer.

## Verification

`cargo nextest run --workspace` on the bumped tree: 13147 passed, 0 failed — the failure reproduced locally first and this is what clears it. The new test also passes at main's own `0.18.0`, so it stands independently of the release.