### PR TITLE
fix(release): stop uploading the same asset twice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -721,6 +721,20 @@ jobs:
             sbom.cdx.json
             sbom.cdx.json.bundle
           )
+          # `artifacts/*.tar.gz` and `artifacts/*.tar.gz.bundle` already match
+          # the runtime-overlay, initramfs and sdk-sidecar tarballs that the
+          # entries above name explicitly, so each of those files is listed
+          # twice. GitHub accepts the first upload and rejects the second with
+          # `ReleaseAsset.name already exists` — a 422 that arrives *after*
+          # `gh release create` has already created the release, so the run goes
+          # red having published a partially populated release.
+          #
+          # Deduplicated rather than un-overlapped: the explicit entries record
+          # what a release is required to carry and the catch-alls cover what it
+          # may also carry, and both are worth keeping. Sorting is incidental —
+          # upload order does not matter.
+          mapfile -t assets < <(printf '%s\n' "${assets[@]}" | sort -u)
+
           RELEASE_NOTES_PREFIX="$(cat nix/packaging/release/runtime-overlay-operational-note.md)"
           # A semver prerelease tag (`v0.18.0-rc.1`) must not become GitHub's
           # "Latest" release. `mvmctl update` resolves

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -43,6 +43,84 @@ fn justfile() -> String {
     fs::read_to_string("Justfile").expect("Justfile must be readable")
 }
 
+/// The published asset list must not name the same file twice.
+///
+/// `artifacts/*.tar.gz` matches every tarball, including the runtime-overlay,
+/// initramfs and sdk-sidecar ones the list also names explicitly. Passing a
+/// duplicate to `gh release create` makes GitHub accept the first upload and
+/// reject the second with `ReleaseAsset.name already exists` — HTTP 422,
+/// arriving *after* the release has been created, so the run goes red having
+/// published a half-populated release.
+///
+/// This is checked as an overlap between the glob patterns rather than as the
+/// presence of the `sort -u` that fixes it, so removing the overlap a different
+/// way keeps the test honest, and re-introducing an overlapping catch-all
+/// without deduplicating fails it.
+#[test]
+fn the_release_asset_list_cannot_upload_one_file_twice() {
+    let workflow = release_workflow();
+
+    let start = workflow
+        .find("assets=(")
+        .expect("the publish step must build an assets array");
+    let len = workflow[start..]
+        .find("\n          )")
+        .expect("the assets array must be closed");
+    let body = &workflow[start..start + len];
+
+    let patterns: Vec<&str> = body
+        .lines()
+        .skip(1)
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .collect();
+    assert!(
+        patterns.len() > 5,
+        "parsed {} asset patterns — the parse broke, and a test that checks \
+         nothing passes forever",
+        patterns.len()
+    );
+
+    // A catch-all `dir/*.suffix` subsumes any `dir/prefix-*.suffix` beside it:
+    // both expand over the same directory and end in the same suffix.
+    let mut overlaps = Vec::new();
+    for broad in &patterns {
+        let Some((dir, suffix)) = broad.split_once("/*") else {
+            continue;
+        };
+        for narrow in &patterns {
+            if narrow == broad {
+                continue;
+            }
+            if narrow.starts_with(&format!("{dir}/")) && narrow.ends_with(suffix) {
+                overlaps.push(format!("{broad} also matches {narrow}"));
+            }
+        }
+    }
+
+    if !overlaps.is_empty() {
+        assert!(
+            workflow.contains(r#"mapfile -t assets < <(printf '%s\n' "${assets[@]}" | sort -u)"#),
+            "the asset list has overlapping globs and is not deduplicated, so \
+             `gh release create` uploads a file twice and GitHub refuses the \
+             second with a 422 after creating the release:\n  {}",
+            overlaps.join("\n  ")
+        );
+
+        let dedupe = workflow.find("| sort -u)").expect("checked above");
+        // The invocation, not the phrase: `gh release create` also appears in
+        // the comment above the array, which precedes the dedupe and would make
+        // this ordering check fail against correct code.
+        let create = workflow
+            .find("gh release create \"${TAG_NAME}\"")
+            .expect("the publish step must create the release under the pushed tag");
+        assert!(
+            dedupe < create,
+            "the list must be deduplicated before the release is created"
+        );
+    }
+}
+
 /// The release prep must test the tree it pushes, not the tree before it.
 ///
 /// `just release` runs the workspace suite and *then* calls `_release-prep`,


### PR DESCRIPTION
The v0.18.0-rc.1 publish failed with:

```
HTTP 422: Validation Failed (.../releases/384889475/assets?name=runtime-overlay-aarch64.tar.gz)
ReleaseAsset.name already exists
```

## Cause

The asset list opens with `artifacts/*.tar.gz` and `artifacts/*.tar.gz.bundle`, which already match the runtime-overlay, initramfs and sdk-sidecar tarballs the list then names explicitly. Each of those files is handed to `gh release create` **twice** — GitHub accepts the first upload and rejects the second.

## Why the timing matters

The 422 arrives *after* the release has been created. The run ends red having published a release missing most of its assets: tag exists, release exists, downloader 404s. In this instance `gh` rolled the release back, but nothing in the workflow guarantees that — it is luck, not design.

## The fix

Deduplicated rather than un-overlapped. The explicit entries record what a release is *required* to carry; the catch-alls cover what it *may* also carry. Both are worth keeping, and dropping either would silently narrow what ships.

## Why it took three attempts to find

This step had never run. The first release attempt died in the build matrix (#3201) and the second at the boot-image asset gate — so `Create GitHub Release` was reached for the first time today.

That is the same shape as the other two release defects this week: the only thing that exercises this code is a tag push, so each failure is discovered serially, one release attempt at a time. Tracked in #3199.

## The test

It asserts the **overlap** between glob patterns, not the presence of the `sort -u` that fixes it — so removing the overlap another way keeps it honest, and adding a new overlapping catch-all without deduplicating fails it.

Verified by deleting the dedupe and re-running: it fails and names all three overlapping pairs.

```
artifacts/*.tar.gz also matches artifacts/runtime-overlay-*.tar.gz
artifacts/*.tar.gz also matches artifacts/initramfs-*.tar.gz
artifacts/*.tar.gz also matches artifacts/sdk-sidecar-*-glibc.tar.gz
```

Its first draft was wrong in a way worth recording: it located the publish command with `find("gh release create")`, which matched that phrase inside the comment above the array, so the ordering assertion failed against correct code. It now anchors on the invocation.

`cargo nextest run -p mvmctl --test release_assets`: 41 passed. actionlint clean.