### PR TITLE
Record the Cloudflare Worker production rollout

### DIFF
--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -440,8 +440,10 @@ Last updated: 2026-09-07
       `specs/plans/2026-08-27-cloudflare-pages-cutover.md`. The assets-only
       Worker config, local/CI deployment commands, credential preflight, static
       asset limit checks, WebLinux bundle gate, and header verification are in
-      place. The first Worker deployment, production-domain move, rollback
-      window, and old-project cleanup remain.
+      place. The `mvm` Worker is deployed, `runmvm.com` is attached and verified,
+      and the CI token has Workers Scripts edit permission. The rollback window
+      and audited cleanup of the old Pages project and unused `runmvm` Worker
+      remain.
 
 - [ ] **Cold-boot guest wall clock — issue #2956.**
       `specs/plans/2026-08-27-cold-boot-wall-clock.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -453,10 +453,11 @@
       and the existing complete-WebLinux-bundle and live COOP/COEP checks.
       Five focused Node tests and all 40 release-asset workflow contract tests
       pass, along with the workspace compile, Clippy, and policy gates.
-      Remaining: confirm the CI token has Workers Scripts edit permission,
-      verify the first `workers.dev` deployment, inventory and move the current
-      production domains, and retire the old Pages project plus unused `runmvm`
-      Worker after a rollback window.
+      Production now serves from the `mvm` Worker at both its `workers.dev`
+      hostname and `runmvm.com`; the account-scoped CI token has Workers Scripts
+      edit permission, and live route, 404, WebLinux bundle, TLS, and COOP/COEP
+      checks pass. Remaining: after the rollback window, audit and retire the old
+      Pages project plus the unused `runmvm` Worker.
 
 - [ ] **Cold-boot guest wall clock — issue #2956.**
       `specs/plans/2026-08-27-cold-boot-wall-clock.md`.

--- a/specs/plans/2026-09-07-cloudflare-workers-static-assets.md
+++ b/specs/plans/2026-09-07-cloudflare-workers-static-assets.md
@@ -26,13 +26,14 @@ putting static requests through unnecessary Worker code.
 
 ## Production rollout
 
-- [ ] Confirm `CLOUDFLARE_API_TOKEN` is account-scoped and has **Workers Scripts:
-      Edit** permission before merging the deployment change.
-- [ ] Deploy `mvm` from `main`, verify its `workers.dev` URL, representative
+- [x] Confirm `CLOUDFLARE_API_TOKEN` is account-scoped and has **Workers Scripts:
+      Edit** permission before the first automated Worker deployment.
+- [x] Deploy `mvm` from `main`, verify its `workers.dev` URL, representative
       documentation routes, the custom 404 page, and the browser WebLinux demo.
-- [ ] Inventory every custom domain on the old Pages project, attach each
-      production hostname (including `gomicrovm.com`) to the `mvm` Worker, and
-      verify traffic, TLS, and COOP/COEP headers on `/` and `/demo/weblinux/`.
+- [x] Inventory every custom domain on the old Pages project, attach each
+      production hostname to the `mvm` Worker, and verify traffic, TLS, and
+      COOP/COEP headers on `/` and `/demo/weblinux/`. The inventory found
+      `runmvm.com` as the sole custom hostname on the Pages project.
 - [ ] After a rollback window, remove the old `mvm` Pages project and delete the
       unused `runmvm` Worker only after confirming it has no domains, routes,
       bindings, secrets, or triggers.
@@ -48,3 +49,13 @@ putting static requests through unnecessary Worker code.
   `assets.run_worker_first` requires an explicit use case and review.
 - Production cutover retains the Pages endpoint as a rollback target until the
   Worker has passed the live header and browser-demo checks.
+
+## Rollout evidence
+
+- The account-owned `mvm-deploy` token has Workers Scripts write access, and the
+  post-merge workflow authenticated with it successfully.
+- The `mvm` Worker serves both its `workers.dev` hostname and `runmvm.com`; the
+  homepage, documentation, custom 404, and complete WebLinux asset set passed
+  live checks, including the required COOP/COEP headers.
+- The detached `mvm-8a8.pages.dev` project and the unused `runmvm` Worker remain
+  available through the rollback window and are not production traffic targets.


### PR DESCRIPTION
## Summary

- mark the Worker deployment and runmvm.com cutover complete
- record the CI token permission and live verification evidence
- keep legacy Pages and runmvm Worker cleanup open through the rollback window

## Validation

- cargo run -p xtask -- check-sprint-append
- git diff --check