### PR TITLE
release: re-record the macOS/HVF evidence after the release-tooling fixes

### DIFF
--- a/specs/evidence/e2e/macos-hvf.json
+++ b/specs/evidence/e2e/macos-hvf.json
@@ -1,8 +1,8 @@
 {
   "lane": "macos-hvf",
-  "commit": "2025b830f01da8a8dfe6f14ca7b970e2084f6d86",
-  "material_digest": "4ba4755a1a8535ec38b2f9359343556e087ebb86a94c487ec14b37bcfaa6c294",
-  "recorded_at": "2026-09-07T06:09:13Z",
+  "commit": "ee7270990ee2ba29d6653e42e7854520a0e380e9",
+  "material_digest": "3df5037669791a4dd02dcd24067e0f10e6820821515b8fa467ebd1b69bfdfd5e",
+  "recorded_at": "2026-09-07T20:40:34Z",
   "host": {
     "os": "Darwin",
     "os_version": "26.5.2",


### PR DESCRIPTION
Required before re-tagging v0.18.0-rc.1.

The previous record no longer describes main: #3200 changed the `Justfile` and #3201 changed `rust-toolchain.toml`, both material paths, so the digest moved and `check-release-evidence` refuses it.

Re-run rather than re-stamped — attaching the earlier log to the new digest would assert a run against a tree it never ran on.

308 scenarios (307 passed, 1 skipped) on Darwin arm64. `check-release-evidence` passes against this tree.