### PR TITLE
fix: align public page gutters and clean docs startup

### DIFF
--- a/crates/mvm-conformance/build.rs
+++ b/crates/mvm-conformance/build.rs
@@ -8,7 +8,7 @@
 //! included by `tests/doc_rust_examples.rs`, so `cargo check -p mvm-conformance
 //! --tests` type-checks it against the real workspace crates. A block that
 //! cannot compile as written — an IR shape sketch with `…` in it — opts out
-//! with ```rust,ignore and must say why on its first line.
+//! with ```rust ignore and must say why on its first line.
 
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
@@ -117,10 +117,14 @@ fn rust_blocks(contents: &str) -> Vec<RustBlock> {
             continue;
         }
         if let Some(info) = trimmed.strip_prefix("```") {
-            let token = info.split_whitespace().next().unwrap_or_default();
-            let mut parts = token.split(',');
+            let mut tokens = info.split_whitespace();
+            let first = tokens.next().unwrap_or_default();
+            let mut parts = first.split(',');
             if parts.next().map(str::to_ascii_lowercase).as_deref() == Some("rust") {
-                let ignored = parts.any(|a| a == "ignore" || a == "no_compile");
+                let ignored = parts
+                    .chain(tokens.flat_map(|token| token.split(',')))
+                    .map(str::to_ascii_lowercase)
+                    .any(|attribute| attribute == "ignore" || attribute == "no_compile");
                 open = Some((index + 1, ignored));
                 body.clear();
             }

--- a/crates/mvm-conformance/src/doc_examples.rs
+++ b/crates/mvm-conformance/src/doc_examples.rs
@@ -72,8 +72,7 @@ pub struct CodeBlock {
     pub line: usize,
     /// The fence's language token, lowercased; empty for a bare ``` fence.
     pub language: String,
-    /// Comma-separated fence attributes after the language (`rust,ignore`),
-    /// following rustdoc's convention.
+    /// Fence attributes after the language (`rust ignore` or `rust,ignore`).
     pub attributes: Vec<String>,
     /// The block body, newline-joined, without the fences.
     pub body: String,
@@ -210,8 +209,8 @@ fn is_placeholder(token: &str) -> bool {
 
 /// Split a documentation file into its fenced code blocks.
 ///
-/// Info strings beyond the language (```nix "mkGuest") are ignored: only the
-/// first whitespace-delimited token is the language.
+/// The first info-string token is the language. Later whitespace- or
+/// comma-separated tokens are retained as attributes.
 pub fn code_blocks(file: &str, contents: &str) -> Vec<CodeBlock> {
     let mut blocks = Vec::new();
     let mut open: Option<CodeBlock> = None;
@@ -231,23 +230,15 @@ pub fn code_blocks(file: &str, contents: &str) -> Vec<CodeBlock> {
             }
             None => {
                 if let Some(info) = trimmed.strip_prefix("```") {
+                    let mut tokens = info.split_whitespace();
+                    let first = tokens.next().unwrap_or_default();
+                    let mut parts = first.split(',');
                     open = Some(CodeBlock {
                         file: file.to_string(),
                         line: index + 1,
-                        language: info
-                            .split_whitespace()
-                            .next()
-                            .unwrap_or_default()
-                            .split(',')
-                            .next()
-                            .unwrap_or_default()
-                            .to_ascii_lowercase(),
-                        attributes: info
-                            .split_whitespace()
-                            .next()
-                            .unwrap_or_default()
-                            .split(',')
-                            .skip(1)
+                        language: parts.next().unwrap_or_default().to_ascii_lowercase(),
+                        attributes: parts
+                            .chain(tokens.flat_map(|token| token.split(',')))
                             .map(|attribute| attribute.trim().to_ascii_lowercase())
                             .filter(|attribute| !attribute.is_empty())
                             .collect(),
@@ -1267,6 +1258,18 @@ mod tests {
     fn code_blocks_ignore_the_info_string_beyond_the_language() {
         let blocks = code_blocks("doc.md", "```nix \"mkGuest\"\n{}\n```\n");
         assert_eq!(blocks[0].language, "nix");
+    }
+
+    #[test]
+    fn code_blocks_accept_whitespace_separated_fence_attributes() {
+        let blocks = code_blocks(
+            "doc.md",
+            "```rust ignore\n// illustrative: incomplete type sketch\n```\n",
+        );
+
+        assert_eq!(blocks[0].language, "rust");
+        assert!(blocks[0].is_ignored());
+        assert_eq!(blocks[0].ignore_reason(), Some("incomplete type sketch"));
     }
 
     #[test]

--- a/crates/mvm-conformance/tests/doc_rust_examples.rs
+++ b/crates/mvm-conformance/tests/doc_rust_examples.rs
@@ -7,7 +7,7 @@
 //! directly above the offending function.
 //!
 //! Blocks that cannot compile as written (IR shape sketches carrying `…`) opt
-//! out with ```rust,ignore and must state why; the `bdd` suite checks that the
+//! out with ```rust ignore and must state why; the `bdd` suite checks that the
 //! reason is there.
 
 include!(concat!(env!("OUT_DIR"), "/doc_rust_examples.rs"));

--- a/public/package.json
+++ b/public/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "packageManager": "pnpm@10.33.2",
   "scripts": {
-    "dev": "astro dev",
+    "dev": "node scripts/clear-content-cache.mjs && astro dev",
     "start": "astro dev",
     "build": "astro build",
     "deploy": "pnpm build && pnpm check:deploy-assets && wrangler pages deploy --branch=main",
@@ -16,7 +16,7 @@
     "check:samples": "node scripts/check-sample-provenance.mjs",
     "check:perf": "node scripts/check-perf-provenance.mjs",
     "check:headers": "node scripts/check-isolation-headers.mjs",
-    "check:shell": "node --test tests/site-shell.test.mjs",
+    "check:shell": "node --test tests/site-shell.test.mjs tests/clear-content-cache.test.mjs",
     "check:deploy-assets": "node scripts/check-weblinux-deploy-assets.mjs dist",
     "check": "pnpm check:tokens && pnpm check:samples && pnpm check:perf && pnpm check:headers && pnpm check:shell && pnpm build"
   },

--- a/public/public/theme.css
+++ b/public/public/theme.css
@@ -127,8 +127,12 @@ h1, h2, h3, h4 {
 }
 a { color: inherit; }
 
-.container { max-width: 72rem; margin: 0 auto; padding: 0 1.5rem; }
-@media (min-width: 640px) { .container { padding: 0 2rem; } }
+.container {
+  width: 100%;
+  max-width: calc(var(--site-content-width) + (2 * var(--site-gutter)));
+  margin: 0 auto;
+  padding-inline: var(--site-gutter);
+}
 
 /* Eyebrow — small mono caps, same treatment as the docs sidebar group
    labels and homepage eyebrows. */

--- a/public/scripts/clear-content-cache.mjs
+++ b/public/scripts/clear-content-cache.mjs
@@ -1,0 +1,14 @@
+import { rm } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const defaultPublicRoot = dirname(dirname(scriptPath));
+
+export async function clearContentCache(publicRoot = defaultPublicRoot) {
+  await rm(join(publicRoot, ".astro", "data-store.json"), { force: true });
+}
+
+if (process.argv[1] === scriptPath) {
+  await clearContentCache();
+}

--- a/public/src/components/PricingContent.astro
+++ b/public/src/components/PricingContent.astro
@@ -7,9 +7,11 @@
   }
   .intro-inner {
     position: relative;
-    max-width: 72rem; margin: 0 auto; padding: 4rem 1.5rem 3.2rem;
+    box-sizing: border-box;
+    width: 100%;
+    max-width: calc(var(--site-content-width) + (2 * var(--site-gutter)));
+    margin: 0 auto; padding: 4rem var(--site-gutter) 3.2rem;
   }
-  @media (min-width: 640px) { .intro-inner { padding-inline: 2rem; } }
   .intro .kicker { margin-bottom: 1.5rem; }
   .intro h1 {
     font-weight: 600;
@@ -164,7 +166,7 @@
     .enterprise { grid-template-columns: 1fr; }
     .practice-list li { grid-template-columns: 1fr; gap: 0.35rem; }
     .billing-note { grid-template-columns: 1fr; }
-    .intro-inner { padding: 2.75rem 1.5rem 2.25rem; }
+    .intro-inner { padding-block: 2.75rem 2.25rem; }
   }
 </style>
 

--- a/public/src/components/architecture/Architecture.astro
+++ b/public/src/components/architecture/Architecture.astro
@@ -345,17 +345,15 @@ import { Footer } from "../landing/Footer";
     --guest: var(--color-plane-sealed);
     --guest-soft: var(--color-plane-sealed-soft);
 
-    max-width: 62rem;
+    box-sizing: border-box;
+    width: 100%;
+    max-width: calc(var(--site-content-width) + (2 * var(--site-gutter)));
     margin: 0 auto;
-    padding: 5rem 1.5rem 6rem;
+    padding: 5rem var(--site-gutter) 6rem;
     color: var(--ink);
     font-family: var(--font-body);
     font-size: 1rem;
     line-height: 1.65;
-  }
-
-  @media (min-width: 640px) {
-    .arch { padding-inline: 2rem; }
   }
 
   @media (min-width: 64rem) {

--- a/public/src/content/docs/guides/ir-to-image.mdx
+++ b/public/src/content/docs/guides/ir-to-image.mdx
@@ -48,7 +48,7 @@ The IR is a JSON document with a fixed schema. It describes one or more applicat
 
 The top-level shape:
 
-```rust,ignore
+```rust ignore
 // illustrative: the canonical shape of `mvm_contract::ir::Workload`, written with elisions
 pub struct Workload {
     pub schema_version: String,                       // currently "0.1"
@@ -494,7 +494,7 @@ The Workload IR types live in `crates/mvm-contract/src/ir/workload.rs`. The full
 
 ### `Source` — where the code comes from
 
-```rust,ignore
+```rust ignore
 // illustrative: IR variant shape; sibling types are named but not in scope here
 enum Source {
     LocalPath  { path: String, include: Vec<String>, exclude: Vec<String> },
@@ -511,7 +511,7 @@ enum Source {
 
 ### `Image` — what the rootfs is built from
 
-```rust,ignore
+```rust ignore
 // illustrative: IR variant shape; sibling types are named but not in scope here
 enum Image {
     NixPackages { packages: Vec<String> },
@@ -523,7 +523,7 @@ enum Image {
 
 ### `Dependencies` — language deps that aren't in stdlib
 
-```rust,ignore
+```rust ignore
 // illustrative: IR variant shape; sibling types are named but not in scope here
 enum Dependencies {
     Python { lockfile: String, tool: PythonTool },   // Uv | PipTools
@@ -544,7 +544,7 @@ If your workload only needs the language standard library, set `dependencies = m
 
 ### `Entrypoint` — how the wrapper inside the microVM is dispatched
 
-```rust,ignore
+```rust ignore
 // illustrative: IR variant shape; sibling types are named but not in scope here
 enum Entrypoint {
     Command  { command: Vec<String>, working_dir: String, env: BTreeMap<…> },

--- a/public/src/content/docs/tutorials/any-language.md
+++ b/public/src/content/docs/tutorials/any-language.md
@@ -14,7 +14,7 @@ The runtime is language-agnostic. Python and TypeScript SDKs are authoring surfa
 
 Example command entrypoint in Workload IR authoring:
 
-```rust,ignore
+```rust ignore
 // illustrative: one builder call shown on its own, without the surrounding workload
 entrypoint_command(["bash", "-lc", "your-runtime your-program"])
 ```

--- a/public/src/overrides/Header.astro
+++ b/public/src/overrides/Header.astro
@@ -165,7 +165,7 @@ const navLinks = [
     width: calc(100% + (2 * var(--sl-nav-pad-x)));
     margin-inline: calc(-1 * var(--sl-nav-pad-x));
     /* Same gutter scale as Section.tsx (px-6 sm:px-8). */
-    padding-inline: 1.5rem;
+    padding-inline: var(--site-gutter);
     border-bottom: 1px solid var(--sl-color-hairline);
     background: var(--sl-color-bg);
     backdrop-filter: blur(12px);
@@ -176,19 +176,13 @@ const navLinks = [
     margin-inline: 0;
   }
 
-  @media (min-width: 640px) {
-    .landing-header {
-      padding-inline: 2rem;
-    }
-  }
-
   .landing-header-inner {
     display: flex;
     align-items: center;
     justify-content: space-between;
     /* Same max-width as Section.tsx's inner div (max-w-6xl); the gutter
        itself is carried by .landing-header's padding above. */
-    max-width: 72rem;
+    max-width: var(--site-content-width);
     margin-inline: auto;
     padding-block: 1rem;
   }
@@ -346,13 +340,13 @@ const navLinks = [
        its own copy of the trick to line up with it. */
     width: calc(100% + (2 * var(--sl-nav-pad-x)));
     margin-inline: calc(-1 * var(--sl-nav-pad-x));
-    padding: 0 1.5rem 1rem;
+    padding: 0 var(--site-gutter) 1rem;
     border-top: 1px solid var(--sl-color-hairline-light);
   }
 
   .landing-header--standalone .landing-mobile-nav {
-    width: calc(100% + 3rem);
-    margin-inline: -1.5rem;
+    width: calc(100% + (2 * var(--site-gutter)));
+    margin-inline: calc(-1 * var(--site-gutter));
   }
 
   .landing-mobile-nav.is-open {
@@ -361,12 +355,7 @@ const navLinks = [
 
   @media (min-width: 640px) {
     .landing-mobile-nav {
-      padding-inline: 2rem;
-    }
-
-    .landing-header--standalone .landing-mobile-nav {
-      width: calc(100% + 4rem);
-      margin-inline: -2rem;
+      padding-inline: var(--site-gutter);
     }
   }
 

--- a/public/src/styles/custom.css
+++ b/public/src/styles/custom.css
@@ -12,6 +12,12 @@
  *  internal color names through our tokens.
  */
 :root {
+  /* Public pages share the landing page's 72rem content column and one
+     responsive outer gutter. Docs keep using Starlight's independent
+     --sl-content-* sizing below. */
+  --site-content-width: 72rem;
+  --site-gutter: 1.5rem;
+
   --sl-color-accent-low: var(--color-accent-low);
   --sl-color-accent: var(--color-accent);
   --sl-color-accent-high: var(--color-accent-high);
@@ -64,6 +70,12 @@
      gutter (Section.tsx's `px-6`), so both page families share one
      margin rhythm at narrow widths. */
   --sl-content-pad-x: 1.5rem;
+}
+
+@media (min-width: 640px) {
+  :root {
+    --site-gutter: 2rem;
+  }
 }
 
 /*  Tell the browser the supported schemes so native form controls,
@@ -598,8 +610,11 @@ nav[aria-label="Main"] ul ul li {
 }
 
 .blog-shell {
-  width: min(100% - 2rem, 72rem);
+  box-sizing: border-box;
+  width: 100%;
+  max-width: calc(var(--site-content-width) + (2 * var(--site-gutter)));
   margin-inline: auto;
+  padding-inline: var(--site-gutter);
 }
 
 .blog-brand,

--- a/public/tests/clear-content-cache.test.mjs
+++ b/public/tests/clear-content-cache.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { clearContentCache } from "../scripts/clear-content-cache.mjs";
+
+test("clearContentCache removes only Astro's generated content store", async () => {
+  const publicRoot = await mkdtemp(join(tmpdir(), "mvm-docs-cache-"));
+  const astroCache = join(publicRoot, ".astro");
+  const dataStore = join(astroCache, "data-store.json");
+  const generatedTypes = join(astroCache, "content.d.ts");
+
+  try {
+    await mkdir(astroCache);
+    await writeFile(dataStore, "stale");
+    await writeFile(generatedTypes, "keep");
+
+    await clearContentCache(publicRoot);
+
+    await assert.rejects(access(dataStore));
+    await access(generatedTypes);
+  } finally {
+    await rm(publicRoot, { recursive: true, force: true });
+  }
+});
+
+test("clearContentCache succeeds when no content store exists", async () => {
+  const publicRoot = await mkdtemp(join(tmpdir(), "mvm-docs-cache-"));
+
+  try {
+    await clearContentCache(publicRoot);
+  } finally {
+    await rm(publicRoot, { recursive: true, force: true });
+  }
+});

--- a/public/tests/site-shell.test.mjs
+++ b/public/tests/site-shell.test.mjs
@@ -1,9 +1,17 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 
 const publicRoot = new URL("../", import.meta.url).pathname;
+
+function markdownFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return markdownFiles(path);
+    return /\.mdx?$/.test(entry.name) ? [path] : [];
+  });
+}
 
 test("shared navigation makes the blog discoverable", () => {
   const header = readFileSync(join(publicRoot, "src/overrides/Header.astro"), "utf8");
@@ -36,4 +44,33 @@ test("homepage content renders immediately without a reveal animation", () => {
   assert.doesNotMatch(landing, /classList\.add\("hydrated"\)/);
   assert.doesNotMatch(header, /classList\.add\("js"\)/);
   assert.doesNotMatch(styles, /html\.js .*site-reveal|site-reveal-failsafe/);
+});
+
+test("non-doc pages share one content width and responsive gutter", () => {
+  const header = readFileSync(join(publicRoot, "src/overrides/Header.astro"), "utf8");
+  const blogStyles = readFileSync(join(publicRoot, "src/styles/custom.css"), "utf8");
+  const architecture = readFileSync(
+    join(publicRoot, "src/components/architecture/Architecture.astro"),
+    "utf8",
+  );
+  const pricing = readFileSync(join(publicRoot, "src/components/PricingContent.astro"), "utf8");
+  const staticTheme = readFileSync(join(publicRoot, "public/theme.css"), "utf8");
+
+  assert.match(blogStyles, /--site-content-width:\s*72rem/);
+  assert.match(blogStyles, /--site-gutter:\s*1\.5rem/);
+  assert.match(blogStyles, /--site-gutter:\s*2rem/);
+
+  for (const source of [header, blogStyles, architecture, pricing, staticTheme]) {
+    assert.match(source, /var\(--site-content-width\)/);
+    assert.match(source, /var\(--site-gutter\)/);
+  }
+});
+
+test("docs development clears stale content cache and uses valid code fence languages", () => {
+  const packageJson = JSON.parse(readFileSync(join(publicRoot, "package.json"), "utf8"));
+
+  assert.equal(packageJson.scripts.dev, "node scripts/clear-content-cache.mjs && astro dev");
+  for (const path of markdownFiles(join(publicRoot, "src/content"))) {
+    assert.doesNotMatch(readFileSync(path, "utf8"), /^```[^\s,]+,/m, path);
+  }
 });

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -8,7 +8,9 @@ Last updated: 2026-09-07
       `specs/plans/2026-09-07-shared-site-shell.md`.
       Homepage, blog, and pricing share one responsive header; Blog is present
       in the shared navigation; the page reveal is removed; and CI regressions
-      cover the shared shell. Website-source merges to `main` automatically
+      cover the shared shell. All non-doc routes also share one responsive
+      content gutter, and docs development starts without stale content IDs or
+      invalid Rust fence labels. Website-source merges to `main` automatically
       publish through the existing Pages workflow. PR review remains.
 
 - [x] **Public CVE evidence corpus.**

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -17,8 +17,11 @@
       sections render immediately without the previous reveal effect. Focused
       regressions are wired into website CI, and website-source merges to
       `main` now publish automatically through the existing Pages workflow.
-      The deny-all article is explicitly excluded from this UI-only delivery
-      branch.
+      The homepage, blog, architecture, and pricing routes now share the same
+      responsive 72rem content gutter, and `docs-dev` clears only stale Astro
+      content data before startup while retaining warning-free Rust example
+      metadata. The deny-all article is explicitly excluded from this UI-only
+      delivery branch.
 
 - [x] **Publish the reviewed CVE evidence corpus.**
       `specs/plans/2026-09-06-public-cve-corpus.md`.

--- a/specs/plans/2026-09-07-shared-site-shell.md
+++ b/specs/plans/2026-09-07-shared-site-shell.md
@@ -5,13 +5,15 @@ Validation: check-sprint-append
 
 **Status: IMPLEMENTATION COMPLETE — PR REVIEW PENDING**
 **Last updated: 2026-09-07**
-**Branch:** `fix/shared-site-shell`
+**Branch:** `fix/site-spacing-doc-loader`
 
 ## Goal
 
 Use the homepage header consistently across the public blog and pricing routes,
 make the blog discoverable from the shared navigation, and render homepage
-content immediately without the scroll-triggered reveal effect.
+content immediately without the scroll-triggered reveal effect. Keep every
+non-doc route on the same responsive content gutter, and keep docs development
+free of stale content-loader and invalid code-fence warnings.
 
 This UI-only workstream intentionally excludes the separate deny-all article,
 which remains private under its own release review.
@@ -28,3 +30,14 @@ which remains private under its own release review.
 - [x] Run the complete website check and production static build.
 - [x] Deploy website source changes automatically after they merge to `main`,
       while preserving release, tag, and manual deployment triggers.
+- [x] Give the homepage, blog, architecture, and pricing routes one shared
+      72rem content width with 1.5rem/2rem responsive gutters; leave docs on
+      Starlight's independent content sizing.
+- [x] Clear only Astro's generated content data store before `docs-dev` so a
+      stale cache cannot emit duplicate IDs.
+- [x] Use renderer-valid `rust ignore` fence metadata while preserving the
+      conformance compiler's explicit opt-out contract.
+- [x] Add regressions for the public-page gutter, targeted cache cleanup,
+      Markdown fence metadata, and whitespace-separated conformance attributes.
+- [x] Verify the website build and exact `docs-dev` startup, plus desktop and
+      mobile browser geometry across every non-doc route.


### PR DESCRIPTION
## Summary
- use one responsive 72rem content gutter across the homepage, blog, architecture, and pricing while leaving docs sizing unchanged
- clear the stale generated Astro content store before docs development so startup no longer emits duplicate content IDs
- use renderer-valid Rust fence metadata while preserving conformance opt-outs

## Testing
- pnpm check
- just docs-dev (warning-free startup)
- cargo fmt --all --check
- just dev-check
- just dev-clippy
- just dev-test
- browser geometry at 1280px and 375px across /, /blog/, /architecture/, and /pricing/