### PR TITLE
feat(release): let a dry run reach the publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,7 +358,7 @@ jobs:
     # Dry-run guard: a `workflow_dispatch` with dry_run=true builds + packages
     # (the `build` job) but never reaches this publish job — only a tag push or
     # an explicit dry_run=false dispatch publishes.
-    if: ${{ !cancelled() && needs.bdd.result == 'success' && needs.e2e-docs.result == 'success' && needs.build.result == 'success' && needs.initramfs-image.result == 'success' && (github.event_name == 'push' || github.event.inputs.dry_run == 'false') }}
+    if: ${{ !cancelled() && needs.bdd.result == 'success' && needs.e2e-docs.result == 'success' && needs.build.result == 'success' && needs.initramfs-image.result == 'success' }}
     # This job mints the one keyless identity every installed mvmctl trusts:
     # `release.yml@refs/tags/v{version}`, the sole entry in
     # RELEASE_IDENTITY_TEMPLATES. The environment's policy admits `v*` tags and
@@ -464,6 +464,7 @@ jobs:
           cat checksums-sha256.txt
 
       - name: Sign release tarballs, checksum manifests, and SBOM
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -526,6 +527,7 @@ jobs:
       # them individually here would assert a per-file guarantee the pipeline
       # does not otherwise make.
       - name: Attest build provenance for the release tarballs (release-provenance)
+        if: ${{ github.event_name == 'push' }}
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: artifacts/*.tar.gz
@@ -545,6 +547,7 @@ jobs:
       # are best-effort and the release gates only on the binary build); a
       # PRESENT artifact that cannot be consumed fails the release here.
       - name: Verify the published artifacts survive the consumer path
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         env:
           TAG_NAME: ${{ github.ref_name }}
@@ -612,6 +615,7 @@ jobs:
       # the Fulcio short-lived cert, and the Rekor inclusion proof —
       # mvm-security::image_verify consumes exactly this format.
       - name: Sign image manifests (plan 36)
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -642,6 +646,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
+          # A tag push is the only real publish. Everything else — a manual
+          # dispatch, dry_run either way — is a rehearsal, and rehearses against
+          # a draft.
+          DRY_RUN: ${{ github.event_name != 'push' }}
         run: |
           set -euo pipefail
           # nullglob: image globs that matched nothing (their job failed)
@@ -713,18 +721,58 @@ jobs:
             prerelease=(--prerelease)
             echo "::notice::${TAG_NAME} carries a prerelease segment — publishing it as a prerelease, not as latest"
           fi
-          gh release create "${TAG_NAME}" \
-            --title "${TAG_NAME}" \
+          # A dry run publishes to a throwaway draft under a scratch tag and
+          # deletes it in the next step. This is the same `gh release create`
+          # with the same asset list, deliberately: the defects worth catching
+          # here are properties of that list and of GitHub's reaction to it — a
+          # duplicate asset name is a 422 from the upload endpoint, not
+          # something a local check can produce. A separate mock publish would
+          # be free to drift from this one, and the drift is exactly the class
+          # of bug it would be built to find.
+          #
+          # A draft is not listed as a release and is not resolved by
+          # `/releases/latest`, so it is invisible to `mvmctl update` for the
+          # seconds it exists.
+          publish_tag="${TAG_NAME}"
+          draft=()
+          if [ "${DRY_RUN}" = "true" ]; then
+            publish_tag="dry-run-${GITHUB_RUN_ID}"
+            draft=(--draft)
+            prerelease=()
+            echo "::notice::dry run — publishing ${publish_tag} as a draft, then deleting it"
+          fi
+          gh release create "${publish_tag}" \
+            --title "${publish_tag}" \
+            "${draft[@]}" \
             "${prerelease[@]}" \
             --generate-notes \
             --notes "${RELEASE_NOTES_PREFIX}" \
             "${assets[@]}"
+
+      # Always, even if the publish failed: `gh release create` can create the
+      # release and then fail uploading an asset, which is how the duplicate
+      # name surfaced. Leaving that draft behind would accumulate one per dry
+      # run and leave the next one reasoning about a tag it did not create.
+      - name: Delete the dry-run draft release
+        if: ${{ always() && github.event_name != 'push' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          tag="dry-run-${GITHUB_RUN_ID}"
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release delete "${tag}" --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag
+            echo "deleted dry-run draft ${tag}"
+          else
+            echo "no dry-run draft ${tag} to delete"
+          fi
 
       # The "release: published" event fired by `gh release create` runs under
       # GITHUB_TOKEN, which by design does not trigger downstream workflows.
       # workflow_dispatch is exempt from that rule, so chain publish-crates
       # explicitly here. This keeps crates.io in sync with GitHub releases.
       - name: Trigger crates.io publish workflow
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
@@ -743,6 +791,7 @@ jobs:
       # explicitly rather than relying on an event that demonstrably does not
       # arrive.
       - name: Trigger kernel build + publish workflow
+        if: ${{ github.event_name == 'push' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}
@@ -759,7 +808,11 @@ jobs:
   # match their recorded hash fails here, surfacing it instead of shipping silently.
   verify-release:
     needs: [release]
-    if: ${{ needs.release.result == 'success' }}
+    # Tag pushes only. A dry run publishes a draft and deletes it, so there is
+    # no release left to download, and the signatures this asserts are minted
+    # under a `refs/tags/*` identity a dispatch cannot produce. Running it there
+    # would fail for reasons that say nothing about the release.
+    if: ${{ github.event_name == 'push' && needs.release.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -101,6 +101,78 @@ fn the_release_verifier_waits_for_the_kernel_assets_it_triggers() {
     }
 }
 
+/// The publish path must be reachable without pushing a tag.
+///
+/// Every release defect found while cutting v0.18.0-rc.1 lived in the publish
+/// job, and the publish job used to be unreachable except by a tag push: the
+/// dry run stopped after `build`. So each attempt surfaced exactly one defect,
+/// at roughly two and a half hours per discovery, four times over — a missing
+/// cross-compile target, an incomplete boot image, a transient 403, and a
+/// duplicate asset name that 422'd *after* the release had been created.
+///
+/// A dry run reaches `gh release create` against a throwaway draft, so those
+/// same failures surface in minutes. The draft is deleted afterwards, and
+/// `always()` on the cleanup matters: a create that succeeds and then fails
+/// uploading leaves a draft behind, which is exactly the case that produced the
+/// 422.
+///
+/// What a dry run cannot prove is asserted here too, by requiring the signing
+/// and downstream-trigger steps to stay tag-only: their keyless identity pins
+/// `refs/tags/*`, which a dispatch cannot mint. Pretending otherwise would make
+/// a green dry run mean more than it does.
+#[test]
+fn a_dry_run_reaches_the_publish_step_without_a_tag() {
+    let workflow = release_workflow();
+
+    let create = workflow
+        .find("gh release create \"${publish_tag}\"")
+        .expect("the publish step must create the release under a computed tag");
+
+    assert!(
+        workflow.contains("publish_tag=\"dry-run-${GITHUB_RUN_ID}\""),
+        "a dry run must publish under a scratch tag, never the real one"
+    );
+    assert!(
+        workflow.contains("draft=(--draft)"),
+        "a dry run must publish a draft — a draft is not listed and is not \
+         resolved by /releases/latest, so `mvmctl update` cannot see it"
+    );
+
+    let cleanup = workflow
+        .find("name: Delete the dry-run draft release")
+        .expect("a dry run must delete the draft it created");
+    assert!(
+        create < cleanup,
+        "the draft must be deleted after it is created, not before"
+    );
+    assert!(
+        workflow[cleanup..].starts_with("name: Delete the dry-run draft release")
+            && workflow[cleanup..cleanup + 400].contains("always()"),
+        "cleanup must run even when the publish failed, or a create that fails \
+         part-way through its uploads leaves the draft behind"
+    );
+
+    // A dry run runs from a branch, so anything minting or verifying a keyless
+    // signature pinned to `refs/tags/*` has to stay on the tag path.
+    for step in [
+        "Sign release tarballs, checksum manifests, and SBOM",
+        "Attest build provenance for the release tarballs (release-provenance)",
+        "Sign image manifests (plan 36)",
+        "Trigger crates.io publish workflow",
+        "Trigger kernel build + publish workflow",
+    ] {
+        let at = workflow
+            .find(step)
+            .unwrap_or_else(|| panic!("{step} must exist"));
+        let window = &workflow[at..(at + 300).min(workflow.len())];
+        assert!(
+            window.contains("github.event_name == 'push'"),
+            "{step} must be gated to tag pushes: a dry run cannot mint a \
+             refs/tags identity, and must not publish or trigger anything real"
+        );
+    }
+}
+
 /// The published asset list must not name the same file twice.
 ///
 /// `artifacts/*.tar.gz` matches every tarball, including the runtime-overlay,
@@ -170,8 +242,8 @@ fn the_release_asset_list_cannot_upload_one_file_twice() {
         // the comment above the array, which precedes the dedupe and would make
         // this ordering check fail against correct code.
         let create = workflow
-            .find("gh release create \"${TAG_NAME}\"")
-            .expect("the publish step must create the release under the pushed tag");
+            .find("gh release create \"${publish_tag}\"")
+            .expect("the publish step must create the release under a computed tag");
         assert!(
             dedupe < create,
             "the list must be deduplicated before the release is created"
@@ -1318,9 +1390,16 @@ fn a_prerelease_tag_is_not_published_as_the_latest_release() {
          prerelease segment, so a stable tag still publishes as latest"
     );
 
+    // `publish_tag` defaults to `TAG_NAME` and differs only on a dry run, so a
+    // real tag push still publishes under the pushed tag — asserted just below.
     let create = workflow
-        .find("gh release create \"${TAG_NAME}\"")
-        .expect("release.yml must create the release under the pushed tag");
+        .find("gh release create \"${publish_tag}\"")
+        .expect("release.yml must create the release under a computed tag");
+    assert!(
+        workflow.contains("publish_tag=\"${TAG_NAME}\""),
+        "the computed tag must default to the pushed tag, or a real release \
+         publishes under something other than the tag that triggered it"
+    );
     let guard = workflow
         .find("prerelease=(--prerelease)")
         .expect("checked above");


### PR DESCRIPTION
Closes the gap behind #3199. Every release defect found cutting v0.18.0-rc.1 lived in the publish job, and the publish job was **unreachable except by pushing a tag** — the dry run stopped after `build`.

So each attempt surfaced exactly one defect, at ~2.5 hours per discovery:

| attempt | died at |
|---|---|
| 1 | `build (aarch64-unknown-linux-gnu)` — target unpinned |
| 2 | boot-image asset gate — image predated the sidecar split |
| 3 | `Download all artifacts` — transient 403 |
| 3 (rerun) | `Create GitHub Release` — duplicate asset name, 422 |

Four bugs, four tag pushes, ~10 hours. All four were reachable in minutes.

## What this does

A dry run now runs the **same publish job** against a throwaway draft under a scratch tag, then deletes it.

Same `gh release create`, same asset list, deliberately. The failures worth catching are properties of that list and of GitHub's reaction to it — a duplicate asset name is a 422 from the upload endpoint, and no local check produces one. A separate mock publish would be free to drift from the real one, and **that drift is the class of bug it would exist to find**.

A draft is not listed and is not resolved by `/releases/latest`, so it is invisible to `mvmctl update` for the seconds it exists.

Cleanup runs under `always()` because a create can succeed and then fail mid-upload — exactly how the duplicate name surfaced. Without it, each dry run would leave a draft behind.

## What a dry run cannot prove — also pinned

The signing, attestation and downstream-trigger steps stay tag-only: their keyless identity regexp pins `refs/tags/*`, which a dispatch from a branch cannot mint. `verify-release` stays tag-only for the same reason, and because a dry run leaves no release to download.

The test asserts those gates, so a green dry run cannot come to mean more than it does. That is the honest limit: a dry run proves the asset list, the boot-image attach, the download, and the upload — not the signatures.

## Two assertions moved with the code

`a_prerelease_tag_is_not_published_as_the_latest_release` and `the_release_asset_list_cannot_upload_one_file_twice` anchored on `gh release create "${TAG_NAME}"`, now `"${publish_tag}"`. Both were repointed, plus a **new** assertion that `publish_tag` defaults to `TAG_NAME` — otherwise the indirection could silently let a real release publish under something other than the tag that triggered it.

## Verification

44 release-asset tests and 78 workflow tests pass; actionlint clean. Both shell branches exercised directly: dry run yields `dry-run-<run-id> --draft`, a real tag yields `v0.18.0-rc.1 --prerelease` unchanged. Verified the new test fails when `--draft` is removed.

Next use: #3227 (pack manifests never reaching the boot image release) becomes diagnosable in minutes rather than a tag cycle.