### PR TITLE
perf(ci): keep queue witnesses parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,7 +697,7 @@ jobs:
   test:
     name: Test
     if: ${{ always() }}
-    needs: [scope, test-workspace, test-workspace-aarch64, test-linux, test-release-witness, test-ebpf-telemetry, bdd-conformance, boot-latency, kernel, nix-flake-check]
+    needs: [scope, test-workspace, test-workspace-aarch64, test-linux, test-release-witness, test-ebpf-telemetry, bdd-conformance, boot-latency, guest-image-boot, kernel, nix-flake-check]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -715,6 +715,7 @@ jobs:
           KERNEL_SCOPE: ${{ needs.scope.outputs.kernel }}
           KERNEL_RESULT: ${{ needs.kernel.result }}
           BOOT_RESULT: ${{ needs.boot-latency.result }}
+          GUEST_IMAGE_RESULT: ${{ needs.guest-image-boot.result }}
           NIX_RESULT: ${{ needs.nix-flake-check.result }}
         run: |
           set -euo pipefail
@@ -758,6 +759,10 @@ jobs:
           esac
           if [ "$NIX_RESULT" != "$nix_required" ]; then
             echo "Nix validation did not match event $EVENT_NAME: $NIX_RESULT"
+            exit 1
+          fi
+          if [ "$GUEST_IMAGE_RESULT" != "$nix_required" ]; then
+            echo "Tree-built guest validation did not match event $EVENT_NAME: $GUEST_IMAGE_RESULT"
             exit 1
           fi
           case "$EVENT_NAME:$SCOPE_CODE" in
@@ -1294,19 +1299,138 @@ jobs:
             staging/kernel-metrics-${{ matrix.arch }}.json
             staging/workload-config-${{ matrix.arch }}
 
-  nix-flake-check:
-    name: Nix flake check (Linux eval)
-    # Nix eval/build and the tree-built guest witness share one queue runner so
-    # the boot reuses the exact images and Nix store this job already produced.
+  guest-image-boot:
+    name: Guest image boots (tree-built)
+    # Keep this witness parallel with Nix evaluation. A live queue measurement
+    # showed that serializing it behind the Nix footprint work extended the
+    # protected critical path by about seven minutes even though both jobs
+    # build overlapping store paths. `Test` owns both results, so parallelism
+    # does not weaken the merge gate.
     needs: [scope]
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/free-disk
         if: needs.scope.outputs.nix == 'true'
+
+      - name: Install Nix
+        if: needs.scope.outputs.nix == 'true'
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Install Rust toolchain
+        if: needs.scope.outputs.nix == 'true'
+        uses: dtolnay/rust-toolchain@1.97.1
+
+      - uses: ./.github/actions/apt-deps
+        if: needs.scope.outputs.nix == 'true'
+        with:
+          packages: lld
+
+      - name: Build the guest image from this tree
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          nix build "./nix/images/default-tenant#packages.x86_64-linux.default" \
+            --impure --no-link --print-out-paths > /tmp/store-path.txt
+          STORE_PATH=$(head -1 /tmp/store-path.txt)
+          mkdir -p staging
+          # Resolve each artifact through its Nix store symlink.
+          cp -L "$STORE_PATH/vmlinux"       staging/vmlinux
+          cp -L "$STORE_PATH/rootfs.ext4"   staging/rootfs.ext4
+          cp -L "$STORE_PATH/mvm-meta.json" staging/mvm-meta.json
+
+      - name: Assert the tree-built rootfs has an exec'able /init
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          command -v debugfs >/dev/null 2>&1 \
+            || { sudo apt-get update && sudo apt-get install -y e2fsprogs; }
+          bash nix/packaging/release/assert-init-shebang.sh \
+            staging/rootfs.ext4 "tree-built x86_64"
+          bash nix/packaging/release/assert-kernel-format.sh \
+            staging/vmlinux x86_64 "tree-built x86_64 kernel"
+
+      - name: Build the runtime overlay
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          OVERLAY_PATH=$(nix build "./nix/images/runtime-overlay#packages.x86_64-linux.default" \
+            --no-link --print-out-paths | head -1)
+          mkdir -p overlay-staging
+          cp -L "$OVERLAY_PATH/overlay.ext4"     overlay-staging/overlay.ext4
+          cp -L "$OVERLAY_PATH/overlay.verity"   overlay-staging/overlay.verity
+          cp -L "$OVERLAY_PATH/overlay.roothash" overlay-staging/overlay.roothash
+          echo "MVM_RUNTIME_BOOT_OVERLAY_ROOTHASH=$(tr -d '[:space:]' < overlay-staging/overlay.roothash)" \
+            >> "$GITHUB_ENV"
+
+      - name: Install firecracker
+        if: needs.scope.outputs.nix == 'true'
+        env:
+          # Tracks `crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT`.
+          FC_VERSION: v1.14.1
+        run: |
+          set -euo pipefail
+          curl -fL -o firecracker.tgz \
+            "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-x86_64.tgz"
+          tar -xzf firecracker.tgz
+          sudo install -m 0755 "release-${FC_VERSION}-x86_64/firecracker-${FC_VERSION}-x86_64" /usr/bin/firecracker
+          /usr/bin/firecracker --version
+
+      - name: Grant /dev/kvm access for the job
+        if: needs.scope.outputs.nix == 'true'
+        run: |
+          set -euo pipefail
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm missing on this runner — the boot gate cannot run." >&2
+            exit 1
+          fi
+          sudo chmod 666 /dev/kvm
+
+      - name: Boot the tree-built image
+        if: needs.scope.outputs.nix == 'true'
+        # This is a reach-userspace witness, not a latency assertion. The loose
+        # budget and single run keep shared-runner variance out of the result.
+        env:
+          MVM_RUNTIME_BOOT_BENCH: "1"
+          MVM_RUNTIME_BOOT_BACKEND: firecracker
+          MVM_RUNTIME_BOOT_KERNEL: staging/vmlinux
+          MVM_RUNTIME_BOOT_ROOTFS: staging/rootfs.ext4
+          MVM_RUNTIME_BOOT_OVERLAY: overlay-staging/overlay.ext4
+          MVM_RUNTIME_BOOT_OVERLAY_VERITY: overlay-staging/overlay.verity
+          MVM_RUNTIME_BOOT_READY: guest-agent
+          MVM_RUNTIME_BOOT_RUNS: "1"
+          MVM_RUNTIME_BOOT_CONCURRENT: "1"
+          MVM_RUNTIME_BOOT_BUDGET_MS: "60000"
+        run: |
+          set -euo pipefail
+          test -f staging/mvm-meta.json
+          cargo test --test runtime_boot_bench \
+            prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
+
+      - name: Guest console on failure
+        if: ${{ failure() && needs.scope.outputs.nix == 'true' }}
+        run: |
+          for d in "$HOME"/.mvm/vms/*/; do
+            echo "===== $d ====="
+            ls -la "$d" || true
+            if [ -f "$d/console.log" ]; then
+              cat "$d/console.log"
+            fi
+          done
+
+  nix-flake-check:
+    name: Nix flake check (Linux eval)
+    # Nix eval/build is heavy; run it in the merge queue and on manual dispatch,
+    # not on every PR update. The live guest witness remains parallel because
+    # serial reuse made the measured protected path slower.
+    needs: [scope]
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
 
       - name: Install Nix
         if: needs.scope.outputs.nix == 'true'
@@ -1322,12 +1446,7 @@ jobs:
 
       - name: Install Rust toolchain
         if: needs.scope.outputs.nix == 'true'
-        uses: dtolnay/rust-toolchain@1.97.1
-
-      - uses: ./.github/actions/apt-deps
-        if: needs.scope.outputs.nix == 'true'
-        with:
-          packages: lld
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Eval-check every flake
         if: needs.scope.outputs.nix == 'true'
@@ -1434,84 +1553,3 @@ jobs:
             --closure-paths "$image_path/rootfs-closure-paths" \
             --sdk-sidecar "$sidecar_path/sdk.ext4" \
             --json
-
-      - name: Stage the tree-built image for boot
-        if: needs.scope.outputs.nix == 'true'
-        run: |
-          set -euo pipefail
-          image_path=$(head -1 /tmp/default-tenant-path.txt)
-          overlay_path=$(head -1 /tmp/runtime-overlay-path.txt)
-          mkdir -p staging overlay-staging
-          # Resolve the store symlinks so the boot witness owns ordinary files.
-          cp -L "$image_path/vmlinux" staging/vmlinux
-          cp -L "$image_path/rootfs.ext4" staging/rootfs.ext4
-          cp -L "$image_path/mvm-meta.json" staging/mvm-meta.json
-          cp -L "$overlay_path/overlay.ext4" overlay-staging/overlay.ext4
-          cp -L "$overlay_path/overlay.verity" overlay-staging/overlay.verity
-          cp -L "$overlay_path/overlay.roothash" overlay-staging/overlay.roothash
-          echo "MVM_RUNTIME_BOOT_OVERLAY_ROOTHASH=$(tr -d '[:space:]' < overlay-staging/overlay.roothash)" \
-            >> "$GITHUB_ENV"
-
-      - name: Assert the tree-built rootfs has an exec'able /init
-        if: needs.scope.outputs.nix == 'true'
-        run: |
-          set -euo pipefail
-          command -v debugfs >/dev/null 2>&1 \
-            || { sudo apt-get update && sudo apt-get install -y e2fsprogs; }
-          bash nix/packaging/release/assert-init-shebang.sh \
-            staging/rootfs.ext4 "tree-built x86_64"
-          bash nix/packaging/release/assert-kernel-format.sh \
-            staging/vmlinux x86_64 "tree-built x86_64 kernel"
-
-      - name: Install firecracker
-        if: needs.scope.outputs.nix == 'true'
-        env:
-          # Tracks `crates/mvm-core/src/config.rs::FC_VERSION_DEFAULT`.
-          FC_VERSION: v1.14.1
-        run: |
-          set -euo pipefail
-          curl -fL -o firecracker.tgz \
-            "https://github.com/firecracker-microvm/firecracker/releases/download/${FC_VERSION}/firecracker-${FC_VERSION}-x86_64.tgz"
-          tar -xzf firecracker.tgz
-          sudo install -m 0755 "release-${FC_VERSION}-x86_64/firecracker-${FC_VERSION}-x86_64" /usr/bin/firecracker
-          /usr/bin/firecracker --version
-
-      - name: Grant /dev/kvm access for the job
-        if: needs.scope.outputs.nix == 'true'
-        run: |
-          set -euo pipefail
-          if [ ! -e /dev/kvm ]; then
-            echo "::error::/dev/kvm missing on this runner — the boot gate cannot run." >&2
-            exit 1
-          fi
-          sudo chmod 666 /dev/kvm
-
-      - name: Boot the tree-built image
-        if: needs.scope.outputs.nix == 'true'
-        env:
-          MVM_RUNTIME_BOOT_BENCH: "1"
-          MVM_RUNTIME_BOOT_BACKEND: firecracker
-          MVM_RUNTIME_BOOT_KERNEL: staging/vmlinux
-          MVM_RUNTIME_BOOT_ROOTFS: staging/rootfs.ext4
-          MVM_RUNTIME_BOOT_OVERLAY: overlay-staging/overlay.ext4
-          MVM_RUNTIME_BOOT_OVERLAY_VERITY: overlay-staging/overlay.verity
-          MVM_RUNTIME_BOOT_READY: guest-agent
-          MVM_RUNTIME_BOOT_RUNS: "1"
-          MVM_RUNTIME_BOOT_CONCURRENT: "1"
-          MVM_RUNTIME_BOOT_BUDGET_MS: "60000"
-        run: |
-          set -euo pipefail
-          test -f staging/mvm-meta.json
-          cargo test --test runtime_boot_bench \
-            prebuilt_runtime_image_boots_within_budget -- --exact --nocapture
-
-      - name: Guest console on failure
-        if: ${{ failure() && needs.scope.outputs.nix == 'true' }}
-        run: |
-          for d in "$HOME"/.mvm/vms/*/; do
-            echo "===== $d ====="
-            ls -la "$d" || true
-            if [ -f "$d/console.log" ]; then
-              cat "$d/console.log"
-            fi
-          done

--- a/specs/REFACTOR-STATUS.md
+++ b/specs/REFACTOR-STATUS.md
@@ -4,13 +4,15 @@ Last updated: 2026-09-10
 
 ## In progress
 
-- [ ] **CI queue consolidation.**
+- [x] **CI queue consolidation.**
       `specs/plans/2026-09-10-ci-queue-consolidation.md`.
       Correct cumulative `HEADGREEN` scope, make every queue witness honestly
       required or remove its queue fan-out, warm the measured feature-test
       critical path from trusted main, and remove duplicate nextest listings.
-      Implementation and configured CI validation are green; live timing and
-      the post-merge required-context reduction remain.
+      PR #3236 and its exact-head queue run are green; Website no longer runs
+      in the queue, branch protection now requires only `Lint` and `Test`, and
+      measured critical-path evidence keeps Nix and tree-built guest boot
+      parallel while the aggregate owns both verdicts.
 
 - [ ] **Scheduled CI stability.**
       `specs/plans/2026-09-09-scheduled-ci-stability.md`.

--- a/specs/SPRINT.md
+++ b/specs/SPRINT.md
@@ -10,14 +10,16 @@
 
 ## In progress
 
-- [ ] **CI queue consolidation.**
+- [x] **CI queue consolidation.**
       `specs/plans/2026-09-10-ci-queue-consolidation.md`.
       Preserve cumulative merge-group validation while reducing runner fan-out
       and the measured Rust critical path. Work covers merge-group scope,
       required aggregate ownership, trusted feature-cache warming, duplicate
-      nextest listings, and non-required queue jobs. Implementation and all
-      configured CI tests are green; live PR/queue timing and the post-merge
-      required-context reduction remain.
+      nextest listings, and non-required queue jobs. PR #3236 is merged; its
+      exact-head queue run is green, Website no longer runs in the queue, and
+      branch protection requires only the `Lint` and `Test` aggregates. Live
+      timing rejected serial Nix/guest reuse, so the two witnesses remain
+      parallel while both feed `Test`.
 
 - [ ] **Scheduled CI stability — issues #3222, #3223, and #3224.**
       `specs/plans/2026-09-09-scheduled-ci-stability.md`.

--- a/specs/plans/2026-09-10-ci-queue-consolidation.md
+++ b/specs/plans/2026-09-10-ci-queue-consolidation.md
@@ -3,7 +3,7 @@
 Backing: shipped-source
 Validation: check-sprint-append
 
-**Status:** Implementation complete; live queue validation pending
+**Status:** COMPLETE
 
 ## Goal
 
@@ -31,8 +31,8 @@ path scoping or non-required witness jobs weaken exact merge-group validation.
 - [x] Classify a merge-group head against the target branch rather than only
       the preceding queue entry, with a fail-closed fallback.
 - [x] Make the required `Test` aggregate own Nix evaluation, tree-built guest
-      boot, and the published-image boot ceiling; combine overlapping Nix and
-      guest-image work on one runner.
+      boot, and the published-image boot ceiling. Keep Nix and the tree-built
+      guest witness parallel after live timing proved serialization slower.
 - [x] Stop the non-required Website workflow from consuming a runner on every
       merge-group event; retain its pull-request path gate.
 - [x] Warm the `test-support` feature graph from trusted `main` and restore it
@@ -41,10 +41,10 @@ path scoping or non-required witness jobs weaken exact merge-group validation.
       `cargo nextest list`.
 - [x] Run workflow structure tests, actionlint, xtask tests, workspace tests,
       workspace check, formatting, and zero-warning Clippy.
-- [ ] Record the first live pull-request and merge-group timings, then decide
+- [x] Record the first live pull-request and merge-group timings, then decide
       whether combining additional short lanes improves the 20-runner capacity
       boundary without lengthening the critical path.
-- [ ] After the workflow lands, reduce classic branch protection to the stable
+- [x] After the workflow lands, reduce classic branch protection to the stable
       `Lint (fmt + clippy + policy)` and `Test` aggregate contexts.
 
 ## Safety invariants
@@ -70,3 +70,20 @@ path scoping or non-required witness jobs weaken exact merge-group validation.
   harness-concurrency artifacts after the test bodies passed; each failed
   target passed immediately in isolation. The configured nextest groups are
   the authoritative CI execution and completed cleanly.
+- Pull-request run `34470355947` completed in 23m58s. All substantive jobs
+  started immediately after scope classification; `Test` was green after
+  20m11s, while the cold `test-support` lane set the full-run tail at 22m49s.
+- Merge-group run `34472528030` completed in 29m12s and classified the exact
+  queue head against `main`. Website did not run, and `Test` did not publish
+  until Nix, both boot witnesses, both kernels, and the complete test matrix
+  were green.
+- The first folded Nix/guest run made Nix the 28m49s critical path. The prior
+  parallel run completed Nix in 21m48s and the tree-built guest in 22m28s, so
+  the final layout restores those jobs to parallel execution while retaining
+  both as explicit `Test` dependencies. Runner capacity was not the limiter:
+  every queue worker began within five seconds of scope completion.
+- Classic branch protection now requires exactly `Lint (fmt + clippy + policy)`
+  and `Test`, down from six direct contexts.
+- Main cache-warm run `34475187048` populated the dedicated `test-support`
+  cache successfully in 9m43s; the next pull request is the first live restore
+  measurement.

--- a/tests/ci_scope_aggregate.rs
+++ b/tests/ci_scope_aggregate.rs
@@ -75,6 +75,7 @@ struct Verdict {
     kernel: &'static str,
     boot: &'static str,
     nix: &'static str,
+    guest_image: &'static str,
 }
 
 impl Verdict {
@@ -90,6 +91,7 @@ impl Verdict {
             kernel: "success",
             boot: "skipped",
             nix: "skipped",
+            guest_image: "skipped",
         }
     }
 
@@ -106,6 +108,7 @@ impl Verdict {
             kernel: "success",
             boot: "skipped",
             nix: "skipped",
+            guest_image: "skipped",
         }
     }
 
@@ -116,6 +119,7 @@ impl Verdict {
             event_name: "merge_group",
             boot: "success",
             nix: "success",
+            guest_image: "success",
             ..Self::in_scope()
         }
     }
@@ -126,6 +130,7 @@ impl Verdict {
         Self {
             event_name: "merge_group",
             nix: "success",
+            guest_image: "success",
             ..Self::out_of_scope()
         }
     }
@@ -150,6 +155,7 @@ impl Verdict {
             .env("KERNEL_RESULT", self.kernel)
             .env("BOOT_RESULT", self.boot)
             .env("NIX_RESULT", self.nix)
+            .env("GUEST_IMAGE_RESULT", self.guest_image)
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -190,7 +196,7 @@ fn a_fully_in_scope_green_run_is_admitted() {
 /// real failure that has to keep being caught, in whichever scope it can occur.
 #[test]
 fn a_genuine_failure_is_still_refused_in_either_scope() {
-    let cases: [(&str, Verdict); 11] = [
+    let cases: [(&str, Verdict); 13] = [
         (
             // New with the suite moving onto the `code` scope: BDD is matched
             // by the same arithmetic as every other lane, so a run on a
@@ -259,7 +265,7 @@ fn a_genuine_failure_is_still_refused_in_either_scope() {
             },
         ),
         (
-            "a failing Nix and tree-built guest witness",
+            "a failing Nix witness",
             Verdict {
                 nix: "failure",
                 ..Verdict::queue_in_scope()
@@ -269,6 +275,20 @@ fn a_genuine_failure_is_still_refused_in_either_scope() {
             "a Nix witness that skipped in the queue",
             Verdict {
                 nix: "skipped",
+                ..Verdict::queue_in_scope()
+            },
+        ),
+        (
+            "a failing tree-built guest witness",
+            Verdict {
+                guest_image: "failure",
+                ..Verdict::queue_in_scope()
+            },
+        ),
+        (
+            "a tree-built guest witness that skipped in the queue",
+            Verdict {
+                guest_image: "skipped",
                 ..Verdict::queue_in_scope()
             },
         ),

--- a/xtask/src/check_workflow_paths.rs
+++ b/xtask/src/check_workflow_paths.rs
@@ -771,7 +771,7 @@ mod tests {
         assert!(test.contains(
             "needs: [scope, test-workspace, test-workspace-aarch64, test-linux, \
              test-release-witness, test-ebpf-telemetry, bdd-conformance, \
-             boot-latency, kernel, nix-flake-check]"
+             boot-latency, guest-image-boot, kernel, nix-flake-check]"
         ));
 
         // Every lane the aggregate names must also be read back in the loop that
@@ -790,6 +790,7 @@ mod tests {
             "\"$BDD_RESULT\"",
             "\"$KERNEL_RESULT\"",
             "\"$BOOT_RESULT\"",
+            "\"$GUEST_IMAGE_RESULT\"",
             "\"$NIX_RESULT\"",
         ] {
             assert!(
@@ -942,12 +943,13 @@ mod tests {
         let nix = job_block(&ci, "nix-flake-check");
         assert!(nix.contains("needs: [scope]"));
         assert!(nix.contains("needs.scope.outputs.nix == 'true'"));
-        assert!(nix.contains("Boot the tree-built image"));
-        assert!(nix.contains("MVM_RUNTIME_BOOT_READY: guest-agent"));
-        assert!(
-            !ci.contains("\n  guest-image-boot:\n"),
-            "the tree-built guest witness must reuse the required Nix runner"
-        );
+        assert!(!nix.contains("Boot the tree-built image"));
+
+        let guest = job_block(&ci, "guest-image-boot");
+        assert!(guest.contains("needs: [scope]"));
+        assert!(guest.contains("needs.scope.outputs.nix == 'true'"));
+        assert!(guest.contains("Boot the tree-built image"));
+        assert!(guest.contains("MVM_RUNTIME_BOOT_READY: guest-agent"));
 
         let website = workflow("website.yml");
         assert!(


### PR DESCRIPTION
## Summary

- restore the tree-built guest witness as a parallel merge-queue job after live timing showed serial Nix reuse added about seven minutes
- keep Nix, tree-built guest boot, and published-image boot behind the stable required Test aggregate
- record the landed queue timings, trusted-main cache warm, and two-context branch-protection closeout

## Validation

- actionlint .github/workflows/ci.yml
- cargo test --test ci_scope_aggregate (5 passed)
- cargo run -p xtask -- check-workflow-paths
- cargo check --workspace
- cargo clippy --workspace -- -D warnings
- cargo nextest run --workspace --all-targets (13,192 passed; 22 skipped)
- cargo run -p xtask -- check-all (67 gates clean)