### PR TITLE
docs(blog): CVE-2024-5565 teardown — Vanna's exec() on LLM output

### DIFF
--- a/public/public/blog/cve-2024-5565-vanna.svg
+++ b/public/public/blog/cve-2024-5565-vanna.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+<title id="title">CVE-2024-5565 attack chain</title>
+<desc id="desc">untrusted question/data then LLM then generated Python then exec() then host process — the chain CVE-2024-5565 follows in vanna 0.5.5, ending at exec(plotly_code, globals(), ldict).</desc>
+<defs>
+<linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0d1117"/><stop offset="0.5" stop-color="#121821"/><stop offset="1" stop-color="#0b1620"/></linearGradient>
+<filter id="soft" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#010409" flood-opacity="0.42"/></filter>
+</defs>
+<rect width="1600" height="900" fill="url(#bg)"/>
+<g opacity="0.20" stroke="#30363d" stroke-width="1">
+<path d="M120 160H1480M120 300H1480M120 440H1480M120 580H1480M120 720H1480"/>
+<path d="M320 110V820M620 110V820M920 110V820M1220 110V820"/>
+</g>
+<text x="120" y="190" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="64" fill="#e6edf3" font-weight="650" text-anchor="start">CVE-2024-5565</text>
+<text x="120" y="244" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="30" fill="#8b949e" font-weight="500" text-anchor="start">vanna 0.5.5 — caught by mvm-scout before merge</text>
+<g filter="url(#soft)">
+<rect x="120" y="360" width="248" height="190" rx="18" fill="#161b22" stroke="#58a6ff" stroke-width="2" />
+<text x="244.0" y="449.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">untrusted</text>
+<text x="244.0" y="483.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">question/data</text>
+<path d="M370.0 442.0 l13 13 l-13 13" fill="none" stroke="#8b949e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="398" y="360" width="248" height="190" rx="18" fill="#161b22" stroke="#30363d" stroke-width="2" />
+<text x="522.0" y="449.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">LLM</text>
+<path d="M648.0 442.0 l13 13 l-13 13" fill="none" stroke="#8b949e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="676" y="360" width="248" height="190" rx="18" fill="#161b22" stroke="#30363d" stroke-width="2" />
+<text x="800.0" y="449.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">generated Python</text>
+<path d="M926.0 442.0 l13 13 l-13 13" fill="none" stroke="#8b949e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="954" y="360" width="248" height="190" rx="18" fill="#161b22" stroke="#30363d" stroke-width="2" />
+<text x="1078.0" y="449.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">exec()</text>
+<path d="M1204.0 442.0 l13 13 l-13 13" fill="none" stroke="#8b949e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="1232" y="360" width="248" height="190" rx="18" fill="#161b22" stroke="#f85149" stroke-width="2" />
+<text x="1356.0" y="449.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">host process</text>
+</g>
+<text x="1356.0" y="598" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="25" fill="#f85149" font-weight="500" text-anchor="middle">exec(plotly_code, globals(), ldict)</text>
+<rect x="120" y="660" width="1360" height="120" rx="20" fill="#0e141b" stroke="#30363d" stroke-width="2" />
+<text x="160" y="706" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="19" fill="#8b949e" font-weight="600" text-anchor="start">ROOT CAUSE</text>
+<text x="160" y="748" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="start">src/vanna/base/base.py:1998</text>
+<text x="1140" y="706" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="19" fill="#8b949e" font-weight="600" text-anchor="start">DETECTED BY</text>
+<text x="1140" y="748" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="27" fill="#3fb950" font-weight="500" text-anchor="start">SCOUT-RCE-002</text>
+</svg>

--- a/public/src/content/blog/cve-2024-5565-vanna.md
+++ b/public/src/content/blog/cve-2024-5565-vanna.md
@@ -1,0 +1,86 @@
+---
+title: "CVE-2024-5565 — Vanna's exec() call turns prompt injection into code execution"
+description: "A teardown of how Vanna's text-to-SQL visualization feature hands LLM-generated Python straight to exec(), and how mvm-scout's SCOUT-RCE-002 rule caught the pattern and cleared on the one-line fix."
+date: 2026-09-06
+tags:
+  - security
+  - cve-teardown
+  - prompt-injection
+  - python
+  - llm
+  - vanna
+heroImage: /blog/cve-2024-5565-vanna.svg
+heroAlt: "A diagram showing an untrusted question or data source flowing into an LLM, which generates Python plotting code, which is passed to exec() and runs with the host process's own privileges."
+---
+
+## The bug
+
+Vanna is a text-to-SQL library: you ask it a question in natural language, and it asks an LLM to write SQL, run it, and chart the result. The charting step is where CVE-2024-5565 lives. To draw the chart, Vanna asks the LLM to write Plotly code, and then it runs whatever comes back.
+
+That's the whole vulnerability. There's no sandbox, no allowlist of safe operations, no parser that checks the generated code is actually a chart. It's a natural-language interface with `exec()` sitting behind it. CVSS scores it 8.1, GitHub rates it Critical, and the advisory (GHSA-7735-w2jp-gvg6) tracks the same identifier. It's fixed in 0.7.9; anything at 0.5.5 or the surrounding range is exposed.
+
+What makes this one worth a teardown isn't the exec-on-LLM-output pattern itself — that shape shows up across the LLM tooling ecosystem — it's how directly the fix maps to the flaw. One function call, in one file, on one line, is the entire attack surface. That makes it an unusually clean case for asking whether a detection rule is actually tracking the root cause, or just pattern-matching on noise nearby.
+
+## The mechanism
+
+The vulnerable code lives in `src/vanna/base/base.py`, line 1998:
+
+```python
+exec(plotly_code, globals(), ldict)
+```
+
+`plotly_code` is text the LLM produced. It's handed to `exec()` along with the real `globals()` dict — not a restricted namespace, the actual module globals. Anything the model was steered into emitting runs as native Python inside the host process, with access to whatever that process can already reach: imports, the filesystem, sockets, credentials sitting in memory or environment variables.
+
+The attacker doesn't need direct access to the codebase or the process to trigger this. They need to influence what the LLM writes. That can be a crafted question a user types in, a poisoned row in the underlying dataset that the LLM summarizes as part of building the chart, or any of the standard indirect-prompt-injection vectors where the model reads untrusted content and treats instructions embedded in it as if they came from the operator. Once the model can be steered into emitting `import os; os.system(...)` instead of `fig = px.bar(...)`, the charting feature is a general-purpose code execution primitive.
+
+## What the scan found
+
+We ran mvm-scout (rev `59aae67`) against the vulnerable specimen. Its `SCOUT-RCE-002` rule is built to flag exactly this shape — unguarded dynamic execution of externally-influenced input — and it fired on the exec() call at line 1998.
+
+Seven rules fired against this specimen in total, but six of them are not evidence of anything specific to this CVE: `SCOUT-AGENT-001`, `SCOUT-AUTHORITY-001`, `SCOUT-CVE-001`, `SCOUT-SECRET-001`, `SCOUT-SECRET-003`, and `SCOUT-SSRF-001` all fired identically on both the vulnerable specimen and the patched control. A rule that fires the same way regardless of whether the vulnerability is present isn't telling you anything about the vulnerability — it's describing something else about the codebase. We're not citing those six as evidence for this writeup, and you should be skeptical of any teardown that lumps a pile of same-on-both-sides hits in with the one that actually discriminates.
+
+`SCOUT-RCE-002` is the one rule that behaved differently between the two, which is what makes it worth reporting.
+
+## The falsification
+
+This is the part that actually matters, more than the initial hit. A rule firing on vulnerable code is easy — the hard part is showing it isn't firing on something incidental to the file, the library, or the sample.
+
+The entire diff between the specimen and the control is one line:
+
+```diff
+1998c1998
+<             exec(plotly_code, globals(), ldict)
+---
+>             ldict["fig"] = safe_eval_plotly_expression(plotly_code, df)
+```
+
+Everything else in the file — imports, surrounding functions, class structure, the rest of the 1998 lines above and below — is untouched. We reran mvm-scout against that single-line mutation. `SCOUT-RCE-002` went from firing to silent. Nothing else changed in the rule output for that check.
+
+That's the differential: `SCOUT-RCE-002` fires on the specimen, clears on the control, and the only thing that moved between the two runs is the line the CVE is actually about. If the rule had kept firing after the patch, that would mean it was keying off something else in the file — a library name, an import pattern, incidental structure — and the earlier hit would have been coincidence dressed up as detection. It didn't. The signal tracks the root cause.
+
+## What this evidence does not show
+
+This is scout-detection evidence, not an MVM containment trace, and it's worth being precise about the boundary.
+
+No exploit was attempted or blocked in this run. We didn't craft a malicious question, feed Vanna a poisoned data source, or demonstrate that the injection path is reachable by an attacker-controlled prompt in an actual deployment — we compared static source across a specimen and a one-line control. `mvm_outcome` was not tested here, so nothing in this report supports a claim that MVM prevented the breach, contained anything in a guest, or stopped an exploit from running. Those are separate, not-yet-tested questions, and this run doesn't speak to them either way.
+
+The defensible statement is narrower than that, and it's the one this report actually makes: `mvm-scout` caught the vulnerable `exec()` pattern in the specimen and correctly cleared once the code was changed to use a constrained evaluator. Nothing here certifies Vanna, `mvm-scout`, or MVM. It documents one detection result, on one specimen/control pair, run on 2026-09-06. The underlying CVE still fires wherever the patch is absent, regardless of what any scanner reports about it.
+
+## The evidence behind this post
+
+Every figure above came out of a run, not a writeup. These are the exact inputs, so you can re-derive them:
+
+| | |
+|---|---|
+| Advisory | CVE-2024-5565 |
+| Package | vanna 0.5.5 (PyPI) |
+| Fixed in | 0.7.9 |
+| Severity / CVSS | Critical · 8.1 |
+| Root cause | `src/vanna/base/base.py:1998` |
+| Detected by | `SCOUT-RCE-002` |
+| Scanned bytes (sha256) | `6022fd32186b19ea15bfd75af3935d5af110b67a9f9164b28f9019a3fc10d135` |
+| mvm-assurance revision | `59aae67` |
+| Containment demo | not run |
+
+The scan target was the unmodified upstream file at that tag — the digest above is
+of the bytes the project published. The control differs from it by exactly one line.


### PR DESCRIPTION
The second CVE teardown, generated from a recorded `mvm-scout` evidence run rather than written by hand. Follows #3197.

## The bug

Vanna turns a question into SQL, then asks an LLM to write the Plotly code that charts the result — and runs the answer:

```python
exec(plotly_code, globals(), ldict)
```

`plotly_code` is raw model output, executed against the real `globals()`. Steer the model — via the question, or via data it summarizes — and a charting feature becomes arbitrary code execution. Fixed in 0.7.9.

## What the evidence shows

| | |
|---|---|
| Advisory | CVE-2024-5565 · Critical · CVSS 8.1 |
| Root cause | `src/vanna/base/base.py:1998` |
| Detected by | `SCOUT-RCE-002` |
| Differential | **STRONG** — fires on the specimen, clears on the control |
| Scanned bytes | `6022fd32186b19ea15bfd75af3935d5af110b67a9f9164b28f9019a3fc10d135` |
| Containment | not run |

The digest is of the unmodified upstream file at tag `v0.5.5`, and the control differs from it by exactly one line. Six other rules fire identically on both sides; the post names them as noise rather than citing them as evidence, which is the part worth reading.

## Claim discipline

Detection-only, and it says so. `render-post.py` refuses to emit prose the run does not support — `certified`, `prevented the CVE`, Scout credited with prevention, or a containment claim with no containment leg — and requires a "what this does not show" section. Machine facts are injected from the run, never authored.

## Verification

`pnpm build` in `public/`: 143 pages, no errors. Renders at `/blog/cve-2024-5565-vanna/` with its generated hero and evidence table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)