### PR TITLE
fix(warm): activate the standby parent before capturing it

### DIFF
--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -47,6 +47,38 @@ const ACTIVATION_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_
 /// `ActivateEnvironmentError` or an unexpected response) is returned
 /// immediately, never retried.
 pub fn activate_workload(vm: &dyn RunningVm, config: &VmStartConfig) -> Result<()> {
+    activate_with(config, &|| {
+        vm.vsock_connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
+            .context("connect to guest agent for activation")
+    })
+}
+
+/// Activate a guest addressed by VM name rather than by a live `RunningVm`.
+///
+/// The standby factory parent is spawned through the driver's standby path,
+/// which hands back a `StandbyHandle` and no `RunningVm` — but activation only
+/// ever needed a vsock connection to the agent, and `vsock_transport::for_vm`
+/// resolves one from the name exactly as the post-restore signal does.
+///
+/// Shares [`activate_workload`]'s retry loop rather than restating it: the
+/// distinction between "the agent is not listening yet" and "the agent rejected
+/// this" is the whole substance of that loop, and a second copy would be free to
+/// drift from it.
+pub fn activate_workload_by_name(vm_name: &str, config: &VmStartConfig) -> Result<()> {
+    activate_with(config, &|| {
+        mvm_vmm::vsock_transport::for_vm(vm_name)
+            .with_context(|| format!("resolving vsock transport for {vm_name}"))?
+            .connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
+            .with_context(|| format!("connect to guest agent on {vm_name} for activation"))
+    })
+}
+
+/// The shared body: build the environment, then retry connect+handshake until
+/// the agent answers or the deadline passes.
+fn activate_with<S>(config: &VmStartConfig, connect: &dyn Fn() -> Result<S>) -> Result<()>
+where
+    S: std::io::Read + std::io::Write + Send,
+{
     let env = build_activation_environment(config)?;
     let started = std::time::Instant::now();
     let deadline = started + ACTIVATION_READY_TIMEOUT;
@@ -54,7 +86,7 @@ pub fn activate_workload(vm: &dyn RunningVm, config: &VmStartConfig) -> Result<(
     loop {
         attempt = attempt.saturating_add(1);
         let attempt_started = std::time::Instant::now();
-        match activate_once(vm, &env) {
+        match activate_once(connect, &env) {
             Ok(()) => {
                 // Attempt count and the split between waiting and working are
                 // what distinguish "the guest was slow" from "the schedule
@@ -80,10 +112,11 @@ pub fn activate_workload(vm: &dyn RunningVm, config: &VmStartConfig) -> Result<(
 }
 
 /// One connect + handshake + `ActivateEnvironment` round-trip.
-fn activate_once(vm: &dyn RunningVm, env: &ActivateEnvironment) -> Result<()> {
-    let mut stream = vm
-        .vsock_connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
-        .context("connect to guest agent for activation")?;
+fn activate_once<S>(connect: &dyn Fn() -> Result<S>, env: &ActivateEnvironment) -> Result<()>
+where
+    S: std::io::Read + std::io::Write + Send,
+{
+    let mut stream = connect()?;
     activate_over_stream(&mut stream, env)
 }
 

--- a/crates/mvm-runtime/src/microvm/activation.rs
+++ b/crates/mvm-runtime/src/microvm/activation.rs
@@ -47,38 +47,6 @@ const ACTIVATION_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_
 /// `ActivateEnvironmentError` or an unexpected response) is returned
 /// immediately, never retried.
 pub fn activate_workload(vm: &dyn RunningVm, config: &VmStartConfig) -> Result<()> {
-    activate_with(config, &|| {
-        vm.vsock_connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
-            .context("connect to guest agent for activation")
-    })
-}
-
-/// Activate a guest addressed by VM name rather than by a live `RunningVm`.
-///
-/// The standby factory parent is spawned through the driver's standby path,
-/// which hands back a `StandbyHandle` and no `RunningVm` — but activation only
-/// ever needed a vsock connection to the agent, and `vsock_transport::for_vm`
-/// resolves one from the name exactly as the post-restore signal does.
-///
-/// Shares [`activate_workload`]'s retry loop rather than restating it: the
-/// distinction between "the agent is not listening yet" and "the agent rejected
-/// this" is the whole substance of that loop, and a second copy would be free to
-/// drift from it.
-pub fn activate_workload_by_name(vm_name: &str, config: &VmStartConfig) -> Result<()> {
-    activate_with(config, &|| {
-        mvm_vmm::vsock_transport::for_vm(vm_name)
-            .with_context(|| format!("resolving vsock transport for {vm_name}"))?
-            .connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
-            .with_context(|| format!("connect to guest agent on {vm_name} for activation"))
-    })
-}
-
-/// The shared body: build the environment, then retry connect+handshake until
-/// the agent answers or the deadline passes.
-fn activate_with<S>(config: &VmStartConfig, connect: &dyn Fn() -> Result<S>) -> Result<()>
-where
-    S: std::io::Read + std::io::Write + Send,
-{
     let env = build_activation_environment(config)?;
     let started = std::time::Instant::now();
     let deadline = started + ACTIVATION_READY_TIMEOUT;
@@ -86,7 +54,7 @@ where
     loop {
         attempt = attempt.saturating_add(1);
         let attempt_started = std::time::Instant::now();
-        match activate_once(connect, &env) {
+        match activate_once(vm, &env) {
             Ok(()) => {
                 // Attempt count and the split between waiting and working are
                 // what distinguish "the guest was slow" from "the schedule
@@ -112,11 +80,10 @@ where
 }
 
 /// One connect + handshake + `ActivateEnvironment` round-trip.
-fn activate_once<S>(connect: &dyn Fn() -> Result<S>, env: &ActivateEnvironment) -> Result<()>
-where
-    S: std::io::Read + std::io::Write + Send,
-{
-    let mut stream = connect()?;
+fn activate_once(vm: &dyn RunningVm, env: &ActivateEnvironment) -> Result<()> {
+    let mut stream = vm
+        .vsock_connect(mvm_agentd::vsock::GUEST_AGENT_PORT)
+        .context("connect to guest agent for activation")?;
     activate_over_stream(&mut stream, env)
 }
 

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -855,53 +855,24 @@ impl<D: VmmDriver, S: NetworkEndpointSpawner, B: BrokerRegistrar> WorkloadRunner
             .driver
             .spawn_standby_parent(&StandbyParentSpawn { spec, boot: &boot })?;
 
-        // Activate before capturing, exactly as `start_workload` does after its
-        // own boot.
-        //
-        // A guest booted under the universal initramfs runs its agent as PID 1
-        // in `Awaiting`, where the activation gate accepts `ActivateEnvironment`
-        // and refuses every other verb with `NotActivated`. That agent *serves*
-        // — it answers the readiness probe — so a capture that waits only for
-        // reachability captures a parent that is reachable and unactivated, and
-        // every child forked from it inherits that state. The claim's
-        // `PostRestore` is then refused, the standby is marked dead, and the run
-        // silently cold-boots (#3039).
-        //
-        // Activating the parent is safe to share across its children:
-        // `build_activation_environment` describes block devices and verity —
-        // `data_dev`, `hash_dev`, `roothash` — not identity or secrets, and a
-        // parent and its children share a rootfs by construction. It carries no
-        // plan and no grant either way; `factory_parent_config` drops those on
-        // purpose, and that is unchanged here.
+        // The universal initramfs waits in a fail-closed pre-activation state.
+        // Capturing it there would make every restored child refuse PostRestore
+        // and fall back to a cold boot. The parent shares only its rootfs device
+        // and verity environment; factory_parent_config has already removed all
+        // workload identity, secrets, plan, and grant authority.
         if crate::microvm::booted_with_universal_initramfs(&parent_config) {
-            // A driver with no host-side vsock transport runs hypervisor-free:
-            // no guest is listening, so there is nothing to activate. Resolving
-            // the transport first separates that from a real activation
-            // failure, which stays fatal — capturing an unactivated parent is
-            // the whole defect.
-            //
-            // A real driver whose transport is genuinely missing is not hidden
-            // by this. The claim's own post-restore call resolves the same
-            // transport and fails there instead.
-            match mvm_vmm::vsock_transport::for_vm(&spec.id) {
-                Ok(_) => {
-                    crate::microvm::activate_workload_by_name(&spec.id, &parent_config).map_err(
-                        |e| {
-                            StandbyError::SpawnFailed(format!(
-                                "activate standby parent '{}' before capture: {e:#}",
-                                spec.id
-                            ))
-                        },
-                    )?;
-                }
-                Err(e) => {
-                    tracing::debug!(
-                        standby = %spec.id,
-                        error = %e,
-                        "no host-side vsock transport; skipping parent activation"
-                    );
-                }
-            }
+            let parent = self.driver.attach(&VmId(spec.id.clone())).map_err(|e| {
+                StandbyError::SpawnFailed(format!(
+                    "attach standby parent '{}' for activation: {e:#}",
+                    spec.id
+                ))
+            })?;
+            crate::microvm::activate_workload(parent.as_ref(), &parent_config).map_err(|e| {
+                StandbyError::SpawnFailed(format!(
+                    "activate standby parent '{}' before capture: {e:#}",
+                    spec.id
+                ))
+            })?;
         }
 
         let control = self.driver.vm_full_control(&spec.id).ok_or_else(|| {
@@ -3210,6 +3181,7 @@ mod tests {
         let store = CheckpointStore::at(home.path().join("checkpoints"));
         let driver = MockDriver::default().with_vm_full_rootfs(Path::new(&rootfs));
         let guest = spawn_activation_guest(driver.clone(), "shape-parity");
+        let parent_guest = spawn_activation_guest(driver.clone(), "standby-parity");
         let runner = WorkloadRunner::new(
             driver,
             RecordingSpawner::new("/run/ep.sock"),
@@ -3232,6 +3204,7 @@ mod tests {
                 &spec,
             )
             .expect("warm parent spawns for that launch");
+        parent_guest.join().expect("parent guest thread");
 
         let booted = runner.driver.booted_specs();
         assert_eq!(booted.len(), 2, "one workload boot, then one parent boot");

--- a/crates/mvm-runtime/src/workload_runner/runner.rs
+++ b/crates/mvm-runtime/src/workload_runner/runner.rs
@@ -855,6 +855,55 @@ impl<D: VmmDriver, S: NetworkEndpointSpawner, B: BrokerRegistrar> WorkloadRunner
             .driver
             .spawn_standby_parent(&StandbyParentSpawn { spec, boot: &boot })?;
 
+        // Activate before capturing, exactly as `start_workload` does after its
+        // own boot.
+        //
+        // A guest booted under the universal initramfs runs its agent as PID 1
+        // in `Awaiting`, where the activation gate accepts `ActivateEnvironment`
+        // and refuses every other verb with `NotActivated`. That agent *serves*
+        // — it answers the readiness probe — so a capture that waits only for
+        // reachability captures a parent that is reachable and unactivated, and
+        // every child forked from it inherits that state. The claim's
+        // `PostRestore` is then refused, the standby is marked dead, and the run
+        // silently cold-boots (#3039).
+        //
+        // Activating the parent is safe to share across its children:
+        // `build_activation_environment` describes block devices and verity —
+        // `data_dev`, `hash_dev`, `roothash` — not identity or secrets, and a
+        // parent and its children share a rootfs by construction. It carries no
+        // plan and no grant either way; `factory_parent_config` drops those on
+        // purpose, and that is unchanged here.
+        if crate::microvm::booted_with_universal_initramfs(&parent_config) {
+            // A driver with no host-side vsock transport runs hypervisor-free:
+            // no guest is listening, so there is nothing to activate. Resolving
+            // the transport first separates that from a real activation
+            // failure, which stays fatal — capturing an unactivated parent is
+            // the whole defect.
+            //
+            // A real driver whose transport is genuinely missing is not hidden
+            // by this. The claim's own post-restore call resolves the same
+            // transport and fails there instead.
+            match mvm_vmm::vsock_transport::for_vm(&spec.id) {
+                Ok(_) => {
+                    crate::microvm::activate_workload_by_name(&spec.id, &parent_config).map_err(
+                        |e| {
+                            StandbyError::SpawnFailed(format!(
+                                "activate standby parent '{}' before capture: {e:#}",
+                                spec.id
+                            ))
+                        },
+                    )?;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        standby = %spec.id,
+                        error = %e,
+                        "no host-side vsock transport; skipping parent activation"
+                    );
+                }
+            }
+        }
+
         let control = self.driver.vm_full_control(&spec.id).ok_or_else(|| {
             StandbyError::SpawnFailed(format!(
                 "backend cannot capture a warm parent's memory for standby '{}'",


### PR DESCRIPTION
Advances #3039. Fixes the first of two failures; the issue stays open for the second.

## The defect

A guest booted under the universal initramfs runs its agent as PID 1 in `Awaiting`, where the activation gate accepts `ActivateEnvironment` and refuses every other verb with `NotActivated` (`mvm-guest-agent.rs:246`).

`start_workload` sends that verb after its own boot (`runner.rs:416`). **The factory-parent path never did.** So a parent was captured unactivated, every child forked from it inherited that state, the claim's `PostRestore` was refused, the standby was marked dead, and the run silently cold-booted.

## The invariant that looked sufficient

The issue notes `wait_for_guest_agent`'s invariant — *"a parent captured before the agent listener is serving would make every later post-restore identity handshake impossible"* — and concludes it holds. It does hold. It just is not enough:

**Serving and activated are different states, and only the first is observable from outside.** An unactivated agent serves — it answers the readiness probe and refuses everything else.

## Confirmed on the guest, not argued

A parent captured after this change shows on its console:

```
device-mapper: verity: sha256 using shash "sha256-ce"
EXT4-fs (dm-0): mounted filesystem ... ro without journal
```

That is what `ActivateEnvironment` does, and it did not happen before. The child then clears the gate — the failure **moves** from `NotActivated` to a later one in the child's session handshake (`Broken pipe`). That second failure was unreachable behind the first, so this reveals rather than causes it, and #3039 stays open for it.

## Safe to share across children

Checked rather than assumed: `build_activation_environment` describes **block devices and verity** — `data_dev`, `hash_dev`, `roothash` — not identity or secrets. A parent and its children share a rootfs by construction, so that is precisely what a child should inherit. The parent still carries no plan and no grant; `factory_parent_config` drops those deliberately and this does not touch it.

## Implementation notes

After `spawn_standby_parent`, the runner reopens the live parent through the existing `VmmDriver::attach` seam and calls the same `activate_workload` path used by a normal workload boot. Each driver therefore retains ownership of its guest transport, and the mock driver exercises the same contract without a filesystem-specific bypass.

The runner parity test now serves both activation handshakes and proves the workload and parent still boot the same sealed device shape. Activation failure remains fatal so an unactivated parent is never captured.

## Validation

- Failed test passes in the default and `test-support` configurations.
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo run -p xtask -- check-all` — 67 gates clean

The full local workspace test run passed the repaired runtime path, then hit one unrelated host-dependent CLI test whose fixed 1,500-millicore request does not exceed this machine's CPU ceiling. That test passed in the original #3238 CI run.

## Risk

Low. The warm claim currently fails **100% of the time**, so this cannot regress a working path.
