### PR TITLE
release: record the macOS/HVF documented-surface evidence for v0.18.0-rc.1

### DIFF
--- a/specs/evidence/e2e/macos-hvf.json
+++ b/specs/evidence/e2e/macos-hvf.json
@@ -1,0 +1,19 @@
+{
+  "lane": "macos-hvf",
+  "commit": "2025b830f01da8a8dfe6f14ca7b970e2084f6d86",
+  "material_digest": "4ba4755a1a8535ec38b2f9359343556e087ebb86a94c487ec14b37bcfaa6c294",
+  "recorded_at": "2026-09-07T06:09:13Z",
+  "host": {
+    "os": "Darwin",
+    "os_version": "26.5.2",
+    "arch": "arm64"
+  },
+  "suite": {
+    "features": 75,
+    "scenarios_total": 308,
+    "scenarios_passed": 307,
+    "scenarios_skipped": 1,
+    "steps_total": 1232,
+    "steps_passed": 1231
+  }
+}


### PR DESCRIPTION
Required before tagging v0.18.0-rc.1.

`e2e-docs.yml` runs `check-release-evidence macos-hvf` because no hosted Apple Silicon runner can boot a workload backend (#3011) — the macOS lane is a recorded local run or it is nothing.

308 scenarios (307 passed, 1 skipped) on Darwin arm64, recorded against the bumped tree after the fuzz-lockfile refresh.

`specs/` is not a material path, so this record does not alter the digest it attests to — it can be committed without invalidating itself.

Recorded and verified before opening: `check-release-evidence` passes against this tree.