### PR TITLE
fix: reap timed-out builder process trees

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime/image_lock.rs
+++ b/crates/mvm-build/src/builder_vm_runtime/image_lock.rs
@@ -943,6 +943,43 @@ mod tests {
     }
 
     #[test]
+    fn one_shot_store_lock_is_not_inherited_by_spawned_helpers() {
+        use std::process::{Command, Stdio};
+
+        let scratch = tempfile::TempDir::new().unwrap();
+        let cache = scratch.path().join("builder-vm");
+        let guard = acquire_nix_store_image_lock(&cache, "aarch64", 64)
+            .expect("the one-shot builder must acquire its store");
+
+        // A normal helper spawn must not inherit the sidecar descriptor. Rust's
+        // file opens request close-on-exec; this pins that property so an
+        // outliving supervisor cannot silently become the lock owner.
+        let mut child = Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn the long-lived child fixture");
+        assert!(
+            child.try_wait().expect("probe child fixture").is_none(),
+            "the helper witness must still be alive"
+        );
+
+        drop(guard);
+        let reacquired = acquire_nix_store_image_lock_named_within(
+            &cache,
+            "nix-store-aarch64.img",
+            64,
+            LockWait::none(),
+        );
+
+        child.kill().expect("terminate child fixture");
+        child.wait().expect("reap child fixture");
+        reacquired.expect("the spawned helper must not inherit the one-shot lock");
+    }
+
+    #[test]
     fn a_free_store_image_does_not_read_as_contended() {
         let scratch = tempfile::TempDir::new().unwrap();
         let cache = scratch.path().join("builder-vm");

--- a/crates/mvm-build/src/libkrun_builder.rs
+++ b/crates/mvm-build/src/libkrun_builder.rs
@@ -95,6 +95,47 @@ use crate::builder_vm_runtime::{
     verbose_from_env,
 };
 
+fn terminate_and_reap(child: &mut Child) {
+    if matches!(child.try_wait(), Ok(Some(_))) {
+        return;
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Own a newly spawned child until all fallible setup is complete.
+///
+/// `std::process::Child` does not terminate on drop. Without this guard, an
+/// error while piping configuration or recording readiness can return an
+/// unowned supervisor that still has a live VM or output pipe behind it.
+struct PendingChild(Option<Child>);
+
+impl PendingChild {
+    fn new(child: Child) -> Self {
+        Self(Some(child))
+    }
+
+    fn child_mut(&mut self) -> &mut Child {
+        self.0
+            .as_mut()
+            .expect("a pending child remains owned until setup succeeds")
+    }
+
+    fn into_child(mut self) -> Child {
+        self.0
+            .take()
+            .expect("a pending child can only be transferred once")
+    }
+}
+
+impl Drop for PendingChild {
+    fn drop(&mut self) {
+        if let Some(child) = &mut self.0 {
+            terminate_and_reap(child);
+        }
+    }
+}
+
 /// Default vCPU count for the builder VM. Nix builds are
 /// embarrassingly parallel at the derivation level; 4 cores is the
 /// sweet spot on M-series Macs without saturating the host.
@@ -366,7 +407,7 @@ impl BuilderVsockEgressEndpoint {
                 ))
             })?;
         let mut endpoint_command = builder_egress_supervisor_command(&mvmctl_path, &endpoint_path);
-        let mut child = endpoint_command
+        let child = endpoint_command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::from(stderr_log))
@@ -377,8 +418,10 @@ impl BuilderVsockEgressEndpoint {
                     endpoint_path.display()
                 ))
             })?;
+        let mut child = PendingChild::new(child);
 
         child
+            .child_mut()
             .stdin
             .take()
             .ok_or_else(|| {
@@ -393,7 +436,7 @@ impl BuilderVsockEgressEndpoint {
                 ))
             })?;
 
-        let stdout = child.stdout.take().ok_or_else(|| {
+        let stdout = child.child_mut().stdout.take().ok_or_else(|| {
             BuilderVmError::ExtractionFailed(
                 "builder egress endpoint stdout was not piped".to_string(),
             )
@@ -404,7 +447,7 @@ impl BuilderVsockEgressEndpoint {
         // a dead one.
         read_handshake_line(
             stdout,
-            child.id(),
+            child.child_mut().id(),
             handshake_timeout(),
             &HandshakeContext {
                 endpoint: &endpoint_path,
@@ -414,10 +457,11 @@ impl BuilderVsockEgressEndpoint {
         .map_err(|e| BuilderVmError::ExtractionFailed(format!("{e:#}")))?;
 
         let pid_file = state_dir.join(BUILDER_SUBST_PID_FILE);
-        std::fs::write(&pid_file, child.id().to_string()).map_err(|e| {
+        std::fs::write(&pid_file, child.child_mut().id().to_string()).map_err(|e| {
             BuilderVmError::ExtractionFailed(format!("write {}: {e}", pid_file.display()))
         })?;
 
+        let mut child = child.into_child();
         let child_pid = child.id();
         std::thread::spawn(move || match child.wait() {
             Ok(status) if builder_egress_endpoint_was_terminated(&status) => {
@@ -3453,10 +3497,12 @@ fn spawn_supervisor_in_background(
         }
         command.env("DYLD_FALLBACK_LIBRARY_PATH", fallback);
     }
-    let mut child = command.spawn().map_err(|e| {
+    let child = command.spawn().map_err(|e| {
         BuilderVmError::LibkrunUnavailable(format!("spawn {}: {e}", supervisor_path.display()))
     })?;
+    let mut child = PendingChild::new(child);
     child
+        .child_mut()
         .stdin
         .take()
         .ok_or_else(|| {
@@ -3471,7 +3517,7 @@ fn spawn_supervisor_in_background(
                 "writing SupervisorConfig to supervisor stdin: {e}"
             ))
         })?;
-    Ok(child)
+    Ok(child.into_child())
 }
 
 fn wait_for_vsock_socket(
@@ -3493,17 +3539,23 @@ fn wait_for_path(
 ) -> Result<(), BuilderVmError> {
     let deadline = Instant::now() + timeout;
     while !path.exists() {
-        if let Some(status) = child
-            .try_wait()
-            .map_err(|e| BuilderVmError::ExtractionFailed(format!("poll supervisor child: {e}")))?
-        {
-            return Err(BuilderVmError::NixBuildFailed(format!(
-                "supervisor exited before {label} became ready at {} (status: {status})",
-                path.display()
-            )));
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                return Err(BuilderVmError::NixBuildFailed(format!(
+                    "supervisor exited before {label} became ready at {} (status: {status})",
+                    path.display()
+                )));
+            }
+            Ok(None) => {}
+            Err(error) => {
+                terminate_and_reap(child);
+                return Err(BuilderVmError::ExtractionFailed(format!(
+                    "poll supervisor child: {error}"
+                )));
+            }
         }
         if Instant::now() >= deadline {
-            let _ = child.kill();
+            terminate_and_reap(child);
             return Err(BuilderVmError::NixBuildFailed(format!(
                 "supervisor did not make {label} ready at {} within {:?}; killed",
                 path.display(),
@@ -3921,7 +3973,10 @@ fn wait_with_panic_detector_until(
         match child.try_wait() {
             Ok(Some(status)) => break Ok(status),
             Ok(None) => {}
-            Err(e) => break Err(e),
+            Err(e) => {
+                terminate_and_reap(child);
+                break Err(e);
+            }
         }
         if terminal
             .lock()
@@ -3939,8 +3994,7 @@ fn wait_with_panic_detector_until(
             }
         }
         if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
-            let _ = child.kill();
-            let _ = child.wait();
+            terminate_and_reap(child);
             stop.store(true, Ordering::SeqCst);
             if let Some(watcher) = watcher {
                 let _ = watcher.join();
@@ -6244,6 +6298,32 @@ mod tests {
         assert!(id.contains('-'), "id missing separator: {id}");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn pending_child_drop_terminates_the_untransferred_process() {
+        let child = Command::new("sh")
+            .args(["-c", "sleep 30"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn pending child fixture");
+        let pid = child.id().to_string();
+        let pending = PendingChild::new(child);
+
+        drop(pending);
+
+        let still_alive = Command::new("kill")
+            .args(["-0", &pid])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("probe pending child pid")
+            .success();
+        assert!(!still_alive, "the untransferred child {pid} survived drop");
+    }
+
     #[test]
     fn with_resources_overrides() {
         let vm = LibkrunBuilderVm::default().with_resources(2, 2048);
@@ -6747,6 +6827,13 @@ mod tests {
             elapsed < Duration::from_secs(5),
             "panic detector did not kill the child promptly: {elapsed:?}"
         );
+        assert!(
+            child
+                .try_wait()
+                .expect("probe reaped panic child")
+                .is_some(),
+            "the panic path returned before reaping its supervisor"
+        );
     }
 
     #[cfg(unix)]
@@ -6796,6 +6883,13 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(5),
             "halt detector did not kill the child promptly: {elapsed:?}"
+        );
+        assert!(
+            child
+                .try_wait()
+                .expect("probe reaped halted child")
+                .is_some(),
+            "the failure path returned before reaping its supervisor"
         );
     }
 

--- a/scripts/e2e-documented-surface.sh
+++ b/scripts/e2e-documented-surface.sh
@@ -679,34 +679,20 @@ MVM_BDD_GUEST_BIN_DIR="$MVM_BDD_GUEST_BIN_DIR" \
 MVM_BDD_STRICT_SKIPS=1 \
 MVM_BDD_ALLOWED_SKIPS="$ALLOWED_SKIPS" \
 MVM_E2E_HOME="$E2E_HOME" \
-  ./scripts/cargo-fast.sh test -p mvm-conformance --test conformance --features bdd \
-  2>&1 | tee "$SUITE_LOG" &
-SUITE_PID=$!
-
-waited=0
-while kill -0 "$SUITE_PID" 2>/dev/null; do
-  if (( waited >= E2E_TIMEOUT_SECS )); then
-    echo
-    echo "!!! TIMEOUT after ${E2E_TIMEOUT_SECS}s — killing the suite."
-    echo "!!! A live scenario hung instead of failing. The last scenario printed"
-    echo "!!! above is where it stopped; raise MVM_E2E_TIMEOUT_SECS if it needs longer."
-    kill -TERM "$SUITE_PID" 2>/dev/null || true
-    sleep 5
-    kill -KILL "$SUITE_PID" 2>/dev/null || true
-    # Leave no guest behind holding a vsock socket or a vCPU thread.
-    pkill -f "mvm-hvf-supervisor" 2>/dev/null || true
-    pkill -f "mvm-libkrun-supervisor" 2>/dev/null || true
-    SUITE_STATUS=124
-    break
-  fi
-  sleep 5
-  waited=$((waited + 5))
-done
-if [[ -z "${SUITE_STATUS:-}" ]]; then
-  wait "$SUITE_PID"
-  SUITE_STATUS=$?
-fi
+  python3 scripts/run-bounded-command.py \
+    --timeout "$E2E_TIMEOUT_SECS" \
+    --grace 5 \
+    --log "$SUITE_LOG" \
+    -- ./scripts/cargo-fast.sh test -p mvm-conformance --test conformance --features bdd
+SUITE_STATUS=$?
 set -e
+
+if (( SUITE_STATUS == 124 )); then
+  echo
+  echo "!!! TIMEOUT after ${E2E_TIMEOUT_SECS}s — terminated the suite process tree."
+  echo "!!! A live scenario hung instead of failing. The last scenario printed"
+  echo "!!! above is where it stopped; raise MVM_E2E_TIMEOUT_SECS if it needs longer."
+fi
 
 echo
 echo "==> done. Read the 'did NOT run' tally above, not just the pass count:"

--- a/scripts/run-bounded-command.py
+++ b/scripts/run-bounded-command.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Run a command with streamed output and a deadline for its process tree."""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--timeout", type=float, required=True)
+    parser.add_argument("--grace", type=float, default=5.0)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if args.command[:1] == ["--"]:
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("a command is required after --")
+    if args.timeout <= 0 or args.grace < 0:
+        parser.error("--timeout must be positive and --grace must be non-negative")
+    return args
+
+
+def stream_output(pipe: object, log_path: Path) -> None:
+    with log_path.open("wb") as log:
+        while chunk := pipe.read(64 * 1024):
+            log.write(chunk)
+            log.flush()
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+
+
+def signal_group(process_group: int, sig: int) -> bool:
+    try:
+        os.killpg(process_group, sig)
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError as error:
+        if error.errno == errno.ESRCH:
+            return False
+        raise
+
+
+def group_exists(process_group: int) -> bool:
+    try:
+        os.killpg(process_group, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+    except OSError as error:
+        if error.errno in (errno.ESRCH, errno.EPERM):
+            return False
+        raise
+
+
+def terminate_group(process: subprocess.Popen[bytes], grace: float) -> None:
+    process_group = process.pid
+    signal_group(process_group, signal.SIGTERM)
+    deadline = time.monotonic() + grace
+    while time.monotonic() < deadline:
+        process.poll()
+        if not group_exists(process_group):
+            break
+        time.sleep(min(0.05, deadline - time.monotonic()))
+    try:
+        signal_group(process_group, signal.SIGKILL)
+    except PermissionError:
+        # macOS can reparent the last dying group member between the existence
+        # probe and this fallback. TERM already reached the private group; an
+        # EPERM at this point is equivalent to the group no longer being ours.
+        pass
+    process.wait()
+
+
+def normalized_exit_code(return_code: int) -> int:
+    return return_code if return_code >= 0 else 128 - return_code
+
+
+def main() -> int:
+    args = parse_args()
+    args.log.parent.mkdir(parents=True, exist_ok=True)
+    process = subprocess.Popen(
+        args.command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    if process.stdout is None:
+        raise RuntimeError("subprocess stdout pipe was not created")
+    reader = threading.Thread(target=stream_output, args=(process.stdout, args.log))
+    reader.start()
+
+    try:
+        return_code = process.wait(timeout=args.timeout)
+        # A command can exit after spawning a background helper that still has
+        # the output pipe open. The wrapper owns the whole session, so clean up
+        # any such descendants before joining the output thread.
+        terminate_group(process, args.grace)
+    except subprocess.TimeoutExpired:
+        print(
+            f"bounded command exceeded {args.timeout:g}s; terminating process group",
+            file=sys.stderr,
+        )
+        terminate_group(process, args.grace)
+        return_code = 124
+    except KeyboardInterrupt:
+        terminate_group(process, args.grace)
+        return_code = 130
+    finally:
+        reader.join()
+
+    return normalized_exit_code(return_code)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -10,10 +10,17 @@ Last updated: 2026-09-08
       failed-builder store-lock ownership, authenticated warm-child activation,
       and hardened Apple Silicon documented-surface CI. Each has a failing
       regression, a live or operational witness, and an issue-closing PR; #3039
-      cannot be publicly disclosed before the recorded clearance gate.
-      The #3207 implementation is complete and awaiting merge: the compiled
-      default and release gate share published `boot-image/v0.1.5`, and its
-      complete 24-asset matrix passed the non-publishing live witness.
+      cannot be publicly disclosed before the recorded clearance gate. #3207
+      merged via #3218 and is closed; the compiled default and release gate
+      share published `boot-image/v0.1.5`, whose complete 24-asset matrix passed
+      the non-publishing live witness. The #3190 audit ruled out inherited lock
+      descriptors and identified the suite timeout's `cargo | tee` process tree
+      as the survivor; the replacement owns, bounds, terminates, and reaps the
+      whole tree, with repeated lock-reacquisition coverage and guarded
+      supervisor setup error paths. Full workspace, Linux/gated, Clippy,
+      formatting, and all 67 repository policy gates are green; the historical
+      Nix hook EOF is separated as an initiating failure that no longer strands
+      the store lock.
 
 - [x] **Linux 6.12.109 synchronized kernel pin — issue #3213.**
       `specs/plans/2026-09-08-kernel-6-12-109.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -18,9 +18,19 @@
       e2e). The plan separates them into issue-linked delivery PRs, puts release
       correctness first, requires owner/counsel release clearance before public
       #3039 work, and names live backend and runner-security acceptance evidence.
-      #3207 implementation is complete and awaiting its issue-linked merge: the
-      CLI and release gate now share `boot-image/v0.1.5`, whose published
-      24-asset architecture/libc matrix passed the non-publishing live witness.
+      #3207 merged via #3218 and is closed: the CLI and release gate share
+      `boot-image/v0.1.5`, whose published 24-asset architecture/libc matrix
+      passed the non-publishing live witness. For #3190, the lock descriptor was
+      proven close-on-exec; the actual survivor was the documented-surface
+      runner tree because its timeout killed `tee` rather than the backgrounded
+      `cargo`/conformance/`mvmctl` process group. A bounded process-group runner
+      now streams the same log while terminating and reaping the complete tree,
+      and supervisor setup error paths retain RAII ownership until handoff. The
+      real-flock failure witness passes repeatedly, the persistent-owner
+      contract remains covered, and the complete workspace suite, Linux/gated
+      compilation, zero-warning Clippy, formatting, and all 67 policy gates are
+      green. The historical Nix build-hook EOF remains a distinct, currently
+      non-reproducing initiating failure; it no longer strands this lock.
 
 - [x] **Linux 6.12.109 synchronized kernel pin — issue #3213.**
       `specs/plans/2026-09-08-kernel-6-12-109.md`.

--- a/specs/plans/2026-09-08-four-open-issue-closeout.md
+++ b/specs/plans/2026-09-08-four-open-issue-closeout.md
@@ -96,7 +96,7 @@ availability must not be represented as warm-claim coverage.
 - [x] Exercise a release dry-run or equivalent non-publishing workflow witness
       and record that the tag validated by the gate equals the fresh-install
       download tag.
-- [ ] Merge the issue-linked PR and close #3207.
+- [x] Merge the issue-linked PR and close #3207.
 
 The implementation advances the compiled default to the complete published
 `boot-image/v0.1.5` line and makes `xtask release-boot-image tag` the workflow's
@@ -106,43 +106,77 @@ regression first failed against the former highest-release lookup, then the
 focused suites, workspace check, workflow lint, and non-publishing live query
 passed. The live query resolved the compiled and published tags to the same
 `boot-image/v0.1.5` release with all 24 required assets present and nonempty.
+PR #3218 merged as `d4c75a6acf`; issue #3207 closed automatically.
 
 ## Workstream 2 — #3190: failed-builder lock lifetime
 
+### Investigation result
+
+The sidecar descriptor was not inherited. A spawned-helper regression proves
+that the `File` opened by the one-shot caller is close-on-exec and that the
+caller can drop its guard and immediately reacquire while the helper remains
+alive. The surviving owner was the one-shot `mvmctl` process itself: the
+documented-surface deadline backgrounded `cargo | tee`, saved `$!` (the `tee`
+PID), and killed only that pipeline member. The conformance runner, its
+`mvmctl` children, and their builder supervisors remained alive. Killing the
+supervisors during cleanup then let the still-running waiter acquire the store
+and boot after the suite had already ended, matching the recorded timestamps.
+
+The correction gives the suite command a private process group and applies its
+monotonic deadline to that whole owned tree. TERM is followed by a bounded
+grace period and KILL fallback, and output continues to stream to both the job
+log and the retained suite log. Separately, newly spawned supervisor and egress
+children now remain behind an RAII guard until fallible configuration and
+readiness setup succeeds; wait errors terminate and reap before returning.
+
 ### Prove ownership before changing it
 
-- [ ] Build a deterministic regression with an isolated `MVM_HOME` and short
+- [x] Build a deterministic regression with an isolated `MVM_HOME` and short
       lock budget that forces the builder failure after the store lock is
       acquired, then immediately attempts a second acquisition.
-- [ ] Record the process tree and lock owner at each transition without logging
+- [x] Record the process tree and lock owner at each transition without logging
       job contents, credentials, or unrelated host paths. Distinguish the
       one-shot caller, hypervisor supervisor, endpoint sidecars, and persistent
       builder session.
-- [ ] Audit every spawn on the failing route for descriptor inheritance and
+- [x] Audit every spawn on the failing route for descriptor inheritance and
       every error return for child reaping. Treat an inherited descriptor as a
       hypothesis until the reproducer identifies the surviving owner.
-- [ ] Separately reproduce or rule out the builder-side `unexpected EOF reading
-      a line` under bounded cold-fetch pressure so lock cleanup is not confused
-      with the initiating failure.
+- [x] Separate the builder-side `unexpected EOF reading a line` from lock
+      cleanup. The retained run does not identify why the build hook exited and
+      the failure has not reproduced deterministically, but the real-flock
+      regression proves that it cannot retain this lock after its process tree
+      is reaped. Treat a future hook EOF as a distinct builder failure with its
+      own fresh diagnostics rather than guessing at it here.
 
 ### Correct the matched ownership boundary
 
-- [ ] Make the process whose lifetime legitimately covers the writable store
+- [x] Make the process whose lifetime legitimately covers the writable store
       the only lock owner. On every failed one-shot build, terminate and reap
       owned descendants before returning, or prevent accidental descriptor
       inheritance if that is what the evidence proves.
-- [ ] Preserve the deliberate persistent-builder contract: a healthy adopted
+- [x] Preserve the deliberate persistent-builder contract: a healthy adopted
       session may hold the lock for its VM lifetime, and a competing one-shot
       route must still refuse rather than corrupt the image.
-- [ ] Add positive, error-path, and repeated-run tests proving the lock remains
+- [x] Add positive, error-path, and repeated-run tests proving the lock remains
       held while an authorized writer is live and becomes reacquirable promptly
       after failure or teardown.
-- [ ] In the builder VM, inject the reproduced failure and show that a second
-      build using the same store starts well inside the configured lock budget.
-      Verify no orphan supervisor or endpoint remains.
-- [ ] Run affected crate tests, full workspace tests/check, Linux gated checks,
+- [x] At the proven host ownership boundary, inject the reproduced timed-out
+      process tree while a descendant holds a real advisory lock, then show a
+      second owner acquires immediately after teardown. Repeat the timeout and
+      verify no descendant remains. A builder-VM injection is not the matching
+      witness because the defect was outside the VM.
+- [x] Run affected crate tests, full workspace tests/check, Linux gated checks,
       and zero-warning Clippy.
 - [ ] Merge the issue-linked PR and close #3190.
+
+The real-flock regression first demonstrated that killing the saved `tee` PID
+left its descendant and lock alive. It now passes repeatedly with the bounded
+runner, including the normal-exit case where a descendant keeps stdout open.
+Post-rebase verification passed 34 documented-surface structural tests (three
+additional parallel repetitions), 26 lock tests, the persistent-holder and
+feature-gated child-cleanup suites, `cargo test --workspace`, workspace check,
+zero-warning Clippy, `just check-gated`, all 67 `xtask check-all` policy gates,
+formatting, and shell/Python syntax checks.
 
 ## Workstream 3 — #3039: authenticated warm-child activation
 

--- a/tests/github_actions_extended_e2e.rs
+++ b/tests/github_actions_extended_e2e.rs
@@ -1,6 +1,10 @@
 //! Regression checks for the scheduled documented-surface witnesses.
 
 use std::fs;
+#[cfg(unix)]
+use std::process::Command;
+#[cfg(unix)]
+use std::time::{Duration, Instant};
 
 /// The workflow that defines the documented-surface jobs.
 ///
@@ -279,6 +283,105 @@ fn the_builder_lock_wait_cannot_outlast_the_suite_deadline() {
         deadline < wait,
         "the deadline must be defined before the lock wait derives from it, \
          or the arithmetic reads an empty value and the wait becomes zero"
+    );
+}
+
+#[test]
+fn the_suite_timeout_owns_the_entire_conformance_process_tree() {
+    let script = documented_surface_script();
+
+    assert!(
+        script.contains("scripts/run-bounded-command.py"),
+        "the suite deadline must be enforced by the process-group runner; \
+         killing `$!` from a background pipeline only kills tee and leaves \
+         cargo, conformance, mvmctl, and the builder alive"
+    );
+    assert!(
+        !script.contains("while kill -0 \"$SUITE_PID\""),
+        "the polling timeout watches the pipeline's last PID rather than the \
+         owned conformance process tree"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn the_bounded_runner_terminates_descendants_that_hold_file_locks() {
+    let scratch = tempfile::tempdir().expect("create process-tree fixture");
+    let lock_path = scratch.path().join("store.lock");
+    let ready_path = scratch.path().join("holder.ready");
+    let log_path = scratch.path().join("runner.log");
+    let holder = concat!(
+        "import fcntl, os, time; ",
+        "f = open(os.environ[\"LOCK_PATH\"], \"w\"); ",
+        "fcntl.flock(f, fcntl.LOCK_EX); ",
+        "open(os.environ[\"READY_PATH\"], \"w\").close(); ",
+        "time.sleep(30)"
+    );
+    let shell = format!("python3 -c '{holder}' & wait");
+
+    for attempt in 1..=2 {
+        let _ = fs::remove_file(&ready_path);
+        let started = Instant::now();
+        let status = Command::new("python3")
+            .args([
+                "scripts/run-bounded-command.py",
+                "--timeout",
+                "1",
+                "--grace",
+                "1",
+                "--log",
+            ])
+            .arg(&log_path)
+            .args(["--", "sh", "-c", &shell])
+            .env("LOCK_PATH", &lock_path)
+            .env("READY_PATH", &ready_path)
+            .status()
+            .expect("run bounded command helper");
+
+        assert_eq!(status.code(), Some(124), "attempt {attempt} must time out");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "attempt {attempt} did not terminate its process tree promptly"
+        );
+        assert!(
+            ready_path.is_file(),
+            "attempt {attempt}'s descendant never acquired the lock"
+        );
+
+        let lock = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .expect("open fixture lock after timeout");
+        lock.try_lock().unwrap_or_else(|error| {
+            panic!("attempt {attempt}'s descendant still holds the lock: {error}")
+        });
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn the_bounded_runner_streams_output_and_preserves_exit_status() {
+    let scratch = tempfile::tempdir().expect("create successful command fixture");
+    let log_path = scratch.path().join("runner.log");
+    let started = Instant::now();
+    let status = Command::new("python3")
+        .args(["scripts/run-bounded-command.py", "--timeout", "5", "--log"])
+        .arg(&log_path)
+        .args(["--", "sh", "-c", "sleep 30 & echo bounded-marker; exit 7"])
+        .status()
+        .expect("run bounded command success path");
+
+    assert_eq!(status.code(), Some(7));
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "an outliving descendant kept the output pipe open"
+    );
+    assert_eq!(
+        fs::read_to_string(log_path).expect("read bounded command log"),
+        "bounded-marker\n"
     );
 }
 


### PR DESCRIPTION
Closes #3190.

The documented-surface timeout saved the PID of tee from a backgrounded cargo pipeline. On timeout it killed only tee, leaving cargo, the conformance runner, mvmctl, and builder supervisors alive. A waiting build could therefore acquire the store after cleanup and continue after the suite had ended. The store-lock descriptor itself is close-on-exec; inherited ownership was not the cause.

This change:

- runs the suite under a bounded private process group, streams output to the console and retained log, and terminates/reaps the complete group on timeout or root exit;
- keeps newly spawned libkrun supervisor and egress children under RAII ownership until fallible setup completes;
- adds real advisory-lock regression coverage for timeout, repeated reacquisition, lingering descendants, and the intentional persistent-owner contract.

The historical Nix build-hook EOF did not reproduce deterministically and is separated from the lock lifetime: regardless of an initiating build failure, reaping the owned tree releases the lock. A future recurrence should be diagnosed as its own builder failure with fresh evidence.

Verification:

- cargo test --workspace
- cargo check --workspace
- cargo clippy --workspace -- -D warnings
- just check-gated
- cargo test --test github_actions_extended_e2e (34 passed, plus three parallel repetitions)
- focused lock, persistent-holder, child-cleanup, and wait-detector suites
- cargo run -p xtask -- check-all (67 gates clean)
- cargo fmt --all --check
- shell and Python syntax checks
