### PR TITLE
fix(release): mint the attested builder pack where its identity is verifiable

### DIFF
--- a/.github/workflows/release-boot-image.yml
+++ b/.github/workflows/release-boot-image.yml
@@ -154,63 +154,26 @@ jobs:
       # consumer silently fails open on. This wakes up when the consumer side
       # learns to reconstruct this identity. The same applies to the runtime
       # pack in the default-microvm job below.
-      - name: Produce and keyless-sign attested builder pack manifest
-        # The pack is an accelerator, never a hard dependency. A Fulcio/Rekor/OIDC
-        # hiccup must not block the plain vmlinux/rootfs publish below, so a
-        # signing failure here is tolerated: the job continues, no pack ships, and
-        # installed binaries fall back to the plain checksum download.
-        continue-on-error: true
-        env:
-          ARCH: ${{ matrix.arch }}
-          REPOSITORY: ${{ github.repository }}
-          REF: ${{ github.ref }}
-        run: |
-          set -euo pipefail
-          # On a tag push, REF is refs/tags/vX.Y.Z — exactly the SAN cosign
-          # embeds in the certificate and exactly what a released mvmctl
-          # (version X.Y.Z) reconstructs when verifying the pack. Skip pack
-          # production unless the ref is a version tag whose version equals the
-          # crate version; anything else yields an identity no installed binary
-          # can reconstruct, so it would silently fail-open to the plain download.
-          # Skipping keeps that outcome explicit and still ships the plain image.
-          if [[ "${REF}" != refs/tags/v* ]]; then
-            echo "::notice::${REF} is not a version tag; skipping attested builder pack."
-            exit 0
-          fi
-          TAG_VERSION="${REF#refs/tags/v}"
-          CRATE_VERSION="$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[] | select(.name=="mvm-cli") | .version')"
-          if [[ "${TAG_VERSION}" != "${CRATE_VERSION}" ]]; then
-            echo "::warning::tag ${REF} does not match crate version v${CRATE_VERSION}; installed binaries could not verify this pack — skipping attested builder pack."
-            exit 0
-          fi
-          IDENTITY="https://github.com/${REPOSITORY}/.github/workflows/release.yml@${REF}"
-          REVOCATION_CHANNEL="https://github.com/${REPOSITORY}/releases/download/revocations/builder-vm-revocations.json"
-          # The published location of the SBOM this release ships, so the
-          # manifest's SBOM reference points at a real download instead of a
-          # path that only exists on the runner that built it.
-          SBOM_URI="https://github.com/${REPOSITORY}/releases/download/${REF#refs/tags/}/builder-vm-${ARCH}.sbom.txt"
-          cargo run --release -p mvm-build --example mvm-builder-pack-tool -- \
-            --vmlinux "$STORE_PATH/vmlinux" --rootfs "$STORE_PATH/rootfs.ext4" \
-            --arch "$ARCH" --channel stable --keyless \
-            --identity "$IDENTITY" \
-            --out-dir staging \
-            --sbom "staging/builder-vm-${ARCH}.sbom.txt" \
-            --sbom-uri "$SBOM_URI" \
-            --revocation-channel "$REVOCATION_CHANNEL"
-          mv staging/manifest.json "staging/builder-vm-${ARCH}.pack-manifest.json"
-
-          # Keyless OIDC sign — no secret key needed. --new-bundle-format emits
-          # the Sigstore bundle (with verificationMaterial) that the installed
-          # binary's Rust verifier parses; the legacy --bundle format is not
-          # accepted by that stack. The bundle carries the signature, the
-          # short-lived cert, and the transparency-log inclusion proof.
-          cosign sign-blob \
-            --yes \
-            --new-bundle-format \
-            --bundle "staging/builder-vm-${ARCH}.pack-manifest.json.bundle" \
-            "staging/builder-vm-${ARCH}.pack-manifest.json"
-
+      # The attested builder pack is minted in `release.yml`, not here.
+      #
+      # A step lived here that could never run: it guarded on `refs/tags/v*`,
+      # and this workflow only triggers on `boot-image/v*`, so it exited 0
+      # having produced nothing on every run since it was written while
+      # reporting success. `verify-release` reported the resulting absence for
+      # the first time on v0.18.0-rc.1.
+      #
+      # Fixing the guard would not have been enough. An installed mvmctl
+      # verifies the builder pack against `release.yml@refs/tags/v{version}`,
+      # an identity only that workflow can mint — `release_trust` keeps the two
+      # identity lists apart so a signature over a boot image cannot validate a
+      # CLI artifact. So the pack has to be produced where the identity is, and
+      # `release.yml` already downloads this image's kernel, rootfs and SBOM
+      # before it publishes.
+      #
+      # The runtime pack below is in the same position but is not moved: it
+      # additionally needs `rootfs.verity` and `rootfs.roothash`, which are not
+      # published as release assets, and nothing fetches it. Left as-is rather
+      # than moved half-way or deleted.
       - name: Generate builder VM checksums
         env:
           ARCH: ${{ matrix.arch }}
@@ -224,11 +187,16 @@ jobs:
           FILES=("builder-vm-vmlinux-${ARCH}" "builder-vm-rootfs-${ARCH}.ext4")
           [ -f "builder-vm-${ARCH}.cmdline.txt" ]   && FILES+=("builder-vm-${ARCH}.cmdline.txt")
           [ -f "builder-vm-${ARCH}.manifest.json" ] && FILES+=("builder-vm-${ARCH}.manifest.json")
-          # The attested pack is optional (signing may be skipped or fail); only
-          # checksum its files when they are actually present.
-          if [ -f "builder-vm-${ARCH}.pack-manifest.json.bundle" ]; then
-            FILES+=("builder-vm-${ARCH}.pack-manifest.json" "builder-vm-${ARCH}.pack-manifest.json.bundle" "builder-vm-${ARCH}.sbom.txt")
-          fi
+          # The SBOM is produced unconditionally by the step above and shipped
+          # on the release, so it is checksummed unconditionally.
+          #
+          # It used to be added only inside a test for the attested pack's
+          # bundle, and that pack was never produced here — the guard could not
+          # be satisfied in this workflow — so the SBOM has never been listed in
+          # this manifest. The pack files themselves are gone from this list
+          # because they are now minted in `release.yml`, under the only
+          # identity that can verify them.
+          [ -f "builder-vm-${ARCH}.sbom.txt" ] && FILES+=("builder-vm-${ARCH}.sbom.txt")
           sha256sum "${FILES[@]}" > "builder-vm-${ARCH}-checksums-sha256.txt"
 
       - name: Upload builder VM image artifacts
@@ -240,8 +208,6 @@ jobs:
             staging/builder-vm-rootfs-${{ matrix.arch }}.ext4
             staging/builder-vm-${{ matrix.arch }}.cmdline.txt
             staging/builder-vm-${{ matrix.arch }}.manifest.json
-            staging/builder-vm-${{ matrix.arch }}.pack-manifest.json
-            staging/builder-vm-${{ matrix.arch }}.pack-manifest.json.bundle
             staging/builder-vm-${{ matrix.arch }}.sbom.txt
             staging/builder-vm-${{ matrix.arch }}-checksums-sha256.txt
 
@@ -913,8 +879,6 @@ jobs:
             artifacts/builder-vm-rootfs-*
             artifacts/builder-vm-*.cmdline.txt
             artifacts/builder-vm-*.manifest.json
-            artifacts/builder-vm-*.pack-manifest.json
-            artifacts/builder-vm-*.pack-manifest.json.bundle
             artifacts/builder-vm-*.sbom.txt
             artifacts/builder-vm-*-checksums-sha256.txt
             artifacts/builder-vm-*-checksums-sha256.txt.bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -453,6 +453,82 @@ jobs:
                 artifacts/default-microvm-*-checksums-sha256.txt.bundle
           ls -la artifacts/
 
+      # The attested builder pack has to be minted here, and only here.
+      #
+      # An installed mvmctl verifies it against
+      # `RELEASE_IDENTITY_TEMPLATES` — `release.yml@refs/tags/v{version}`,
+      # reconstructed from its own version. `release-boot-image.yml` used to
+      # carry this step, where that identity is unmintable: that workflow only
+      # runs on `boot-image/v*`, so its guard (`refs/tags/v*`) could never be
+      # satisfied and the step exited 0 having produced nothing, on every run
+      # since it was written. `release.yml` globbed for the result, `nullglob`
+      # dropped the unmatched pattern, and the CLI's fetch fell back to the
+      # unattested checksum download with a warning. Nothing failed, so nothing
+      # was noticed until `verify-release` ran for the first time since v0.17.0.
+      #
+      # Moving it does not merely fix the guard. A pack signed under a
+      # `boot-image/*` identity could not have been verified even if produced:
+      # `release_trust` keeps the two identity lists separate precisely so a
+      # signature over a boot image cannot validate a CLI artifact.
+      #
+      # Tag pushes only: the whole point is the `refs/tags/v*` SAN, which a
+      # dispatch cannot mint. A dry run therefore does not exercise this, and
+      # publishes without the pack — the same fail-open the CLI already handles.
+      - name: Produce and keyless-sign the attested builder pack
+        if: ${{ github.event_name == 'push' }}
+        env:
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          IDENTITY="https://github.com/${REPOSITORY}/.github/workflows/release.yml@${REF}"
+          REVOCATION_CHANNEL="https://github.com/${REPOSITORY}/releases/download/revocations/builder-vm-revocations.json"
+
+          for arch in aarch64 x86_64; do
+            kernel="artifacts/builder-vm-vmlinux-${arch}"
+            rootfs="artifacts/builder-vm-rootfs-${arch}.ext4"
+            sbom="artifacts/builder-vm-${arch}.sbom.txt"
+
+            # Same complete-or-absent contract the image assets already follow:
+            # an image job that did not run leaves these absent on purpose, and
+            # a release without the pack is degraded rather than wrong. A
+            # partial set is neither, so it fails.
+            present=0
+            for f in "$kernel" "$rootfs" "$sbom"; do
+              [ -f "$f" ] && present=$((present + 1))
+            done
+            if [ "$present" -eq 0 ]; then
+              echo "::notice::no builder image for ${arch}; skipping its attested pack"
+              continue
+            fi
+            if [ "$present" -ne 3 ]; then
+              echo "::error::builder image for ${arch} is partial (${present}/3 inputs) — refusing to mint a pack over an incomplete image" >&2
+              exit 1
+            fi
+
+            SBOM_URI="https://github.com/${REPOSITORY}/releases/download/${TAG_NAME}/builder-vm-${arch}.sbom.txt"
+            cargo run --release -p mvm-build --example mvm-builder-pack-tool -- \
+              --vmlinux "$kernel" --rootfs "$rootfs" \
+              --arch "$arch" --channel stable --keyless \
+              --identity "$IDENTITY" \
+              --out-dir artifacts \
+              --sbom "$sbom" \
+              --sbom-uri "$SBOM_URI" \
+              --revocation-channel "$REVOCATION_CHANNEL"
+            mv artifacts/manifest.json "artifacts/builder-vm-${arch}.pack-manifest.json"
+
+            # --new-bundle-format: the Sigstore bundle carrying
+            # verificationMaterial that the installed binary's Rust verifier
+            # parses. The legacy --bundle format is not accepted by that stack.
+            cosign sign-blob \
+              --yes \
+              --new-bundle-format \
+              --bundle "artifacts/builder-vm-${arch}.pack-manifest.json.bundle" \
+              "artifacts/builder-vm-${arch}.pack-manifest.json"
+            echo "minted attested builder pack for ${arch}"
+          done
+
       - name: Generate combined checksum file
         shell: bash
         run: |

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -43,6 +43,69 @@ fn justfile() -> String {
     fs::read_to_string("Justfile").expect("Justfile must be readable")
 }
 
+/// The attested builder pack must be minted by the workflow whose identity
+/// verifies it.
+///
+/// An installed mvmctl checks the pack against
+/// `release.yml@refs/tags/v{version}`, reconstructed from its own version
+/// (`release_trust::RELEASE_IDENTITY_TEMPLATES`). `release-boot-image.yml`
+/// cannot mint that: it only runs on `boot-image/v*`. It carried this step
+/// anyway, behind a `refs/tags/v*` guard that could never be satisfied there —
+/// so it exited 0 having produced nothing, on every run since it was written,
+/// while reporting success.
+///
+/// The absence was invisible from both ends: `release.yml` globbed for the
+/// result and `nullglob` dropped the unmatched pattern, and the CLI's fetch
+/// falls back to the unattested checksum download with a warning. Attestation
+/// for the builder pack had therefore never worked in any release.
+///
+/// Fixing the guard would not have sufficed. `release_trust` keeps the CLI and
+/// boot-image identity lists deliberately separate so a signature over a boot
+/// image cannot validate a CLI artifact, so a pack signed under a
+/// `boot-image/*` identity would have been unverifiable even if produced.
+#[test]
+fn the_attested_builder_pack_is_minted_where_its_identity_is_verifiable() {
+    let release = release_workflow();
+    let boot_image = boot_image_workflow();
+
+    assert!(
+        release.contains("mvm-builder-pack-tool"),
+        "release.yml must mint the builder pack: it is the only workflow that \
+         runs at refs/tags/v* and so the only one whose identity an installed \
+         mvmctl can reconstruct"
+    );
+    assert!(
+        !boot_image.contains("builder-vm-${ARCH}.pack-manifest.json"),
+        "release-boot-image.yml must not claim to produce the builder pack — it \
+         cannot mint the identity that verifies it, so the step could only ever \
+         report success while emitting nothing"
+    );
+
+    // The pack must exist before the release that publishes it is created.
+    let mint = release
+        .find("mvm-builder-pack-tool")
+        .expect("checked above");
+    let create = release
+        .find("gh release create \"${publish_tag}\"")
+        .expect("release.yml must create the release");
+    assert!(
+        mint < create,
+        "the pack must be minted before the release is created, or the asset \
+         glob silently matches nothing and the release ships without it"
+    );
+
+    // Signing requires the tag ref, so this cannot run on a dispatch. Asserting
+    // it keeps a dry run honest about what it did not prove.
+    let step = release
+        .find("name: Produce and keyless-sign the attested builder pack")
+        .expect("the minting step must be named");
+    assert!(
+        release[step..mint].contains("github.event_name == 'push'"),
+        "pack minting must be gated to tag pushes: the SAN it signs under is \
+         the tag ref, which a dispatch cannot produce"
+    );
+}
+
 /// The post-publish verifier must not race the assets the publish job triggers.
 ///
 /// `release` ends by dispatching `kernel-build.yml` and does not wait for it, so
@@ -1063,11 +1126,24 @@ fn boot_image_release_recipe_refuses_an_existing_tag() {
 /// policy admits `v*` and nothing else — GitHub tag globs anchor at the start
 /// and do not cross `/`. Every gated job was refused one second in, with no
 /// steps run and nothing in the log to read.
+/// Jobs in the boot image train that cosign-sign a pack manifest in-job.
+///
+/// A named set rather than an inline literal: it has shrunk to one entry and
+/// may grow again, and the point of the assertion is which jobs are in it.
+const PACK_SIGNING_JOBS: &[&str] = &["default-microvm"];
+
 #[test]
 fn the_moved_jobs_keep_the_boot_image_signing_environment() {
     let boot_image = boot_image_workflow();
-    // The two jobs that cosign-sign a pack manifest inside the job itself.
-    for job in ["builder-vm-image", "default-microvm"] {
+    // The jobs that cosign-sign a pack manifest inside the job itself.
+    //
+    // `builder-vm-image` was here until its attested pack moved to
+    // `release.yml`, which is the only workflow whose identity an installed
+    // mvmctl can reconstruct for that pack. It signs nothing now — the
+    // checksum manifests it produces are signed by the publish job — so it is
+    // moved out rather than the assertion being weakened, which is what the
+    // failure message asked for.
+    for job in PACK_SIGNING_JOBS {
         let block = job_block(&boot_image, job);
         assert!(
             block.contains("cosign sign-blob"),


### PR DESCRIPTION
Fixes #3227. The attested builder pack has **never been produced, in any release**.

## What was happening

`release-boot-image.yml` carried the step behind a `refs/tags/v*` guard — and that workflow triggers only on `boot-image/v*`. The guard could not be satisfied there, so the step exited 0 having emitted nothing **while reporting success**.

The run log for `boot-image/v0.1.5` says it outright:

```
##[notice] refs/tags/boot-image/v0.1.5 is not a version tag; skipping attested builder pack.
```

Confirmed by downloading that run's workflow artifact: six files, no `pack-manifest.json`, no `.bundle`. Lost before upload — the publish globs were innocent.

Nothing reported the absence from either end. `release.yml` globbed for the result and `nullglob` dropped the unmatched pattern; the CLI's fetch falls back to the plain checksum download with a warning. So the path was dead in every direction — **produced never, published never, fetched always, degraded silently** — until `verify-release` ran for the first time since v0.17.0.

## Why this moves rather than fixes the guard

Repairing the guard would not have worked. An installed mvmctl verifies the pack against `release.yml@refs/tags/v{version}`, reconstructed from its own version:

```rust
const RELEASE_IDENTITY_TEMPLATES: &[&str] =
    &[".../release.yml@refs/tags/v{version}"];
```

And `release_trust` keeps the CLI and boot-image identity lists deliberately separate so *"a signature minted over a boot image could not validate a CLI tarball and the reverse."* A pack signed under a `boot-image/*` identity was **unverifiable even in principle**.

So the pack must be minted where the identity lives. `release.yml` already downloads the image's kernel, rootfs and SBOM before publishing, so it has everything the tool needs.

Same complete-or-absent contract the image assets follow: no image for an arch skips its pack; a partial set fails rather than minting a pack over an incomplete image.

## Two things surfaced while removing the old step

**The SBOM has never been checksummed.** It was added to the manifest only inside a test for the pack bundle's existence — and the pack was never produced, so the branch never taken. Now listed unconditionally, which is what it always should have been.

**The runtime pack is in the same unreachable position but is left alone.** It additionally needs `rootfs.verity` and `rootfs.roothash`, which are not published as release assets, and **nothing in the tree fetches it**. Moving it half-way or deleting it would both be guesses.

## An existing test caught this and said what to do

`the_moved_jobs_keep_the_boot_image_signing_environment` failed with:

> builder-vm-image is listed here because it signs; if it no longer does, move it out of this list rather than dropping the assertion

So it moved out rather than the assertion being weakened. Its checksum manifests are signed by the publish job, so nothing lost a signature. The list became a named const — partly because clippy's `single_element_loop` fires on a one-entry literal, and partly because *which jobs are in it* is the thing the assertion is about.

## Verification

80 workflow tests pass; actionlint clean on both workflows. The new test was verified to fail when the pack tool invocation is removed, and asserts placement (minted before the release is created) and gating (tag pushes only — a dispatch cannot mint the SAN).

**Limitation:** because minting requires the tag ref, the dry run added in #3229 does not exercise this step. That is stated in the test rather than left implicit.