### PR TITLE
perf(ci): consolidate merge queue validation

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -15,13 +15,10 @@ name: Warm the Rust build cache
 # lint-features-test-support, lint-features-embed, test-workspace, test-linux
 # and test-ebpf-telemetry, each from cold today.
 #
-# Note what this entry does *not* cover. It is built with default features, so
-# the three lint-features lanes restore its dependency artifacts and then
-# rebuild every workspace crate whose feature resolution differs — which is why
-# the test-support lane still costs ~19 minutes warm. Warming the non-default
-# feature sets too would need its own `key:` per set, and the repo cache is
-# capped at 10 GB with LRU eviction, so an extra entry of this size risks
-# evicting the one every lane depends on. Measure before adding one.
+# The test-support graph differs enough to rebuild almost every workspace crate
+# after restoring the default entry, so it has a dedicated trusted-main key.
+# Keeping it separate prevents its feature fingerprints from diluting the entry
+# restored by every other Rust lane.
 
 on:
   push:
@@ -131,3 +128,36 @@ jobs:
       # genuine breakage is caught by the lanes that gate.
       - name: Build the workspace to populate the cache
         run: ./scripts/cargo-stable.sh clippy --workspace --all-targets -- -D warnings
+
+  warm-test-support:
+    name: Warm test-support
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/free-disk
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.97.1
+
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: lld
+
+      - uses: ./.github/actions/install-zigbuild
+
+      - uses: ./.github/actions/rust-cache
+        with:
+          key: test-support
+          save: "true"
+
+      - name: Warm test-support feature tests
+        run: |
+          cargo test --no-run --features test-support --lib \
+            -p mvm-backends -p mvm-runtime -p mvm-client -p mvm-cli -p mvm-vmm \
+            -p mvm-fs
+          cargo test --no-run -p mvmctl --features test-support \
+            --test audit_emissions_live
+          cargo check -p mvm-cli --features test-support \
+            --example verification_loop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
-  # Classify the exact commit range once, before allocating expensive runners.
-  # Pull-request and merge-group events expose different SHA fields, so keeping
-  # this in one fail-closed job prevents lane-specific path filters drifting.
+  # Classify each pull request, or the cumulative merge-group head against its
+  # target branch, once before allocating expensive runners. Keeping this in one
+  # fail-closed job prevents lane-specific path filters drifting.
   scope:
     name: CI scope
     runs-on: ubuntu-latest
@@ -48,7 +48,7 @@ jobs:
         id: decide
         env:
           EVENT: ${{ github.event_name }}
-          MG_BASE: ${{ github.event.merge_group.base_sha }}
+          MG_BASE_REF: ${{ github.event.merge_group.base_ref }}
           MG_HEAD: ${{ github.event.merge_group.head_sha }}
           PR_BASE: ${{ github.event.pull_request.base.sha }}
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
@@ -56,7 +56,7 @@ jobs:
           set -euo pipefail
 
           set_all() {
-            for output in code bdd nix architecture kernel; do
+            for output in code nix architecture kernel; do
               echo "${output}=true" >> "$GITHUB_OUTPUT"
             done
           }
@@ -68,7 +68,27 @@ jobs:
           fi
 
           case "$EVENT" in
-            merge_group)  BASE="$MG_BASE"; HEAD="$MG_HEAD" ;;
+            merge_group)
+              case "$MG_BASE_REF" in
+                refs/heads/*) TARGET_BRANCH="${MG_BASE_REF#refs/heads/}" ;;
+                *)
+                  set_all
+                  echo "invalid merge-group base ref $MG_BASE_REF — running every lane to stay safe"
+                  exit 0
+                  ;;
+              esac
+              if ! git fetch --no-tags origin "$TARGET_BRANCH"; then
+                set_all
+                echo "could not fetch $MG_BASE_REF — running every lane to stay safe"
+                exit 0
+              fi
+              if ! BASE=$(git merge-base "origin/$TARGET_BRANCH" "$MG_HEAD"); then
+                set_all
+                echo "could not find the merge base for $MG_BASE_REF..$MG_HEAD — running every lane to stay safe"
+                exit 0
+              fi
+              HEAD="$MG_HEAD"
+              ;;
             pull_request) BASE="$PR_BASE"; HEAD="$PR_HEAD" ;;
             *) echo "::error::unhandled event $EVENT" >&2; exit 1 ;;
           esac
@@ -542,6 +562,8 @@ jobs:
       - uses: ./.github/actions/install-zigbuild
 
       - uses: ./.github/actions/rust-cache
+        with:
+          key: test-support
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -675,12 +697,13 @@ jobs:
   test:
     name: Test
     if: ${{ always() }}
-    needs: [scope, test-workspace, test-workspace-aarch64, test-linux, test-release-witness, test-ebpf-telemetry, bdd-conformance, kernel]
+    needs: [scope, test-workspace, test-workspace-aarch64, test-linux, test-release-witness, test-ebpf-telemetry, bdd-conformance, boot-latency, kernel, nix-flake-check]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Require every test lane to pass
         env:
+          EVENT_NAME: ${{ github.event_name }}
           SCOPE_RESULT: ${{ needs.scope.result }}
           SCOPE_CODE: ${{ needs.scope.outputs.code }}
           WORKSPACE_RESULT: ${{ needs.test-workspace.result }}
@@ -691,6 +714,8 @@ jobs:
           BDD_RESULT: ${{ needs.bdd-conformance.result }}
           KERNEL_SCOPE: ${{ needs.scope.outputs.kernel }}
           KERNEL_RESULT: ${{ needs.kernel.result }}
+          BOOT_RESULT: ${{ needs.boot-latency.result }}
+          NIX_RESULT: ${{ needs.nix-flake-check.result }}
         run: |
           set -euo pipefail
           if [ "$SCOPE_RESULT" != success ]; then
@@ -724,6 +749,24 @@ jobs:
           # was removed — failed every PR that does not touch a kernel path.
           if [ "$KERNEL_RESULT" != success ]; then
             echo "Kernel validation did not succeed (scope $KERNEL_SCOPE): $KERNEL_RESULT"
+            exit 1
+          fi
+          case "$EVENT_NAME" in
+            pull_request) nix_required=skipped ;;
+            merge_group|workflow_dispatch) nix_required=success ;;
+            *) echo "Invalid event name: $EVENT_NAME"; exit 1 ;;
+          esac
+          if [ "$NIX_RESULT" != "$nix_required" ]; then
+            echo "Nix validation did not match event $EVENT_NAME: $NIX_RESULT"
+            exit 1
+          fi
+          case "$EVENT_NAME:$SCOPE_CODE" in
+            merge_group:true|workflow_dispatch:true) boot_required=success ;;
+            pull_request:*|merge_group:false|workflow_dispatch:false) boot_required=skipped ;;
+            *) echo "Invalid boot scope: event=$EVENT_NAME code=$SCOPE_CODE"; exit 1 ;;
+          esac
+          if [ "$BOOT_RESULT" != "$boot_required" ]; then
+            echo "Published-image boot did not match event/scope $EVENT_NAME/$SCOPE_CODE: $BOOT_RESULT"
             exit 1
           fi
 
@@ -1251,165 +1294,19 @@ jobs:
             staging/kernel-metrics-${{ matrix.arch }}.json
             staging/workload-config-${{ matrix.arch }}
 
-  guest-image-boot:
-    name: Guest image boots (tree-built)
-    # The gap #2635 names: nothing builds the guest image generator's output and
-    # starts it before the change is on main. The only lane that boots a
-    # tree-built image runs on a `boot-image/v*` tag, which is after the merge.
-    # That is how a rootfs whose /init the kernel could not exec shipped for five
-    # weeks with every checksum verifying clean, and how five successive release
-    # runs each surfaced exactly one more layer — an unattached overlay, a guest
-    # never told where the overlay was, a sidecar field the serializer dropped —
-    # none of which any static check can see, because each one needs a guest that
-    # actually runs.
-    #
-    # Merge queue, not per-PR, and the cost argument is wall-clock rather than
-    # runner-minutes: this job takes ~33 minutes, and the merge-group CI it joins
-    # already takes 32-36, so running in parallel it adds close to nothing to how
-    # long a merge takes. Per-PR it would be pure addition on every push.
-    # `nix-flake-check` above sets the same precedent for the same reason.
+  nix-flake-check:
+    name: Nix flake check (Linux eval)
+    # Nix eval/build and the tree-built guest witness share one queue runner so
+    # the boot reuses the exact images and Nix store this job already produced.
     needs: [scope]
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/free-disk
         if: needs.scope.outputs.nix == 'true'
-
-      - name: Install Nix
-        if: needs.scope.outputs.nix == 'true'
-        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-
-      - name: Install Rust toolchain
-        if: needs.scope.outputs.nix == 'true'
-        uses: dtolnay/rust-toolchain@1.97.1
-
-      - uses: ./.github/actions/apt-deps
-        if: needs.scope.outputs.nix == 'true'
-        with:
-          packages: lld
-
-      - name: Build the guest image from this tree
-        if: needs.scope.outputs.nix == 'true'
-        run: |
-          set -euo pipefail
-          nix build "./nix/images/default-tenant#packages.x86_64-linux.default" \
-            --impure --no-link --print-out-paths > /tmp/store-path.txt
-          STORE_PATH=$(head -1 /tmp/store-path.txt)
-          mkdir -p staging
-          # cp -L so each artifact resolves through its nix-store symlink.
-          cp -L "$STORE_PATH/vmlinux"       staging/vmlinux
-          cp -L "$STORE_PATH/rootfs.ext4"   staging/rootfs.ext4
-          cp -L "$STORE_PATH/mvm-meta.json" staging/mvm-meta.json
-
-      - name: Assert the tree-built rootfs has an exec'able /init
-        if: needs.scope.outputs.nix == 'true'
-        run: |
-          set -euo pipefail
-          # The cheap half, and the one that catches the defect that actually
-          # shipped. Runs before the boot so a rootfs the kernel cannot exec
-          # fails here, where the message says so, rather than as a panic.
-          command -v debugfs >/dev/null 2>&1 \
-            || { sudo apt-get update && sudo apt-get install -y e2fsprogs; }
-          bash nix/packaging/release/assert-init-shebang.sh \
-            staging/rootfs.ext4 "tree-built x86_64"
-          bash nix/packaging/release/assert-kernel-format.sh \
-            staging/vmlinux x86_64 "tree-built x86_64 kernel"
-
-      # The prod rootfs bakes no agent — /init resolves it from /mvm/runtime,
-      # the runtime overlay attached as a second virtio-blk drive. The nix store
-      # is warm from the image build, so this is usually a store lookup rather
-      # than a build.
-      - name: Build the runtime overlay
-        if: needs.scope.outputs.nix == 'true'
-        run: |
-          set -euo pipefail
-          OVERLAY_PATH=$(nix build "./nix/images/runtime-overlay#packages.x86_64-linux.default" \
-            --no-link --print-out-paths | head -1)
-          mkdir -p overlay-staging
-          cp -L "$OVERLAY_PATH/overlay.ext4"     overlay-staging/overlay.ext4
-          cp -L "$OVERLAY_PATH/overlay.verity"   overlay-staging/overlay.verity
-          cp -L "$OVERLAY_PATH/overlay.roothash" overlay-staging/overlay.roothash
-          echo "MVM_RUNTIME_BOOT_OVERLAY_ROOTHASH=$(tr -d '[:space:]' < overlay-staging/overlay.roothash)" \
-            >> "$GITHUB_ENV"
-
-      - name: Install firecracker
-        if: needs.scope.outputs.nix == 'true'
-        env:
-          # Tracks `crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT`.
-          FC_VERSION: v1.14.1
-        run: |
-          set -euo pipefail
-          curl -fL -o firecracker.tgz \
-            "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-x86_64.tgz"
-          tar -xzf firecracker.tgz
-          sudo install -m 0755 "release-${FC_VERSION}-x86_64/firecracker-${FC_VERSION}-x86_64" /usr/bin/firecracker
-          /usr/bin/firecracker --version
-
-      - name: Grant /dev/kvm access for the job
-        if: needs.scope.outputs.nix == 'true'
-        run: |
-          set -euo pipefail
-          if [ ! -e /dev/kvm ]; then
-            echo "::error::/dev/kvm missing on this runner — the boot gate cannot run." >&2
-            exit 1
-          fi
-          sudo chmod 666 /dev/kvm
-
-      - name: Boot the tree-built image
-        if: needs.scope.outputs.nix == 'true'
-        # Not a latency assertion. The budget is an order of magnitude above the
-        # observed median and RUNS/CONCURRENT are 1, because the only question
-        # here is whether this tree's image reaches userspace and binds its
-        # agent. Latency belongs to `boot-latency`, which pins a *published*
-        # image deliberately so a regression is unambiguous between host code
-        # and image — the two lanes answer different questions and neither
-        # substitutes for the other.
-        env:
-          MVM_RUNTIME_BOOT_BENCH: "1"
-          MVM_RUNTIME_BOOT_BACKEND: firecracker
-          MVM_RUNTIME_BOOT_KERNEL: staging/vmlinux
-          MVM_RUNTIME_BOOT_ROOTFS: staging/rootfs.ext4
-          MVM_RUNTIME_BOOT_OVERLAY: overlay-staging/overlay.ext4
-          MVM_RUNTIME_BOOT_OVERLAY_VERITY: overlay-staging/overlay.verity
-          MVM_RUNTIME_BOOT_READY: guest-agent
-          MVM_RUNTIME_BOOT_RUNS: "1"
-          MVM_RUNTIME_BOOT_CONCURRENT: "1"
-          MVM_RUNTIME_BOOT_BUDGET_MS: "60000"
-        run: |
-          set -euo pipefail
-          # No copy needed: the runtime-overlay admission gate reads
-          # `mvm-meta.json` from the rootfs's own directory, and the build step
-          # already staged it beside `rootfs.ext4`.
-          test -f staging/mvm-meta.json
-          cargo test --test runtime_boot_bench \
-            prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
-
-      - name: Guest console on failure
-        if: ${{ failure() && needs.scope.outputs.nix == 'true' }}
-        run: |
-          for d in "$HOME"/.mvm/vms/*/; do
-            echo "===== $d ====="
-            ls -la "$d" || true
-            # `if`, not `A && B || C`: with the latter the `|| true` also runs
-            # when `cat` itself fails, which would hide a console.log that
-            # exists but cannot be read — the one case worth seeing here.
-            if [ -f "$d/console.log" ]; then
-              cat "$d/console.log"
-            fi
-          done
-
-  nix-flake-check:
-    name: Nix flake check (Linux eval)
-    # Nix eval/build is heavy; run it in the merge queue and on manual dispatch,
-    # not on every PR update.
-    needs: [scope]
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
 
       - name: Install Nix
         if: needs.scope.outputs.nix == 'true'
@@ -1425,7 +1322,12 @@ jobs:
 
       - name: Install Rust toolchain
         if: needs.scope.outputs.nix == 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.97.1
+
+      - uses: ./.github/actions/apt-deps
+        if: needs.scope.outputs.nix == 'true'
+        with:
+          packages: lld
 
       - name: Eval-check every flake
         if: needs.scope.outputs.nix == 'true'
@@ -1532,3 +1434,84 @@ jobs:
             --closure-paths "$image_path/rootfs-closure-paths" \
             --sdk-sidecar "$sidecar_path/sdk.ext4" \
             --json
+
+      - name: Stage the tree-built image for boot
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          image_path=$(head -1 /tmp/default-tenant-path.txt)
+          overlay_path=$(head -1 /tmp/runtime-overlay-path.txt)
+          mkdir -p staging overlay-staging
+          # Resolve the store symlinks so the boot witness owns ordinary files.
+          cp -L "$image_path/vmlinux" staging/vmlinux
+          cp -L "$image_path/rootfs.ext4" staging/rootfs.ext4
+          cp -L "$image_path/mvm-meta.json" staging/mvm-meta.json
+          cp -L "$overlay_path/overlay.ext4" overlay-staging/overlay.ext4
+          cp -L "$overlay_path/overlay.verity" overlay-staging/overlay.verity
+          cp -L "$overlay_path/overlay.roothash" overlay-staging/overlay.roothash
+          echo "MVM_RUNTIME_BOOT_OVERLAY_ROOTHASH=$(tr -d '[:space:]' < overlay-staging/overlay.roothash)" \
+            >> "$GITHUB_ENV"
+
+      - name: Assert the tree-built rootfs has an exec'able /init
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          command -v debugfs >/dev/null 2>&1 \
+            || { sudo apt-get update && sudo apt-get install -y e2fsprogs; }
+          bash nix/packaging/release/assert-init-shebang.sh \
+            staging/rootfs.ext4 "tree-built x86_64"
+          bash nix/packaging/release/assert-kernel-format.sh \
+            staging/vmlinux x86_64 "tree-built x86_64 kernel"
+
+      - name: Install firecracker
+        if: needs.scope.outputs.nix == 'true'
+        env:
+          # Tracks `crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT`.
+          FC_VERSION: v1.14.1
+        run: |
+          set -euo pipefail
+          curl -fL -o firecracker.tgz \
+            "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-x86_64.tgz"
+          tar -xzf firecracker.tgz
+          sudo install -m 0755 "release-${FC_VERSION}-x86_64/firecracker-${FC_VERSION}-x86_64" /usr/bin/firecracker
+          /usr/bin/firecracker --version
+
+      - name: Grant /dev/kvm access for the job
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm missing on this runner — the boot gate cannot run." >&2
+            exit 1
+          fi
+          sudo chmod 666 /dev/kvm
+
+      - name: Boot the tree-built image
+        if: needs.scope.outputs.nix == 'true'
+        env:
+          MVM_RUNTIME_BOOT_BENCH: "1"
+          MVM_RUNTIME_BOOT_BACKEND: firecracker
+          MVM_RUNTIME_BOOT_KERNEL: staging/vmlinux
+          MVM_RUNTIME_BOOT_ROOTFS: staging/rootfs.ext4
+          MVM_RUNTIME_BOOT_OVERLAY: overlay-staging/overlay.ext4
+          MVM_RUNTIME_BOOT_OVERLAY_VERITY: overlay-staging/overlay.verity
+          MVM_RUNTIME_BOOT_READY: guest-agent
+          MVM_RUNTIME_BOOT_RUNS: "1"
+          MVM_RUNTIME_BOOT_CONCURRENT: "1"
+          MVM_RUNTIME_BOOT_BUDGET_MS: "60000"
+        run: |
+          set -euo pipefail
+          test -f staging/mvm-meta.json
+          cargo test --test runtime_boot_bench \
+            prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
+
+      - name: Guest console on failure
+        if: ${{ failure() && needs.scope.outputs.nix == 'true' }}
+        run: |
+          for d in "$HOME"/.mvm/vms/*/; do
+            echo "===== $d ====="
+            ls -la "$d" || true
+            if [ -f "$d/console.log" ]; then
+              cat "$d/console.log"
+            fi
+          done

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -19,9 +19,6 @@ on:
       - "web/mvm-demo-guest/**"
       - ".github/workflows/workers.yml"
       - ".github/workflows/website.yml"
-  merge_group:
-    types: [checks_requested]
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -1,8 +1,16 @@
 # Refactor status
 
-Last updated: 2026-09-09
+Last updated: 2026-09-10
 
 ## In progress
+
+- [ ] **CI queue consolidation.**
+      `specs/plans/2026-09-10-ci-queue-consolidation.md`.
+      Correct cumulative `HEADGREEN` scope, make every queue witness honestly
+      required or remove its queue fan-out, warm the measured feature-test
+      critical path from trusted main, and remove duplicate nextest listings.
+      Implementation and configured CI validation are green; live timing and
+      the post-merge required-context reduction remain.
 
 - [ ] **Scheduled CI stability.**
       `specs/plans/2026-09-09-scheduled-ci-stability.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,6 +10,15 @@
 
 ## In progress
 
+- [ ] **CI queue consolidation.**
+      `specs/plans/2026-09-10-ci-queue-consolidation.md`.
+      Preserve cumulative merge-group validation while reducing runner fan-out
+      and the measured Rust critical path. Work covers merge-group scope,
+      required aggregate ownership, trusted feature-cache warming, duplicate
+      nextest listings, and non-required queue jobs. Implementation and all
+      configured CI tests are green; live PR/queue timing and the post-merge
+      required-context reduction remain.
+
 - [ ] **Scheduled CI stability — issues #3222, #3223, and #3224.**
       `specs/plans/2026-09-09-scheduled-ci-stability.md`.
       Harden release-asset downloads against transient connection failures,

--- a/specs/plans/2026-09-10-ci-queue-consolidation.md
+++ b/specs/plans/2026-09-10-ci-queue-consolidation.md
@@ -1,5 +1,8 @@
 # CI queue consolidation
 
+Backing: shipped-source
+Validation: check-sprint-append
+
 **Status:** Implementation complete; live queue validation pending
 
 ## Goal

--- a/specs/plans/2026-09-10-ci-queue-consolidation.md
+++ b/specs/plans/2026-09-10-ci-queue-consolidation.md
@@ -1,0 +1,69 @@
+# CI queue consolidation
+
+**Status:** Implementation complete; live queue validation pending
+
+## Goal
+
+Reduce pull-request and merge-queue latency and runner fan-out without letting
+path scoping or non-required witness jobs weaken exact merge-group validation.
+
+## Measured baseline
+
+- A code-changing pull request publishes up to twenty check runs after the
+  feature-coverage split. The split itself is beneficial: three parallel jobs
+  replaced a 35-minute serial lane and reduced the required critical path to
+  roughly 23 minutes.
+- `test-support` and `Test workspace` are now the two approximately 21-minute
+  lanes. `check-nextest-groups` spends about five minutes issuing four test
+  listings for two duplicated filters.
+- The repository Actions cache is at 10.63 GB across 4,550 entries. The trusted
+  main-branch Rust workspace entry is about 338 MiB; merge-ref Nix entries make
+  up most of the object count.
+- The merge queue uses `HEADGREEN`. A two-entry group merged while the earlier
+  entry's required Nix job was still running because the head entry classified
+  only its delta from the preceding queue entry and reported Nix out of scope.
+
+## Work
+
+- [x] Classify a merge-group head against the target branch rather than only
+      the preceding queue entry, with a fail-closed fallback.
+- [x] Make the required `Test` aggregate own Nix evaluation, tree-built guest
+      boot, and the published-image boot ceiling; combine overlapping Nix and
+      guest-image work on one runner.
+- [x] Stop the non-required Website workflow from consuming a runner on every
+      merge-group event; retain its pull-request path gate.
+- [x] Warm the `test-support` feature graph from trusted `main` and restore it
+      under a dedicated cache key in pull-request and queue validation.
+- [x] Deduplicate identical nextest override filters before invoking
+      `cargo nextest list`.
+- [x] Run workflow structure tests, actionlint, xtask tests, workspace tests,
+      workspace check, formatting, and zero-warning Clippy.
+- [ ] Record the first live pull-request and merge-group timings, then decide
+      whether combining additional short lanes improves the 20-runner capacity
+      boundary without lengthening the critical path.
+- [ ] After the workflow lands, reduce classic branch protection to the stable
+      `Lint (fmt + clippy + policy)` and `Test` aggregate contexts.
+
+## Safety invariants
+
+- Required checks validate the exact merge-group head, including every queued
+  pull request represented by that head.
+- No pull-request or ephemeral merge ref writes a trusted Rust cache entry.
+- A skipped scoped lane is accepted only when the aggregate proves that the
+  corresponding scope is out of range.
+- Boot and Nix witnesses either feed a required aggregate or do not claim to
+  gate merging.
+
+## Validation
+
+- `actionlint` passes for the three changed workflows.
+- The executable aggregate matrix passes for pull requests, in-scope and
+  out-of-scope merge groups, and deliberate lane failures.
+- `cargo nextest run --workspace --all-targets` passes all 13,192 selected
+  tests; 22 live or measurement tests remain intentionally skipped.
+- `cargo check --workspace`, `cargo clippy --workspace -- -D warnings`, and
+  `cargo fmt --all -- --check` pass.
+- Two direct `cargo test --workspace` attempts exposed independent existing
+  harness-concurrency artifacts after the test bodies passed; each failed
+  target passed immediately in isolation. The configured nextest groups are
+  the authoritative CI execution and completed cleanly.

--- a/tests/ci_scope_aggregate.rs
+++ b/tests/ci_scope_aggregate.rs
@@ -64,6 +64,7 @@ fn aggregate_script() -> String {
 
 /// One `needs.*.result` / scope combination fed to the aggregate.
 struct Verdict {
+    event_name: &'static str,
     scope_result: &'static str,
     code: &'static str,
     lanes: &'static str,
@@ -72,18 +73,23 @@ struct Verdict {
     bdd: &'static str,
     kernel_scope: &'static str,
     kernel: &'static str,
+    boot: &'static str,
+    nix: &'static str,
 }
 
 impl Verdict {
     /// An everything-in-scope, everything-green run.
     fn in_scope() -> Self {
         Self {
+            event_name: "pull_request",
             scope_result: "success",
             code: "true",
             lanes: "success",
             bdd: "success",
             kernel_scope: "true",
             kernel: "success",
+            boot: "skipped",
+            nix: "skipped",
         }
     }
 
@@ -91,12 +97,36 @@ impl Verdict {
     /// job-level `if:`, so it still runs and still reports `success`.
     fn out_of_scope() -> Self {
         Self {
+            event_name: "pull_request",
             scope_result: "success",
             code: "false",
             lanes: "skipped",
             bdd: "skipped",
             kernel_scope: "false",
             kernel: "success",
+            boot: "skipped",
+            nix: "skipped",
+        }
+    }
+
+    /// The cumulative merge-group head runs every queue job for an in-scope
+    /// code and Nix change.
+    fn queue_in_scope() -> Self {
+        Self {
+            event_name: "merge_group",
+            boot: "success",
+            nix: "success",
+            ..Self::in_scope()
+        }
+    }
+
+    /// A docs-only merge group still executes the Nix job so its stable check
+    /// name reports success, while all scoped steps and the boot ceiling skip.
+    fn queue_out_of_scope() -> Self {
+        Self {
+            event_name: "merge_group",
+            nix: "success",
+            ..Self::out_of_scope()
         }
     }
 
@@ -104,6 +134,7 @@ impl Verdict {
     fn accepts(&self) -> bool {
         let mut child = Command::new("bash")
             .arg("-s")
+            .env("EVENT_NAME", self.event_name)
             .env("SCOPE_RESULT", self.scope_result)
             .env("SCOPE_CODE", self.code)
             .env("WORKSPACE_RESULT", self.lanes)
@@ -117,6 +148,8 @@ impl Verdict {
             .env("BDD_RESULT", self.bdd)
             .env("KERNEL_SCOPE", self.kernel_scope)
             .env("KERNEL_RESULT", self.kernel)
+            .env("BOOT_RESULT", self.boot)
+            .env("NIX_RESULT", self.nix)
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -149,13 +182,15 @@ fn a_fully_out_of_scope_run_is_admitted() {
 #[test]
 fn a_fully_in_scope_green_run_is_admitted() {
     assert!(Verdict::in_scope().accepts());
+    assert!(Verdict::queue_in_scope().accepts());
+    assert!(Verdict::queue_out_of_scope().accepts());
 }
 
 /// The gate must not have been widened into a rubber stamp. Each of these is a
 /// real failure that has to keep being caught, in whichever scope it can occur.
 #[test]
 fn a_genuine_failure_is_still_refused_in_either_scope() {
-    let cases: [(&str, Verdict); 7] = [
+    let cases: [(&str, Verdict); 11] = [
         (
             // New with the suite moving onto the `code` scope: BDD is matched
             // by the same arithmetic as every other lane, so a run on a
@@ -207,6 +242,34 @@ fn a_genuine_failure_is_still_refused_in_either_scope() {
             Verdict {
                 scope_result: "failure",
                 ..Verdict::in_scope()
+            },
+        ),
+        (
+            "a failing published-image boot ceiling",
+            Verdict {
+                boot: "failure",
+                ..Verdict::queue_in_scope()
+            },
+        ),
+        (
+            "a published-image boot that ran while out of scope",
+            Verdict {
+                boot: "success",
+                ..Verdict::queue_out_of_scope()
+            },
+        ),
+        (
+            "a failing Nix and tree-built guest witness",
+            Verdict {
+                nix: "failure",
+                ..Verdict::queue_in_scope()
+            },
+        ),
+        (
+            "a Nix witness that skipped in the queue",
+            Verdict {
+                nix: "skipped",
+                ..Verdict::queue_in_scope()
             },
         ),
     ];

--- a/xtask/src/check_nextest_groups.rs
+++ b/xtask/src/check_nextest_groups.rs
@@ -9,7 +9,7 @@
 
 use anyhow::{Context, Result, bail};
 use nextest_metadata::ListCommand as NextestList;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::Path;
 
 /// Parsed nextest override entry.
@@ -40,10 +40,25 @@ pub fn run(workspace: &Path) -> Result<()> {
         return Ok(());
     }
 
+    let listings = unique_filters(&overrides)
+        .into_iter()
+        .map(|filter| {
+            let result =
+                list_matching_tests(workspace, filter).map_err(|error| format!("{error:#}"));
+            (filter.to_string(), result)
+        })
+        .collect::<BTreeMap<_, _>>();
+
     let mut failures = Vec::new();
     for ov in &overrides {
         if let Some(failure) = check_override(ov, &workspace_members, |filter| {
-            list_matching_tests(workspace, filter)
+            match listings
+                .get(filter)
+                .expect("every extracted override filter must have a cached listing")
+            {
+                Ok(count) => Ok(*count),
+                Err(error) => bail!(error.clone()),
+            }
         }) {
             failures.push(failure);
         } else {
@@ -66,6 +81,15 @@ pub fn run(workspace: &Path) -> Result<()> {
             failures.len()
         );
     }
+}
+
+fn unique_filters(overrides: &[OverrideFilter]) -> Vec<&str> {
+    overrides
+        .iter()
+        .map(|override_filter| override_filter.filter.as_str())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 fn check_override(
@@ -252,6 +276,35 @@ test-group = "serial"
         .unwrap();
 
         assert!(extract_overrides(&config).is_err());
+    }
+
+    #[test]
+    fn duplicate_profile_filters_are_listed_once() {
+        let overrides = vec![
+            OverrideFilter {
+                profile: "default".to_string(),
+                filter: "package(mvm-core) and test(/foo/)".to_string(),
+                test_group: "serial".to_string(),
+            },
+            OverrideFilter {
+                profile: "ci".to_string(),
+                filter: "package(mvm-core) and test(/foo/)".to_string(),
+                test_group: "serial".to_string(),
+            },
+            OverrideFilter {
+                profile: "ci".to_string(),
+                filter: "package(mvm-hostd) and binary(bar)".to_string(),
+                test_group: "serial".to_string(),
+            },
+        ];
+
+        assert_eq!(
+            unique_filters(&overrides),
+            vec![
+                "package(mvm-core) and test(/foo/)",
+                "package(mvm-hostd) and binary(bar)",
+            ]
+        );
     }
 
     #[test]

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -770,7 +770,8 @@ mod tests {
         assert!(test.contains("name: Test"));
         assert!(test.contains(
             "needs: [scope, test-workspace, test-workspace-aarch64, test-linux, \
-             test-release-witness, test-ebpf-telemetry, bdd-conformance, kernel]"
+             test-release-witness, test-ebpf-telemetry, bdd-conformance, \
+             boot-latency, kernel, nix-flake-check]"
         ));
 
         // Every lane the aggregate names must also be read back in the loop that
@@ -788,6 +789,8 @@ mod tests {
             "\"$EBPF_RESULT\"",
             "\"$BDD_RESULT\"",
             "\"$KERNEL_RESULT\"",
+            "\"$BOOT_RESULT\"",
+            "\"$NIX_RESULT\"",
         ] {
             assert!(
                 test.contains(expected),
@@ -875,14 +878,16 @@ mod tests {
 
     #[test]
     fn merge_group_ci_skips_rust_work_for_non_code_diffs_without_losing_gates() {
-        let workflow = ci_workflow();
-        let scope = job_block(&workflow, "scope");
+        let ci = ci_workflow();
+        let scope = job_block(&ci, "scope");
         for expected in [
-            "MG_BASE: ${{ github.event.merge_group.base_sha }}",
+            "MG_BASE_REF: ${{ github.event.merge_group.base_ref }}",
             "MG_HEAD: ${{ github.event.merge_group.head_sha }}",
             "PR_BASE: ${{ github.event.pull_request.base.sha }}",
             "PR_HEAD: ${{ github.event.pull_request.head.sha }}",
             "git diff --name-only -z",
+            "git merge-base",
+            "origin/$TARGET_BRANCH",
             "grep -zE",
             "could not diff $BASE..$HEAD — running every lane to stay safe",
             "invalid or missing ${name} scope",
@@ -907,7 +912,7 @@ mod tests {
             "test-linux",
             "test-ebpf-telemetry",
         ] {
-            let block = job_block(&workflow, job);
+            let block = job_block(&ci, job);
             assert!(
                 block.contains("needs: [scope]"),
                 "{job} must depend on CI scope"
@@ -922,30 +927,42 @@ mod tests {
         // but not which version of that crate is installed, so an upstream
         // release retroactively changes this lane. Now that the lane gates the
         // merge, an unpinned install lets a publish elsewhere block the queue.
-        let ebpf = job_block(&workflow, "test-ebpf-telemetry");
+        let ebpf = job_block(&ci, "test-ebpf-telemetry");
         assert!(
             ebpf.contains("cargo +nightly install --locked --version ")
                 && ebpf.contains("bpf-linker"),
             "eBPF lane must install a pinned bpf-linker version"
         );
 
-        let policy = job_block(&workflow, "lint-policy");
+        let policy = job_block(&ci, "lint-policy");
         assert!(policy.contains("needs: [scope]"));
         assert!(!policy.contains("needs.scope.outputs.code == 'true'"));
         assert!(policy.contains("needs.scope.outputs.architecture == 'true'"));
 
-        let nix = job_block(&workflow, "nix-flake-check");
+        let nix = job_block(&ci, "nix-flake-check");
         assert!(nix.contains("needs: [scope]"));
         assert!(nix.contains("needs.scope.outputs.nix == 'true'"));
+        assert!(nix.contains("Boot the tree-built image"));
+        assert!(nix.contains("MVM_RUNTIME_BOOT_READY: guest-agent"));
+        assert!(
+            !ci.contains("\n  guest-image-boot:\n"),
+            "the tree-built guest witness must reuse the required Nix runner"
+        );
 
-        let kernel = job_block(&workflow, "kernel");
+        let website = workflow("website.yml");
+        assert!(
+            !website.contains("merge_group:"),
+            "the non-required Website workflow must not consume every merge-group runner slot"
+        );
+
+        let kernel = job_block(&ci, "kernel");
         assert!(kernel.contains("needs: [scope]"));
         assert!(kernel.contains("if: needs.scope.outputs.kernel == 'true'"));
         assert!(kernel.contains("name: Build kernels (${{ matrix.arch }})"));
         assert!(kernel.contains("needs.scope.outputs.kernel == 'true'"));
 
         for aggregate in ["lint", "test"] {
-            let block = job_block(&workflow, aggregate);
+            let block = job_block(&ci, aggregate);
             assert!(block.contains("needs.scope.result"));
             assert!(block.contains("SCOPE_CODE: ${{ needs.scope.outputs.code }}"));
             assert!(
@@ -1410,8 +1427,12 @@ mod tests {
         assert!(warm.contains("DeterminateSystems/magic-nix-cache-action@v14"));
         assert!(warm.contains("Build Nix outputs to populate the binary cache"));
         assert!(warm.contains("save: \"true\""));
+        assert!(warm.contains("key: test-support"));
+        assert!(warm.contains("Warm test-support feature tests"));
 
         let ci = ci_workflow();
+        let support = job_block(&ci, "lint-features-test-support");
+        assert!(support.contains("key: test-support"));
         let nix = job_block(&ci, "nix-flake-check");
         assert!(nix.contains("DeterminateSystems/magic-nix-cache-action@v14"));
         assert!(nix.contains("use-flakehub: false"));


### PR DESCRIPTION
Summary:
- classify the cumulative merge-group head against its target branch
- make Test own Nix and boot witnesses while reusing one Nix/guest runner
- remove the non-required Website merge-group run
- warm the test-support feature graph from trusted main
- deduplicate identical nextest filter listings

Validation:
- actionlint on changed workflows
- cargo nextest run --workspace --all-targets: 13,192 passed, 22 skipped
- cargo check --workspace
- cargo clippy --workspace -- -D warnings
- cargo fmt --all -- --check
- focused aggregate and workflow-structure regressions