### PR TITLE
fix(release): pin the one release target that is actually cross-compiled

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,16 @@
 [toolchain]
 channel = "nightly-2026-08-25"
 components = ["clippy", "rustfmt", "rust-src", "rustc-codegen-cranelift"]
-targets = ["aarch64-unknown-linux-musl", "wasm32-wasip1", "x86_64-unknown-linux-musl"]
+# `aarch64-unknown-linux-gnu` is the release matrix's only true
+# cross-compile: every other published target is its runner's native
+# triple, so their std comes with the toolchain. This one does not, and
+# `dtolnay/rust-toolchain` installing it does not help — that installs it
+# for the action's own toolchain, while this file overrides which
+# toolchain cargo actually uses. The result was `can't find crate for
+# core` at release time, on the one target nothing else builds.
+targets = [
+    "aarch64-unknown-linux-gnu",
+    "aarch64-unknown-linux-musl",
+    "wasm32-wasip1",
+    "x86_64-unknown-linux-musl",
+]

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -122,6 +122,84 @@ fn the_release_prep_refreshes_the_detached_fuzz_lockfiles() {
     );
 }
 
+/// Every cross-compiled release target must have its std installed by the
+/// toolchain this repo actually pins.
+///
+/// `release.yml` passes `targets:` to `dtolnay/rust-toolchain`, which installs
+/// them for *the action's* toolchain. `rust-toolchain.toml` then overrides
+/// which toolchain cargo uses, and the override does not inherit those targets.
+/// A target listed only in the workflow therefore has no `core`/`std` at build
+/// time, and the build fails with E0463.
+///
+/// It failed exactly once and only in the worst place: no PR lane builds
+/// `aarch64-unknown-linux-gnu`, so the first evidence was a tagged release
+/// pipeline going red. That is what this test replaces.
+///
+/// A target that is its runner's native triple is exempt — its std ships with
+/// the toolchain, and listing every host triple here would make each
+/// contributor install std for platforms they never build.
+#[test]
+fn every_cross_compiled_release_target_is_pinned_by_the_toolchain_file() {
+    let workflow = release_workflow();
+    let toolchain_file =
+        fs::read_to_string("rust-toolchain.toml").expect("rust-toolchain.toml must be readable");
+
+    // Only the `targets = [...]` array counts. Searching the whole file would
+    // match the comment above that array, which names the very target it
+    // explains — the first draft of this test passed with the target removed,
+    // for exactly that reason.
+    let targets_start = toolchain_file
+        .find("targets = [")
+        .expect("rust-toolchain.toml must declare a targets array");
+    let targets_len = toolchain_file[targets_start..]
+        .find(']')
+        .expect("the targets array must be closed");
+    let toolchain = &toolchain_file[targets_start..targets_start + targets_len];
+
+    // Runner image -> the triple its rustc is native to.
+    let native = [
+        ("macos-latest", "aarch64-apple-darwin"),
+        ("ubuntu-latest", "x86_64-unknown-linux-gnu"),
+        ("ubuntu-24.04-arm", "aarch64-unknown-linux-gnu"),
+    ];
+
+    // The build matrix entries, as `- target: X` followed by `os: Y`.
+    let mut pairs = Vec::new();
+    let lines: Vec<&str> = workflow.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        let Some(target) = line.trim().strip_prefix("- target: ") else {
+            continue;
+        };
+        let os = lines[i + 1..]
+            .iter()
+            .take(6)
+            .find_map(|l| l.trim().strip_prefix("os: "))
+            .unwrap_or_else(|| panic!("matrix entry {target} names no runner"));
+        pairs.push((target.trim().to_string(), os.trim().to_string()));
+    }
+
+    assert!(
+        !pairs.is_empty(),
+        "no build matrix entries found — the parse broke, and a test that \
+         checks nothing passes forever"
+    );
+
+    for (target, os) in &pairs {
+        let is_native = native
+            .iter()
+            .any(|(runner, triple)| runner == os && triple == target);
+        if is_native {
+            continue;
+        }
+        assert!(
+            toolchain.contains(target),
+            "{target} is cross-compiled on {os} but rust-toolchain.toml does not \
+             pin it, so the pinned toolchain has no std for it and the release \
+             build fails with `can't find crate for core`"
+        );
+    }
+}
+
 fn ci_workflow() -> String {
     let path = Path::new(".github/workflows/ci.yml");
     fs::read_to_string(path)


### PR DESCRIPTION
The v0.18.0-rc.1 pipeline (run 34101892146) failed on `build (aarch64-unknown-linux-gnu, ubuntu-latest)` with `error[E0463]: can't find crate for core` compiling cfg-if, 99 seconds in.

**Nothing published.** The `release` job requires every build to succeed, so it and `verify-release` were skipped. Every other job was green, including the Linux/Firecracker e2e, BDD, both initramfs images, and the macOS recorded-evidence lane.

## Cause

`release.yml` passes `targets:` to `dtolnay/rust-toolchain`, which installs them for **that action's** toolchain. `rust-toolchain.toml` then overrides which toolchain cargo actually uses, and the override does not inherit those targets. The pinned nightly had no std for `aarch64-unknown-linux-gnu`.

The workflow's own `targets:` line is what makes this hard to see — it looks like it has already covered exactly this case.

The other three published targets are each their runner's native triple, so their std ships with the toolchain and they built fine. This is the matrix's only true cross-compile, and the only one absent from the file.

## Why it took a tagged release to find

No lane outside `release.yml` builds this target — I grepped every workflow. So it could have been broken for months with nothing to reveal it, and the first evidence available was a release pipeline going red.

The test closes that gap without adding a build lane: it walks `release.yml`'s build matrix, exempts targets native to their runner, and requires the rest to be pinned in `rust-toolchain.toml`. Exempting native triples matters — listing every host triple would make each contributor install std for platforms they never build.

## The test's first draft was wrong

It passed with the fix removed. It searched the whole file and matched the **comment** above the array, which names the very target it explains. It now parses the `targets = [...]` array alone, and I re-verified by deleting the entry while leaving that comment in place: it fails, naming the target and the runner.

`cargo nextest run -p mvmctl --test release_assets`: 36 passed. fmt and clippy clean.