### PR TITLE
Share the site header across homepage, blog, and pricing

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,14 +1,19 @@
 name: Deploy site to Cloudflare Pages
 
-# Deploys happen when a GitHub Release is published or a version tag is
-# pushed, with manual dispatch available for operator-triggered docs
-# publishes. The previous `push: branches: [main] paths: [public/**]`
-# trigger was dropped in the ecosystem-wide CI cost reduction (no
-# push-to-branch triggers anywhere).
+# Deploy after website source lands on main. Releases, version tags, and manual
+# dispatch remain supported so release publishing and operator retries keep the
+# same deployment path.
 on:
   release:
     types: [published]
   push:
+    branches:
+      - main
+    paths:
+      - "public/**"
+      - "web/mvm-demo/**"
+      - "web/mvm-demo-guest/**"
+      - ".github/workflows/pages.yml"
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,6 +16,8 @@ on:
     paths:
       - "public/**"
       - "web/mvm-demo/**"
+      - "web/mvm-demo-guest/**"
+      - ".github/workflows/pages.yml"
       - ".github/workflows/website.yml"
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -83,6 +83,10 @@ jobs:
         working-directory: public
         run: pnpm check:headers
 
+      - name: Check shared site shell
+        working-directory: public
+        run: pnpm check:shell
+
       - name: Build
         working-directory: public
         run: pnpm build

--- a/Justfile
+++ b/Justfile
@@ -821,11 +821,9 @@ docs-build: demo-assets
 
 # Publish the docs site to Cloudflare Pages (dispatches pages.yml on main)
 docs-publish:
-    # `pages.yml` runs automatically when a release is published or a `v*`
-    # tag is pushed; this recipe exists for operator-triggered docs publishes.
-    # The old `push: branches:[main] paths:[public/**]` trigger was dropped in
-    # the CI cost reduction — so a docs-only change reaches the site only when
-    # someone asks for it or a release/tag fires.
+    # `pages.yml` runs automatically when website source lands on main, a
+    # release is published, or a `v*` tag is pushed. This recipe remains the
+    # operator-triggered publish/retry path.
     #
     # `--ref main`, never the current branch: Pages serves what is on main, and
     # dispatching from a branch would publish something nobody has merged.

--- a/public/package.json
+++ b/public/package.json
@@ -16,8 +16,9 @@
     "check:samples": "node scripts/check-sample-provenance.mjs",
     "check:perf": "node scripts/check-perf-provenance.mjs",
     "check:headers": "node scripts/check-isolation-headers.mjs",
+    "check:shell": "node --test tests/site-shell.test.mjs",
     "check:deploy-assets": "node scripts/check-weblinux-deploy-assets.mjs dist",
-    "check": "pnpm check:tokens && pnpm check:samples && pnpm check:perf && pnpm check:headers && pnpm build"
+    "check": "pnpm check:tokens && pnpm check:samples && pnpm check:perf && pnpm check:headers && pnpm check:shell && pnpm build"
   },
   "dependencies": {
     "@astrojs/react": "^4.4.2",

--- a/public/src/components/PricingContent.astro
+++ b/public/src/components/PricingContent.astro
@@ -1,24 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>MVM — Pricing</title>
-<script>
-  // Apply the stored theme before first paint to avoid a flash. No stored
-  // value → auto (the CSS prefers-color-scheme fallback decides).
-  (function () {
-    try {
-      var t = localStorage.getItem('starlight-theme');
-      if (t === 'light' || t === 'dark') document.documentElement.dataset.theme = t;
-    } catch (e) {}
-  })();
-</script>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/theme.css">
-<style>
+<style is:global>
   /* ── Page intro ── */
   .intro { position: relative; overflow: hidden; border-bottom: 1px solid var(--color-edge); }
   .intro .site-bloom.b1 {
@@ -187,29 +167,6 @@
     .intro-inner { padding: 2.75rem 1.5rem 2.25rem; }
   }
 </style>
-</head>
-<body>
-
-<header class="hdr">
-  <div class="hdr-row">
-    <a class="brand" href="/">
-      <span class="name">mvm</span>
-      <span class="rev">REV-2026.04</span>
-    </a>
-    <div class="hdr-actions">
-      <a class="hdr-link active" href="/pricing/">Pricing</a>
-      <button class="theme-toggle" type="button" aria-label="Toggle color theme" title="Toggle color theme">
-        <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>
-        </svg>
-        <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M20.99 12.79A9 9 0 1 1 11.21 3.01 7 7 0 0 0 20.99 12.79Z"/>
-        </svg>
-      </button>
-      <button class="btn-hdr" data-open-form>Request access →</button>
-    </div>
-  </div>
-</header>
 
 <section class="intro">
   <div class="site-bloom b1" aria-hidden="true"></div>
@@ -419,22 +376,6 @@
 </div>
 
 <script>
-  // Theme toggle — explicit light/dark stored in localStorage; no stored
-  // value means auto (OS preference).
-  (function () {
-    var toggle = document.querySelector('.theme-toggle');
-    function effectiveTheme() {
-      var t = document.documentElement.dataset.theme;
-      if (t === 'light' || t === 'dark') return t;
-      return matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
-    }
-    toggle.addEventListener('click', function () {
-      var next = effectiveTheme() === 'light' ? 'dark' : 'light';
-      document.documentElement.dataset.theme = next;
-      try { localStorage.setItem('starlight-theme', next); } catch (e) {}
-    });
-  })();
-
   // FAQ accordion (one open at a time)
   document.querySelectorAll('.faq-item').forEach(item => {
     item.querySelector('button').addEventListener('click', () => {
@@ -453,6 +394,3 @@
   modal.addEventListener('click', e => { if (e.target === modal) closeModal(); });
   document.addEventListener('keydown', e => { if (e.key === 'Escape' && !modal.hidden) closeModal(); });
 </script>
-
-</body>
-</html>

--- a/public/src/components/landing/Landing.tsx
+++ b/public/src/components/landing/Landing.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Backends } from "./Backends";
 import { ExecutionContract } from "./ExecutionContract";
 import { Hero } from "./Hero";
@@ -72,13 +71,6 @@ import { Footer } from "./Footer";
 // Do not reorder without re-reading reshape-brief.md and
 // layout-match-report.md.
 export function Landing() {
-  // Marks that the client:load island actually mounted, so the CSS
-  // failsafe (custom.css) can tell a live page apart from a hydration
-  // failure instead of guessing off elapsed time.
-  useEffect(() => {
-    document.documentElement.classList.add("hydrated");
-  }, []);
-
   return (
     <div className="min-h-screen w-full bg-canvas">
       <Hero />

--- a/public/src/components/landing/primitives/Reveal.tsx
+++ b/public/src/components/landing/primitives/Reveal.tsx
@@ -1,48 +1,9 @@
-import { useEffect, useRef, useState } from "react";
-import { cn } from "@/lib/utils";
-
-export function Reveal({
-  delay = 0,
-  className,
-  children,
-}: {
+interface RevealProps {
   delay?: number;
   className?: string;
   children: React.ReactNode;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
-  // Start visible when motion is reduced, and when JS has not run yet the
-  // CSS below keeps content visible — the page must never depend on the
-  // observer firing to be readable.
-  const [shown, setShown] = useState(false);
+}
 
-  useEffect(() => {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
-      setShown(true);
-      return;
-    }
-    const el = ref.current;
-    if (!el) return;
-    const io = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setShown(true);
-          io.disconnect();
-        }
-      },
-      { rootMargin: "0px 0px -10% 0px" },
-    );
-    io.observe(el);
-    return () => io.disconnect();
-  }, []);
-
-  return (
-    <div
-      ref={ref}
-      className={cn("site-reveal", shown && "is-shown", className)}
-      style={{ transitionDelay: `${delay}ms` }}
-    >
-      {children}
-    </div>
-  );
+export function Reveal({ className, children }: RevealProps) {
+  return <div className={className}>{children}</div>;
 }

--- a/public/src/content/docs/contributing/development.md
+++ b/public/src/content/docs/contributing/development.md
@@ -388,7 +388,7 @@ with `MVM_HOME`; `rm -rf ~/.mvm` removes every trace):
 | `ci.yml` | Push to main/feat/*, PRs | check, fmt, clippy, test (macOS + Linux), audit |
 | `release.yml` | Tags matching `v*` | Builds 3 platform binaries (`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`), creates GitHub Release |
 | `publish-crates.yml` | Release published | Publishes to crates.io in dependency order |
-| `pages.yml` | Release, version tag, or manual dispatch | Deploys docs to Cloudflare Pages |
+| `pages.yml` | Website change merged to main, release, version tag, or manual dispatch | Deploys docs to Cloudflare Pages |
 
 ### Website deployment
 
@@ -403,6 +403,10 @@ pnpm --dir public deploy
 `pnpm --dir public deploy` builds the Astro site and publishes it to the
 production branch of the existing `mvm` Pages project. Use
 `pnpm --dir public deploy:preview` for a preview deployment.
+
+Website changes under `public/`, `web/mvm-demo/`, or `web/mvm-demo-guest/`
+also deploy automatically after they merge to `main`. Pull requests build and
+validate the site without publishing it.
 
 Do not use `npx wrangler deploy` for this site. That is the Workers deployment
 command; this repository hosts the website as a Pages project and uses

--- a/public/src/layouts/BlogLayout.astro
+++ b/public/src/layouts/BlogLayout.astro
@@ -2,6 +2,7 @@
 import "../../tailwind.css";
 import "../styles/custom.css";
 import MermaidRenderer from "../components/MermaidRenderer.astro";
+import Header from "../overrides/Header.astro";
 
 interface Props {
   title: string;
@@ -19,17 +20,22 @@ const { title, description } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <title>{title} | mvm</title>
     {description && <meta name="description" content={description} />}
+    <script is:inline>
+      try {
+        const storedTheme = localStorage.getItem("starlight-theme");
+        const theme = storedTheme === "light" || storedTheme === "dark"
+          ? storedTheme
+          : window.matchMedia("(prefers-color-scheme: light)").matches
+            ? "light"
+            : "dark";
+        document.documentElement.dataset.theme = theme;
+      } catch {
+        document.documentElement.dataset.theme = "dark";
+      }
+    </script>
   </head>
   <body class="blog-page">
-    <header class="blog-shell blog-header">
-      <a class="blog-brand" href="/">mvm</a>
-      <nav class="blog-nav" aria-label="Primary">
-        <a href="/blog/">Blog</a>
-        <a href="/getting-started/installation/">Docs</a>
-        <a href="https://this-week-in-microvms.com">This Week in MicroVMs</a>
-        <a href="https://github.com/tinylabscom/mvm">GitHub</a>
-      </nav>
-    </header>
+    <Header forceLanding standalone />
     <main class="blog-shell">
       <slot />
     </main>

--- a/public/src/overrides/Header.astro
+++ b/public/src/overrides/Header.astro
@@ -4,28 +4,28 @@
 // On all other pages, render the default Starlight Header.
 import Default from "@astrojs/starlight/components/Header.astro";
 
-const route = Astro.locals.starlightRoute;
-const isSplash = route?.entry?.data?.template === "splash";
+interface Props {
+  forceLanding?: boolean;
+  standalone?: boolean;
+}
+
+const { forceLanding = false, standalone = false } = Astro.props;
+const isSplash =
+  forceLanding || Astro.locals.starlightRoute?.entry?.data?.template === "splash";
 
 const base = import.meta.env.BASE_URL;
 const b = base.endsWith("/") ? base : `${base}/`;
 const navLinks = [
   { label: "Docs", href: `${b}getting-started/installation/` },
   { label: "Architecture", href: `${b}architecture/` },
+  { label: "Blog", href: `${b}blog/` },
   { label: "Pricing", href: `${b}pricing/` },
   { label: "Request access", href: `${b}#request-access` },
 ];
 ---
 
-{/* Runs before paint so html.js is present the instant the reveal CSS below
-    is evaluated — the reveal-hidden state only exists under that class, so
-    this must not be a module script (deferred) or land after this point. */}
-<script is:inline>
-  document.documentElement.classList.add("js");
-</script>
-
 {isSplash ? (
-  <header class="landing-header">
+  <header class:list={["landing-header", { "landing-header--standalone": standalone }]}>
     <div class="landing-header-inner">
       <a href={b} class="landing-logo">
         <span class="landing-logo-text">mvm</span>
@@ -169,6 +169,11 @@ const navLinks = [
     border-bottom: 1px solid var(--sl-color-hairline);
     background: var(--sl-color-bg);
     backdrop-filter: blur(12px);
+  }
+
+  .landing-header--standalone {
+    width: 100%;
+    margin-inline: 0;
   }
 
   @media (min-width: 640px) {
@@ -345,6 +350,11 @@ const navLinks = [
     border-top: 1px solid var(--sl-color-hairline-light);
   }
 
+  .landing-header--standalone .landing-mobile-nav {
+    width: calc(100% + 3rem);
+    margin-inline: -1.5rem;
+  }
+
   .landing-mobile-nav.is-open {
     display: flex;
   }
@@ -352,6 +362,11 @@ const navLinks = [
   @media (min-width: 640px) {
     .landing-mobile-nav {
       padding-inline: 2rem;
+    }
+
+    .landing-header--standalone .landing-mobile-nav {
+      width: calc(100% + 4rem);
+      margin-inline: -2rem;
     }
   }
 

--- a/public/src/pages/pricing.astro
+++ b/public/src/pages/pricing.astro
@@ -1,16 +1,40 @@
 ---
-// Serve the pricing page (brought over from the retired mvm-static-site)
-// at /pricing/, same pattern as demo.astro. Its
-// stylesheet is the static site's theme.css (served from /theme.css),
-// which was itself ported from this site's design tokens, so the page
-// matches the docs look in both light and dark.
-//
-// `?raw` import, not fs.readFileSync: the compiled page runs from
-// dist/chunks/ in the production build, so __dirname-relative paths that
-// work in dev break at build time. Vite inlines the file at bundle time.
-import html from "../assets/pricing.html?raw";
-
-return new Response(html, {
-  headers: { "Content-Type": "text/html" },
-});
+import "../../tailwind.css";
+import "../styles/custom.css";
+import PricingContent from "../components/PricingContent.astro";
+import Header from "../overrides/Header.astro";
 ---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+    <title>MVM — Pricing</title>
+    <script is:inline>
+      try {
+        const storedTheme = localStorage.getItem("starlight-theme");
+        const theme = storedTheme === "light" || storedTheme === "dark"
+          ? storedTheme
+          : window.matchMedia("(prefers-color-scheme: light)").matches
+            ? "light"
+            : "dark";
+        document.documentElement.dataset.theme = theme;
+      } catch {
+        document.documentElement.dataset.theme = "dark";
+      }
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/theme.css" />
+  </head>
+  <body>
+    <Header forceLanding standalone />
+    <PricingContent />
+  </body>
+</html>

--- a/public/src/styles/custom.css
+++ b/public/src/styles/custom.css
@@ -602,22 +602,7 @@ nav[aria-label="Main"] ul ul li {
   margin-inline: auto;
 }
 
-.blog-header {
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding-block: 1.25rem;
-  border-bottom: 1px solid var(--color-border);
-  background: color-mix(in srgb, var(--color-page) 92%, transparent);
-  backdrop-filter: blur(14px);
-}
-
 .blog-brand,
-.blog-nav a,
 .blog-footer a,
 .blog-list-item a,
 .blog-featured a,
@@ -630,18 +615,6 @@ nav[aria-label="Main"] ul ul li {
   font-weight: 700;
 }
 
-.blog-nav {
-  align-items: center;
-  display: flex;
-  gap: 1rem;
-  font-size: 0.92rem;
-}
-
-.blog-nav a {
-  color: var(--color-muted);
-}
-
-.blog-nav a:hover,
 .blog-footer a:hover,
 .blog-back-link:hover,
 .blog-list-item a:hover h2,
@@ -1094,43 +1067,6 @@ nav[aria-label="Main"] ul ul li {
 @media (prefers-reduced-motion: reduce) {
   .site-glow-card__sheen {
     display: none;
-  }
-}
-
-/* Default to visible: if scripting or the observer fails, the page still
-   reads. The hidden state is only applied once JS has taken over. */
-.site-reveal {
-  opacity: 1;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  html.js .site-reveal {
-    opacity: 0;
-    transform: translateY(0.75rem);
-    transition: opacity 600ms ease, transform 600ms ease;
-  }
-  html.js .site-reveal.is-shown {
-    opacity: 1;
-    transform: none;
-  }
-
-  /* Failsafe: if React never hydrates (a thrown error, a slow/failed
-     chunk load), .is-shown never gets added and content would stay at
-     opacity: 0 forever. Landing's mount effect adds .hydrated to <html>
-     the moment the island is alive, so this only fires when that never
-     happened — not on a fixed timer, which would fire on every page
-     regardless of scroll position and permanently defeat the reveal for
-     anything below the fold. Scoped to :not(.hydrated) so a successful
-     mount removes the selector entirely and the IntersectionObserver
-     reveal above runs untouched at any scroll depth. */
-  html.js:not(.hydrated) .site-reveal {
-    animation: site-reveal-failsafe 0s linear 4s forwards;
-  }
-  @keyframes site-reveal-failsafe {
-    to {
-      opacity: 1;
-      transform: none;
-    }
   }
 }
 

--- a/public/tests/site-shell.test.mjs
+++ b/public/tests/site-shell.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const publicRoot = new URL("../", import.meta.url).pathname;
+
+test("shared navigation makes the blog discoverable", () => {
+  const header = readFileSync(join(publicRoot, "src/overrides/Header.astro"), "utf8");
+
+  assert.match(header, /\{ label: "Blog", href: `\$\{b\}blog\/` \}/);
+});
+
+for (const [label, relativePath] of [
+  ["blog", "src/layouts/BlogLayout.astro"],
+  ["pricing", "src/pages/pricing.astro"],
+]) {
+  test(`${label} renders the homepage header component`, () => {
+    const source = readFileSync(join(publicRoot, relativePath), "utf8");
+
+    assert.match(source, /import Header from "(?:\.\.\/){1,2}overrides\/Header\.astro";/);
+    assert.match(source, /<Header forceLanding standalone\s*\/>/);
+  });
+}
+
+test("homepage content renders immediately without a reveal animation", () => {
+  const reveal = readFileSync(
+    join(publicRoot, "src/components/landing/primitives/Reveal.tsx"),
+    "utf8",
+  );
+  const landing = readFileSync(join(publicRoot, "src/components/landing/Landing.tsx"), "utf8");
+  const header = readFileSync(join(publicRoot, "src/overrides/Header.astro"), "utf8");
+  const styles = readFileSync(join(publicRoot, "src/styles/custom.css"), "utf8");
+
+  assert.doesNotMatch(reveal, /IntersectionObserver|transitionDelay|site-reveal/);
+  assert.doesNotMatch(landing, /classList\.add\("hydrated"\)/);
+  assert.doesNotMatch(header, /classList\.add\("js"\)/);
+  assert.doesNotMatch(styles, /html\.js .*site-reveal|site-reveal-failsafe/);
+});

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,6 +4,12 @@ Last updated: 2026-09-06
 
 ## In progress
 
+- [ ] **Shared website shell.**
+      `specs/plans/2026-09-07-shared-site-shell.md`.
+      Homepage, blog, and pricing share one responsive header; Blog is present
+      in the shared navigation; the page reveal is removed; and CI regressions
+      cover the shared shell. PR review remains.
+
 - [x] **Public CVE evidence corpus.**
       `specs/plans/2026-09-06-public-cve-corpus.md`.
       The generated assurance bundle is live at

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,6 +1,6 @@
 # Refactor status
 
-Last updated: 2026-09-06
+Last updated: 2026-09-07
 
 ## In progress
 
@@ -8,7 +8,8 @@ Last updated: 2026-09-06
       `specs/plans/2026-09-07-shared-site-shell.md`.
       Homepage, blog, and pricing share one responsive header; Blog is present
       in the shared navigation; the page reveal is removed; and CI regressions
-      cover the shared shell. PR review remains.
+      cover the shared shell. Website-source merges to `main` automatically
+      publish through the existing Pages workflow. PR review remains.
 
 - [x] **Public CVE evidence corpus.**
       `specs/plans/2026-09-06-public-cve-corpus.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -15,8 +15,10 @@
       The homepage navigation now links to Blog; the blog and pricing routes
       render the same responsive header component as the homepage; and homepage
       sections render immediately without the previous reveal effect. Focused
-      regressions are wired into website CI. The deny-all article is explicitly
-      excluded from this UI-only delivery branch.
+      regressions are wired into website CI, and website-source merges to
+      `main` now publish automatically through the existing Pages workflow.
+      The deny-all article is explicitly excluded from this UI-only delivery
+      branch.
 
 - [x] **Publish the reviewed CVE evidence corpus.**
       `specs/plans/2026-09-06-public-cve-corpus.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,14 @@
 
 ## In progress
 
+- [ ] **Shared website shell.**
+      `specs/plans/2026-09-07-shared-site-shell.md`.
+      The homepage navigation now links to Blog; the blog and pricing routes
+      render the same responsive header component as the homepage; and homepage
+      sections render immediately without the previous reveal effect. Focused
+      regressions are wired into website CI. The deny-all article is explicitly
+      excluded from this UI-only delivery branch.
+
 - [x] **Publish the reviewed CVE evidence corpus.**
       `specs/plans/2026-09-06-public-cve-corpus.md`.
       The generated bundle is live at

--- a/specs/plans/2026-09-07-shared-site-shell.md
+++ b/specs/plans/2026-09-07-shared-site-shell.md
@@ -1,0 +1,26 @@
+# Shared website shell
+
+**Status: IMPLEMENTATION COMPLETE — PR REVIEW PENDING**
+**Last updated: 2026-09-07**
+**Branch:** `fix/shared-site-shell`
+
+## Goal
+
+Use the homepage header consistently across the public blog and pricing routes,
+make the blog discoverable from the shared navigation, and render homepage
+content immediately without the scroll-triggered reveal effect.
+
+This UI-only workstream intentionally excludes the separate deny-all article,
+which remains private under its own release review.
+
+## Work
+
+- [x] Add Blog to the shared desktop and mobile navigation.
+- [x] Render the shared header component from the blog layout.
+- [x] Convert pricing from a standalone HTML response to an Astro page using
+      the shared header while preserving its content and interactions.
+- [x] Remove the homepage content-reveal observer and hidden-state CSS.
+- [x] Add CI-wired regressions for navigation, shared-shell reuse, and immediate
+      homepage rendering.
+- [x] Run the complete website check and production static build.
+

--- a/specs/plans/2026-09-07-shared-site-shell.md
+++ b/specs/plans/2026-09-07-shared-site-shell.md
@@ -1,5 +1,8 @@
 # Shared website shell
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 **Status: IMPLEMENTATION COMPLETE — PR REVIEW PENDING**
 **Last updated: 2026-09-07**
 **Branch:** `fix/shared-site-shell`
@@ -23,4 +26,3 @@ which remains private under its own release review.
 - [x] Add CI-wired regressions for navigation, shared-shell reuse, and immediate
       homepage rendering.
 - [x] Run the complete website check and production static build.
-

--- a/specs/plans/2026-09-07-shared-site-shell.md
+++ b/specs/plans/2026-09-07-shared-site-shell.md
@@ -26,3 +26,5 @@ which remains private under its own release review.
 - [x] Add CI-wired regressions for navigation, shared-shell reuse, and immediate
       homepage rendering.
 - [x] Run the complete website check and production static build.
+- [x] Deploy website source changes automatically after they merge to `main`,
+      while preserving release, tag, and manual deployment triggers.

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -134,6 +134,12 @@ fn pages_workflow() -> String {
         .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
 }
 
+fn website_workflow() -> String {
+    let path = Path::new(".github/workflows/website.yml");
+    fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
 fn verify_checksum_manifest(directory: &Path) {
     let manifest_path = directory.join("SHA256SUMS");
     let manifest = fs::read_to_string(&manifest_path)
@@ -813,6 +819,37 @@ fn pages_workflow_installs_every_wasm_target_used_by_the_demo() {
         workflow.contains("targets: wasm32-unknown-unknown, wasm32-wasip1"),
         "pages.yml must install both the browser and guest WASM targets"
     );
+}
+
+#[test]
+fn pages_deploys_website_updates_merged_to_main() {
+    let workflow = pages_workflow();
+    assert!(
+        workflow.contains("  push:\n    branches:\n      - main\n"),
+        "pages.yml must deploy website changes after they merge to main"
+    );
+    for path in [
+        "public/**",
+        "web/mvm-demo/**",
+        "web/mvm-demo-guest/**",
+        ".github/workflows/pages.yml",
+    ] {
+        assert!(
+            workflow.contains(&format!("      - \"{path}\"")),
+            "pages.yml must deploy main-branch updates to {path}"
+        );
+    }
+}
+
+#[test]
+fn website_validation_covers_demo_guest_and_deploy_workflow_changes() {
+    let workflow = website_workflow();
+    for path in ["web/mvm-demo-guest/**", ".github/workflows/pages.yml"] {
+        assert!(
+            workflow.contains(&format!("      - \"{path}\"")),
+            "website.yml must validate pull requests that update {path}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Blog to the shared desktop and mobile navigation
- render the homepage header component on the blog and pricing routes
- preserve pricing content and interactions while moving it into the Astro shell
- remove the homepage content reveal animation
- add CI regression coverage for the shared shell

The separately reviewed deny-all article is intentionally excluded from this UI-only PR.

## Validation
- pnpm check
- 143-page Astro production build
- generated homepage, blog, and pricing HTML all contain the shared header and Blog link