### PR TITLE
build(kernel): bump synchronized pins to 6.12.109

### DIFF
--- a/nix/images/kernel/base.nix
+++ b/nix/images/kernel/base.nix
@@ -48,10 +48,10 @@ let
   # kernel — lets both of mvm's kernels track the latest point release exactly
   # and keeps the two pins from drifting apart. Bump `kernelVersion` + `hash`
   # together (the tarball's own sha256, e.g. via `nix store prefetch-file`).
-  kernelVersion = "6.12.108";
+  kernelVersion = "6.12.109";
   kernelSrc = pkgs.fetchurl {
     url = "mirror://kernel/linux/kernel/v6.x/linux-${kernelVersion}.tar.xz";
-    hash = "sha256-4dHqIA0i1VyfXV+uWeabs7SUUVcF/DOQzVQjHuT0uq8=";
+    hash = "sha256-VITlUqM04VAZ9K66ieW1jwRlHPL04k4E3p8VLxw44/o=";
   };
   # The builder's overlay filesystem triggers a GNU tar directory-metadata
   # race while unpacking this archive. Materialize the source with bsdtar once

--- a/nix/packages/libkrunfw.nix
+++ b/nix/packages/libkrunfw.nix
@@ -20,8 +20,8 @@ assert lib.elem variant [
 
 let
   kernelSrc = fetchurl {
-    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.108.tar.xz";
-    hash = "sha256-4dHqIA0i1VyfXV+uWeabs7SUUVcF/DOQzVQjHuT0uq8=";
+    url = "mirror://kernel/linux/kernel/v6.x/linux-6.12.109.tar.xz";
+    hash = "sha256-VITlUqM04VAZ9K66ieW1jwRlHPL04k4E3p8VLxw44/o=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace Makefile \
-      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.108' \
+      --replace-fail 'KERNEL_VERSION = linux-6.12.91' 'KERNEL_VERSION = linux-6.12.109' \
       --replace-fail 'curl $(KERNEL_REMOTE) -o $(KERNEL_TARBALL)' 'ln -s ${kernelSrc} $(KERNEL_TARBALL)'
     substituteInPlace patches/0008-virtio-vsock-support-dgrams.patch \
       --replace-fail 'virtio_transport_alloc_skb(&info, dgram_len, false,' \

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,8 +1,14 @@
 # Refactor status
 
-Last updated: 2026-09-07
+Last updated: 2026-09-08
 
 ## In progress
+
+- [ ] **Linux 6.12.109 synchronized kernel pin — issue #3213.**
+      `specs/plans/2026-09-08-kernel-6-12-109.md`.
+      Both kernel consumers use the kernel.org-verified archive and SRI hash;
+      structural coverage, the workspace suite, check, and zero-warning Clippy
+      are green. Builder-VM and merge validation remain.
 
 - [ ] **Shared website shell.**
       `specs/plans/2026-09-07-shared-site-shell.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,13 @@
 
 ## In progress
 
+- [ ] **Linux 6.12.109 synchronized kernel pin — issue #3213.**
+      `specs/plans/2026-09-08-kernel-6-12-109.md`.
+      The custom workload/builder kernel and libkrunfw firmware build use the
+      same kernel.org-verified Linux 6.12.109 archive and SRI hash. The
+      structural synchronization suite, full workspace tests/check, and
+      zero-warning Clippy are green; builder-VM and merge validation remain.
+
 - [ ] **Shared website shell.**
       `specs/plans/2026-09-07-shared-site-shell.md`.
       The homepage navigation now links to Blog; the blog and pricing routes

--- a/specs/plans/2026-09-08-kernel-6-12-109.md
+++ b/specs/plans/2026-09-08-kernel-6-12-109.md
@@ -1,0 +1,46 @@
+# Linux 6.12.109 kernel pin refresh
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Issue:** [#3213](https://github.com/tinylabscom/mvm/issues/3213)
+
+## Outcome
+
+The custom workload/builder kernel and libkrunfw firmware build consume the
+same verified Linux 6.12.109 LTS source archive. Structural coverage keeps the
+version and source hash synchronized.
+
+## Delivery checklist
+
+- [x] Verify the upstream `linux-6.12.109.tar.xz` SHA-256 against kernel.org's
+      signed checksum manifest and the release maintainer's detached signature.
+- [x] Update the custom workload/builder kernel source pin and SRI hash.
+- [x] Update the libkrunfw kernel source pin, substitution, and SRI hash.
+- [x] Move the structural synchronization pin, so both consumers must land
+      together.
+- [x] Pass the focused synchronization test and local pin-parity checks.
+- [ ] Pass the Linux builder-VM Nix evaluation and kernel-build checks.
+- [x] Record the completed implementation in the sprint and refactor rollup.
+- [ ] Merge the tested pull request and close #3213 through its linkage.
+
+## Source verification
+
+The upstream archive SHA-256 is
+`5484e552a334e15019f4aeba89e5b58f04651cf2f4e24e04de9f152f1c38e3fa`,
+which converts to the Nix SRI hash
+`sha256-VITlUqM04VAZ9K66ieW1jwRlHPL04k4E3p8VLxw44/o=`.
+
+The downloaded archive hashes to the digest published in kernel.org's
+clearsigned `v6.x/sha256sums.asc` manifest. Independently, Greg
+Kroah-Hartman's detached release signature verifies for the uncompressed
+archive with fingerprint
+`647F 2865 4894 E3BD 4571 99BE 38DB BDC8 6092 693E`, which kernel.org
+publishes as his release-signing fingerprint. The same checksum manifest still
+carries the outgoing 6.12.108 digest unchanged.
+
+## Rollout
+
+The pin is the source of truth for both consumers; it does not itself
+re-kernel anything already running. Per the watcher's remediation line, built
+VMs move with `mvmctl vm rekernel`, and the fleet rollout is mvmd's.

--- a/specs/sprint/delivery/3213-kernel-pin-6-12-109.md
+++ b/specs/sprint/delivery/3213-kernel-pin-6-12-109.md
@@ -1,0 +1,13 @@
+# Linux 6.12.109 kernel pin refresh
+
+- [x] Updated the libkrunfw firmware build and custom workload/builder kernels
+      from Linux 6.12.108 to 6.12.109.
+- [x] Verified the archive digest against kernel.org's clearsigned SHA-256
+      manifest, confirmed it by hashing the downloaded archive, and verified
+      the release maintainer's detached signature independently.
+- [x] Moved the structural parity pin so the two consumers cannot drift apart.
+- [x] Pass the structural synchronization suite and repository policy gates.
+- [ ] Record the Linux builder validation after it passes.
+- [ ] Merge the linked pull request through the queue.
+
+Owning plan: `specs/plans/2026-09-08-kernel-6-12-109.md`.

--- a/tests/nix_flake_structure.rs
+++ b/tests/nix_flake_structure.rs
@@ -373,8 +373,8 @@ fn native_vmm_recipes_are_source_built_and_pinned() {
         );
     }
 
-    const KERNEL_VERSION: &str = "6.12.108";
-    const KERNEL_HASH: &str = "sha256-4dHqIA0i1VyfXV+uWeabs7SUUVcF/DOQzVQjHuT0uq8=";
+    const KERNEL_VERSION: &str = "6.12.109";
+    const KERNEL_HASH: &str = "sha256-VITlUqM04VAZ9K66ieW1jwRlHPL04k4E3p8VLxw44/o=";
     assert!(
         libkrunfw.contains(&format!("linux-{KERNEL_VERSION}.tar.xz"))
             && libkrunfw.contains(&format!("hash = \"{KERNEL_HASH}\""))


### PR DESCRIPTION
Closes #3213.

The kernel freshness watcher reported both synchronized consumers one patch release behind. This moves the custom workload/builder kernel and the libkrunfw firmware build together to Linux 6.12.109.

Source verification:

- kernel.org checksum: `5484e552a334e15019f4aeba89e5b58f04651cf2f4e24e04de9f152f1c38e3fa`
- Nix SRI: `sha256-VITlUqM04VAZ9K66ieW1jwRlHPL04k4E3p8VLxw44/o=`
- downloaded archive matches the kernel.org checksum manifest
- detached release signature verifies under Greg Kroah-Hartman fingerprint `647F 2865 4894 E3BD 4571 99BE 38DB BDC8 6092 693E`

Validation:

- `cargo test --test nix_flake_structure` (56 passed)
- `cargo run -p xtask -- check-kernel-pin-freshness` (`UpToDate`, no action recommended)
- full workspace unit/integration suite plus isolated `mvm-build` doctest
- workspace check and zero-warning Clippy
- sprint, plan-name, backing, doc-claim, formatting, and diff gates

The Linux kernel evaluation/build jobs remain the merge-time architecture witnesses.