### PR TITLE
docs(blog): CVE-2026-8838 teardown — eval() in redshift-connector's array decoder

### DIFF
--- a/public/public/blog/cve-2026-8838-redshift-connector.svg
+++ b/public/public/blog/cve-2026-8838-redshift-connector.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" role="img" aria-labelledby="title desc">
+<title id="title">CVE-2026-8838 attack chain</title>
+<desc id="desc">query result bytes then array decoder then eval() then client process — the chain CVE-2026-8838 follows in redshift-connector 2.1.13, ending at eval(&quot;[&quot; + data[idx:idx+length].decode(_client_encoding).replace(&quot; &quot;, &quot;,&quot;) + &quot;]&quot;).</desc>
+<defs>
+<linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#0d1117"/><stop offset="0.5" stop-color="#121821"/><stop offset="1" stop-color="#0b1620"/></linearGradient>
+<filter id="soft" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#010409" flood-opacity="0.42"/></filter>
+</defs>
+<rect width="1600" height="900" fill="url(#bg)"/>
+<g opacity="0.20" stroke="#30363d" stroke-width="1">
+<path d="M120 160H1480M120 300H1480M120 440H1480M120 580H1480M120 720H1480"/>
+<path d="M320 110V820M620 110V820M920 110V820M1220 110V820"/>
+</g>
+<text x="120" y="190" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="64" fill="#e6edf3" font-weight="650" text-anchor="start">CVE-2026-8838</text>
+<text x="120" y="244" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="30" fill="#8b949e" font-weight="500" text-anchor="start">redshift-connector 2.1.13 — caught by mvm-scout before merge</text>
+<g filter="url(#soft)">
+<rect x="120" y="360" width="317" height="190" rx="18" fill="#161b22" stroke="#58a6ff" stroke-width="2" />
+<text x="278.5" y="449.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">query result bytes</text>
+<path d="M439.0 442.0 l13 13 l-13 13" fill="none" stroke="#8b949e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="467" y="360" width="317" height="190" rx="18" fill="#161b22" stroke="#30363d" stroke-width="2" />
+<text x="625.5" y="449.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">array decoder</text>
+<path d="M786.0 442.0 l13 13 l-13 13" fill="none" stroke="#8b949e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="814" y="360" width="317" height="190" rx="18" fill="#161b22" stroke="#30363d" stroke-width="2" />
+<text x="972.5" y="449.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">eval()</text>
+<path d="M1133.0 442.0 l13 13 l-13 13" fill="none" stroke="#8b949e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+<rect x="1161" y="360" width="317" height="190" rx="18" fill="#161b22" stroke="#f85149" stroke-width="2" />
+<text x="1319.5" y="449.0" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="middle">client process</text>
+</g>
+<text x="1319.5" y="598" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="25" fill="#f85149" font-weight="500" text-anchor="middle">eval(&quot;[&quot; + data[idx:idx+length].decode(_client_encoding).replace(&quot; &quot;, &quot;,&quot;) + &quot;]&quot;)</text>
+<rect x="120" y="660" width="1360" height="120" rx="20" fill="#0e141b" stroke="#30363d" stroke-width="2" />
+<text x="160" y="706" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="19" fill="#8b949e" font-weight="600" text-anchor="start">ROOT CAUSE</text>
+<text x="160" y="748" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="27" fill="#e6edf3" font-weight="500" text-anchor="start">redshift_connector/utils/type_utils.py:86</text>
+<text x="1140" y="706" font-family="ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="19" fill="#8b949e" font-weight="600" text-anchor="start">DETECTED BY</text>
+<text x="1140" y="748" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="27" fill="#3fb950" font-weight="500" text-anchor="start">SCOUT-RCE-002</text>
+</svg>

--- a/public/src/content/blog/cve-2026-8838-redshift-connector.md
+++ b/public/src/content/blog/cve-2026-8838-redshift-connector.md
@@ -1,0 +1,76 @@
+---
+title: "CVE-2026-8838: an eval() sink in redshift-connector's array decoder"
+description: "A differential test shows mvm-scout's SCOUT-RCE-002 rule tracks the exact eval() call behind CVE-2026-8838, not just the redshift-connector package or version."
+date: 2026-09-07
+tags:
+  - security
+  - cve
+  - detection-engineering
+  - python
+  - static-analysis
+heroImage: /blog/cve-2026-8838-redshift-connector.svg
+heroAlt: "Diagram showing a Redshift query result flowing through redshift-connector's numeric array decoder into an eval() call, ending at arbitrary code execution in the client process."
+---
+
+## The bug
+
+redshift-connector, the official Python driver for Amazon Redshift, decodes numeric array values from query results by handing the decoded bytes to Python's `eval()`. That's the whole vulnerability in one sentence, and it's worth sitting with, because `eval()` doesn't parse — it executes. The driver isn't reading a list of numbers, it's compiling and running whatever expression shows up in that field.
+
+Here's the line, `redshift_connector/utils/type_utils.py:86`:
+
+```python
+return eval("[" + data[idx : idx + length].decode(_client_encoding).replace(" ", ",") + "]")
+```
+
+The intent is clear enough: take a space-separated string like `1 2 3`, turn it into `1,2,3`, wrap it in brackets, and eval the result as a Python list literal. For well-formed numeric output that works. But `eval()` doesn't know the difference between `1,2,3` and `__import__('os').system('id')`. Anything that can influence the bytes the client decodes as this array type — a malicious or compromised Redshift server, a proxy sitting in the query path, injected data that ends up in a result set — gets to run arbitrary Python in the client process. That's CVE-2026-8838, CVSS 9.8, GitHub-rated Critical.
+
+The fix, landed in 2.1.14, replaces the eval call with direct integer parsing:
+
+```python
+return [int(x) for x in data[idx : idx + length].decode(_client_encoding).split()]
+```
+
+Same job, no code execution path. A list comprehension over `int()` can raise `ValueError` on bad input; it can't spawn a shell.
+
+## What we tested
+
+We run mvm-scout, our static detection tool, against known-vulnerable and known-patched source to see whether its rules actually track root causes or just pattern-match on package names and version strings. For this CVE we had two things to check the rule against: the vulnerable specimen (redshift-connector 2.1.13, the affected version) and a mutated control where the only change is the one-line fix shown above — the eval call swapped for the list comprehension. Source digest for the specimen: `e4f3600cddaef5d25ecf8dbc8d07a7c52396ff44c4e1fa5b2d5d2bf484de5d81`.
+
+mvm-scout's rule for this pattern, `SCOUT-RCE-002`, fired on the specimen and did not fire on the mutated control. That's the result that matters: the rule is keying on the `eval()` call itself, not on the file it lives in or the version string attached to the package.
+
+A second rule, `SCOUT-CVE-001`, fired on both the specimen and the control. We're not citing that as evidence of anything, because a rule that fires identically before and after the fix isn't detecting the bug — it's detecting the package or version identity, which is a different (and much weaker) thing to detect. Two OSV-tracked advisories, `GHSA-29h4-r29x-hchv` and `PYSEC-2026-521`, also correctly resolved as affecting the vulnerable version and not the fixed one, which just confirms the version-range bookkeeping is doing its job — separate from, and less interesting than, the source-level result.
+
+## The falsification
+
+The specimen/control split is the part worth trusting, and it's worth explaining why. Anyone can write a rule that matches on `redshift-connector` or on a CVE ID string; that rule will "detect" the vulnerability forever, including in versions where it's already fixed, because it never looks at the code. `SCOUT-CVE-001`'s behavior here is a live example of exactly that failure mode.
+
+The mutation test rules that out for `SCOUT-RCE-002`. The entire diff between the specimen and the control is one line — `eval(...)` becomes a list comprehension. Nothing else in the file, the package metadata, or the version string changes. When that single line changes, the rule's verdict flips from fire to silent. That's a real differential: the rule is reading the `eval()` call, not the surrounding context. If the rule had instead kept firing on the patched control, that would tell us it's noise — matching on the file path or the function name rather than the dangerous construct. It didn't.
+
+## What this does not show
+
+This evidence shows that mvm-scout's `SCOUT-RCE-002` rule catches the specific vulnerable pattern in redshift-connector's source, and stops catching it once the one-line fix is applied. It does not show more than that.
+
+We did not run a containment demonstration against this CVE — no microVM, no sandbox, no attempt to exploit the `eval()` sink at runtime. `mvm_outcome` for this run is NOT_TESTED, and nothing here should be read as MVM having prevented CVE-2026-8838 or having prevented a breach; MVM prevents breaches, not CVEs, and in this run it wasn't exercised against this one at all. This is source-level static pattern detection, evaluated as a differential between two versions of a file we already knew was vulnerable and fixed, respectively.
+
+It also doesn't establish that the `eval()` sink is reachable from an untrusted input path in any given deployment. Whether an attacker can actually get a crafted value into the query result that reaches this decoder depends on the deployment — what's between the client and the Redshift server, whether results are ever influenced by untrusted data, whether a proxy sits in between. Answering that requires a live exploitation attempt or a data-flow trace from an actual input source to this sink, and we didn't do either here.
+
+The underlying bug is unaffected by any of this tooling. It fires wherever the vulnerable code runs, regardless of what static analysis has or hasn't been pointed at it. Upgrading redshift-connector to 2.1.14 or later, which contains the fix, is the only thing that closes it.
+
+## The evidence behind this post
+
+Every figure above came out of a run, not a writeup. These are the exact inputs, so you can re-derive them:
+
+| | |
+|---|---|
+| Advisory | CVE-2026-8838 |
+| Package | redshift-connector 2.1.13 (PyPI) |
+| Fixed in | 2.1.14 |
+| Severity / CVSS | Critical · 9.8 |
+| Root cause | `redshift_connector/utils/type_utils.py:86` |
+| Detected by | `SCOUT-RCE-002` |
+| Scanned bytes (sha256) | `e4f3600cddaef5d25ecf8dbc8d07a7c52396ff44c4e1fa5b2d5d2bf484de5d81` |
+| mvm-assurance revision | `f3da33d` |
+| Containment demo | not run |
+
+The scan target was the unmodified upstream file at that tag — the digest above is
+of the bytes the project published. The control differs from it by exactly one line.


### PR DESCRIPTION
A CVE teardown generated from a recorded `mvm-scout` evidence run, not written by hand.

## The bug

`redshift-connector` (AWS's Python driver) decodes a numeric array from the server by string-splicing it and calling `eval()`:

```python
# v2.1.13 — redshift_connector/utils/type_utils.py:86
return eval("[" + data[idx:idx+length].decode(_client_encoding).replace(" ", ",") + "]")
```

Bytes off the wire become code in the client process. Fixed in v2.1.14 by parsing integers instead:

```python
return [int(x) for x in data[idx:idx+length].decode(_client_encoding).split()]
```

## What the evidence shows

| | |
|---|---|
| Advisory | CVE-2026-8838 · Critical · CWE-94 |
| Root cause | `redshift_connector/utils/type_utils.py:86` |
| Detected by | `SCOUT-RCE-002` |
| Differential | **STRONG** — fires on the specimen, clears on the control |
| Containment | not run |

The control is the same file with that one line replaced by upstream's own fix. `SCOUT-RCE-002` fires on the specimen and clears on the control, so the finding is bound to the `eval()` call rather than to the file or the package.

## Selection

This CVE came out of a 50-advisory sweep (`mvm-scout advisories` → `evidence-qualify`). Of eight candidates that initially qualified, this is the one that survived verification: the others cleared only because their files had been deleted at the fixed ref, or because the rule matched something that was never a vulnerability. Those false signals are fixed in mvm-assurance#89.

## Claim discipline

Detection only, and the post says so. `render-post.py` refuses prose the run does not support — `certified`, `prevented the CVE`, Scout credited with prevention, or any containment claim without a containment leg — and requires a "what this does not show" section. It rejected one draft of this post before accepting it. Machine facts are injected from the run, never authored.

## Verification

`pnpm build`: 144 pages, no errors. Renders at `/blog/cve-2026-8838-redshift-connector/` with its generated hero and evidence table. A grep of the built HTML for `certif`, `prevented the breach`, and `prevented the CVE` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
