### PR TITLE
fix(release): stop the post-publish verifier racing its own trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -767,6 +767,51 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
+      # The `release` job ends by dispatching `kernel-build.yml` and does not
+      # wait for it, so the workload kernels and their signed per-arch checksum
+      # manifests land on the release minutes after this job becomes eligible.
+      # Downloading immediately captured the release mid-publish, and the
+      # verifier then reported those assets missing — a red gate on a release
+      # that was fine, every single time, which is the failure mode that trains
+      # people to ignore a gate.
+      #
+      # Waiting for the assets rather than for the run: this job cares that the
+      # bytes are on the release, and polling the release says that directly.
+      # Reading it from a fire-and-forget dispatch would mean guessing which run
+      # id the dispatch produced.
+      #
+      # Bounded, and a timeout is a failure: assets that never arrive are the
+      # incomplete release this gate exists to catch, and must not be waited on
+      # forever or quietly skipped.
+      - name: Wait for the asynchronously published kernel assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          required=(
+            vmlinux-aarch64-workload
+            vmlinux-x86_64-workload
+            kernel-aarch64-checksums-sha256.txt
+            kernel-x86_64-checksums-sha256.txt
+          )
+          for _ in $(seq 1 40); do
+            present=$(gh release view "${TAG_NAME}" --repo "${GITHUB_REPOSITORY}" \
+              --json assets --jq '.assets[].name' 2>/dev/null || true)
+            missing=()
+            for name in "${required[@]}"; do
+              printf '%s\n' "${present}" | grep -qx "${name}" || missing+=("${name}")
+            done
+            if [ ${#missing[@]} -eq 0 ]; then
+              echo "kernel assets present on ${TAG_NAME}"
+              exit 0
+            fi
+            echo "waiting for ${#missing[@]} kernel asset(s): ${missing[*]}"
+            sleep 30
+          done
+          echo "::error::${TAG_NAME} never received: ${missing[*]} — kernel-build.yml did not publish them within 20 minutes, so the release is incomplete." >&2
+          exit 1
+
       - name: Download published release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -43,6 +43,64 @@ fn justfile() -> String {
     fs::read_to_string("Justfile").expect("Justfile must be readable")
 }
 
+/// The post-publish verifier must not race the assets the publish job triggers.
+///
+/// `release` ends by dispatching `kernel-build.yml` and does not wait for it, so
+/// the workload kernels and their signed per-arch checksum manifests land on the
+/// release minutes after `verify-release` becomes eligible. Downloading straight
+/// away captured the release mid-publish and reported those assets missing —
+/// v0.18.0-rc.1 published a complete, signed release and its own gate called it
+/// broken.
+///
+/// A gate that fails on every correct release is worse than no gate: it teaches
+/// people to skip reading it, and then it cannot report the incomplete release
+/// it exists to catch.
+///
+/// Asserted as an ordering — the wait must come before the download — because a
+/// wait that runs after the assets have been fetched changes nothing.
+#[test]
+fn the_release_verifier_waits_for_the_kernel_assets_it_triggers() {
+    let workflow = release_workflow();
+
+    let dispatch = workflow
+        .find("gh workflow run kernel-build.yml")
+        .expect("the release job must trigger the kernel build");
+    let wait = workflow
+        .find("Wait for the asynchronously published kernel assets")
+        .expect(
+            "verify-release must wait for the kernel assets, or it verifies a \
+             release that is still being published",
+        );
+    let download = workflow
+        .find("gh release download \"${TAG_NAME}\"")
+        .expect("verify-release must download the published assets");
+
+    assert!(
+        dispatch < wait,
+        "the wait only makes sense after the dispatch it is waiting on"
+    );
+    assert!(
+        wait < download,
+        "the wait must precede the download, or the verifier still captures the \
+         release mid-publish"
+    );
+
+    // Every asset the verifier requires of the kernel train must be waited for.
+    // Waiting for a subset leaves exactly the same race for the rest.
+    for asset in [
+        "vmlinux-aarch64-workload",
+        "vmlinux-x86_64-workload",
+        "kernel-aarch64-checksums-sha256.txt",
+        "kernel-x86_64-checksums-sha256.txt",
+    ] {
+        assert!(
+            workflow[wait..download].contains(asset),
+            "{asset} is verified but not waited for, so it can still be missing \
+             when the verifier looks"
+        );
+    }
+}
+
 /// The published asset list must not name the same file twice.
 ///
 /// `artifacts/*.tar.gz` matches every tarball, including the runtime-overlay,


### PR DESCRIPTION
`verify-release` failed on v0.18.0-rc.1, reporting the workload kernels and their per-arch checksum manifests missing from a release that was complete and signed.

They were not missing. They had not been uploaded yet.

## The race

The `release` job ends with a fire-and-forget dispatch:

```bash
gh workflow run kernel-build.yml --ref "${TAG_NAME}"
```

It does not wait. `verify-release` (`needs: [release]`) then starts immediately and downloads the release **mid-publish**.

Measured on the rc: the release carried **66 assets** when the verifier looked and **76** afterwards — and the ten it gained were exactly the ones it had called missing.

## Why this matters more than one red run

The gate fails on *every* correct release, which is worse than having no gate. A check that is always red is one people stop reading, and then it cannot report the incomplete release it exists to catch.

It cost real time here: the red was diagnosed as a stale verifier **twice** before the asset count moving under a repeated query showed what was actually happening. The verifier was right; the reasoning about it was wrong.

## The fix

Waits for the assets, not for the run. This job's question is whether the bytes are on the release, and polling the release answers it directly — resolving a run id from a fire-and-forget dispatch would be a guess.

Bounded at 20 minutes, and **a timeout is a failure**: assets that never arrive are precisely the incomplete release this gate is for, and must not be waited on forever or quietly skipped.

## The test

Asserts ordering — dispatch before wait, wait before download — because a wait placed after the download changes nothing. It also requires *every* kernel asset the verifier checks to be waited for, since waiting for a subset leaves the same race for the rest.

Verified by deleting the wait step: it fails, naming what is wrong.

## Not in scope

The same run also reported missing attested pack manifests (`builder-vm-*.pack-manifest.json`). Those are absent for a different reason — not a race — and are filed separately rather than folded in here. They are produced and signed by `release-boot-image.yml` but do not reach the boot image release, and the CLI's fetch of them falls back to the checksum download with a warning, so rc.1 remains usable.

`cargo nextest run -p mvmctl --test release_assets`: 44 passed. actionlint clean; the wait's shell logic was exercised directly for both the all-present and partially-missing cases, including the empty-array path under `set -u`.