### PR TITLE
release: re-record the macOS/HVF evidence for v0.18.0-rc.1

### DIFF
--- a/specs/evidence/e2e/macos-hvf.json
+++ b/specs/evidence/e2e/macos-hvf.json
@@ -1,8 +1,8 @@
 {
   "lane": "macos-hvf",
-  "commit": "02266fbda9f43174ac1e7f9823e3d7ed3c1c5e6a",
-  "material_digest": "aa4c1e345ce0a19d5ace64524a98b60728a357e9ab1dee6ded5699bc79a21fa3",
-  "recorded_at": "2026-09-08T05:02:08Z",
+  "commit": "7f900f09a9323c1b6dc44001dbe63d6ff843a5b1",
+  "material_digest": "2362a830eb20beb534d4da6dca5555b424c7e75b98bbbd88e2125b3309d2a44b",
+  "recorded_at": "2026-09-08T18:15:29Z",
   "host": {
     "os": "Darwin",
     "os_version": "26.5.2",


### PR DESCRIPTION
Last blocker before tagging v0.18.0-rc.1.

The prior record stopped describing main when #3203 edited a comment in the `docs-publish` recipe. The `Justfile` is a material path, so the digest moved even though nothing the suite exercises changed.

Re-run rather than re-stamped — the gate cannot know a comment is inert, and attaching the earlier log to the new digest would assert a run against a tree it never ran on.

308 scenarios (307 passed, 1 skipped) on Darwin arm64. `check-release-evidence` passes against this tree.