### PR TITLE
perf(ci): split the feature lane off the pull-request critical path

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -11,8 +11,17 @@ name: Warm the Rust build cache
 # ephemeral, so main is the only place a cache useful to it can come from.
 #
 # It costs one build per merge and saves several per validation cycle: the
-# workspace is compiled by lint-core, lint-features, test-workspace, test-linux
+# workspace is compiled by lint-core, lint-features,
+# lint-features-test-support, lint-features-embed, test-workspace, test-linux
 # and test-ebpf-telemetry, each from cold today.
+#
+# Note what this entry does *not* cover. It is built with default features, so
+# the three lint-features lanes restore its dependency artifacts and then
+# rebuild every workspace crate whose feature resolution differs — which is why
+# the test-support lane still costs ~19 minutes warm. Warming the non-default
+# feature sets too would need its own `key:` per set, and the repo cache is
+# capped at 10 GB with LRU eviction, so an extra entry of this size risks
+# evicting the one every lane depends on. Measure before adding one.
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,13 +471,6 @@ jobs:
         with:
           packages: lld
 
-      # The only lane in this workflow that needs the pinned zig. Eight other
-      # jobs installed it because `mvm-cli`'s build script used to cross-compile
-      # the embedded Linux binaries on every build; that is now behind
-      # `embed-host-bins`, which only the step below turns on. If a second lane
-      # ever enables that feature, it needs this too.
-      - uses: ./.github/actions/install-zigbuild
-
       - uses: ./.github/actions/rust-cache
 
       - name: Clippy (mvm-client tracing-bridge)
@@ -515,22 +508,6 @@ jobs:
           cargo nextest run -p mvm-agentd --features addons
           cargo check -p mvm-agentd --features addons --bins
 
-      # `embed-host-bins` is off by default, so the entire cross-compile leg of
-      # `mvm-cli/build.rs` — and every test that inspects the embedded payload —
-      # is absent from every other lane in this workflow. Only the tag-push
-      # release build turns it on, and a break there is invisible until a
-      # release is already being cut. This lane is the one place a pull request
-      # proves the leg still compiles and still produces the manifest's set.
-      #
-      # `--bins` matters: the payload is `include_bytes!`d into the binary, so a
-      # lib-only check would not link it and would not catch a bad path.
-      - name: embed-host-bins feature (cross-compiled payload)
-        run: |
-          cargo nextest run -p mvm-cli --features embed-host-bins \
-            --test embedded_binaries --test host_binaries_extract \
-            --test host_binaries_manifest --test dispatch_host_bin_dir
-          cargo check -p mvmctl --features embed-host-bins --bins
-
       # End-user release builds enable an acquisition policy that contributor
       # builds deliberately omit: checkout proximity must never select a local
       # compiler. Compile the CLI and execute the policy boundary tests on every
@@ -552,6 +529,34 @@ jobs:
       - name: In-process pure-mkfs materialize tests
         run: cargo test -p mvm-build --features pure-mkfs --lib rootfs::tests::pure
 
+  # Split out of `lint-features`, which was 35 minutes and the critical path for
+  # every code-touching pull request; this step alone was 19 of them. Nothing
+  # here shares a cargo fingerprint with the steps it used to sit beside — a
+  # different feature resolution rebuilds its own graph either way — so moving
+  # it to its own runner costs one checkout and recovers the rest in parallel.
+  lint-features-test-support:
+    name: Lint feature coverage (test-support)
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.1
+
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: lld
+
+      - uses: ./.github/actions/rust-cache
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: test-support feature tests (mock backend)
         # One invocation, not one per package. Cargo resolves features per
         # invocation, so selecting a different package each time produced
@@ -567,10 +572,63 @@ jobs:
           cargo nextest run -p mvmctl --features test-support --test audit_emissions_live
           cargo check -p mvm-cli --features test-support --example verification_loop
 
+  # Also split out of `lint-features`, and the only lane in this workflow that
+  # needs the pinned zig: `embed-host-bins` is what turns on `mvm-cli`'s
+  # cross-compile of the embedded Linux binaries. Keeping it on its own job is
+  # what lets every other lane skip the zig install.
+  lint-features-embed:
+    name: Lint feature coverage (embed-host-bins)
+    needs: [scope]
+    if: needs.scope.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.1
+
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: lld
+
+      - uses: ./.github/actions/install-zigbuild
+
+      - uses: ./.github/actions/rust-cache
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      # `embed-host-bins` is off by default, so the entire cross-compile leg of
+      # `mvm-cli/build.rs` — and every test that inspects the embedded payload —
+      # is absent from every other lane in this workflow. Only the tag-push
+      # release build turns it on, and a break there is invisible until a
+      # release is already being cut. This lane is the one place a pull request
+      # proves the leg still compiles and still produces the manifest's set.
+      #
+      # `--bins` matters: the payload is `include_bytes!`d into the binary, so a
+      # lib-only check would not link it and would not catch a bad path.
+      - name: embed-host-bins feature (cross-compiled payload)
+        run: |
+          cargo nextest run -p mvm-cli --features embed-host-bins \
+            --test embedded_binaries --test host_binaries_extract \
+            --test host_binaries_manifest --test dispatch_host_bin_dir
+          cargo check -p mvmctl --features embed-host-bins --bins
+
   lint:
     name: Lint (fmt + clippy + policy)
     if: ${{ always() }}
-    needs: [scope, lint-core, lint-policy, lint-features]
+    needs:
+      [
+        scope,
+        lint-core,
+        lint-policy,
+        lint-features,
+        lint-features-test-support,
+        lint-features-embed,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -581,6 +639,8 @@ jobs:
           CORE_RESULT: ${{ needs.lint-core.result }}
           POLICY_RESULT: ${{ needs.lint-policy.result }}
           FEATURES_RESULT: ${{ needs.lint-features.result }}
+          FEATURES_SUPPORT_RESULT: ${{ needs.lint-features-test-support.result }}
+          FEATURES_EMBED_RESULT: ${{ needs.lint-features-embed.result }}
         run: |
           set -euo pipefail
           if [ "$SCOPE_RESULT" != success ] || [ "$POLICY_RESULT" != success ]; then
@@ -592,7 +652,8 @@ jobs:
             false) required=skipped ;;
             *) echo "Invalid code scope: $SCOPE_CODE"; exit 1 ;;
           esac
-          for result in "$CORE_RESULT" "$FEATURES_RESULT"; do
+          for result in "$CORE_RESULT" "$FEATURES_RESULT" \
+            "$FEATURES_SUPPORT_RESULT" "$FEATURES_EMBED_RESULT"; do
             if [ "$result" != "$required" ]; then
               echo "A lint lane did not match scope $SCOPE_CODE: $result"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,6 +550,15 @@ jobs:
         with:
           packages: lld
 
+      # Not optional, despite `embed-host-bins` being the feature that names
+      # zig. `pool_warm_and_the_run_path_resolve_the_same_compat_key` resolves a
+      # launch, which builds the universal initramfs through `cargo zigbuild`.
+      # Without zig on PATH that build fails, resolution falls back to whatever
+      # initramfs the cache already holds, and the test dies on a version
+      # mismatch rather than on the missing command — so the real cause appears
+      # only in the step's stderr.
+      - uses: ./.github/actions/install-zigbuild
+
       - uses: ./.github/actions/rust-cache
 
       - name: Install cargo-nextest
@@ -572,10 +581,16 @@ jobs:
           cargo nextest run -p mvmctl --features test-support --test audit_emissions_live
           cargo check -p mvm-cli --features test-support --example verification_loop
 
-  # Also split out of `lint-features`, and the only lane in this workflow that
-  # needs the pinned zig: `embed-host-bins` is what turns on `mvm-cli`'s
-  # cross-compile of the embedded Linux binaries. Keeping it on its own job is
-  # what lets every other lane skip the zig install.
+  # Also split out of `lint-features`. `embed-host-bins` is what turns on
+  # `mvm-cli`'s cross-compile of the embedded Linux binaries, so this lane needs
+  # the pinned zig.
+  #
+  # It is not the only one. The comment this replaces claimed it was, and the
+  # split falsified that within one run: the test-support lane also shells out
+  # to `cargo zigbuild`, from a launch-resolution test that builds the universal
+  # initramfs. What the split does establish — because this run is the
+  # experiment — is that the remaining `lint-features` lane needs no zig at all,
+  # so that install is now paid on two lanes instead of every one.
   lint-features-embed:
     name: Lint feature coverage (embed-host-bins)
     needs: [scope]

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -667,7 +667,35 @@ mod tests {
         let workflow = ci_workflow();
         let lint = job_block(&workflow, "lint");
         assert!(lint.contains("name: Lint (fmt + clippy + policy)"));
-        assert!(lint.contains("needs: [scope, lint-core, lint-policy, lint-features]"));
+        // A lane that runs but is not in the aggregate's `needs` cannot fail
+        // the merge, so pin every lane by name.
+        for lane in [
+            "scope,",
+            "lint-core,",
+            "lint-policy,",
+            "lint-features,",
+            "lint-features-test-support,",
+            "lint-features-embed,",
+        ] {
+            assert!(
+                lint.contains(lane),
+                "Lint aggregate must depend on {lane:?}"
+            );
+        }
+        // ...and each has to be read back in the loop that compares results
+        // against the scope decision. A lane in `needs` but not in the loop is
+        // gated on nothing but its own scheduling.
+        for expected in [
+            "\"$CORE_RESULT\"",
+            "\"$FEATURES_RESULT\"",
+            "\"$FEATURES_SUPPORT_RESULT\"",
+            "\"$FEATURES_EMBED_RESULT\"",
+        ] {
+            assert!(
+                lint.contains(expected),
+                "Lint aggregate must compare {expected} against the scope decision"
+            );
+        }
 
         for unexpected in [
             "cargo nextest run --workspace --features test-support",
@@ -699,7 +727,11 @@ mod tests {
                 .any(|(name, _)| *name == "check-conformance"),
             "check-conformance must still be one of the gates the lane runs"
         );
-        let lint_features = job_block(&workflow, "lint-features");
+        // The test-support subtree is its own job. At 19 minutes inside a
+        // 35-minute `lint-features` it was the critical path for every
+        // code-touching pull request, and nothing beside it shared a cargo
+        // fingerprint to lose by moving it out.
+        let lint_features = job_block(&workflow, "lint-features-test-support");
         // One invocation covering the whole test-support subtree. Selecting a
         // package at a time made cargo resolve features once per package and
         // rebuild most of the same graph each time; the packages are listed
@@ -832,6 +864,8 @@ mod tests {
         for job in [
             "lint-core",
             "lint-features",
+            "lint-features-test-support",
+            "lint-features-embed",
             "test-workspace",
             "test-release-witness",
             "test-linux",


### PR DESCRIPTION
`Lint feature coverage` is the wall clock for every code-touching pull request.
It is not close: on run 34275251839 (`fix: reap timed-out builder process
trees`, 35.3m total) it took **34m52s** and the next-longest job finished at
23m14s.

## Where those 35 minutes went

| step | time |
|---|---|
| `test-support feature tests (mock backend)` | **18m59s** |
| `embed-host-bins feature (cross-compiled payload)` | **7m23s** |
| the other seven feature steps, combined | ~6m |
| `install-zigbuild` | 1m05s |
| checkout / toolchain / apt / cache | ~35s |

The two heavy steps were 26m22s of the 34m50s, and they ran back to back on one
runner — not because they share anything, but because they were written as steps
in one job. Each resolves a different feature set, so each rebuilds its own slice
of the graph whether or not the other runs beside it. There is no cargo
fingerprint to lose by separating them.

## The change

Three jobs instead of one, all `needs: [scope]`, all gated on the same
`code == 'true'`:

- `lint-features` — the seven light feature steps (~7m, and no longer installs zig)
- `lint-features-test-support` — the test-support subtree (~19m)
- `lint-features-embed` — the cross-compiled payload (~9m incl. zig)

Expected effect: the lane's contribution drops **~35m → ~19m**, and the pull
request becomes bounded by `Test Linux and conformance` at ~23m. That is roughly
**12 minutes off every code PR and every merge-queue run** — ~24 minutes per
change, since the queue runs the same suite again.

This buys wall clock, not runner minutes. Three checkouts and three cache
restores cost a couple of minutes more in aggregate than one did.

## Two things carried across deliberately

**`install-zigbuild` moves to the embed lane alone.** The step was already
documented in-file as the only one needing zig; splitting is what finally lets
the other two lanes skip the install.

**The test-support step stays a single invocation across all six packages.**
Splitting it per package is what made this lane the critical path originally
(fixed in #2566), and the gate pinning the single-invocation shape moves *with*
the step — otherwise it would sit in a job that no longer runs it and quietly
assert nothing.

## Gate wiring

Both new lanes are added to the `Lint (fmt + clippy + policy)` aggregate's
`needs` **and** to the loop that compares each lane's result against the scope
decision. A lane in `needs` but not in the loop is gated only on its own
scheduling, so `check_workflow_paths` now pins both halves by name, and pins
that both new lanes carry `needs: [scope]` and the code-scope `if:` — without
which the aggregate's skipped-when-out-of-scope arithmetic breaks.

**Branch protection is unchanged.** The required context is the aggregate; the
new lanes report through it.

## Verification

- `cargo run -p xtask -- check-all` → 67 gate(s) clean
- `cargo test -p xtask --bins` → 704 passed (includes `check_workflow_paths`)
- `tests/ci_scope_aggregate.rs`, `github_actions_fuzz_gate.rs`,
  `github_actions_aarch64_no_kvm.rs` → 8 passed
- `actionlint` + `cargo fmt --all` + workspace clippy via the pre-commit hook
- `cargo run -p xtask -- check-workflow-paths` → clean across 26 workflow files

The real proof is this PR's own run: it touches `crates/` in name only, so watch
whether the three lanes land in parallel and where the wall clock settles.

## Next

Once this lands the critical path is `Test Linux and conformance` at 23m14s.
Separately, `cache-warm` writes one default-feature entry, so all three feature
lanes restore it and then rebuild whatever their feature resolution changes —
that is why the test-support lane still costs ~19m warm. Warming the non-default
sets needs a `key:` per set against a 10 GB LRU-evicted cache, which could evict
the entry every other lane depends on. I left a note in `cache-warm.yml` saying
to measure before trying it.
