### PR TITLE
release: re-record the macOS/HVF evidence for v0.18.0-rc.1

### DIFF
--- a/specs/evidence/e2e/macos-hvf.json
+++ b/specs/evidence/e2e/macos-hvf.json
@@ -1,8 +1,8 @@
 {
   "lane": "macos-hvf",
-  "commit": "ee7270990ee2ba29d6653e42e7854520a0e380e9",
-  "material_digest": "3df5037669791a4dd02dcd24067e0f10e6820821515b8fa467ebd1b69bfdfd5e",
-  "recorded_at": "2026-09-07T20:40:34Z",
+  "commit": "032d719429e0a177c3bfc67c8421b6af551487cb",
+  "material_digest": "ebbdfc40c1dc2edd9e067a9f21a76d61e3c27420f151e25aa7c9507562836ee8",
+  "recorded_at": "2026-09-08T04:12:47Z",
   "host": {
     "os": "Darwin",
     "os_version": "26.5.2",


### PR DESCRIPTION
Last blocker before tagging v0.18.0-rc.1.

The prior record stopped describing main when #3203 edited a comment in the `docs-publish` recipe. The `Justfile` is a material path, so the digest moved even though nothing the suite exercises changed.

Re-run rather than re-stamped — the gate cannot know a comment is inert, and attaching the earlier log to the new digest would assert a run against a tree it never ran on.

308 scenarios (307 passed, 1 skipped) on Darwin arm64. `check-release-evidence` passes against this tree.