### PR TITLE
Validate the boot image tag shipped by the CLI

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -682,7 +682,7 @@ jobs:
         id: bundle-fixture
         run: |
           set -euo pipefail
-          /tmp/mvmctl-source-under-test image boot update --tag boot-image/v0.1.3 --force
+          /tmp/mvmctl-source-under-test image boot update --tag boot-image/v0.1.5 --force
 
           slot_hash=$(printf '%s' 'hosted-no-kvm-exit-code-7' | sha256sum | cut -d' ' -f1)
           revision_hash=$(printf '%s' 'source-kernel-release-rootfs-exit-code-7' | sha256sum | cut -d' ' -f1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -968,7 +968,7 @@ jobs:
       # nobody had published. Boot images get their own tags precisely so
       # this pin stops moving with the CLI's version — keep it in step with
       # `DEFAULT_BOOT_IMAGE_TAG` in mvm-core's config.
-      IMAGE_TAG: boot-image/v0.1.3
+      IMAGE_TAG: boot-image/v0.1.5
       # Must track `crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT`. The
       # launch path passes `--enable-pci`, which older Firecracker rejects
       # outright: it exits before creating its API socket, and the only symptom

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -390,7 +390,7 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      # Dual-publish: attach the newest boot image train's assets to this CLI
+      # Dual-publish: attach the CLI's compiled boot image train assets to this CLI
       # release too. It re-uploads bytes, never rebuilds them — the images are
       # built exactly once, by release-boot-image.yml.
       #
@@ -416,27 +416,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # Highest version, not most recently created. `gh release list`
-          # orders by creation date, so `.[0]` picks whichever release was cut
-          # last — and the two disagree the moment one is re-cut out of order.
-          # That is not hypothetical: v0.1.1 published, then v0.1.0 was re-cut
-          # after a fix landed, leaving the newer release at the lower version.
-          # Sorting by parsed semver makes which image a CLI release ships a
-          # property of the version, not of the order someone happened to push.
-          # The strict N.N.N match also drops anything that is not a plain
-          # release tag rather than trying to order it.
-          # No `-r`: `gh --jq` already prints a string result raw, and gh has no
-          # such flag. Passing one consumes `--jq`'s value, demoting the real
-          # expression to a positional argument, and gh rejects the whole
-          # invocation with `unknown command "<the entire jq program>"`.
-          BOOT_TAG="$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
-            --json tagName --jq '
-              [ .[].tagName
-                | select(test("^boot-image/v[0-9]+\\.[0-9]+\\.[0-9]+$"))
-                | {tag: ., v: (ltrimstr("boot-image/v") | split(".") | map(tonumber))} ]
-              | sort_by(.v) | last | .tag // empty')"
+          # Read the same Rust constant embedded in the released mvmctl. An
+          # independently selected newest tag can be complete while the image
+          # users actually fetch is missing or incomplete.
+          BOOT_TAG="$(cargo run --quiet --package xtask -- release-boot-image tag)"
           if [ -z "${BOOT_TAG}" ]; then
-            echo "::error::no boot-image/v* release exists, so this release would ship with no boot image assets and every fresh install would 404 on first boot. Publish a boot-image/v* tag first, then re-run this release." >&2
+            echo "::error::the compiled default boot image tag is empty; refusing to publish" >&2
+            exit 1
+          fi
+          if ! gh release view "${BOOT_TAG}" --repo "${GITHUB_REPOSITORY}" --json tagName > /dev/null; then
+            echo "::error::the CLI embeds ${BOOT_TAG}, but no release with that tag exists. Publish that boot image release or intentionally advance the compiled default before retrying." >&2
             exit 1
           fi
           echo "Attaching boot image assets from ${BOOT_TAG}"
@@ -451,31 +440,8 @@ jobs:
           # means download_builder_vm_image 404s for everyone. The consumer-path
           # check further down covers only runtime-overlay and sdk-sidecar, and
           # skips whatever is absent, so nothing else in this job would notice.
-          missing=()
-          for arch in aarch64 x86_64; do
-            for f in \
-              "default-microvm-vmlinux-${arch}" \
-              "default-microvm-rootfs-${arch}.ext4" \
-              "default-microvm-meta-${arch}.json" \
-              "default-microvm-${arch}-checksums-sha256.txt" \
-              "builder-vm-vmlinux-${arch}" \
-              "builder-vm-rootfs-${arch}.ext4" \
-              "builder-vm-${arch}-checksums-sha256.txt" \
-              "runtime-overlay-${arch}.tar.gz"; do
-              [ -s "artifacts/${f}" ] || missing+=("${f}")
-            done
-            for libc in glibc musl; do
-              for f in \
-                "sdk-sidecar-${arch}-${libc}.tar.gz" \
-                "sdk-sidecar-${arch}-${libc}.tar.gz.sha256"; do
-                [ -s "artifacts/${f}" ] || missing+=("${f}")
-              done
-            done
-          done
-          if [ ${#missing[@]} -gt 0 ]; then
-            echo "::error::${BOOT_TAG} is incomplete — refusing to ship a CLI release whose boot image would 404 on first boot. Missing: ${missing[*]}" >&2
-            exit 1
-          fi
+          cargo run --quiet --package xtask -- \
+            release-boot-image validate "${BOOT_TAG}" artifacts
           # Drop the bundles this job re-mints. The signing step below writes
           # its bundle with create-new semantics, so leaving the boot image
           # train's copy in place would fail that step outright rather than be

--- a/crates/mvm-core/src/config.rs
+++ b/crates/mvm-core/src/config.rs
@@ -20,7 +20,7 @@ pub const FC_VERSION_DEFAULT: &str = match option_env!("MVM_FC_VERSION") {
 /// validate a different image from the one users receive.
 pub const DEFAULT_BOOT_IMAGE_TAG: &str = match option_env!("MVM_BOOT_IMAGE_TAG") {
     Some(t) => t,
-    None => "boot-image/v0.1.3",
+    None => "boot-image/v0.1.5",
 };
 
 /// Host CPU architecture for arch-tagged downloads (the Firecracker release

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -11,6 +11,9 @@ Last updated: 2026-09-08
       and hardened Apple Silicon documented-surface CI. Each has a failing
       regression, a live or operational witness, and an issue-closing PR; #3039
       cannot be publicly disclosed before the recorded clearance gate.
+      The #3207 implementation is complete and awaiting merge: the compiled
+      default and release gate share published `boot-image/v0.1.5`, and its
+      complete 24-asset matrix passed the non-publishing live witness.
 
 - [x] **Linux 6.12.109 synchronized kernel pin — issue #3213.**
       `specs/plans/2026-09-08-kernel-6-12-109.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -18,6 +18,9 @@
       e2e). The plan separates them into issue-linked delivery PRs, puts release
       correctness first, requires owner/counsel release clearance before public
       #3039 work, and names live backend and runner-security acceptance evidence.
+      #3207 implementation is complete and awaiting its issue-linked merge: the
+      CLI and release gate now share `boot-image/v0.1.5`, whose published
+      24-asset architecture/libc matrix passed the non-publishing live witness.
 
 - [x] **Linux 6.12.109 synchronized kernel pin — issue #3213.**
       `specs/plans/2026-09-08-kernel-6-12-109.md`.

--- a/specs/plans/2026-09-08-four-open-issue-closeout.md
+++ b/specs/plans/2026-09-08-four-open-issue-closeout.md
@@ -71,32 +71,41 @@ availability must not be represented as warm-claim coverage.
 
 ### Reproduce and decide
 
-- [ ] Add a failing structural test that reads the compiled
+- [x] Add a failing structural test that reads the compiled
       `DEFAULT_BOOT_IMAGE_TAG` and the release workflow's selected tag and
       demonstrates the current mismatch.
-- [ ] Make the consumer contract authoritative: the release gate must validate
+- [x] Make the consumer contract authoritative: the release gate must validate
       and attach the exact boot-image tag the built CLI will request. Remove the
       independent "highest published tag" decision from the CLI release path.
-- [ ] Keep the boot-image publishing train independent; no CLI release may
+- [x] Keep the boot-image publishing train independent; no CLI release may
       silently advance the default to an image release that does not exist.
 
 ### Implement and verify
 
-- [ ] Expose or consume the default tag through one machine-readable path that
+- [x] Expose or consume the default tag through one machine-readable path that
       both the release test and workflow can verify without duplicating a second
       version literal.
-- [ ] Validate the complete current asset matrix for that exact tag before any
+- [x] Validate the complete current asset matrix for that exact tag before any
       CLI release is created, including both architectures and both SDK libc
       variants.
-- [ ] Extend `tests/release_assets.rs` with positive coverage and negative
+- [x] Extend `tests/release_assets.rs` with positive coverage and negative
       fixtures for a divergent tag, a missing release, and an incomplete asset
       set.
-- [ ] Run the focused release-asset suite, workflow lint, repository policy
+- [x] Run the focused release-asset suite, workflow lint, repository policy
       gates, workspace tests/check, and zero-warning Clippy.
-- [ ] Exercise a release dry-run or equivalent non-publishing workflow witness
+- [x] Exercise a release dry-run or equivalent non-publishing workflow witness
       and record that the tag validated by the gate equals the fresh-install
       download tag.
 - [ ] Merge the issue-linked PR and close #3207.
+
+The implementation advances the compiled default to the complete published
+`boot-image/v0.1.5` line and makes `xtask release-boot-image tag` the workflow's
+machine-readable source. The validator refuses a divergent tag and any empty or
+missing member of the 24-asset architecture/libc matrix. The structural
+regression first failed against the former highest-release lookup, then the
+focused suites, workspace check, workflow lint, and non-publishing live query
+passed. The live query resolved the compiled and published tags to the same
+`boot-image/v0.1.5` release with all 24 required assets present and nonempty.
 
 ## Workstream 2 — #3190: failed-builder lock lifetime
 

--- a/tests/github_actions_aarch64_no_kvm.rs
+++ b/tests/github_actions_aarch64_no_kvm.rs
@@ -32,8 +32,6 @@ const REQUIRED_BOOTSTRAP: &str =
     "/tmp/mvmctl-source-under-test --builder qemu bootstrap --production -v";
 const REQUIRED_QEMU_BUILD: &str =
     "/tmp/mvmctl-source-under-test --builder qemu machine build --flake examples/exit_code";
-const REQUIRED_BOOT_IMAGE_UPDATE: &str =
-    "/tmp/mvmctl-source-under-test image boot update --tag boot-image/v0.1.3 --force";
 const REQUIRED_SOURCE_KERNEL: &str = ".mvm-ci/cache/kernels/x86_64/workload/bzImage";
 const REQUIRED_SOURCE_FLAKE_RESTORE: &str = "mv nix/images/builder-vm.hidden nix/images/builder-vm";
 const REQUIRED_SOURCE_KERNEL_BUILD: &str =
@@ -218,7 +216,10 @@ fn no_kvm_smokes_use_source_binary_and_bound_hosted_tcg_to_boot() {
         build_job.contains("needs: no-kvm-bootstrap")
             && build_job.contains(&format!("name: {BINARY_ARTIFACT}"))
             && build_job.contains(&format!("name: {BOOTSTRAP_ARTIFACT}"))
-            && build_job.contains(REQUIRED_BOOT_IMAGE_UPDATE)
+            && build_job.contains(&format!(
+                "/tmp/mvmctl-source-under-test image boot update --tag {} --force",
+                mvmctl::core::config::DEFAULT_BOOT_IMAGE_TAG
+            ))
             && build_job.contains(REQUIRED_SOURCE_KERNEL)
             && build_job.contains(REQUIRED_SOURCE_KERNEL_VERIFY)
             && build_job.contains(REQUIRED_ENTRYPOINT_PATCH)

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -1010,10 +1010,20 @@ fn website_validation_covers_demo_guest_and_deploy_workflow_changes() {
 
 #[test]
 fn release_lookups_pass_the_filter_directly_to_gh_jq() {
-    for (name, workflow) in [
+    let workflows = [
         ("workers.yml", website_deploy_workflow()),
         ("release.yml", release_workflow()),
-    ] {
+    ];
+    let release_list_lookups = workflows
+        .iter()
+        .filter(|(_, workflow)| workflow.contains("gh release list"))
+        .collect::<Vec<_>>();
+    assert!(
+        !release_list_lookups.is_empty(),
+        "the fixture must include at least one release-list lookup"
+    );
+
+    for (name, workflow) in release_list_lookups {
         assert!(
             workflow.contains("--json tagName --jq '"),
             "{name} must pass its semantic-version filter directly to gh --jq"
@@ -1273,6 +1283,67 @@ fn the_ci_boot_witness_pins_the_compiled_boot_image_tag() {
     assert!(
         ci_workflow().contains(&format!("IMAGE_TAG: {tag}")),
         "the merge-queue boot witness must validate the compiled default boot image tag {tag}"
+    );
+}
+
+/// The CLI release must validate the same boot-image tag embedded in the CLI.
+///
+/// Selecting an independently discovered release can produce a green gate for
+/// bytes that a fresh installation never requests. The release job therefore
+/// asks the Rust workspace for the compiled default and must not choose a tag
+/// by publication order or version sorting.
+#[test]
+fn the_cli_release_validates_the_compiled_boot_image_tag() {
+    let workflow = release_workflow();
+    let step = workflow
+        .split("- name: Attach the boot image release assets to this release")
+        .nth(1)
+        .expect("release.yml must attach boot image assets")
+        .split("\n      - name:")
+        .next()
+        .expect("the boot-image attachment step must have a body");
+
+    assert!(
+        step.contains(
+            "BOOT_TAG=\"$(cargo run --quiet --package xtask -- release-boot-image tag)\""
+        ),
+        "the release gate must obtain BOOT_TAG from the compiled Rust default:\n{step}"
+    );
+    assert!(
+        !step.contains("gh release list") && !step.contains("sort_by(.v)"),
+        "the release gate must not independently select a highest published tag:\n{step}"
+    );
+    assert!(
+        step.contains("release-boot-image validate \"${BOOT_TAG}\" artifacts"),
+        "the release gate must validate the downloaded matrix against that exact tag:\n{step}"
+    );
+}
+
+#[test]
+fn the_cli_release_refuses_a_missing_compiled_boot_image_release() {
+    let workflow = release_workflow();
+    let step = workflow
+        .split("- name: Attach the boot image release assets to this release")
+        .nth(1)
+        .expect("release.yml must attach boot image assets")
+        .split("\n      - name:")
+        .next()
+        .expect("the boot-image attachment step must have a body");
+    let existence_check = step
+        .find("gh release view \"${BOOT_TAG}\"")
+        .expect("the compiled boot image release must be checked explicitly");
+    let download = step
+        .find("gh release download \"${BOOT_TAG}\"")
+        .expect("the compiled boot image release must be downloaded");
+
+    assert!(
+        existence_check < download,
+        "the matching release must exist before any asset download starts:\n{step}"
+    );
+    assert!(
+        step[existence_check..download].contains("exit 1")
+            && step[existence_check..download].contains("the CLI embeds ${BOOT_TAG}"),
+        "a missing compiled-tag release must fail with an actionable error:\n{step}"
     );
 }
 

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -941,8 +941,10 @@ mod tests {
             "bounded bundle preparation must not boot a builder VM"
         );
         assert!(
-            build.contains("image boot update --tag boot-image/v0.1.3 --force")
-                && bootstrap.contains("mv nix/images/builder-vm.hidden nix/images/builder-vm")
+            build.contains(&format!(
+                "image boot update --tag {} --force",
+                mvm_core::config::DEFAULT_BOOT_IMAGE_TAG
+            )) && bootstrap.contains("mv nix/images/builder-vm.hidden nix/images/builder-vm")
                 && bootstrap.contains("sudo chmod 0666 /dev/kvm")
                 && bootstrap.contains("sudo chmod a+r")
                 && bootstrap.contains("/boot/vmlinuz-$(uname -r)")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -89,6 +89,7 @@ mod gen_stubs;
 mod ir_parity;
 mod perf;
 mod prose_citations;
+mod release_boot_image;
 mod release_evidence;
 mod rust_source;
 mod sprint;
@@ -269,6 +270,7 @@ fn main() -> Result<()> {
                 .collect();
             release_evidence::check(&workspace, &lanes)
         }
+        Some("release-boot-image") => release_boot_image::run(&args[2..]),
         Some("check-single-fixture-corpus") => {
             let workspace = workspace_root();
             check_single_fixture_corpus::run(&workspace)
@@ -470,7 +472,7 @@ fn main() -> Result<()> {
             check_all::run_all(&workspace)
         }
         Some(other) => anyhow::bail!(
-            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-sdk-transport-free, check-sdk-cdylib-deps, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, record-release-evidence, check-release-evidence, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-asserted-absence, check-agent-notes, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-virtio-fs, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, check-vcpu-ceilings, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
+            "Unknown xtask: {:?}. Available: gen-man, check-all, check-adr-coverage, check-no-display-on-secret-types, check-audit-positional, check-doc-claims, check-machine-doc-guards, check-forbidden-deps, check-core-runtime-free, check-sdk-transport-free, check-sdk-cdylib-deps, check-content-address-determinism, check-deferrals, check-honesty, check-closure-budget, check-workspace-dep-inheritance, check-duplicate-majors, check-binary-size, check-kernel-config-budget, check-kernel-pin-freshness, check-builder-shell-job-sites, check-guest-entropy-seed, check-guest-agent-runtime-free, check-guest-agent-in-all-images, check-guest-images-no-builder-tools, check-guest-binary-lists, check-no-overclaim, check-two-surfaces, check-no-spec-refs-in-comments, check-no-string-backend-dispatch, check-plan-names, record-release-evidence, check-release-evidence, release-boot-image, check-single-home, check-single-fixture-corpus, check-test-home-isolation, check-no-network-literals, check-cli-runtime-surface, check-cli-help-matches-docs, check-claim-catalog, check-sprint-append, sprint, check-dormant-controls, check-witness-citations, check-asserted-absence, check-agent-notes, check-declared-backing, check-claim-witness-freshness, check-abi-layout, check-mutation-witnesses, check-nextest-groups, check-conformance, check-trust-gradient, check-single-network-path, check-no-virtio-fs, check-no-guest-tool-client, check-one-guest-protocol, check-single-workload-env, check-build-egress-callers, check-verified-kernel-reads, check-stream-redaction-seam, check-guest-init-parity, check-require-grant-token-allowlist, check-mvm-host-binaries-sync, check-per-vm-host-binaries-sync, check-workflow-paths, check-runtime-overlay-version, check-single-grants-projection, check-single-exec-secs-writer, check-single-host-predicate, check-backend-resource-controls, check-vcpu-ceilings, perf, network-perf, build-dev-image, gen-stubs, check-stubs, gen-ir-parity, check-ir-parity",
             other
         ),
         None => {
@@ -652,6 +654,9 @@ fn main() -> Result<()> {
             );
             eprintln!(
                 "  check-release-evidence [lane...]        CI gate — fail unless each lane's evidence covers the current tree"
+            );
+            eprintln!(
+                "  release-boot-image <tag|validate>       Print and validate the boot-image line embedded in the CLI"
             );
             eprintln!(
                 "  check-single-fixture-corpus             CI gate — fail if the golden machine-fixtures corpus is shadowed"

--- a/xtask/src/release_boot_image.rs
+++ b/xtask/src/release_boot_image.rs
@@ -1,0 +1,163 @@
+//! Release-time validation for the boot-image line embedded in `mvmctl`.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+const ARCHITECTURES: [&str; 2] = ["aarch64", "x86_64"];
+const SDK_LIBCS: [&str; 2] = ["glibc", "musl"];
+
+pub(crate) fn run(args: &[String]) -> Result<()> {
+    match args.first().map(String::as_str) {
+        Some("tag") if args.len() == 1 => {
+            println!("{}", mvm_core::config::DEFAULT_BOOT_IMAGE_TAG);
+            Ok(())
+        }
+        Some("validate") if args.len() == 3 => validate_release(&args[1], Path::new(&args[2])),
+        _ => bail!(
+            "usage: release-boot-image tag | release-boot-image validate <tag> <artifact-dir>"
+        ),
+    }
+}
+
+fn validate_release(tag: &str, artifact_dir: &Path) -> Result<()> {
+    let expected = mvm_core::config::DEFAULT_BOOT_IMAGE_TAG;
+    if tag != expected {
+        bail!(
+            "release selected boot image tag {tag:?}, but the CLI embeds {expected:?}; refusing to validate different bytes"
+        );
+    }
+
+    let missing = required_assets()
+        .into_iter()
+        .filter(|name| !is_nonempty_file(&artifact_dir.join(name)))
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        bail!(
+            "{tag} is incomplete; refusing to ship a CLI release whose boot image would fail on first boot. Missing: {}",
+            missing.join(" ")
+        );
+    }
+    Ok(())
+}
+
+fn is_nonempty_file(path: &Path) -> bool {
+    fs::metadata(path).is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0)
+}
+
+fn required_assets() -> Vec<String> {
+    let mut assets = Vec::new();
+    for arch in ARCHITECTURES {
+        assets.extend([
+            format!("default-microvm-vmlinux-{arch}"),
+            format!("default-microvm-rootfs-{arch}.ext4"),
+            format!("default-microvm-meta-{arch}.json"),
+            format!("default-microvm-{arch}-checksums-sha256.txt"),
+            format!("builder-vm-vmlinux-{arch}"),
+            format!("builder-vm-rootfs-{arch}.ext4"),
+            format!("builder-vm-{arch}-checksums-sha256.txt"),
+            format!("runtime-overlay-{arch}.tar.gz"),
+        ]);
+        for libc in SDK_LIBCS {
+            assets.extend([
+                format!("sdk-sidecar-{arch}-{libc}.tar.gz"),
+                format!("sdk-sidecar-{arch}-{libc}.tar.gz.sha256"),
+            ]);
+        }
+    }
+    assets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn complete_fixture() -> tempfile::TempDir {
+        let fixture = tempfile::tempdir().expect("create release fixture");
+        for asset in required_assets() {
+            fs::write(fixture.path().join(asset), b"release bytes")
+                .expect("write release fixture asset");
+        }
+        fixture
+    }
+
+    #[test]
+    fn accepts_the_compiled_tag_with_the_complete_asset_matrix() {
+        let fixture = complete_fixture();
+        validate_release(mvm_core::config::DEFAULT_BOOT_IMAGE_TAG, fixture.path())
+            .expect("the compiled tag and complete matrix must validate");
+    }
+
+    #[test]
+    fn rejects_a_tag_that_diverges_from_the_compiled_default() {
+        let fixture = complete_fixture();
+        let error = validate_release("boot-image/v999.0.0", fixture.path())
+            .expect_err("a different tag must fail closed");
+        assert!(
+            error
+                .to_string()
+                .contains("refusing to validate different bytes"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
+    fn rejects_an_incomplete_asset_matrix() {
+        let fixture = complete_fixture();
+        let missing = "sdk-sidecar-x86_64-musl.tar.gz.sha256";
+        fs::remove_file(fixture.path().join(missing)).expect("remove fixture asset");
+
+        let error = validate_release(mvm_core::config::DEFAULT_BOOT_IMAGE_TAG, fixture.path())
+            .expect_err("an incomplete release must fail closed");
+        assert!(
+            error.to_string().contains(missing),
+            "the error must name the missing asset: {error:#}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_assets_as_missing() {
+        let fixture = complete_fixture();
+        let empty = "runtime-overlay-aarch64.tar.gz";
+        fs::write(fixture.path().join(empty), b"").expect("empty fixture asset");
+
+        let error = validate_release(mvm_core::config::DEFAULT_BOOT_IMAGE_TAG, fixture.path())
+            .expect_err("an empty release asset must fail closed");
+        assert!(
+            error.to_string().contains(empty),
+            "the error must name the empty asset: {error:#}"
+        );
+    }
+
+    #[test]
+    fn required_matrix_covers_both_architectures_and_sdk_libcs() {
+        let assets = required_assets();
+        assert_eq!(assets.len(), 24, "the release matrix must stay exhaustive");
+        for arch in ARCHITECTURES {
+            assert!(
+                assets.iter().any(|asset| asset.contains(arch)),
+                "the matrix must include {arch}"
+            );
+            for libc in SDK_LIBCS {
+                let needle = format!("sdk-sidecar-{arch}-{libc}");
+                assert!(
+                    assets.iter().any(|asset| asset.starts_with(&needle)),
+                    "the matrix must include {arch}/{libc}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn nonexistent_artifact_directory_is_an_incomplete_release() {
+        let path = PathBuf::from("this-release-directory-does-not-exist");
+        let error = validate_release(mvm_core::config::DEFAULT_BOOT_IMAGE_TAG, &path)
+            .expect_err("a missing release fixture must fail closed");
+        assert!(
+            error.to_string().contains("Missing:"),
+            "unexpected error: {error:#}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3207

The CLI release gate now obtains its boot-image tag from the same compiled Rust constant used by fresh installations, refuses a missing release or divergent tag, and validates the complete 24-asset architecture/libc matrix. The compiled default and pinned CI witness advance to the complete published boot-image/v0.1.5 release.

Validation:
- cargo test --test release_assets
- cargo test -p xtask release_boot_image
- cargo test --workspace --quiet -- --test-threads=1 (all non-doctest targets passed; doctests rerun separately after a nested-Cargo artifact race)
- cargo test --workspace --doc --quiet -- --test-threads=1
- cargo check --workspace
- cargo clippy --workspace -- -D warnings
- cargo run --package xtask -- check-all
- actionlint on release.yml, ci.yml, and ci-full.yml
- non-publishing release query: boot-image/v0.1.5, 24/24 required assets present and nonempty