### PR TITLE
perf(cli): stop backends that boot no kernel resolving an initramfs

### DIFF
--- a/crates/mvm-cli/src/commands/vm/checkpoint.rs
+++ b/crates/mvm-cli/src/commands/vm/checkpoint.rs
@@ -1061,7 +1061,7 @@ fn boot_forked_child(p: BootForkedChildParams<'_>) -> Result<()> {
         &effective_hypervisor,
         parent_meta.runtime_overlay_version.as_deref(),
     )?;
-    super::up::attach_universal_initramfs_if_cached(&mut start_config)?;
+    super::up::attach_universal_initramfs_if_cached(&mut start_config, &effective_hypervisor)?;
 
     populate_fork_rootfs_verity(&mut start_config, p.instance_rootfs)?;
 

--- a/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
+++ b/crates/mvm-cli/src/commands/vm/up/oci_persist.rs
@@ -283,7 +283,7 @@ pub(in crate::commands) fn start_persistent_oci_machine(
     // authoritative RPC gates as well.
     start_config.dev_console = preopen_console_for_profile(profile);
     attach_runtime_overlay_if_cached(&mut start_config, backend_name)?;
-    attach_universal_initramfs_if_cached(&mut start_config)?;
+    attach_universal_initramfs_if_cached(&mut start_config, backend_name)?;
     emit_runtime_source_status(&start_config);
     if let Some(ctx) = admission.as_ref() {
         thread_tenant_id(&mut start_config, &ctx.admitted);

--- a/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
+++ b/crates/mvm-cli/src/commands/vm/up/runtime_source.rs
@@ -284,10 +284,47 @@ pub(crate) fn universal_initramfs_available() -> bool {
     mvm_build::initramfs::resolve_or_seed_from_default_cache(&cache_root, version, arch).is_ok()
 }
 
+/// Backends that boot a kernel, and so have something to mount an initramfs
+/// with.
+///
+/// The same allow-list shape `attach_runtime_overlay_if_cached_version` uses to
+/// gate its own build arm, and for the same reason: resolving falls through to
+/// a `cargo zigbuild` of the guest agent on a cold cache. The overlay has been
+/// gated since it was written; this leg was not, so every launch resolution
+/// under a backend that never starts a guest cross-compiled one anyway. Four
+/// mock-backed audit tests spent eight minutes each doing exactly that, because
+/// a test sandbox isolates `MVM_HOME` *and* `HOME` — which makes its cache cold
+/// and the seed-from-default-cache fallback empty, every time.
+///
+/// Spelled out rather than derived from a `BackendDescriptor` field, because
+/// neither existing field means this. `bundled_kernel` is "brings its own
+/// kernel, so there is no on-disk path to hash" and is true for libkrun alone.
+/// `tier` is an isolation statement — Tier 3 happens to hold exactly the three
+/// backends excluded here, but it holds them because they are test-only or
+/// browser-tier, not because they boot no kernel, and a Tier 3 backend that did
+/// boot one would quietly lose its initramfs.
+///
+/// An allow-list rather than a deny-list of the three, because the two fail in
+/// opposite directions. A new *booting* backend missing from this list boots
+/// without an initramfs and cannot mount its runtime overlay, which the launch
+/// path already fails closed on — loudly. A new *non-booting* backend missing
+/// from a deny-list would silently cross-compile a guest agent it never runs,
+/// which is this bug again, undetected.
+const KERNEL_BOOTING_HYPERVISORS: [&str; 5] =
+    ["firecracker", "hvf", "qemu", "libkrun", "apple-container"];
+
 #[tracing::instrument(skip_all)]
 pub(crate) fn attach_universal_initramfs_if_cached(
     start_config: &mut mvm_core::vm_backend::VmStartConfig,
+    hypervisor: &str,
 ) -> Result<()> {
+    // `wasm` runs a WASI module directly and `mock` records calls without
+    // starting a guest. Neither can mount an initramfs, so attaching one is
+    // meaningless and resolving one is pure cost.
+    if !KERNEL_BOOTING_HYPERVISORS.contains(&hypervisor) {
+        tracing::debug!(hypervisor, "backend boots no kernel; skipping initramfs");
+        return Ok(());
+    }
     attach_universal_initramfs_with_resolver(start_config, |env, cache_root, version, arch| {
         mvm_build::initramfs::resolve_or_build_local_initramfs(env, cache_root, version, arch)
     })
@@ -1698,7 +1735,7 @@ mod universal_initramfs_attach_tests {
             kernel_path: Some("/dummy/vmlinux".to_string()),
             ..Default::default()
         };
-        attach_universal_initramfs_if_cached(&mut sc).unwrap();
+        attach_universal_initramfs_if_cached(&mut sc, "firecracker").unwrap();
 
         assert!(
             sc.initrd_path.is_some(),
@@ -1711,6 +1748,54 @@ mod universal_initramfs_attach_tests {
                 .contains("initramfs.cpio.gz"),
             "attached path should point at the cpio.gz image"
         );
+    }
+
+    /// A backend that never boots a kernel must not reach the resolver at all.
+    ///
+    /// Asserting only that `initrd_path` stays `None` would pass for the
+    /// expensive reason too — a cold cache leaves it unset after doing the work.
+    /// The cost is the resolve, so the resolver itself is what has to stay
+    /// untouched. `seed_warm_universal_initramfs` makes the difference
+    /// observable: a resolver that ran would find the warm artifact and attach
+    /// it.
+    #[test]
+    fn a_backend_that_boots_no_kernel_never_resolves_an_initramfs() {
+        for hypervisor in ["mock", "wasm"] {
+            let mut env = TestEnv::new();
+            let dir = tempfile::tempdir().unwrap();
+            env.isolate_mvm_home(dir.path());
+            seed_warm_universal_initramfs(dir.path());
+
+            let mut sc = VmStartConfig {
+                kernel_path: Some("/dummy/vmlinux".to_string()),
+                ..Default::default()
+            };
+            attach_universal_initramfs_if_cached(&mut sc, hypervisor).unwrap();
+
+            assert!(
+                sc.initrd_path.is_none(),
+                "{hypervisor} boots no kernel, so nothing should have resolved \
+                 an initramfs — a warm cache was available and was still not read"
+            );
+        }
+    }
+
+    /// Every name the allow-list admits has to be a backend that exists, or the
+    /// gate silently stops covering one. The reverse — a booting backend
+    /// missing from the list — surfaces as a guest that cannot mount its
+    /// runtime overlay, which the launch path already fails closed on.
+    #[test]
+    fn the_kernel_booting_allow_list_names_only_real_backends() {
+        let known: Vec<String> = mvm_runtime::catalog::descriptors()
+            .iter()
+            .map(|d| d.instantiate_dyn().name().to_string())
+            .collect();
+        for name in KERNEL_BOOTING_HYPERVISORS {
+            assert!(
+                known.iter().any(|k| k == name),
+                "{name} is in the kernel-booting allow-list but is not a backend; known: {known:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mvm-cli/src/exec.rs
+++ b/crates/mvm-cli/src/exec.rs
@@ -1439,7 +1439,10 @@ pub fn resolve_launch(
 
     let t_initramfs = std::time::Instant::now();
     sub.start(SubPhase::AttachInitramfs);
-    crate::commands::vm::up::attach_universal_initramfs_if_cached(&mut start_config)?;
+    crate::commands::vm::up::attach_universal_initramfs_if_cached(
+        &mut start_config,
+        backend.name(),
+    )?;
     sub.finish(SubPhase::AttachInitramfs);
     tracing::debug!(
         ms = t_initramfs.elapsed().as_secs_f64() * 1000.0,

--- a/crates/mvm-cli/src/exec/session.rs
+++ b/crates/mvm-cli/src/exec/session.rs
@@ -172,7 +172,10 @@ pub fn boot_session_vm(
     }
 
     crate::commands::vm::up::attach_runtime_overlay_if_cached(&mut start_config, backend.name())?;
-    crate::commands::vm::up::attach_universal_initramfs_if_cached(&mut start_config)?;
+    crate::commands::vm::up::attach_universal_initramfs_if_cached(
+        &mut start_config,
+        backend.name(),
+    )?;
 
     let use_snapshot = !admitted_workload
         && snap_info.is_some()


### PR DESCRIPTION
`attach_universal_initramfs_if_cached` resolved an initramfs for every launch,
whatever backend it was for. Resolving falls through to
`build_initramfs_with_cargo` on a cold cache — so a `mock` VM, which never
starts a guest, **cross-compiled a static guest agent to musl with `cargo
zigbuild`** before recording a call it was going to record anyway.

The runtime-overlay attach sitting immediately above it in `resolve_launch` has
always gated its build arm on an allow-list of real booting hypervisors. This
leg never got the same gate. That's the whole bug.

## Why it stayed invisible

Test sandboxes isolate `MVM_HOME` **and** `HOME` — the second deliberately, so
no test touches the OS keystore. But `seed_from_default_cache` reads
`$HOME/.mvm/cache`, so an isolated sandbox has a cold cache *and* an empty
fallback to seed from, every single time. Every developer's real cache is warm,
so nobody saw it locally; every CI runner is cold, so CI paid it on every test.

And nextest gives each test its own process, so the four worst offenders queued
on cargo's machine-global package lock — each waiting out the others' builds.

## Measured

| | before | after |
|---|---|---|
| `pause_emits_workload_sleep_audit_entry` (local, this branch) | **78.5s** | **1.9s** |
| `audit_emissions_live`, all 63 tests | 630s *(CI)* | **11.4s** |
| `pool_warm_and_the_run_path_resolve_the_same_compat_key` | 294.6s *(CI)* | 0.014s |
| `exec::tests::resolve_launch_yields_a_bootable_config…` | 278.3s *(CI)* | 0.014s |

The whole `--features test-support` lib set — **4316 tests — runs in 34.6s**
locally. In CI that lane's two nextest invocations were 357s + 630s.

This also lands on every contributor's `just test`, on a cold cache.

## Design notes

**Spelled out rather than derived from a `BackendDescriptor` field.** Neither
existing field means this: `bundled_kernel` is "brings its own kernel, so
there's no on-disk path to hash" (libkrun alone), and `tier` is an *isolation*
statement — Tier 3 happens to hold exactly the three backends excluded here, but
because they're test-only or browser-tier, not because they boot no kernel. A
Tier 3 backend that did boot one would quietly lose its initramfs.

**An allow-list, not a deny-list of the three**, because they fail in opposite
directions. A new *booting* backend missing from the allow-list boots without an
initramfs and can't mount its runtime overlay — which the launch path already
fails closed on, loudly. A new *non-booting* backend missing from a deny-list
would silently cross-compile a guest agent it never runs: this bug again,
undetected.

## Tests

Two, both chosen so they can't pass for the wrong reason:

- `a_backend_that_boots_no_kernel_never_resolves_an_initramfs` seeds a **warm**
  cache first. Asserting only that `initrd_path` stayed `None` would also pass
  for the expensive reason — a cold cache leaves it unset after doing all the
  work. The cost *is* the resolve, so the resolver is what must stay untouched;
  a resolver that ran would find the warm artifact and attach it.
- `the_kernel_booting_allow_list_names_only_real_backends` reads
  `catalog::descriptors()`, so the gate can't quietly stop covering a backend
  that was renamed.

## Verification

- `cargo nextest run --features test-support --lib -p mvm-backends -p mvm-runtime -p mvm-client -p mvm-cli -p mvm-vmm -p mvm-fs` → **4316 passed** in 34.6s
- `cargo nextest run -p mvmctl --features test-support --test audit_emissions_live` → 63 passed in 11.4s
- `cargo run -p xtask -- check-all` → 67 gate(s) clean
- `cargo clippy -p mvm-cli --features test-support --all-targets -- -D warnings` clean
- `cargo fmt --all` clean
