### PR TITLE
perf(ci): give the Gherkin suite a single owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.validate.outputs.code }}
-      bdd: ${{ steps.validate.outputs.bdd }}
       nix: ${{ steps.validate.outputs.nix }}
       architecture: ${{ steps.validate.outputs.architecture }}
       kernel: ${{ steps.validate.outputs.kernel }}
@@ -125,26 +124,10 @@ jobs:
             echo "kernel=false" >> "$GITHUB_OUTPUT"
           fi
 
-          # The Gherkin scenarios drive the real `mvmctl` binary and the built
-          # language SDKs, so the drift they catch lives in four places: the SDK
-          # sources, the CLI surface those SDKs shell to, the scenarios and
-          # their fixtures, and the golden argv corpus binding the two.
-          #
-          # Deliberately narrower than the full suite's reach: scenarios over
-          # egress, snapshots and verified boot are driven by crates outside
-          # this filter and remain covered only by the release-tag `bdd` lane.
-          # Widening that is a separate call about PR latency, not an oversight.
-          if grep -zE '^(crates/mvm-sdk/|crates/mvm-cli/|crates/mvm-conformance/|features/|tests/machine-fixtures/|\.github/workflows/(ci|bdd)\.yml$|[Jj]ustfile$)' "$CHANGED_FILE" >/dev/null; then
-            echo "bdd=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "bdd=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Validate classification
         id: validate
         env:
           CODE: ${{ steps.decide.outputs.code }}
-          BDD: ${{ steps.decide.outputs.bdd }}
           NIX: ${{ steps.decide.outputs.nix }}
           ARCHITECTURE: ${{ steps.decide.outputs.architecture }}
           KERNEL: ${{ steps.decide.outputs.kernel }}
@@ -158,7 +141,6 @@ jobs:
             esac
           }
           validate code "$CODE"
-          validate bdd "$BDD"
           validate nix "$NIX"
           validate architecture "$ARCHITECTURE"
           validate kernel "$KERNEL"
@@ -678,10 +660,16 @@ jobs:
   # The Gherkin scenarios previously ran only from release-tag workflows, so a
   # PR could break a scenario and merge green. Same reusable workflow the
   # release path calls, gated on the narrower `bdd` scope.
+  # The single owner of the Gherkin suite, and gated on `code` rather than the
+  # narrower `bdd` scope because it inherited `ci-linux-coverage.sh`'s trigger
+  # along with its `just bdd`. `bdd` is a strict subset of `code` — `crates/`
+  # contains `crates/mvm-cli/`, `tests/` contains `tests/machine-fixtures/`, and
+  # both cover `features/` and the Justfile — so this widening admits exactly
+  # the runs the Linux lane was already covering and no others.
   bdd-conformance:
     name: BDD conformance
     needs: [scope]
-    if: needs.scope.outputs.bdd == 'true'
+    if: needs.scope.outputs.code == 'true'
     uses: ./.github/workflows/bdd.yml
 
   test:
@@ -700,7 +688,6 @@ jobs:
           LINUX_RESULT: ${{ needs.test-linux.result }}
           RELEASE_WITNESS_RESULT: ${{ needs.test-release-witness.result }}
           EBPF_RESULT: ${{ needs.test-ebpf-telemetry.result }}
-          SCOPE_BDD: ${{ needs.scope.outputs.bdd }}
           BDD_RESULT: ${{ needs.bdd-conformance.result }}
           KERNEL_SCOPE: ${{ needs.scope.outputs.kernel }}
           KERNEL_RESULT: ${{ needs.kernel.result }}
@@ -715,23 +702,16 @@ jobs:
             false) required=skipped ;;
             *) echo "Invalid code scope: $SCOPE_CODE"; exit 1 ;;
           esac
-          for result in "$WORKSPACE_RESULT" "$WORKSPACE_AARCH64_RESULT" "$LINUX_RESULT" "$RELEASE_WITNESS_RESULT" "$EBPF_RESULT"; do
+          # BDD joins this loop rather than being matched separately: it became
+          # the single owner of the Gherkin suite and took on the `code` scope
+          # with it, so it now shares the arithmetic instead of keying off the
+          # narrower `bdd` output.
+          for result in "$WORKSPACE_RESULT" "$WORKSPACE_AARCH64_RESULT" "$LINUX_RESULT" "$RELEASE_WITNESS_RESULT" "$EBPF_RESULT" "$BDD_RESULT"; do
             if [ "$result" != "$required" ]; then
               echo "A test lane did not match scope $SCOPE_CODE: $result"
               exit 1
             fi
           done
-          # The BDD and kernel lanes key off their own narrower scopes, so they
-          # are matched separately rather than folded into the loop above.
-          case "$SCOPE_BDD" in
-            true) bdd_required=success ;;
-            false) bdd_required=skipped ;;
-            *) echo "Invalid bdd scope: $SCOPE_BDD"; exit 1 ;;
-          esac
-          if [ "$BDD_RESULT" != "$bdd_required" ]; then
-            echo "BDD conformance did not match scope $SCOPE_BDD: $BDD_RESULT"
-            exit 1
-          fi
           # The kernel job carries no job-level `if:` — a skipped matrix job
           # cannot expand its arch, so it would report a single check still
           # carrying the un-expanded matrix placeholder in its name, matching
@@ -914,16 +894,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v8.2.0
-        with:
-          version: "0.12.5"
-
-      - name: Set up Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22"
-
+      # No uv, Node or `just` here. All three existed for the `just bdd` this
+      # lane no longer runs — the suite builds the TypeScript SDK, which is what
+      # needed Node and uv. What is left is the wasm/no_std targets, the browser
+      # demo (wasm-pack plus a system python3) and the ext4 oracle, none of which
+      # touch them.
       - uses: ./.github/actions/free-disk
 
       - name: Install Rust toolchain
@@ -941,11 +916,6 @@ jobs:
         run: |
           rustup toolchain install 1.97.1 --profile minimal \
             --target wasm32-unknown-unknown,wasm32-wasip1,riscv32imac-unknown-none-elf
-
-      - name: Install just
-        uses: taiki-e/install-action@v2
-        with:
-          tool: just
 
       - name: Run Linux, no_std, filesystem, and conformance coverage
         run: bash scripts/ci-linux-coverage.sh

--- a/scripts/ci-linux-coverage.sh
+++ b/scripts/ci-linux-coverage.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 # Keep Linux-only compile, filesystem, and conformance coverage in one reusable
 # lane so it can run beside the workspace test lane without duplicating the
 # coverage in a second workflow definition.
+#
+# The Gherkin suite is deliberately NOT here. `just bdd` ran at the end of this
+# script and again in the `bdd-conformance` job, so on any pull request touching
+# `crates/mvm-cli/` the same 252 scenarios ran twice — about 16 minutes of this
+# lane's 20, and what made it the slowest job in the workflow. `bdd-conformance`
+# owns the suite now and is gated on the `code` scope, which is what this lane
+# runs on, so nothing lost a trigger. `check_workflow_paths` fails if `just bdd`
+# comes back here.
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
@@ -95,4 +103,3 @@ if ! cmp -s /tmp/sample.ext4.verity /tmp/vs.verity; then
 fi
 
 cargo test -p mvm-conformance --test meta
-just bdd

--- a/tests/ci_scope_aggregate.rs
+++ b/tests/ci_scope_aggregate.rs
@@ -67,7 +67,8 @@ struct Verdict {
     scope_result: &'static str,
     code: &'static str,
     lanes: &'static str,
-    bdd_scope: &'static str,
+    /// Kept separate from `lanes` even though it now shares their scope, so
+    /// "the BDD lane skipped while in scope" stays expressible on its own.
     bdd: &'static str,
     kernel_scope: &'static str,
     kernel: &'static str,
@@ -80,7 +81,6 @@ impl Verdict {
             scope_result: "success",
             code: "true",
             lanes: "success",
-            bdd_scope: "true",
             bdd: "success",
             kernel_scope: "true",
             kernel: "success",
@@ -94,7 +94,6 @@ impl Verdict {
             scope_result: "success",
             code: "false",
             lanes: "skipped",
-            bdd_scope: "false",
             bdd: "skipped",
             kernel_scope: "false",
             kernel: "success",
@@ -115,7 +114,6 @@ impl Verdict {
             .env("LINUX_RESULT", self.lanes)
             .env("RELEASE_WITNESS_RESULT", self.lanes)
             .env("EBPF_RESULT", self.lanes)
-            .env("SCOPE_BDD", self.bdd_scope)
             .env("BDD_RESULT", self.bdd)
             .env("KERNEL_SCOPE", self.kernel_scope)
             .env("KERNEL_RESULT", self.kernel)
@@ -157,7 +155,18 @@ fn a_fully_in_scope_green_run_is_admitted() {
 /// real failure that has to keep being caught, in whichever scope it can occur.
 #[test]
 fn a_genuine_failure_is_still_refused_in_either_scope() {
-    let cases: [(&str, Verdict); 6] = [
+    let cases: [(&str, Verdict); 7] = [
+        (
+            // New with the suite moving onto the `code` scope: BDD is matched
+            // by the same arithmetic as every other lane, so a run on a
+            // docs-only PR is as wrong as a skip on a code one. Under the old
+            // `bdd`-keyed branch this combination was legal.
+            "a bdd lane that ran while out of scope",
+            Verdict {
+                bdd: "success",
+                ..Verdict::out_of_scope()
+            },
+        ),
         (
             "a failing kernel build, in scope",
             Verdict {

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -776,10 +776,11 @@ mod tests {
         // Every lane the aggregate names must also be read back in the loop that
         // compares results against the scope decision. A lane in `needs` but not
         // in the loop is gated on nothing but its own scheduling.
-        // `bdd-conformance` and `kernel` key off their own narrower scopes, so
-        // they are matched against `$SCOPE_BDD` / `$KERNEL_SCOPE` outside the
-        // loop rather than folded into it — but they still have to be read back
-        // somewhere, which is what this pins.
+        // `kernel` is the only lane still keying off its own narrower scope, so
+        // it is matched against `$KERNEL_SCOPE` outside the loop rather than
+        // folded into it — but it still has to be read back somewhere, which is
+        // what this pins. `bdd-conformance` joined the loop when it took the
+        // Gherkin suite, and the `code` scope, off the Linux lane.
         for expected in [
             "\"$WORKSPACE_RESULT\"",
             "\"$LINUX_RESULT\"",
@@ -828,13 +829,48 @@ mod tests {
         for expected in [
             "cargo +1.97.1 build -p mvm-contract --target wasm32-unknown-unknown",
             "cargo test -p mvm-conformance --test meta",
-            "just bdd",
         ] {
             assert!(
                 linux_coverage.contains(expected),
                 "Linux coverage script must contain {expected:?}"
             );
         }
+
+        // One owner for the Gherkin suite. It ran here *and* in
+        // `bdd-conformance`, so every pull request touching `crates/mvm-cli/`
+        // paid for 252 scenarios twice — about 16 of this lane's 20 minutes.
+        // Pin both halves: gone from here, still present there.
+        // Executable lines only. A `#` line naming the suite is the comment
+        // explaining why it left, and a gate that cannot tell prose from a
+        // command forces that explanation to be written around it.
+        let linux_commands = linux_coverage
+            .lines()
+            .filter(|line| !line.trim_start().starts_with('#'))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !linux_commands.contains("just bdd"),
+            "the Gherkin suite belongs to bdd-conformance; running it here too \
+             is the duplicate that made this the slowest lane in the workflow"
+        );
+        let bdd_workflow = std::fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("..")
+                .join(".github/workflows/bdd.yml"),
+        )
+        .expect("BDD workflow must be readable");
+        assert!(
+            bdd_workflow.contains("just bdd"),
+            "bdd-conformance must still run the Gherkin suite"
+        );
+        // ...and it has to be reachable on every run the Linux lane covers,
+        // which is what taking the suite from that lane made it responsible
+        // for. `bdd` is a strict subset of `code`, so this is the wider gate.
+        assert!(
+            job_block(&workflow, "bdd-conformance")
+                .contains("if: needs.scope.outputs.code == 'true'"),
+            "bdd-conformance must carry the code scope it inherited with the suite"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`just bdd` ran in two places: at the end of `scripts/ci-linux-coverage.sh`, and
in the `bdd-conformance` job.

`bdd` scope is a **strict subset** of `code` scope — `crates/` contains
`crates/mvm-cli/`, `tests/` contains `tests/machine-fixtures/`, and both cover
`features/` and the Justfile. So every pull request touching the CLI ran the
same 252 scenarios twice, under two different nightlies:

| | scope | toolchain | measured |
|---|---|---|---|
| `bdd-conformance` | `bdd` | nightly-2026-08-25 + cranelift | 14m15s |
| `test-linux` → `ci-linux-coverage.sh` | `code` | floating nightly | ~16m of its 20m19s |

## What that lane actually spends its time on

Derived from the job log's timestamps, of `Test Linux and conformance`'s 20m19s:

| phase | time |
|---|---|
| setup | ~3m |
| wasm/no_std targets + browser demo | ~2m |
| **ext4 oracle** — 3 images (one >512 MB), loopback mounts, veritysetup | **15 seconds** |
| building the conformance/BDD binaries | ~8m15s |
| running 252 BDD scenarios | ~7m41s |

The Linux-only work the lane is named for is a rounding error next to the suite
it had quietly adopted.

## The change

`bdd-conformance` keeps the suite and takes the `code` scope the Linux lane ran
under, so **the set of runs covered is unchanged**. What changes is that
broad-scope runs get the pinned nightly with cranelift instead of a floating one.

Expect `test-linux` to drop to roughly 5 minutes and ~16 duplicated
runner-minutes to disappear per run. Wall clock moves less than that — `Test
workspace` sits at 21m12s and becomes the new ceiling — so this is mostly about
removing the duplicate and unblocking what comes next.

## Falling out of it

- **The `bdd` scope classifier had no consumer left**, so it goes with the
  duplicate rather than sitting dead. Its comment claimed the wider scenarios
  were "covered only by the release-tag `bdd` lane" — not true for as long as
  the Linux lane has run `just bdd`.
- **`Set up uv`, `Set up Node` and `Install just`** existed for the suite's
  TypeScript SDK build. What remains needs wasm-pack and a system python3.
- **BDD folds into the test aggregate's main loop** instead of being matched
  against its own scope. That makes a new state illegal — a BDD lane that *runs*
  on a docs-only PR — and `a_genuine_failure_is_still_refused_in_either_scope`
  gains that case.

## Gate

`check_workflow_paths` pins both halves: `just bdd` gone from the Linux script,
still present in `bdd.yml`, and `bdd-conformance` carrying the `code` scope it
inherited. The check reads **executable lines only** — a `#` line naming the
suite is the comment explaining why it left, and a gate that can't tell prose
from a command forces that explanation to be written around it. (It caught my
own comment first, which is how I know.)

## Verification

- `cargo run -p xtask -- check-all` → 67 gate(s) clean
- `cargo test -p xtask --bins` → 704 passed
- `tests/ci_scope_aggregate.rs` → 5 passed, executing the aggregate's real shell
  against the scope matrix (including the new out-of-scope BDD case)
- `tests/github_actions_bdd_gate.rs` → 9 passed
- `actionlint` + `cargo fmt --all` + workspace clippy via the pre-commit hook

Stacks conceptually on #3231 but is based on `main` and touches different jobs.
