### PR TITLE
Stabilize scheduled CI witnesses

### DIFF
--- a/crates/mvm-build/src/builder_vm_runtime/image_lock.rs
+++ b/crates/mvm-build/src/builder_vm_runtime/image_lock.rs
@@ -971,12 +971,24 @@ mod tests {
             &cache,
             "nix-store-aarch64.img",
             64,
-            LockWait::none(),
+            // Distinguish a transient release from real inheritance: the
+            // bounded wait stays far below the deliberately outliving
+            // helper's lifetime, so a helper that owns the descriptor still
+            // makes this witness fail.
+            LockWait::of(Duration::from_secs(5)),
         );
+        let helper_still_alive = child
+            .try_wait()
+            .expect("probe helper after lock reacquisition")
+            .is_none();
 
         child.kill().expect("terminate child fixture");
         child.wait().expect("reap child fixture");
         reacquired.expect("the spawned helper must not inherit the one-shot lock");
+        assert!(
+            helper_still_alive,
+            "the lock must be reacquired before the helper exits"
+        );
     }
 
     #[test]

--- a/crates/mvm-cli/src/commands/env/artifact_verify.rs
+++ b/crates/mvm-cli/src/commands/env/artifact_verify.rs
@@ -231,10 +231,18 @@ pub(crate) fn verify_artifact_hash(
 /// already-complete file curl handles it gracefully. Corruption is
 /// still caught downstream by the SHA-256 gate (`verify_artifact_hash`),
 /// which deletes on mismatch so the next run restarts clean.
+/// Transient transport failures are retried three times with a short fixed
+/// delay. HTTP failures remain visible through `-f`, and no downloaded bytes
+/// are trusted until the existing signature and digest gates accept them.
 pub(super) fn curl_download_args(dest: &str, url: &str) -> Vec<String> {
     vec![
         "-fSL".to_string(),
         "--progress-bar".to_string(),
+        "--retry".to_string(),
+        "3".to_string(),
+        "--retry-delay".to_string(),
+        "2".to_string(),
+        "--retry-all-errors".to_string(),
         "-C".to_string(),
         "-".to_string(),
         "-o".to_string(),
@@ -298,6 +306,18 @@ mod tests {
             "expected `-C -`: {args:?}"
         );
         assert!(args.contains(&"-fSL".to_string()));
+        assert!(
+            args.windows(2).any(|w| w == ["--retry", "3"]),
+            "expected three bounded retries: {args:?}"
+        );
+        assert!(
+            args.windows(2).any(|w| w == ["--retry-delay", "2"]),
+            "expected a fixed retry delay: {args:?}"
+        );
+        assert!(
+            args.contains(&"--retry-all-errors".to_string()),
+            "connection resets must be retried: {args:?}"
+        );
         assert_eq!(args.last().unwrap(), "https://example/x");
     }
 

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,8 +1,16 @@
 # Refactor status
 
-Last updated: 2026-09-08
+Last updated: 2026-09-09
 
 ## In progress
+
+- [ ] **Scheduled CI stability.**
+      `specs/plans/2026-09-09-scheduled-ci-stability.md`.
+      Issues #3222 and #3223 identify independent transient failures in the
+      Extended and Security schedules; #3224 is the resulting stale-claim
+      alarm. The work preserves fail-closed artifact verification and
+      single-writer locking while making both witnesses robust, then requires
+      fresh successful scheduled-lane evidence before closeout.
 
 - [ ] **Four-open-issue closeout.**
       `specs/plans/2026-09-08-four-open-issue-closeout.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,15 @@
 
 ## In progress
 
+- [ ] **Scheduled CI stability — issues #3222, #3223, and #3224.**
+      `specs/plans/2026-09-09-scheduled-ci-stability.md`.
+      Harden release-asset downloads against transient connection failures,
+      make the close-on-exec lock witness tolerate unrelated concurrent
+      pre-exec windows without allowing an outliving helper to retain the
+      lock. The focused regressions, 871-test mutation baseline, full executable
+      workspace suite, compile/Clippy/format gates, and 67 policy gates are
+      green; merge and fresh Extended/Security evidence remain before closeout.
+
 - [ ] **Close the four remaining open issues.**
       `specs/plans/2026-09-08-four-open-issue-closeout.md`.
       The verified baseline is #3207 (release/default boot-tag drift), #3190

--- a/specs/plans/2026-09-09-scheduled-ci-stability.md
+++ b/specs/plans/2026-09-09-scheduled-ci-stability.md
@@ -1,0 +1,53 @@
+# Scheduled CI stability
+
+Backing: shipped-source
+Validation: check-sprint-append
+
+**Opened:** 2026-09-09
+**Baseline:** `main` at `e3abd2808f`
+
+## Outcome
+
+Close #3222 and #3223 by correcting the two independent failures in the
+scheduled Extended and Security lanes, then restore the fresh claim-bearing
+evidence required to close #3224. Artifact identity verification and builder
+store single-writer exclusion remain fail closed.
+
+## Verified failures
+
+| Issue | Failure | Completion witness |
+| --- | --- | --- |
+| #3222 | A transient connection reset while fetching a published boot kernel exhausted the single curl attempt and was reported as a missing release asset. | The shared release downloader retries transient failures with a bounded policy, retains resumable partial files, and still requires signed-manifest and SHA-256 verification. |
+| #3223 | The mutation lane's unmodified baseline observed immediate lock contention; the old witness could not distinguish a transient release from the deliberately outliving helper retaining the descriptor. | The witness allows only a short bounded release window and still fails while its deliberately outliving helper retains the lock. |
+| #3224 | The claim freshness watcher rejected the failed Security schedule as stale claim-bearing evidence. | A fresh successful Security run restores every registered claim witness and the watcher reconciles the issue. |
+
+## Tasks
+
+- [x] Add a failing downloader-argument regression for bounded retries on
+      connection resets.
+- [x] Add bounded retry flags to the shared resumable curl downloader without
+      bypassing signature or digest verification.
+- [x] Stabilize the lock close-on-exec witness with a short explicit wait and
+      prove the designated long-lived helper remains alive when reacquisition
+      succeeds.
+- [x] Run focused tests, workspace tests/check, zero-warning Clippy, formatting,
+      gated/Linux checks where required, and repository policy gates.
+- [ ] Merge the issue-linked pull request after all protected-main checks pass.
+- [ ] Run or observe fresh successful Extended and Security schedules, verify
+      claim freshness, and close #3222, #3223, and #3224 with run evidence.
+
+## Local validation
+
+- The retry-argument regression failed before the downloader change and passes
+  afterward.
+- `cargo test -p mvm-cli curl_download_args_request_resume -- --nocapture`
+- `cargo test -p mvm-build one_shot_store_lock_is_not_inherited_by_spawned_helpers -- --nocapture`
+- `cargo nextest run -p mvm-build` — 871 tests passed, including the exact
+  mutation-lane baseline that failed in the scheduled Security run.
+- `cargo test --workspace` — complete workspace and Rustdoc suite passed. An
+  earlier isolated `mvm-build` Rustdoc dependency-link lookup failed once; the
+  exact doctest target and the subsequent full rerun both passed.
+- `cargo check --workspace`
+- `cargo clippy --workspace -- -D warnings`
+- `cargo fmt --all -- --check`
+- `cargo run -p xtask -- check-all` — 67 gates clean.


### PR DESCRIPTION
Addresses #3222, #3223, and #3224.

- retry resumable release-asset downloads after bounded transient transport failures while retaining signature and digest verification
- give the close-on-exec lock witness a bounded reacquisition window that remains shorter than the deliberately outliving helper
- record the validation and post-merge scheduled-evidence closeout plan

Local validation:
- cargo test --workspace
- cargo nextest run -p mvm-build (871 passed)
- cargo check --workspace
- cargo clippy --workspace -- -D warnings
- cargo fmt --all -- --check
- cargo run -p xtask -- check-all (67 gates clean)