### PR TITLE
fix(release): test the bumped tree, and fix the locks the bump breaks

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -700,6 +700,22 @@ _release-prep VERSION:
     sed -i.bak -E "s/(^[[:space:]]*version = \")[0-9][^\"]*(\")/\1$V\2/" nix/packages/mvmctl.nix nix/packages/mvm-sdk-cdylib.nix
     rm nix/packages/*.bak
     git add nix/images/runtime-overlay/flake.nix nix/packages/mvmctl.nix nix/packages/mvm-sdk-cdylib.nix
+    # The cargo-fuzz crates are separate workspaces with their own lockfiles,
+    # each pinning the internal `mvm-*` crates by version. A bump leaves every
+    # one of them naming the old version, and ci.yml's "cargo-fuzz crates still
+    # compile" step runs `cargo check --locked` per manifest — a lock that would
+    # have to change is the failure.
+    #
+    # Invisible on the PR: that step sits behind a change-detector and
+    # `check-all` cannot see detached lockfiles at all. v0.18.0-rc.1 was evicted
+    # from the merge queue three times before anyone looked at a merge-group log.
+    #
+    # `cargo metadata` re-resolves and rewrites each lock without compiling.
+    for manifest in crates/*/fuzz*/Cargo.toml crates/deps/*/fuzz*/Cargo.toml; do
+        [ -f "$manifest" ] || continue
+        cargo metadata --manifest-path "$manifest" --format-version 1 >/dev/null
+        git add "$(dirname "$manifest")/Cargo.lock"
+    done
     git-cliff --tag "v$V" --unreleased --prepend CHANGELOG.md
     # Fail closed if git-cliff did not add the new section (silently shipped
     # v0.15.2/v0.16.0/v0.16.1 with no changelog entry — never again).
@@ -708,6 +724,16 @@ _release-prep VERSION:
         exit 1
     fi
     git add Cargo.toml Cargo.lock CHANGELOG.md
+    # Gate the commit on the bumped tree. `just release` runs the workspace
+    # suite before calling this recipe, which green-lights the tree as it was
+    # *before* the version changed — so the tree actually being pushed was never
+    # run. That is how a pre-release-unaware version parser reached CI on
+    # v0.18.0-rc.1: no published version had ever carried a `-rc.1` suffix, so
+    # the defect was unreachable until the bump, and the bump was never tested.
+    #
+    # A gate that runs before a mutation cannot witness the mutation.
+    echo "==> re-running the workspace suite against the bumped tree"
+    cargo nextest run --workspace
     git commit -m "release: v$V"
     git push -u origin "$BRANCH"
     gh pr create --base main --head "$BRANCH" --title "release: v$V" \

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -43,6 +43,85 @@ fn justfile() -> String {
     fs::read_to_string("Justfile").expect("Justfile must be readable")
 }
 
+/// The release prep must test the tree it pushes, not the tree before it.
+///
+/// `just release` runs the workspace suite and *then* calls `_release-prep`,
+/// which is where the version actually changes. So the suite green-lights the
+/// pre-bump tree while the bumped tree — the one that becomes the release — was
+/// never run.
+///
+/// That is not hypothetical: a version parser that could not read a
+/// pre-release suffix reached CI on v0.18.0-rc.1 because no published version
+/// had ever carried one, making the defect unreachable until the bump.
+#[test]
+fn the_release_prep_runs_the_suite_after_the_version_is_bumped() {
+    let justfile = justfile();
+    let prep = justfile
+        .find("_release-prep VERSION:")
+        .expect("the shared release prep recipe must exist");
+    let body = &justfile[prep..];
+
+    let bump = body
+        .find("version = \\\"$V\\\"")
+        .expect("_release-prep must rewrite the workspace version");
+    let suite = body
+        .find("cargo nextest run --workspace")
+        .expect("_release-prep must run the workspace suite against the bumped tree");
+    let commit = body
+        .find(r#"git commit -m "release: v$V""#)
+        .expect("_release-prep must commit the bump");
+
+    assert!(
+        bump < suite,
+        "the suite must run after the version is rewritten, or it witnesses the \
+         tree as it was before the release"
+    );
+    assert!(
+        suite < commit,
+        "the suite must gate the commit, or a failing bumped tree is still pushed"
+    );
+}
+
+/// A version bump invalidates every detached fuzz lockfile, so the bump has to
+/// fix them.
+///
+/// The cargo-fuzz crates are separate workspaces pinning the internal `mvm-*`
+/// crates by version, and `ci.yml` checks them with `cargo check --locked`. The
+/// step sits behind a change-detector and `check-all` cannot see detached
+/// lockfiles, so nothing on the PR evaluates them — v0.18.0-rc.1 was 13-green
+/// on its PR and was evicted from the merge queue three times.
+#[test]
+fn the_release_prep_refreshes_the_detached_fuzz_lockfiles() {
+    let justfile = justfile();
+    let prep = justfile
+        .find("_release-prep VERSION:")
+        .expect("the shared release prep recipe must exist");
+    let body = &justfile[prep..];
+
+    assert!(
+        body.contains("crates/*/fuzz*/Cargo.toml"),
+        "_release-prep must walk the fuzz manifests, or their locks keep naming \
+         the previous version and the merge queue rejects the release"
+    );
+    assert!(
+        body.contains("crates/deps/*/fuzz*/Cargo.toml"),
+        "the fuzz crate under crates/deps must be refreshed too — ci.yml globs \
+         both paths, so covering one leaves the gate red"
+    );
+
+    let refresh = body
+        .find("cargo metadata --manifest-path")
+        .expect("_release-prep must re-resolve each fuzz lock");
+    let commit = body
+        .find(r#"git commit -m "release: v$V""#)
+        .expect("_release-prep must commit the bump");
+    assert!(
+        refresh < commit,
+        "the locks must be refreshed before the commit, or the release PR \
+         carries the stale ones"
+    );
+}
+
 fn ci_workflow() -> String {
     let path = Path::new(".github/workflows/ci.yml");
     fs::read_to_string(path)


### PR DESCRIPTION
Fixes #3199. Both defects cost a merge-queue cycle while cutting v0.18.0-rc.1, and both would recur on every future release.

## The suite ran before the bump

`just release` runs the workspace suite, then calls `_release-prep`, which is where the version actually changes. So the suite green-lights the tree as it was **before** the bump, and the bumped tree — the one that becomes the release — was never run by the recipe that produced it.

That is how #3196 reached CI instead of a laptop: `parse_version_triple` could not read a pre-release suffix, no published version had ever carried one, so the defect was unreachable until the bump and the bump was never tested.

The suite now runs after the rewrite and gates the commit.

## The bump broke nine lockfiles and did not fix them

The cargo-fuzz crates are separate workspaces whose lockfiles pin the internal `mvm-*` crates by version. `ci.yml` checks them with `cargo check --locked`, so a lock still naming the previous version is a hard failure.

**Invisible on the PR.** That step sits behind a change-detector and `check-all` cannot see detached lockfiles at all, so #3194 was 13-green on its PR while being evicted from the merge queue three times. Both red jobs traced to it, which reads as two independent failures but is not: `lint-policy` is the job *displayed* as `Invariant` (`ci.yml:237`), so the lint aggregate failed only because its policy lane had.

`_release-prep` now refreshes them alongside the nix pins it already rewrites, using `cargo metadata` — re-resolves and rewrites each lock without compiling, all nine in seconds.

Both globs are covered because `ci.yml` globs both: `crates/*/fuzz*` and `crates/deps/*/fuzz*`. Refreshing only the first leaves the gate red for `libkrun-sys`.

## The tests assert ordering, not presence

Presence alone would pass with the suite back where it was. They pin that the suite runs *after* the version is rewritten and *before* the commit, and that the locks are refreshed before the commit.

## The shared shape

A gate that runs before a mutation cannot witness the mutation — the same shape as the e2e lock-wait tie fixed in #3189, where the builder's lock wait equalled the suite deadline so the waiter could never lose and the contention error could never be raised.

`cargo nextest run -p mvmctl --test release_assets`: 37 passed. Justfile parses.