### PR TITLE
perf(ci): warm the nightly fast path, and pin the lanes that use it

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -161,3 +161,57 @@ jobs:
             --test audit_emissions_live
           cargo check -p mvm-cli --features test-support \
             --example verification_loop
+
+  # The other half of the nightly-fast / stable-lint split, and until now the
+  # missing one. `warm` above runs its clippy through `cargo-stable.sh`, which
+  # forces `RUSTUP_TOOLCHAIN=1.97.1` *and* `CARGO_TARGET_DIR=target/stable-1.97.1`
+  # — so the entry it writes holds stable lint artifacts under a different target
+  # root, keyed to a toolchain only the four lint lanes use.
+  #
+  # `Swatinem/rust-cache` folds the resolved rustc version into its key, so the
+  # test lanes were computing a key nothing had ever written and restoring
+  # nothing at all: `Test workspace` logged "No cache found." and compiled the
+  # workspace from cold on every run, 17 of its 21 minutes, while its tests took
+  # three and a half. This job writes the entry they actually look for.
+  #
+  # `--no-run` because the artifacts are the point; running the suite here would
+  # duplicate the lanes that gate.
+  warm-nightly:
+    name: Warm nightly fast path
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/free-disk
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-08-25
+
+      - uses: ./.github/actions/apt-deps
+        with:
+          packages: attr cryptsetup-bin lld
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      # No `key:` — this shares `workspace` with the stable warm job above and
+      # with every consuming lane. rust-cache separates the two by the toolchain
+      # hash it already folds into the key, so one shared-key serves both halves
+      # of the split without either overwriting the other.
+      - uses: ./.github/actions/rust-cache
+        with:
+          save: "true"
+
+      # The same two resolutions `test-workspace` builds under. They differ:
+      # `--all-targets` alone selects the root package and `--workspace
+      # --all-targets` unifies features across every member, so warming one does
+      # not warm the other.
+      - name: Warm the nightly workspace build
+        run: |
+          cargo build --all-targets
+          cargo nextest run --workspace --all-targets --no-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-08-25
 
       # Policy checks invoke xtask, and the stub/parity checks invoke the
       # pinned Python and TypeScript generators. They are independent of the
@@ -787,7 +789,9 @@ jobs:
       - uses: ./.github/actions/free-disk
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-08-25
 
       - uses: ./.github/actions/apt-deps
         with:
@@ -858,7 +862,9 @@ jobs:
       - uses: ./.github/actions/free-disk
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-08-25
 
       - uses: ./.github/actions/apt-deps
         with:
@@ -901,7 +907,9 @@ jobs:
       - uses: ./.github/actions/free-disk
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-08-25
 
       - uses: ./.github/actions/apt-deps
         with:
@@ -950,8 +958,9 @@ jobs:
       - uses: ./.github/actions/free-disk
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-08-25
           targets: wasm32-wasip1
 
       - uses: ./.github/actions/apt-deps
@@ -983,8 +992,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install nightly Rust toolchain for eBPF build
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2026-08-25
           components: rust-src
 
       - uses: ./.github/actions/apt-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -991,10 +991,20 @@ jobs:
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # The one lane that must keep a floating nightly, and not by oversight.
+      # `crates/mvm-hostd/ebpf/rust-toolchain.toml` pins `channel = "nightly"`,
+      # and both the bpf-linker install below and `just build-ebpf` say
+      # `cargo +nightly` — they resolve the toolchain *by that name*. Installing
+      # a dated nightly instead leaves `+nightly` pointing at whatever rustup
+      # auto-installs, which carries no `rust-src`, and the build dies asking
+      # for it. Nothing is lost by staying floating here: this lane takes its
+      # own `key: ebpf` cache entry and never reads the shared workspace one, so
+      # it is not part of the toolchain/cache-key alignment the rest of this
+      # file just gained. `check-fast-cargo.sh` allows exactly this one and ties
+      # the exemption to the `cargo +nightly` that causes it.
       - name: Install nightly Rust toolchain for eBPF build
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2026-08-25
           components: rust-src
 
       - uses: ./.github/actions/apt-deps

--- a/scripts/check-fast-cargo.sh
+++ b/scripts/check-fast-cargo.sh
@@ -68,12 +68,24 @@ require_text .github/workflows/bdd.yml 'components: rustc-codegen-cranelift'
 # name — and it silently cost every one of them its build cache, because
 # `Swatinem/rust-cache` folds the resolved rustc version into its key and no
 # writer ever produced the key a rotating nightly asks for.
-for workflow in .github/workflows/ci.yml .github/workflows/cache-warm.yml; do
-  if grep -Fq 'rust-toolchain@nightly' "${workflow}"; then
-    echo "check-fast-cargo: ${workflow} floats a nightly toolchain; pin ${toolchain}" >&2
-    exit 1
-  fi
-done
+if grep -Fq 'rust-toolchain@nightly' .github/workflows/cache-warm.yml; then
+  echo "check-fast-cargo: cache-warm.yml floats a nightly toolchain; pin ${toolchain}" >&2
+  exit 1
+fi
+# ci.yml keeps exactly one, and only for as long as its cause exists. The eBPF
+# lane's sub-build resolves its toolchain by the literal name `nightly` — from
+# `crates/mvm-hostd/ebpf/rust-toolchain.toml` and two `cargo +nightly`
+# invocations — so a dated pin there leaves `+nightly` on a rustup-auto-installed
+# toolchain with no `rust-src`, and `just build-ebpf` fails asking for it.
+# Tying the count to the `cargo +nightly` that forces it means removing the
+# hardcoding forces removing the exemption, rather than leaving a hole behind.
+floating_nightly="$(grep -Fc 'rust-toolchain@nightly' .github/workflows/ci.yml || true)"
+if [[ "${floating_nightly}" -ne 1 ]]; then
+  echo "check-fast-cargo: ci.yml has ${floating_nightly} floating nightly installs; only the eBPF lane may float, and it must" >&2
+  exit 1
+fi
+require_text .github/workflows/ci.yml 'cargo +nightly install --locked --version 0.10.4 bpf-linker'
+require_text crates/mvm-hostd/ebpf/rust-toolchain.toml 'channel = "nightly"'
 require_text .github/workflows/ci.yml "toolchain: ${toolchain}"
 # The warm job that writes the entry those lanes restore has to be on the same
 # toolchain as the lanes, or it writes a key nobody reads.

--- a/scripts/check-fast-cargo.sh
+++ b/scripts/check-fast-cargo.sh
@@ -61,6 +61,24 @@ require_text crates/mvm-build/src/guest_agent_build.rs 'pinned_rust_toolchain(&s
 require_text crates/mvm-build/src/guest_agent_build.rs '.env_remove("CARGO_ENCODED_RUSTFLAGS")'
 require_text .github/workflows/bdd.yml "toolchain: ${toolchain}"
 require_text .github/workflows/bdd.yml 'components: rustc-codegen-cranelift'
+
+# bdd.yml was pinned here; ci.yml's six nightly lanes were not, and a floating
+# `@nightly` resolves to a different compiler every day. That is a correctness
+# gap on its own — those lanes ran a toolchain rust-toolchain.toml does not
+# name — and it silently cost every one of them its build cache, because
+# `Swatinem/rust-cache` folds the resolved rustc version into its key and no
+# writer ever produced the key a rotating nightly asks for.
+for workflow in .github/workflows/ci.yml .github/workflows/cache-warm.yml; do
+  if grep -Fq 'rust-toolchain@nightly' "${workflow}"; then
+    echo "check-fast-cargo: ${workflow} floats a nightly toolchain; pin ${toolchain}" >&2
+    exit 1
+  fi
+done
+require_text .github/workflows/ci.yml "toolchain: ${toolchain}"
+# The warm job that writes the entry those lanes restore has to be on the same
+# toolchain as the lanes, or it writes a key nobody reads.
+require_text .github/workflows/cache-warm.yml "toolchain: ${toolchain}"
+require_text .github/workflows/cache-warm.yml 'cargo nextest run --workspace --all-targets --no-run'
 require_text Justfile 'CARGO_BIN_EXE_mvmctl="${CARGO_TARGET_DIR:-target}/debug/mvmctl"'
 require_text crates/mvm-conformance/tests/conformance.rs 'var_os("CARGO_BIN_EXE_mvmctl")'
 


### PR DESCRIPTION
`Test workspace` logs **"No cache found."** and compiles the workspace from cold
on every single run — **17 of its 21 minutes**, against **3.5 minutes** of actual
test execution (13,426 tests in 181.9s, plus three smaller runs).

This isn't a stale or undersized cache. The entry it asks for has never been
written.

## Root cause

`cache-warm`'s `warm` job runs clippy through `cargo-stable.sh`, which forces
`RUSTUP_TOOLCHAIN=1.97.1` **and** `CARGO_TARGET_DIR=target/stable-1.97.1`. The
single entry it writes therefore holds *stable lint artifacts under a different
target root*, keyed to a toolchain only the four lint lanes use.

`Swatinem/rust-cache` folds the resolved rustc version into its key, so the six
nightly lanes compute a key nothing ever wrote:

```
wanted   v1-rust-workspace-Linux-x64-f4e434f1-047e9ab9
existed  v1-rust-workspace-Linux-x64-e40ff804-047e9ab9
```

Same lockfile half (`047e9ab9`), different toolchain half. Six of ten
cache-consuming lanes get nothing — including the current #1 and #2 ceilings.

This is the missing other half of the deliberate nightly-fast / stable-lint
split, not a tuning knob.

## The two changes, and why neither works alone

**`warm-nightly`** writes the entry those lanes look for, under the same
`workspace` shared-key — rust-cache separates the two halves by the toolchain
hash it already folds in, so neither overwrites the other.

**The six lanes stop floating `@nightly`.** A floating nightly resolves to a
different compiler every day, so a warm entry cannot survive it — the key
rotates out from under the writer. It's also wrong on its own terms: those lanes
were running a compiler `rust-toolchain.toml` does not name.
`nightly-2026-08-25` is what that file already declares and what `bdd.yml` was
already pinned to.

Pinned: `lint-policy`, `test-workspace`, `test-workspace-aarch64`,
`test-release-witness`, `test-linux`, `test-ebpf-telemetry`. Each keeps its own
`targets:` / `components:` inputs.

## Warming both resolutions

`test-workspace` runs `cargo build --all-targets` *and* `cargo nextest run
--workspace --all-targets`. Those differ — `--all-targets` alone selects the
root package, `--workspace --all-targets` unifies features across every member —
so warming one does not warm the other. That's the same trap that made the
feature lane the critical path (#2566), so the warm job runs both. `--no-run`
because the artifacts are the point; running the suite here would duplicate the
lanes that gate.

## Gate

`check-fast-cargo.sh` already pinned `bdd.yml` to this toolchain and simply did
not reach `ci.yml`. It does now, and it **refuses a floating nightly** in either
workflow rather than only asserting a pin is present — so the failure mode that
started this can't return quietly. I verified it by reverting one pin and
watching it go red, then restoring it.

## Cost

One additional cache entry. Measured against the existing `v1-rust-test-support`
entry (0.70 GB, build artifacts) versus `v1-rust-workspace` (0.35 GB, clippy),
expect roughly 0.7–1.0 GB. The repo cache currently sits at 10.43 GB against a
10 GB cap, so this will evict something — LRU takes the coldest, which is the
nightly-only `cargo-mutation-*` set (~3.66 GB). I'm sending the trim of those as
a separate PR so the budget change is independently revertable.

## Verification

- `bash scripts/check-fast-cargo.sh` clean; **fails as intended** on a reverted pin
- `cargo run -p xtask -- check-all` → 67 gate(s) clean
- `cargo test -p xtask --bins` → 705 passed
- `ci_scope_aggregate`, `github_actions_bdd_gate`, `github_actions_fuzz_gate`,
  `github_actions_aarch64_no_kvm` → 17 passed
- `actionlint` clean on both workflows

The real proof is the run after this merges and `cache-warm` has written once —
`Test workspace` should stop logging "No cache found."
